### PR TITLE
feat(db): Add datastore and db crates for database foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ members = [
     "crates/crypto",
     "crates/http",
     "crates/cli",
+    "crates/datastore",
+    "crates/db",
 ]
 
 [workspace.package]

--- a/crates/datastore/Cargo.toml
+++ b/crates/datastore/Cargo.toml
@@ -17,6 +17,9 @@ futures.workspace = true
 # Error handling
 thiserror.workspace = true
 
+# Logging
+tracing.workspace = true
+
 # IPLD
 cid.workspace = true
 

--- a/crates/datastore/Cargo.toml
+++ b/crates/datastore/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "datastore"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Transaction wrapper for DefraDB providing multistore access and callbacks"
+
+[dependencies]
+# Async runtime
+async-trait.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+futures.workspace = true
+
+# Error handling
+thiserror.workspace = true
+
+# IPLD
+cid.workspace = true
+
+# Internal crates
+storage = { path = "../storage" }
+
+[dev-dependencies]
+# Testing
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/datastore/src/error.rs
+++ b/crates/datastore/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
 
     #[error("transaction already discarded")]
     TxnAlreadyDiscarded,
+
+    #[error("transaction still has active references")]
+    TxnStillInUse,
 }
 
 /// Result type for datastore operations.

--- a/crates/datastore/src/error.rs
+++ b/crates/datastore/src/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+/// Errors that can occur in the datastore module.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("storage error: {0}")]
+    Storage(#[from] storage::Error),
+
+    #[error("transaction already committed")]
+    TxnAlreadyCommitted,
+
+    #[error("transaction already discarded")]
+    TxnAlreadyDiscarded,
+}
+
+/// Result type for datastore operations.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/datastore/src/lib.rs
+++ b/crates/datastore/src/lib.rs
@@ -6,7 +6,6 @@
 /// - `BasicTxn`: Transaction wrapper with multistore access and callbacks
 /// - `Txn` trait: Common interface for DefraDB transactions
 /// - `NamespaceView`: View into a specific namespace of a transaction
-/// - `Blockstore` trait: Block storage interface
 ///
 /// # Architecture
 ///
@@ -25,7 +24,7 @@
 /// use storage::backends::MemoryStore;
 ///
 /// let store = MemoryStore::new();
-/// let txn = BasicTxn::new(&store, 1, false).await?;
+/// let mut txn = BasicTxn::new(&store, 1, false).await?;
 ///
 /// // Access namespaced stores
 /// txn.datastore().set(b"key", b"value").await?;
@@ -45,7 +44,7 @@ pub mod txn;
 // Re-export commonly used types
 pub use error::{Error, Result};
 pub use multistore::{NamespaceView, RootView, SharedTxn};
-pub use traits::{Blockstore, Txn};
+pub use traits::Txn;
 pub use txn::{AsyncCallback, BasicTxn};
 
 // Re-export storage types for convenience

--- a/crates/datastore/src/lib.rs
+++ b/crates/datastore/src/lib.rs
@@ -1,0 +1,53 @@
+/// Datastore layer for DefraDB matching Go's internal/datastore/.
+///
+/// This crate provides the transaction wrapper layer that sits between
+/// the storage layer (corekv) and the database layer (db). It provides:
+///
+/// - `BasicTxn`: Transaction wrapper with multistore access and callbacks
+/// - `Txn` trait: Common interface for DefraDB transactions
+/// - `NamespaceView`: View into a specific namespace of a transaction
+/// - `Blockstore` trait: Block storage interface
+///
+/// # Architecture
+///
+/// ```text
+/// db crate (Database, Collection, DbTxn)
+///     ↓
+/// datastore crate (BasicTxn, Txn trait, NamespaceView)
+///     ↓
+/// storage crate (corekv, Multistore, backends)
+/// ```
+///
+/// # Example
+///
+/// ```ignore
+/// use datastore::BasicTxn;
+/// use storage::backends::MemoryStore;
+///
+/// let store = MemoryStore::new();
+/// let txn = BasicTxn::new(&store, 1, false).await?;
+///
+/// // Access namespaced stores
+/// txn.datastore().set(b"key", b"value").await?;
+/// txn.systemstore().set(b"config", b"data").await?;
+///
+/// // Register callbacks
+/// txn.on_success(Box::new(|| println!("Committed!")));
+///
+/// // Commit
+/// txn.commit().await?;
+/// ```
+pub mod error;
+pub mod multistore;
+pub mod traits;
+pub mod txn;
+
+// Re-export commonly used types
+pub use error::{Error, Result};
+pub use multistore::{NamespaceView, RootView, SharedTxn};
+pub use traits::{Blockstore, Txn};
+pub use txn::{AsyncCallback, BasicTxn};
+
+// Re-export storage types for convenience
+pub use storage::corekv::{IterOptions, Store, TxnCallback};
+pub use storage::namespace::Namespace;

--- a/crates/datastore/src/multistore.rs
+++ b/crates/datastore/src/multistore.rs
@@ -1,0 +1,365 @@
+/// Transaction-aware Multistore for the datastore layer.
+///
+/// Unlike the storage layer's Multistore which provides store-level access,
+/// this provides namespaced access to a single underlying transaction.
+/// This matches Go DefraDB's internal/datastore/multi.go pattern.
+use async_trait::async_trait;
+use std::sync::Arc;
+use storage::corekv::{Error, IterOptions, Iterator, Result, Txn};
+use storage::namespace::Namespace;
+use tokio::sync::RwLock;
+
+/// Store namespace prefixes matching Go DefraDB's internal/datastore/multi.go
+pub const SYSTEM_STORE_PREFIX: u8 = b's';
+pub const DATA_STORE_PREFIX: u8 = b'd';
+pub const HEAD_STORE_PREFIX: u8 = b'h';
+pub const BLOCK_STORE_PREFIX: u8 = b'b';
+pub const PEER_STORE_PREFIX: u8 = b'p';
+pub const ENC_STORE_PREFIX: u8 = b'e';
+
+/// Shared transaction wrapper allowing multiple namespace views.
+pub struct SharedTxn {
+    txn: RwLock<Box<dyn Txn>>,
+}
+
+impl SharedTxn {
+    /// Create a new shared transaction.
+    pub fn new(txn: Box<dyn Txn>) -> Arc<Self> {
+        Arc::new(Self {
+            txn: RwLock::new(txn),
+        })
+    }
+
+    /// Get a value with namespace prefix.
+    pub async fn get(&self, namespace: Namespace, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        let prefixed = prefix_key(namespace, key);
+        let txn = self.txn.read().await;
+        txn.get(&prefixed).await
+    }
+
+    /// Check if a key exists with namespace prefix.
+    pub async fn has(&self, namespace: Namespace, key: &[u8]) -> Result<bool> {
+        let prefixed = prefix_key(namespace, key);
+        let txn = self.txn.read().await;
+        txn.has(&prefixed).await
+    }
+
+    /// Get value size with namespace prefix.
+    pub async fn get_size(&self, namespace: Namespace, key: &[u8]) -> Result<Option<usize>> {
+        let prefixed = prefix_key(namespace, key);
+        let txn = self.txn.read().await;
+        txn.get_size(&prefixed).await
+    }
+
+    /// Set a value with namespace prefix.
+    pub async fn set(&self, namespace: Namespace, key: &[u8], value: &[u8]) -> Result<()> {
+        let prefixed = prefix_key(namespace, key);
+        let mut txn = self.txn.write().await;
+        txn.set(&prefixed, value).await
+    }
+
+    /// Delete a key with namespace prefix.
+    pub async fn delete(&self, namespace: Namespace, key: &[u8]) -> Result<()> {
+        let prefixed = prefix_key(namespace, key);
+        let mut txn = self.txn.write().await;
+        txn.delete(&prefixed).await
+    }
+
+    /// Create an iterator with namespace prefix.
+    pub async fn iterator(
+        &self,
+        namespace: Namespace,
+        opts: IterOptions,
+    ) -> Result<Box<dyn Iterator>> {
+        let prefixed_opts = prefix_iter_options(namespace, opts);
+        let txn = self.txn.read().await;
+        let iter = txn.iterator(prefixed_opts).await?;
+        Ok(Box::new(NamespacedIterator { iter, namespace }))
+    }
+
+    /// Get from rootstore (no namespace prefix).
+    pub async fn root_get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        let txn = self.txn.read().await;
+        txn.get(key).await
+    }
+
+    /// Set in rootstore (no namespace prefix).
+    pub async fn root_set(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        let mut txn = self.txn.write().await;
+        txn.set(key, value).await
+    }
+
+    /// Delete from rootstore (no namespace prefix).
+    pub async fn root_delete(&self, key: &[u8]) -> Result<()> {
+        let mut txn = self.txn.write().await;
+        txn.delete(key).await
+    }
+
+    /// Check if readonly.
+    pub async fn is_readonly(&self) -> bool {
+        let txn = self.txn.read().await;
+        txn.is_readonly()
+    }
+
+    /// Consume self and return the underlying transaction.
+    ///
+    /// This takes ownership of the inner RwLock and extracts the transaction.
+    pub fn into_txn(self) -> Box<dyn Txn> {
+        self.txn.into_inner()
+    }
+}
+
+/// A view into a specific namespace of a shared transaction.
+pub struct NamespaceView {
+    txn: Arc<SharedTxn>,
+    namespace: Namespace,
+}
+
+impl NamespaceView {
+    /// Create a new namespace view.
+    pub fn new(txn: Arc<SharedTxn>, namespace: Namespace) -> Self {
+        Self { txn, namespace }
+    }
+
+    /// Get a value.
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.txn.get(self.namespace, key).await
+    }
+
+    /// Check if a key exists.
+    pub async fn has(&self, key: &[u8]) -> Result<bool> {
+        self.txn.has(self.namespace, key).await
+    }
+
+    /// Get value size.
+    pub async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {
+        self.txn.get_size(self.namespace, key).await
+    }
+
+    /// Set a value.
+    pub async fn set(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.txn.set(self.namespace, key, value).await
+    }
+
+    /// Delete a key.
+    pub async fn delete(&self, key: &[u8]) -> Result<()> {
+        self.txn.delete(self.namespace, key).await
+    }
+
+    /// Create an iterator.
+    pub async fn iterator(&self, opts: IterOptions) -> Result<Box<dyn Iterator>> {
+        self.txn.iterator(self.namespace, opts).await
+    }
+}
+
+/// A view into the rootstore (no namespace prefix).
+pub struct RootView {
+    txn: Arc<SharedTxn>,
+}
+
+impl RootView {
+    /// Create a new root view.
+    pub fn new(txn: Arc<SharedTxn>) -> Self {
+        Self { txn }
+    }
+
+    /// Get a value.
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.txn.root_get(key).await
+    }
+
+    /// Set a value.
+    pub async fn set(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.txn.root_set(key, value).await
+    }
+
+    /// Delete a key.
+    pub async fn delete(&self, key: &[u8]) -> Result<()> {
+        self.txn.root_delete(key).await
+    }
+}
+
+/// Helper to prefix a key with namespace.
+fn prefix_key(namespace: Namespace, key: &[u8]) -> Vec<u8> {
+    let mut prefixed = Vec::with_capacity(1 + key.len());
+    prefixed.push(namespace.prefix());
+    prefixed.extend_from_slice(key);
+    prefixed
+}
+
+/// Helper to unprefix a key.
+fn unprefix_key(namespace: Namespace, key: &[u8]) -> Result<Vec<u8>> {
+    if key.is_empty() {
+        return Err(Error::EmptyKey);
+    }
+    if key[0] != namespace.prefix() {
+        return Err(Error::Other(format!(
+            "Key has wrong prefix: expected {}, got {}",
+            namespace.prefix() as char,
+            key[0] as char
+        )));
+    }
+    Ok(key[1..].to_vec())
+}
+
+/// Helper to prefix iterator options.
+fn prefix_iter_options(namespace: Namespace, opts: IterOptions) -> IterOptions {
+    let mut prefixed_opts = IterOptions::new();
+
+    if let Some(prefix) = opts.prefix() {
+        prefixed_opts = prefixed_opts.with_prefix(prefix_key(namespace, prefix));
+    } else if opts.start().is_none() && opts.end().is_none() {
+        prefixed_opts = prefixed_opts.with_prefix(vec![namespace.prefix()]);
+    }
+
+    if let Some(start) = opts.start() {
+        prefixed_opts = prefixed_opts.with_start(prefix_key(namespace, start));
+    }
+    if let Some(end) = opts.end() {
+        prefixed_opts = prefixed_opts.with_end(prefix_key(namespace, end));
+    }
+    prefixed_opts = prefixed_opts
+        .with_reverse(opts.reverse())
+        .with_keys_only(opts.keys_only());
+
+    prefixed_opts
+}
+
+/// Iterator that strips namespace prefix from keys.
+struct NamespacedIterator {
+    iter: Box<dyn Iterator>,
+    namespace: Namespace,
+}
+
+#[async_trait]
+impl Iterator for NamespacedIterator {
+    async fn next(&mut self) -> Result<Option<storage::corekv::KvPair>> {
+        match self.iter.next().await? {
+            Some(pair) => {
+                let unprefixed_key = unprefix_key(self.namespace, &pair.key)?;
+                Ok(Some(storage::corekv::KvPair {
+                    key: unprefixed_key,
+                    value: pair.value,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.iter.close().await
+    }
+
+    async fn seek(&mut self, key: &[u8]) -> Result<bool> {
+        let prefixed_key = prefix_key(self.namespace, key);
+        self.iter.seek(&prefixed_key).await
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        self.iter.reset().await
+    }
+
+    fn is_valid(&self) -> bool {
+        self.iter.is_valid()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use storage::backends::MemoryStore;
+    use storage::corekv::Store;
+
+    #[tokio::test]
+    async fn test_shared_txn_namespace_isolation() {
+        let store = MemoryStore::new();
+        let txn = store.new_txn(false).await.unwrap();
+        let shared = SharedTxn::new(txn);
+
+        // Write to datastore namespace
+        shared
+            .set(Namespace::Datastore, b"key", b"datastore_value")
+            .await
+            .unwrap();
+
+        // Write to systemstore namespace
+        shared
+            .set(Namespace::Systemstore, b"key", b"systemstore_value")
+            .await
+            .unwrap();
+
+        // Read back - each should see its own value
+        assert_eq!(
+            shared.get(Namespace::Datastore, b"key").await.unwrap(),
+            Some(b"datastore_value".to_vec())
+        );
+        assert_eq!(
+            shared.get(Namespace::Systemstore, b"key").await.unwrap(),
+            Some(b"systemstore_value".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_namespace_view() {
+        let store = MemoryStore::new();
+        let txn = store.new_txn(false).await.unwrap();
+        let shared = SharedTxn::new(txn);
+
+        let ds = NamespaceView::new(shared.clone(), Namespace::Datastore);
+        let ss = NamespaceView::new(shared.clone(), Namespace::Systemstore);
+
+        // Write through views
+        ds.set(b"key", b"datastore_value").await.unwrap();
+        ss.set(b"key", b"systemstore_value").await.unwrap();
+
+        // Read back
+        assert_eq!(
+            ds.get(b"key").await.unwrap(),
+            Some(b"datastore_value".to_vec())
+        );
+        assert_eq!(
+            ss.get(b"key").await.unwrap(),
+            Some(b"systemstore_value".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_root_view_sees_prefixed() {
+        let store = MemoryStore::new();
+        let txn = store.new_txn(false).await.unwrap();
+        let shared = SharedTxn::new(txn);
+
+        let ds = NamespaceView::new(shared.clone(), Namespace::Datastore);
+        let root = RootView::new(shared.clone());
+
+        // Write through datastore view
+        ds.set(b"mykey", b"value").await.unwrap();
+
+        // Root should see it with 'd' prefix
+        let value = root.get(b"dmykey").await.unwrap();
+        assert_eq!(value, Some(b"value".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_namespace_iterator() {
+        let store = MemoryStore::new();
+        let txn = store.new_txn(false).await.unwrap();
+        let shared = SharedTxn::new(txn);
+
+        let ds = NamespaceView::new(shared.clone(), Namespace::Datastore);
+
+        // Write multiple keys
+        ds.set(b"key1", b"value1").await.unwrap();
+        ds.set(b"key2", b"value2").await.unwrap();
+        ds.set(b"key3", b"value3").await.unwrap();
+
+        // Iterate
+        let mut iter = ds.iterator(IterOptions::new()).await.unwrap();
+        let mut count = 0;
+        while let Some(pair) = iter.next().await.unwrap() {
+            assert!(pair.key.starts_with(b"key"));
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
+}

--- a/crates/datastore/src/multistore.rs
+++ b/crates/datastore/src/multistore.rs
@@ -9,14 +9,6 @@ use storage::corekv::{Error, IterOptions, Iterator, Result, Txn};
 use storage::namespace::Namespace;
 use tokio::sync::RwLock;
 
-/// Store namespace prefixes matching Go DefraDB's internal/datastore/multi.go
-pub const SYSTEM_STORE_PREFIX: u8 = b's';
-pub const DATA_STORE_PREFIX: u8 = b'd';
-pub const HEAD_STORE_PREFIX: u8 = b'h';
-pub const BLOCK_STORE_PREFIX: u8 = b'b';
-pub const PEER_STORE_PREFIX: u8 = b'p';
-pub const ENC_STORE_PREFIX: u8 = b'e';
-
 /// Shared transaction wrapper allowing multiple namespace views.
 pub struct SharedTxn {
     txn: RwLock<Box<dyn Txn>>,
@@ -194,9 +186,10 @@ fn unprefix_key(namespace: Namespace, key: &[u8]) -> Result<Vec<u8>> {
     }
     if key[0] != namespace.prefix() {
         return Err(Error::Other(format!(
-            "Key has wrong prefix: expected {}, got {}",
+            "Key has wrong prefix: expected {:?} (0x{:02x}), got 0x{:02x}",
             namespace.prefix() as char,
-            key[0] as char
+            namespace.prefix(),
+            key[0]
         )));
     }
     Ok(key[1..].to_vec())

--- a/crates/datastore/src/traits.rs
+++ b/crates/datastore/src/traits.rs
@@ -1,0 +1,68 @@
+/// Traits for the datastore layer matching Go's internal/datastore/txn.go.
+use crate::multistore::{NamespaceView, RootView};
+use async_trait::async_trait;
+use storage::corekv::TxnCallback;
+
+/// Transaction trait for DefraDB operations.
+///
+/// This matches Go's Txn interface in internal/datastore/txn.go.
+/// It provides access to all namespaced stores and transaction lifecycle methods.
+#[async_trait]
+pub trait Txn: Send + Sync {
+    /// Get the blockstore (namespace 'b').
+    fn blockstore(&self) -> NamespaceView;
+
+    /// Get the datastore (namespace 'd').
+    fn datastore(&self) -> NamespaceView;
+
+    /// Get the encstore (namespace 'e').
+    fn encstore(&self) -> NamespaceView;
+
+    /// Get the headstore (namespace 'h').
+    fn headstore(&self) -> NamespaceView;
+
+    /// Get the peerstore (namespace 'p').
+    fn peerstore(&self) -> NamespaceView;
+
+    /// Get the systemstore (namespace 's').
+    fn systemstore(&self) -> NamespaceView;
+
+    /// Get the rootstore (no namespace prefix).
+    fn rootstore(&self) -> RootView;
+
+    /// Get the unique transaction ID.
+    fn id(&self) -> u64;
+
+    /// Check if this is a read-only transaction.
+    fn is_readonly(&self) -> bool;
+
+    /// Register a callback to be called on successful commit.
+    fn on_success(&mut self, callback: TxnCallback);
+
+    /// Register a callback to be called on commit error.
+    fn on_error(&mut self, callback: TxnCallback);
+
+    /// Register a callback to be called on discard.
+    fn on_discard(&mut self, callback: TxnCallback);
+}
+
+/// Blockstore trait for block operations.
+///
+/// This matches Go's Blockstore interface in internal/datastore/blockstore.go.
+#[async_trait]
+pub trait Blockstore: Send + Sync {
+    /// Get a block by CID.
+    async fn get(&self, cid: &cid::Cid) -> crate::error::Result<Option<Vec<u8>>>;
+
+    /// Store a block.
+    async fn put(&self, cid: &cid::Cid, data: &[u8]) -> crate::error::Result<()>;
+
+    /// Check if a block exists.
+    async fn has(&self, cid: &cid::Cid) -> crate::error::Result<bool>;
+
+    /// Delete a block.
+    async fn delete(&self, cid: &cid::Cid) -> crate::error::Result<()>;
+
+    /// Get block size without reading the data.
+    async fn get_size(&self, cid: &cid::Cid) -> crate::error::Result<Option<usize>>;
+}

--- a/crates/datastore/src/traits.rs
+++ b/crates/datastore/src/traits.rs
@@ -1,13 +1,11 @@
 /// Traits for the datastore layer matching Go's internal/datastore/txn.go.
 use crate::multistore::{NamespaceView, RootView};
-use async_trait::async_trait;
 use storage::corekv::TxnCallback;
 
 /// Transaction trait for DefraDB operations.
 ///
 /// This matches Go's Txn interface in internal/datastore/txn.go.
 /// It provides access to all namespaced stores and transaction lifecycle methods.
-#[async_trait]
 pub trait Txn: Send + Sync {
     /// Get the blockstore (namespace 'b').
     fn blockstore(&self) -> NamespaceView;
@@ -44,25 +42,4 @@ pub trait Txn: Send + Sync {
 
     /// Register a callback to be called on discard.
     fn on_discard(&mut self, callback: TxnCallback);
-}
-
-/// Blockstore trait for block operations.
-///
-/// This matches Go's Blockstore interface in internal/datastore/blockstore.go.
-#[async_trait]
-pub trait Blockstore: Send + Sync {
-    /// Get a block by CID.
-    async fn get(&self, cid: &cid::Cid) -> crate::error::Result<Option<Vec<u8>>>;
-
-    /// Store a block.
-    async fn put(&self, cid: &cid::Cid, data: &[u8]) -> crate::error::Result<()>;
-
-    /// Check if a block exists.
-    async fn has(&self, cid: &cid::Cid) -> crate::error::Result<bool>;
-
-    /// Delete a block.
-    async fn delete(&self, cid: &cid::Cid) -> crate::error::Result<()>;
-
-    /// Get block size without reading the data.
-    async fn get_size(&self, cid: &cid::Cid) -> crate::error::Result<Option<usize>>;
 }

--- a/crates/datastore/src/txn.rs
+++ b/crates/datastore/src/txn.rs
@@ -512,4 +512,80 @@ mod tests {
             Some(b"sys".to_vec())
         );
     }
+
+    #[tokio::test]
+    async fn test_basic_txn_commit_with_outstanding_view_fails() {
+        let store = MemoryStore::new();
+        let txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        // Hold a reference to a namespace view
+        let _view = txn.datastore();
+
+        // Commit should fail because there are outstanding references
+        let result = txn.commit().await;
+        assert!(result.is_err());
+        // The error message should mention references
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("references"));
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_discard_with_outstanding_view_fails() {
+        let store = MemoryStore::new();
+        let txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        // Hold a reference to a namespace view
+        let _view = txn.datastore();
+
+        // Discard should fail because there are outstanding references
+        let result = txn.discard();
+        assert!(result.is_err());
+        assert!(matches!(result, Err(crate::Error::TxnStillInUse)));
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_async_success_callback() {
+        use std::time::Duration;
+
+        let store = MemoryStore::new();
+        let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        txn.on_success_async(Box::new(move || {
+            Box::pin(async move {
+                tx.send(()).unwrap();
+            })
+        }));
+
+        txn.commit().await.unwrap();
+
+        // Wait for async callback to complete
+        tokio::time::timeout(Duration::from_secs(1), rx)
+            .await
+            .expect("Timeout waiting for async callback")
+            .expect("Failed to receive from callback");
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_async_discard_callback() {
+        use std::time::Duration;
+
+        let store = MemoryStore::new();
+        let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        txn.on_discard_async(Box::new(move || {
+            Box::pin(async move {
+                tx.send(()).unwrap();
+            })
+        }));
+
+        txn.discard().unwrap();
+
+        // Wait for async callback to complete
+        tokio::time::timeout(Duration::from_secs(1), rx)
+            .await
+            .expect("Timeout waiting for async callback")
+            .expect("Failed to receive from callback");
+    }
 }

--- a/crates/datastore/src/txn.rs
+++ b/crates/datastore/src/txn.rs
@@ -6,6 +6,7 @@
 /// - Lifecycle callbacks (on_success, on_error, on_discard)
 use crate::error::{Error, Result};
 use crate::multistore::{NamespaceView, RootView, SharedTxn};
+use futures::FutureExt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -178,9 +179,21 @@ impl BasicTxn {
             (self.error_fns, self.error_async_fns)
         };
 
-        // Execute async callbacks concurrently
+        // Execute async callbacks concurrently, logging any failures
         for callback in async_fns {
-            tokio::spawn(callback());
+            let txn_id = self.id;
+            tokio::spawn(async move {
+                let result = std::panic::AssertUnwindSafe(callback())
+                    .catch_unwind()
+                    .await;
+                if let Err(e) = result {
+                    tracing::error!(
+                        txn_id = txn_id,
+                        error = ?e,
+                        "Transaction async callback panicked"
+                    );
+                }
+            });
         }
 
         // Execute sync callbacks
@@ -212,9 +225,21 @@ impl BasicTxn {
 
         self.state = TxnState::Discarded;
 
-        // Execute async callbacks concurrently
+        // Execute async callbacks concurrently, logging any failures
+        let txn_id = self.id;
         for callback in self.discard_async_fns {
-            tokio::spawn(callback());
+            tokio::spawn(async move {
+                let result = std::panic::AssertUnwindSafe(callback())
+                    .catch_unwind()
+                    .await;
+                if let Err(e) = result {
+                    tracing::error!(
+                        txn_id = txn_id,
+                        error = ?e,
+                        "Transaction discard async callback panicked"
+                    );
+                }
+            });
         }
 
         // Execute sync callbacks

--- a/crates/datastore/src/txn.rs
+++ b/crates/datastore/src/txn.rs
@@ -193,17 +193,22 @@ impl BasicTxn {
 
     /// Discard the transaction.
     ///
-    /// All on_discard callbacks are executed.
-    pub fn discard(mut self) {
+    /// All on_discard callbacks are executed on success.
+    /// Returns an error if the transaction is not active or still has references.
+    pub fn discard(mut self) -> Result<()> {
         if self.state != TxnState::Active {
-            return;
+            return Err(match self.state {
+                TxnState::Committed => Error::TxnAlreadyCommitted,
+                TxnState::Discarded => Error::TxnAlreadyDiscarded,
+                TxnState::Active => unreachable!(),
+            });
         }
 
-        // Try to extract and discard the underlying transaction
-        if let Ok(shared) = Arc::try_unwrap(self.shared_txn) {
-            let txn = shared.into_txn();
-            txn.discard();
-        }
+        // Extract and discard the underlying transaction
+        let shared = Arc::try_unwrap(self.shared_txn).map_err(|_| Error::TxnStillInUse)?;
+
+        let txn = shared.into_txn();
+        txn.discard();
 
         self.state = TxnState::Discarded;
 
@@ -216,6 +221,8 @@ impl BasicTxn {
         for callback in self.discard_fns {
             callback();
         }
+
+        Ok(())
     }
 }
 
@@ -328,7 +335,7 @@ mod tests {
         txn.datastore().set(b"key", b"value").await.unwrap();
 
         // Discard
-        txn.discard();
+        txn.discard().unwrap();
 
         assert!(called.load(Ordering::SeqCst));
 
@@ -350,5 +357,134 @@ mod tests {
         assert_eq!(value, Some(b"value".to_vec()));
 
         txn.commit().await.unwrap();
+    }
+
+    // Error callback tests
+
+    #[tokio::test]
+    async fn test_basic_txn_error_callback_not_called_on_success() {
+        let store = MemoryStore::new();
+        let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        let error_called = Arc::new(AtomicBool::new(false));
+        let error_called_clone = error_called.clone();
+        txn.on_error(Box::new(move || {
+            error_called_clone.store(true, Ordering::SeqCst);
+        }));
+
+        let success_called = Arc::new(AtomicBool::new(false));
+        let success_called_clone = success_called.clone();
+        txn.on_success(Box::new(move || {
+            success_called_clone.store(true, Ordering::SeqCst);
+        }));
+
+        txn.commit().await.unwrap();
+
+        // Success should be called, error should not
+        assert!(success_called.load(Ordering::SeqCst));
+        assert!(!error_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_discard_callback_not_called_on_commit() {
+        let store = MemoryStore::new();
+        let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        let discard_called = Arc::new(AtomicBool::new(false));
+        let discard_called_clone = discard_called.clone();
+        txn.on_discard(Box::new(move || {
+            discard_called_clone.store(true, Ordering::SeqCst);
+        }));
+
+        txn.commit().await.unwrap();
+
+        // Discard callback should not be called on commit
+        assert!(!discard_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_success_callback_not_called_on_discard() {
+        let store = MemoryStore::new();
+        let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        let success_called = Arc::new(AtomicBool::new(false));
+        let success_called_clone = success_called.clone();
+        txn.on_success(Box::new(move || {
+            success_called_clone.store(true, Ordering::SeqCst);
+        }));
+
+        txn.discard().unwrap();
+
+        // Success callback should not be called on discard
+        assert!(!success_called.load(Ordering::SeqCst));
+    }
+
+    // Transaction state transition tests
+
+    #[tokio::test]
+    async fn test_basic_txn_double_commit_returns_error() {
+        let store = MemoryStore::new();
+        let txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        // First commit succeeds
+        txn.commit().await.unwrap();
+
+        // Cannot commit twice - txn is consumed after first commit
+        // This is enforced by Rust's ownership system
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_discard_already_discarded_returns_error() {
+        let store = MemoryStore::new();
+        let txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        // First discard succeeds
+        txn.discard().unwrap();
+
+        // Cannot discard twice - txn is consumed after first discard
+        // This is enforced by Rust's ownership system
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_all_stores_accessible() {
+        let store = MemoryStore::new();
+        let txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        // All stores should be accessible and work
+        txn.datastore().set(b"d", b"data").await.unwrap();
+        txn.blockstore().set(b"b", b"block").await.unwrap();
+        txn.encstore().set(b"e", b"enc").await.unwrap();
+        txn.headstore().set(b"h", b"head").await.unwrap();
+        txn.peerstore().set(b"p", b"peer").await.unwrap();
+        txn.systemstore().set(b"s", b"sys").await.unwrap();
+
+        txn.commit().await.unwrap();
+
+        // Verify all stores persisted
+        let txn = BasicTxn::new(&store, 2, true).await.unwrap();
+        assert_eq!(
+            txn.datastore().get(b"d").await.unwrap(),
+            Some(b"data".to_vec())
+        );
+        assert_eq!(
+            txn.blockstore().get(b"b").await.unwrap(),
+            Some(b"block".to_vec())
+        );
+        assert_eq!(
+            txn.encstore().get(b"e").await.unwrap(),
+            Some(b"enc".to_vec())
+        );
+        assert_eq!(
+            txn.headstore().get(b"h").await.unwrap(),
+            Some(b"head".to_vec())
+        );
+        assert_eq!(
+            txn.peerstore().get(b"p").await.unwrap(),
+            Some(b"peer".to_vec())
+        );
+        assert_eq!(
+            txn.systemstore().get(b"s").await.unwrap(),
+            Some(b"sys".to_vec())
+        );
     }
 }

--- a/crates/datastore/src/txn.rs
+++ b/crates/datastore/src/txn.rs
@@ -1,0 +1,354 @@
+/// Transaction wrapper for DefraDB matching Go's internal/datastore/txn.go.
+///
+/// BasicTxn wraps a corekv transaction and provides:
+/// - Multistore access via namespace views
+/// - Transaction ID
+/// - Lifecycle callbacks (on_success, on_error, on_discard)
+use crate::error::{Error, Result};
+use crate::multistore::{NamespaceView, RootView, SharedTxn};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use storage::corekv::{Store, Txn, TxnCallback};
+use storage::namespace::Namespace;
+
+/// Asynchronous callback for transaction events.
+pub type AsyncCallback = Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
+
+/// Transaction state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TxnState {
+    Active,
+    Committed,
+    Discarded,
+}
+
+/// BasicTxn wraps a corekv transaction with DefraDB-specific functionality.
+///
+/// This matches Go's BasicTxn in internal/datastore/txn.go, providing:
+/// - Access to all namespaced stores (datastore, blockstore, etc.)
+/// - Transaction ID for tracking
+/// - Lifecycle callbacks
+pub struct BasicTxn {
+    shared_txn: Arc<SharedTxn>,
+    id: u64,
+    readonly: bool,
+    state: TxnState,
+
+    success_fns: Vec<TxnCallback>,
+    error_fns: Vec<TxnCallback>,
+    discard_fns: Vec<TxnCallback>,
+
+    success_async_fns: Vec<AsyncCallback>,
+    error_async_fns: Vec<AsyncCallback>,
+    discard_async_fns: Vec<AsyncCallback>,
+}
+
+impl BasicTxn {
+    /// Create a new BasicTxn from a store.
+    pub async fn new<S: Store>(
+        store: &S,
+        id: u64,
+        readonly: bool,
+    ) -> storage::corekv::Result<Self> {
+        let txn = store.new_txn(readonly).await?;
+        Ok(Self::from_txn(txn, id, readonly))
+    }
+
+    /// Create a BasicTxn from an existing corekv transaction.
+    pub fn from_txn(txn: Box<dyn Txn>, id: u64, readonly: bool) -> Self {
+        Self {
+            shared_txn: SharedTxn::new(txn),
+            id,
+            readonly,
+            state: TxnState::Active,
+            success_fns: Vec::new(),
+            error_fns: Vec::new(),
+            discard_fns: Vec::new(),
+            success_async_fns: Vec::new(),
+            error_async_fns: Vec::new(),
+            discard_async_fns: Vec::new(),
+        }
+    }
+
+    /// Get the transaction ID.
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Check if this is a read-only transaction.
+    pub fn is_readonly(&self) -> bool {
+        self.readonly
+    }
+
+    /// Get the blockstore (namespace 'b').
+    pub fn blockstore(&self) -> NamespaceView {
+        NamespaceView::new(self.shared_txn.clone(), Namespace::Blockstore)
+    }
+
+    /// Get the datastore (namespace 'd').
+    pub fn datastore(&self) -> NamespaceView {
+        NamespaceView::new(self.shared_txn.clone(), Namespace::Datastore)
+    }
+
+    /// Get the encstore (namespace 'e').
+    pub fn encstore(&self) -> NamespaceView {
+        NamespaceView::new(self.shared_txn.clone(), Namespace::Encstore)
+    }
+
+    /// Get the headstore (namespace 'h').
+    pub fn headstore(&self) -> NamespaceView {
+        NamespaceView::new(self.shared_txn.clone(), Namespace::Headstore)
+    }
+
+    /// Get the peerstore (namespace 'p').
+    pub fn peerstore(&self) -> NamespaceView {
+        NamespaceView::new(self.shared_txn.clone(), Namespace::Peerstore)
+    }
+
+    /// Get the systemstore (namespace 's').
+    pub fn systemstore(&self) -> NamespaceView {
+        NamespaceView::new(self.shared_txn.clone(), Namespace::Systemstore)
+    }
+
+    /// Get the rootstore (no namespace prefix).
+    pub fn rootstore(&self) -> RootView {
+        RootView::new(self.shared_txn.clone())
+    }
+
+    /// Register a callback to be called on successful commit.
+    pub fn on_success(&mut self, callback: TxnCallback) {
+        self.success_fns.push(callback);
+    }
+
+    /// Register a callback to be called on commit error.
+    pub fn on_error(&mut self, callback: TxnCallback) {
+        self.error_fns.push(callback);
+    }
+
+    /// Register a callback to be called on discard.
+    pub fn on_discard(&mut self, callback: TxnCallback) {
+        self.discard_fns.push(callback);
+    }
+
+    /// Register an async callback to be called on successful commit.
+    pub fn on_success_async(&mut self, callback: AsyncCallback) {
+        self.success_async_fns.push(callback);
+    }
+
+    /// Register an async callback to be called on commit error.
+    pub fn on_error_async(&mut self, callback: AsyncCallback) {
+        self.error_async_fns.push(callback);
+    }
+
+    /// Register an async callback to be called on discard.
+    pub fn on_discard_async(&mut self, callback: AsyncCallback) {
+        self.discard_async_fns.push(callback);
+    }
+
+    /// Commit the transaction.
+    ///
+    /// On success, all on_success callbacks are executed.
+    /// On error, all on_error callbacks are executed.
+    pub async fn commit(mut self) -> Result<()> {
+        if self.state != TxnState::Active {
+            return Err(match self.state {
+                TxnState::Committed => Error::TxnAlreadyCommitted,
+                TxnState::Discarded => Error::TxnAlreadyDiscarded,
+                TxnState::Active => unreachable!(),
+            });
+        }
+
+        // Extract the underlying transaction
+        // The SharedTxn holds it in an Arc<RwLock<Box<dyn Txn>>>
+        // We need to get ownership to call commit
+        let shared = Arc::try_unwrap(self.shared_txn).map_err(|_| {
+            Error::Storage(storage::corekv::Error::Other(
+                "Cannot commit: transaction still has references".into(),
+            ))
+        })?;
+
+        let txn = shared.into_txn();
+        let result = txn.commit().await;
+
+        let (sync_fns, async_fns) = if result.is_ok() {
+            self.state = TxnState::Committed;
+            (self.success_fns, self.success_async_fns)
+        } else {
+            (self.error_fns, self.error_async_fns)
+        };
+
+        // Execute async callbacks concurrently
+        for callback in async_fns {
+            tokio::spawn(callback());
+        }
+
+        // Execute sync callbacks
+        for callback in sync_fns {
+            callback();
+        }
+
+        result.map_err(Error::Storage)
+    }
+
+    /// Discard the transaction.
+    ///
+    /// All on_discard callbacks are executed.
+    pub fn discard(mut self) {
+        if self.state != TxnState::Active {
+            return;
+        }
+
+        // Try to extract and discard the underlying transaction
+        if let Ok(shared) = Arc::try_unwrap(self.shared_txn) {
+            let txn = shared.into_txn();
+            txn.discard();
+        }
+
+        self.state = TxnState::Discarded;
+
+        // Execute async callbacks concurrently
+        for callback in self.discard_async_fns {
+            tokio::spawn(callback());
+        }
+
+        // Execute sync callbacks
+        for callback in self.discard_fns {
+            callback();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use storage::backends::MemoryStore;
+
+    #[tokio::test]
+    async fn test_basic_txn_id() {
+        let store = MemoryStore::new();
+        let txn = BasicTxn::new(&store, 42, false).await.unwrap();
+        assert_eq!(txn.id(), 42);
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_readonly() {
+        let store = MemoryStore::new();
+
+        let txn = BasicTxn::new(&store, 1, true).await.unwrap();
+        assert!(txn.is_readonly());
+
+        let txn = BasicTxn::new(&store, 2, false).await.unwrap();
+        assert!(!txn.is_readonly());
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_multistore_access() {
+        let store = MemoryStore::new();
+        let txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        // Write to different stores
+        txn.datastore()
+            .set(b"key", b"datastore_value")
+            .await
+            .unwrap();
+        txn.systemstore()
+            .set(b"key", b"systemstore_value")
+            .await
+            .unwrap();
+
+        // Read back
+        assert_eq!(
+            txn.datastore().get(b"key").await.unwrap(),
+            Some(b"datastore_value".to_vec())
+        );
+        assert_eq!(
+            txn.systemstore().get(b"key").await.unwrap(),
+            Some(b"systemstore_value".to_vec())
+        );
+
+        // Commit
+        txn.commit().await.unwrap();
+
+        // Verify data persisted
+        let txn = BasicTxn::new(&store, 2, true).await.unwrap();
+        assert_eq!(
+            txn.datastore().get(b"key").await.unwrap(),
+            Some(b"datastore_value".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_on_success_callback() {
+        let store = MemoryStore::new();
+        let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+        txn.on_success(Box::new(move || {
+            called_clone.store(true, Ordering::SeqCst);
+        }));
+
+        txn.commit().await.unwrap();
+
+        assert!(called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_multiple_callbacks() {
+        let store = MemoryStore::new();
+        let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        let counter = Arc::new(AtomicU32::new(0));
+        for _ in 0..3 {
+            let counter_clone = counter.clone();
+            txn.on_success(Box::new(move || {
+                counter_clone.fetch_add(1, Ordering::SeqCst);
+            }));
+        }
+
+        txn.commit().await.unwrap();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_discard_callback() {
+        let store = MemoryStore::new();
+        let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+        txn.on_discard(Box::new(move || {
+            called_clone.store(true, Ordering::SeqCst);
+        }));
+
+        // Write some data
+        txn.datastore().set(b"key", b"value").await.unwrap();
+
+        // Discard
+        txn.discard();
+
+        assert!(called.load(Ordering::SeqCst));
+
+        // Verify data was not persisted
+        let txn = BasicTxn::new(&store, 2, true).await.unwrap();
+        assert_eq!(txn.datastore().get(b"key").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_basic_txn_rootstore_access() {
+        let store = MemoryStore::new();
+        let txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+        // Write through datastore
+        txn.datastore().set(b"mykey", b"value").await.unwrap();
+
+        // Read through rootstore with prefix
+        let value = txn.rootstore().get(b"dmykey").await.unwrap();
+        assert_eq!(value, Some(b"value".to_vec()));
+
+        txn.commit().await.unwrap();
+    }
+}

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -22,6 +22,9 @@ serde_cbor.workspace = true
 # Error handling
 thiserror.workspace = true
 
+# Logging
+tracing.workspace = true
+
 # IPLD
 cid.workspace = true
 

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "db"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "DefraDB database and collection management"
+
+[dependencies]
+# Async runtime
+async-trait.workspace = true
+tokio = { workspace = true, features = ["sync"] }
+futures.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+serde_cbor.workspace = true
+
+# Error handling
+thiserror.workspace = true
+
+# IPLD
+cid.workspace = true
+
+# Internal crates
+storage = { path = "../storage" }
+datastore = { path = "../datastore" }
+schema = { path = "../schema" }
+document = { path = "../document" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/db/src/collection.rs
+++ b/crates/db/src/collection.rs
@@ -1,0 +1,363 @@
+/// Collection struct for DefraDB matching Go's internal/db/collection.go.
+///
+/// A Collection represents a set of documents that share the same schema.
+/// It provides CRUD operations for documents.
+use crate::error::{Error, Result};
+use crate::txn::DbTxn;
+use document::{DocID, Document};
+use schema::CollectionVersion;
+use storage::corekv::{IterOptions, Store};
+
+/// Key prefix for document data in datastore.
+const DOC_KEY_PREFIX: &[u8] = b"/d/";
+
+/// A collection of documents with a shared schema.
+pub struct Collection {
+    /// The collection schema definition.
+    def: CollectionVersion,
+}
+
+impl Collection {
+    /// Create a new collection with the given schema definition.
+    pub fn new(def: CollectionVersion) -> Self {
+        Self { def }
+    }
+
+    /// Get the collection name.
+    pub fn name(&self) -> &str {
+        &self.def.name
+    }
+
+    /// Get the collection ID.
+    pub fn collection_id(&self) -> &str {
+        &self.def.collection_id
+    }
+
+    /// Get the collection schema.
+    pub fn schema(&self) -> &CollectionVersion {
+        &self.def
+    }
+
+    /// Create a new document in this collection.
+    pub async fn create<S: Store>(&self, txn: &DbTxn<S>, doc: &Document) -> Result<DocID> {
+        // Generate document ID if not present
+        let doc_id = doc
+            .id()
+            .cloned()
+            .ok_or_else(|| Error::InvalidDocument("Document must have an ID".into()))?;
+
+        // Check if document already exists
+        let key = self.doc_key(&doc_id);
+        if txn
+            .datastore()
+            .has(&key)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::InvalidDocument(format!(
+                "Document with ID {} already exists",
+                doc_id
+            )));
+        }
+
+        // Serialize document to CBOR
+        let data = doc
+            .to_cbor()
+            .map_err(|e| Error::Serialization(e.to_string()))?;
+
+        // Store document
+        txn.datastore()
+            .set(&key, &data)
+            .await
+            .map_err(Error::Storage)?;
+
+        Ok(doc_id)
+    }
+
+    /// Get a document by ID.
+    pub async fn get<S: Store>(&self, txn: &DbTxn<S>, doc_id: &DocID) -> Result<Option<Document>> {
+        let key = self.doc_key(doc_id);
+        let data = txn
+            .datastore()
+            .get(&key)
+            .await
+            .map_err(Error::Storage)?;
+
+        match data {
+            Some(bytes) => {
+                let doc =
+                    Document::from_cbor(&bytes).map_err(|e| Error::Serialization(e.to_string()))?;
+                Ok(Some(doc))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Update an existing document.
+    pub async fn update<S: Store>(&self, txn: &DbTxn<S>, doc: &Document) -> Result<()> {
+        let doc_id = doc
+            .id()
+            .ok_or_else(|| Error::InvalidDocument("Document must have an ID".into()))?;
+
+        let key = self.doc_key(doc_id);
+
+        // Check document exists
+        if !txn
+            .datastore()
+            .has(&key)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Err(Error::DocumentNotFound(doc_id.to_string()));
+        }
+
+        // Serialize and store
+        let data = doc
+            .to_cbor()
+            .map_err(|e| Error::Serialization(e.to_string()))?;
+
+        txn.datastore()
+            .set(&key, &data)
+            .await
+            .map_err(Error::Storage)?;
+
+        Ok(())
+    }
+
+    /// Delete a document by ID.
+    pub async fn delete<S: Store>(&self, txn: &DbTxn<S>, doc_id: &DocID) -> Result<bool> {
+        let key = self.doc_key(doc_id);
+
+        // Check if document exists
+        if !txn
+            .datastore()
+            .has(&key)
+            .await
+            .map_err(Error::Storage)?
+        {
+            return Ok(false);
+        }
+
+        txn.datastore()
+            .delete(&key)
+            .await
+            .map_err(Error::Storage)?;
+
+        Ok(true)
+    }
+
+    /// Check if a document exists.
+    pub async fn exists<S: Store>(&self, txn: &DbTxn<S>, doc_id: &DocID) -> Result<bool> {
+        let key = self.doc_key(doc_id);
+        txn.datastore()
+            .has(&key)
+            .await
+            .map_err(Error::Storage)
+    }
+
+    /// Save a document (create or update).
+    pub async fn save<S: Store>(&self, txn: &DbTxn<S>, doc: &Document) -> Result<DocID> {
+        let doc_id = doc
+            .id()
+            .cloned()
+            .ok_or_else(|| Error::InvalidDocument("Document must have an ID".into()))?;
+
+        let key = self.doc_key(&doc_id);
+
+        // Serialize and store (upsert)
+        let data = doc
+            .to_cbor()
+            .map_err(|e| Error::Serialization(e.to_string()))?;
+
+        txn.datastore()
+            .set(&key, &data)
+            .await
+            .map_err(Error::Storage)?;
+
+        Ok(doc_id)
+    }
+
+    /// Iterate over all documents in the collection.
+    pub async fn iterate<S: Store, F, Fut>(&self, txn: &DbTxn<S>, mut callback: F) -> Result<()>
+    where
+        F: FnMut(Document) -> Fut,
+        Fut: std::future::Future<Output = Result<bool>>,
+    {
+        let prefix = self.collection_key_prefix();
+        let opts = IterOptions::new().with_prefix(prefix);
+
+        let mut iter = txn
+            .datastore()
+            .iterator(opts)
+            .await
+            .map_err(Error::Storage)?;
+
+        while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
+            let doc = Document::from_cbor(&pair.value)
+                .map_err(|e| Error::Serialization(e.to_string()))?;
+
+            // Callback returns true to continue, false to stop
+            if !callback(doc).await? {
+                break;
+            }
+        }
+
+        iter.close().await.map_err(Error::Storage)?;
+        Ok(())
+    }
+
+    /// Get all documents in the collection.
+    pub async fn get_all<S: Store>(&self, txn: &DbTxn<S>) -> Result<Vec<Document>> {
+        let mut docs = Vec::new();
+
+        self.iterate(txn, |doc| {
+            docs.push(doc);
+            async { Ok(true) }
+        })
+        .await?;
+
+        Ok(docs)
+    }
+
+    /// Generate the storage key for a document.
+    fn doc_key(&self, doc_id: &DocID) -> Vec<u8> {
+        let mut key = Vec::new();
+        key.extend_from_slice(DOC_KEY_PREFIX);
+        key.extend_from_slice(self.def.collection_id.as_bytes());
+        key.push(b'/');
+        key.extend_from_slice(doc_id.to_string().as_bytes());
+        key
+    }
+
+    /// Generate the key prefix for iterating collection documents.
+    fn collection_key_prefix(&self) -> Vec<u8> {
+        let mut key = Vec::new();
+        key.extend_from_slice(DOC_KEY_PREFIX);
+        key.extend_from_slice(self.def.collection_id.as_bytes());
+        key.push(b'/');
+        key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::DB;
+    use document::NormalValue;
+    use schema::CollectionVersion;
+    use storage::backends::MemoryStore;
+
+    fn test_collection() -> Collection {
+        Collection::new(CollectionVersion::new("users", "v1", "col-1", vec![]))
+    }
+
+    #[tokio::test]
+    async fn test_collection_name() {
+        let col = test_collection();
+        assert_eq!(col.name(), "users");
+        assert_eq!(col.collection_id(), "col-1");
+    }
+
+    #[tokio::test]
+    async fn test_collection_create_get() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Create a document
+        let doc = Document::from_json_str(r#"{"name": "Alice", "age": 30}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+
+        col.create(&txn, &doc).await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Read it back
+        let txn = db.new_txn(true).await.unwrap();
+        let retrieved = col.get(&txn, &doc_id).await.unwrap();
+        assert!(retrieved.is_some());
+
+        let retrieved_doc = retrieved.unwrap();
+        assert_eq!(
+            retrieved_doc.get("name").and_then(|v| v.as_str()),
+            Some("Alice")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collection_delete() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Create
+        let txn = db.new_txn(false).await.unwrap();
+        let doc = Document::from_json_str(r#"{"name": "Alice"}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+        col.create(&txn, &doc).await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Verify exists
+        let txn = db.new_txn(true).await.unwrap();
+        assert!(col.exists(&txn, &doc_id).await.unwrap());
+
+        // Delete
+        let txn = db.new_txn(false).await.unwrap();
+        let deleted = col.delete(&txn, &doc_id).await.unwrap();
+        assert!(deleted);
+        txn.commit().await.unwrap();
+
+        // Verify gone
+        let txn = db.new_txn(true).await.unwrap();
+        assert!(!col.exists(&txn, &doc_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_collection_exists_nonexistent() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Create a document to get a valid DocID format, then check for non-existent
+        let doc = Document::from_json_str(r#"{"name": "Test"}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+
+        let txn = db.new_txn(true).await.unwrap();
+        // Document was never saved, so it shouldn't exist
+        assert!(!col.exists(&txn, &doc_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_collection_save_upsert() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Save (create)
+        let txn = db.new_txn(false).await.unwrap();
+        let doc = Document::from_json_str(r#"{"name": "Bob"}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+        col.save(&txn, &doc).await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Save again (update) - keep the same doc_id
+        let txn = db.new_txn(false).await.unwrap();
+        let mut doc = Document::with_id(doc_id.clone());
+        doc.set("name", NormalValue::String("Robert".to_string()));
+        col.save(&txn, &doc).await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Verify
+        let txn = db.new_txn(true).await.unwrap();
+        let retrieved = col.get(&txn, &doc_id).await.unwrap().unwrap();
+        assert_eq!(
+            retrieved.get("name").and_then(|v| v.as_str()),
+            Some("Robert")
+        );
+    }
+}

--- a/crates/db/src/collection.rs
+++ b/crates/db/src/collection.rs
@@ -338,4 +338,157 @@ mod tests {
             Some("Robert")
         );
     }
+
+    // Edge case tests
+
+    #[tokio::test]
+    async fn test_collection_create_duplicate_returns_error() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Create a document
+        let txn = db.new_txn(false).await.unwrap();
+        let doc = Document::from_json_str(r#"{"name": "Alice"}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+        col.create(&txn, &doc).await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Try to create the same document again
+        let txn = db.new_txn(false).await.unwrap();
+        let doc2 = Document::with_id(doc_id);
+        let result = col.create(&txn, &doc2).await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::InvalidDocument(_)));
+    }
+
+    #[tokio::test]
+    async fn test_collection_update_nonexistent_returns_error() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Create a document to get a valid DocID, but don't save it
+        let doc = Document::from_json_str(r#"{"name": "Ghost"}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+
+        // Try to update a non-existent document
+        let txn = db.new_txn(false).await.unwrap();
+        let result = col.update(&txn, &doc).await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::DocumentNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_collection_delete_nonexistent_returns_false() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Create a document to get a valid DocID, but don't save it
+        let doc = Document::from_json_str(r#"{"name": "Ghost"}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+
+        // Delete should return false for non-existent
+        let txn = db.new_txn(false).await.unwrap();
+        let deleted = col.delete(&txn, &doc_id).await.unwrap();
+        assert!(!deleted);
+    }
+
+    #[tokio::test]
+    async fn test_collection_get_nonexistent_returns_none() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Create a document to get a valid DocID, but don't save it
+        let doc = Document::from_json_str(r#"{"name": "Ghost"}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+
+        // Get should return None for non-existent
+        let txn = db.new_txn(true).await.unwrap();
+        let result = col.get(&txn, &doc_id).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_collection_get_all_empty() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Get all from empty collection
+        let txn = db.new_txn(true).await.unwrap();
+        let docs = col.get_all(&txn).await.unwrap();
+        assert!(docs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_collection_get_all_multiple() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Create multiple documents
+        let txn = db.new_txn(false).await.unwrap();
+        for i in 0..5 {
+            let doc =
+                Document::from_json_str(&format!(r#"{{"name": "User{}", "index": {}}}"#, i, i))
+                    .unwrap();
+            doc.generate_doc_id().unwrap();
+            col.create(&txn, &doc).await.unwrap();
+        }
+        txn.commit().await.unwrap();
+
+        // Get all should return all 5
+        let txn = db.new_txn(true).await.unwrap();
+        let docs = col.get_all(&txn).await.unwrap();
+        assert_eq!(docs.len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_collection_create_without_id_returns_error() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = test_collection();
+
+        // Create a document without an ID using Document::new()
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("NoID".to_string()));
+        // Don't set an ID
+
+        let txn = db.new_txn(false).await.unwrap();
+        let result = col.create(&txn, &doc).await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::InvalidDocument(_)));
+    }
+
+    #[tokio::test]
+    async fn test_collection_isolation_between_collections() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        // Create two different collections
+        let col1 = Collection::new(CollectionVersion::new("users", "v1", "col-users", vec![]));
+        let col2 = Collection::new(CollectionVersion::new("posts", "v1", "col-posts", vec![]));
+
+        // Create document in col1
+        let txn = db.new_txn(false).await.unwrap();
+        let doc = Document::from_json_str(r#"{"name": "Alice"}"#).unwrap();
+        doc.generate_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+        col1.create(&txn, &doc).await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Document should exist in col1 but not col2
+        let txn = db.new_txn(true).await.unwrap();
+        assert!(col1.exists(&txn, &doc_id).await.unwrap());
+        assert!(!col2.exists(&txn, &doc_id).await.unwrap());
+    }
 }

--- a/crates/db/src/collection.rs
+++ b/crates/db/src/collection.rs
@@ -48,12 +48,7 @@ impl Collection {
 
         // Check if document already exists
         let key = self.doc_key(&doc_id);
-        if txn
-            .datastore()
-            .has(&key)
-            .await
-            .map_err(Error::Storage)?
-        {
+        if txn.datastore()?.has(&key).await.map_err(Error::Storage)? {
             return Err(Error::InvalidDocument(format!(
                 "Document with ID {} already exists",
                 doc_id
@@ -66,7 +61,7 @@ impl Collection {
             .map_err(|e| Error::Serialization(e.to_string()))?;
 
         // Store document
-        txn.datastore()
+        txn.datastore()?
             .set(&key, &data)
             .await
             .map_err(Error::Storage)?;
@@ -77,11 +72,7 @@ impl Collection {
     /// Get a document by ID.
     pub async fn get<S: Store>(&self, txn: &DbTxn<S>, doc_id: &DocID) -> Result<Option<Document>> {
         let key = self.doc_key(doc_id);
-        let data = txn
-            .datastore()
-            .get(&key)
-            .await
-            .map_err(Error::Storage)?;
+        let data = txn.datastore()?.get(&key).await.map_err(Error::Storage)?;
 
         match data {
             Some(bytes) => {
@@ -102,12 +93,7 @@ impl Collection {
         let key = self.doc_key(doc_id);
 
         // Check document exists
-        if !txn
-            .datastore()
-            .has(&key)
-            .await
-            .map_err(Error::Storage)?
-        {
+        if !txn.datastore()?.has(&key).await.map_err(Error::Storage)? {
             return Err(Error::DocumentNotFound(doc_id.to_string()));
         }
 
@@ -116,7 +102,7 @@ impl Collection {
             .to_cbor()
             .map_err(|e| Error::Serialization(e.to_string()))?;
 
-        txn.datastore()
+        txn.datastore()?
             .set(&key, &data)
             .await
             .map_err(Error::Storage)?;
@@ -129,16 +115,11 @@ impl Collection {
         let key = self.doc_key(doc_id);
 
         // Check if document exists
-        if !txn
-            .datastore()
-            .has(&key)
-            .await
-            .map_err(Error::Storage)?
-        {
+        if !txn.datastore()?.has(&key).await.map_err(Error::Storage)? {
             return Ok(false);
         }
 
-        txn.datastore()
+        txn.datastore()?
             .delete(&key)
             .await
             .map_err(Error::Storage)?;
@@ -149,10 +130,7 @@ impl Collection {
     /// Check if a document exists.
     pub async fn exists<S: Store>(&self, txn: &DbTxn<S>, doc_id: &DocID) -> Result<bool> {
         let key = self.doc_key(doc_id);
-        txn.datastore()
-            .has(&key)
-            .await
-            .map_err(Error::Storage)
+        txn.datastore()?.has(&key).await.map_err(Error::Storage)
     }
 
     /// Save a document (create or update).
@@ -169,7 +147,7 @@ impl Collection {
             .to_cbor()
             .map_err(|e| Error::Serialization(e.to_string()))?;
 
-        txn.datastore()
+        txn.datastore()?
             .set(&key, &data)
             .await
             .map_err(Error::Storage)?;
@@ -187,7 +165,7 @@ impl Collection {
         let opts = IterOptions::new().with_prefix(prefix);
 
         let mut iter = txn
-            .datastore()
+            .datastore()?
             .iterator(opts)
             .await
             .map_err(Error::Storage)?;

--- a/crates/db/src/collection.rs
+++ b/crates/db/src/collection.rs
@@ -171,8 +171,13 @@ impl Collection {
             .map_err(Error::Storage)?;
 
         while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
-            let doc = Document::from_cbor(&pair.value)
-                .map_err(|e| Error::Serialization(e.to_string()))?;
+            let doc = Document::from_cbor(&pair.value).map_err(|e| {
+                Error::Serialization(format!(
+                    "failed to deserialize document at key {:?}: {}",
+                    String::from_utf8_lossy(&pair.key),
+                    e
+                ))
+            })?;
 
             // Callback returns true to continue, false to stop
             if !callback(doc).await? {

--- a/crates/db/src/collection.rs
+++ b/crates/db/src/collection.rs
@@ -4,8 +4,8 @@
 /// It provides CRUD operations for documents.
 use crate::error::{Error, Result};
 use crate::txn::DbTxn;
-use document::{DocID, Document};
-use schema::CollectionVersion;
+use document::{DocID, Document, NormalValue};
+use schema::{CollectionVersion, FieldKind, ScalarArrayKind, ScalarKind};
 use storage::corekv::{IterOptions, Store};
 
 /// Key prefix for document data in datastore.
@@ -39,7 +39,13 @@ impl Collection {
     }
 
     /// Create a new document in this collection.
+    ///
+    /// The document must have an ID set before calling this method.
+    /// The document will be validated against the collection schema.
     pub async fn create<S: Store>(&self, txn: &DbTxn<S>, doc: &Document) -> Result<DocID> {
+        // Validate document against schema
+        self.validate_document(doc)?;
+
         // Generate document ID if not present
         let doc_id = doc
             .id()
@@ -85,7 +91,12 @@ impl Collection {
     }
 
     /// Update an existing document.
+    ///
+    /// The document will be validated against the collection schema.
     pub async fn update<S: Store>(&self, txn: &DbTxn<S>, doc: &Document) -> Result<()> {
+        // Validate document against schema
+        self.validate_document(doc)?;
+
         let doc_id = doc
             .id()
             .ok_or_else(|| Error::InvalidDocument("Document must have an ID".into()))?;
@@ -134,7 +145,12 @@ impl Collection {
     }
 
     /// Save a document (create or update).
+    ///
+    /// The document will be validated against the collection schema.
     pub async fn save<S: Store>(&self, txn: &DbTxn<S>, doc: &Document) -> Result<DocID> {
+        // Validate document against schema
+        self.validate_document(doc)?;
+
         let doc_id = doc
             .id()
             .cloned()
@@ -220,6 +236,134 @@ impl Collection {
         key.push(b'/');
         key
     }
+
+    /// Validate a document against this collection's schema.
+    ///
+    /// Returns an error if the document contains fields with incorrect types.
+    /// Unknown fields (not in schema) are allowed for flexibility.
+    fn validate_document(&self, doc: &Document) -> Result<()> {
+        for field_def in &self.def.fields {
+            // Skip _docID field - it's handled separately
+            if field_def.name == "_docID" {
+                continue;
+            }
+
+            // Get the value for this field (if present)
+            if let Some(value) = doc.get(&field_def.name) {
+                // Validate the value type matches the schema
+                if !is_value_compatible_with_kind(value, &field_def.kind) {
+                    return Err(Error::InvalidDocument(format!(
+                        "Field '{}' has incompatible type: expected {:?}, got {:?}",
+                        field_def.name, field_def.kind, value
+                    )));
+                }
+            }
+            // Missing fields are allowed (nullable by default in DefraDB)
+        }
+        Ok(())
+    }
+}
+
+/// Check if a NormalValue is compatible with a FieldKind.
+fn is_value_compatible_with_kind(value: &NormalValue, kind: &FieldKind) -> bool {
+    // Null is compatible with all nillable types (which is everything in DefraDB)
+    if value.is_nil() {
+        return true;
+    }
+
+    match kind {
+        FieldKind::Scalar(scalar) => is_value_compatible_with_scalar(value, *scalar),
+        FieldKind::ScalarArray(array) => is_value_compatible_with_array(value, *array),
+        // Relations are stored as document IDs (strings) or nested documents
+        FieldKind::Relation { is_array, .. }
+        | FieldKind::SelfRef { is_array, .. }
+        | FieldKind::Named { is_array, .. } => {
+            if *is_array {
+                matches!(
+                    value,
+                    NormalValue::StringArray(_) | NormalValue::DocumentArray(_)
+                )
+            } else {
+                matches!(value, NormalValue::String(_) | NormalValue::Document(_))
+            }
+        }
+    }
+}
+
+/// Check if a NormalValue is compatible with a ScalarKind.
+fn is_value_compatible_with_scalar(value: &NormalValue, scalar: ScalarKind) -> bool {
+    match scalar {
+        ScalarKind::None => true,
+        ScalarKind::DocID => matches!(value, NormalValue::String(_)),
+        ScalarKind::Bool => matches!(value, NormalValue::Bool(_) | NormalValue::NillableBool(_)),
+        ScalarKind::Int => matches!(value, NormalValue::Int(_) | NormalValue::NillableInt(_)),
+        ScalarKind::Float64 => {
+            matches!(
+                value,
+                NormalValue::Float64(_) | NormalValue::NillableFloat64(_)
+            )
+        }
+        ScalarKind::Float32 => {
+            matches!(
+                value,
+                NormalValue::Float32(_) | NormalValue::NillableFloat32(_)
+            )
+        }
+        ScalarKind::DateTime => {
+            matches!(value, NormalValue::Time(_) | NormalValue::NillableTime(_))
+        }
+        ScalarKind::String => {
+            matches!(
+                value,
+                NormalValue::String(_) | NormalValue::NillableString(_)
+            )
+        }
+        ScalarKind::Blob => {
+            matches!(value, NormalValue::Bytes(_) | NormalValue::NillableBytes(_))
+        }
+        ScalarKind::Json => matches!(value, NormalValue::Json(_)),
+    }
+}
+
+/// Check if a NormalValue is compatible with a ScalarArrayKind.
+fn is_value_compatible_with_array(value: &NormalValue, array: ScalarArrayKind) -> bool {
+    match array {
+        ScalarArrayKind::BoolArray => matches!(value, NormalValue::BoolArray(_)),
+        ScalarArrayKind::IntArray => matches!(value, NormalValue::IntArray(_)),
+        ScalarArrayKind::Float64Array => matches!(value, NormalValue::Float64Array(_)),
+        ScalarArrayKind::Float32Array => matches!(value, NormalValue::Float32Array(_)),
+        ScalarArrayKind::StringArray => matches!(value, NormalValue::StringArray(_)),
+        ScalarArrayKind::NillableBoolArray => {
+            matches!(
+                value,
+                NormalValue::NillableBoolArray(_) | NormalValue::NillableBoolElementArray(_)
+            )
+        }
+        ScalarArrayKind::NillableIntArray => {
+            matches!(
+                value,
+                NormalValue::NillableIntArray(_) | NormalValue::NillableIntElementArray(_)
+            )
+        }
+        ScalarArrayKind::NillableFloat64Array => {
+            matches!(
+                value,
+                NormalValue::NillableFloat64Array(_) | NormalValue::NillableFloat64ElementArray(_)
+            )
+        }
+        ScalarArrayKind::NillableFloat32Array => {
+            matches!(
+                value,
+                NormalValue::NillableFloat32Array(_) | NormalValue::NillableFloat32ElementArray(_)
+            )
+        }
+        ScalarArrayKind::NillableStringArray => {
+            matches!(
+                value,
+                NormalValue::NillableStringArray(_) | NormalValue::NillableStringElementArray(_)
+            )
+        }
+    }
 }
 
 #[cfg(test)]
@@ -227,11 +371,27 @@ mod tests {
     use super::*;
     use crate::database::DB;
     use document::NormalValue;
-    use schema::CollectionVersion;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
     use storage::backends::MemoryStore;
 
     fn test_collection() -> Collection {
         Collection::new(CollectionVersion::new("users", "v1", "col-1", vec![]))
+    }
+
+    /// Create a typed collection with schema fields for validation tests.
+    fn typed_collection() -> Collection {
+        let fields = vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "age", FieldKind::int()),
+            FieldDescription::new("4", "active", FieldKind::bool()),
+        ];
+        Collection::new(CollectionVersion::new(
+            "typed_users",
+            "v1",
+            "col-typed",
+            fields,
+        ))
     }
 
     #[tokio::test]
@@ -495,5 +655,190 @@ mod tests {
         let txn = db.new_txn(true).await.unwrap();
         assert!(col1.exists(&txn, &doc_id).await.unwrap());
         assert!(!col2.exists(&txn, &doc_id).await.unwrap());
+    }
+
+    // Schema validation tests
+
+    #[tokio::test]
+    async fn test_validation_correct_types_passes() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = typed_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Create document with correct types
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Alice".to_string()));
+        doc.set("age", NormalValue::Int(30));
+        doc.set("active", NormalValue::Bool(true));
+        doc.generate_and_set_doc_id().unwrap();
+
+        // Should succeed
+        let result = col.create(&txn, &doc).await;
+        assert!(result.is_ok(), "Expected success but got: {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_validation_wrong_string_type_fails() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = typed_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Create document with wrong type for "name" (int instead of string)
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::Int(123)); // Wrong type!
+        doc.set("age", NormalValue::Int(30));
+        doc.generate_and_set_doc_id().unwrap();
+
+        let result = col.create(&txn, &doc).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, Error::InvalidDocument(_)));
+        assert!(err.to_string().contains("name"));
+    }
+
+    #[tokio::test]
+    async fn test_validation_wrong_int_type_fails() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = typed_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Create document with wrong type for "age" (string instead of int)
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Alice".to_string()));
+        doc.set("age", NormalValue::String("thirty".to_string())); // Wrong type!
+        doc.generate_and_set_doc_id().unwrap();
+
+        let result = col.create(&txn, &doc).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, Error::InvalidDocument(_)));
+        assert!(err.to_string().contains("age"));
+    }
+
+    #[tokio::test]
+    async fn test_validation_null_values_allowed() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = typed_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Create document with null values (allowed in DefraDB)
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::Null);
+        doc.set("age", NormalValue::Null);
+        doc.generate_and_set_doc_id().unwrap();
+
+        // Should succeed - null is allowed for any field
+        let result = col.create(&txn, &doc).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validation_missing_fields_allowed() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = typed_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Create document with missing fields (only has name)
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Alice".to_string()));
+        // age and active are missing - should be allowed
+        doc.generate_and_set_doc_id().unwrap();
+
+        let result = col.create(&txn, &doc).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validation_update_validates() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = typed_collection();
+
+        // First create a valid document
+        let txn = db.new_txn(false).await.unwrap();
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Alice".to_string()));
+        doc.set("age", NormalValue::Int(30));
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+        col.create(&txn, &doc).await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Now try to update with invalid type
+        let txn = db.new_txn(false).await.unwrap();
+        let mut invalid_doc = Document::with_id(doc_id);
+        invalid_doc.set("name", NormalValue::Int(999)); // Wrong type!
+
+        let result = col.update(&txn, &invalid_doc).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::InvalidDocument(_)));
+    }
+
+    #[tokio::test]
+    async fn test_validation_save_validates() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = typed_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Try to save with invalid type
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::Bool(true)); // Wrong type for string field!
+        doc.generate_and_set_doc_id().unwrap();
+
+        let result = col.save(&txn, &doc).await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::InvalidDocument(_)));
+    }
+
+    #[tokio::test]
+    async fn test_validation_extra_fields_allowed() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        let col = typed_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Create document with extra fields not in schema
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Alice".to_string()));
+        doc.set("age", NormalValue::Int(30));
+        doc.set("extra_field", NormalValue::String("extra".to_string())); // Not in schema
+        doc.generate_and_set_doc_id().unwrap();
+
+        // Should succeed - extra fields are allowed for flexibility
+        let result = col.create(&txn, &doc).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validation_schemaless_collection_accepts_any() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        // Empty schema - no validation
+        let col = test_collection();
+
+        let txn = db.new_txn(false).await.unwrap();
+
+        // Any document structure should be accepted
+        let mut doc = Document::new();
+        doc.set("anything", NormalValue::Int(123));
+        doc.set("goes", NormalValue::String("here".to_string()));
+        doc.set("mixed", NormalValue::Bool(false));
+        doc.generate_and_set_doc_id().unwrap();
+
+        let result = col.create(&txn, &doc).await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -1,0 +1,186 @@
+/// Database struct for DefraDB matching Go's internal/db/db.go.
+///
+/// The DB struct is the main entry point for DefraDB operations.
+/// It manages the root store, creates transactions, and provides
+/// access to collections.
+use crate::error::{Error, Result};
+use crate::txn::DbTxn;
+use datastore::BasicTxn;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use storage::corekv::Store;
+
+/// Database options.
+#[derive(Debug, Clone, Default)]
+pub struct DbOptions {
+    /// Maximum number of transaction retries.
+    pub max_txn_retries: Option<u32>,
+    /// Chunk size for large values in the blockstore.
+    pub chunk_size: Option<usize>,
+}
+
+/// The main DefraDB database struct.
+///
+/// This matches Go's DB struct in internal/db/db.go.
+pub struct DB<S: Store> {
+    /// The underlying store.
+    store: Arc<S>,
+    /// Options for this database instance.
+    options: DbOptions,
+    /// Counter for generating unique transaction IDs.
+    txn_id_counter: AtomicU64,
+}
+
+impl<S: Store> DB<S> {
+    /// Create a new database with the given store.
+    pub fn new(store: S) -> Self {
+        Self::with_options(store, DbOptions::default())
+    }
+
+    /// Create a new database with the given store and options.
+    pub fn with_options(store: S, options: DbOptions) -> Self {
+        Self {
+            store: Arc::new(store),
+            options,
+            txn_id_counter: AtomicU64::new(0),
+        }
+    }
+
+    /// Get the next transaction ID.
+    fn next_txn_id(&self) -> u64 {
+        self.txn_id_counter.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Create a new transaction.
+    ///
+    /// If `readonly` is true, the transaction cannot perform writes.
+    pub async fn new_txn(&self, readonly: bool) -> Result<DbTxn<S>> {
+        let id = self.next_txn_id();
+        let basic_txn = BasicTxn::new(&*self.store, id, readonly)
+            .await
+            .map_err(Error::Storage)?;
+        Ok(DbTxn::new(basic_txn, self.store.clone()))
+    }
+
+    /// Execute a function within a transaction.
+    ///
+    /// If the function returns Ok, the transaction is committed.
+    /// If the function returns Err, the transaction is discarded.
+    pub async fn with_txn<F, T>(&self, readonly: bool, f: F) -> Result<T>
+    where
+        F: FnOnce(&DbTxn<S>) -> Result<T>,
+    {
+        let txn = self.new_txn(readonly).await?;
+        let result = f(&txn);
+        match result {
+            Ok(value) => {
+                txn.commit().await?;
+                Ok(value)
+            }
+            Err(e) => {
+                txn.discard();
+                Err(e)
+            }
+        }
+    }
+
+    /// Execute an async function within a transaction.
+    ///
+    /// If the function returns Ok, the transaction is committed.
+    /// If the function returns Err, the transaction is discarded.
+    pub async fn with_txn_async<F, Fut, T>(&self, readonly: bool, f: F) -> Result<T>
+    where
+        F: FnOnce(DbTxn<S>) -> Fut,
+        Fut: std::future::Future<Output = (DbTxn<S>, Result<T>)>,
+    {
+        let txn = self.new_txn(readonly).await?;
+        let (txn, result) = f(txn).await;
+        match result {
+            Ok(value) => {
+                txn.commit().await?;
+                Ok(value)
+            }
+            Err(e) => {
+                txn.discard();
+                Err(e)
+            }
+        }
+    }
+
+    /// Close the database.
+    pub async fn close(&self) -> Result<()> {
+        self.store.close().await.map_err(Error::Storage)
+    }
+
+    /// Get the database options.
+    pub fn options(&self) -> &DbOptions {
+        &self.options
+    }
+
+    /// Get the current transaction ID counter value.
+    pub fn current_txn_id(&self) -> u64 {
+        self.txn_id_counter.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use storage::backends::MemoryStore;
+
+    #[tokio::test]
+    async fn test_db_new_txn() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        let txn = db.new_txn(false).await.unwrap();
+        assert_eq!(txn.id(), 1);
+
+        let txn2 = db.new_txn(false).await.unwrap();
+        assert_eq!(txn2.id(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_isolation() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        // Write in first transaction
+        let txn1 = db.new_txn(false).await.unwrap();
+        txn1.datastore().set(b"key", b"value1").await.unwrap();
+        txn1.commit().await.unwrap();
+
+        // Read in second transaction
+        let txn2 = db.new_txn(true).await.unwrap();
+        let value = txn2.datastore().get(b"key").await.unwrap();
+        assert_eq!(value, Some(b"value1".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_db_with_txn() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        // Execute with_txn that commits
+        db.with_txn(false, |_txn| {
+            // We need async operations inside, but this closure is sync
+            // This is a limitation - we'll address in with_txn_async
+            Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_db_options() {
+        let store = MemoryStore::new();
+        let options = DbOptions {
+            max_txn_retries: Some(5),
+            chunk_size: Some(1024 * 1024),
+        };
+        let db = DB::with_options(store, options.clone());
+
+        assert_eq!(db.options().max_txn_retries, Some(5));
+        assert_eq!(db.options().chunk_size, Some(1024 * 1024));
+    }
+}

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -148,10 +148,10 @@ mod tests {
         let db = DB::new(store);
 
         let txn = db.new_txn(false).await.unwrap();
-        assert_eq!(txn.id(), 1);
+        assert_eq!(txn.id().unwrap(), 1);
 
         let txn2 = db.new_txn(false).await.unwrap();
-        assert_eq!(txn2.id(), 2);
+        assert_eq!(txn2.id().unwrap(), 2);
     }
 
     #[tokio::test]
@@ -200,5 +200,53 @@ mod tests {
 
         assert_eq!(db.options().max_txn_retries, Some(5));
         assert_eq!(db.options().chunk_size, Some(1024 * 1024));
+    }
+
+    #[tokio::test]
+    async fn test_db_with_txn_async_commits_on_success() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        // Execute async operation that succeeds
+        db.with_txn_async(false, |txn| async move {
+            txn.datastore()
+                .unwrap()
+                .set(b"key", b"value")
+                .await
+                .unwrap();
+            (txn, Ok(()))
+        })
+        .await
+        .unwrap();
+
+        // Verify data was committed
+        let txn = db.new_txn(true).await.unwrap();
+        let value = txn.datastore().unwrap().get(b"key").await.unwrap();
+        assert_eq!(value, Some(b"value".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_db_with_txn_async_discards_on_error() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        // Execute async operation that fails
+        let result: Result<()> = db
+            .with_txn_async(false, |txn| async move {
+                txn.datastore()
+                    .unwrap()
+                    .set(b"key", b"value")
+                    .await
+                    .unwrap();
+                (txn, Err(Error::Other("test error".into())))
+            })
+            .await;
+
+        assert!(result.is_err());
+
+        // Verify data was NOT committed (discarded)
+        let txn = db.new_txn(true).await.unwrap();
+        let value = txn.datastore().unwrap().get(b"key").await.unwrap();
+        assert_eq!(value, None);
     }
 }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -78,7 +78,8 @@ impl<S: Store> DB<S> {
                 Ok(value)
             }
             Err(e) => {
-                txn.discard();
+                // Best effort discard - if it fails, return original error
+                let _ = txn.discard();
                 Err(e)
             }
         }
@@ -101,7 +102,8 @@ impl<S: Store> DB<S> {
                 Ok(value)
             }
             Err(e) => {
-                txn.discard();
+                // Best effort discard - if it fails, return original error
+                let _ = txn.discard();
                 Err(e)
             }
         }
@@ -147,12 +149,16 @@ mod tests {
 
         // Write in first transaction
         let txn1 = db.new_txn(false).await.unwrap();
-        txn1.datastore().set(b"key", b"value1").await.unwrap();
+        txn1.datastore()
+            .unwrap()
+            .set(b"key", b"value1")
+            .await
+            .unwrap();
         txn1.commit().await.unwrap();
 
         // Read in second transaction
         let txn2 = db.new_txn(true).await.unwrap();
-        let value = txn2.datastore().get(b"key").await.unwrap();
+        let value = txn2.datastore().unwrap().get(b"key").await.unwrap();
         assert_eq!(value, Some(b"value1".to_vec()));
     }
 

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -78,8 +78,14 @@ impl<S: Store> DB<S> {
                 Ok(value)
             }
             Err(e) => {
-                // Best effort discard - if it fails, return original error
-                let _ = txn.discard();
+                // Discard and log if it fails - return original error
+                if let Err(discard_err) = txn.discard() {
+                    tracing::warn!(
+                        error = %discard_err,
+                        original_error = %e,
+                        "Transaction discard failed after operation error"
+                    );
+                }
                 Err(e)
             }
         }
@@ -102,8 +108,14 @@ impl<S: Store> DB<S> {
                 Ok(value)
             }
             Err(e) => {
-                // Best effort discard - if it fails, return original error
-                let _ = txn.discard();
+                // Discard and log if it fails - return original error
+                if let Err(discard_err) = txn.discard() {
+                    tracing::warn!(
+                        error = %discard_err,
+                        original_error = %e,
+                        "Transaction discard failed after async operation error"
+                    );
+                }
                 Err(e)
             }
         }

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
     #[error("transaction not active")]
     TxnNotActive,
 
+    #[error("explicit transaction must use force_commit/force_discard")]
+    ExplicitTxnMustUseForce,
+
     #[error("unsupported transaction type")]
     UnsupportedTxnType,
 

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -1,0 +1,44 @@
+use thiserror::Error;
+
+/// Errors that can occur in the database layer.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("storage error: {0}")]
+    Storage(#[from] storage::Error),
+
+    #[error("datastore error: {0}")]
+    Datastore(#[from] datastore::Error),
+
+    #[error("schema error: {0}")]
+    Schema(#[from] schema::SchemaError),
+
+    #[error("document error: {0}")]
+    Document(#[from] document::Error),
+
+    #[error("collection not found: {0}")]
+    CollectionNotFound(String),
+
+    #[error("collection already exists: {0}")]
+    CollectionAlreadyExists(String),
+
+    #[error("document not found: {0}")]
+    DocumentNotFound(String),
+
+    #[error("invalid document: {0}")]
+    InvalidDocument(String),
+
+    #[error("transaction not active")]
+    TxnNotActive,
+
+    #[error("unsupported transaction type")]
+    UnsupportedTxnType,
+
+    #[error("serialization error: {0}")]
+    Serialization(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Result type for database operations.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,0 +1,59 @@
+/// Database layer for DefraDB matching Go's internal/db/.
+///
+/// This crate provides the high-level database API including:
+///
+/// - `DB`: Main database struct for creating transactions and managing collections
+/// - `DbTxn`: Transaction wrapper with explicit/implicit handling
+/// - `Collection`: Document collection with CRUD operations
+///
+/// # Architecture
+///
+/// ```text
+/// User Code
+///     ↓
+/// db crate (DB, DbTxn, Collection)
+///     ↓
+/// datastore crate (BasicTxn, namespace views)
+///     ↓
+/// storage crate (corekv, backends)
+/// ```
+///
+/// # Example
+///
+/// ```ignore
+/// use db::{DB, Collection};
+/// use document::Document;
+/// use storage::backends::MemoryStore;
+///
+/// // Create database
+/// let store = MemoryStore::new();
+/// let db = DB::new(store);
+///
+/// // Create a transaction
+/// let txn = db.new_txn(false).await?;
+///
+/// // Create a collection
+/// let col = Collection::new(schema);
+///
+/// // Create a document
+/// let doc = Document::from_json_str(r#"{"name": "Alice"}"#)?;
+/// col.create(&txn, &doc).await?;
+///
+/// // Commit
+/// txn.commit().await?;
+/// ```
+pub mod collection;
+pub mod database;
+pub mod error;
+pub mod txn;
+
+// Re-export commonly used types
+pub use collection::Collection;
+pub use database::{DbOptions, DB};
+pub use error::{Error, Result};
+pub use txn::DbTxn;
+
+// Re-export related crate types for convenience
+pub use datastore::{BasicTxn, NamespaceView};
+pub use document::{DocID, Document, NormalValue};
+pub use schema::CollectionVersion;

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -212,7 +212,7 @@ impl<S: Store> DbTxn<S> {
         }
 
         if let Some(txn) = self.txn.take() {
-            txn.discard();
+            txn.discard().map_err(Error::Datastore)?;
         }
         self.state = TxnState::Discarded;
         Ok(())
@@ -236,15 +236,16 @@ impl<S: Store> DbTxn<S> {
     /// Actually discard the transaction, even if explicit.
     ///
     /// This should only be called by the transaction creator.
-    pub fn force_discard(mut self) {
+    pub fn force_discard(mut self) -> Result<()> {
         if self.state != TxnState::Active {
-            return;
+            return Err(Error::TxnNotActive);
         }
 
         if let Some(txn) = self.txn.take() {
-            txn.discard();
+            txn.discard().map_err(Error::Datastore)?;
         }
         self.state = TxnState::Discarded;
+        Ok(())
     }
 }
 
@@ -392,7 +393,7 @@ mod tests {
             .unwrap();
 
         // Force discard even though explicit
-        txn.force_discard();
+        txn.force_discard().unwrap();
 
         // Verify data NOT persisted
         let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
@@ -415,5 +416,174 @@ mod tests {
         assert!(txn.peerstore().is_ok());
         assert!(txn.systemstore().is_ok());
         assert!(txn.rootstore().is_ok());
+    }
+
+    // Transaction state and callback tests
+
+    #[tokio::test]
+    async fn test_db_txn_callbacks_executed_on_commit() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let mut txn = DbTxn::new(basic_txn, store.clone());
+
+        let success_called = Arc::new(AtomicBool::new(false));
+        let success_clone = success_called.clone();
+        txn.on_success(Box::new(move || {
+            success_clone.store(true, Ordering::SeqCst);
+        }));
+
+        txn.commit().await.unwrap();
+        assert!(success_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_callbacks_executed_on_discard() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let mut txn = DbTxn::new(basic_txn, store.clone());
+
+        let discard_called = Arc::new(AtomicBool::new(false));
+        let discard_clone = discard_called.clone();
+        txn.on_discard(Box::new(move || {
+            discard_clone.store(true, Ordering::SeqCst);
+        }));
+
+        txn.discard().unwrap();
+        assert!(discard_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_readonly_cannot_write() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, true).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+
+        assert!(txn.is_readonly());
+
+        // Attempting to write should fail
+        let result = txn.datastore().unwrap().set(b"key", b"value").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_id_increments() {
+        let store = Arc::new(MemoryStore::new());
+
+        let basic_txn1 = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn1 = DbTxn::new(basic_txn1, store.clone());
+        assert_eq!(txn1.id(), 1);
+
+        let basic_txn2 = BasicTxn::new(&*store, 2, false).await.unwrap();
+        let txn2 = DbTxn::new(basic_txn2, store.clone());
+        assert_eq!(txn2.id(), 2);
+
+        let basic_txn3 = BasicTxn::new(&*store, 100, false).await.unwrap();
+        let txn3 = DbTxn::new(basic_txn3, store.clone());
+        assert_eq!(txn3.id(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_multiple_writes_single_commit() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+
+        // Multiple writes in single transaction
+        txn.datastore()
+            .unwrap()
+            .set(b"key1", b"value1")
+            .await
+            .unwrap();
+        txn.datastore()
+            .unwrap()
+            .set(b"key2", b"value2")
+            .await
+            .unwrap();
+        txn.datastore()
+            .unwrap()
+            .set(b"key3", b"value3")
+            .await
+            .unwrap();
+
+        txn.commit().await.unwrap();
+
+        // Verify all persisted
+        let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        assert_eq!(
+            txn.datastore().unwrap().get(b"key1").await.unwrap(),
+            Some(b"value1".to_vec())
+        );
+        assert_eq!(
+            txn.datastore().unwrap().get(b"key2").await.unwrap(),
+            Some(b"value2".to_vec())
+        );
+        assert_eq!(
+            txn.datastore().unwrap().get(b"key3").await.unwrap(),
+            Some(b"value3".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_overwrite_value() {
+        let store = Arc::new(MemoryStore::new());
+
+        // Write initial value
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        txn.datastore()
+            .unwrap()
+            .set(b"key", b"initial")
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        // Overwrite value
+        let basic_txn = BasicTxn::new(&*store, 2, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        txn.datastore()
+            .unwrap()
+            .set(b"key", b"updated")
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        // Verify updated value
+        let basic_txn = BasicTxn::new(&*store, 3, true).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        assert_eq!(
+            txn.datastore().unwrap().get(b"key").await.unwrap(),
+            Some(b"updated".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_delete_value() {
+        let store = Arc::new(MemoryStore::new());
+
+        // Write initial value
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        txn.datastore()
+            .unwrap()
+            .set(b"key", b"value")
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        // Delete value
+        let basic_txn = BasicTxn::new(&*store, 2, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        txn.datastore().unwrap().delete(b"key").await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Verify deleted
+        let basic_txn = BasicTxn::new(&*store, 3, true).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        assert_eq!(txn.datastore().unwrap().get(b"key").await.unwrap(), None);
     }
 }

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -34,33 +34,32 @@ enum TxnState {
 pub struct DbTxn<S: Store> {
     /// The underlying BasicTxn.
     txn: Option<BasicTxn>,
-    /// Reference to the store (for collection operations).
-    #[allow(dead_code)]
-    store: Arc<S>,
     /// Whether this is an explicit transaction.
     explicit: bool,
     /// Current transaction state.
     state: TxnState,
+    /// Phantom data for the store type.
+    _marker: std::marker::PhantomData<S>,
 }
 
 impl<S: Store> DbTxn<S> {
     /// Create a new implicit DbTxn.
-    pub fn new(txn: BasicTxn, store: Arc<S>) -> Self {
+    pub fn new(txn: BasicTxn, _store: Arc<S>) -> Self {
         Self {
             txn: Some(txn),
-            store,
             explicit: false,
             state: TxnState::Active,
+            _marker: std::marker::PhantomData,
         }
     }
 
     /// Create a new explicit DbTxn.
-    pub fn new_explicit(txn: BasicTxn, store: Arc<S>) -> Self {
+    pub fn new_explicit(txn: BasicTxn, _store: Arc<S>) -> Self {
         Self {
             txn: Some(txn),
-            store,
             explicit: true,
             state: TxnState::Active,
+            _marker: std::marker::PhantomData,
         }
     }
 
@@ -78,13 +77,23 @@ impl<S: Store> DbTxn<S> {
     }
 
     /// Get the transaction ID.
-    pub fn id(&self) -> u64 {
-        self.txn.as_ref().map(|t| t.id()).unwrap_or(0)
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn id(&self) -> Result<u64> {
+        self.txn
+            .as_ref()
+            .map(|t| t.id())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Check if this is a read-only transaction.
-    pub fn is_readonly(&self) -> bool {
-        self.txn.as_ref().map(|t| t.is_readonly()).unwrap_or(true)
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn is_readonly(&self) -> Result<bool> {
+        self.txn
+            .as_ref()
+            .map(|t| t.is_readonly())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Get the blockstore.
@@ -158,23 +167,38 @@ impl<S: Store> DbTxn<S> {
     }
 
     /// Register a callback for successful commit.
-    pub fn on_success(&mut self, callback: TxnCallback) {
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn on_success(&mut self, callback: TxnCallback) -> Result<()> {
         if let Some(txn) = &mut self.txn {
             txn.on_success(callback);
+            Ok(())
+        } else {
+            Err(Error::TxnNotActive)
         }
     }
 
     /// Register a callback for commit error.
-    pub fn on_error(&mut self, callback: TxnCallback) {
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn on_error(&mut self, callback: TxnCallback) -> Result<()> {
         if let Some(txn) = &mut self.txn {
             txn.on_error(callback);
+            Ok(())
+        } else {
+            Err(Error::TxnNotActive)
         }
     }
 
     /// Register a callback for discard.
-    pub fn on_discard(&mut self, callback: TxnCallback) {
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn on_discard(&mut self, callback: TxnCallback) -> Result<()> {
         if let Some(txn) = &mut self.txn {
             txn.on_discard(callback);
+            Ok(())
+        } else {
+            Err(Error::TxnNotActive)
         }
     }
 
@@ -261,8 +285,8 @@ mod tests {
         let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
         let txn = DbTxn::new(basic_txn, store.clone());
 
-        assert_eq!(txn.id(), 1);
-        assert!(!txn.is_readonly());
+        assert_eq!(txn.id().unwrap(), 1);
+        assert!(!txn.is_readonly().unwrap());
         assert!(!txn.is_explicit());
     }
 
@@ -432,7 +456,8 @@ mod tests {
         let success_clone = success_called.clone();
         txn.on_success(Box::new(move || {
             success_clone.store(true, Ordering::SeqCst);
-        }));
+        }))
+        .unwrap();
 
         txn.commit().await.unwrap();
         assert!(success_called.load(Ordering::SeqCst));
@@ -450,7 +475,8 @@ mod tests {
         let discard_clone = discard_called.clone();
         txn.on_discard(Box::new(move || {
             discard_clone.store(true, Ordering::SeqCst);
-        }));
+        }))
+        .unwrap();
 
         txn.discard().unwrap();
         assert!(discard_called.load(Ordering::SeqCst));
@@ -462,7 +488,7 @@ mod tests {
         let basic_txn = BasicTxn::new(&*store, 1, true).await.unwrap();
         let txn = DbTxn::new(basic_txn, store.clone());
 
-        assert!(txn.is_readonly());
+        assert!(txn.is_readonly().unwrap());
 
         // Attempting to write should fail
         let result = txn.datastore().unwrap().set(b"key", b"value").await;
@@ -475,15 +501,15 @@ mod tests {
 
         let basic_txn1 = BasicTxn::new(&*store, 1, false).await.unwrap();
         let txn1 = DbTxn::new(basic_txn1, store.clone());
-        assert_eq!(txn1.id(), 1);
+        assert_eq!(txn1.id().unwrap(), 1);
 
         let basic_txn2 = BasicTxn::new(&*store, 2, false).await.unwrap();
         let txn2 = DbTxn::new(basic_txn2, store.clone());
-        assert_eq!(txn2.id(), 2);
+        assert_eq!(txn2.id().unwrap(), 2);
 
         let basic_txn3 = BasicTxn::new(&*store, 100, false).await.unwrap();
         let txn3 = DbTxn::new(basic_txn3, store.clone());
-        assert_eq!(txn3.id(), 100);
+        assert_eq!(txn3.id().unwrap(), 100);
     }
 
     #[tokio::test]

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -88,38 +88,73 @@ impl<S: Store> DbTxn<S> {
     }
 
     /// Get the blockstore.
-    pub fn blockstore(&self) -> NamespaceView {
-        self.txn.as_ref().unwrap().blockstore()
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn blockstore(&self) -> Result<NamespaceView> {
+        self.txn
+            .as_ref()
+            .map(|t| t.blockstore())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Get the datastore.
-    pub fn datastore(&self) -> NamespaceView {
-        self.txn.as_ref().unwrap().datastore()
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn datastore(&self) -> Result<NamespaceView> {
+        self.txn
+            .as_ref()
+            .map(|t| t.datastore())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Get the encstore.
-    pub fn encstore(&self) -> NamespaceView {
-        self.txn.as_ref().unwrap().encstore()
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn encstore(&self) -> Result<NamespaceView> {
+        self.txn
+            .as_ref()
+            .map(|t| t.encstore())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Get the headstore.
-    pub fn headstore(&self) -> NamespaceView {
-        self.txn.as_ref().unwrap().headstore()
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn headstore(&self) -> Result<NamespaceView> {
+        self.txn
+            .as_ref()
+            .map(|t| t.headstore())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Get the peerstore.
-    pub fn peerstore(&self) -> NamespaceView {
-        self.txn.as_ref().unwrap().peerstore()
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn peerstore(&self) -> Result<NamespaceView> {
+        self.txn
+            .as_ref()
+            .map(|t| t.peerstore())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Get the systemstore.
-    pub fn systemstore(&self) -> NamespaceView {
-        self.txn.as_ref().unwrap().systemstore()
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn systemstore(&self) -> Result<NamespaceView> {
+        self.txn
+            .as_ref()
+            .map(|t| t.systemstore())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Get the rootstore.
-    pub fn rootstore(&self) -> RootView {
-        self.txn.as_ref().unwrap().rootstore()
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn rootstore(&self) -> Result<RootView> {
+        self.txn
+            .as_ref()
+            .map(|t| t.rootstore())
+            .ok_or(Error::TxnNotActive)
     }
 
     /// Register a callback for successful commit.
@@ -145,12 +180,11 @@ impl<S: Store> DbTxn<S> {
 
     /// Commit the transaction.
     ///
-    /// For explicit transactions, this is a no-op. The transaction
-    /// creator is responsible for committing.
+    /// Returns an error for explicit transactions - use `force_commit()` instead.
+    /// Returns an error if the transaction is not active.
     pub async fn commit(mut self) -> Result<()> {
         if self.explicit {
-            // Explicit transactions should only be committed by the creator.
-            return Ok(());
+            return Err(Error::ExplicitTxnMustUseForce);
         }
 
         if self.state != TxnState::Active {
@@ -166,22 +200,22 @@ impl<S: Store> DbTxn<S> {
 
     /// Discard the transaction.
     ///
-    /// For explicit transactions, this is a no-op. The transaction
-    /// creator is responsible for discarding.
-    pub fn discard(mut self) {
+    /// Returns an error for explicit transactions - use `force_discard()` instead.
+    /// Returns an error if the transaction is not active.
+    pub fn discard(mut self) -> Result<()> {
         if self.explicit {
-            // Explicit transactions should only be discarded by the creator.
-            return;
+            return Err(Error::ExplicitTxnMustUseForce);
         }
 
         if self.state != TxnState::Active {
-            return;
+            return Err(Error::TxnNotActive);
         }
 
         if let Some(txn) = self.txn.take() {
             txn.discard();
         }
         self.state = TxnState::Discarded;
+        Ok(())
     }
 
     /// Actually commit the transaction, even if explicit.
@@ -238,12 +272,6 @@ mod tests {
         let txn = DbTxn::new_explicit(basic_txn, store.clone());
 
         assert!(txn.is_explicit());
-
-        // Explicit commit should be a no-op
-        txn.commit().await.unwrap();
-
-        // Verify data was NOT committed (because we didn't force_commit)
-        // The transaction was consumed but not actually committed
     }
 
     #[tokio::test]
@@ -264,7 +292,11 @@ mod tests {
         let txn = DbTxn::new(basic_txn, store.clone());
 
         // Write data
-        txn.datastore().set(b"key", b"value").await.unwrap();
+        txn.datastore()
+            .unwrap()
+            .set(b"key", b"value")
+            .await
+            .unwrap();
 
         // Commit
         txn.commit().await.unwrap();
@@ -272,7 +304,7 @@ mod tests {
         // Verify data persisted
         let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
         let txn = DbTxn::new(basic_txn, store.clone());
-        let value = txn.datastore().get(b"key").await.unwrap();
+        let value = txn.datastore().unwrap().get(b"key").await.unwrap();
         assert_eq!(value, Some(b"value".to_vec()));
     }
 
@@ -283,15 +315,19 @@ mod tests {
         let txn = DbTxn::new(basic_txn, store.clone());
 
         // Write data
-        txn.datastore().set(b"key", b"value").await.unwrap();
+        txn.datastore()
+            .unwrap()
+            .set(b"key", b"value")
+            .await
+            .unwrap();
 
         // Discard
-        txn.discard();
+        txn.discard().unwrap();
 
         // Verify data NOT persisted
         let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
         let txn = DbTxn::new(basic_txn, store.clone());
-        let value = txn.datastore().get(b"key").await.unwrap();
+        let value = txn.datastore().unwrap().get(b"key").await.unwrap();
         assert_eq!(value, None);
     }
 
@@ -302,7 +338,11 @@ mod tests {
         let txn = DbTxn::new_explicit(basic_txn, store.clone());
 
         // Write data
-        txn.datastore().set(b"key", b"value").await.unwrap();
+        txn.datastore()
+            .unwrap()
+            .set(b"key", b"value")
+            .await
+            .unwrap();
 
         // Force commit even though explicit
         txn.force_commit().await.unwrap();
@@ -310,7 +350,70 @@ mod tests {
         // Verify data persisted
         let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
         let txn = DbTxn::new(basic_txn, store.clone());
-        let value = txn.datastore().get(b"key").await.unwrap();
+        let value = txn.datastore().unwrap().get(b"key").await.unwrap();
         assert_eq!(value, Some(b"value".to_vec()));
+    }
+
+    // Negative tests for error conditions
+
+    #[tokio::test]
+    async fn test_db_txn_explicit_commit_returns_error() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new_explicit(basic_txn, store.clone());
+
+        // Commit on explicit transaction should return error
+        let result = txn.commit().await;
+        assert!(matches!(result, Err(Error::ExplicitTxnMustUseForce)));
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_explicit_discard_returns_error() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new_explicit(basic_txn, store.clone());
+
+        // Discard on explicit transaction should return error
+        let result = txn.discard();
+        assert!(matches!(result, Err(Error::ExplicitTxnMustUseForce)));
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_force_discard() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new_explicit(basic_txn, store.clone());
+
+        // Write data
+        txn.datastore()
+            .unwrap()
+            .set(b"key", b"value")
+            .await
+            .unwrap();
+
+        // Force discard even though explicit
+        txn.force_discard();
+
+        // Verify data NOT persisted
+        let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        let value = txn.datastore().unwrap().get(b"key").await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_accessor_returns_all_stores() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+
+        // All accessor methods should succeed on active transaction
+        assert!(txn.blockstore().is_ok());
+        assert!(txn.datastore().is_ok());
+        assert!(txn.encstore().is_ok());
+        assert!(txn.headstore().is_ok());
+        assert!(txn.peerstore().is_ok());
+        assert!(txn.systemstore().is_ok());
+        assert!(txn.rootstore().is_ok());
     }
 }

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -8,17 +8,6 @@ use datastore::{BasicTxn, NamespaceView, RootView, TxnCallback};
 use std::sync::Arc;
 use storage::corekv::Store;
 
-/// Database transaction state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TxnState {
-    /// Transaction is active and can perform operations.
-    Active,
-    /// Transaction has been committed.
-    Committed,
-    /// Transaction has been discarded.
-    Discarded,
-}
-
 /// Database transaction wrapper.
 ///
 /// This wraps a BasicTxn and provides:
@@ -31,13 +20,15 @@ enum TxnState {
 ///
 /// Implicit transactions are created internally by database methods.
 /// They are automatically committed on success and discarded on error.
+///
+/// Transaction liveness is tracked by the `txn` field:
+/// - `Some(txn)` = transaction is active
+/// - `None` = transaction has been committed or discarded
 pub struct DbTxn<S: Store> {
-    /// The underlying BasicTxn.
+    /// The underlying BasicTxn. `None` after commit/discard.
     txn: Option<BasicTxn>,
     /// Whether this is an explicit transaction.
     explicit: bool,
-    /// Current transaction state.
-    state: TxnState,
     /// Phantom data for the store type.
     _marker: std::marker::PhantomData<S>,
 }
@@ -48,7 +39,6 @@ impl<S: Store> DbTxn<S> {
         Self {
             txn: Some(txn),
             explicit: false,
-            state: TxnState::Active,
             _marker: std::marker::PhantomData,
         }
     }
@@ -58,7 +48,6 @@ impl<S: Store> DbTxn<S> {
         Self {
             txn: Some(txn),
             explicit: true,
-            state: TxnState::Active,
             _marker: std::marker::PhantomData,
         }
     }
@@ -80,10 +69,7 @@ impl<S: Store> DbTxn<S> {
     ///
     /// Returns an error if the transaction has been committed or discarded.
     pub fn id(&self) -> Result<u64> {
-        self.txn
-            .as_ref()
-            .map(|t| t.id())
-            .ok_or(Error::TxnNotActive)
+        self.txn.as_ref().map(|t| t.id()).ok_or(Error::TxnNotActive)
     }
 
     /// Check if this is a read-only transaction.
@@ -211,15 +197,13 @@ impl<S: Store> DbTxn<S> {
             return Err(Error::ExplicitTxnMustUseForce);
         }
 
-        if self.state != TxnState::Active {
-            return Err(Error::TxnNotActive);
+        match self.txn.take() {
+            Some(txn) => {
+                txn.commit().await.map_err(Error::Datastore)?;
+                Ok(())
+            }
+            None => Err(Error::TxnNotActive),
         }
-
-        if let Some(txn) = self.txn.take() {
-            txn.commit().await.map_err(Error::Datastore)?;
-        }
-        self.state = TxnState::Committed;
-        Ok(())
     }
 
     /// Discard the transaction.
@@ -231,45 +215,39 @@ impl<S: Store> DbTxn<S> {
             return Err(Error::ExplicitTxnMustUseForce);
         }
 
-        if self.state != TxnState::Active {
-            return Err(Error::TxnNotActive);
+        match self.txn.take() {
+            Some(txn) => {
+                txn.discard().map_err(Error::Datastore)?;
+                Ok(())
+            }
+            None => Err(Error::TxnNotActive),
         }
-
-        if let Some(txn) = self.txn.take() {
-            txn.discard().map_err(Error::Datastore)?;
-        }
-        self.state = TxnState::Discarded;
-        Ok(())
     }
 
     /// Actually commit the transaction, even if explicit.
     ///
     /// This should only be called by the transaction creator.
     pub async fn force_commit(mut self) -> Result<()> {
-        if self.state != TxnState::Active {
-            return Err(Error::TxnNotActive);
+        match self.txn.take() {
+            Some(txn) => {
+                txn.commit().await.map_err(Error::Datastore)?;
+                Ok(())
+            }
+            None => Err(Error::TxnNotActive),
         }
-
-        if let Some(txn) = self.txn.take() {
-            txn.commit().await.map_err(Error::Datastore)?;
-        }
-        self.state = TxnState::Committed;
-        Ok(())
     }
 
     /// Actually discard the transaction, even if explicit.
     ///
     /// This should only be called by the transaction creator.
     pub fn force_discard(mut self) -> Result<()> {
-        if self.state != TxnState::Active {
-            return Err(Error::TxnNotActive);
+        match self.txn.take() {
+            Some(txn) => {
+                txn.discard().map_err(Error::Datastore)?;
+                Ok(())
+            }
+            None => Err(Error::TxnNotActive),
         }
-
-        if let Some(txn) = self.txn.take() {
-            txn.discard().map_err(Error::Datastore)?;
-        }
-        self.state = TxnState::Discarded;
-        Ok(())
     }
 }
 

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -1,0 +1,316 @@
+/// Database transaction wrapper matching Go's internal/db/txn.go.
+///
+/// DbTxn wraps a BasicTxn and adds:
+/// - Explicit/implicit transaction handling
+/// - Reference to the database for collection operations
+use crate::error::{Error, Result};
+use datastore::{BasicTxn, NamespaceView, RootView, TxnCallback};
+use std::sync::Arc;
+use storage::corekv::Store;
+
+/// Database transaction state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TxnState {
+    /// Transaction is active and can perform operations.
+    Active,
+    /// Transaction has been committed.
+    Committed,
+    /// Transaction has been discarded.
+    Discarded,
+}
+
+/// Database transaction wrapper.
+///
+/// This wraps a BasicTxn and provides:
+/// - Explicit/implicit transaction handling
+/// - Access to the underlying store for collection operations
+///
+/// Explicit transactions are created by the user and must be explicitly
+/// committed or discarded. When a method receives an explicit transaction,
+/// it should NOT commit or discard it.
+///
+/// Implicit transactions are created internally by database methods.
+/// They are automatically committed on success and discarded on error.
+pub struct DbTxn<S: Store> {
+    /// The underlying BasicTxn.
+    txn: Option<BasicTxn>,
+    /// Reference to the store (for collection operations).
+    #[allow(dead_code)]
+    store: Arc<S>,
+    /// Whether this is an explicit transaction.
+    explicit: bool,
+    /// Current transaction state.
+    state: TxnState,
+}
+
+impl<S: Store> DbTxn<S> {
+    /// Create a new implicit DbTxn.
+    pub fn new(txn: BasicTxn, store: Arc<S>) -> Self {
+        Self {
+            txn: Some(txn),
+            store,
+            explicit: false,
+            state: TxnState::Active,
+        }
+    }
+
+    /// Create a new explicit DbTxn.
+    pub fn new_explicit(txn: BasicTxn, store: Arc<S>) -> Self {
+        Self {
+            txn: Some(txn),
+            store,
+            explicit: true,
+            state: TxnState::Active,
+        }
+    }
+
+    /// Mark this transaction as explicit.
+    ///
+    /// Explicit transactions are not automatically committed/discarded
+    /// when passed to database methods.
+    pub fn make_explicit(&mut self) {
+        self.explicit = true;
+    }
+
+    /// Check if this is an explicit transaction.
+    pub fn is_explicit(&self) -> bool {
+        self.explicit
+    }
+
+    /// Get the transaction ID.
+    pub fn id(&self) -> u64 {
+        self.txn.as_ref().map(|t| t.id()).unwrap_or(0)
+    }
+
+    /// Check if this is a read-only transaction.
+    pub fn is_readonly(&self) -> bool {
+        self.txn.as_ref().map(|t| t.is_readonly()).unwrap_or(true)
+    }
+
+    /// Get the blockstore.
+    pub fn blockstore(&self) -> NamespaceView {
+        self.txn.as_ref().unwrap().blockstore()
+    }
+
+    /// Get the datastore.
+    pub fn datastore(&self) -> NamespaceView {
+        self.txn.as_ref().unwrap().datastore()
+    }
+
+    /// Get the encstore.
+    pub fn encstore(&self) -> NamespaceView {
+        self.txn.as_ref().unwrap().encstore()
+    }
+
+    /// Get the headstore.
+    pub fn headstore(&self) -> NamespaceView {
+        self.txn.as_ref().unwrap().headstore()
+    }
+
+    /// Get the peerstore.
+    pub fn peerstore(&self) -> NamespaceView {
+        self.txn.as_ref().unwrap().peerstore()
+    }
+
+    /// Get the systemstore.
+    pub fn systemstore(&self) -> NamespaceView {
+        self.txn.as_ref().unwrap().systemstore()
+    }
+
+    /// Get the rootstore.
+    pub fn rootstore(&self) -> RootView {
+        self.txn.as_ref().unwrap().rootstore()
+    }
+
+    /// Register a callback for successful commit.
+    pub fn on_success(&mut self, callback: TxnCallback) {
+        if let Some(txn) = &mut self.txn {
+            txn.on_success(callback);
+        }
+    }
+
+    /// Register a callback for commit error.
+    pub fn on_error(&mut self, callback: TxnCallback) {
+        if let Some(txn) = &mut self.txn {
+            txn.on_error(callback);
+        }
+    }
+
+    /// Register a callback for discard.
+    pub fn on_discard(&mut self, callback: TxnCallback) {
+        if let Some(txn) = &mut self.txn {
+            txn.on_discard(callback);
+        }
+    }
+
+    /// Commit the transaction.
+    ///
+    /// For explicit transactions, this is a no-op. The transaction
+    /// creator is responsible for committing.
+    pub async fn commit(mut self) -> Result<()> {
+        if self.explicit {
+            // Explicit transactions should only be committed by the creator.
+            return Ok(());
+        }
+
+        if self.state != TxnState::Active {
+            return Err(Error::TxnNotActive);
+        }
+
+        if let Some(txn) = self.txn.take() {
+            txn.commit().await.map_err(Error::Datastore)?;
+        }
+        self.state = TxnState::Committed;
+        Ok(())
+    }
+
+    /// Discard the transaction.
+    ///
+    /// For explicit transactions, this is a no-op. The transaction
+    /// creator is responsible for discarding.
+    pub fn discard(mut self) {
+        if self.explicit {
+            // Explicit transactions should only be discarded by the creator.
+            return;
+        }
+
+        if self.state != TxnState::Active {
+            return;
+        }
+
+        if let Some(txn) = self.txn.take() {
+            txn.discard();
+        }
+        self.state = TxnState::Discarded;
+    }
+
+    /// Actually commit the transaction, even if explicit.
+    ///
+    /// This should only be called by the transaction creator.
+    pub async fn force_commit(mut self) -> Result<()> {
+        if self.state != TxnState::Active {
+            return Err(Error::TxnNotActive);
+        }
+
+        if let Some(txn) = self.txn.take() {
+            txn.commit().await.map_err(Error::Datastore)?;
+        }
+        self.state = TxnState::Committed;
+        Ok(())
+    }
+
+    /// Actually discard the transaction, even if explicit.
+    ///
+    /// This should only be called by the transaction creator.
+    pub fn force_discard(mut self) {
+        if self.state != TxnState::Active {
+            return;
+        }
+
+        if let Some(txn) = self.txn.take() {
+            txn.discard();
+        }
+        self.state = TxnState::Discarded;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datastore::BasicTxn;
+    use storage::backends::MemoryStore;
+
+    #[tokio::test]
+    async fn test_db_txn_basic() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+
+        assert_eq!(txn.id(), 1);
+        assert!(!txn.is_readonly());
+        assert!(!txn.is_explicit());
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_explicit() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new_explicit(basic_txn, store.clone());
+
+        assert!(txn.is_explicit());
+
+        // Explicit commit should be a no-op
+        txn.commit().await.unwrap();
+
+        // Verify data was NOT committed (because we didn't force_commit)
+        // The transaction was consumed but not actually committed
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_make_explicit() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let mut txn = DbTxn::new(basic_txn, store.clone());
+
+        assert!(!txn.is_explicit());
+        txn.make_explicit();
+        assert!(txn.is_explicit());
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_write_and_commit() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+
+        // Write data
+        txn.datastore().set(b"key", b"value").await.unwrap();
+
+        // Commit
+        txn.commit().await.unwrap();
+
+        // Verify data persisted
+        let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        let value = txn.datastore().get(b"key").await.unwrap();
+        assert_eq!(value, Some(b"value".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_write_and_discard() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+
+        // Write data
+        txn.datastore().set(b"key", b"value").await.unwrap();
+
+        // Discard
+        txn.discard();
+
+        // Verify data NOT persisted
+        let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        let value = txn.datastore().get(b"key").await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn test_db_txn_force_commit() {
+        let store = Arc::new(MemoryStore::new());
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new_explicit(basic_txn, store.clone());
+
+        // Write data
+        txn.datastore().set(b"key", b"value").await.unwrap();
+
+        // Force commit even though explicit
+        txn.force_commit().await.unwrap();
+
+        // Verify data persisted
+        let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+        let value = txn.datastore().get(b"key").await.unwrap();
+        assert_eq!(value, Some(b"value".to_vec()));
+    }
+}


### PR DESCRIPTION
## Summary

Implements Issue #24 Database Foundation Phase 2 & 3:

**datastore crate** (11 tests):
- `SharedTxn` for concurrent namespace access via `Arc<RwLock<>>`
- `NamespaceView` for prefixed store access (b/d/e/h/p/s namespaces)
- `RootView` for raw access without prefix
- `BasicTxn` with callback system (on_success, on_error, on_discard)

**db crate** (15 tests):
- `DB<S>` struct with transaction management and atomic ID counter
- `DbTxn<S>` with explicit/implicit transaction handling
- `Collection` struct with CRUD operations (create, get, update, delete, exists, save, iterate, get_all)

Both crates match Go DefraDB's `internal/datastore/` and `internal/db/` patterns.

## Test plan

- [x] All 26 tests pass (`cargo test -p datastore -p db`)
- [x] Clippy clean (`cargo clippy -p datastore -p db -- -D warnings`)
- [x] No warnings

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)