### PR TITLE
feat(defra-core): implement Go-compatible Block structures with DAG-CBOR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ aes-gcm = "0.10"
 # IPLD
 cid = { version = "0.11", features = ["serde"] }
 multihash = "0.19"
+serde_ipld_dagcbor = "0.6"
 
 # GraphQL
 graphql-parser = "0.4"

--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -1635,7 +1635,11 @@ mod tests {
         // all_cids should skip the malformed key and return only valid CIDs
         // (matching Go behavior of logging error and continuing)
         let cids = blockstore.all_cids().await.unwrap();
-        assert_eq!(cids.len(), 2, "Should return only valid CIDs, skipping malformed key");
+        assert_eq!(
+            cids.len(),
+            2,
+            "Should return only valid CIDs, skipping malformed key"
+        );
         assert!(cids.contains(&cid1));
         assert!(cids.contains(&cid2));
     }
@@ -1658,7 +1662,11 @@ mod tests {
         // Block key: raw CID bytes (no prefix)
         let block_key = BlockstoreKey::new(cid);
         let block_bytes = block_key.bytes();
-        assert_eq!(block_bytes, cid.to_bytes(), "Block key should be raw CID bytes");
+        assert_eq!(
+            block_bytes,
+            cid.to_bytes(),
+            "Block key should be raw CID bytes"
+        );
 
         // Merge key: 'm' prefix + CID bytes
         let merge_key = ToMergeIndexKey::new(cid);
@@ -1702,7 +1710,10 @@ mod tests {
             cidv1_bytes[0], b'm',
             "CIDv1 should not start with 'm' - would break is_merge_key filtering"
         );
-        assert_eq!(cidv1_bytes[0], 0x01, "CIDv1 should start with version byte 0x01");
+        assert_eq!(
+            cidv1_bytes[0], 0x01,
+            "CIDv1 should start with version byte 0x01"
+        );
         assert!(!ToMergeIndexKey::is_merge_key(&cidv1_bytes));
 
         // CIDv0 test (Qm... format)
@@ -1713,7 +1724,10 @@ mod tests {
             "CIDv0 should not start with 'm' - would break is_merge_key filtering"
         );
         // CIDv0 starts with the multihash directly (0x12 for sha2-256)
-        assert_eq!(cidv0_bytes[0], 0x12, "CIDv0 should start with sha2-256 code 0x12");
+        assert_eq!(
+            cidv0_bytes[0], 0x12,
+            "CIDv0 should start with sha2-256 code 0x12"
+        );
         assert!(!ToMergeIndexKey::is_merge_key(&cidv0_bytes));
 
         // Edge case: raw codec CIDv1

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -19,6 +19,10 @@ serde_json.workspace = true
 # IPLD
 cid.workspace = true
 multihash.workspace = true
+serde_ipld_dagcbor.workspace = true
+
+# Cryptography (for CID generation)
+sha2.workspace = true
 
 # Async
 async-trait.workspace = true

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -1,132 +1,759 @@
-//! IPLD block types and operations
+//! IPLD Block types and operations for DefraDB
+//!
+//! This module provides Go-compatible Block structures with DAG-CBOR serialization.
+//! All types match the Go implementation in `internal/core/block/` for wire compatibility.
 
-use crate::{types::DocId, Result};
+use cid::Cid;
+use multihash::Multihash;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
-/// Content Identifier (CID) for content-addressed blocks
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Cid(String);
+use crate::{Error, Result};
 
-impl Cid {
-    /// Create a new CID from a string
-    pub fn new(cid: impl Into<String>) -> Self {
-        Self(cid.into())
-    }
+/// DAG-CBOR codec identifier (multicodec 0x71)
+pub const DAG_CBOR_CODEC: u64 = 0x71;
 
-    /// Get the string representation
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
+/// SHA2-256 multihash code
+pub const SHA2_256_CODE: u64 = 0x12;
 
-    /// Parse a CID from a string
-    pub fn parse(s: &str) -> Result<Self> {
-        // TODO: Validate CID format
-        Ok(Self(s.to_string()))
-    }
-}
+// ============================================================================
+// Block - The fundamental unit of content-addressed storage
+// ============================================================================
 
-impl std::fmt::Display for Cid {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// An IPLD block - content-addressed data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// IPLD Block for DefraDB - content-addressed data with CRDT deltas
+///
+/// Matches Go's `internal/core/block/block.go:Block` structure exactly for
+/// wire compatibility. Uses DAG-CBOR serialization with deterministic field ordering.
+///
+/// # Serialization
+///
+/// - Empty slices become `None` for space efficiency (omitted in CBOR)
+/// - Heads and links are sorted lexicographically by CID string
+/// - Uses CIDv1 with DAG-CBOR codec (0x71) and SHA2-256 hash
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Block {
-    /// Content identifier
-    pub cid: Cid,
+    /// CRDT delta payload
+    pub delta: CrdtDelta,
 
-    /// Block data (CBOR-encoded)
-    pub data: Vec<u8>,
+    /// Previous block CIDs (sorted lexicographically by string)
+    ///
+    /// `None` = nil (omitted in CBOR), `Some(vec![])` would be empty array
+    /// but is normalized to `None` in constructor for space efficiency.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heads: Option<Vec<Cid>>,
 
-    /// Links to other blocks
-    pub links: Vec<Cid>,
+    /// Named links to other blocks (sorted lexicographically by CID)
+    ///
+    /// Used for field-level links in composite blocks. Empty for field-level blocks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<DAGLink>>,
+
+    /// Optional link to encryption metadata block
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encryption: Option<Cid>,
+
+    /// Optional link to signature block
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Cid>,
 }
 
 impl Block {
-    /// Create a new block
-    pub fn new(cid: Cid, data: Vec<u8>) -> Self {
+    /// Create a new block with sorted heads and links
+    ///
+    /// Matches Go's `New()` behavior:
+    /// - Sorts heads lexicographically by CID string
+    /// - Sorts links lexicographically by CID string
+    /// - Converts empty slices to `None` for space efficiency
+    pub fn new(delta: CrdtDelta, heads: Vec<Cid>, links: Vec<DAGLink>) -> Self {
+        // Sort and normalize heads
+        let mut sorted_heads = heads;
+        sorted_heads.sort_by_key(|a| a.to_string());
+        let heads = if sorted_heads.is_empty() {
+            None
+        } else {
+            Some(sorted_heads)
+        };
+
+        // Sort and normalize links
+        let mut sorted_links = links;
+        sorted_links.sort();
+        let links = if sorted_links.is_empty() {
+            None
+        } else {
+            Some(sorted_links)
+        };
+
         Self {
-            cid,
-            data,
-            links: Vec::new(),
+            delta,
+            heads,
+            links,
+            encryption: None,
+            signature: None,
         }
     }
 
-    /// Add a link to another block
-    pub fn add_link(&mut self, cid: Cid) {
-        self.links.push(cid);
+    /// Create a block with encryption and/or signature
+    pub fn new_with_options(
+        delta: CrdtDelta,
+        heads: Vec<Cid>,
+        links: Vec<DAGLink>,
+        encryption: Option<Cid>,
+        signature: Option<Cid>,
+    ) -> Self {
+        let mut block = Self::new(delta, heads, links);
+        block.encryption = encryption;
+        block.signature = signature;
+        block
     }
 
-    /// Get the block size in bytes
-    pub fn size(&self) -> usize {
-        self.data.len()
+    /// Serialize to DAG-CBOR bytes
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        serde_ipld_dagcbor::to_vec(self).map_err(|e| Error::Serialization(e.to_string()))
+    }
+
+    /// Deserialize from DAG-CBOR bytes
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))
+    }
+
+    /// Generate CID from block content
+    ///
+    /// Uses CIDv1 with DAG-CBOR codec (0x71) and SHA2-256 hash.
+    /// Equivalent to Go's `GenerateLink()`.
+    pub fn generate_cid(&self) -> Result<Cid> {
+        let bytes = self.to_dag_cbor()?;
+        generate_cid_from_bytes(&bytes)
+    }
+
+    /// Get all CID links in this block (heads + named links)
+    ///
+    /// Returns heads first, then named links (in order).
+    /// Matches Go's `AllLinks()` method.
+    pub fn all_links(&self) -> Vec<Cid> {
+        let mut links = Vec::new();
+
+        if let Some(ref heads) = self.heads {
+            links.extend(heads.iter().cloned());
+        }
+
+        if let Some(ref dag_links) = self.links {
+            links.extend(dag_links.iter().map(|l| l.link));
+        }
+
+        links
+    }
+
+    /// Get a specific named link by name
+    ///
+    /// Matches Go's `GetLinkByName()` method.
+    pub fn get_link_by_name(&self, name: &str) -> Option<&Cid> {
+        self.links
+            .as_ref()?
+            .iter()
+            .find(|l| l.name == name)
+            .map(|l| &l.link)
+    }
+
+    /// Check if this block has encryption
+    pub fn is_encrypted(&self) -> bool {
+        self.encryption.is_some()
+    }
+
+    /// Check if this block is signed
+    pub fn is_signed(&self) -> bool {
+        self.signature.is_some()
+    }
+
+    /// Clone the block (shallow copy of links, deep copy of delta)
+    ///
+    /// Matches Go's `Clone()` behavior.
+    pub fn clone_block(&self) -> Self {
+        Self {
+            delta: self.delta.clone(),
+            heads: self.heads.clone(),
+            links: self.links.clone(),
+            encryption: self.encryption,
+            signature: self.signature,
+        }
     }
 }
 
-/// Block delta - represents a change to a document
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockDelta {
-    /// Document this delta applies to
-    pub doc_id: DocId,
+// ============================================================================
+// DAGLink - Named link to another block
+// ============================================================================
 
-    /// The block CID
-    pub cid: Cid,
+/// Link to another block with a name
+///
+/// Matches Go's `internal/core/block/block.go:DAGLink`.
+/// The name is typically a field name or "_head" for composite head links.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DAGLink {
+    /// Field name or "_head" for composite head
+    pub name: String,
+
+    /// CID of the linked block
+    pub link: Cid,
+}
+
+impl DAGLink {
+    /// Create a new DAGLink
+    pub fn new(name: impl Into<String>, link: Cid) -> Self {
+        Self {
+            name: name.into(),
+            link,
+        }
+    }
+}
+
+impl PartialOrd for DAGLink {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DAGLink {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Sort by link CID string (matching Go behavior)
+        self.link.to_string().cmp(&other.link.to_string())
+    }
+}
+
+// ============================================================================
+// CrdtDelta - CRDT delta payloads embedded in blocks
+// ============================================================================
+
+/// CRDT delta types that can be embedded in a Block
+///
+/// Matches Go's `crdt.CRDT` interface. Uses serde enum representation
+/// compatible with Go's CBOR encoding.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum CrdtDelta {
+    /// LWW Register delta
+    #[serde(rename = "lww")]
+    Lww(LwwDeltaPayload),
+
+    /// Counter delta
+    #[serde(rename = "counter")]
+    Counter(CounterDeltaPayload),
+
+    /// Document composite delta
+    #[serde(rename = "composite")]
+    Composite(CompositeDeltaPayload),
+
+    /// Collection delta
+    #[serde(rename = "collection")]
+    Collection(CollectionDeltaPayload),
+}
+
+impl CrdtDelta {
+    /// Get the priority of this delta
+    pub fn priority(&self) -> u64 {
+        match self {
+            CrdtDelta::Lww(d) => d.priority,
+            CrdtDelta::Counter(d) => d.priority,
+            CrdtDelta::Composite(d) => d.priority,
+            CrdtDelta::Collection(d) => d.priority,
+        }
+    }
+
+    /// Set the priority of this delta
+    pub fn set_priority(&mut self, priority: u64) {
+        match self {
+            CrdtDelta::Lww(d) => d.priority = priority,
+            CrdtDelta::Counter(d) => d.priority = priority,
+            CrdtDelta::Composite(d) => d.priority = priority,
+            CrdtDelta::Collection(d) => d.priority = priority,
+        }
+    }
+
+    /// Get the document ID
+    pub fn doc_id(&self) -> &[u8] {
+        match self {
+            CrdtDelta::Lww(d) => &d.doc_id,
+            CrdtDelta::Counter(d) => &d.doc_id,
+            CrdtDelta::Composite(d) => &d.doc_id,
+            CrdtDelta::Collection(d) => &d.doc_id,
+        }
+    }
+}
+
+/// LWW Register delta payload for block embedding
+///
+/// Matches Go's `crdt.LWWDelta` structure.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LwwDeltaPayload {
+    /// Document ID
+    #[serde(rename = "docID")]
+    pub doc_id: Vec<u8>,
+
+    /// Field name
+    #[serde(rename = "fieldName")]
+    pub field_name: String,
 
     /// Priority for conflict resolution
     pub priority: u64,
 
-    /// Links to parent blocks (previous document states)
-    pub links: Vec<Cid>,
+    /// Schema version identifier
+    #[serde(rename = "schemaVersionID")]
+    pub schema_version_id: String,
 
-    /// The actual delta data
+    /// The value data (empty = deletion/tombstone)
     pub data: Vec<u8>,
 }
 
-impl BlockDelta {
-    /// Create a new block delta
-    pub fn new(doc_id: DocId, cid: Cid, priority: u64) -> Self {
+/// Counter delta payload for block embedding
+///
+/// Matches Go's `crdt.CounterDelta` structure.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CounterDeltaPayload {
+    /// Document ID
+    #[serde(rename = "docID")]
+    pub doc_id: Vec<u8>,
+
+    /// Field name
+    #[serde(rename = "fieldName")]
+    pub field_name: String,
+
+    /// Priority
+    pub priority: u64,
+
+    /// Nonce for idempotency
+    pub nonce: i64,
+
+    /// Schema version identifier
+    #[serde(rename = "schemaVersionID")]
+    pub schema_version_id: String,
+
+    /// Increment/decrement value (encoded)
+    pub data: Vec<u8>,
+}
+
+/// Composite delta payload for block embedding
+///
+/// Matches Go's `crdt.DocCompositeDelta` structure.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CompositeDeltaPayload {
+    /// Document ID
+    #[serde(rename = "docID")]
+    pub doc_id: Vec<u8>,
+
+    /// Schema version identifier
+    #[serde(rename = "schemaVersionID")]
+    pub schema_version_id: String,
+
+    /// Priority
+    pub priority: u64,
+
+    /// Document status (1 = active, 2 = deleted)
+    #[serde(default)]
+    pub status: u8,
+}
+
+/// Collection delta payload for block embedding
+///
+/// Matches Go's `crdt.CollectionDelta` structure.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CollectionDeltaPayload {
+    /// Document ID
+    #[serde(rename = "docID")]
+    pub doc_id: Vec<u8>,
+
+    /// Schema version identifier
+    #[serde(rename = "schemaVersionID")]
+    pub schema_version_id: String,
+
+    /// Priority
+    pub priority: u64,
+}
+
+// ============================================================================
+// Encryption - Encryption metadata block
+// ============================================================================
+
+/// Encryption metadata block
+///
+/// Matches Go's `internal/core/block/encryption.go:Encryption`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Encryption {
+    /// Document ID bytes
+    #[serde(rename = "docID")]
+    pub doc_id: Vec<u8>,
+
+    /// Field name (None for document-level encryption)
+    #[serde(rename = "fieldName", default, skip_serializing_if = "Option::is_none")]
+    pub field_name: Option<String>,
+
+    /// Encryption key
+    pub key: Vec<u8>,
+}
+
+impl Encryption {
+    /// Create a new encryption block
+    pub fn new(doc_id: Vec<u8>, key: Vec<u8>) -> Self {
         Self {
             doc_id,
-            cid,
-            priority,
-            links: Vec::new(),
-            data: Vec::new(),
+            field_name: None,
+            key,
         }
+    }
+
+    /// Create a field-level encryption block
+    pub fn new_for_field(doc_id: Vec<u8>, field_name: String, key: Vec<u8>) -> Self {
+        Self {
+            doc_id,
+            field_name: Some(field_name),
+            key,
+        }
+    }
+
+    /// Serialize to DAG-CBOR bytes
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        serde_ipld_dagcbor::to_vec(self).map_err(|e| Error::Serialization(e.to_string()))
+    }
+
+    /// Deserialize from DAG-CBOR bytes
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))
+    }
+
+    /// Generate CID for this encryption block
+    pub fn generate_cid(&self) -> Result<Cid> {
+        let bytes = self.to_dag_cbor()?;
+        generate_cid_from_bytes(&bytes)
     }
 }
 
-/// Block header - metadata about a block
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockHeader {
-    /// Block CID
-    pub cid: Cid,
+// ============================================================================
+// Signature - Block signature
+// ============================================================================
 
-    /// Block height in the DAG
-    pub height: u64,
+/// Signature block
+///
+/// Matches Go's `internal/core/block/signature.go:Signature`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Signature {
+    /// Signature header with algorithm and identity
+    pub header: SignatureHeader,
 
-    /// Links to previous blocks
-    pub links: Vec<Cid>,
+    /// Signature value bytes
+    pub value: Vec<u8>,
 }
+
+impl Signature {
+    /// Create a new signature
+    pub fn new(header: SignatureHeader, value: Vec<u8>) -> Self {
+        Self { header, value }
+    }
+
+    /// Serialize to DAG-CBOR bytes
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        serde_ipld_dagcbor::to_vec(self).map_err(|e| Error::Serialization(e.to_string()))
+    }
+
+    /// Deserialize from DAG-CBOR bytes
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))
+    }
+
+    /// Generate CID for this signature block
+    pub fn generate_cid(&self) -> Result<Cid> {
+        let bytes = self.to_dag_cbor()?;
+        generate_cid_from_bytes(&bytes)
+    }
+}
+
+/// Signature header with algorithm type and identity
+///
+/// Matches Go's `internal/core/block/signature.go:SignatureHeader`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SignatureHeader {
+    /// Algorithm type: "ES256K" (secp256k1) or "EdDSA" (Ed25519)
+    #[serde(rename = "type")]
+    pub sig_type: SignatureType,
+
+    /// Signer identity (public key bytes)
+    pub identity: Vec<u8>,
+}
+
+impl SignatureHeader {
+    /// Create a new signature header
+    pub fn new(sig_type: SignatureType, identity: Vec<u8>) -> Self {
+        Self { sig_type, identity }
+    }
+}
+
+/// Signature algorithm types
+///
+/// Matches Go's signature type constants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SignatureType {
+    /// ECDSA with secp256k1 curve
+    #[serde(rename = "ES256K")]
+    ES256K,
+
+    /// EdDSA with Ed25519 curve
+    EdDSA,
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Generate CID from raw bytes using DAG-CBOR codec and SHA2-256
+fn generate_cid_from_bytes(bytes: &[u8]) -> Result<Cid> {
+    // Hash with SHA2-256
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+
+    // Create multihash
+    let mh = Multihash::<64>::wrap(SHA2_256_CODE, &digest)
+        .map_err(|e| Error::BlockError(format!("Failed to create multihash: {}", e)))?;
+
+    // Create CIDv1 with DAG-CBOR codec
+    Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
-    #[test]
-    fn test_cid_creation() {
-        let cid = Cid::new("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi");
-        assert!(!cid.as_str().is_empty());
+    fn test_cid() -> Cid {
+        Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap()
+    }
+
+    fn test_cid2() -> Cid {
+        Cid::from_str("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy").unwrap()
+    }
+
+    fn test_lww_delta() -> CrdtDelta {
+        CrdtDelta::Lww(LwwDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            field_name: "name".to_string(),
+            priority: 1,
+            schema_version_id: "schema1".to_string(),
+            data: b"John".to_vec(),
+        })
     }
 
     #[test]
-    fn test_block_creation() {
-        let cid = Cid::new("test-cid");
-        let data = vec![1, 2, 3, 4];
-        let block = Block::new(cid, data);
+    fn test_block_dag_cbor_roundtrip() {
+        let block = Block::new(test_lww_delta(), vec![], vec![]);
 
-        assert_eq!(block.size(), 4);
-        assert_eq!(block.links.len(), 0);
+        let bytes = block.to_dag_cbor().unwrap();
+        let restored = Block::from_dag_cbor(&bytes).unwrap();
+
+        assert_eq!(block, restored);
+    }
+
+    #[test]
+    fn test_block_cid_generation_deterministic() {
+        let block = Block::new(test_lww_delta(), vec![], vec![]);
+
+        let cid1 = block.generate_cid().unwrap();
+        let cid2 = block.generate_cid().unwrap();
+
+        assert_eq!(cid1, cid2);
+    }
+
+    #[test]
+    fn test_block_cid_uses_dag_cbor_codec() {
+        let block = Block::new(test_lww_delta(), vec![], vec![]);
+        let cid = block.generate_cid().unwrap();
+
+        assert_eq!(cid.codec(), DAG_CBOR_CODEC);
+    }
+
+    #[test]
+    fn test_heads_sorted_lexicographically() {
+        let cid_z = test_cid(); // bafybeig...
+        let cid_a = test_cid2(); // bafkreig... (comes after bafybeig)
+
+        // Note: bafkreig > bafybeig lexicographically
+        let block = Block::new(test_lww_delta(), vec![cid_a, cid_z], vec![]);
+
+        let heads = block.heads.unwrap();
+        assert!(
+            heads[0].to_string() < heads[1].to_string(),
+            "Heads should be sorted: {} < {}",
+            heads[0],
+            heads[1]
+        );
+    }
+
+    #[test]
+    fn test_empty_heads_becomes_none() {
+        let block = Block::new(test_lww_delta(), vec![], vec![]);
+        assert!(block.heads.is_none());
+    }
+
+    #[test]
+    fn test_empty_links_becomes_none() {
+        let block = Block::new(test_lww_delta(), vec![], vec![]);
+        assert!(block.links.is_none());
+    }
+
+    #[test]
+    fn test_all_links_returns_heads_then_links() {
+        let head1 = test_cid();
+        let head2 = test_cid2();
+        let link1 = DAGLink::new("field1", test_cid());
+        let link2 = DAGLink::new("field2", test_cid2());
+
+        let block = Block::new(test_lww_delta(), vec![head1, head2], vec![link1, link2]);
+
+        let all = block.all_links();
+        assert_eq!(all.len(), 4);
+        // First two should be heads (sorted)
+        // Last two should be links (sorted)
+    }
+
+    #[test]
+    fn test_get_link_by_name() {
+        let link = DAGLink::new("myfield", test_cid());
+        let block = Block::new(test_lww_delta(), vec![], vec![link.clone()]);
+
+        assert_eq!(block.get_link_by_name("myfield"), Some(&link.link));
+        assert_eq!(block.get_link_by_name("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_is_encrypted_and_signed() {
+        let mut block = Block::new(test_lww_delta(), vec![], vec![]);
+        assert!(!block.is_encrypted());
+        assert!(!block.is_signed());
+
+        block.encryption = Some(test_cid());
+        assert!(block.is_encrypted());
+
+        block.signature = Some(test_cid2());
+        assert!(block.is_signed());
+    }
+
+    #[test]
+    fn test_dag_link_ordering() {
+        let link_a = DAGLink::new("a", test_cid());
+        let link_b = DAGLink::new("b", test_cid2());
+
+        // Ordering is by CID string, not by name
+        let mut links = vec![link_b.clone(), link_a.clone()];
+        links.sort();
+
+        // bafkreig < bafybeig (k < y in ASCII)
+        assert_eq!(links[0].link, test_cid2());
+        assert_eq!(links[1].link, test_cid());
+    }
+
+    #[test]
+    fn test_encryption_roundtrip() {
+        let enc = Encryption::new(b"doc1".to_vec(), b"key123".to_vec());
+
+        let bytes = enc.to_dag_cbor().unwrap();
+        let restored = Encryption::from_dag_cbor(&bytes).unwrap();
+
+        assert_eq!(enc, restored);
+    }
+
+    #[test]
+    fn test_encryption_with_field_name() {
+        let enc = Encryption::new_for_field(
+            b"doc1".to_vec(),
+            "secret_field".to_string(),
+            b"key".to_vec(),
+        );
+
+        let bytes = enc.to_dag_cbor().unwrap();
+        let restored = Encryption::from_dag_cbor(&bytes).unwrap();
+
+        assert_eq!(restored.field_name, Some("secret_field".to_string()));
+    }
+
+    #[test]
+    fn test_signature_roundtrip() {
+        let sig = Signature::new(
+            SignatureHeader::new(SignatureType::EdDSA, b"pubkey".to_vec()),
+            b"signature_value".to_vec(),
+        );
+
+        let bytes = sig.to_dag_cbor().unwrap();
+        let restored = Signature::from_dag_cbor(&bytes).unwrap();
+
+        assert_eq!(sig, restored);
+    }
+
+    #[test]
+    fn test_signature_type_serialization() {
+        let header_ed = SignatureHeader::new(SignatureType::EdDSA, vec![]);
+        let header_ec = SignatureHeader::new(SignatureType::ES256K, vec![]);
+
+        // Verify the type serializes correctly
+        let bytes_ed = serde_ipld_dagcbor::to_vec(&header_ed).unwrap();
+        let bytes_ec = serde_ipld_dagcbor::to_vec(&header_ec).unwrap();
+
+        let restored_ed: SignatureHeader = serde_ipld_dagcbor::from_slice(&bytes_ed).unwrap();
+        let restored_ec: SignatureHeader = serde_ipld_dagcbor::from_slice(&bytes_ec).unwrap();
+
+        assert_eq!(restored_ed.sig_type, SignatureType::EdDSA);
+        assert_eq!(restored_ec.sig_type, SignatureType::ES256K);
+    }
+
+    #[test]
+    fn test_crdt_delta_priority() {
+        let mut delta = test_lww_delta();
+        assert_eq!(delta.priority(), 1);
+
+        delta.set_priority(42);
+        assert_eq!(delta.priority(), 42);
+    }
+
+    #[test]
+    fn test_composite_delta_roundtrip() {
+        let delta = CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 5,
+            status: 1,
+        });
+
+        let block = Block::new(delta, vec![], vec![]);
+        let bytes = block.to_dag_cbor().unwrap();
+        let restored = Block::from_dag_cbor(&bytes).unwrap();
+
+        if let CrdtDelta::Composite(c) = &restored.delta {
+            assert_eq!(c.status, 1);
+            assert_eq!(c.priority, 5);
+        } else {
+            panic!("Expected Composite delta");
+        }
+    }
+
+    #[test]
+    fn test_block_with_heads_and_links() {
+        let head = test_cid();
+        let link = DAGLink::new("field", test_cid2());
+
+        let block = Block::new_with_options(
+            test_lww_delta(),
+            vec![head],
+            vec![link],
+            Some(test_cid()),
+            Some(test_cid2()),
+        );
+
+        assert!(block.heads.is_some());
+        assert!(block.links.is_some());
+        assert!(block.is_encrypted());
+        assert!(block.is_signed());
+
+        // Roundtrip
+        let bytes = block.to_dag_cbor().unwrap();
+        let restored = Block::from_dag_cbor(&bytes).unwrap();
+        assert_eq!(block, restored);
     }
 }

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -163,19 +163,6 @@ impl Block {
     pub fn is_signed(&self) -> bool {
         self.signature.is_some()
     }
-
-    /// Clone the block (shallow copy of links, deep copy of delta)
-    ///
-    /// Matches Go's `Clone()` behavior.
-    pub fn clone_block(&self) -> Self {
-        Self {
-            delta: self.delta.clone(),
-            heads: self.heads.clone(),
-            links: self.links.clone(),
-            encryption: self.encryption,
-            signature: self.signature,
-        }
-    }
 }
 
 // ============================================================================
@@ -730,6 +717,50 @@ mod tests {
             assert_eq!(c.priority, 5);
         } else {
             panic!("Expected Composite delta");
+        }
+    }
+
+    #[test]
+    fn test_counter_delta_roundtrip() {
+        let delta = CrdtDelta::Counter(CounterDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            field_name: "counter_field".to_string(),
+            priority: 3,
+            nonce: -42,
+            schema_version_id: "v1".to_string(),
+            data: vec![1, 2, 3, 4],
+        });
+
+        let block = Block::new(delta, vec![], vec![]);
+        let bytes = block.to_dag_cbor().unwrap();
+        let restored = Block::from_dag_cbor(&bytes).unwrap();
+
+        if let CrdtDelta::Counter(c) = &restored.delta {
+            assert_eq!(c.nonce, -42);
+            assert_eq!(c.field_name, "counter_field");
+            assert_eq!(c.data, vec![1, 2, 3, 4]);
+        } else {
+            panic!("Expected Counter delta");
+        }
+    }
+
+    #[test]
+    fn test_collection_delta_roundtrip() {
+        let delta = CrdtDelta::Collection(CollectionDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            schema_version_id: "v2".to_string(),
+            priority: 10,
+        });
+
+        let block = Block::new(delta, vec![], vec![]);
+        let bytes = block.to_dag_cbor().unwrap();
+        let restored = Block::from_dag_cbor(&bytes).unwrap();
+
+        if let CrdtDelta::Collection(c) = &restored.delta {
+            assert_eq!(c.priority, 10);
+            assert_eq!(c.schema_version_id, "v2");
+        } else {
+            panic!("Expected Collection delta");
         }
     }
 

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -11,6 +11,11 @@ pub mod store;
 pub mod transaction;
 pub mod types;
 
+pub use block::{
+    Block, CollectionDeltaPayload, CompositeDeltaPayload, CounterDeltaPayload, CrdtDelta, DAGLink,
+    Encryption, LwwDeltaPayload, Signature, SignatureHeader, SignatureType, DAG_CBOR_CODEC,
+    SHA2_256_CODE,
+};
 pub use error::{Error, Result};
 
 /// Version information for DefraDB

--- a/crates/storage/src/stores/blockstore.rs
+++ b/crates/storage/src/stores/blockstore.rs
@@ -398,7 +398,9 @@ mod tests {
             let mut corrupted_merge_key = vec![Namespace::Blockstore.prefix()]; // 'b'
             corrupted_merge_key.push(MERGE_PREFIX); // 'm'
             corrupted_merge_key.extend_from_slice(&[0xFF, 0xFF, 0xFF]); // Invalid CID bytes
-            txn.set(&corrupted_merge_key, &[OBJECT_MARKER]).await.unwrap();
+            txn.set(&corrupted_merge_key, &[OBJECT_MARKER])
+                .await
+                .unwrap();
             txn.commit().await.unwrap();
         }
 
@@ -407,7 +409,10 @@ mod tests {
         let txn_bs = txn.as_any().downcast_ref::<BlockstoreTxn>().unwrap();
         let result = txn_bs.get_unmerged_cids().await;
 
-        assert!(result.is_err(), "Should return error on corrupted merge key");
+        assert!(
+            result.is_err(),
+            "Should return error on corrupted merge key"
+        );
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("Data corruption detected") || err_msg.contains("could not be parsed"),
@@ -455,6 +460,9 @@ mod tests {
         // is_merged returns true when marker doesn't exist, but block also doesn't exist
         // The important thing is the CID doesn't appear in unmerged list
         let unmerged = txn_bs.get_unmerged_cids().await.unwrap();
-        assert!(!unmerged.contains(&cid), "Deleted block should not be in unmerged list");
+        assert!(
+            !unmerged.contains(&cid),
+            "Deleted block should not be in unmerged list"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Implements Go-compatible Block structures with DAG-CBOR serialization
- Adds CID generation using CIDv1 + DAG-CBOR codec + SHA2-256
- Includes helper methods matching Go's `internal/core/block/` package

## Changes

- **Block** - Main content-addressed block with delta, heads, links, encryption, signature
- **DAGLink** - Named links to other blocks (sorted by CID)
- **CrdtDelta** - Enum with `Lww`, `Counter`, `Composite`, `Collection` variants
- **Encryption** - Encryption metadata for encrypted blocks
- **Signature/SignatureHeader** - Signature types for signed blocks

## Key Features

- DAG-CBOR serialization (`to_dag_cbor()`, `from_dag_cbor()`)
- CID generation (`generate_cid()`) - CIDv1 + codec 0x71 + SHA2-256
- Go-compatible sorting (heads/links sorted lexicographically by CID string)
- Empty slices normalized to `None` for space efficiency

## Test plan

- [x] 26 tests pass in defra-core
- [x] Roundtrip serialization tests
- [x] CID generation determinism tests
- [x] Sorting behavior tests
- [x] Clippy clean
- [x] Formatting clean

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)