### PR TITLE
feat(blockstore): implement IPFS-compatible blockstore with Go feature parity

### DIFF
--- a/crates/blockstore/Cargo.toml
+++ b/crates/blockstore/Cargo.toml
@@ -6,5 +6,28 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "IPFS-compatible blockstore with merge tracking for DefraDB"
 
 [dependencies]
+# Internal dependencies
+storage = { path = "../storage" }
+
+# IPLD
+cid = { workspace = true }
+multihash = { workspace = true }
+
+# Crypto (for hash verification)
+sha2 = { workspace = true }
+
+# Async
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/blockstore/src/error.rs
+++ b/crates/blockstore/src/error.rs
@@ -1,0 +1,30 @@
+//! Blockstore error types
+
+use thiserror::Error;
+
+/// Result type for blockstore operations
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Blockstore errors
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Storage layer error
+    #[error("storage error: {0}")]
+    Storage(#[from] storage::corekv::Error),
+
+    /// CID parsing error
+    #[error("invalid CID: {0}")]
+    InvalidCid(#[from] cid::Error),
+
+    /// Block not found
+    #[error("block not found: {0}")]
+    NotFound(String),
+
+    /// Hash mismatch - data doesn't match CID (detected when hash_on_read enabled)
+    #[error("hash mismatch for CID {cid}: data hash doesn't match expected hash")]
+    HashMismatch { cid: String },
+
+    /// Internal error
+    #[error("internal error: {0}")]
+    Internal(String),
+}

--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -81,8 +81,19 @@ impl<S: Store + 'static> DefraBlockstore<S> {
 
     /// Verify that data matches the CID hash
     ///
-    /// This implementation supports SHA2-256 (code 0x12), which is the most common
-    /// hash algorithm used in IPFS/IPLD.
+    /// # Supported Algorithms
+    ///
+    /// Currently supports SHA2-256 (code 0x12), which is the most common hash
+    /// algorithm used in IPFS/IPLD and DefraDB.
+    ///
+    /// # Go Compatibility Note
+    ///
+    /// The Go implementation uses `cid.Prefix().Sum(data)` which delegates to the
+    /// go-multihash library and supports all registered hash algorithms. This Rust
+    /// implementation explicitly handles SHA2-256 only. Unsupported algorithms are
+    /// logged and skipped (verification passes) rather than erroring, matching the
+    /// principle of being permissive on read. If DefraDB ever uses non-SHA256 hashes,
+    /// this function should be extended to support them.
     fn verify_hash(&self, cid: &Cid, data: &[u8]) -> Result<()> {
         use sha2::{Digest, Sha256};
 
@@ -722,6 +733,122 @@ mod tests {
     }
 
     // ==================== Go Compatibility Tests ====================
+
+    #[tokio::test]
+    async fn test_get_with_default_cid_returns_none() {
+        // Go implementation checks `!k.Defined()` and returns ErrNotFound
+        // Rust CID library doesn't have a "defined" concept the same way,
+        // but we should handle edge cases gracefully
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        // CIDv0 with all zeros - this is technically parseable but represents
+        // an invalid/empty multihash
+        let zero_bytes = vec![0x12, 0x20]; // SHA2-256 code + 32 byte length, but no digest
+        let result = Cid::try_from(zero_bytes.as_slice());
+        // This should fail to parse (incomplete multihash)
+        assert!(result.is_err());
+
+        // A properly formed but "empty content" CID (hash of empty data)
+        // This is valid and should return None when not stored
+        let empty_data_cid = cid_from_data(b"");
+        let result = blockstore.get(&empty_data_cid).await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_operations_with_cidv0() {
+        // CIDv0 is the legacy format used by IPFS - ensure compatibility
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        // CIDv0 example (Qm... format, base58btc encoded)
+        let cidv0 = Cid::from_str("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n").unwrap();
+        let data = b"cidv0 test data";
+
+        // All operations should work with CIDv0
+        blockstore.put(&cidv0, data).await.unwrap();
+        assert!(blockstore.has(&cidv0).await.unwrap());
+        assert_eq!(blockstore.get(&cidv0).await.unwrap(), Some(data.to_vec()));
+        assert_eq!(blockstore.get_size(&cidv0).await.unwrap(), Some(data.len()));
+
+        let cids = blockstore.all_cids().await.unwrap();
+        assert!(cids.contains(&cidv0));
+
+        blockstore.delete(&cidv0).await.unwrap();
+        assert!(!blockstore.has(&cidv0).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_put_already_merged_block_stays_merged() {
+        // Critical Go compatibility test:
+        // When a block is put, merged, then put again, it should stay merged
+        // Go skips put entirely if block exists, so no new merge marker is created
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+        let data = b"original data";
+
+        // Step 1: Put block (creates merge marker)
+        blockstore.put(&cid, data).await.unwrap();
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+
+        // Step 2: Mark as merged (removes marker)
+        blockstore.mark_as_merged(&cid).await.unwrap();
+        assert!(blockstore.is_merged(&cid).await.unwrap());
+
+        // Step 3: Put same block again
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Step 4: Should STILL be merged (put was no-op because block existed)
+        assert!(
+            blockstore.is_merged(&cid).await.unwrap(),
+            "Re-putting an already-merged block should not create a new merge marker"
+        );
+
+        // Unmerged list should be empty
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(
+            !unmerged.contains(&cid),
+            "Re-put block should not appear in unmerged list"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_put_many_with_existing_merged_block() {
+        // Same test but for put_many - existing merged blocks should stay merged
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid1 = test_cid();
+        let cid2 = test_cid2();
+        let data1 = b"data one";
+        let data2 = b"data two";
+
+        // Put and merge cid1
+        blockstore.put(&cid1, data1).await.unwrap();
+        blockstore.mark_as_merged(&cid1).await.unwrap();
+        assert!(blockstore.is_merged(&cid1).await.unwrap());
+
+        // Now put_many with cid1 (existing merged) and cid2 (new)
+        let blocks: Vec<(&Cid, &[u8])> = vec![(&cid1, data1.as_slice()), (&cid2, data2.as_slice())];
+        blockstore.put_many(&blocks).await.unwrap();
+
+        // cid1 should still be merged
+        assert!(
+            blockstore.is_merged(&cid1).await.unwrap(),
+            "Existing merged block should stay merged after put_many"
+        );
+
+        // cid2 should be unmerged (newly added)
+        assert!(!blockstore.is_merged(&cid2).await.unwrap());
+
+        // Only cid2 should be in unmerged list
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(!unmerged.contains(&cid1));
+        assert!(unmerged.contains(&cid2));
+    }
 
     #[tokio::test]
     async fn test_put_same_cid_different_data_no_overwrite() {

--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -70,8 +70,8 @@ impl<S: Store + 'static> DefraBlockstore<S> {
     ///
     /// * `store` - The underlying key-value store
     /// * `is_p2p` - If true, enables merge tracking for P2P synchronization.
-    ///              Blocks put in P2P mode are initially marked as "unmerged"
-    ///              until explicitly merged via `mark_as_merged`.
+    ///   Blocks put in P2P mode are initially marked as "unmerged"
+    ///   until explicitly merged via `mark_as_merged`.
     pub fn new(store: Arc<S>, is_p2p: bool) -> Self {
         Self {
             store: InternalBlockstore::new(store, is_p2p),
@@ -539,10 +539,7 @@ mod tests {
         // This simulates data corruption
         {
             let mut txn = blockstore.store.new_txn(false).await.unwrap();
-            let bs_txn = txn
-                .as_any_mut()
-                .downcast_mut::<BlockstoreTxn>()
-                .unwrap();
+            let bs_txn = txn.as_any_mut().downcast_mut::<BlockstoreTxn>().unwrap();
             bs_txn.put_block(&cid, corrupted_data).await.unwrap();
             txn.commit().await.unwrap();
         }
@@ -722,5 +719,396 @@ mod tests {
         // Not in unmerged list
         let unmerged = blockstore.get_unmerged().await.unwrap();
         assert!(!unmerged.contains(&cid));
+    }
+
+    // ==================== Go Compatibility Tests ====================
+
+    #[tokio::test]
+    async fn test_put_same_cid_different_data_no_overwrite() {
+        // Critical: Content-addressed stores MUST be immutable by CID
+        // If put() overwrote data, it would violate content-addressing invariants
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+        let original_data = b"original data";
+        let new_data = b"different data";
+
+        // Put original
+        blockstore.put(&cid, original_data).await.unwrap();
+
+        // Put with same CID but different data (should be ignored per Go behavior)
+        blockstore.put(&cid, new_data).await.unwrap();
+
+        // Should still have original data
+        let retrieved = blockstore.get(&cid).await.unwrap();
+        assert_eq!(retrieved, Some(original_data.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_put_many_duplicate_cids_in_batch() {
+        // Verify behavior when same CID appears multiple times in one batch
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+        let data1 = b"first data";
+        let data2 = b"second data";
+
+        // Put same CID twice in one batch - first write should win
+        let blocks: Vec<(&Cid, &[u8])> = vec![(&cid, data1.as_slice()), (&cid, data2.as_slice())];
+        blockstore.put_many(&blocks).await.unwrap();
+
+        // Should have first data (first write wins within transaction)
+        let retrieved = blockstore.get(&cid).await.unwrap();
+        assert_eq!(retrieved, Some(data1.to_vec()));
+
+        // Should only appear once in all_cids
+        let cids = blockstore.all_cids().await.unwrap();
+        assert_eq!(cids.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mark_as_merged_nonexistent_block() {
+        // Verify mark_as_merged behavior for non-existent blocks
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+
+        // Should not error when marking non-existent block as merged
+        // This is a no-op - deleting a merge key that doesn't exist
+        let result = blockstore.mark_as_merged(&cid).await;
+        assert!(result.is_ok());
+
+        // Block still doesn't exist
+        assert!(!blockstore.has(&cid).await.unwrap());
+
+        // is_merged still returns false (block doesn't exist)
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+    }
+
+    // ==================== Edge Case Tests ====================
+
+    #[tokio::test]
+    async fn test_empty_block() {
+        // Empty blocks are valid in IPLD (e.g., empty directory nodes)
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let data: &[u8] = b"";
+        let cid = cid_from_data(data);
+
+        // Put empty block
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Verify retrieval
+        let retrieved = blockstore.get(&cid).await.unwrap();
+        assert_eq!(retrieved, Some(vec![]));
+
+        // Verify size
+        assert_eq!(blockstore.get_size(&cid).await.unwrap(), Some(0));
+
+        // Verify has
+        assert!(blockstore.has(&cid).await.unwrap());
+
+        // Verify hash_on_read works with empty data
+        blockstore.hash_on_read(true);
+        let verified = blockstore.get(&cid).await.unwrap();
+        assert_eq!(verified, Some(vec![]));
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent_block() {
+        // Delete should be idempotent - deleting non-existent block is a no-op
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+
+        // Should succeed silently (idempotent)
+        let result = blockstore.delete(&cid).await;
+        assert!(result.is_ok());
+
+        // Still doesn't exist
+        assert!(!blockstore.has(&cid).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent_block_p2p_mode() {
+        // Verify idempotent delete in P2P mode too
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+
+        // Should succeed silently
+        let result = blockstore.delete(&cid).await;
+        assert!(result.is_ok());
+
+        // Not in unmerged list
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(!unmerged.contains(&cid));
+    }
+
+    #[tokio::test]
+    async fn test_hash_on_read_unsupported_algorithm_skipped() {
+        // Verify unsupported hash algorithms are skipped with warning (not error)
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        // Create a CID with identity hash (code 0x00) - no actual hashing
+        use multihash::Multihash;
+        let data = b"identity hash data";
+        let hash = Multihash::<64>::wrap(0x00, data).unwrap(); // Identity hash
+        let cid = Cid::new_v1(0x55, hash); // raw codec
+
+        // Store the block
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Enable hash_on_read
+        blockstore.hash_on_read(true);
+
+        // Should succeed - unsupported algorithm is skipped, not errored
+        let result = blockstore.get(&cid).await.unwrap();
+        assert_eq!(result, Some(data.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_hash_on_read_blake2b_skipped() {
+        // Verify blake2b-256 (code 0xb220) is skipped
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        use multihash::Multihash;
+        let data = b"blake2b test data";
+        // Create a fake blake2b-256 multihash (just for testing skip behavior)
+        let fake_digest = [0u8; 32];
+        let hash = Multihash::<64>::wrap(0xb220, &fake_digest).unwrap();
+        let cid = Cid::new_v1(0x55, hash);
+
+        // Store with this CID
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Enable hash_on_read
+        blockstore.hash_on_read(true);
+
+        // Should succeed - blake2b is skipped
+        let result = blockstore.get(&cid).await.unwrap();
+        assert_eq!(result, Some(data.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_large_block() {
+        // Test with 256KB block (typical IPFS chunk size)
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        // Generate 256KB of data
+        let data: Vec<u8> = (0..262144).map(|i| (i % 256) as u8).collect();
+        let cid = cid_from_data(&data);
+
+        // Put large block
+        blockstore.put(&cid, &data).await.unwrap();
+
+        // Verify retrieval
+        let retrieved = blockstore.get(&cid).await.unwrap();
+        assert_eq!(retrieved, Some(data.clone()));
+
+        // Verify size
+        assert_eq!(blockstore.get_size(&cid).await.unwrap(), Some(262144));
+
+        // Verify hash_on_read works with large data
+        blockstore.hash_on_read(true);
+        let verified = blockstore.get(&cid).await.unwrap();
+        assert_eq!(verified, Some(data));
+    }
+
+    #[tokio::test]
+    async fn test_large_block_many() {
+        // Test put_many with multiple large blocks
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        // Generate three 64KB blocks
+        let data1: Vec<u8> = (0..65536).map(|i| (i % 256) as u8).collect();
+        let data2: Vec<u8> = (0..65536).map(|i| ((i + 100) % 256) as u8).collect();
+        let data3: Vec<u8> = (0..65536).map(|i| ((i + 200) % 256) as u8).collect();
+
+        let cid1 = cid_from_data(&data1);
+        let cid2 = cid_from_data(&data2);
+        let cid3 = cid_from_data(&data3);
+
+        // Put all at once
+        let blocks: Vec<(&Cid, &[u8])> = vec![
+            (&cid1, data1.as_slice()),
+            (&cid2, data2.as_slice()),
+            (&cid3, data3.as_slice()),
+        ];
+        blockstore.put_many(&blocks).await.unwrap();
+
+        // Verify all exist
+        assert_eq!(blockstore.get(&cid1).await.unwrap(), Some(data1));
+        assert_eq!(blockstore.get(&cid2).await.unwrap(), Some(data2));
+        assert_eq!(blockstore.get(&cid3).await.unwrap(), Some(data3));
+    }
+
+    // ==================== Concurrency Tests ====================
+
+    #[tokio::test]
+    async fn test_concurrent_put_different_cids() {
+        // Verify concurrent puts to different CIDs work correctly
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+
+        let cid1 = test_cid();
+        let cid2 = test_cid2();
+        let cid3 = test_cid3();
+        let data1 = b"concurrent data 1";
+        let data2 = b"concurrent data 2";
+        let data3 = b"concurrent data 3";
+
+        let bs1 = blockstore.clone();
+        let bs2 = blockstore.clone();
+        let bs3 = blockstore.clone();
+
+        // Concurrent puts
+        let (r1, r2, r3) = tokio::join!(
+            async move { bs1.put(&cid1, data1).await },
+            async move { bs2.put(&cid2, data2).await },
+            async move { bs3.put(&cid3, data3).await }
+        );
+
+        r1.unwrap();
+        r2.unwrap();
+        r3.unwrap();
+
+        // Verify all exist with correct data
+        assert_eq!(blockstore.get(&cid1).await.unwrap(), Some(data1.to_vec()));
+        assert_eq!(blockstore.get(&cid2).await.unwrap(), Some(data2.to_vec()));
+        assert_eq!(blockstore.get(&cid3).await.unwrap(), Some(data3.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_put_same_cid() {
+        // Verify concurrent puts to same CID (both should succeed, first wins)
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+
+        let cid = test_cid();
+        let data1 = b"first writer";
+        let data2 = b"second writer";
+
+        let bs1 = blockstore.clone();
+        let bs2 = blockstore.clone();
+
+        // Concurrent puts to same CID
+        let (r1, r2) = tokio::join!(async move { bs1.put(&cid, data1).await }, async move {
+            bs2.put(&cid, data2).await
+        });
+
+        // Both should succeed (one writes, one is no-op)
+        r1.unwrap();
+        r2.unwrap();
+
+        // Data should be consistent (whichever wrote first)
+        let retrieved = blockstore.get(&cid).await.unwrap();
+        assert!(retrieved == Some(data1.to_vec()) || retrieved == Some(data2.to_vec()));
+
+        // Only one copy should exist
+        let cids = blockstore.all_cids().await.unwrap();
+        assert_eq!(cids.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_get_and_put() {
+        // Verify concurrent get and put operations
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+
+        let cid = test_cid();
+        let data = b"concurrent access data";
+
+        // First put the data
+        blockstore.put(&cid, data).await.unwrap();
+
+        let bs1 = blockstore.clone();
+        let bs2 = blockstore.clone();
+        let bs3 = blockstore.clone();
+
+        // Concurrent reads and a write (to different CID)
+        let cid2 = test_cid2();
+        let (r1, r2, r3) = tokio::join!(
+            async move { bs1.get(&cid).await },
+            async move { bs2.get(&cid).await },
+            async move { bs3.put(&cid2, b"other data").await }
+        );
+
+        // All should succeed
+        assert_eq!(r1.unwrap(), Some(data.to_vec()));
+        assert_eq!(r2.unwrap(), Some(data.to_vec()));
+        r3.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_hash_on_read_toggle() {
+        // Verify hash_on_read toggle is thread-safe
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+
+        let data = b"hash verification data";
+        let cid = cid_from_data(data);
+        blockstore.put(&cid, data).await.unwrap();
+
+        let bs1 = blockstore.clone();
+        let bs2 = blockstore.clone();
+        let bs3 = blockstore.clone();
+
+        // Concurrent toggle and reads
+        let (_, _, r3) = tokio::join!(
+            async move {
+                bs1.hash_on_read(true);
+            },
+            async move {
+                bs2.hash_on_read(false);
+            },
+            async move { bs3.get(&cid).await }
+        );
+
+        // Read should succeed regardless of toggle state
+        assert_eq!(r3.unwrap(), Some(data.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_p2p_merge_tracking() {
+        // Verify concurrent merge operations in P2P mode
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true)); // P2P mode
+
+        let cid1 = test_cid();
+        let cid2 = test_cid2();
+
+        // Put blocks
+        blockstore.put(&cid1, b"block1").await.unwrap();
+        blockstore.put(&cid2, b"block2").await.unwrap();
+
+        let bs1 = blockstore.clone();
+        let bs2 = blockstore.clone();
+
+        // Concurrent merge operations
+        let (r1, r2) = tokio::join!(async move { bs1.mark_as_merged(&cid1).await }, async move {
+            bs2.mark_as_merged(&cid2).await
+        });
+
+        r1.unwrap();
+        r2.unwrap();
+
+        // Both should be merged
+        assert!(blockstore.is_merged(&cid1).await.unwrap());
+        assert!(blockstore.is_merged(&cid2).await.unwrap());
+
+        // Unmerged list should be empty
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(unmerged.is_empty());
     }
 }

--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -1595,4 +1595,131 @@ mod tests {
             total_ops
         );
     }
+
+    // ==================== Error Path Tests ====================
+
+    #[tokio::test]
+    async fn test_all_cids_skips_malformed_keys_like_go() {
+        // Go implementation (corekv/blockstore/blockstore.go:163-167):
+        // k, err := cid.Cast(key)
+        // if err != nil {
+        //     log.ErrorContextE(ctx, "Error parsing key from binary", err)
+        //     continue  // Skips unparseable keys
+        // }
+        //
+        // This test verifies Rust matches Go's behavior of logging and skipping
+        // keys that cannot be parsed as CIDs.
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store.clone(), false);
+
+        // Add some valid blocks
+        let cid1 = test_cid();
+        let cid2 = test_cid2();
+        blockstore.put(&cid1, b"data1").await.unwrap();
+        blockstore.put(&cid2, b"data2").await.unwrap();
+
+        // Directly write a malformed key to the underlying store
+        // This simulates data corruption - a key that's neither a valid CID
+        // nor a merge marker. Use a key that won't parse as CID.
+        // CIDv1 starts with 0x01, CIDv0 with 0x12. Use 0xAA to guarantee failure.
+        let malformed_key = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        {
+            let mut txn = store.new_txn(false).await.unwrap();
+            // Write to blockstore namespace (prefix 'b')
+            let mut namespaced_key = vec![b'b'];
+            namespaced_key.extend_from_slice(&malformed_key);
+            txn.set(&namespaced_key, b"garbage").await.unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        // all_cids should skip the malformed key and return only valid CIDs
+        // (matching Go behavior of logging error and continuing)
+        let cids = blockstore.all_cids().await.unwrap();
+        assert_eq!(cids.len(), 2, "Should return only valid CIDs, skipping malformed key");
+        assert!(cids.contains(&cid1));
+        assert!(cids.contains(&cid2));
+    }
+
+    #[tokio::test]
+    async fn test_go_key_format_compatibility() {
+        // Verify our key encoding matches Go's format exactly.
+        // Go (defradb/internal/datastore/blockstore.go:54-59):
+        // func newToMergeKey(cid []byte) []byte {
+        //     l := len(cid)
+        //     key := make([]byte, l+1)
+        //     copy(key[1:], cid)
+        //     key[0] = toMergeIndexPrefix  // 'm' = 0x6D
+        //     return key
+        // }
+        use storage::keys::blockstore::{BlockstoreKey, ToMergeIndexKey, MERGE_PREFIX};
+
+        let cid = test_cid();
+
+        // Block key: raw CID bytes (no prefix)
+        let block_key = BlockstoreKey::new(cid);
+        let block_bytes = block_key.bytes();
+        assert_eq!(block_bytes, cid.to_bytes(), "Block key should be raw CID bytes");
+
+        // Merge key: 'm' prefix + CID bytes
+        let merge_key = ToMergeIndexKey::new(cid);
+        let merge_bytes = merge_key.bytes();
+
+        // First byte must be 'm' (0x6D)
+        assert_eq!(merge_bytes[0], MERGE_PREFIX);
+        assert_eq!(merge_bytes[0], b'm');
+        assert_eq!(merge_bytes[0], 0x6D);
+
+        // Rest must be exact CID bytes
+        assert_eq!(&merge_bytes[1..], cid.to_bytes().as_slice());
+
+        // Total length: 1 (prefix) + CID bytes
+        assert_eq!(merge_bytes.len(), 1 + cid.to_bytes().len());
+
+        // Verify CIDv0 format too (legacy IPFS)
+        let cidv0 = Cid::from_str("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n").unwrap();
+        let merge_key_v0 = ToMergeIndexKey::new(cidv0);
+        let merge_bytes_v0 = merge_key_v0.bytes();
+        assert_eq!(merge_bytes_v0[0], b'm');
+        assert_eq!(&merge_bytes_v0[1..], cidv0.to_bytes().as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_cid_bytes_cannot_start_with_merge_prefix() {
+        // Safety test: Verify that valid CID binary encodings cannot start
+        // with 'm' (0x6D = 109), which would cause false positives in
+        // is_merge_key() filtering.
+        //
+        // CIDv0: Starts with 0x12 (sha2-256 multihash code)
+        // CIDv1: Starts with 0x01 (version byte)
+        //
+        // 0x6D (109) is not a valid CID start byte.
+        use storage::keys::blockstore::ToMergeIndexKey;
+
+        // CIDv1 test
+        let cidv1 = test_cid();
+        let cidv1_bytes = cidv1.to_bytes();
+        assert_ne!(
+            cidv1_bytes[0], b'm',
+            "CIDv1 should not start with 'm' - would break is_merge_key filtering"
+        );
+        assert_eq!(cidv1_bytes[0], 0x01, "CIDv1 should start with version byte 0x01");
+        assert!(!ToMergeIndexKey::is_merge_key(&cidv1_bytes));
+
+        // CIDv0 test (Qm... format)
+        let cidv0 = Cid::from_str("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n").unwrap();
+        let cidv0_bytes = cidv0.to_bytes();
+        assert_ne!(
+            cidv0_bytes[0], b'm',
+            "CIDv0 should not start with 'm' - would break is_merge_key filtering"
+        );
+        // CIDv0 starts with the multihash directly (0x12 for sha2-256)
+        assert_eq!(cidv0_bytes[0], 0x12, "CIDv0 should start with sha2-256 code 0x12");
+        assert!(!ToMergeIndexKey::is_merge_key(&cidv0_bytes));
+
+        // Edge case: raw codec CIDv1
+        let raw_cid = cid_from_data(b"test data");
+        let raw_bytes = raw_cid.to_bytes();
+        assert_eq!(raw_bytes[0], 0x01, "Raw CIDv1 should start with 0x01");
+        assert!(!ToMergeIndexKey::is_merge_key(&raw_bytes));
+    }
 }

--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -1,14 +1,726 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+//! IPFS-compatible blockstore with merge tracking for DefraDB
+//!
+//! This crate provides a public API layer for IPLD block storage with
+//! CRDT merge tracking support for P2P synchronization.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Application Layer
+//!     ↓
+//! Blockstore Trait (this crate - public API)
+//!     ↓
+//! storage::stores::Blockstore (internal implementation)
+//!     ↓
+//! CoreKV Backend (Memory/RocksDB)
+//! ```
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use blockstore::{Blockstore, DefraBlockstore};
+//! use storage::backends::MemoryStore;
+//! use std::sync::Arc;
+//!
+//! // Create a blockstore
+//! let store = Arc::new(MemoryStore::new());
+//! let blockstore = DefraBlockstore::new(store, false);
+//!
+//! // Store a block
+//! let cid = /* compute CID from data */;
+//! blockstore.put(&cid, b"block data").await?;
+//!
+//! // Retrieve a block
+//! let data = blockstore.get(&cid).await?;
+//!
+//! // Enable hash verification on read
+//! blockstore.hash_on_read(true);
+//! let verified_data = blockstore.get(&cid).await?; // Will verify hash
+//! ```
+
+mod error;
+mod traits;
+
+pub use error::{Error, Result};
+pub use traits::Blockstore;
+
+use async_trait::async_trait;
+use cid::Cid;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use storage::corekv::{IterOptions, Key, Store};
+use storage::keys::blockstore::{BlockstoreKey, ToMergeIndexKey};
+use storage::stores::blockstore::BlockstoreTxn;
+use storage::stores::Blockstore as InternalBlockstore;
+
+/// DefraDB blockstore implementation
+///
+/// Wraps the internal storage::stores::Blockstore with a clean public API.
+/// Supports both P2P mode (with merge tracking) and local mode (no tracking).
+pub struct DefraBlockstore<S: Store> {
+    store: InternalBlockstore<S>,
+    /// Whether to verify hash on read
+    rehash: AtomicBool,
+}
+
+impl<S: Store + 'static> DefraBlockstore<S> {
+    /// Create a new blockstore
+    ///
+    /// # Arguments
+    ///
+    /// * `store` - The underlying key-value store
+    /// * `is_p2p` - If true, enables merge tracking for P2P synchronization.
+    ///              Blocks put in P2P mode are initially marked as "unmerged"
+    ///              until explicitly merged via `mark_as_merged`.
+    pub fn new(store: Arc<S>, is_p2p: bool) -> Self {
+        Self {
+            store: InternalBlockstore::new(store, is_p2p),
+            rehash: AtomicBool::new(false),
+        }
+    }
+
+    /// Verify that data matches the CID hash
+    ///
+    /// This implementation supports SHA2-256 (code 0x12), which is the most common
+    /// hash algorithm used in IPFS/IPLD.
+    fn verify_hash(&self, cid: &Cid, data: &[u8]) -> Result<()> {
+        use sha2::{Digest, Sha256};
+
+        let mh = cid.hash();
+        let code = mh.code();
+
+        // Compute hash based on the multihash code
+        let computed_digest: Vec<u8> = match code {
+            0x12 => {
+                // SHA2-256
+                let mut hasher = Sha256::new();
+                hasher.update(data);
+                hasher.finalize().to_vec()
+            }
+            _ => {
+                // For unsupported hash algorithms, skip verification with a warning
+                tracing::warn!(
+                    hash_code = code,
+                    cid = %cid,
+                    "Hash verification skipped: unsupported hash algorithm"
+                );
+                return Ok(());
+            }
+        };
+
+        // Compare the computed digest with the CID's digest
+        if mh.digest() != computed_digest.as_slice() {
+            return Err(Error::HashMismatch {
+                cid: cid.to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<S: Store + 'static> Blockstore for DefraBlockstore<S> {
+    async fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
+        let txn = self.store.new_txn(true).await?;
+        let bs_txn = txn
+            .as_any()
+            .downcast_ref::<BlockstoreTxn>()
+            .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+        let result = bs_txn.get_block(cid).await?;
+
+        // If hash_on_read is enabled and we got data, verify the hash
+        if self.rehash.load(Ordering::Relaxed) {
+            if let Some(ref data) = result {
+                self.verify_hash(cid, data)?;
+            }
+        }
+
+        Ok(result)
+    }
+
+    async fn put(&self, cid: &Cid, data: &[u8]) -> Result<()> {
+        // Optimization: Has is cheaper than Set, so check if we already have it
+        // This matches the Go implementation behavior
+        if self.has(cid).await? {
+            return Ok(());
+        }
+
+        let mut txn = self.store.new_txn(false).await?;
+        {
+            let bs_txn = txn
+                .as_any_mut()
+                .downcast_mut::<BlockstoreTxn>()
+                .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+            bs_txn.put_block(cid, data).await?;
+        }
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn put_many(&self, blocks: &[(&Cid, &[u8])]) -> Result<()> {
+        if blocks.is_empty() {
+            return Ok(());
+        }
+
+        let mut txn = self.store.new_txn(false).await?;
+        {
+            let bs_txn = txn
+                .as_any_mut()
+                .downcast_mut::<BlockstoreTxn>()
+                .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+            for (cid, data) in blocks {
+                // Optimization: skip if already exists (matches Go behavior)
+                if bs_txn.has_block(cid).await? {
+                    continue;
+                }
+                bs_txn.put_block(cid, data).await?;
+            }
+        }
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn has(&self, cid: &Cid) -> Result<bool> {
+        let txn = self.store.new_txn(true).await?;
+        let bs_txn = txn
+            .as_any()
+            .downcast_ref::<BlockstoreTxn>()
+            .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+        let result = bs_txn.has_block(cid).await?;
+        Ok(result)
+    }
+
+    async fn delete(&self, cid: &Cid) -> Result<()> {
+        let mut txn = self.store.new_txn(false).await?;
+        {
+            let bs_txn = txn
+                .as_any_mut()
+                .downcast_mut::<BlockstoreTxn>()
+                .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+            bs_txn.delete_block(cid).await?;
+        }
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn get_size(&self, cid: &Cid) -> Result<Option<usize>> {
+        let txn = self.store.new_txn(true).await?;
+        let block_key = BlockstoreKey::new(*cid);
+        let result = txn.get_size(&block_key.bytes()).await?;
+        Ok(result)
+    }
+
+    async fn all_cids(&self) -> Result<Vec<Cid>> {
+        let txn = self.store.new_txn(true).await?;
+
+        // Iterate all keys that don't start with merge prefix
+        // Block keys are raw CID bytes, merge keys start with 'm'
+        let opts = IterOptions::new().with_keys_only(true);
+        let mut iter = txn.iterator(opts).await?;
+
+        let mut cids = Vec::new();
+        while let Some(pair) = iter.next().await? {
+            // Skip merge marker keys (start with 'm')
+            if ToMergeIndexKey::is_merge_key(&pair.key) {
+                continue;
+            }
+
+            // Parse the key as a CID
+            match BlockstoreKey::from_bytes(&pair.key) {
+                Ok(key) => cids.push(key.cid),
+                Err(e) => {
+                    tracing::warn!(
+                        key_bytes = ?pair.key,
+                        error = %e,
+                        "Skipping key that could not be parsed as CID"
+                    );
+                }
+            }
+        }
+
+        Ok(cids)
+    }
+
+    fn hash_on_read(&self, enabled: bool) {
+        self.rehash.store(enabled, Ordering::Relaxed);
+    }
+
+    async fn is_merged(&self, cid: &Cid) -> Result<bool> {
+        // Match Go semantics: return false if block doesn't exist
+        let txn = self.store.new_txn(true).await?;
+        let bs_txn = txn
+            .as_any()
+            .downcast_ref::<BlockstoreTxn>()
+            .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+
+        // First check if block exists
+        let has_block = bs_txn.has_block(cid).await?;
+        if !has_block {
+            return Ok(false);
+        }
+
+        // Block exists, check merge status
+        let result = bs_txn.is_merged(cid).await?;
+        Ok(result)
+    }
+
+    async fn mark_as_merged(&self, cid: &Cid) -> Result<()> {
+        let mut txn = self.store.new_txn(false).await?;
+        {
+            let bs_txn = txn
+                .as_any_mut()
+                .downcast_mut::<BlockstoreTxn>()
+                .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+            bs_txn.mark_as_merged(cid).await?;
+        }
+        txn.commit().await?;
+        Ok(())
+    }
+
+    async fn get_unmerged(&self) -> Result<Vec<Cid>> {
+        let txn = self.store.new_txn(true).await?;
+        let bs_txn = txn
+            .as_any()
+            .downcast_ref::<BlockstoreTxn>()
+            .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+        let result = bs_txn.get_unmerged_cids().await?;
+        Ok(result)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
+    use storage::backends::MemoryStore;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn test_cid() -> Cid {
+        Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap()
+    }
+
+    fn test_cid2() -> Cid {
+        Cid::from_str("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy").unwrap()
+    }
+
+    fn test_cid3() -> Cid {
+        // Another valid CIDv1
+        Cid::from_str("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku").unwrap()
+    }
+
+    /// Create a CID from data using SHA2-256 (for hash verification tests)
+    fn cid_from_data(data: &[u8]) -> Cid {
+        use multihash::Multihash;
+        use sha2::{Digest, Sha256};
+
+        // Compute SHA2-256 hash
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let digest = hasher.finalize();
+
+        // Create multihash with SHA2-256 code (0x12)
+        let hash = Multihash::<64>::wrap(0x12, &digest).unwrap();
+        Cid::new_v1(0x55, hash) // raw codec
+    }
+
+    // ==================== Basic CRUD Tests ====================
+
+    #[tokio::test]
+    async fn test_basic_put_get() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+        let data = b"hello world";
+
+        // Put
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Get
+        let retrieved = blockstore.get(&cid).await.unwrap();
+        assert_eq!(retrieved, Some(data.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_get_nonexistent_block() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+
+        // Get non-existent block should return None, not error
+        let result = blockstore.get(&cid).await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_has() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+        let data = b"test data";
+
+        // Should not exist initially
+        assert!(!blockstore.has(&cid).await.unwrap());
+
+        // Put
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Should exist now
+        assert!(blockstore.has(&cid).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+        let data = b"to be deleted";
+
+        // Put
+        blockstore.put(&cid, data).await.unwrap();
+        assert!(blockstore.has(&cid).await.unwrap());
+
+        // Delete
+        blockstore.delete(&cid).await.unwrap();
+
+        // Should not exist anymore
+        assert!(!blockstore.has(&cid).await.unwrap());
+        assert_eq!(blockstore.get(&cid).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_get_size() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+        let data = b"test data for size";
+
+        // Should return None for non-existent block
+        assert_eq!(blockstore.get_size(&cid).await.unwrap(), None);
+
+        // Put
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Should return size
+        let size = blockstore.get_size(&cid).await.unwrap();
+        assert_eq!(size, Some(data.len()));
+    }
+
+    #[tokio::test]
+    async fn test_put_many() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid1 = test_cid();
+        let cid2 = test_cid2();
+        let data1 = b"block one";
+        let data2 = b"block two";
+
+        // Put many
+        let blocks: Vec<(&Cid, &[u8])> = vec![(&cid1, data1.as_slice()), (&cid2, data2.as_slice())];
+        blockstore.put_many(&blocks).await.unwrap();
+
+        // Verify both exist
+        assert_eq!(blockstore.get(&cid1).await.unwrap(), Some(data1.to_vec()));
+        assert_eq!(blockstore.get(&cid2).await.unwrap(), Some(data2.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_put_many_empty() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        // Should handle empty input
+        let blocks: Vec<(&Cid, &[u8])> = vec![];
+        blockstore.put_many(&blocks).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_all_cids() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid1 = test_cid();
+        let cid2 = test_cid2();
+        let cid3 = test_cid3();
+
+        // Initially empty
+        let cids = blockstore.all_cids().await.unwrap();
+        assert!(cids.is_empty());
+
+        // Put some blocks
+        blockstore.put(&cid1, b"data1").await.unwrap();
+        blockstore.put(&cid2, b"data2").await.unwrap();
+        blockstore.put(&cid3, b"data3").await.unwrap();
+
+        // Should list all CIDs
+        let cids = blockstore.all_cids().await.unwrap();
+        assert_eq!(cids.len(), 3);
+        assert!(cids.contains(&cid1));
+        assert!(cids.contains(&cid2));
+        assert!(cids.contains(&cid3));
+    }
+
+    #[tokio::test]
+    async fn test_deduplication() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+        let data = b"original data";
+
+        // Put twice with same CID
+        blockstore.put(&cid, data).await.unwrap();
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Should only appear once in all_cids
+        let cids = blockstore.all_cids().await.unwrap();
+        assert_eq!(cids.len(), 1);
+        assert_eq!(cids[0], cid);
+    }
+
+    // ==================== HashOnRead Tests ====================
+
+    #[tokio::test]
+    async fn test_hash_on_read_disabled_by_default() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        // Hash on read should be disabled by default
+        assert!(!blockstore.rehash.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn test_hash_on_read_enable_disable() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        // Enable
+        blockstore.hash_on_read(true);
+        assert!(blockstore.rehash.load(Ordering::Relaxed));
+
+        // Disable
+        blockstore.hash_on_read(false);
+        assert!(!blockstore.rehash.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn test_hash_on_read_valid_data() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let data = b"test data for hash verification";
+        let cid = cid_from_data(data);
+
+        // Put the block
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Enable hash on read
+        blockstore.hash_on_read(true);
+
+        // Get should succeed with valid data
+        let result = blockstore.get(&cid).await.unwrap();
+        assert_eq!(result, Some(data.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_hash_on_read_corrupted_data() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let original_data = b"original data";
+        let corrupted_data = b"corrupted data";
+        let cid = cid_from_data(original_data);
+
+        // Directly write corrupted data to the store using the CID
+        // This simulates data corruption
+        {
+            let mut txn = blockstore.store.new_txn(false).await.unwrap();
+            let bs_txn = txn
+                .as_any_mut()
+                .downcast_mut::<BlockstoreTxn>()
+                .unwrap();
+            bs_txn.put_block(&cid, corrupted_data).await.unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        // Without hash_on_read, we get the corrupted data
+        blockstore.hash_on_read(false);
+        let result = blockstore.get(&cid).await.unwrap();
+        assert_eq!(result, Some(corrupted_data.to_vec()));
+
+        // With hash_on_read enabled, it should detect the mismatch
+        blockstore.hash_on_read(true);
+        let result = blockstore.get(&cid).await;
+        assert!(result.is_err());
+        match result {
+            Err(Error::HashMismatch { cid: cid_str }) => {
+                assert_eq!(cid_str, cid.to_string());
+            }
+            other => panic!("Expected HashMismatch error, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_hash_on_read_nonexistent_block() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        let cid = test_cid();
+
+        // Enable hash on read
+        blockstore.hash_on_read(true);
+
+        // Get non-existent block should return None, not error
+        // (no hash to verify when block doesn't exist)
+        let result = blockstore.get(&cid).await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ==================== Merge Tracking Tests (P2P mode) ====================
+
+    #[tokio::test]
+    async fn test_p2p_merge_tracking_lifecycle() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+        let data = b"p2p block";
+
+        // Put block - should be unmerged initially
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Check unmerged status
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+
+        // Get unmerged - should include this CID
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(unmerged.contains(&cid));
+
+        // Mark as merged
+        blockstore.mark_as_merged(&cid).await.unwrap();
+
+        // Now should be merged
+        assert!(blockstore.is_merged(&cid).await.unwrap());
+
+        // Should not appear in unmerged list
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(!unmerged.contains(&cid));
+    }
+
+    #[tokio::test]
+    async fn test_local_mode_no_merge_tracking() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false); // Local mode
+
+        let cid = test_cid();
+        let data = b"local block";
+
+        // Put block
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Should be immediately "merged" in local mode
+        assert!(blockstore.is_merged(&cid).await.unwrap());
+
+        // Unmerged list should be empty
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(unmerged.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_is_merged_nonexistent_block() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+
+        // is_merged for non-existent block should return false (matches Go behavior)
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_is_merged_nonexistent_block_local_mode() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false); // Local mode
+
+        let cid = test_cid();
+
+        // is_merged for non-existent block should return false even in local mode
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_get_unmerged_filtering() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid1 = test_cid();
+        let cid2 = test_cid2();
+
+        // Put two blocks
+        blockstore.put(&cid1, b"data1").await.unwrap();
+        blockstore.put(&cid2, b"data2").await.unwrap();
+
+        // Both unmerged
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert_eq!(unmerged.len(), 2);
+
+        // Merge one
+        blockstore.mark_as_merged(&cid1).await.unwrap();
+
+        // Only one should be unmerged now
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert_eq!(unmerged.len(), 1);
+        assert!(unmerged.contains(&cid2));
+        assert!(!unmerged.contains(&cid1));
+    }
+
+    #[tokio::test]
+    async fn test_all_cids_excludes_merge_markers() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid1 = test_cid();
+        let cid2 = test_cid2();
+
+        // Put blocks (creates merge markers in P2P mode)
+        blockstore.put(&cid1, b"data1").await.unwrap();
+        blockstore.put(&cid2, b"data2").await.unwrap();
+
+        // all_cids should only return actual block CIDs, not merge markers
+        let cids = blockstore.all_cids().await.unwrap();
+        assert_eq!(cids.len(), 2);
+        assert!(cids.contains(&cid1));
+        assert!(cids.contains(&cid2));
+    }
+
+    #[tokio::test]
+    async fn test_delete_removes_merge_marker() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+
+        // Put block
+        blockstore.put(&cid, b"data").await.unwrap();
+
+        // Verify unmerged
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+
+        // Delete block
+        blockstore.delete(&cid).await.unwrap();
+
+        // Block should be gone
+        assert!(!blockstore.has(&cid).await.unwrap());
+
+        // is_merged returns false for non-existent block
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+
+        // Not in unmerged list
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(!unmerged.contains(&cid));
     }
 }

--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -1238,4 +1238,361 @@ mod tests {
         let unmerged = blockstore.get_unmerged().await.unwrap();
         assert!(unmerged.is_empty());
     }
+
+    #[tokio::test]
+    async fn test_concurrent_delete_during_read() {
+        // Verify behavior when delete races with read
+        // Either outcome is acceptable: read returns data OR read returns None
+        // But there should be no errors or panics
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+
+        let cid = test_cid();
+        let data = b"data that may be deleted";
+
+        // Put initial data
+        blockstore.put(&cid, data).await.unwrap();
+
+        // Run multiple iterations to increase chance of race
+        for _ in 0..10 {
+            // Re-add the block if it was deleted
+            if !blockstore.has(&cid).await.unwrap() {
+                blockstore.put(&cid, data).await.unwrap();
+            }
+
+            let bs_read = blockstore.clone();
+            let bs_delete = blockstore.clone();
+
+            // Race: concurrent read and delete
+            let (read_result, delete_result) =
+                tokio::join!(async move { bs_read.get(&cid).await }, async move {
+                    bs_delete.delete(&cid).await
+                });
+
+            // Delete should always succeed (idempotent)
+            assert!(delete_result.is_ok());
+
+            // Read should succeed (returning Some or None, but no error)
+            let read_value = read_result.unwrap();
+            // Either we got the data or it was already deleted - both are valid
+            assert!(
+                read_value.is_none() || read_value == Some(data.to_vec()),
+                "Read during delete should return None or valid data, got {:?}",
+                read_value
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_delete_and_has() {
+        // Verify has() behavior during concurrent delete
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+
+        let cid = test_cid();
+        blockstore.put(&cid, b"data").await.unwrap();
+
+        for _ in 0..10 {
+            if !blockstore.has(&cid).await.unwrap() {
+                blockstore.put(&cid, b"data").await.unwrap();
+            }
+
+            let bs_has = blockstore.clone();
+            let bs_delete = blockstore.clone();
+
+            let (has_result, delete_result) =
+                tokio::join!(async move { bs_has.has(&cid).await }, async move {
+                    bs_delete.delete(&cid).await
+                });
+
+            // Both operations should succeed without error
+            assert!(delete_result.is_ok());
+            assert!(has_result.is_ok());
+            // has() returns true or false depending on race timing - both valid
+        }
+    }
+
+    // ==================== Merge Lifecycle Edge Cases ====================
+
+    #[tokio::test]
+    async fn test_is_merged_after_delete_of_merged_block() {
+        // Test lifecycle: put -> merge -> delete -> is_merged
+        // After deleting a merged block, is_merged should return false
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+        let data = b"block to merge then delete";
+
+        // Step 1: Put block (creates merge marker in P2P mode)
+        blockstore.put(&cid, data).await.unwrap();
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+
+        // Step 2: Mark as merged
+        blockstore.mark_as_merged(&cid).await.unwrap();
+        assert!(blockstore.is_merged(&cid).await.unwrap());
+
+        // Step 3: Delete the merged block
+        blockstore.delete(&cid).await.unwrap();
+
+        // Step 4: Verify is_merged returns false (block doesn't exist)
+        assert!(
+            !blockstore.is_merged(&cid).await.unwrap(),
+            "is_merged should return false for deleted block"
+        );
+
+        // Also verify block is actually gone
+        assert!(!blockstore.has(&cid).await.unwrap());
+        assert_eq!(blockstore.get(&cid).await.unwrap(), None);
+
+        // And not in unmerged list
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(!unmerged.contains(&cid));
+    }
+
+    #[tokio::test]
+    async fn test_is_merged_after_delete_of_unmerged_block() {
+        // Test lifecycle: put -> delete (without merging) -> is_merged
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+
+        // Put block (unmerged)
+        blockstore.put(&cid, b"unmerged block").await.unwrap();
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+
+        // Delete without merging
+        blockstore.delete(&cid).await.unwrap();
+
+        // is_merged should return false
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+
+        // Verify cleanup - not in unmerged list either
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(!unmerged.contains(&cid));
+    }
+
+    #[tokio::test]
+    async fn test_merge_then_reput_then_delete() {
+        // Complex lifecycle: put -> merge -> delete -> put again -> check state
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+
+        // Initial: put and merge
+        blockstore.put(&cid, b"first").await.unwrap();
+        blockstore.mark_as_merged(&cid).await.unwrap();
+        assert!(blockstore.is_merged(&cid).await.unwrap());
+
+        // Delete
+        blockstore.delete(&cid).await.unwrap();
+        assert!(!blockstore.is_merged(&cid).await.unwrap());
+
+        // Re-put (should create new merge marker in P2P mode)
+        blockstore.put(&cid, b"second").await.unwrap();
+
+        // Should be unmerged again (new block, new merge marker)
+        assert!(
+            !blockstore.is_merged(&cid).await.unwrap(),
+            "Re-added block should be unmerged"
+        );
+
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert!(
+            unmerged.contains(&cid),
+            "Re-added block should appear in unmerged list"
+        );
+    }
+
+    // ==================== Stress Tests ====================
+
+    #[tokio::test]
+    async fn test_stress_many_blocks() {
+        // Stress test with many blocks to verify scaling behavior
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        const NUM_BLOCKS: usize = 500;
+        let mut cids = Vec::with_capacity(NUM_BLOCKS);
+
+        // Generate and store many blocks
+        for i in 0..NUM_BLOCKS {
+            let data = format!("block data {}", i);
+            let cid = cid_from_data(data.as_bytes());
+            blockstore.put(&cid, data.as_bytes()).await.unwrap();
+            cids.push(cid);
+        }
+
+        // Verify all_cids returns all blocks
+        let all = blockstore.all_cids().await.unwrap();
+        assert_eq!(
+            all.len(),
+            NUM_BLOCKS,
+            "all_cids should return all {} blocks",
+            NUM_BLOCKS
+        );
+
+        // Verify all CIDs are present
+        for cid in &cids {
+            assert!(all.contains(cid), "Missing CID: {}", cid);
+        }
+
+        // Verify random access still works
+        for (i, cid) in cids.iter().enumerate().step_by(50) {
+            let expected = format!("block data {}", i);
+            let data = blockstore.get(cid).await.unwrap();
+            assert_eq!(data, Some(expected.into_bytes()));
+        }
+
+        // Verify has() for all blocks
+        for cid in &cids {
+            assert!(blockstore.has(cid).await.unwrap());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stress_many_blocks_p2p_merge_tracking() {
+        // Stress test merge tracking with many blocks in P2P mode
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true); // P2P mode
+
+        const NUM_BLOCKS: usize = 200;
+        let mut cids = Vec::with_capacity(NUM_BLOCKS);
+
+        // Store many blocks (all unmerged initially)
+        for i in 0..NUM_BLOCKS {
+            let data = format!("p2p block {}", i);
+            let cid = cid_from_data(data.as_bytes());
+            blockstore.put(&cid, data.as_bytes()).await.unwrap();
+            cids.push(cid);
+        }
+
+        // All should be unmerged
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert_eq!(unmerged.len(), NUM_BLOCKS);
+
+        // Merge half of them
+        for cid in cids.iter().take(NUM_BLOCKS / 2) {
+            blockstore.mark_as_merged(cid).await.unwrap();
+        }
+
+        // Verify correct split
+        let unmerged = blockstore.get_unmerged().await.unwrap();
+        assert_eq!(
+            unmerged.len(),
+            NUM_BLOCKS / 2,
+            "Half should still be unmerged"
+        );
+
+        // Verify merged status
+        for (i, cid) in cids.iter().enumerate() {
+            let is_merged = blockstore.is_merged(cid).await.unwrap();
+            if i < NUM_BLOCKS / 2 {
+                assert!(is_merged, "Block {} should be merged", i);
+            } else {
+                assert!(!is_merged, "Block {} should be unmerged", i);
+            }
+        }
+
+        // all_cids should still return all blocks (merged or not)
+        let all = blockstore.all_cids().await.unwrap();
+        assert_eq!(all.len(), NUM_BLOCKS);
+    }
+
+    #[tokio::test]
+    async fn test_stress_put_many_batch() {
+        // Stress test put_many with large batches
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, false);
+
+        const BATCH_SIZE: usize = 100;
+
+        // Generate batch of blocks
+        let blocks: Vec<(Cid, Vec<u8>)> = (0..BATCH_SIZE)
+            .map(|i| {
+                let data = format!("batch block {}", i).into_bytes();
+                let cid = cid_from_data(&data);
+                (cid, data)
+            })
+            .collect();
+
+        // Convert to references for put_many
+        let block_refs: Vec<(&Cid, &[u8])> =
+            blocks.iter().map(|(c, d)| (c, d.as_slice())).collect();
+
+        // Put all at once
+        blockstore.put_many(&block_refs).await.unwrap();
+
+        // Verify all were stored
+        for (cid, expected_data) in &blocks {
+            let data = blockstore.get(cid).await.unwrap();
+            assert_eq!(data.as_ref(), Some(expected_data));
+        }
+
+        // Verify count
+        let all = blockstore.all_cids().await.unwrap();
+        assert_eq!(all.len(), BATCH_SIZE);
+    }
+
+    #[tokio::test]
+    async fn test_stress_concurrent_operations() {
+        // Stress test with many concurrent operations
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+
+        // Pre-populate with some blocks
+        let mut cids = Vec::new();
+        for i in 0..50 {
+            let data = format!("preload {}", i);
+            let cid = cid_from_data(data.as_bytes());
+            blockstore.put(&cid, data.as_bytes()).await.unwrap();
+            cids.push(cid);
+        }
+
+        let success_count = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+
+        // Spawn many concurrent readers
+        for cid in cids.iter().cloned() {
+            let bs = blockstore.clone();
+            let counter = success_count.clone();
+            handles.push(tokio::spawn(async move {
+                for _ in 0..10 {
+                    if bs.get(&cid).await.is_ok() {
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }));
+        }
+
+        // Spawn concurrent writers (new blocks)
+        for i in 0..20 {
+            let bs = blockstore.clone();
+            let counter = success_count.clone();
+            handles.push(tokio::spawn(async move {
+                let data = format!("concurrent write {}", i);
+                let cid = cid_from_data(data.as_bytes());
+                if bs.put(&cid, data.as_bytes()).await.is_ok() {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
+            }));
+        }
+
+        // Wait for all operations
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // All operations should have succeeded
+        let total_ops = success_count.load(Ordering::Relaxed);
+        assert!(
+            total_ops >= 500,
+            "Expected at least 500 successful ops, got {}",
+            total_ops
+        );
+    }
 }

--- a/crates/blockstore/src/traits.rs
+++ b/crates/blockstore/src/traits.rs
@@ -1,0 +1,125 @@
+//! Blockstore trait definition
+//!
+//! The `Blockstore` trait defines the public API for IPLD block storage
+//! with merge tracking support for P2P synchronization.
+
+use async_trait::async_trait;
+use cid::Cid;
+
+use crate::Result;
+
+/// IPFS-compatible blockstore trait
+///
+/// This trait provides the public API for storing and retrieving IPLD blocks.
+/// Implementations support optional merge tracking for P2P synchronization.
+///
+/// # Block Storage
+///
+/// Blocks are stored and retrieved by their Content Identifier (CID).
+/// CIDs are cryptographic hashes of the block content, ensuring
+/// content-addressed storage with automatic deduplication.
+///
+/// # Hash Verification (HashOnRead)
+///
+/// When enabled via `hash_on_read(true)`, the blockstore verifies that
+/// retrieved data matches the CID hash. This provides protection against
+/// data corruption but adds computational overhead.
+///
+/// # Merge Tracking (P2P Mode)
+///
+/// In P2P mode, blocks received from peers are initially marked as "unmerged".
+/// This allows the CRDT merge system to process them before they're considered
+/// part of the local state. The lifecycle is:
+///
+/// 1. `put()` - Store block, mark as unmerged (P2P mode only)
+/// 2. `get_unmerged()` - Get all blocks pending merge
+/// 3. (CRDT system processes and merges blocks)
+/// 4. `mark_as_merged()` - Remove from unmerged tracking
+///
+/// In local mode (non-P2P), blocks are immediately considered merged.
+#[async_trait]
+pub trait Blockstore: Send + Sync {
+    /// Retrieve a block by its CID
+    ///
+    /// If `hash_on_read` is enabled, verifies that the retrieved data
+    /// matches the CID hash before returning. Returns an error if the
+    /// hash doesn't match.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(data))` - Block data if found (and verified if hash_on_read enabled)
+    /// * `Ok(None)` - Block not found
+    /// * `Err(Error::HashMismatch)` - Data doesn't match CID (if hash_on_read enabled)
+    /// * `Err(Error)` - Operation failed
+    async fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>>;
+
+    /// Store a block with the given CID
+    ///
+    /// In P2P mode, the block is marked as unmerged until `mark_as_merged` is called.
+    /// In local mode, the block is immediately considered merged.
+    ///
+    /// Storing a block with a CID that already exists is a no-op (deduplication).
+    async fn put(&self, cid: &Cid, data: &[u8]) -> Result<()>;
+
+    /// Store multiple blocks in a single transaction
+    ///
+    /// This is more efficient than calling `put` multiple times for batch operations.
+    async fn put_many(&self, blocks: &[(&Cid, &[u8])]) -> Result<()>;
+
+    /// Check if a block exists
+    async fn has(&self, cid: &Cid) -> Result<bool>;
+
+    /// Delete a block
+    ///
+    /// Also removes any merge tracking for this block.
+    async fn delete(&self, cid: &Cid) -> Result<()>;
+
+    /// Get the size of a block without reading the entire content
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(size))` - Block size in bytes
+    /// * `Ok(None)` - Block not found
+    /// * `Err(Error)` - Operation failed
+    async fn get_size(&self, cid: &Cid) -> Result<Option<usize>>;
+
+    /// Get all CIDs stored in the blockstore
+    ///
+    /// Note: This may be expensive for large blockstores.
+    async fn all_cids(&self) -> Result<Vec<Cid>>;
+
+    /// Enable or disable hash verification on read
+    ///
+    /// When enabled, `get()` will verify that the retrieved data matches
+    /// the CID hash. This provides data integrity verification but adds
+    /// computational overhead.
+    ///
+    /// Default: disabled
+    fn hash_on_read(&self, enabled: bool);
+
+    // Merge tracking methods (for P2P sync)
+
+    /// Check if a block has been merged
+    ///
+    /// Returns `false` if:
+    /// - The block doesn't exist, OR
+    /// - The block exists but has an unmerged marker (P2P mode)
+    ///
+    /// Returns `true` if:
+    /// - The block exists AND has no unmerged marker
+    async fn is_merged(&self, cid: &Cid) -> Result<bool>;
+
+    /// Mark a block as merged
+    ///
+    /// After calling this, `is_merged` will return true and the block
+    /// will no longer appear in `get_unmerged` results.
+    async fn mark_as_merged(&self, cid: &Cid) -> Result<()>;
+
+    /// Get all unmerged block CIDs
+    ///
+    /// Returns CIDs of blocks that have been received via P2P but not yet
+    /// processed by the CRDT merge system.
+    ///
+    /// In local mode, always returns an empty vector.
+    async fn get_unmerged(&self) -> Result<Vec<Cid>>;
+}

--- a/crates/crdt/src/counter.rs
+++ b/crates/crdt/src/counter.rs
@@ -1234,6 +1234,9 @@ mod tests {
             5,
         );
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("schema_version_id"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("schema_version_id"));
     }
 }

--- a/crates/crdt/src/lww.rs
+++ b/crates/crdt/src/lww.rs
@@ -664,11 +664,17 @@ mod tests {
             b"value".to_vec(),
         );
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("schema_version_id"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("schema_version_id"));
 
         let result = LwwDelta::delete(b"doc1".to_vec(), "name".to_string(), 10, "".to_string());
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("schema_version_id"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("schema_version_id"));
     }
 
     #[tokio::test]

--- a/crates/crdt/tests/property_tests.rs
+++ b/crates/crdt/tests/property_tests.rs
@@ -577,8 +577,14 @@ async fn test_counter_multiple_nonces() {
     };
 
     let store = MemoryStore::new();
-    let counter =
-        Counter::new("v1".to_string(), b"doc1", "count".to_string(), true, NumericKind::Int64).unwrap();
+    let counter = Counter::new(
+        "v1".to_string(),
+        b"doc1",
+        "count".to_string(),
+        true,
+        NumericKind::Int64,
+    )
+    .unwrap();
     let mut txn = store.new_txn(false).await.unwrap();
 
     // Apply multiple different nonces
@@ -609,8 +615,14 @@ async fn test_counter_nonce_replay_protection() {
     };
 
     let store = MemoryStore::new();
-    let counter =
-        Counter::new("v1".to_string(), b"doc1", "count".to_string(), true, NumericKind::Int64).unwrap();
+    let counter = Counter::new(
+        "v1".to_string(),
+        b"doc1",
+        "count".to_string(),
+        true,
+        NumericKind::Int64,
+    )
+    .unwrap();
     let mut txn = store.new_txn(false).await.unwrap();
 
     let delta = CounterDelta::new_int64(
@@ -696,8 +708,8 @@ async fn test_lww_empty_value_handling() {
     assert_eq!(lww.value(&*txn).await.unwrap(), b"value");
 
     // Delete (empty value)
-    let delete = LwwDelta::delete(b"doc1".to_vec(), "name".to_string(), 20, "v1".to_string())
-        .unwrap();
+    let delete =
+        LwwDelta::delete(b"doc1".to_vec(), "name".to_string(), 20, "v1".to_string()).unwrap();
     lww.merge(&mut *txn, &ctx, &delete).await.unwrap();
     assert!(lww.value(&*txn).await.is_err()); // Should be deleted
 }
@@ -800,7 +812,10 @@ async fn test_composite_doc_id_mismatch() {
 
     let result = composite.merge(&mut *txn, &ctx, &delta).await;
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("document ID mismatch"));
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("document ID mismatch"));
 }
 
 #[tokio::test]
@@ -820,7 +835,10 @@ async fn test_composite_schema_version_mismatch() {
 
     let result = composite.merge(&mut *txn, &ctx, &delta).await;
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("schema version mismatch"));
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("schema version mismatch"));
 }
 
 #[tokio::test]

--- a/crates/defra-core/src/types.rs
+++ b/crates/defra-core/src/types.rs
@@ -127,8 +127,7 @@ pub struct CID(cid::Cid);
 impl CID {
     /// Create a CID from bytes with validation
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let c = cid::Cid::try_from(bytes)
-            .map_err(|e| Error::InvalidCID(e.to_string()))?;
+        let c = cid::Cid::try_from(bytes).map_err(|e| Error::InvalidCID(e.to_string()))?;
 
         // Validate version
         match c.version() {

--- a/crates/storage/src/backends/memory.rs
+++ b/crates/storage/src/backends/memory.rs
@@ -30,7 +30,6 @@
 /// txn.set(b"key", b"value").await?;
 /// txn.commit().await?;
 /// ```
-
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
@@ -38,7 +37,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::corekv::{
-    AsyncTxnCallback, Dropable, Error, Iterator, IterOptions, KvPair, Reader, Result, Store, Txn,
+    AsyncTxnCallback, Dropable, Error, IterOptions, Iterator, KvPair, Reader, Result, Store, Txn,
     TxnCallback, Writer,
 };
 
@@ -291,7 +290,9 @@ impl Writer for MemoryTxn {
             return Err(Error::EmptyKey);
         }
 
-        self.pending.lock().insert(key.to_vec(), Some(value.to_vec()));
+        self.pending
+            .lock()
+            .insert(key.to_vec(), Some(value.to_vec()));
         Ok(())
     }
 
@@ -373,10 +374,7 @@ impl Txn for MemoryTxn {
             // NOTE: These may not complete if the process exits before they finish
             tokio::spawn(async move {
                 Self::execute_async_callbacks(on_discard_async).await;
-                tracing::debug!(
-                    count = callback_count,
-                    "Async discard callbacks completed"
-                );
+                tracing::debug!(count = callback_count, "Async discard callbacks completed");
             });
         }
     }
@@ -563,9 +561,9 @@ impl Iterator for MemoryIterator {
 #[cfg(test)]
 mod shared_tests {
     use super::*;
-    use crate::generate_backend_tests;
     use crate::generate_backend_concurrency_tests;
     use crate::generate_backend_dropable_tests;
+    use crate::generate_backend_tests;
 
     async fn create_store() -> MemoryStore {
         MemoryStore::new()

--- a/crates/storage/src/backends/mod.rs
+++ b/crates/storage/src/backends/mod.rs
@@ -38,7 +38,6 @@
 /// // For production
 /// let rocksdb_store = RocksDBStore::open("/path/to/db")?;
 /// ```
-
 pub mod memory;
 pub mod rocksdb;
 

--- a/crates/storage/src/backends/rocksdb.rs
+++ b/crates/storage/src/backends/rocksdb.rs
@@ -37,19 +37,16 @@
 /// txn.set(b"key", b"value").await?;
 /// txn.commit().await?;
 /// ```
-
 use async_trait::async_trait;
 use parking_lot::Mutex;
-use rocksdb::{
-    DBWithThreadMode, MultiThreaded, Options, Snapshot, WriteBatch, WriteOptions,
-};
+use rocksdb::{DBWithThreadMode, MultiThreaded, Options, Snapshot, WriteBatch, WriteOptions};
 use std::mem::ManuallyDrop;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::corekv::{
-    AsyncTxnCallback, Error, Iterator, IterOptions, KvPair, Reader, Result, Store, Txn,
+    AsyncTxnCallback, Error, IterOptions, Iterator, KvPair, Reader, Result, Store, Txn,
     TxnCallback, Writer,
 };
 
@@ -328,7 +325,8 @@ impl Reader for RocksDBTxn {
 
         // Use a BTreeMap to merge DB data with pending writes
         // Only collect keys that match the filter criteria to avoid loading entire DB
-        let mut merged: std::collections::BTreeMap<Vec<u8>, Vec<u8>> = std::collections::BTreeMap::new();
+        let mut merged: std::collections::BTreeMap<Vec<u8>, Vec<u8>> =
+            std::collections::BTreeMap::new();
 
         // Determine iteration bounds based on options
         let (start_bound, end_bound) = if let Some(prefix) = opts.prefix() {
@@ -351,7 +349,10 @@ impl Reader for RocksDBTxn {
             }
             (Some(start), Some(end))
         } else if opts.start().is_some() || opts.end().is_some() {
-            (opts.start().map(|s| s.to_vec()), opts.end().map(|e| e.to_vec()))
+            (
+                opts.start().map(|s| s.to_vec()),
+                opts.end().map(|e| e.to_vec()),
+            )
         } else {
             (None, None)
         };
@@ -359,11 +360,17 @@ impl Reader for RocksDBTxn {
         // Use appropriate iterator mode based on bounds
         // Use snapshot iterator for consistent reads (snapshot isolation)
         let db_iter = match (&start_bound, opts.reverse()) {
-            (Some(start), false) => self.snapshot.iterator(rocksdb::IteratorMode::From(start, rocksdb::Direction::Forward)),
+            (Some(start), false) => self.snapshot.iterator(rocksdb::IteratorMode::From(
+                start,
+                rocksdb::Direction::Forward,
+            )),
             (Some(_), true) => {
                 // For reverse with start bound, we need to start from end_bound or prefix end
                 if let Some(ref end) = end_bound {
-                    self.snapshot.iterator(rocksdb::IteratorMode::From(end, rocksdb::Direction::Reverse))
+                    self.snapshot.iterator(rocksdb::IteratorMode::From(
+                        end,
+                        rocksdb::Direction::Reverse,
+                    ))
                 } else {
                     self.snapshot.iterator(rocksdb::IteratorMode::End)
                 }
@@ -381,11 +388,17 @@ impl Reader for RocksDBTxn {
             if let Some(prefix) = opts.prefix() {
                 if !key_vec.starts_with(prefix) {
                     // For forward iteration, if we've passed the prefix range, stop
-                    if !opts.reverse() && key_vec.as_slice() >= end_bound.as_ref().map(|e| e.as_slice()).unwrap_or(&[0xFF]) {
+                    if !opts.reverse()
+                        && key_vec.as_slice()
+                            >= end_bound.as_ref().map(|e| e.as_slice()).unwrap_or(&[0xFF])
+                    {
                         break;
                     }
                     // For reverse iteration, if we're before the prefix range, stop
-                    if opts.reverse() && key_vec.as_slice() < start_bound.as_ref().map(|s| s.as_slice()).unwrap_or(&[]) {
+                    if opts.reverse()
+                        && key_vec.as_slice()
+                            < start_bound.as_ref().map(|s| s.as_slice()).unwrap_or(&[])
+                    {
                         break;
                     }
                     continue;
@@ -468,7 +481,12 @@ impl Reader for RocksDBTxn {
             data.reverse();
         }
 
-        Ok(Box::new(SimpleIterator { data, position: 0, closed: false, reverse }))
+        Ok(Box::new(SimpleIterator {
+            data,
+            position: 0,
+            closed: false,
+            reverse,
+        }))
     }
 }
 
@@ -488,7 +506,9 @@ impl Writer for RocksDBTxn {
         }
 
         // Track in pending for read-your-writes
-        self.pending.lock().insert(key.to_vec(), Some(value.to_vec()));
+        self.pending
+            .lock()
+            .insert(key.to_vec(), Some(value.to_vec()));
 
         // Add to batch
         self.batch.lock().put(key, value);
@@ -571,10 +591,7 @@ impl Txn for RocksDBTxn {
             // NOTE: These may not complete if the process exits before they finish
             tokio::spawn(async move {
                 Self::execute_async_callbacks(on_discard_async).await;
-                tracing::debug!(
-                    count = callback_count,
-                    "Async discard callbacks completed"
-                );
+                tracing::debug!(count = callback_count, "Async discard callbacks completed");
             });
         }
     }
@@ -698,8 +715,8 @@ impl Iterator for SimpleIterator {
 #[cfg(test)]
 mod shared_tests {
     use super::*;
-    use crate::generate_backend_tests;
     use crate::generate_backend_concurrency_tests;
+    use crate::generate_backend_tests;
     use tempfile::TempDir;
 
     // Each test gets a fresh store - TempDir cleanup is automatic
@@ -707,7 +724,7 @@ mod shared_tests {
         let temp_dir = TempDir::new().unwrap();
         // Keep the TempDir so it lives for the duration of the test
         let path = temp_dir.path().to_path_buf();
-        std::mem::forget(temp_dir);  // Prevent cleanup until test ends
+        std::mem::forget(temp_dir); // Prevent cleanup until test ends
         RocksDBStore::open(&path).unwrap()
     }
 

--- a/crates/storage/src/backends/test_suite.rs
+++ b/crates/storage/src/backends/test_suite.rs
@@ -19,10 +19,9 @@
 ///     // Then invoke the test macros or call test functions
 /// }
 /// ```
-
 use crate::corekv::{Error, IterOptions, Store};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering};
 
 // ============================================================================
 // BASIC OPERATIONS
@@ -56,7 +55,10 @@ pub async fn test_delete<S: Store>(store: &S) {
 
     // Delete
     let mut txn = store.new_txn(false).await.unwrap();
-    assert_eq!(txn.get(b"to_delete").await.unwrap(), Some(b"value".to_vec()));
+    assert_eq!(
+        txn.get(b"to_delete").await.unwrap(),
+        Some(b"value".to_vec())
+    );
     txn.delete(b"to_delete").await.unwrap();
     assert_eq!(txn.get(b"to_delete").await.unwrap(), None);
     txn.commit().await.unwrap();
@@ -215,8 +217,8 @@ pub async fn test_binary_key_ordering<S: Store>(store: &S) {
     // Insert keys that would sort differently if treated as strings vs bytes
     // Byte order: 0x00 < 0x41 ('A') < 0x61 ('a') < 0xFF
     txn.set(b"\x00", b"first").await.unwrap();
-    txn.set(b"A", b"second").await.unwrap();  // 0x41
-    txn.set(b"a", b"third").await.unwrap();   // 0x61
+    txn.set(b"A", b"second").await.unwrap(); // 0x41
+    txn.set(b"a", b"third").await.unwrap(); // 0x61
     txn.set(b"\xff", b"fourth").await.unwrap();
 
     txn.commit().await.unwrap();
@@ -254,7 +256,10 @@ pub async fn test_empty_key_rejected<S: Store>(store: &S) {
 pub async fn test_readonly_transaction<S: Store>(store: &S) {
     let mut txn = store.new_txn(true).await.unwrap();
 
-    assert!(matches!(txn.set(b"key", b"value").await, Err(Error::ReadOnlyTxn)));
+    assert!(matches!(
+        txn.set(b"key", b"value").await,
+        Err(Error::ReadOnlyTxn)
+    ));
     assert!(matches!(txn.delete(b"key").await, Err(Error::ReadOnlyTxn)));
 
     // Read operations should work
@@ -302,7 +307,10 @@ pub async fn test_success_callback<S: Store>(store: &S) {
     txn.set(b"key", b"value").await.unwrap();
     txn.commit().await.unwrap();
 
-    assert!(called.load(Ordering::SeqCst), "Success callback should be invoked");
+    assert!(
+        called.load(Ordering::SeqCst),
+        "Success callback should be invoked"
+    );
 }
 
 /// Test discard callback is invoked
@@ -319,7 +327,10 @@ pub async fn test_discard_callback<S: Store>(store: &S) {
     txn.set(b"key", b"value").await.unwrap();
     txn.discard();
 
-    assert!(called.load(Ordering::SeqCst), "Discard callback should be invoked");
+    assert!(
+        called.load(Ordering::SeqCst),
+        "Discard callback should be invoked"
+    );
 }
 
 /// Test async success callback
@@ -340,7 +351,10 @@ pub async fn test_async_success_callback<S: Store>(store: &S) {
     txn.set(b"key", b"value").await.unwrap();
     txn.commit().await.unwrap();
 
-    assert!(called.load(Ordering::SeqCst), "Async callback should be awaited during commit");
+    assert!(
+        called.load(Ordering::SeqCst),
+        "Async callback should be awaited during commit"
+    );
 }
 
 // ============================================================================
@@ -389,17 +403,23 @@ pub async fn test_async_callback_panic_safety<S: Store>(store: &S) {
     let count1 = count.clone();
     txn.on_success_async(Box::new(move || {
         let c = count1.clone();
-        Box::pin(async move { c.fetch_add(1, Ordering::SeqCst); })
+        Box::pin(async move {
+            c.fetch_add(1, Ordering::SeqCst);
+        })
     }));
 
     txn.on_success_async(Box::new(|| {
-        Box::pin(async { panic!("Intentional async panic"); })
+        Box::pin(async {
+            panic!("Intentional async panic");
+        })
     }));
 
     let count3 = count.clone();
     txn.on_success_async(Box::new(move || {
         let c = count3.clone();
-        Box::pin(async move { c.fetch_add(1, Ordering::SeqCst); })
+        Box::pin(async move {
+            c.fetch_add(1, Ordering::SeqCst);
+        })
     }));
 
     txn.set(b"key", b"value").await.unwrap();
@@ -574,7 +594,10 @@ pub async fn test_iterator_start_equals_end<S: Store>(store: &S) {
         .with_end(b"b".to_vec());
     let mut iter = txn.iterator(opts).await.unwrap();
 
-    assert!(iter.next().await.unwrap().is_none(), "start == end should yield empty iterator");
+    assert!(
+        iter.next().await.unwrap().is_none(),
+        "start == end should yield empty iterator"
+    );
 }
 
 /// Test prefix with no matches
@@ -671,7 +694,7 @@ pub async fn test_iterator_reverse_with_bounds<S: Store>(store: &S) {
     let txn = store.new_txn(true).await.unwrap();
     let opts = IterOptions::new()
         .with_start(b"d".to_vec())
-        .with_end(b"n".to_vec())  // exclusive
+        .with_end(b"n".to_vec()) // exclusive
         .with_reverse(true);
     let mut iter = txn.iterator(opts).await.unwrap();
 
@@ -714,7 +737,7 @@ pub async fn test_iterator_item_at_end_excluded<S: Store>(store: &S) {
     let txn = store.new_txn(true).await.unwrap();
     let opts = IterOptions::new()
         .with_start(b"a".to_vec())
-        .with_end(b"c".to_vec());  // c should be excluded
+        .with_end(b"c".to_vec()); // c should be excluded
     let mut iter = txn.iterator(opts).await.unwrap();
 
     let mut keys = vec![];
@@ -749,7 +772,7 @@ pub async fn test_iterator_empty_prefix<S: Store>(store: &S) {
     txn.commit().await.unwrap();
 
     let txn = store.new_txn(true).await.unwrap();
-    let opts = IterOptions::new().with_prefix(vec![]);  // Empty prefix
+    let opts = IterOptions::new().with_prefix(vec![]); // Empty prefix
     let mut iter = txn.iterator(opts).await.unwrap();
 
     let mut count = 0;
@@ -771,7 +794,7 @@ pub async fn test_iterator_prefix_with_start<S: Store>(store: &S) {
     let txn = store.new_txn(true).await.unwrap();
     let opts = IterOptions::new()
         .with_prefix(b"pre/".to_vec())
-        .with_start(b"pre/b".to_vec());  // Start at b within prefix
+        .with_start(b"pre/b".to_vec()); // Start at b within prefix
     let mut iter = txn.iterator(opts).await.unwrap();
 
     let mut keys = vec![];
@@ -794,7 +817,10 @@ pub async fn test_multiple_iterators<S: Store>(store: &S) {
 
     // Create two iterators on the same transaction
     let mut iter1 = txn.iterator(IterOptions::new()).await.unwrap();
-    let mut iter2 = txn.iterator(IterOptions::new().with_reverse(true)).await.unwrap();
+    let mut iter2 = txn
+        .iterator(IterOptions::new().with_reverse(true))
+        .await
+        .unwrap();
 
     // iter1 should go forward
     let kv1 = iter1.next().await.unwrap().unwrap();
@@ -831,7 +857,10 @@ pub async fn test_iterator_seek<S: Store>(store: &S) {
     let mut iter = txn.iterator(IterOptions::new()).await.unwrap();
 
     // Seek to 'c'
-    assert!(iter.seek(b"c").await.unwrap(), "Seek to existing key should return true");
+    assert!(
+        iter.seek(b"c").await.unwrap(),
+        "Seek to existing key should return true"
+    );
 
     // Next should return 'c'
     let kv = iter.next().await.unwrap().unwrap();
@@ -860,10 +889,17 @@ pub async fn test_iterator_seek_between_keys<S: Store>(store: &S) {
     let mut iter = txn.iterator(IterOptions::new()).await.unwrap();
 
     // Seek to 'bb' (doesn't exist, should position at 'cc')
-    assert!(iter.seek(b"bb").await.unwrap(), "Seek to non-existing key should find next");
+    assert!(
+        iter.seek(b"bb").await.unwrap(),
+        "Seek to non-existing key should find next"
+    );
 
     let kv = iter.next().await.unwrap().unwrap();
-    assert_eq!(kv.key_bytes(), b"cc", "Should be positioned at next key >= seek target");
+    assert_eq!(
+        kv.key_bytes(),
+        b"cc",
+        "Should be positioned at next key >= seek target"
+    );
 }
 
 /// Test iterator seek past all keys
@@ -877,7 +913,10 @@ pub async fn test_iterator_seek_past_end<S: Store>(store: &S) {
     let mut iter = txn.iterator(IterOptions::new()).await.unwrap();
 
     // Seek past all keys
-    assert!(!iter.seek(b"z").await.unwrap(), "Seek past end should return false");
+    assert!(
+        !iter.seek(b"z").await.unwrap(),
+        "Seek past end should return false"
+    );
 
     // Iterator should be exhausted
     assert!(iter.next().await.unwrap().is_none());
@@ -981,7 +1020,11 @@ pub async fn test_iterator_reverse_start_only<S: Store>(store: &S) {
         keys.push(String::from_utf8_lossy(kv.key_bytes()).to_string());
     }
 
-    assert_eq!(keys, vec!["k4", "k3", "k2"], "Reverse with start should exclude keys below start");
+    assert_eq!(
+        keys,
+        vec!["k4", "k3", "k2"],
+        "Reverse with start should exclude keys below start"
+    );
 }
 
 /// Test reverse iterator with end bound only.
@@ -997,7 +1040,7 @@ pub async fn test_iterator_reverse_end_only<S: Store>(store: &S) {
     let txn = store.new_txn(true).await.unwrap();
     let opts = IterOptions::new()
         .with_reverse(true)
-        .with_end(b"k3".to_vec());  // k3 and k4 should be excluded
+        .with_end(b"k3".to_vec()); // k3 and k4 should be excluded
     let mut iter = txn.iterator(opts).await.unwrap();
 
     let mut keys = vec![];
@@ -1005,20 +1048,24 @@ pub async fn test_iterator_reverse_end_only<S: Store>(store: &S) {
         keys.push(String::from_utf8_lossy(kv.key_bytes()).to_string());
     }
 
-    assert_eq!(keys, vec!["k2", "k1"], "Reverse with end should exclude keys >= end");
+    assert_eq!(
+        keys,
+        vec!["k2", "k1"],
+        "Reverse with end should exclude keys >= end"
+    );
 }
 
 /// Test reverse iterator with single item at/above end bound (should yield nothing).
 /// This is a known edge case from Go implementation - single item >= end should not be yielded.
 pub async fn test_iterator_reverse_end_single_item_out_of_bounds<S: Store>(store: &S) {
     let mut txn = store.new_txn(false).await.unwrap();
-    txn.set(b"k3", b"v3").await.unwrap();  // Only item, at the end bound
+    txn.set(b"k3", b"v3").await.unwrap(); // Only item, at the end bound
     txn.commit().await.unwrap();
 
     let txn = store.new_txn(true).await.unwrap();
     let opts = IterOptions::new()
         .with_reverse(true)
-        .with_end(b"k3".to_vec());  // k3 is exactly at end, should be excluded
+        .with_end(b"k3".to_vec()); // k3 is exactly at end, should be excluded
     let mut iter = txn.iterator(opts).await.unwrap();
 
     assert!(
@@ -1038,7 +1085,7 @@ pub async fn test_iterator_reverse_start_end_no_items_in_range<S: Store>(store: 
     let opts = IterOptions::new()
         .with_reverse(true)
         .with_start(b"k2".to_vec())
-        .with_end(b"k4".to_vec());  // Range [k2, k4) has no items
+        .with_end(b"k4".to_vec()); // Range [k2, k4) has no items
     let mut iter = txn.iterator(opts).await.unwrap();
 
     assert!(
@@ -1115,13 +1162,17 @@ pub async fn test_iterator_reverse_end_seek<S: Store>(store: &S) {
     let txn = store.new_txn(true).await.unwrap();
     let opts = IterOptions::new()
         .with_reverse(true)
-        .with_end(b"k3".to_vec());  // Excludes k3 and k4
+        .with_end(b"k3".to_vec()); // Excludes k3 and k4
     let mut iter = txn.iterator(opts).await.unwrap();
 
     // Seek to k4 (which is outside bounds) should find k2 (highest in bounds)
     assert!(iter.seek(b"k4").await.unwrap());
     let kv = iter.next().await.unwrap().unwrap();
-    assert_eq!(kv.key_bytes(), b"k2", "Seek outside end bound should find highest in-bounds key");
+    assert_eq!(
+        kv.key_bytes(),
+        b"k2",
+        "Seek outside end bound should find highest in-bounds key"
+    );
 }
 
 /// Test reverse iterator with prefix.
@@ -1210,7 +1261,7 @@ pub async fn test_iterator_reset_after_exhaustion<S: Store>(store: &S) {
     assert_eq!(kv.value_bytes(), b"v1");
     let kv = iter.next().await.unwrap().unwrap();
     assert_eq!(kv.value_bytes(), b"v2");
-    assert!(iter.next().await.unwrap().is_none());  // Exhausted
+    assert!(iter.next().await.unwrap().is_none()); // Exhausted
 
     // Reset
     iter.reset().await.unwrap();
@@ -1274,7 +1325,11 @@ pub async fn test_iterator_seek_respects_start_bound<S: Store>(store: &S) {
     assert!(iter.seek(b"k1").await.unwrap());
 
     let kv = iter.next().await.unwrap().unwrap();
-    assert_eq!(kv.key_bytes(), b"k2", "Seek before start should position at start");
+    assert_eq!(
+        kv.key_bytes(),
+        b"k2",
+        "Seek before start should position at start"
+    );
 }
 
 /// Test multiple resets in sequence.
@@ -1326,7 +1381,7 @@ pub async fn test_empty_value_handling<S: Store>(store: &S) {
 pub async fn test_iterator_empty_values<S: Store>(store: &S) {
     let mut txn = store.new_txn(false).await.unwrap();
     txn.set(b"k1", b"v1").await.unwrap();
-    txn.set(b"k2", b"").await.unwrap();  // Empty value
+    txn.set(b"k2", b"").await.unwrap(); // Empty value
     txn.set(b"k3", b"v3").await.unwrap();
     txn.commit().await.unwrap();
 
@@ -1339,7 +1394,11 @@ pub async fn test_iterator_empty_values<S: Store>(store: &S) {
 
     let kv = iter.next().await.unwrap().unwrap();
     assert_eq!(kv.key_bytes(), b"k2");
-    assert_eq!(kv.value_bytes(), b"", "Empty value should be empty slice, not skipped");
+    assert_eq!(
+        kv.value_bytes(),
+        b"",
+        "Empty value should be empty slice, not skipped"
+    );
 
     let kv = iter.next().await.unwrap().unwrap();
     assert_eq!(kv.key_bytes(), b"k3");
@@ -1370,9 +1429,18 @@ pub async fn test_drop_all<S: Store + crate::corekv::Dropable>(store: &S) {
 
     // Verify data is gone
     let txn = store.new_txn(true).await.unwrap();
-    assert!(!txn.has(b"key1").await.unwrap(), "key1 should be deleted after drop_all");
-    assert!(!txn.has(b"key2").await.unwrap(), "key2 should be deleted after drop_all");
-    assert!(!txn.has(b"key3").await.unwrap(), "key3 should be deleted after drop_all");
+    assert!(
+        !txn.has(b"key1").await.unwrap(),
+        "key1 should be deleted after drop_all"
+    );
+    assert!(
+        !txn.has(b"key2").await.unwrap(),
+        "key2 should be deleted after drop_all"
+    );
+    assert!(
+        !txn.has(b"key3").await.unwrap(),
+        "key3 should be deleted after drop_all"
+    );
 }
 
 /// Test drop_all followed by new writes
@@ -1392,7 +1460,10 @@ pub async fn test_drop_all_then_write<S: Store + crate::corekv::Dropable>(store:
 
     // Verify old is gone, new exists
     let txn = store.new_txn(true).await.unwrap();
-    assert!(!txn.has(b"old_key").await.unwrap(), "old_key should be deleted");
+    assert!(
+        !txn.has(b"old_key").await.unwrap(),
+        "old_key should be deleted"
+    );
     assert_eq!(
         txn.get(b"new_key").await.unwrap(),
         Some(b"new_value".to_vec()),
@@ -1428,7 +1499,9 @@ pub async fn test_concurrent_writes_different_keys<S: Store + 'static>(store: Ar
         let commit_count = commit_count.clone();
         handles.push(tokio::spawn(async move {
             let mut txn = store.new_txn(false).await.unwrap();
-            txn.set(format!("key_{}", i).as_bytes(), b"value").await.unwrap();
+            txn.set(format!("key_{}", i).as_bytes(), b"value")
+                .await
+                .unwrap();
             txn.commit().await.unwrap();
             commit_count.fetch_add(1, Ordering::SeqCst);
         }));
@@ -1623,7 +1696,10 @@ pub async fn test_snapshot_isolation_concurrent<S: Store + 'static>(store: Arc<S
             tokio::time::sleep(std::time::Duration::from_millis(i * 5)).await;
 
             let mut writer = store.new_txn(false).await.unwrap();
-            writer.set(b"snapshot_key", format!("writer_{}", i).as_bytes()).await.unwrap();
+            writer
+                .set(b"snapshot_key", format!("writer_{}", i).as_bytes())
+                .await
+                .unwrap();
             writer.commit().await.unwrap();
         }));
     }
@@ -1641,7 +1717,11 @@ pub async fn test_snapshot_isolation_concurrent<S: Store + 'static>(store: Arc<S
         0,
         "Snapshot isolation violated: readers saw different values within same transaction"
     );
-    assert_eq!(total_checks.load(Ordering::SeqCst), 10, "All readers should complete");
+    assert_eq!(
+        total_checks.load(Ordering::SeqCst),
+        10,
+        "All readers should complete"
+    );
 }
 
 /// Test that long-running readers maintain isolation despite many writes.
@@ -1662,7 +1742,10 @@ pub async fn test_snapshot_isolation_long_running_reader<S: Store + 'static>(sto
     // Perform 100 rapid writes
     for i in 0..100 {
         let mut writer = store.new_txn(false).await.unwrap();
-        writer.set(b"long_read_key", format!("write_{}", i).as_bytes()).await.unwrap();
+        writer
+            .set(b"long_read_key", format!("write_{}", i).as_bytes())
+            .await
+            .unwrap();
         writer.commit().await.unwrap();
     }
 
@@ -1765,7 +1848,10 @@ pub async fn test_snapshot_isolation_iterator<S: Store + 'static>(store: Arc<S>)
     // Setup: write 5 keys
     let mut setup = store.new_txn(false).await.unwrap();
     for i in 0..5 {
-        setup.set(format!("iter_key_{}", i).as_bytes(), b"original").await.unwrap();
+        setup
+            .set(format!("iter_key_{}", i).as_bytes(), b"original")
+            .await
+            .unwrap();
     }
     setup.commit().await.unwrap();
 
@@ -1775,7 +1861,10 @@ pub async fn test_snapshot_isolation_iterator<S: Store + 'static>(store: Arc<S>)
     // Concurrent writer adds more keys and modifies existing
     let mut writer = store.new_txn(false).await.unwrap();
     for i in 5..10 {
-        writer.set(format!("iter_key_{}", i).as_bytes(), b"new").await.unwrap();
+        writer
+            .set(format!("iter_key_{}", i).as_bytes(), b"new")
+            .await
+            .unwrap();
     }
     writer.set(b"iter_key_0", b"modified").await.unwrap();
     writer.commit().await.unwrap();
@@ -2250,6 +2339,6 @@ macro_rules! generate_backend_dropable_tests {
     };
 }
 
-pub use generate_backend_tests;
 pub use generate_backend_concurrency_tests;
 pub use generate_backend_dropable_tests;
+pub use generate_backend_tests;

--- a/crates/storage/src/corekv/errors.rs
+++ b/crates/storage/src/corekv/errors.rs
@@ -2,7 +2,6 @@
 ///
 /// These errors represent the various failure modes that can occur
 /// in key-value storage operations, transactions, and iteration.
-
 use thiserror::Error;
 
 /// Result type alias for CoreKV operations.
@@ -191,7 +190,10 @@ mod tests {
         assert_eq!(Error::NotFound.to_string(), "key not found");
         assert_eq!(Error::EmptyKey.to_string(), "empty key");
         assert_eq!(Error::ValueNil.to_string(), "value is nil");
-        assert_eq!(Error::TxnConflict.to_string(), "transaction conflict, retry required");
+        assert_eq!(
+            Error::TxnConflict.to_string(),
+            "transaction conflict, retry required"
+        );
     }
 
     #[test]

--- a/crates/storage/src/corekv/iterator.rs
+++ b/crates/storage/src/corekv/iterator.rs
@@ -3,7 +3,6 @@
 /// This module provides the iterator abstraction for scanning through
 /// key-value pairs in storage, with support for various filtering and
 /// ordering options.
-
 use async_trait::async_trait;
 
 use super::errors::Result;

--- a/crates/storage/src/corekv/mod.rs
+++ b/crates/storage/src/corekv/mod.rs
@@ -64,7 +64,6 @@
 /// }
 /// iter.close().await?;
 /// ```
-
 pub mod errors;
 pub mod iterator;
 pub mod traits;
@@ -74,7 +73,7 @@ pub mod types;
 pub use errors::{Error, Result};
 pub use iterator::{Iterator, KvPair};
 pub use traits::{
-    make_async_callback, make_callback, AsyncTxnCallback, Dropable, Reader, ReaderWriter,
-    Store, Txn, TxnCallback, TxnStore, Writer,
+    make_async_callback, make_callback, AsyncTxnCallback, Dropable, Reader, ReaderWriter, Store,
+    Txn, TxnCallback, TxnStore, Writer,
 };
 pub use types::{IterOptions, Key};

--- a/crates/storage/src/corekv/traits.rs
+++ b/crates/storage/src/corekv/traits.rs
@@ -9,7 +9,6 @@
 /// - TxnStore: Store that supports transactions
 ///
 /// All traits use async_trait to support asynchronous operations.
-
 use async_trait::async_trait;
 use std::future::Future;
 use std::pin::Pin;
@@ -26,7 +25,8 @@ pub type TxnCallback = Box<dyn FnOnce() + Send + 'static>;
 /// Asynchronous callback function type for transaction lifecycle events.
 ///
 /// These callbacks are executed asynchronously when transaction events occur.
-pub type AsyncTxnCallback = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + 'static>;
+pub type AsyncTxnCallback =
+    Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + 'static>;
 
 /// Reader trait for read-only key-value operations.
 ///

--- a/crates/storage/src/corekv/types.rs
+++ b/crates/storage/src/corekv/types.rs
@@ -2,7 +2,6 @@
 ///
 /// This module provides the foundational abstractions for key-value storage,
 /// including the Key trait for typed keys and iteration options.
-
 use std::fmt;
 
 /// Trait for keys that can be serialized to bytes.
@@ -163,7 +162,11 @@ impl fmt::Display for IterOptions {
         if let Some(ref end) = self.end {
             write!(f, "end: {:?}, ", String::from_utf8_lossy(end))?;
         }
-        write!(f, "reverse: {}, keys_only: {} }}", self.reverse, self.keys_only)
+        write!(
+            f,
+            "reverse: {}, keys_only: {} }}",
+            self.reverse, self.keys_only
+        )
     }
 }
 

--- a/crates/storage/src/keys/blockstore.rs
+++ b/crates/storage/src/keys/blockstore.rs
@@ -3,12 +3,17 @@
 /// These keys are prefixed with 'b' at the store level and handle:
 /// - Block storage (CID-based)
 /// - Block merge tracking (for CRDT operations)
-
 use crate::corekv::Key;
 use cid::Cid;
 
 /// Merge marker prefix byte
 pub const MERGE_PREFIX: u8 = b'm';
+
+/// Object marker value for merge tracking entries
+/// This matches the Go implementation which uses 0xff as the marker value.
+/// The value itself is not used for logic (only key existence matters),
+/// but using the same value ensures cross-implementation database compatibility.
+pub const OBJECT_MARKER: u8 = 0xff;
 
 /// BlockstoreKey: Maps CID to block data
 ///

--- a/crates/storage/src/keys/datastore.rs
+++ b/crates/storage/src/keys/datastore.rs
@@ -6,10 +6,7 @@
 /// - Secondary indexes
 /// - Search engine artifacts
 /// - View caching
-
-use super::utils::{
-    encode_uvarint_ascending, InstanceType, SEPARATOR,
-};
+use super::utils::{encode_uvarint_ascending, InstanceType, SEPARATOR};
 use crate::corekv::Key;
 
 /// DataStoreKey: Main key for storing field values in documents

--- a/crates/storage/src/keys/encstore.rs
+++ b/crates/storage/src/keys/encstore.rs
@@ -2,7 +2,6 @@
 ///
 /// These keys are prefixed with 'e' at the store level and handle:
 /// - Encrypted block storage (CID-based, via IPLD)
-
 use crate::corekv::Key;
 use cid::Cid;
 
@@ -83,7 +82,8 @@ mod tests {
     #[test]
     fn test_encstore_key_different_cids() {
         let cid1 = test_cid();
-        let cid2 = Cid::from_str("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy").unwrap();
+        let cid2 =
+            Cid::from_str("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy").unwrap();
 
         let key1 = EncstoreKey::new(cid1);
         let key2 = EncstoreKey::new(cid2);

--- a/crates/storage/src/keys/headstore.rs
+++ b/crates/storage/src/keys/headstore.rs
@@ -135,11 +135,18 @@ impl HeadstoreFieldDefinition {
 
 impl Key for HeadstoreFieldDefinition {
     fn bytes(&self) -> Vec<u8> {
-        format!("/f/{}/{}/{}", self.collection_name, self.field_name, self.cid).into_bytes()
+        format!(
+            "/f/{}/{}/{}",
+            self.collection_name, self.field_name, self.cid
+        )
+        .into_bytes()
     }
 
     fn to_string(&self) -> String {
-        format!("/f/{}/{}/{}", self.collection_name, self.field_name, self.cid)
+        format!(
+            "/f/{}/{}/{}",
+            self.collection_name, self.field_name, self.cid
+        )
     }
 }
 

--- a/crates/storage/src/keys/mod.rs
+++ b/crates/storage/src/keys/mod.rs
@@ -37,7 +37,6 @@
 /// let bytes = key.bytes(); // Serialize for storage
 /// let string = key.to_string(); // Debug representation
 /// ```
-
 pub mod blockstore;
 pub mod datastore;
 pub mod encstore;
@@ -61,8 +60,7 @@ pub use peerstore::{
 };
 pub use systemstore::{
     CollectionID, CollectionIDSequenceKey, CollectionKey, CollectionNameKey, CollectionVersionKey,
-    FieldID, FieldIDSequenceKey, IndexIDSequenceKey, NodeACPKey, P2PCollectionKey,
-    P2PDocumentKey,
+    FieldID, FieldIDSequenceKey, IndexIDSequenceKey, NodeACPKey, P2PCollectionKey, P2PDocumentKey,
 };
 pub use utils::{InstanceType, SEPARATOR};
 
@@ -80,12 +78,7 @@ mod tests {
     #[test]
     fn test_all_key_types_implement_key_trait() {
         // Datastore keys
-        let _: Box<dyn Key> = Box::new(DataStoreKey::new(
-            1,
-            InstanceType::Value,
-            "doc",
-            "field",
-        ));
+        let _: Box<dyn Key> = Box::new(DataStoreKey::new(1, InstanceType::Value, "doc", "field"));
         let _: Box<dyn Key> = Box::new(PrimaryDataStoreKey::new(1, "doc"));
         let _: Box<dyn Key> = Box::new(IndexDataStoreKey::new(1, 2, vec![]));
         let _: Box<dyn Key> = Box::new(DatastoreSE::new("col", "idx", vec![], "doc"));

--- a/crates/storage/src/keys/peerstore.rs
+++ b/crates/storage/src/keys/peerstore.rs
@@ -4,7 +4,6 @@
 /// - Replicator configuration and state
 /// - Replication retry tracking
 /// - Search engine retry tracking
-
 use crate::corekv::Key;
 
 /// ReplicatorKey: Stores replicator configuration and state
@@ -170,11 +169,18 @@ impl PeerstoreSERetry {
 
 impl Key for PeerstoreSERetry {
     fn bytes(&self) -> Vec<u8> {
-        format!("/se-retry/{}/{}/{}", self.peer_id, self.collection_id, self.doc_id).into_bytes()
+        format!(
+            "/se-retry/{}/{}/{}",
+            self.peer_id, self.collection_id, self.doc_id
+        )
+        .into_bytes()
     }
 
     fn to_string(&self) -> String {
-        format!("/se-retry/{}/{}/{}", self.peer_id, self.collection_id, self.doc_id)
+        format!(
+            "/se-retry/{}/{}/{}",
+            self.peer_id, self.collection_id, self.doc_id
+        )
     }
 }
 
@@ -185,10 +191,7 @@ mod tests {
     #[test]
     fn test_replicator_key() {
         let key = ReplicatorKey::new("replicator_user_collection_peer1");
-        assert_eq!(
-            key.to_string(),
-            "/rep/id/replicator_user_collection_peer1"
-        );
+        assert_eq!(key.to_string(), "/rep/id/replicator_user_collection_peer1");
         assert_eq!(key.bytes(), key.to_string().as_bytes());
 
         let prefix = ReplicatorKey::replicator_prefix();

--- a/crates/storage/src/keys/systemstore.rs
+++ b/crates/storage/src/keys/systemstore.rs
@@ -6,7 +6,6 @@
 /// - Sequence counters
 /// - P2P tracking
 /// - Access control policies
-
 use crate::corekv::Key;
 
 /// CollectionKey: Maps collection ID to full collection definition (JSON)
@@ -144,11 +143,18 @@ impl CollectionVersionKey {
 
 impl Key for CollectionVersionKey {
     fn bytes(&self) -> Vec<u8> {
-        format!("/collection/version/{}/{}", self.collection_id, self.version_id).into_bytes()
+        format!(
+            "/collection/version/{}/{}",
+            self.collection_id, self.version_id
+        )
+        .into_bytes()
     }
 
     fn to_string(&self) -> String {
-        format!("/collection/version/{}/{}", self.collection_id, self.version_id)
+        format!(
+            "/collection/version/{}/{}",
+            self.collection_id, self.version_id
+        )
     }
 }
 
@@ -186,11 +192,18 @@ impl FieldID {
 
 impl Key for FieldID {
     fn bytes(&self) -> Vec<u8> {
-        format!("/field/shortID/{}/{}", self.collection_short_id, self.field_id).into_bytes()
+        format!(
+            "/field/shortID/{}/{}",
+            self.collection_short_id, self.field_id
+        )
+        .into_bytes()
     }
 
     fn to_string(&self) -> String {
-        format!("/field/shortID/{}/{}", self.collection_short_id, self.field_id)
+        format!(
+            "/field/shortID/{}/{}",
+            self.collection_short_id, self.field_id
+        )
     }
 }
 

--- a/crates/storage/src/keys/utils.rs
+++ b/crates/storage/src/keys/utils.rs
@@ -2,7 +2,6 @@
 ///
 /// This module provides CockroachDB-style encoding functions that maintain
 /// sort order and are compatible with the Go DefraDB implementation.
-
 use crate::corekv::{Error, Result};
 
 /// Key separator character
@@ -35,7 +34,10 @@ impl InstanceType {
             b'v' => Ok(InstanceType::Value),
             b'p' => Ok(InstanceType::Priority),
             b'd' => Ok(InstanceType::Deleted),
-            _ => Err(Error::Other(format!("Invalid instance type: {}", b as char))),
+            _ => Err(Error::Other(format!(
+                "Invalid instance type: {}",
+                b as char
+            ))),
         }
     }
 
@@ -366,8 +368,14 @@ mod tests {
         assert_eq!(InstanceType::Deleted.as_byte(), b'd');
 
         assert_eq!(InstanceType::from_byte(b'v').unwrap(), InstanceType::Value);
-        assert_eq!(InstanceType::from_byte(b'p').unwrap(), InstanceType::Priority);
-        assert_eq!(InstanceType::from_byte(b'd').unwrap(), InstanceType::Deleted);
+        assert_eq!(
+            InstanceType::from_byte(b'p').unwrap(),
+            InstanceType::Priority
+        );
+        assert_eq!(
+            InstanceType::from_byte(b'd').unwrap(),
+            InstanceType::Deleted
+        );
     }
 
     #[test]
@@ -379,12 +387,12 @@ mod tests {
             1,
             127,
             128,
-            239,      // boundary between 1-byte and 2-byte
-            240,      // first 2-byte value
+            239, // boundary between 1-byte and 2-byte
+            240, // first 2-byte value
             255,
             256,
-            2287,     // boundary between 2-byte and 3-byte
-            2288,     // first 3-byte value
+            2287, // boundary between 2-byte and 3-byte
+            2288, // first 3-byte value
             10000,
             100000,
             1000000,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -95,7 +95,6 @@
 /// - Examples
 /// - API documentation
 /// - Architecture guides
-
 pub mod backends;
 pub mod corekv;
 pub mod keys;
@@ -107,4 +106,6 @@ pub mod stores;
 
 // Re-export commonly used types for convenience
 pub use backends::{MemoryStore, RocksDBStore};
-pub use corekv::{Error, IterOptions, Iterator, KvPair, Reader, ReaderWriter, Result, Store, Txn, Writer};
+pub use corekv::{
+    Error, IterOptions, Iterator, KvPair, Reader, ReaderWriter, Result, Store, Txn, Writer,
+};

--- a/crates/storage/src/namespace.rs
+++ b/crates/storage/src/namespace.rs
@@ -11,7 +11,6 @@
 ///
 /// The NamespacedStore wraps any Store implementation and automatically
 /// prepends the prefix to all keys, ensuring complete isolation between stores.
-
 use crate::corekv::{Error, IterOptions, Iterator, KvPair, Reader, Result, Store, Txn, Writer};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -434,7 +433,9 @@ mod tests {
         // This tests that namespace isolation prevents cross-namespace access
         let datastore = NamespacedStore::new(store.clone(), Namespace::Datastore);
         let mut txn = datastore.new_txn(false).await.unwrap();
-        txn.set(b"bmalicious_key", b"datastore_value").await.unwrap();
+        txn.set(b"bmalicious_key", b"datastore_value")
+            .await
+            .unwrap();
         txn.commit().await.unwrap();
 
         // Blockstore should NOT see this key, even though the key starts with 'b'
@@ -448,7 +449,10 @@ mod tests {
 
         // Also check the key with 'b' prefix doesn't exist in blockstore
         let value = txn.get(b"bmalicious_key").await.unwrap();
-        assert_eq!(value, None, "Blockstore should not see key starting with 'b' from datastore");
+        assert_eq!(
+            value, None,
+            "Blockstore should not see key starting with 'b' from datastore"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/stores/blockstore.rs
+++ b/crates/storage/src/stores/blockstore.rs
@@ -2,9 +2,8 @@
 ///
 /// The Blockstore handles storage of IPLD blocks with merge tracking for CRDT operations.
 /// It tracks which blocks have been merged into the permanent store vs. pending merge.
-
 use crate::corekv::{IterOptions, Iterator, Key, Reader, Result, Store, Txn, Writer};
-use crate::keys::blockstore::{BlockstoreKey, ToMergeIndexKey};
+use crate::keys::blockstore::{BlockstoreKey, ToMergeIndexKey, OBJECT_MARKER};
 use crate::namespace::{Namespace, NamespacedStore};
 use async_trait::async_trait;
 use cid::Cid;
@@ -64,8 +63,8 @@ impl BlockstoreTxn {
         // If this is a P2P store, track it as unmerged
         if self.is_p2p {
             let merge_key = ToMergeIndexKey::new(*cid);
-            // Empty value - we just need the key to exist
-            self.set(&merge_key.bytes(), b"").await?;
+            // Use 0xff marker value to match Go implementation for cross-impl compatibility
+            self.set(&merge_key.bytes(), &[OBJECT_MARKER]).await?;
         }
 
         Ok(())

--- a/crates/storage/src/stores/blockstore.rs
+++ b/crates/storage/src/stores/blockstore.rs
@@ -368,4 +368,93 @@ mod tests {
         let is_merged = txn_bs.is_merged(&cid).await.unwrap();
         assert!(is_merged);
     }
+
+    #[tokio::test]
+    async fn test_get_unmerged_cids_detects_corruption() {
+        // get_unmerged_cids should return an error if it encounters merge keys
+        // that cannot be parsed. This indicates data corruption and the caller
+        // should be aware that results are incomplete.
+        use crate::keys::blockstore::{MERGE_PREFIX, OBJECT_MARKER};
+        use crate::namespace::Namespace;
+
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Blockstore::new(store.clone(), true); // P2P mode
+
+        // Add a valid block first
+        let cid = test_cid();
+        let mut txn = blockstore.new_txn(false).await.unwrap();
+        {
+            let txn_bs = txn.as_any_mut().downcast_mut::<BlockstoreTxn>().unwrap();
+            txn_bs.put_block(&cid, b"valid block").await.unwrap();
+        }
+        txn.commit().await.unwrap();
+
+        // Now inject a corrupted merge key directly into the underlying store.
+        // The key has the correct 'm' prefix but invalid CID bytes after.
+        // This simulates storage corruption.
+        {
+            let mut txn = store.new_txn(false).await.unwrap();
+            // Build the corrupted key: namespace prefix ('b') + 'm' + garbage
+            let mut corrupted_merge_key = vec![Namespace::Blockstore.prefix()]; // 'b'
+            corrupted_merge_key.push(MERGE_PREFIX); // 'm'
+            corrupted_merge_key.extend_from_slice(&[0xFF, 0xFF, 0xFF]); // Invalid CID bytes
+            txn.set(&corrupted_merge_key, &[OBJECT_MARKER]).await.unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        // get_unmerged_cids should detect the corruption and return an error
+        let txn = blockstore.new_txn(true).await.unwrap();
+        let txn_bs = txn.as_any().downcast_ref::<BlockstoreTxn>().unwrap();
+        let result = txn_bs.get_unmerged_cids().await;
+
+        assert!(result.is_err(), "Should return error on corrupted merge key");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Data corruption detected") || err_msg.contains("could not be parsed"),
+            "Error should indicate data corruption: {}",
+            err_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_block_cleans_up_merge_marker() {
+        // Verify delete_block removes both the block and its merge marker
+
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Blockstore::new(store, true); // P2P mode
+
+        let cid = test_cid();
+
+        // Put block (creates merge marker)
+        let mut txn = blockstore.new_txn(false).await.unwrap();
+        {
+            let txn_bs = txn.as_any_mut().downcast_mut::<BlockstoreTxn>().unwrap();
+            txn_bs.put_block(&cid, b"data").await.unwrap();
+        }
+        txn.commit().await.unwrap();
+
+        // Verify block and merge marker exist
+        let txn = blockstore.new_txn(true).await.unwrap();
+        let txn_bs = txn.as_any().downcast_ref::<BlockstoreTxn>().unwrap();
+        assert!(txn_bs.has_block(&cid).await.unwrap());
+        assert!(!txn_bs.is_merged(&cid).await.unwrap()); // has marker = not merged
+        drop(txn);
+
+        // Delete block
+        let mut txn = blockstore.new_txn(false).await.unwrap();
+        {
+            let txn_bs = txn.as_any_mut().downcast_mut::<BlockstoreTxn>().unwrap();
+            txn_bs.delete_block(&cid).await.unwrap();
+        }
+        txn.commit().await.unwrap();
+
+        // Both block and merge marker should be gone
+        let txn = blockstore.new_txn(true).await.unwrap();
+        let txn_bs = txn.as_any().downcast_ref::<BlockstoreTxn>().unwrap();
+        assert!(!txn_bs.has_block(&cid).await.unwrap());
+        // is_merged returns true when marker doesn't exist, but block also doesn't exist
+        // The important thing is the CID doesn't appear in unmerged list
+        let unmerged = txn_bs.get_unmerged_cids().await.unwrap();
+        assert!(!unmerged.contains(&cid), "Deleted block should not be in unmerged list");
+    }
 }

--- a/crates/storage/src/stores/datastore.rs
+++ b/crates/storage/src/stores/datastore.rs
@@ -3,7 +3,6 @@
 /// The Datastore handles storage of document field values, primary keys,
 /// secondary indexes, search engine artifacts, and view caching. It includes
 /// automatic chunking for values larger than 1MB.
-
 use crate::corekv::{Error, IterOptions, Iterator, Key, Reader, Result, Store, Txn, Writer};
 use crate::namespace::{Namespace, NamespacedStore};
 use async_trait::async_trait;
@@ -11,7 +10,6 @@ use std::sync::Arc;
 
 /// Chunk size for large values (1MB)
 pub const CHUNK_SIZE: usize = 1_048_576;
-
 
 /// Datastore provides storage for documents and collection data
 pub struct Datastore<S: Store> {
@@ -142,10 +140,7 @@ impl DatastoreTxn {
         }
 
         if deleted_chunks > 0 {
-            tracing::debug!(
-                deleted_chunks = deleted_chunks,
-                "Deleted chunked value"
-            );
+            tracing::debug!(deleted_chunks = deleted_chunks, "Deleted chunked value");
         }
 
         // Return error if any chunk deletion failed, including all failures
@@ -520,7 +515,10 @@ mod tests {
         let txn = datastore.new_txn(true).await.unwrap();
         let txn_ds = txn.as_any().downcast_ref::<DatastoreTxn>().unwrap();
         let chunk2_key = DatastoreTxn::chunk_key(&key.bytes(), 2);
-        assert!(txn_ds.has(&chunk2_key).await.unwrap(), "Chunk 2 should exist");
+        assert!(
+            txn_ds.has(&chunk2_key).await.unwrap(),
+            "Chunk 2 should exist"
+        );
         drop(txn);
 
         // Now update with a 1-chunk value (1.5 MB - just over CHUNK_SIZE)
@@ -549,7 +547,13 @@ mod tests {
         // Verify chunks 0 and 1 exist (for the 2-chunk value)
         let chunk0_key = DatastoreTxn::chunk_key(&key.bytes(), 0);
         let chunk1_key = DatastoreTxn::chunk_key(&key.bytes(), 1);
-        assert!(txn_ds.has(&chunk0_key).await.unwrap(), "Chunk 0 should exist");
-        assert!(txn_ds.has(&chunk1_key).await.unwrap(), "Chunk 1 should exist");
+        assert!(
+            txn_ds.has(&chunk0_key).await.unwrap(),
+            "Chunk 0 should exist"
+        );
+        assert!(
+            txn_ds.has(&chunk1_key).await.unwrap(),
+            "Chunk 1 should exist"
+        );
     }
 }

--- a/crates/storage/src/stores/headstore.rs
+++ b/crates/storage/src/stores/headstore.rs
@@ -2,7 +2,6 @@
 ///
 /// The Headstore handles storage of document heads, collection heads,
 /// field definitions, collection definitions, and collection set definitions.
-
 use crate::corekv::{Result, Store, Txn};
 use crate::namespace::{Namespace, NamespacedStore};
 use async_trait::async_trait;
@@ -47,8 +46,8 @@ mod tests {
         let store = Arc::new(MemoryStore::new());
         let headstore = Headstore::new(store);
 
-        let cid = Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
-            .unwrap();
+        let cid =
+            Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
         let key = HeadstoreDocKey::new("doc1", "field1", cid);
 
         // Write

--- a/crates/storage/src/stores/mod.rs
+++ b/crates/storage/src/stores/mod.rs
@@ -10,7 +10,6 @@
 /// - Encstore: Encrypted blocks (uses blockstore implementation)
 ///
 /// The Multistore coordinator provides unified access to all stores.
-
 pub mod blockstore;
 pub mod datastore;
 pub mod headstore;

--- a/crates/storage/src/stores/multistore.rs
+++ b/crates/storage/src/stores/multistore.rs
@@ -8,7 +8,6 @@
 /// - Systemstore: Metadata and configuration
 /// - Peerstore: Peer and replication metadata
 /// - Encstore: Encrypted blocks (uses blockstore implementation)
-
 use crate::backends::{MemoryStore, RocksDBStore};
 use crate::corekv::{Result, Store};
 use crate::stores::{
@@ -113,8 +112,8 @@ mod tests {
         txn.commit().await.unwrap();
 
         // Blockstore
-        let cid = Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
-            .unwrap();
+        let cid =
+            Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
         let bs_key = BlockstoreKey::new(cid);
         let mut txn = ms.blockstore.new_txn(false).await.unwrap();
         txn.set(&bs_key.bytes(), b"blockstore_value").await.unwrap();
@@ -193,34 +192,22 @@ mod tests {
         // Blockstore should NOT see the key (different namespace)
         let txn = ms.blockstore.new_txn(true).await.unwrap();
         let value = txn.get(b"shared_key").await.unwrap();
-        assert_eq!(
-            value, None,
-            "Blockstore should not see datastore's data"
-        );
+        assert_eq!(value, None, "Blockstore should not see datastore's data");
 
         // Headstore should NOT see it either
         let txn = ms.headstore.new_txn(true).await.unwrap();
         let value = txn.get(b"shared_key").await.unwrap();
-        assert_eq!(
-            value, None,
-            "Headstore should not see datastore's data"
-        );
+        assert_eq!(value, None, "Headstore should not see datastore's data");
 
         // Systemstore should NOT see it
         let txn = ms.systemstore.new_txn(true).await.unwrap();
         let value = txn.get(b"shared_key").await.unwrap();
-        assert_eq!(
-            value, None,
-            "Systemstore should not see datastore's data"
-        );
+        assert_eq!(value, None, "Systemstore should not see datastore's data");
 
         // Peerstore should NOT see it
         let txn = ms.peerstore.new_txn(true).await.unwrap();
         let value = txn.get(b"shared_key").await.unwrap();
-        assert_eq!(
-            value, None,
-            "Peerstore should not see datastore's data"
-        );
+        assert_eq!(value, None, "Peerstore should not see datastore's data");
     }
 
     #[tokio::test]
@@ -246,7 +233,10 @@ mod tests {
         assert_eq!(txn.get(b"key").await.unwrap(), Some(b"datastore".to_vec()));
 
         let txn = ms.systemstore.new_txn(true).await.unwrap();
-        assert_eq!(txn.get(b"key").await.unwrap(), Some(b"systemstore".to_vec()));
+        assert_eq!(
+            txn.get(b"key").await.unwrap(),
+            Some(b"systemstore".to_vec())
+        );
 
         let txn = ms.peerstore.new_txn(true).await.unwrap();
         assert_eq!(txn.get(b"key").await.unwrap(), Some(b"peerstore".to_vec()));
@@ -417,7 +407,10 @@ mod tests {
 
         // Iterate over datastore - keys should NOT have 'd' prefix
         let txn = ms.datastore.new_txn(true).await.unwrap();
-        let mut iter = txn.iterator(crate::corekv::IterOptions::new()).await.unwrap();
+        let mut iter = txn
+            .iterator(crate::corekv::IterOptions::new())
+            .await
+            .unwrap();
 
         let mut keys = vec![];
         while let Some(kv) = iter.next().await.unwrap() {
@@ -508,7 +501,10 @@ mod tests {
 
         // Rootstore should see both with their prefixes
         let txn = ms.root.new_txn(true).await.unwrap();
-        let mut iter = txn.iterator(crate::corekv::IterOptions::new()).await.unwrap();
+        let mut iter = txn
+            .iterator(crate::corekv::IterOptions::new())
+            .await
+            .unwrap();
 
         let mut keys = vec![];
         while let Some(kv) = iter.next().await.unwrap() {
@@ -516,8 +512,14 @@ mod tests {
         }
 
         // Should see "dmykey" and "smykey" (with namespace prefixes)
-        assert!(keys.contains(&"dmykey".to_string()), "Should see datastore key with 'd' prefix");
-        assert!(keys.contains(&"smykey".to_string()), "Should see systemstore key with 's' prefix");
+        assert!(
+            keys.contains(&"dmykey".to_string()),
+            "Should see datastore key with 'd' prefix"
+        );
+        assert!(
+            keys.contains(&"smykey".to_string()),
+            "Should see systemstore key with 's' prefix"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/stores/peerstore.rs
+++ b/crates/storage/src/stores/peerstore.rs
@@ -2,7 +2,6 @@
 ///
 /// The Peerstore handles storage of replicator configuration, replication
 /// retry tracking, and search engine retry tracking for P2P operations.
-
 use crate::corekv::{Result, Store, Txn};
 use crate::namespace::{Namespace, NamespacedStore};
 use async_trait::async_trait;

--- a/crates/storage/src/stores/rootstore.rs
+++ b/crates/storage/src/stores/rootstore.rs
@@ -3,7 +3,6 @@
 /// The RootStore provides direct access to the underlying store without
 /// namespace prefixing. It serves as the foundation for all other stores
 /// and is used for operations that need to span multiple namespaces.
-
 use crate::corekv::{Result, Store, Txn};
 use async_trait::async_trait;
 use std::sync::Arc;

--- a/crates/storage/src/stores/systemstore.rs
+++ b/crates/storage/src/stores/systemstore.rs
@@ -2,7 +2,6 @@
 ///
 /// The Systemstore handles storage of collection metadata, field metadata,
 /// sequence counters, P2P tracking, and access control policies.
-
 use crate::corekv::{Result, Store, Txn};
 use crate::namespace::{Namespace, NamespacedStore};
 use async_trait::async_trait;


### PR DESCRIPTION
## Summary

- Implements the `blockstore` crate with full feature parity to the Go DefraDB blockstore implementation
- Adds `Blockstore` trait with IPFS-compatible API
- Implements `DefraBlockstore<S>` wrapping the internal `storage::stores::Blockstore`
- Supports both P2P mode (with merge tracking) and local mode

## Features

| Feature | Description |
|---------|-------------|
| `get(cid)` | Retrieve block by CID |
| `put(cid, data)` | Store block with deduplication |
| `put_many(blocks)` | Batch store blocks |
| `has(cid)` | Check block existence |
| `delete(cid)` | Delete block and merge marker |
| `get_size(cid)` | Get block size without reading content |
| `all_cids()` | List all stored CIDs |
| `hash_on_read(bool)` | Enable/disable hash verification on read |
| `is_merged(cid)` | Check if block has been merged (P2P) |
| `mark_as_merged(cid)` | Mark block as merged |
| `get_unmerged()` | Get all unmerged block CIDs |

## Go Feature Parity

- ✅ All IPFS Blockstore methods implemented
- ✅ `HashOnRead` support with SHA2-256 verification
- ✅ `IsMerged` returns `false` for non-existent blocks (matches Go)
- ✅ Put optimization: checks `Has` before `Set`
- ✅ Merge tracking for P2P synchronization

## Test plan

- [x] Basic CRUD operations (9 tests)
- [x] HashOnRead verification including corruption detection (5 tests)
- [x] Merge tracking lifecycle in P2P and local modes (7 tests)
- [x] All 21 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)