### PR TITLE
feat(db): Implement collection lifecycle management

### DIFF
--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -408,9 +408,7 @@ impl Node {
         // Log bootstrap peers (connection will be handled by mDNS discovery)
         if !config.net.peers.is_empty() {
             info!("Bootstrap peers configured: {:?}", config.net.peers);
-            info!(
-                "Note: Direct peer connection requires peer ID; mDNS will discover local peers"
-            );
+            info!("Note: Direct peer connection requires peer ID; mDNS will discover local peers");
         }
 
         // Get and display peer ID

--- a/crates/db/src/collection.rs
+++ b/crates/db/src/collection.rs
@@ -13,7 +13,7 @@ use storage::corekv::{IterOptions, Store};
 const DOC_KEY_PREFIX: &[u8] = b"/d/";
 
 /// A collection of documents with a shared schema.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Collection {
     /// The collection schema definition.
     def: CollectionVersion,

--- a/crates/db/src/collection.rs
+++ b/crates/db/src/collection.rs
@@ -13,6 +13,7 @@ use storage::corekv::{IterOptions, Store};
 const DOC_KEY_PREFIX: &[u8] = b"/d/";
 
 /// A collection of documents with a shared schema.
+#[derive(Clone)]
 pub struct Collection {
     /// The collection schema definition.
     def: CollectionVersion,

--- a/crates/db/src/collection_name.rs
+++ b/crates/db/src/collection_name.rs
@@ -109,4 +109,68 @@ mod tests {
         let s: &str = name.as_ref();
         assert_eq!(s, "Users");
     }
+
+    // Edge case tests matching Go behavior - Go only validates non-empty
+
+    #[test]
+    fn test_whitespace_only_name_allowed() {
+        // Go allows whitespace-only names (they're not empty strings)
+        let name = CollectionName::new("   ");
+        assert!(
+            name.is_ok(),
+            "Whitespace-only names should be allowed per Go behavior"
+        );
+        assert_eq!(name.unwrap().as_str(), "   ");
+    }
+
+    #[test]
+    fn test_leading_trailing_whitespace_allowed() {
+        // Go allows leading/trailing whitespace
+        let name = CollectionName::new("  Users  ");
+        assert!(
+            name.is_ok(),
+            "Leading/trailing whitespace should be allowed per Go behavior"
+        );
+        assert_eq!(name.unwrap().as_str(), "  Users  ");
+    }
+
+    #[test]
+    fn test_tab_and_newline_allowed() {
+        // Go allows control characters
+        let name = CollectionName::new("Users\tTable");
+        assert!(
+            name.is_ok(),
+            "Tab characters should be allowed per Go behavior"
+        );
+
+        let name = CollectionName::new("Users\nTable");
+        assert!(
+            name.is_ok(),
+            "Newline characters should be allowed per Go behavior"
+        );
+    }
+
+    #[test]
+    fn test_unicode_names_allowed() {
+        // Go allows Unicode
+        let name = CollectionName::new("用户表");
+        assert!(name.is_ok(), "Unicode names should be allowed");
+
+        let name = CollectionName::new("Пользователи");
+        assert!(name.is_ok(), "Cyrillic names should be allowed");
+
+        let name = CollectionName::new("🚀Users");
+        assert!(name.is_ok(), "Emoji in names should be allowed");
+    }
+
+    #[test]
+    fn test_very_long_name_allowed() {
+        // Go has no length limit
+        let long_name = "a".repeat(10000);
+        let name = CollectionName::new(&long_name);
+        assert!(
+            name.is_ok(),
+            "Very long names should be allowed per Go behavior"
+        );
+    }
 }

--- a/crates/db/src/collection_name.rs
+++ b/crates/db/src/collection_name.rs
@@ -1,0 +1,112 @@
+//! Validated collection name type.
+
+use crate::error::{Error, Result};
+use std::fmt;
+
+/// A validated collection name.
+///
+/// Collection names must be non-empty and cannot contain forward slashes
+/// (which are used as key separators in the storage layer).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CollectionName(String);
+
+impl CollectionName {
+    /// Create a new validated collection name.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidCollectionName` if:
+    /// - The name is empty
+    /// - The name contains a forward slash (`/`)
+    /// - The name contains a null byte
+    pub fn new(name: &str) -> Result<Self> {
+        if name.is_empty() {
+            return Err(Error::InvalidCollectionName(
+                "collection name cannot be empty".to_string(),
+            ));
+        }
+        if name.contains('/') {
+            return Err(Error::InvalidCollectionName(format!(
+                "collection name '{}' cannot contain '/'",
+                name
+            )));
+        }
+        if name.contains('\0') {
+            return Err(Error::InvalidCollectionName(format!(
+                "collection name '{}' cannot contain null bytes",
+                name
+            )));
+        }
+        Ok(Self(name.to_string()))
+    }
+
+    /// Get the collection name as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the CollectionName and return the inner String.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for CollectionName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for CollectionName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_collection_name() {
+        let name = CollectionName::new("Users").unwrap();
+        assert_eq!(name.as_str(), "Users");
+    }
+
+    #[test]
+    fn test_valid_collection_name_with_special_chars() {
+        let name = CollectionName::new("User_Posts-2024").unwrap();
+        assert_eq!(name.as_str(), "User_Posts-2024");
+    }
+
+    #[test]
+    fn test_empty_name_fails() {
+        let result = CollectionName::new("");
+        assert!(matches!(result, Err(Error::InvalidCollectionName(_))));
+    }
+
+    #[test]
+    fn test_name_with_slash_fails() {
+        let result = CollectionName::new("Users/Posts");
+        assert!(matches!(result, Err(Error::InvalidCollectionName(_))));
+    }
+
+    #[test]
+    fn test_name_with_null_byte_fails() {
+        let result = CollectionName::new("Users\0");
+        assert!(matches!(result, Err(Error::InvalidCollectionName(_))));
+    }
+
+    #[test]
+    fn test_display() {
+        let name = CollectionName::new("Users").unwrap();
+        assert_eq!(format!("{}", name), "Users");
+    }
+
+    #[test]
+    fn test_as_ref() {
+        let name = CollectionName::new("Users").unwrap();
+        let s: &str = name.as_ref();
+        assert_eq!(s, "Users");
+    }
+}

--- a/crates/db/src/collection_snapshot.rs
+++ b/crates/db/src/collection_snapshot.rs
@@ -1,0 +1,141 @@
+//! Immutable collection snapshot for transaction isolation.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::collection::Collection;
+
+/// An immutable snapshot of collection definitions at a point in time.
+///
+/// This type provides snapshot isolation for transactions - each transaction
+/// sees a consistent view of collections throughout its lifetime, even if
+/// collections are created or deleted concurrently.
+///
+/// The snapshot is wrapped in `Arc` internally for efficient cloning and sharing.
+#[derive(Debug, Clone)]
+pub struct CollectionSnapshot {
+    collections: Arc<HashMap<String, Collection>>,
+}
+
+impl CollectionSnapshot {
+    /// Create a new collection snapshot from a HashMap.
+    pub fn new(collections: HashMap<String, Collection>) -> Self {
+        Self {
+            collections: Arc::new(collections),
+        }
+    }
+
+    /// Get a collection by name.
+    pub fn get(&self, name: &str) -> Option<&Collection> {
+        self.collections.get(name)
+    }
+
+    /// Check if a collection exists in the snapshot.
+    pub fn contains(&self, name: &str) -> bool {
+        self.collections.contains_key(name)
+    }
+
+    /// Get the number of collections in the snapshot.
+    pub fn len(&self) -> usize {
+        self.collections.len()
+    }
+
+    /// Check if the snapshot is empty.
+    pub fn is_empty(&self) -> bool {
+        self.collections.is_empty()
+    }
+
+    /// Get collection names as a vector.
+    pub fn names(&self) -> Vec<String> {
+        self.collections.keys().cloned().collect()
+    }
+
+    /// Get an iterator over the collections.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Collection)> {
+        self.collections.iter()
+    }
+}
+
+impl From<HashMap<String, Collection>> for CollectionSnapshot {
+    fn from(collections: HashMap<String, Collection>) -> Self {
+        Self::new(collections)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+    fn test_collection() -> Collection {
+        Collection::new(CollectionVersion::new(
+            "Users",
+            "v1",
+            "col-users",
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        ))
+    }
+
+    #[test]
+    fn test_snapshot_get() {
+        let mut map = HashMap::new();
+        map.insert("Users".to_string(), test_collection());
+        let snapshot = CollectionSnapshot::new(map);
+
+        assert!(snapshot.get("Users").is_some());
+        assert!(snapshot.get("Posts").is_none());
+    }
+
+    #[test]
+    fn test_snapshot_contains() {
+        let mut map = HashMap::new();
+        map.insert("Users".to_string(), test_collection());
+        let snapshot = CollectionSnapshot::new(map);
+
+        assert!(snapshot.contains("Users"));
+        assert!(!snapshot.contains("Posts"));
+    }
+
+    #[test]
+    fn test_snapshot_len() {
+        let mut map = HashMap::new();
+        map.insert("Users".to_string(), test_collection());
+        let snapshot = CollectionSnapshot::new(map);
+
+        assert_eq!(snapshot.len(), 1);
+        assert!(!snapshot.is_empty());
+    }
+
+    #[test]
+    fn test_empty_snapshot() {
+        let snapshot = CollectionSnapshot::new(HashMap::new());
+        assert!(snapshot.is_empty());
+        assert_eq!(snapshot.len(), 0);
+    }
+
+    #[test]
+    fn test_snapshot_clone_is_cheap() {
+        let mut map = HashMap::new();
+        map.insert("Users".to_string(), test_collection());
+        let snapshot1 = CollectionSnapshot::new(map);
+        let snapshot2 = snapshot1.clone();
+
+        // Both should point to the same Arc
+        assert!(Arc::ptr_eq(&snapshot1.collections, &snapshot2.collections));
+    }
+
+    #[test]
+    fn test_snapshot_names() {
+        let mut map = HashMap::new();
+        map.insert("Users".to_string(), test_collection());
+        map.insert(
+            "Posts".to_string(),
+            Collection::new(CollectionVersion::new("Posts", "v1", "col-posts", vec![])),
+        );
+        let snapshot = CollectionSnapshot::new(map);
+
+        let mut names = snapshot.names();
+        names.sort();
+        assert_eq!(names, vec!["Posts", "Users"]);
+    }
+}

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -194,12 +194,22 @@ impl<S: Store> DB<S> {
                 })?;
 
                 let prefix_str = String::from_utf8(prefix.clone()).map_err(|e| {
+                    tracing::error!(
+                        error = ?e,
+                        prefix_bytes = ?&prefix[..prefix.len().min(50)],
+                        "Internal error: collection key prefix contains invalid UTF-8"
+                    );
                     Error::Other(format!("internal error: prefix is not valid UTF-8: {}", e))
                 })?;
 
                 let name = key_str
                     .strip_prefix(&prefix_str)
                     .ok_or_else(|| {
+                        tracing::error!(
+                            key = %key_str,
+                            expected_prefix = %prefix_str,
+                            "Collection key does not match expected prefix - possible data corruption"
+                        );
                         Error::Other(format!(
                             "collection key '{}' does not match expected prefix '{}'",
                             key_str, prefix_str
@@ -229,8 +239,16 @@ impl<S: Store> DB<S> {
             })?;
         }
 
-        txn.discard()
-            .map_err(|e| Error::Other(format!("failed to discard transaction: {}", e)))?;
+        if let Err(discard_err) = txn.discard() {
+            tracing::error!(
+                error = %discard_err,
+                "Transaction discard failed after loading collections"
+            );
+            return Err(Error::Other(format!(
+                "failed to discard transaction: {}",
+                discard_err
+            )));
+        }
 
         let mut cache = self.collections.write().map_err(|e| {
             tracing::error!(error = ?e, "Collection cache lock poisoned during load");
@@ -270,8 +288,13 @@ impl<S: Store> DB<S> {
         };
 
         if exists {
-            txn.discard()
-                .map_err(|e| Error::Other(format!("failed to discard: {}", e)))?;
+            if let Err(discard_err) = txn.discard() {
+                tracing::error!(
+                    error = %discard_err,
+                    collection_name = %name,
+                    "Transaction discard failed while handling CollectionAlreadyExists"
+                );
+            }
             return Err(Error::CollectionAlreadyExists(name));
         }
 
@@ -343,8 +366,13 @@ impl<S: Store> DB<S> {
         };
 
         if !exists {
-            txn.discard()
-                .map_err(|e| Error::Other(format!("failed to discard: {}", e)))?;
+            if let Err(discard_err) = txn.discard() {
+                tracing::error!(
+                    error = %discard_err,
+                    collection_name = %name,
+                    "Transaction discard failed while handling CollectionNotFound"
+                );
+            }
             return Err(Error::CollectionNotFound(name.to_string()));
         }
 
@@ -360,13 +388,41 @@ impl<S: Store> DB<S> {
             let doc_prefix = format!("/d/{}/", collection_id);
             let opts = IterOptions::new().with_prefix(doc_prefix.as_bytes().to_vec());
 
-            let mut iter = datastore.iterator(opts).await.map_err(Error::Storage)?;
+            let mut iter = datastore.iterator(opts).await.map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    collection_name = %name,
+                    "Failed to create iterator for document deletion"
+                );
+                Error::Storage(e)
+            })?;
             let mut keys_to_delete = Vec::new();
 
-            while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
+            while let Some(pair) = iter.next().await.map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    collection_name = %name,
+                    documents_found = keys_to_delete.len(),
+                    "Failed to iterate documents during collection deletion"
+                );
+                Error::Storage(e)
+            })? {
                 keys_to_delete.push(pair.key.clone());
             }
-            iter.close().await.map_err(Error::Storage)?;
+            iter.close().await.map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    collection_name = %name,
+                    "Failed to close iterator during collection deletion"
+                );
+                Error::Storage(e)
+            })?;
+
+            tracing::debug!(
+                collection_name = %name,
+                documents_to_delete = keys_to_delete.len(),
+                "Deleting documents for collection"
+            );
 
             for (i, key) in keys_to_delete.iter().enumerate() {
                 datastore.delete(key).await.map_err(|e| {
@@ -489,8 +545,7 @@ mod tests {
 
         // Execute with_txn that commits
         db.with_txn(false, |_txn| {
-            // We need async operations inside, but this closure is sync
-            // This is a limitation - we'll address in with_txn_async
+            // Sync closure - use with_txn_async for async operations
             Ok(())
         })
         .await
@@ -976,5 +1031,97 @@ mod tests {
                 "Field name mismatch"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_delete_collection_cache_store_inconsistency() {
+        // Test behavior when cache and store diverge (collection in cache but not store)
+        // This tests the safety check in delete_collection that verifies store existence
+        use storage::corekv::Key;
+        use storage::keys::systemstore::CollectionNameKey;
+
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store.clone()));
+
+        // Create a collection normally
+        db.create_collection(test_users_schema()).await.unwrap();
+        assert!(db.has_collection("Users").unwrap());
+
+        // Manually delete from store, bypassing cache (simulating inconsistency)
+        {
+            let txn = db.new_txn(false).await.unwrap();
+            let key = CollectionNameKey::new("Users");
+            {
+                let systemstore = txn.systemstore().unwrap();
+                systemstore.delete(&key.bytes()).await.unwrap();
+            }
+            txn.commit().await.unwrap();
+        }
+
+        // Cache still has it
+        assert!(db.has_collection("Users").unwrap());
+
+        // Now try to delete - should fail gracefully with CollectionNotFound
+        // because the store check catches the inconsistency
+        let result = db.delete_collection("Users").await;
+        assert!(result.is_err());
+        match result {
+            Err(Error::CollectionNotFound(name)) => {
+                assert_eq!(name, "Users");
+            }
+            Err(e) => panic!("Expected CollectionNotFound, got: {:?}", e),
+            Ok(_) => panic!("Expected error but got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_create_and_delete_same_collection() {
+        // Test concurrent create + delete of the same collection
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+
+        // Create collection first
+        db.create_collection(test_users_schema()).await.unwrap();
+
+        // Now race create and delete
+        let db1 = db.clone();
+        let schema = test_users_schema();
+        let handle1 = tokio::spawn(async move {
+            // Delete then create
+            db1.delete_collection("Users").await?;
+            db1.create_collection(schema).await
+        });
+
+        let db2 = db.clone();
+        let handle2 = tokio::spawn(async move {
+            // Just delete
+            db2.delete_collection("Users").await
+        });
+
+        let (r1, r2) = tokio::join!(handle1, handle2);
+
+        // At least one should fail (either both tried to delete, or create raced with delete)
+        let r1 = r1.unwrap();
+        let r2 = r2.unwrap();
+
+        // The important thing is no panics and the database is in a consistent state
+        // Either collection exists or it doesn't
+        let exists = db.has_collection("Users").unwrap();
+        let list = db.list_collections().unwrap();
+
+        // If collection exists, it should be in the list
+        if exists {
+            assert!(list.contains(&"Users".to_string()));
+        } else {
+            assert!(!list.contains(&"Users".to_string()));
+        }
+
+        // Log outcomes for debugging
+        println!(
+            "Concurrent create+delete results: r1={:?}, r2={:?}, exists={}",
+            r1.is_ok(),
+            r2.is_ok(),
+            exists
+        );
     }
 }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -3,12 +3,16 @@
 /// The DB struct is the main entry point for DefraDB operations.
 /// It manages the root store, creates transactions, and provides
 /// access to collections.
+use crate::collection::Collection;
 use crate::error::{Error, Result};
 use crate::txn::DbTxn;
 use datastore::BasicTxn;
+use schema::CollectionVersion;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use storage::corekv::Store;
+use std::sync::{Arc, RwLock};
+use storage::corekv::{IterOptions, Key, Store};
+use storage::keys::systemstore::CollectionNameKey;
 
 /// Database options.
 #[derive(Debug, Clone, Default)]
@@ -29,21 +33,42 @@ pub struct DB<S: Store> {
     options: DbOptions,
     /// Counter for generating unique transaction IDs.
     txn_id_counter: AtomicU64,
+    /// In-memory collection cache (name -> Collection).
+    collections: RwLock<HashMap<String, Collection>>,
 }
 
 impl<S: Store> DB<S> {
     /// Create a new database with the given store.
+    ///
+    /// This creates a DB with an empty collection cache. Use `open()` to
+    /// load existing collections from the store.
     pub fn new(store: S) -> Self {
         Self::with_options(store, DbOptions::default())
     }
 
     /// Create a new database with the given store and options.
+    ///
+    /// This creates a DB with an empty collection cache. Use `open_with_options()`
+    /// to load existing collections from the store.
     pub fn with_options(store: S, options: DbOptions) -> Self {
         Self {
             store: Arc::new(store),
             options,
             txn_id_counter: AtomicU64::new(0),
+            collections: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Open a database and load existing collections from the store.
+    pub async fn open(store: S) -> Result<Self> {
+        Self::open_with_options(store, DbOptions::default()).await
+    }
+
+    /// Open a database with options and load existing collections from the store.
+    pub async fn open_with_options(store: S, options: DbOptions) -> Result<Self> {
+        let db = Self::with_options(store, options);
+        db.load_collections().await?;
+        Ok(db)
     }
 
     /// Get the next transaction ID.
@@ -134,6 +159,175 @@ impl<S: Store> DB<S> {
     /// Get the current transaction ID counter value.
     pub fn current_txn_id(&self) -> u64 {
         self.txn_id_counter.load(Ordering::SeqCst)
+    }
+
+    // =========================================================================
+    // Collection Lifecycle Management
+    // =========================================================================
+
+    /// Load all collections from the SystemStore into the in-memory cache.
+    pub async fn load_collections(&self) -> Result<()> {
+        let txn = self.new_txn(true).await?;
+        let prefix = CollectionNameKey::name_prefix();
+        let mut collections = HashMap::new();
+
+        // Use a block to ensure systemstore reference is dropped before discard
+        {
+            let systemstore = txn.systemstore()?;
+            let opts = IterOptions::new().with_prefix(prefix.clone());
+
+            let mut iter = systemstore.iterator(opts).await.map_err(Error::Storage)?;
+
+            while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
+                // Extract collection name from key: /collection/name/{name}
+                let key_str = String::from_utf8_lossy(&pair.key);
+                let prefix_str = String::from_utf8_lossy(&prefix);
+                let name = key_str
+                    .strip_prefix(&*prefix_str)
+                    .unwrap_or(&key_str)
+                    .to_string();
+
+                // Deserialize CollectionVersion from JSON
+                let schema: CollectionVersion = serde_json::from_slice(&pair.value)
+                    .map_err(|e| Error::Serialization(format!("failed to deserialize schema: {}", e)))?;
+
+                collections.insert(name, Collection::new(schema));
+            }
+
+            iter.close().await.map_err(Error::Storage)?;
+        }
+
+        txn.discard().map_err(|_| Error::TxnNotActive)?;
+
+        // Update in-memory cache
+        let mut cache = self
+            .collections
+            .write()
+            .map_err(|_| Error::Other("collection cache lock poisoned".into()))?;
+        *cache = collections;
+
+        Ok(())
+    }
+
+    /// Create a new collection with schema persistence.
+    pub async fn create_collection(&self, schema: CollectionVersion) -> Result<()> {
+        let name = schema.name.clone();
+
+        // Check if collection already exists
+        if self.has_collection(&name) {
+            return Err(Error::CollectionAlreadyExists(name));
+        }
+
+        // Persist schema to SystemStore
+        let txn = self.new_txn(false).await?;
+
+        let key = CollectionNameKey::new(&name);
+        let data = serde_json::to_vec(&schema)
+            .map_err(|e| Error::Serialization(format!("failed to serialize schema: {}", e)))?;
+
+        // Use a block to ensure systemstore reference is dropped before commit
+        {
+            let systemstore = txn.systemstore()?;
+            systemstore
+                .set(&key.bytes(), &data)
+                .await
+                .map_err(Error::Storage)?;
+        }
+
+        txn.commit().await?;
+
+        // Update in-memory cache
+        let mut cache = self
+            .collections
+            .write()
+            .map_err(|_| Error::Other("collection cache lock poisoned".into()))?;
+        cache.insert(name, Collection::new(schema));
+
+        Ok(())
+    }
+
+    /// Delete a collection and all its documents.
+    pub async fn delete_collection(&self, name: &str) -> Result<()> {
+        // Check if collection exists
+        let collection = self
+            .get_collection(name)
+            .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?;
+
+        let txn = self.new_txn(false).await?;
+
+        // Use a block to ensure store references are dropped before commit
+        {
+            // Delete all documents in the collection
+            let datastore = txn.datastore()?;
+            let doc_prefix = format!("/d/{}/", collection.collection_id());
+            let opts = IterOptions::new().with_prefix(doc_prefix.as_bytes().to_vec());
+
+            let mut iter = datastore.iterator(opts).await.map_err(Error::Storage)?;
+            let mut keys_to_delete = Vec::new();
+
+            while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
+                keys_to_delete.push(pair.key.clone());
+            }
+            iter.close().await.map_err(Error::Storage)?;
+
+            for key in keys_to_delete {
+                datastore.delete(&key).await.map_err(Error::Storage)?;
+            }
+
+            // Delete schema from SystemStore
+            let systemstore = txn.systemstore()?;
+            let key = CollectionNameKey::new(name);
+            systemstore
+                .delete(&key.bytes())
+                .await
+                .map_err(Error::Storage)?;
+        }
+
+        txn.commit().await?;
+
+        // Remove from in-memory cache
+        let mut cache = self
+            .collections
+            .write()
+            .map_err(|_| Error::Other("collection cache lock poisoned".into()))?;
+        cache.remove(name);
+
+        Ok(())
+    }
+
+    /// List all collection names.
+    pub fn list_collections(&self) -> Result<Vec<String>> {
+        let cache = self
+            .collections
+            .read()
+            .map_err(|_| Error::Other("collection cache lock poisoned".into()))?;
+        Ok(cache.keys().cloned().collect())
+    }
+
+    /// Get a collection by name.
+    pub fn get_collection(&self, name: &str) -> Option<Collection> {
+        self.collections
+            .read()
+            .ok()
+            .and_then(|cache| cache.get(name).cloned())
+    }
+
+    /// Check if a collection exists.
+    pub fn has_collection(&self, name: &str) -> bool {
+        self.collections
+            .read()
+            .ok()
+            .map(|cache| cache.contains_key(name))
+            .unwrap_or(false)
+    }
+
+    /// Get a snapshot of all collections (for use by DbTransactionRegistry).
+    pub fn collections_snapshot(&self) -> HashMap<String, Collection> {
+        self.collections
+            .read()
+            .ok()
+            .map(|cache| cache.clone())
+            .unwrap_or_default()
     }
 }
 
@@ -248,5 +442,153 @@ mod tests {
         let txn = db.new_txn(true).await.unwrap();
         let value = txn.datastore().unwrap().get(b"key").await.unwrap();
         assert_eq!(value, None);
+    }
+
+    // =========================================================================
+    // Collection Lifecycle Tests
+    // =========================================================================
+
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+    fn test_users_schema() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "col-users",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn test_create_collection_persists_schema() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        let schema = test_users_schema();
+        db.create_collection(schema).await.unwrap();
+
+        assert!(db.has_collection("Users"));
+        let coll = db.get_collection("Users").unwrap();
+        assert_eq!(coll.name(), "Users");
+    }
+
+    #[tokio::test]
+    async fn test_create_duplicate_collection_fails() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        let schema = test_users_schema();
+        db.create_collection(schema.clone()).await.unwrap();
+
+        // Second create with same name should fail
+        let result = db.create_collection(schema).await;
+        assert!(matches!(result, Err(Error::CollectionAlreadyExists(_))));
+    }
+
+    #[tokio::test]
+    async fn test_list_collections_empty() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        let collections = db.list_collections().unwrap();
+        assert!(collections.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_collections_multiple() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        db.create_collection(test_users_schema()).await.unwrap();
+        db.create_collection(CollectionVersion::new(
+            "Posts",
+            "v1",
+            "col-posts",
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        ))
+        .await
+        .unwrap();
+
+        let mut collections = db.list_collections().unwrap();
+        collections.sort();
+        assert_eq!(collections, vec!["Posts", "Users"]);
+    }
+
+    #[tokio::test]
+    async fn test_delete_collection_removes_data() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        db.create_collection(test_users_schema()).await.unwrap();
+        assert!(db.has_collection("Users"));
+
+        db.delete_collection("Users").await.unwrap();
+        assert!(!db.has_collection("Users"));
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent_collection_fails() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        let result = db.delete_collection("Nonexistent").await;
+        assert!(matches!(result, Err(Error::CollectionNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_has_collection() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        assert!(!db.has_collection("Users"));
+
+        db.create_collection(test_users_schema()).await.unwrap();
+        assert!(db.has_collection("Users"));
+    }
+
+    #[tokio::test]
+    async fn test_get_collection() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        assert!(db.get_collection("Users").is_none());
+
+        db.create_collection(test_users_schema()).await.unwrap();
+        let coll = db.get_collection("Users").unwrap();
+        assert_eq!(coll.collection_id(), "col-users");
+    }
+
+    #[tokio::test]
+    async fn test_open_loads_existing_collections() {
+        // Create a store and populate it with a collection
+        let store = MemoryStore::new();
+
+        // First, create and populate DB
+        {
+            let db = DB::new(store.clone());
+            db.create_collection(test_users_schema()).await.unwrap();
+        }
+
+        // Now open the same store with open() and verify collection loaded
+        let db = DB::open(store).await.unwrap();
+        assert!(db.has_collection("Users"));
+        let coll = db.get_collection("Users").unwrap();
+        assert_eq!(coll.name(), "Users");
+    }
+
+    #[tokio::test]
+    async fn test_collections_snapshot() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        db.create_collection(test_users_schema()).await.unwrap();
+
+        let snapshot = db.collections_snapshot();
+        assert_eq!(snapshot.len(), 1);
+        assert!(snapshot.contains_key("Users"));
     }
 }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -685,4 +685,158 @@ mod tests {
         // Cache should be empty
         assert!(db.list_collections().unwrap().is_empty());
     }
+
+    #[tokio::test]
+    async fn test_load_collections_corrupted_json_returns_error() {
+        use storage::corekv::Key;
+        use storage::keys::systemstore::CollectionNameKey;
+
+        let store = MemoryStore::new();
+
+        // Write corrupted JSON directly to the store
+        {
+            let db = DB::new(store.clone());
+            let txn = db.new_txn(false).await.unwrap();
+
+            // Use block to ensure systemstore is dropped before commit
+            {
+                let systemstore = txn.systemstore().unwrap();
+                let key = CollectionNameKey::new("CorruptedCollection");
+                systemstore
+                    .set(&key.bytes(), b"not valid json {{{")
+                    .await
+                    .unwrap();
+            }
+
+            txn.commit().await.unwrap();
+        }
+
+        // Try to open the database - should fail on load_collections
+        let result = DB::open(store).await;
+        assert!(result.is_err(), "Expected error loading corrupted JSON");
+        match result {
+            Err(Error::Serialization(msg)) => {
+                assert!(
+                    msg.contains("deserialize"),
+                    "Error should mention deserialization: {}",
+                    msg
+                );
+            }
+            Err(e) => panic!("Expected Serialization error, got: {:?}", e),
+            Ok(_) => panic!("Expected error but got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_collection_removes_all_documents_from_store() {
+        use document::{Document, NormalValue};
+
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store.clone()));
+
+        // Create collection and add documents
+        db.create_collection(test_users_schema()).await.unwrap();
+        let collection = db.get_collection("Users").unwrap().unwrap();
+
+        {
+            let txn = db.new_txn(false).await.unwrap();
+            for i in 0..5 {
+                let mut doc = Document::new();
+                doc.set("name", NormalValue::String(format!("User{}", i)));
+                doc.set("age", NormalValue::Int(20 + i));
+                doc.generate_and_set_doc_id().unwrap();
+                collection.create(&txn, &doc).await.unwrap();
+            }
+            txn.commit().await.unwrap();
+        }
+
+        // Verify documents exist
+        {
+            let txn = db.new_txn(true).await.unwrap();
+            let docs = collection.get_all(&txn).await.unwrap();
+            assert_eq!(docs.len(), 5, "Should have 5 documents before delete");
+            txn.discard().unwrap();
+        }
+
+        // Delete the collection
+        db.delete_collection("Users").await.unwrap();
+
+        // Verify documents are gone from the store by checking raw keys
+        let count = {
+            let txn = db.new_txn(true).await.unwrap();
+            let doc_prefix = "/d/col-users/";
+            let opts =
+                storage::corekv::IterOptions::new().with_prefix(doc_prefix.as_bytes().to_vec());
+
+            let count = {
+                let datastore = txn.datastore().unwrap();
+                let mut iter = datastore.iterator(opts).await.unwrap();
+
+                let mut c = 0;
+                while iter.next().await.unwrap().is_some() {
+                    c += 1;
+                }
+                iter.close().await.unwrap();
+                c
+            };
+
+            txn.discard().unwrap();
+            count
+        };
+
+        assert_eq!(count, 0, "All documents should be deleted from store");
+    }
+
+    #[tokio::test]
+    async fn test_schema_roundtrip_preserves_all_fields() {
+        let store = MemoryStore::new();
+
+        let original_schema = CollectionVersion::new(
+            "TestCollection",
+            "v1",
+            "col-test-123",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+                FieldDescription::new("4", "active", FieldKind::bool()),
+            ],
+        );
+
+        // Create collection and persist
+        {
+            let db = DB::new(store.clone());
+            db.create_collection(original_schema.clone()).await.unwrap();
+        }
+
+        // Reopen and load from store
+        let db = DB::open(store).await.unwrap();
+        let loaded = db
+            .get_collection("TestCollection")
+            .unwrap()
+            .expect("Collection should exist");
+        let loaded_schema = loaded.schema();
+
+        // Verify all fields are preserved
+        assert_eq!(loaded_schema.name, original_schema.name);
+        assert_eq!(loaded_schema.version_id, original_schema.version_id);
+        assert_eq!(loaded_schema.collection_id, original_schema.collection_id);
+        assert_eq!(
+            loaded_schema.fields.len(),
+            original_schema.fields.len(),
+            "Field count should match"
+        );
+
+        for (loaded_field, original_field) in loaded_schema
+            .fields
+            .iter()
+            .zip(original_schema.fields.iter())
+        {
+            assert_eq!(loaded_field.id, original_field.id, "Field ID mismatch");
+            assert_eq!(
+                loaded_field.name, original_field.name,
+                "Field name mismatch"
+            );
+        }
+    }
 }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -4,6 +4,8 @@
 /// It manages the root store, creates transactions, and provides
 /// access to collections.
 use crate::collection::Collection;
+use crate::collection_name::CollectionName;
+use crate::collection_snapshot::CollectionSnapshot;
 use crate::error::{Error, Result};
 use crate::txn::DbTxn;
 use datastore::BasicTxn;
@@ -172,13 +174,31 @@ impl<S: Store> DB<S> {
             let systemstore = txn.systemstore()?;
             let opts = IterOptions::new().with_prefix(prefix.clone());
 
-            let mut iter = systemstore.iterator(opts).await.map_err(Error::Storage)?;
+            let mut iter = systemstore.iterator(opts).await.map_err(|e| {
+                tracing::error!(error = ?e, "Failed to create iterator during collection load");
+                Error::Storage(e)
+            })?;
 
-            while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
-                let key_str = String::from_utf8_lossy(&pair.key);
-                let prefix_str = String::from_utf8_lossy(&prefix);
+            while let Some(pair) = iter.next().await.map_err(|e| {
+                tracing::error!(error = ?e, "Failed to iterate collections during database load");
+                Error::Storage(e)
+            })? {
+                // Validate UTF-8 in key to catch data corruption early
+                let key_str = String::from_utf8(pair.key.to_vec()).map_err(|e| {
+                    tracing::error!(
+                        error = ?e,
+                        key_bytes = ?&pair.key[..pair.key.len().min(50)],
+                        "Collection key contains invalid UTF-8"
+                    );
+                    Error::Serialization(format!("collection key contains invalid UTF-8: {}", e))
+                })?;
+
+                let prefix_str = String::from_utf8(prefix.clone()).map_err(|e| {
+                    Error::Other(format!("internal error: prefix is not valid UTF-8: {}", e))
+                })?;
+
                 let name = key_str
-                    .strip_prefix(&*prefix_str)
+                    .strip_prefix(&prefix_str)
                     .ok_or_else(|| {
                         Error::Other(format!(
                             "collection key '{}' does not match expected prefix '{}'",
@@ -189,13 +209,24 @@ impl<S: Store> DB<S> {
 
                 let schema: CollectionVersion =
                     serde_json::from_slice(&pair.value).map_err(|e| {
-                        Error::Serialization(format!("failed to deserialize schema: {}", e))
+                        tracing::error!(
+                            error = ?e,
+                            collection_name = %name,
+                            "Failed to deserialize schema for collection"
+                        );
+                        Error::Serialization(format!(
+                            "failed to deserialize schema for collection '{}': {}",
+                            name, e
+                        ))
                     })?;
 
                 collections.insert(name, Collection::new(schema));
             }
 
-            iter.close().await.map_err(Error::Storage)?;
+            iter.close().await.map_err(|e| {
+                tracing::error!(error = ?e, "Failed to close iterator during collection load");
+                Error::Storage(e)
+            })?;
         }
 
         txn.discard()
@@ -214,8 +245,16 @@ impl<S: Store> DB<S> {
     ///
     /// Uses store-level atomicity to prevent duplicates - checks existence within
     /// the transaction before writing.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidCollectionName` if the collection name is invalid
+    /// - `CollectionAlreadyExists` if a collection with this name already exists
+    /// - `CacheUpdateFailedAfterCommit` if the schema was persisted but cache update failed
     pub async fn create_collection(&self, schema: CollectionVersion) -> Result<()> {
-        let name = schema.name.clone();
+        // Validate collection name
+        let collection_name = CollectionName::new(&schema.name)?;
+        let name = collection_name.as_str().to_string();
 
         let txn = self.new_txn(false).await?;
         let key = CollectionNameKey::new(&name);
@@ -239,8 +278,12 @@ impl<S: Store> DB<S> {
         // Write schema to store
         {
             let systemstore = txn.systemstore()?;
-            let data = serde_json::to_vec(&schema)
-                .map_err(|e| Error::Serialization(format!("failed to serialize schema: {}", e)))?;
+            let data = serde_json::to_vec(&schema).map_err(|e| {
+                Error::Serialization(format!(
+                    "failed to serialize schema for collection '{}': {}",
+                    name, e
+                ))
+            })?;
             systemstore
                 .set(&key.bytes(), &data)
                 .await
@@ -249,10 +292,16 @@ impl<S: Store> DB<S> {
 
         txn.commit().await?;
 
-        // Update cache after successful commit
+        // Update cache after successful commit.
+        // If this fails, the collection IS persisted but not in cache.
+        // A restart will recover by loading from store.
         let mut cache = self.collections.write().map_err(|e| {
-            tracing::error!(error = ?e, "Collection cache lock poisoned during create");
-            Error::LockPoisoned("collection cache lock poisoned during create".into())
+            tracing::error!(
+                error = ?e,
+                collection_name = %name,
+                "Collection cache lock poisoned during create - collection WAS persisted to store. Restart will recover."
+            );
+            Error::CacheUpdateFailedAfterCommit(name.clone())
         })?;
         cache.insert(name, Collection::new(schema));
 
@@ -262,6 +311,11 @@ impl<S: Store> DB<S> {
     /// Delete a collection and all its documents.
     ///
     /// Checks store for existence within transaction for atomic delete.
+    ///
+    /// # Errors
+    ///
+    /// - `CollectionNotFound` if the collection does not exist
+    /// - `CacheUpdateFailedAfterCommit` if the collection was deleted but cache update failed
     pub async fn delete_collection(&self, name: &str) -> Result<()> {
         // Get collection_id from cache (read lock, released before async ops)
         let collection_id = {
@@ -314,17 +368,32 @@ impl<S: Store> DB<S> {
             }
             iter.close().await.map_err(Error::Storage)?;
 
-            for key in keys_to_delete {
-                datastore.delete(&key).await.map_err(Error::Storage)?;
+            for (i, key) in keys_to_delete.iter().enumerate() {
+                datastore.delete(key).await.map_err(|e| {
+                    tracing::error!(
+                        error = ?e,
+                        collection_name = %name,
+                        documents_deleted = i,
+                        documents_total = keys_to_delete.len(),
+                        "Failed to delete document during collection deletion"
+                    );
+                    Error::Storage(e)
+                })?;
             }
         }
 
         txn.commit().await?;
 
-        // Update cache after successful commit
+        // Update cache after successful commit.
+        // If this fails, the collection IS deleted but still in cache.
+        // A restart will recover by loading from store.
         let mut cache = self.collections.write().map_err(|e| {
-            tracing::error!(error = ?e, "Collection cache lock poisoned during delete");
-            Error::LockPoisoned("collection cache lock poisoned during delete".into())
+            tracing::error!(
+                error = ?e,
+                collection_name = %name,
+                "Collection cache lock poisoned during delete - collection WAS deleted from store. Restart will recover."
+            );
+            Error::CacheUpdateFailedAfterCommit(name.to_string())
         })?;
         cache.remove(name);
 
@@ -365,12 +434,14 @@ impl<S: Store> DB<S> {
     }
 
     /// Get a snapshot of all collections (for use by DbTransactionRegistry).
-    pub fn collections_snapshot(&self) -> Result<HashMap<String, Collection>> {
+    ///
+    /// Returns an immutable snapshot that provides snapshot isolation for transactions.
+    pub fn collections_snapshot(&self) -> Result<CollectionSnapshot> {
         let cache = self.collections.read().map_err(|e| {
             tracing::error!(error = ?e, "Collection cache lock poisoned during snapshot");
             Error::LockPoisoned("collection cache lock poisoned during snapshot".into())
         })?;
-        Ok(cache.clone())
+        Ok(CollectionSnapshot::new(cache.clone()))
     }
 }
 
@@ -533,6 +604,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_collection_with_invalid_name_fails() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        // Empty name should fail
+        let empty_schema = CollectionVersion::new(
+            "",
+            "v1",
+            "col-empty",
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        );
+        let result = db.create_collection(empty_schema).await;
+        assert!(
+            matches!(result, Err(Error::InvalidCollectionName(_))),
+            "Expected InvalidCollectionName for empty name, got: {:?}",
+            result
+        );
+
+        // Name with slash should fail
+        let slash_schema = CollectionVersion::new(
+            "Users/Posts",
+            "v1",
+            "col-slash",
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        );
+        let result = db.create_collection(slash_schema).await;
+        assert!(
+            matches!(result, Err(Error::InvalidCollectionName(_))),
+            "Expected InvalidCollectionName for name with slash, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
     async fn test_list_collections_empty() {
         let store = MemoryStore::new();
         let db = DB::new(store);
@@ -621,6 +726,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_open_with_options_loads_existing_collections() {
+        let store = MemoryStore::new();
+
+        {
+            let db = DB::new(store.clone());
+            db.create_collection(test_users_schema()).await.unwrap();
+        }
+
+        // Use open_with_options with custom options
+        let opts = DbOptions {
+            max_txn_retries: Some(10),
+            chunk_size: Some(1024),
+        };
+        let db = DB::open_with_options(store, opts).await.unwrap();
+
+        // Verify collections loaded correctly
+        assert!(db.has_collection("Users").unwrap());
+        let coll = db.get_collection("Users").unwrap().unwrap();
+        assert_eq!(coll.name(), "Users");
+
+        // Verify options were applied
+        assert_eq!(db.options().max_txn_retries, Some(10));
+        assert_eq!(db.options().chunk_size, Some(1024));
+    }
+
+    #[tokio::test]
+    async fn test_open_empty_store_returns_empty_collections() {
+        let store = MemoryStore::new();
+        let db = DB::open(store).await.unwrap();
+        assert!(db.list_collections().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn test_collections_snapshot() {
         let store = MemoryStore::new();
         let db = DB::new(store);
@@ -629,7 +767,7 @@ mod tests {
 
         let snapshot = db.collections_snapshot().unwrap();
         assert_eq!(snapshot.len(), 1);
-        assert!(snapshot.contains_key("Users"));
+        assert!(snapshot.contains("Users"));
     }
 
     #[tokio::test]

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -259,6 +259,30 @@ impl<S: Store> DB<S> {
         Ok(())
     }
 
+    /// Reload the collection cache from persistent storage.
+    ///
+    /// This method is useful for recovering from cache-store inconsistency
+    /// without restarting the application. Call this after receiving a
+    /// `CacheUpdateFailedAfterCommit` error.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// match db.create_collection(schema).await {
+    ///     Ok(_) => println!("Collection created"),
+    ///     Err(Error::CacheUpdateFailedAfterCommit(_)) => {
+    ///         // Collection was persisted but cache update failed
+    ///         db.reload_cache().await?;
+    ///         println!("Cache recovered");
+    ///     }
+    ///     Err(e) => return Err(e),
+    /// }
+    /// ```
+    pub async fn reload_cache(&self) -> Result<()> {
+        tracing::info!("Reloading collection cache from persistent storage");
+        self.load_collections().await
+    }
+
     /// Create a new collection with schema persistence.
     ///
     /// Uses store-level atomicity to prevent duplicates - checks existence within
@@ -317,12 +341,12 @@ impl<S: Store> DB<S> {
 
         // Update cache after successful commit.
         // If this fails, the collection IS persisted but not in cache.
-        // A restart will recover by loading from store.
+        // Call reload_cache() or restart to recover.
         let mut cache = self.collections.write().map_err(|e| {
             tracing::error!(
                 error = ?e,
                 collection_name = %name,
-                "Collection cache lock poisoned during create - collection WAS persisted to store. Restart will recover."
+                "Collection cache lock poisoned during create - collection WAS persisted to store. Call reload_cache() or restart to recover."
             );
             Error::CacheUpdateFailedAfterCommit(name.clone())
         })?;
@@ -442,12 +466,12 @@ impl<S: Store> DB<S> {
 
         // Update cache after successful commit.
         // If this fails, the collection IS deleted but still in cache.
-        // A restart will recover by loading from store.
+        // Call reload_cache() or restart to recover.
         let mut cache = self.collections.write().map_err(|e| {
             tracing::error!(
                 error = ?e,
                 collection_name = %name,
-                "Collection cache lock poisoned during delete - collection WAS deleted from store. Restart will recover."
+                "Collection cache lock poisoned during delete - collection WAS deleted from store. Call reload_cache() or restart to recover."
             );
             Error::CacheUpdateFailedAfterCommit(name.to_string())
         })?;
@@ -1123,5 +1147,49 @@ mod tests {
             r2.is_ok(),
             exists
         );
+    }
+
+    #[tokio::test]
+    async fn test_reload_cache_recovers_from_inconsistency() {
+        // Test that reload_cache() can recover from cache-store inconsistency
+        use storage::corekv::Key;
+        use storage::keys::systemstore::CollectionNameKey;
+
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store.clone()));
+
+        // Create a collection normally
+        db.create_collection(test_users_schema()).await.unwrap();
+        assert!(db.has_collection("Users").unwrap());
+
+        // Simulate cache-store divergence by directly adding to store
+        {
+            let txn = db.new_txn(false).await.unwrap();
+            let schema = CollectionVersion::new(
+                "HiddenCollection",
+                "v1",
+                "col-hidden",
+                vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+            );
+            let key = CollectionNameKey::new("HiddenCollection");
+            {
+                let systemstore = txn.systemstore().unwrap();
+                let data = serde_json::to_vec(&schema).unwrap();
+                systemstore.set(&key.bytes(), &data).await.unwrap();
+            }
+            txn.commit().await.unwrap();
+        }
+
+        // Cache doesn't know about HiddenCollection
+        assert!(!db.has_collection("HiddenCollection").unwrap());
+        assert_eq!(db.list_collections().unwrap().len(), 1);
+
+        // Reload cache from store
+        db.reload_cache().await.unwrap();
+
+        // Now cache should reflect store state
+        assert!(db.has_collection("Users").unwrap());
+        assert!(db.has_collection("HiddenCollection").unwrap());
+        assert_eq!(db.list_collections().unwrap().len(), 2);
     }
 }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -161,17 +161,13 @@ impl<S: Store> DB<S> {
         self.txn_id_counter.load(Ordering::SeqCst)
     }
 
-    // =========================================================================
-    // Collection Lifecycle Management
-    // =========================================================================
-
     /// Load all collections from the SystemStore into the in-memory cache.
     pub async fn load_collections(&self) -> Result<()> {
         let txn = self.new_txn(true).await?;
         let prefix = CollectionNameKey::name_prefix();
         let mut collections = HashMap::new();
 
-        // Use a block to ensure systemstore reference is dropped before discard
+        // Block ensures systemstore reference is dropped before discard
         {
             let systemstore = txn.systemstore()?;
             let opts = IterOptions::new().with_prefix(prefix.clone());
@@ -179,17 +175,22 @@ impl<S: Store> DB<S> {
             let mut iter = systemstore.iterator(opts).await.map_err(Error::Storage)?;
 
             while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
-                // Extract collection name from key: /collection/name/{name}
                 let key_str = String::from_utf8_lossy(&pair.key);
                 let prefix_str = String::from_utf8_lossy(&prefix);
                 let name = key_str
                     .strip_prefix(&*prefix_str)
-                    .unwrap_or(&key_str)
+                    .ok_or_else(|| {
+                        Error::Other(format!(
+                            "collection key '{}' does not match expected prefix '{}'",
+                            key_str, prefix_str
+                        ))
+                    })?
                     .to_string();
 
-                // Deserialize CollectionVersion from JSON
-                let schema: CollectionVersion = serde_json::from_slice(&pair.value)
-                    .map_err(|e| Error::Serialization(format!("failed to deserialize schema: {}", e)))?;
+                let schema: CollectionVersion =
+                    serde_json::from_slice(&pair.value).map_err(|e| {
+                        Error::Serialization(format!("failed to deserialize schema: {}", e))
+                    })?;
 
                 collections.insert(name, Collection::new(schema));
             }
@@ -197,37 +198,49 @@ impl<S: Store> DB<S> {
             iter.close().await.map_err(Error::Storage)?;
         }
 
-        txn.discard().map_err(|_| Error::TxnNotActive)?;
+        txn.discard()
+            .map_err(|e| Error::Other(format!("failed to discard transaction: {}", e)))?;
 
-        // Update in-memory cache
-        let mut cache = self
-            .collections
-            .write()
-            .map_err(|_| Error::Other("collection cache lock poisoned".into()))?;
+        let mut cache = self.collections.write().map_err(|e| {
+            tracing::error!(error = ?e, "Collection cache lock poisoned during load");
+            Error::LockPoisoned("collection cache lock poisoned during load".into())
+        })?;
         *cache = collections;
 
         Ok(())
     }
 
     /// Create a new collection with schema persistence.
+    ///
+    /// Uses store-level atomicity to prevent duplicates - checks existence within
+    /// the transaction before writing.
     pub async fn create_collection(&self, schema: CollectionVersion) -> Result<()> {
         let name = schema.name.clone();
 
-        // Check if collection already exists
-        if self.has_collection(&name) {
+        let txn = self.new_txn(false).await?;
+        let key = CollectionNameKey::new(&name);
+
+        // Check if collection exists in store (must drop systemstore before discard)
+        let exists = {
+            let systemstore = txn.systemstore()?;
+            systemstore
+                .get(&key.bytes())
+                .await
+                .map_err(Error::Storage)?
+                .is_some()
+        };
+
+        if exists {
+            txn.discard()
+                .map_err(|e| Error::Other(format!("failed to discard: {}", e)))?;
             return Err(Error::CollectionAlreadyExists(name));
         }
 
-        // Persist schema to SystemStore
-        let txn = self.new_txn(false).await?;
-
-        let key = CollectionNameKey::new(&name);
-        let data = serde_json::to_vec(&schema)
-            .map_err(|e| Error::Serialization(format!("failed to serialize schema: {}", e)))?;
-
-        // Use a block to ensure systemstore reference is dropped before commit
+        // Write schema to store
         {
             let systemstore = txn.systemstore()?;
+            let data = serde_json::to_vec(&schema)
+                .map_err(|e| Error::Serialization(format!("failed to serialize schema: {}", e)))?;
             systemstore
                 .set(&key.bytes(), &data)
                 .await
@@ -236,30 +249,61 @@ impl<S: Store> DB<S> {
 
         txn.commit().await?;
 
-        // Update in-memory cache
-        let mut cache = self
-            .collections
-            .write()
-            .map_err(|_| Error::Other("collection cache lock poisoned".into()))?;
+        // Update cache after successful commit
+        let mut cache = self.collections.write().map_err(|e| {
+            tracing::error!(error = ?e, "Collection cache lock poisoned during create");
+            Error::LockPoisoned("collection cache lock poisoned during create".into())
+        })?;
         cache.insert(name, Collection::new(schema));
 
         Ok(())
     }
 
     /// Delete a collection and all its documents.
+    ///
+    /// Checks store for existence within transaction for atomic delete.
     pub async fn delete_collection(&self, name: &str) -> Result<()> {
-        // Check if collection exists
-        let collection = self
-            .get_collection(name)
-            .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?;
+        // Get collection_id from cache (read lock, released before async ops)
+        let collection_id = {
+            let cache = self.collections.read().map_err(|e| {
+                tracing::error!(error = ?e, "Collection cache lock poisoned during delete");
+                Error::LockPoisoned("collection cache lock poisoned during delete".into())
+            })?;
+            cache
+                .get(name)
+                .map(|c| c.collection_id().to_string())
+                .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?
+        };
 
         let txn = self.new_txn(false).await?;
+        let schema_key = CollectionNameKey::new(name);
 
-        // Use a block to ensure store references are dropped before commit
+        // Verify collection still exists in store (must drop systemstore before discard)
+        let exists = {
+            let systemstore = txn.systemstore()?;
+            systemstore
+                .get(&schema_key.bytes())
+                .await
+                .map_err(Error::Storage)?
+                .is_some()
+        };
+
+        if !exists {
+            txn.discard()
+                .map_err(|e| Error::Other(format!("failed to discard: {}", e)))?;
+            return Err(Error::CollectionNotFound(name.to_string()));
+        }
+
+        // Delete schema and documents
         {
-            // Delete all documents in the collection
+            let systemstore = txn.systemstore()?;
+            systemstore
+                .delete(&schema_key.bytes())
+                .await
+                .map_err(Error::Storage)?;
+
             let datastore = txn.datastore()?;
-            let doc_prefix = format!("/d/{}/", collection.collection_id());
+            let doc_prefix = format!("/d/{}/", collection_id);
             let opts = IterOptions::new().with_prefix(doc_prefix.as_bytes().to_vec());
 
             let mut iter = datastore.iterator(opts).await.map_err(Error::Storage)?;
@@ -273,23 +317,15 @@ impl<S: Store> DB<S> {
             for key in keys_to_delete {
                 datastore.delete(&key).await.map_err(Error::Storage)?;
             }
-
-            // Delete schema from SystemStore
-            let systemstore = txn.systemstore()?;
-            let key = CollectionNameKey::new(name);
-            systemstore
-                .delete(&key.bytes())
-                .await
-                .map_err(Error::Storage)?;
         }
 
         txn.commit().await?;
 
-        // Remove from in-memory cache
-        let mut cache = self
-            .collections
-            .write()
-            .map_err(|_| Error::Other("collection cache lock poisoned".into()))?;
+        // Update cache after successful commit
+        let mut cache = self.collections.write().map_err(|e| {
+            tracing::error!(error = ?e, "Collection cache lock poisoned during delete");
+            Error::LockPoisoned("collection cache lock poisoned during delete".into())
+        })?;
         cache.remove(name);
 
         Ok(())
@@ -297,37 +333,44 @@ impl<S: Store> DB<S> {
 
     /// List all collection names.
     pub fn list_collections(&self) -> Result<Vec<String>> {
-        let cache = self
-            .collections
-            .read()
-            .map_err(|_| Error::Other("collection cache lock poisoned".into()))?;
+        let cache = self.collections.read().map_err(|e| {
+            tracing::error!(error = ?e, "Collection cache lock poisoned during list");
+            Error::LockPoisoned("collection cache lock poisoned during list".into())
+        })?;
         Ok(cache.keys().cloned().collect())
     }
 
     /// Get a collection by name.
-    pub fn get_collection(&self, name: &str) -> Option<Collection> {
-        self.collections
+    pub fn get_collection(&self, name: &str) -> Result<Option<Collection>> {
+        let cache = self
+            .collections
             .read()
-            .ok()
-            .and_then(|cache| cache.get(name).cloned())
+            .map_err(|e| {
+                tracing::error!(error = ?e, collection_name = %name, "Collection cache lock poisoned during get");
+                Error::LockPoisoned("collection cache lock poisoned during get".into())
+            })?;
+        Ok(cache.get(name).cloned())
     }
 
     /// Check if a collection exists.
-    pub fn has_collection(&self, name: &str) -> bool {
-        self.collections
+    pub fn has_collection(&self, name: &str) -> Result<bool> {
+        let cache = self
+            .collections
             .read()
-            .ok()
-            .map(|cache| cache.contains_key(name))
-            .unwrap_or(false)
+            .map_err(|e| {
+                tracing::error!(error = ?e, collection_name = %name, "Collection cache lock poisoned during has_collection");
+                Error::LockPoisoned("collection cache lock poisoned during has_collection".into())
+            })?;
+        Ok(cache.contains_key(name))
     }
 
     /// Get a snapshot of all collections (for use by DbTransactionRegistry).
-    pub fn collections_snapshot(&self) -> HashMap<String, Collection> {
-        self.collections
-            .read()
-            .ok()
-            .map(|cache| cache.clone())
-            .unwrap_or_default()
+    pub fn collections_snapshot(&self) -> Result<HashMap<String, Collection>> {
+        let cache = self.collections.read().map_err(|e| {
+            tracing::error!(error = ?e, "Collection cache lock poisoned during snapshot");
+            Error::LockPoisoned("collection cache lock poisoned during snapshot".into())
+        })?;
+        Ok(cache.clone())
     }
 }
 
@@ -444,10 +487,6 @@ mod tests {
         assert_eq!(value, None);
     }
 
-    // =========================================================================
-    // Collection Lifecycle Tests
-    // =========================================================================
-
     use schema::{CollectionVersion, FieldDescription, FieldKind};
 
     fn test_users_schema() -> CollectionVersion {
@@ -471,8 +510,8 @@ mod tests {
         let schema = test_users_schema();
         db.create_collection(schema).await.unwrap();
 
-        assert!(db.has_collection("Users"));
-        let coll = db.get_collection("Users").unwrap();
+        assert!(db.has_collection("Users").unwrap());
+        let coll = db.get_collection("Users").unwrap().unwrap();
         assert_eq!(coll.name(), "Users");
     }
 
@@ -486,7 +525,11 @@ mod tests {
 
         // Second create with same name should fail
         let result = db.create_collection(schema).await;
-        assert!(matches!(result, Err(Error::CollectionAlreadyExists(_))));
+        assert!(
+            matches!(result, Err(Error::CollectionAlreadyExists(_))),
+            "Expected CollectionAlreadyExists, got: {:?}",
+            result
+        );
     }
 
     #[tokio::test]
@@ -524,10 +567,10 @@ mod tests {
         let db = DB::new(store);
 
         db.create_collection(test_users_schema()).await.unwrap();
-        assert!(db.has_collection("Users"));
+        assert!(db.has_collection("Users").unwrap());
 
         db.delete_collection("Users").await.unwrap();
-        assert!(!db.has_collection("Users"));
+        assert!(!db.has_collection("Users").unwrap());
     }
 
     #[tokio::test]
@@ -544,10 +587,10 @@ mod tests {
         let store = MemoryStore::new();
         let db = DB::new(store);
 
-        assert!(!db.has_collection("Users"));
+        assert!(!db.has_collection("Users").unwrap());
 
         db.create_collection(test_users_schema()).await.unwrap();
-        assert!(db.has_collection("Users"));
+        assert!(db.has_collection("Users").unwrap());
     }
 
     #[tokio::test]
@@ -555,28 +598,25 @@ mod tests {
         let store = MemoryStore::new();
         let db = DB::new(store);
 
-        assert!(db.get_collection("Users").is_none());
+        assert!(db.get_collection("Users").unwrap().is_none());
 
         db.create_collection(test_users_schema()).await.unwrap();
-        let coll = db.get_collection("Users").unwrap();
+        let coll = db.get_collection("Users").unwrap().unwrap();
         assert_eq!(coll.collection_id(), "col-users");
     }
 
     #[tokio::test]
     async fn test_open_loads_existing_collections() {
-        // Create a store and populate it with a collection
         let store = MemoryStore::new();
 
-        // First, create and populate DB
         {
             let db = DB::new(store.clone());
             db.create_collection(test_users_schema()).await.unwrap();
         }
 
-        // Now open the same store with open() and verify collection loaded
         let db = DB::open(store).await.unwrap();
-        assert!(db.has_collection("Users"));
-        let coll = db.get_collection("Users").unwrap();
+        assert!(db.has_collection("Users").unwrap());
+        let coll = db.get_collection("Users").unwrap().unwrap();
         assert_eq!(coll.name(), "Users");
     }
 
@@ -587,8 +627,62 @@ mod tests {
 
         db.create_collection(test_users_schema()).await.unwrap();
 
-        let snapshot = db.collections_snapshot();
+        let snapshot = db.collections_snapshot().unwrap();
         assert_eq!(snapshot.len(), 1);
         assert!(snapshot.contains_key("Users"));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_create_same_collection() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+
+        let schema = test_users_schema();
+
+        let db1 = db.clone();
+        let schema1 = schema.clone();
+        let handle1 = tokio::spawn(async move { db1.create_collection(schema1).await });
+
+        let db2 = db.clone();
+        let schema2 = schema.clone();
+        let handle2 = tokio::spawn(async move { db2.create_collection(schema2).await });
+
+        let (r1, r2) = tokio::join!(handle1, handle2);
+        let results = [r1.unwrap(), r2.unwrap()];
+
+        let successes = results.iter().filter(|r| r.is_ok()).count();
+        let failures = results.iter().filter(|r| r.is_err()).count();
+
+        assert_eq!(successes, 1, "Exactly one concurrent create should succeed");
+        assert_eq!(failures, 1, "Exactly one concurrent create should fail");
+
+        // Cache should have exactly one collection
+        assert_eq!(db.list_collections().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_delete_same_collection() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+
+        db.create_collection(test_users_schema()).await.unwrap();
+
+        let db1 = db.clone();
+        let handle1 = tokio::spawn(async move { db1.delete_collection("Users").await });
+
+        let db2 = db.clone();
+        let handle2 = tokio::spawn(async move { db2.delete_collection("Users").await });
+
+        let (r1, r2) = tokio::join!(handle1, handle2);
+        let results = [r1.unwrap(), r2.unwrap()];
+
+        let successes = results.iter().filter(|r| r.is_ok()).count();
+        let failures = results.iter().filter(|r| r.is_err()).count();
+
+        assert_eq!(successes, 1, "Exactly one concurrent delete should succeed");
+        assert_eq!(failures, 1, "Exactly one concurrent delete should fail");
+
+        // Cache should be empty
+        assert!(db.list_collections().unwrap().is_empty());
     }
 }

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -3,19 +3,18 @@
 use async_trait::async_trait;
 use document::Document;
 use query::runner::{DocFetcher, FetchByIdsResult};
-use std::collections::HashMap;
 use std::sync::Arc;
 use storage::corekv::Store;
 use tokio::sync::Mutex as TokioMutex;
 use tracing::warn;
 
-use crate::collection::Collection;
+use crate::collection_snapshot::CollectionSnapshot;
 use crate::txn::DbTxn;
 
 /// Document fetcher that uses a database transaction.
 ///
-/// This fetcher holds a reference to an active transaction and collection
-/// definitions, allowing it to fetch documents within the transaction context.
+/// This fetcher holds a reference to an active transaction and a collection
+/// snapshot, allowing it to fetch documents within the transaction context.
 ///
 /// # Ownership Model
 ///
@@ -29,12 +28,12 @@ use crate::txn::DbTxn;
 /// indicating the transaction was consumed. Use `is_consumed()` to check state.
 pub struct DbDocFetcher<S: Store> {
     txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
-    collections: Arc<HashMap<String, Collection>>,
+    collections: CollectionSnapshot,
 }
 
 impl<S: Store> DbDocFetcher<S> {
     /// Create a new transaction-scoped document fetcher.
-    pub(crate) fn new(txn: DbTxn<S>, collections: Arc<HashMap<String, Collection>>) -> Self {
+    pub(crate) fn new(txn: DbTxn<S>, collections: CollectionSnapshot) -> Self {
         Self {
             txn: Arc::new(TokioMutex::new(Some(txn))),
             collections,
@@ -64,7 +63,8 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         let collection = self
             .collections
             .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?
+            .clone();
 
         // Extract the datastore while holding the lock, then release the lock
         // before awaiting. The datastore is Send + Sync so this is safe.
@@ -95,7 +95,8 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         let collection = self
             .collections
             .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?
+            .clone();
 
         // Extract the datastore while holding the lock, then release the lock
         // before awaiting. The datastore is Send + Sync so this is safe.

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     #[error("invalid document: {0}")]
     InvalidDocument(String),
 
+    #[error("invalid collection name: {0}")]
+    InvalidCollectionName(String),
+
     #[error("transaction not active")]
     TxnNotActive,
 
@@ -47,6 +50,11 @@ pub enum Error {
 
     #[error("transaction registry lock poisoned: {0}")]
     LockPoisoned(String),
+
+    #[error(
+        "cache update failed after successful commit for collection '{0}' - restart recommended"
+    )]
+    CacheUpdateFailedAfterCommit(String),
 
     #[error("{0}")]
     Other(String),

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -52,7 +52,7 @@ pub enum Error {
     LockPoisoned(String),
 
     #[error(
-        "cache update failed after successful commit for collection '{0}' - restart recommended"
+        "cache update failed after successful commit for collection '{0}' - call reload_cache() or restart to recover"
     )]
     CacheUpdateFailedAfterCommit(String),
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -43,6 +43,8 @@
 /// txn.commit().await?;
 /// ```
 pub mod collection;
+pub mod collection_name;
+pub mod collection_snapshot;
 pub mod database;
 pub mod doc_fetcher;
 pub mod error;
@@ -52,6 +54,8 @@ pub mod txn_registry;
 
 // Re-export commonly used types
 pub use collection::Collection;
+pub use collection_name::CollectionName;
+pub use collection_snapshot::CollectionSnapshot;
 pub use database::{DbOptions, DB};
 pub use doc_fetcher::DbDocFetcher;
 pub use error::{Error, Result};

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -98,12 +98,12 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
     }
 
     /// Get a snapshot of all collections from the DB.
-    pub fn collections(&self) -> HashMap<String, Collection> {
+    pub fn collections(&self) -> Result<HashMap<String, Collection>> {
         self.db.collections_snapshot()
     }
 
     /// Get a collection by name from the DB.
-    pub fn collection(&self, name: &str) -> Option<Collection> {
+    pub fn collection(&self, name: &str) -> Result<Option<Collection>> {
         self.db.get_collection(name)
     }
 
@@ -255,8 +255,11 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .await
             .map_err(|e| TransactionError::execution(format!("storage error: {}", e)))?;
 
-        // Snapshot collections at transaction start time (matches Go behavior)
-        let collections = Arc::new(self.db.collections_snapshot());
+        // Snapshot collections at transaction start for snapshot isolation -
+        // the transaction sees a consistent view of collections throughout its lifetime
+        let collections = Arc::new(self.db.collections_snapshot().map_err(|e| {
+            TransactionError::execution(format!("failed to snapshot collections: {}", e))
+        })?);
         let fetcher = Arc::new(DbDocFetcher::new(db_txn, collections));
         let ctx = Arc::new(DbTransactionContext::new(txn_id.clone(), readonly, fetcher));
 
@@ -673,7 +676,7 @@ mod tests {
     async fn test_transaction_sees_committed_data() {
         let db = test_db_with_collections().await;
         let registry = DbTransactionRegistry::new(db.clone());
-        let collection = db.get_collection("Users").unwrap();
+        let collection = db.get_collection("Users").unwrap().unwrap();
 
         // Write data in a separate transaction
         let write_txn = db.new_txn(false).await.unwrap();
@@ -700,7 +703,7 @@ mod tests {
     async fn test_get_by_ids_returns_matching_docs() {
         let db = test_db_with_collections().await;
         let registry = DbTransactionRegistry::new(db.clone());
-        let collection = db.get_collection("Users").unwrap();
+        let collection = db.get_collection("Users").unwrap().unwrap();
 
         // Create two documents
         let write_txn = db.new_txn(false).await.unwrap();
@@ -775,7 +778,7 @@ mod tests {
     #[tokio::test]
     async fn test_rollback_discards_uncommitted_writes() {
         let db = test_db_with_collections().await;
-        let collection = db.get_collection("Users").unwrap();
+        let collection = db.get_collection("Users").unwrap().unwrap();
 
         // Write data in a transaction but rollback instead of commit
         let write_txn = db.new_txn(false).await.unwrap();
@@ -802,7 +805,7 @@ mod tests {
     async fn test_transaction_does_not_see_uncommitted_writes() {
         let db = test_db_with_collections().await;
         let registry = DbTransactionRegistry::new(db.clone());
-        let collection = db.get_collection("Users").unwrap();
+        let collection = db.get_collection("Users").unwrap().unwrap();
 
         // Start a reader transaction FIRST
         let reader_txn_id = registry.begin(true).await.unwrap();
@@ -884,7 +887,7 @@ mod tests {
     async fn test_get_by_ids_with_nonexistent_valid_id() {
         let db = test_db_with_collections().await;
         let registry = DbTransactionRegistry::new(db.clone());
-        let collection = db.get_collection("Users").unwrap();
+        let collection = db.get_collection("Users").unwrap().unwrap();
 
         // Create one document
         let write_txn = db.new_txn(false).await.unwrap();
@@ -1062,7 +1065,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.cleaned, 1, "Should have cleaned up 1 old transaction");
+        assert_eq!(
+            result.cleaned, 1,
+            "Should have cleaned up 1 old transaction"
+        );
         assert!(result.is_complete(), "All cleanups should succeed");
         assert_eq!(
             registry.active_transaction_count().unwrap(),
@@ -1101,7 +1107,7 @@ mod tests {
         // another transaction commits should NOT see the committed data.
         let db = test_db_with_collections().await;
         let registry = DbTransactionRegistry::new(db.clone());
-        let collection = db.get_collection("Users").unwrap();
+        let collection = db.get_collection("Users").unwrap().unwrap();
 
         // Step 1: Start reader transaction A FIRST (gets snapshot at this point)
         let reader_txn_id = registry.begin(true).await.unwrap();

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -27,6 +27,7 @@ use storage::corekv::Store;
 use tracing::{error, warn};
 
 use crate::collection::Collection;
+use crate::collection_snapshot::CollectionSnapshot;
 use crate::database::DB;
 use crate::doc_fetcher::DbDocFetcher;
 use crate::error::{Error, Result};
@@ -98,7 +99,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
     }
 
     /// Get a snapshot of all collections from the DB.
-    pub fn collections(&self) -> Result<HashMap<String, Collection>> {
+    pub fn collections(&self) -> Result<CollectionSnapshot> {
         self.db.collections_snapshot()
     }
 
@@ -257,9 +258,9 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
 
         // Snapshot collections at transaction start for snapshot isolation -
         // the transaction sees a consistent view of collections throughout its lifetime
-        let collections = Arc::new(self.db.collections_snapshot().map_err(|e| {
+        let collections = self.db.collections_snapshot().map_err(|e| {
             TransactionError::execution(format!("failed to snapshot collections: {}", e))
-        })?);
+        })?;
         let fetcher = Arc::new(DbDocFetcher::new(db_txn, collections));
         let ctx = Arc::new(DbTransactionContext::new(txn_id.clone(), readonly, fetcher));
 
@@ -1162,5 +1163,141 @@ mod tests {
         );
 
         registry.rollback(&new_reader_txn_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_new_transaction_sees_recently_created_collection() {
+        // Test that a transaction started AFTER a collection is created can see that collection
+        let db = Arc::new(DB::new(MemoryStore::new()));
+        let registry = DbTransactionRegistry::new(db.clone());
+
+        // Create collection after registry is created
+        db.create_collection(CollectionVersion::new(
+            "NewCollection",
+            "v1",
+            "col-new",
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        ))
+        .await
+        .unwrap();
+
+        // New transaction should see the collection
+        let txn_id = registry.begin(true).await.unwrap();
+        let collections = registry.collections().unwrap();
+        assert!(
+            collections.contains("NewCollection"),
+            "New transaction should see recently created collection"
+        );
+
+        registry.rollback(&txn_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_collection_snapshot_isolation_during_deletion() {
+        // Test snapshot isolation: a transaction that started before a collection
+        // is deleted should still be able to query that collection
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db.clone());
+        let collection = db.get_collection("Users").unwrap().unwrap();
+
+        // Add some data to the collection first
+        {
+            let write_txn = db.new_txn(false).await.unwrap();
+            let mut doc = Document::new();
+            doc.set("name", NormalValue::String("Alice".to_string()));
+            doc.set("age", NormalValue::Int(30));
+            doc.generate_and_set_doc_id().unwrap();
+            collection.create(&write_txn, &doc).await.unwrap();
+            write_txn.commit().await.unwrap();
+        }
+
+        // Start a transaction BEFORE deletion
+        let reader_txn_id = registry.begin(true).await.unwrap();
+        let reader_ctx = registry.get(&reader_txn_id).into_result().unwrap().unwrap();
+        let reader_fetcher = reader_ctx.doc_fetcher();
+
+        // Verify reader can see the collection with data
+        let docs_before = reader_fetcher.get_all("Users").await.unwrap();
+        assert_eq!(
+            docs_before.len(),
+            1,
+            "Should see 1 document before deletion"
+        );
+
+        // Now delete the collection from the DB
+        db.delete_collection("Users").await.unwrap();
+
+        // The reader transaction should STILL be able to query the collection
+        // because it has a snapshot from before the deletion
+        let docs_after = reader_fetcher.get_all("Users").await.unwrap();
+        assert_eq!(
+            docs_after.len(),
+            1,
+            "Reader should still see document after deletion due to snapshot isolation"
+        );
+        assert_eq!(
+            docs_after[0].get("name").unwrap().as_str(),
+            Some("Alice"),
+            "Should see the same document content"
+        );
+
+        // However, the DB should report the collection as gone
+        assert!(
+            !db.has_collection("Users").unwrap(),
+            "DB should report collection as deleted"
+        );
+
+        registry.rollback(&reader_txn_id).await.unwrap();
+
+        // A NEW transaction should NOT see the deleted collection
+        let new_txn_id = registry.begin(true).await.unwrap();
+        let new_ctx = registry.get(&new_txn_id).into_result().unwrap().unwrap();
+        let new_fetcher = new_ctx.doc_fetcher();
+
+        let result = new_fetcher.get_all("Users").await;
+        assert!(
+            result.is_err(),
+            "New transaction should not see deleted collection"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("Users"),
+            "Error should mention the collection name"
+        );
+
+        registry.rollback(&new_txn_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_collections_snapshot_is_isolated_from_modifications() {
+        // Test that modifying a snapshot does not affect the original cache
+        let db = test_db_with_collections().await;
+
+        let snapshot = db.collections_snapshot().unwrap();
+        assert!(snapshot.contains("Users"));
+
+        // The snapshot should be an independent copy
+        // (This is implicitly tested by the fact that CollectionSnapshot
+        // wraps an Arc and doesn't expose mutable methods)
+
+        // Adding a new collection should not affect existing snapshots
+        db.create_collection(CollectionVersion::new(
+            "Posts",
+            "v1",
+            "col-posts",
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        ))
+        .await
+        .unwrap();
+
+        // Original snapshot should still only have Users
+        assert_eq!(snapshot.len(), 1);
+        assert!(snapshot.contains("Users"));
+        assert!(!snapshot.contains("Posts"));
+
+        // New snapshot should have both
+        let new_snapshot = db.collections_snapshot().unwrap();
+        assert_eq!(new_snapshot.len(), 2);
+        assert!(new_snapshot.contains("Users"));
+        assert!(new_snapshot.contains("Posts"));
     }
 }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -19,7 +19,6 @@ use query::error::TransactionError;
 use query::txn::{
     GetTransactionResult, TransactionContext, TransactionHandle, TransactionRegistry,
 };
-use schema::CollectionVersion;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -77,22 +76,17 @@ impl CleanupResult {
 /// operation would be unsafe.
 pub struct DbTransactionRegistry<S: Store> {
     db: Arc<DB<S>>,
-    collections: Arc<HashMap<String, Collection>>,
     transactions: RwLock<HashMap<String, Arc<DbTransactionContext<S>>>>,
     id_counter: AtomicU64,
 }
 
 impl<S: Store + 'static> DbTransactionRegistry<S> {
     /// Create a new transaction registry.
-    pub fn new(db: Arc<DB<S>>, schema: Vec<CollectionVersion>) -> Self {
-        let collections: HashMap<String, Collection> = schema
-            .into_iter()
-            .map(|cv| (cv.name.clone(), Collection::new(cv)))
-            .collect();
-
+    ///
+    /// Collections are sourced from the DB's collection cache.
+    pub fn new(db: Arc<DB<S>>) -> Self {
         Self {
             db,
-            collections: Arc::new(collections),
             transactions: RwLock::new(HashMap::new()),
             id_counter: AtomicU64::new(0),
         }
@@ -103,14 +97,14 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         &self.db
     }
 
-    /// Get the collection definitions.
-    pub fn collections(&self) -> &Arc<HashMap<String, Collection>> {
-        &self.collections
+    /// Get a snapshot of all collections from the DB.
+    pub fn collections(&self) -> HashMap<String, Collection> {
+        self.db.collections_snapshot()
     }
 
-    /// Get a collection by name.
-    pub fn collection(&self, name: &str) -> Option<&Collection> {
-        self.collections.get(name)
+    /// Get a collection by name from the DB.
+    pub fn collection(&self, name: &str) -> Option<Collection> {
+        self.db.get_collection(name)
     }
 
     /// Get an existing transaction by ID (for internal use).
@@ -261,7 +255,9 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .await
             .map_err(|e| TransactionError::execution(format!("storage error: {}", e)))?;
 
-        let fetcher = Arc::new(DbDocFetcher::new(db_txn, self.collections.clone()));
+        // Snapshot collections at transaction start time (matches Go behavior)
+        let collections = Arc::new(self.db.collections_snapshot());
+        let fetcher = Arc::new(DbDocFetcher::new(db_txn, collections));
         let ctx = Arc::new(DbTransactionContext::new(txn_id.clone(), readonly, fetcher));
 
         self.transactions
@@ -373,10 +369,19 @@ mod tests {
         )]
     }
 
+    /// Create a test DB with collections pre-registered.
+    async fn test_db_with_collections() -> Arc<DB<MemoryStore>> {
+        let db = Arc::new(DB::new(MemoryStore::new()));
+        for schema in test_schema() {
+            db.create_collection(schema).await.unwrap();
+        }
+        db
+    }
+
     #[tokio::test]
     async fn test_begin_transaction() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         assert!(txn_id.starts_with("txn-"));
@@ -384,8 +389,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_begin_readonly_transaction() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get(&txn_id).into_result().unwrap().unwrap();
@@ -394,8 +399,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_begin_readwrite_transaction() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         let ctx = registry.get(&txn_id).into_result().unwrap().unwrap();
@@ -404,8 +409,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_id_matches() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         let ctx = registry.get(&txn_id).into_result().unwrap().unwrap();
@@ -414,8 +419,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_begin_and_commit() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         let result = registry.commit(&txn_id).await;
@@ -424,8 +429,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_begin_and_rollback() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         let result = registry.rollback(&txn_id).await;
@@ -434,8 +439,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_nonexistent_returns_error() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let nonexistent: TransactionHandle = "nonexistent".parse().unwrap();
         let result = registry.commit(&nonexistent).await;
@@ -445,8 +450,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_rollback_nonexistent_returns_error() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let nonexistent: TransactionHandle = "nonexistent".parse().unwrap();
         let result = registry.rollback(&nonexistent).await;
@@ -456,8 +461,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_nonexistent_returns_not_found() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let nonexistent: TransactionHandle = "nonexistent".parse().unwrap();
         assert!(matches!(
@@ -468,8 +473,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_double_commit_returns_error() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         registry.commit(&txn_id).await.unwrap();
@@ -480,8 +485,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_double_rollback_returns_error() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         registry.rollback(&txn_id).await.unwrap();
@@ -492,8 +497,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_after_rollback_returns_error() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         registry.rollback(&txn_id).await.unwrap();
@@ -504,8 +509,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_rollback_after_commit_returns_error() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         registry.commit(&txn_id).await.unwrap();
@@ -517,8 +522,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_returns_not_found_after_commit() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         assert!(registry.get(&txn_id).is_found());
@@ -532,8 +537,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_returns_not_found_after_rollback() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(false).await.unwrap();
         assert!(registry.get(&txn_id).is_found());
@@ -547,8 +552,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_doc_fetcher_get_all_empty_collection() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get(&txn_id).into_result().unwrap().unwrap();
@@ -562,8 +567,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_doc_fetcher_get_all_unknown_collection() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get(&txn_id).into_result().unwrap().unwrap();
@@ -578,8 +583,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_doc_fetcher_get_by_ids_empty() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get(&txn_id).into_result().unwrap().unwrap();
@@ -594,8 +599,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_doc_fetcher_get_by_ids_invalid_id_returns_error() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get(&txn_id).into_result().unwrap().unwrap();
@@ -612,8 +617,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_consumed_returns_false_before_take() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get_ctx(&txn_id).unwrap().unwrap();
@@ -628,8 +633,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_is_consumed_returns_true_after_take() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get_ctx(&txn_id).unwrap().unwrap();
@@ -645,8 +650,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_doc_fetcher_after_txn_consumed_returns_error() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get_ctx(&txn_id).unwrap().unwrap();
@@ -666,9 +671,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_sees_committed_data() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db.clone(), test_schema());
-        let collection = Collection::new(test_schema().pop().unwrap());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db.clone());
+        let collection = db.get_collection("Users").unwrap();
 
         // Write data in a separate transaction
         let write_txn = db.new_txn(false).await.unwrap();
@@ -693,9 +698,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_by_ids_returns_matching_docs() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db.clone(), test_schema());
-        let collection = Collection::new(test_schema().pop().unwrap());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db.clone());
+        let collection = db.get_collection("Users").unwrap();
 
         // Create two documents
         let write_txn = db.new_txn(false).await.unwrap();
@@ -731,8 +736,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_multiple_concurrent_transactions() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn1 = registry.begin(true).await.unwrap();
         let txn2 = registry.begin(true).await.unwrap();
@@ -752,8 +757,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_ids_are_unique() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let mut ids = Vec::new();
         for _ in 0..10 {
@@ -769,8 +774,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_rollback_discards_uncommitted_writes() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let collection = Collection::new(test_schema().pop().unwrap());
+        let db = test_db_with_collections().await;
+        let collection = db.get_collection("Users").unwrap();
 
         // Write data in a transaction but rollback instead of commit
         let write_txn = db.new_txn(false).await.unwrap();
@@ -795,9 +800,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_does_not_see_uncommitted_writes() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db.clone(), test_schema());
-        let collection = Collection::new(test_schema().pop().unwrap());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db.clone());
+        let collection = db.get_collection("Users").unwrap();
 
         // Start a reader transaction FIRST
         let reader_txn_id = registry.begin(true).await.unwrap();
@@ -824,8 +829,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_parallel_transaction_operations() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = Arc::new(DbTransactionRegistry::new(db, test_schema()));
+        let db = test_db_with_collections().await;
+        let registry = Arc::new(DbTransactionRegistry::new(db));
 
         let handles: Vec<_> = (0..10)
             .map(|i| {
@@ -859,8 +864,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_doc_fetcher_get_by_ids_unknown_collection() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         let txn_id = registry.begin(true).await.unwrap();
         let ctx = registry.get(&txn_id).into_result().unwrap().unwrap();
@@ -877,9 +882,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_by_ids_with_nonexistent_valid_id() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db.clone(), test_schema());
-        let collection = Collection::new(test_schema().pop().unwrap());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db.clone());
+        let collection = db.get_collection("Users").unwrap();
 
         // Create one document
         let write_txn = db.new_txn(false).await.unwrap();
@@ -930,8 +935,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_commit_same_transaction() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = Arc::new(DbTransactionRegistry::new(db, test_schema()));
+        let db = test_db_with_collections().await;
+        let registry = Arc::new(DbTransactionRegistry::new(db));
 
         let txn_id = registry.begin(false).await.unwrap();
 
@@ -956,8 +961,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_rollback_same_transaction() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = Arc::new(DbTransactionRegistry::new(db, test_schema()));
+        let db = test_db_with_collections().await;
+        let registry = Arc::new(DbTransactionRegistry::new(db));
 
         let txn_id = registry.begin(false).await.unwrap();
 
@@ -982,8 +987,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_commit_and_rollback_same_transaction() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = Arc::new(DbTransactionRegistry::new(db, test_schema()));
+        let db = test_db_with_collections().await;
+        let registry = Arc::new(DbTransactionRegistry::new(db));
 
         let txn_id = registry.begin(false).await.unwrap();
 
@@ -1008,8 +1013,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_stale_transactions() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         // Begin some transactions
         let _txn1 = registry.begin(true).await.unwrap();
@@ -1037,8 +1042,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_only_old_transactions() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         // Begin an "old" transaction
         let _old_txn = registry.begin(true).await.unwrap();
@@ -1072,8 +1077,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_active_transaction_count() {
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db, test_schema());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db);
 
         assert_eq!(registry.active_transaction_count().unwrap(), 0);
 
@@ -1094,9 +1099,9 @@ mod tests {
     async fn test_snapshot_isolation_after_external_commit() {
         // This test verifies snapshot isolation: a transaction started before
         // another transaction commits should NOT see the committed data.
-        let db = Arc::new(DB::new(MemoryStore::new()));
-        let registry = DbTransactionRegistry::new(db.clone(), test_schema());
-        let collection = Collection::new(test_schema().pop().unwrap());
+        let db = test_db_with_collections().await;
+        let registry = DbTransactionRegistry::new(db.clone());
+        let collection = db.get_collection("Users").unwrap();
 
         // Step 1: Start reader transaction A FIRST (gets snapshot at this point)
         let reader_txn_id = registry.begin(true).await.unwrap();

--- a/crates/p2p/src/bitswap/access.rs
+++ b/crates/p2p/src/bitswap/access.rs
@@ -198,12 +198,7 @@ impl BlockAccessController {
     /// * `peer_id` - The peer requesting access
     /// * `cid` - The block being requested
     /// * `collection_id` - The collection the block belongs to (if known)
-    pub fn has_access(
-        &self,
-        peer_id: &PeerId,
-        _cid: &Cid,
-        collection_id: Option<&str>,
-    ) -> bool {
+    pub fn has_access(&self, peer_id: &PeerId, _cid: &Cid, collection_id: Option<&str>) -> bool {
         // Fast path: Open mode allows all access
         if self.mode.is_open() {
             return true;

--- a/crates/p2p/src/host.rs
+++ b/crates/p2p/src/host.rs
@@ -452,9 +452,13 @@ impl P2PHost {
         info!("Local peer ID: {}", local_peer_id);
 
         // Pass keypair and blockstore to behaviour for message signing and block exchange
-        let behaviour =
-            DefraBehaviour::new(local_peer_id, local_public_key, keypair.clone(), bitswap_store)
-                .map_err(|e| Error::Behaviour(e.to_string()))?;
+        let behaviour = DefraBehaviour::new(
+            local_peer_id,
+            local_public_key,
+            keypair.clone(),
+            bitswap_store,
+        )
+        .map_err(|e| Error::Behaviour(e.to_string()))?;
 
         let swarm = SwarmBuilder::with_existing_identity(keypair.clone())
             .with_tokio()
@@ -670,10 +674,10 @@ impl P2PHost {
                     missing_count = missing.len(),
                     "Starting Bitswap sync"
                 );
-                let query_id = self
-                    .swarm
-                    .behaviour_mut()
-                    .bitswap_sync(cid, providers, missing.into_iter());
+                let query_id =
+                    self.swarm
+                        .behaviour_mut()
+                        .bitswap_sync(cid, providers, missing.into_iter());
                 if response.send(Ok(query_id)).is_err() {
                     debug!(cid = %cid, "BitswapSync command response dropped - caller cancelled");
                 }
@@ -712,21 +716,36 @@ impl P2PHost {
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!("Listening on {}", address);
-                if self.event_tx.send(HostEvent::Listening(address.clone())).await.is_err() {
+                if self
+                    .event_tx
+                    .send(HostEvent::Listening(address.clone()))
+                    .await
+                    .is_err()
+                {
                     warn!(address = %address, "Failed to send Listening event - receiver dropped");
                 }
             }
 
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 info!("Connected to peer: {}", peer_id);
-                if self.event_tx.send(HostEvent::PeerConnected(peer_id)).await.is_err() {
+                if self
+                    .event_tx
+                    .send(HostEvent::PeerConnected(peer_id))
+                    .await
+                    .is_err()
+                {
                     warn!(peer_id = %peer_id, "Failed to send PeerConnected event - receiver dropped");
                 }
             }
 
             SwarmEvent::ConnectionClosed { peer_id, .. } => {
                 info!("Disconnected from peer: {}", peer_id);
-                if self.event_tx.send(HostEvent::PeerDisconnected(peer_id)).await.is_err() {
+                if self
+                    .event_tx
+                    .send(HostEvent::PeerDisconnected(peer_id))
+                    .await
+                    .is_err()
+                {
                     warn!(peer_id = %peer_id, "Failed to send PeerDisconnected event - receiver dropped");
                 }
             }
@@ -736,7 +755,12 @@ impl P2PHost {
                     debug!("mDNS discovered peer: {} at {}", peer_id, addr);
                     debug!(peer_id = %peer_id, address = %addr, "Adding external address from mDNS discovery");
                     self.swarm.add_external_address(addr);
-                    if self.event_tx.send(HostEvent::PeerDiscovered(peer_id)).await.is_err() {
+                    if self
+                        .event_tx
+                        .send(HostEvent::PeerDiscovered(peer_id))
+                        .await
+                        .is_err()
+                    {
                         warn!(peer_id = %peer_id, "Failed to send PeerDiscovered event - receiver dropped");
                     }
                 }
@@ -768,9 +792,7 @@ impl P2PHost {
                 self.handle_kademlia_event(kad_event).await;
             }
 
-            SwarmEvent::OutgoingConnectionError {
-                peer_id, error, ..
-            } => {
+            SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
                 warn!(
                     peer_id = ?peer_id,
                     error = %error,
@@ -812,7 +834,10 @@ impl P2PHost {
                 );
             }
 
-            SwarmEvent::ExpiredListenAddr { listener_id, address } => {
+            SwarmEvent::ExpiredListenAddr {
+                listener_id,
+                address,
+            } => {
                 debug!(
                     listener_id = ?listener_id,
                     address = %address,
@@ -909,7 +934,10 @@ impl P2PHost {
             } => {
                 error!("Outbound request {:?} failed: {:?}", request_id, error);
                 if let Some(sender) = self.pending_requests.remove(&request_id) {
-                    if sender.send(Err(Error::Transport(format!("{:?}", error)))).is_err() {
+                    if sender
+                        .send(Err(Error::Transport(format!("{:?}", error))))
+                        .is_err()
+                    {
                         debug!(request_id = ?request_id, "PushLog error response dropped - caller cancelled");
                     }
                 }

--- a/crates/p2p/src/sync/dag_sync.rs
+++ b/crates/p2p/src/sync/dag_sync.rs
@@ -667,7 +667,10 @@ mod tests {
         // All links exist locally
         let local_has = |_: &Cid| true;
 
-        let plan = dag_sync.prepare_sync(root, &links, local_has).await.unwrap();
+        let plan = dag_sync
+            .prepare_sync(root, &links, local_has)
+            .await
+            .unwrap();
 
         assert!(matches!(plan, SyncPlan::Complete));
         assert!(dag_sync.state.is_synced(&root).await);
@@ -688,7 +691,10 @@ mod tests {
         let cid2 = test_cid2();
         let local_has = move |cid: &Cid| *cid == cid2;
 
-        let plan = dag_sync.prepare_sync(root, &links, local_has).await.unwrap();
+        let plan = dag_sync
+            .prepare_sync(root, &links, local_has)
+            .await
+            .unwrap();
 
         match plan {
             SyncPlan::NeedsFetch(data) => {
@@ -773,12 +779,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_sync_plan_accessors() {
-        let plan = SyncPlan::needs_fetch_new(
-            test_cid(),
-            vec![test_cid2()],
-            vec![PeerId::random()],
-        )
-        .expect("missing is non-empty");
+        let plan = SyncPlan::needs_fetch_new(test_cid(), vec![test_cid2()], vec![PeerId::random()])
+            .expect("missing is non-empty");
 
         assert!(plan.needs_fetch());
         assert_eq!(plan.missing().unwrap().len(), 1);
@@ -850,7 +852,9 @@ mod tests {
         let mut handles = Vec::new();
         for _ in 0..10 {
             let state_clone = Arc::clone(&state);
-            handles.push(tokio::spawn(async move { state_clone.start_sync(cid).await }));
+            handles.push(tokio::spawn(
+                async move { state_clone.start_sync(cid).await },
+            ));
         }
 
         // Collect results
@@ -909,11 +913,7 @@ mod tests {
     #[test]
     fn test_dag_sync_config_zero_timeout_returns_error() {
         // DagSyncConfig::new should return error if block_fetch_timeout is zero
-        let result = DagSyncConfig::new(
-            Duration::ZERO,
-            None,
-            NonZeroUsize::new(16).unwrap(),
-        );
+        let result = DagSyncConfig::new(Duration::ZERO, None, NonZeroUsize::new(16).unwrap());
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("block_fetch_timeout"));

--- a/crates/p2p/src/sync/manager.rs
+++ b/crates/p2p/src/sync/manager.rs
@@ -483,10 +483,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 "Failed to parse block as IPLD - cannot extract links"
             );
             return Err(Error::BlockParseError {
-                reason: format!(
-                    "Failed to extract references: {}. Block may be corrupt.",
-                    e
-                ),
+                reason: format!("Failed to extract references: {}. Block may be corrupt.", e),
             });
         }
 
@@ -698,7 +695,8 @@ mod tests {
     async fn test_process_pushlog_stores_block() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, mut events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, mut events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
 
         let cid = test_cid();
         let msg = create_test_broadcast(&cid);
@@ -731,7 +729,8 @@ mod tests {
     async fn test_process_pushlog_already_merged() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, mut events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, mut events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
 
         let cid = test_cid();
         let msg = create_test_broadcast(&cid);
@@ -757,7 +756,8 @@ mod tests {
     async fn test_mark_as_merged() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, _events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, _events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
 
         let cid = test_cid();
         let msg = create_test_broadcast(&cid);
@@ -779,7 +779,8 @@ mod tests {
     async fn test_get_unmerged() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, _events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, _events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
 
         let cid = test_cid();
         let msg = create_test_broadcast(&cid);
@@ -808,7 +809,8 @@ mod tests {
     async fn test_process_pushlog_invalid_cid_returns_error() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, _events) = SyncManager::new(blockstore, test_peer_state(), SyncConfig::default());
+        let (manager, _events) =
+            SyncManager::new(blockstore, test_peer_state(), SyncConfig::default());
 
         // Create a broadcast with invalid CID bytes
         let msg = PushLogBroadcast::new(
@@ -837,7 +839,8 @@ mod tests {
 
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, mut events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, mut events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
         let manager = Arc::new(manager);
 
         let cid = test_cid();
@@ -892,7 +895,8 @@ mod tests {
     async fn test_process_pushlog_returns_error_when_receiver_dropped() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
 
         // Drop the event receiver immediately
         drop(events);
@@ -918,7 +922,8 @@ mod tests {
     async fn test_already_merged_returns_error_when_receiver_dropped() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
 
         let cid = test_cid();
         let msg = create_test_broadcast(&cid);
@@ -945,7 +950,8 @@ mod tests {
     async fn test_pending_dag_count_initially_zero() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, _events) = SyncManager::new(blockstore, test_peer_state(), SyncConfig::default());
+        let (manager, _events) =
+            SyncManager::new(blockstore, test_peer_state(), SyncConfig::default());
 
         assert_eq!(manager.pending_dag_count(), 0);
     }
@@ -954,7 +960,8 @@ mod tests {
     async fn test_pending_dag_tracking() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, mut events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, mut events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
 
         // Create a block that has links (simulated by creating IPLD-like data)
         // For simplicity, we'll use a block that fails to parse as IPLD,
@@ -983,7 +990,8 @@ mod tests {
     async fn test_blockstore_accessor() {
         let store = Arc::new(MemoryStore::new());
         let blockstore = Arc::new(DefraBlockstore::new(store, true));
-        let (manager, _events) = SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
+        let (manager, _events) =
+            SyncManager::new(blockstore.clone(), test_peer_state(), SyncConfig::default());
 
         // Verify blockstore accessor returns the same blockstore
         let cid = test_cid();

--- a/crates/p2p/src/sync/peer_state.rs
+++ b/crates/p2p/src/sync/peer_state.rs
@@ -470,7 +470,11 @@ pub struct PeerStats {
 
 impl PeerStats {
     /// Create new peer statistics (internal use only).
-    pub(crate) fn new(total_peers: usize, connected_peers: usize, total_tracked_cids: usize) -> Self {
+    pub(crate) fn new(
+        total_peers: usize,
+        connected_peers: usize,
+        total_tracked_cids: usize,
+    ) -> Self {
         debug_assert!(
             connected_peers <= total_peers,
             "connected_peers ({}) must be <= total_peers ({})",
@@ -747,16 +751,16 @@ mod tests {
         tracker.peer_connected(peer);
 
         // Create 5 different CIDs
-        let cid1 = Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
-            .unwrap();
-        let cid2 = Cid::from_str("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy")
-            .unwrap();
-        let cid3 = Cid::from_str("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku")
-            .unwrap();
-        let cid4 = Cid::from_str("bafybeibdqagjfxgsqiafpmyohldmiu4qn6ucudpzqlxkfrmb6dzbggbkxy")
-            .unwrap();
-        let cid5 = Cid::from_str("bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77oxmxbyjaoj4i")
-            .unwrap();
+        let cid1 =
+            Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
+        let cid2 =
+            Cid::from_str("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy").unwrap();
+        let cid3 =
+            Cid::from_str("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku").unwrap();
+        let cid4 =
+            Cid::from_str("bafybeibdqagjfxgsqiafpmyohldmiu4qn6ucudpzqlxkfrmb6dzbggbkxy").unwrap();
+        let cid5 =
+            Cid::from_str("bafkreigaknpexyvxt76zgkitavbwx6ejgfheup5oybpm77oxmxbyjaoj4i").unwrap();
 
         // Add first 3 CIDs - all should be present
         tracker.peer_has_cid(&peer, cid1);
@@ -794,12 +798,12 @@ mod tests {
         let peer = test_peer_id();
         tracker.peer_connected(peer);
 
-        let cid1 = Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
-            .unwrap();
-        let cid2 = Cid::from_str("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy")
-            .unwrap();
-        let cid3 = Cid::from_str("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku")
-            .unwrap();
+        let cid1 =
+            Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
+        let cid2 =
+            Cid::from_str("bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy").unwrap();
+        let cid3 =
+            Cid::from_str("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku").unwrap();
 
         // Add 3 CIDs
         tracker.peer_has_cid(&peer, cid1);
@@ -831,10 +835,9 @@ mod tests {
             let tracker_clone = Arc::clone(&tracker);
             let handle = thread::spawn(move || {
                 let peer = PeerId::random();
-                let cid = Cid::from_str(
-                    "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
-                )
-                .unwrap();
+                let cid =
+                    Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+                        .unwrap();
 
                 // Perform various operations
                 tracker_clone.peer_connected(peer);
@@ -910,9 +913,9 @@ mod tests {
         // Create tracker with small max_peers limit
         let tracker = PeerStateTracker::with_full_config(
             Duration::from_secs(3600),
-            100,   // max_cids_per_peer
-            1000,  // max_total_cids
-            5,     // max_peers (small for testing)
+            100,  // max_cids_per_peer
+            1000, // max_total_cids
+            5,    // max_peers (small for testing)
         );
 
         // Add 6 peers - peer 6 should trigger eviction
@@ -933,9 +936,9 @@ mod tests {
         // Test that disconnected peers get evicted before connected ones
         let tracker = PeerStateTracker::with_full_config(
             Duration::from_secs(3600),
-            100,   // max_cids_per_peer
-            1000,  // max_total_cids
-            3,     // max_peers (small for testing)
+            100,  // max_cids_per_peer
+            1000, // max_total_cids
+            3,    // max_peers (small for testing)
         );
 
         // Add 2 peers

--- a/crates/p2p/src/sync/replication.rs
+++ b/crates/p2p/src/sync/replication.rs
@@ -238,7 +238,11 @@ impl ReplicationLoop {
         );
 
         // Start Bitswap sync via host
-        match coordinator.host().bitswap_sync(root_cid, providers, missing).await {
+        match coordinator
+            .host()
+            .bitswap_sync(root_cid, providers, missing)
+            .await
+        {
             Ok(query_id) => {
                 // Register the query so we can track completion
                 coordinator.manager().register_query(query_id, root_cid);
@@ -516,7 +520,11 @@ impl ReplicationLoop {
                         "Block merged during recovery but marking failed - will be reprocessed next startup"
                     );
                 }
-                ReplicationResult::MergedButBroadcastFailed { cid, doc_id, broadcast_error } => {
+                ReplicationResult::MergedButBroadcastFailed {
+                    cid,
+                    doc_id,
+                    broadcast_error,
+                } => {
                     // Merge succeeded - count as success (broadcast not expected during recovery)
                     success_count += 1;
                     tracing::debug!(
@@ -666,7 +674,11 @@ mod tests {
         // We can't easily test the full loop without a coordinator
         // but we can verify the handler trait works
         let result = handler
-            .handle_block(&cid, b"test data", BlockMetadata::normal("doc1", "col1", "peer1"))
+            .handle_block(
+                &cid,
+                b"test data",
+                BlockMetadata::normal("doc1", "col1", "peer1"),
+            )
             .await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_merged());

--- a/crates/p2p/tests/integration.rs
+++ b/crates/p2p/tests/integration.rs
@@ -1722,7 +1722,9 @@ async fn test_dag_sync_handle_sync_complete_failure() {
     dag_sync.state().start_sync(cid).await;
 
     // Complete with failure - should return Err
-    let result = dag_sync.handle_sync_complete(cid, false, Some("sync failed")).await;
+    let result = dag_sync
+        .handle_sync_complete(cid, false, Some("sync failed"))
+        .await;
     assert!(result.is_err(), "sync failure should return error");
 
     // Should be neither syncing nor synced (can retry)
@@ -1744,8 +1746,8 @@ async fn test_replicator_registry_access_control() {
     // Create controller with access control enabled
     let controller = BlockAccessController::controlled(registry);
 
-    let cid = cid::Cid::try_from("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
-        .unwrap();
+    let cid =
+        cid::Cid::try_from("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
 
     // peer1 should have access (is replicator)
     assert!(controller.has_access(&peer1, &cid, Some("users")));
@@ -1792,8 +1794,8 @@ async fn test_replicator_registry_multiple_collections() {
 async fn test_bitswap_store_adapter_contains() {
     use blockstore::{Blockstore, DefraBlockstore};
     use p2p::{BitswapStore, BitswapStoreAdapter};
-    use storage::backends::MemoryStore;
     use std::str::FromStr;
+    use storage::backends::MemoryStore;
 
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, false));
@@ -1820,8 +1822,8 @@ async fn test_bitswap_store_adapter_contains() {
 async fn test_bitswap_store_adapter_get() {
     use blockstore::{Blockstore, DefraBlockstore};
     use p2p::{BitswapStore, BitswapStoreAdapter};
-    use storage::backends::MemoryStore;
     use std::str::FromStr;
+    use storage::backends::MemoryStore;
 
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, false));
@@ -1942,10 +1944,10 @@ async fn test_dag_sync_state_concurrent_operations() {
 
 #[tokio::test]
 async fn test_replication_handles_missing_block_in_store() {
-    use p2p::sync::{MergeHandler, MergeOutcome, ReplicationConfig, ReplicationLoop, SyncConfig};
     use blockstore::DefraBlockstore;
-    use storage::backends::MemoryStore;
+    use p2p::sync::{MergeHandler, MergeOutcome, ReplicationConfig, ReplicationLoop, SyncConfig};
     use std::str::FromStr;
+    use storage::backends::MemoryStore;
 
     // Create coordinator with an EMPTY blockstore
     let (handle, _events) = create_and_start_host().await;
@@ -2021,10 +2023,7 @@ async fn test_replication_handles_missing_block_in_store() {
                 error
             );
         }
-        other => panic!(
-            "Expected Failed result for missing block, got {:?}",
-            other
-        ),
+        other => panic!("Expected Failed result for missing block, got {:?}", other),
     }
 
     handle.shutdown().await.ok();
@@ -2033,10 +2032,10 @@ async fn test_replication_handles_missing_block_in_store() {
 #[tokio::test]
 async fn test_bitswap_store_adapter_insert_and_retrieve_roundtrip() {
     use blockstore::{Blockstore, DefraBlockstore};
+    use libipld::multihash::{Code, MultihashDigest};
+    use libipld::{Block, IpldCodec};
     use p2p::{BitswapStore, BitswapStoreAdapter};
     use storage::backends::MemoryStore;
-    use libipld::{Block, IpldCodec};
-    use libipld::multihash::{Code, MultihashDigest};
 
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, false));
@@ -2081,8 +2080,8 @@ async fn test_bitswap_store_adapter_insert_and_retrieve_roundtrip() {
 async fn test_rebroadcast_on_merge_enabled() {
     use blockstore::{Blockstore, DefraBlockstore};
     use p2p::sync::{
-        MergeHandler, MergeOutcome, ReplicationConfig, ReplicationLoop,
-        ReplicationResult, SyncConfig, SyncCoordinator, SyncEvent,
+        MergeHandler, MergeOutcome, ReplicationConfig, ReplicationLoop, ReplicationResult,
+        SyncConfig, SyncCoordinator, SyncEvent,
     };
     use std::str::FromStr;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -2168,7 +2167,10 @@ async fn test_rebroadcast_on_merge_enabled() {
     let results = ReplicationLoop::drain(coordinator.clone(), &mut rx, handler, config).await;
 
     // Verify merge handler was called
-    assert!(merge_called.load(Ordering::SeqCst), "Merge handler should have been called");
+    assert!(
+        merge_called.load(Ordering::SeqCst),
+        "Merge handler should have been called"
+    );
 
     // Should have exactly one result
     assert_eq!(results.len(), 1, "Should have exactly one result");
@@ -2176,7 +2178,9 @@ async fn test_rebroadcast_on_merge_enabled() {
     // Result should be Merged or MergedButBroadcastFailed
     // (MergedButBroadcastFailed happens when no peers are connected to receive the broadcast)
     match &results[0] {
-        ReplicationResult::Merged { cid: result_cid, .. } => {
+        ReplicationResult::Merged {
+            cid: result_cid, ..
+        } => {
             assert_eq!(*result_cid, cid);
         }
         ReplicationResult::MergedButBroadcastFailed {
@@ -2277,10 +2281,15 @@ async fn test_rebroadcast_on_merge_disabled_no_broadcast_attempt() {
 
     // Should be plain Merged (NOT MergedButBroadcastFailed since no broadcast was attempted)
     match &results[0] {
-        ReplicationResult::Merged { cid: result_cid, .. } => {
+        ReplicationResult::Merged {
+            cid: result_cid, ..
+        } => {
             assert_eq!(*result_cid, cid);
         }
-        other => panic!("Expected Merged result when rebroadcast disabled, got {:?}", other),
+        other => panic!(
+            "Expected Merged result when rebroadcast disabled, got {:?}",
+            other
+        ),
     }
 
     handle.shutdown().await.ok();
@@ -2293,10 +2302,7 @@ async fn test_rebroadcast_on_merge_disabled_no_broadcast_attempt() {
 #[tokio::test]
 async fn test_recover_unmerged_with_no_blocks() {
     use blockstore::DefraBlockstore;
-    use p2p::sync::{
-        MergeHandler, MergeOutcome, ReplicationLoop, SyncConfig,
-        SyncCoordinator,
-    };
+    use p2p::sync::{MergeHandler, MergeOutcome, ReplicationLoop, SyncConfig, SyncCoordinator};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use storage::backends::MemoryStore;
 
@@ -2356,9 +2362,7 @@ async fn test_recover_unmerged_with_no_blocks() {
 #[tokio::test]
 async fn test_recover_unmerged_with_handler_failure() {
     use blockstore::{Blockstore, DefraBlockstore};
-    use p2p::sync::{
-        MergeHandler, MergeOutcome, ReplicationLoop, SyncConfig, SyncCoordinator,
-    };
+    use p2p::sync::{MergeHandler, MergeOutcome, ReplicationLoop, SyncConfig, SyncCoordinator};
     use std::str::FromStr;
     use storage::backends::MemoryStore;
 
@@ -2424,8 +2428,7 @@ async fn test_recover_unmerged_with_handler_failure() {
 async fn test_recover_unmerged_success_marks_as_merged() {
     use blockstore::{Blockstore, DefraBlockstore};
     use p2p::sync::{
-        MergeHandler, MergeOutcome, ReplicationLoop, ReplicationResult, SyncConfig,
-        SyncCoordinator,
+        MergeHandler, MergeOutcome, ReplicationLoop, ReplicationResult, SyncConfig, SyncCoordinator,
     };
     use std::str::FromStr;
     use storage::backends::MemoryStore;
@@ -2487,7 +2490,9 @@ async fn test_recover_unmerged_success_marks_as_merged() {
 
     // Should be Merged result
     match &results[0] {
-        ReplicationResult::Merged { cid: result_cid, .. } => {
+        ReplicationResult::Merged {
+            cid: result_cid, ..
+        } => {
             assert_eq!(*result_cid, cid);
         }
         other => panic!("Expected Merged result, got {:?}", other),
@@ -2519,8 +2524,14 @@ async fn test_dag_sync_missing_blocks_empty_store() {
 
     // With empty store and a link that isn't local, should return NeedsFetch
     // local_has returns false for all CIDs (nothing local)
-    let plan = dag_sync.prepare_sync(root_cid, &[link_cid], |_| false).await.unwrap();
-    assert!(plan.needs_fetch(), "Should need to fetch missing link from empty store");
+    let plan = dag_sync
+        .prepare_sync(root_cid, &[link_cid], |_| false)
+        .await
+        .unwrap();
+    assert!(
+        plan.needs_fetch(),
+        "Should need to fetch missing link from empty store"
+    );
 }
 
 #[tokio::test]
@@ -2576,7 +2587,10 @@ async fn test_dag_sync_multiple_missing_blocks() {
         cid::Cid::from_str("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku").unwrap();
 
     // local_has returns false for all CIDs (nothing local)
-    let plan = dag_sync.prepare_sync(cid, &[missing1, missing2], |_| false).await.unwrap();
+    let plan = dag_sync
+        .prepare_sync(cid, &[missing1, missing2], |_| false)
+        .await
+        .unwrap();
 
     match plan {
         SyncPlan::NeedsFetch(data) => {
@@ -2611,12 +2625,18 @@ async fn test_dag_sync_with_providers() {
     peer_state.peer_has_cid(&peer, link_cid);
 
     // Prepare sync with missing blocks - local_has returns false
-    let plan = dag_sync.prepare_sync(root_cid, &[link_cid], |_| false).await.unwrap();
+    let plan = dag_sync
+        .prepare_sync(root_cid, &[link_cid], |_| false)
+        .await
+        .unwrap();
 
     match plan {
         SyncPlan::NeedsFetch(data) => {
             // The peer should be in providers since it has the link CID
-            assert!(data.providers().contains(&peer), "Peer should be a provider");
+            assert!(
+                data.providers().contains(&peer),
+                "Peer should be a provider"
+            );
         }
         _ => panic!("Expected NeedsFetch plan"),
     }
@@ -2650,7 +2670,10 @@ async fn test_dag_sync_failure_allows_retry() {
     assert!(!dag_sync.state().is_synced(&root_cid).await);
 
     // Should be able to start sync again with a link that's missing
-    let plan = dag_sync.prepare_sync(root_cid, &[link_cid], |_| false).await.unwrap();
+    let plan = dag_sync
+        .prepare_sync(root_cid, &[link_cid], |_| false)
+        .await
+        .unwrap();
     assert!(plan.needs_fetch(), "Should be able to retry after failure");
 }
 
@@ -2675,8 +2698,8 @@ async fn test_cross_collection_access_denial() {
     // Create controller with access control enabled
     let controller = BlockAccessController::controlled(registry);
 
-    let cid = cid::Cid::try_from("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
-        .unwrap();
+    let cid =
+        cid::Cid::try_from("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
 
     // Peer A should have access to "users" collection
     assert!(
@@ -2731,8 +2754,8 @@ async fn test_access_mode_open_allows_all() {
     // Create controller with OPEN access (no ACP)
     let controller = BlockAccessController::open(registry);
 
-    let cid = cid::Cid::try_from("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
-        .unwrap();
+    let cid =
+        cid::Cid::try_from("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap();
 
     // Any peer should have access with Open mode
     let random_peer = libp2p::PeerId::random();
@@ -2753,9 +2776,9 @@ async fn test_access_mode_open_allows_all() {
 #[tokio::test]
 async fn test_find_missing_links_with_real_ipld_blocks() {
     use blockstore::{Blockstore, DefraBlockstore};
+    use libipld::cbor::DagCborCodec;
     use libipld::multihash::Code;
     use libipld::{Block as IpldBlock, DefaultParams, Ipld};
-    use libipld::cbor::DagCborCodec;
     use storage::backends::MemoryStore;
 
     // Create a coordinator with a real blockstore
@@ -2781,7 +2804,10 @@ async fn test_find_missing_links_with_real_ipld_blocks() {
     let parent_cid = cid::Cid::try_from(parent_block.cid().to_bytes().as_slice()).unwrap();
 
     // Store ONLY the parent in the blockstore (leaf is missing)
-    blockstore.put(&parent_cid, parent_block.data()).await.unwrap();
+    blockstore
+        .put(&parent_cid, parent_block.data())
+        .await
+        .unwrap();
 
     // Now use the coordinator's internal find_missing_links logic
     // We can test this by broadcasting a message with the parent block
@@ -2814,7 +2840,11 @@ async fn test_find_missing_links_with_real_ipld_blocks() {
         .await;
 
     // Should succeed (store the block and identify missing links)
-    assert!(result.is_ok(), "Should process IPLD block with links: {:?}", result);
+    assert!(
+        result.is_ok(),
+        "Should process IPLD block with links: {:?}",
+        result
+    );
 
     // Verify the parent block is in the blockstore
     assert!(
@@ -2834,9 +2864,9 @@ async fn test_find_missing_links_with_real_ipld_blocks() {
 #[tokio::test]
 async fn test_find_missing_links_with_multiple_links() {
     use blockstore::{Blockstore, DefraBlockstore};
+    use libipld::cbor::DagCborCodec;
     use libipld::multihash::Code;
     use libipld::{Block as IpldBlock, DefaultParams, Ipld};
-    use libipld::cbor::DagCborCodec;
     use storage::backends::MemoryStore;
 
     let (handle, _events) = create_and_start_host().await;
@@ -2865,9 +2895,15 @@ async fn test_find_missing_links_with_multiple_links() {
     let parent_cid = cid::Cid::try_from(parent_block.cid().to_bytes().as_slice()).unwrap();
 
     // Store ONLY the parent and one leaf (leaf2 is missing)
-    blockstore.put(&parent_cid, parent_block.data()).await.unwrap();
+    blockstore
+        .put(&parent_cid, parent_block.data())
+        .await
+        .unwrap();
     let leaf1_cid_native = cid::Cid::try_from(leaf1_cid.to_bytes().as_slice()).unwrap();
-    blockstore.put(&leaf1_cid_native, leaf1_block.data()).await.unwrap();
+    blockstore
+        .put(&leaf1_cid_native, leaf1_block.data())
+        .await
+        .unwrap();
 
     let collection_id = "test-multi-links";
     coordinator
@@ -2991,9 +3027,9 @@ async fn test_handle_bitswap_complete_failure_clears_syncing() {
 
 #[tokio::test]
 async fn test_end_to_end_dag_sync_with_local_blocks() {
+    use libipld::cbor::DagCborCodec;
     use libipld::multihash::Code;
     use libipld::{Block as IpldBlock, DefaultParams, Ipld};
-    use libipld::cbor::DagCborCodec;
     use p2p::sync::{DagSync, PeerStateTracker, SyncPlan};
     use std::collections::HashSet;
 
@@ -3051,9 +3087,9 @@ async fn test_end_to_end_dag_sync_with_local_blocks() {
 #[tokio::test]
 async fn test_end_to_end_dag_sync_needs_fetch() {
     use blockstore::{Blockstore, DefraBlockstore};
+    use libipld::cbor::DagCborCodec;
     use libipld::multihash::Code;
     use libipld::{Block as IpldBlock, DefaultParams, Ipld};
-    use libipld::cbor::DagCborCodec;
     use p2p::sync::{DagSync, PeerStateTracker, SyncPlan};
     use storage::backends::MemoryStore;
 
@@ -3077,7 +3113,10 @@ async fn test_end_to_end_dag_sync_needs_fetch() {
     let parent_cid = cid::Cid::try_from(parent_block.cid().to_bytes().as_slice()).unwrap();
 
     // Store ONLY the parent (child is missing)
-    blockstore.put(&parent_cid, parent_block.data()).await.unwrap();
+    blockstore
+        .put(&parent_cid, parent_block.data())
+        .await
+        .unwrap();
 
     // Add a connected peer that could provide the missing block
     let provider_peer = libp2p::PeerId::random();
@@ -3093,7 +3132,11 @@ async fn test_end_to_end_dag_sync_needs_fetch() {
         SyncPlan::NeedsFetch(data) => {
             assert_eq!(data.root(), parent_cid, "Root should match");
             assert_eq!(data.missing().len(), 1, "Should have one missing block");
-            assert_eq!(data.missing()[0], child1_cid_native, "Missing CID should match");
+            assert_eq!(
+                data.missing()[0],
+                child1_cid_native,
+                "Missing CID should match"
+            );
             assert!(
                 !data.providers().is_empty(),
                 "Should have at least one provider"

--- a/crates/query/tests/transaction_integration_tests.rs
+++ b/crates/query/tests/transaction_integration_tests.rs
@@ -26,11 +26,20 @@ fn test_schema() -> Vec<CollectionVersion> {
     )]
 }
 
+/// Create a test DB with collections pre-registered.
+async fn test_db_with_collections() -> Arc<DB<MemoryStore>> {
+    let db = Arc::new(DB::new(MemoryStore::new()));
+    for schema in test_schema() {
+        db.create_collection(schema).await.unwrap();
+    }
+    db
+}
+
 #[tokio::test]
 async fn test_transaction_begin_commit_flow() {
     // Setup: create DB, registry, and query runner
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
 
     // For this test we need a fetcher that can read from the DB.
     // Since we're testing transactions, we'll use the registry's transaction-scoped fetcher.
@@ -49,8 +58,8 @@ async fn test_transaction_begin_commit_flow() {
 
 #[tokio::test]
 async fn test_transaction_begin_rollback_flow() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -64,8 +73,8 @@ async fn test_transaction_begin_rollback_flow() {
 
 #[tokio::test]
 async fn test_transaction_double_commit_fails() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -82,8 +91,8 @@ async fn test_transaction_double_commit_fails() {
 
 #[tokio::test]
 async fn test_transaction_commit_after_rollback_fails() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -99,8 +108,8 @@ async fn test_transaction_commit_after_rollback_fails() {
 
 #[tokio::test]
 async fn test_execute_query_in_transaction() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -128,8 +137,8 @@ async fn test_execute_query_in_transaction() {
 
 #[tokio::test]
 async fn test_execute_multiple_queries_in_transaction() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -147,8 +156,8 @@ async fn test_execute_multiple_queries_in_transaction() {
 
 #[tokio::test]
 async fn test_query_on_nonexistent_transaction_fails() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -163,8 +172,8 @@ async fn test_query_on_nonexistent_transaction_fails() {
 
 #[tokio::test]
 async fn test_query_after_commit_fails() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -181,8 +190,8 @@ async fn test_query_after_commit_fails() {
 
 #[tokio::test]
 async fn test_query_after_rollback_fails() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -199,8 +208,8 @@ async fn test_query_after_rollback_fails() {
 
 #[tokio::test]
 async fn test_readonly_transaction_flag() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -217,8 +226,8 @@ async fn test_readonly_transaction_flag() {
 
 #[tokio::test]
 async fn test_transaction_guard_commit() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -236,8 +245,8 @@ async fn test_transaction_guard_commit() {
 
 #[tokio::test]
 async fn test_transaction_guard_rollback() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -253,8 +262,8 @@ async fn test_transaction_guard_rollback() {
 
 #[tokio::test]
 async fn test_concurrent_transactions() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 
@@ -282,8 +291,8 @@ async fn test_concurrent_transactions() {
 
 #[tokio::test]
 async fn test_query_error_does_not_invalidate_transaction() {
-    let db = Arc::new(DB::new(MemoryStore::new()));
-    let registry = DbTransactionRegistry::new(db.clone(), test_schema());
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
     let fetcher = query::test_utils::MockFetcher::new();
     let runner = QueryRunner::with_registry(fetcher, test_schema(), registry);
 


### PR DESCRIPTION
## Summary

- Add dynamic collection management to the DB struct with schema persistence in SystemStore
- Collections can now be created, deleted, and listed at runtime instead of being pre-defined at registry initialization
- Implements issue #55

## Changes

### `crates/db/src/database.rs`
- Added `collections: RwLock<HashMap<String, Collection>>` field to `DB` struct
- Added `open()` and `open_with_options()` async constructors that load collections from SystemStore
- Added collection lifecycle methods:
  - `create_collection(schema)` - Persists schema and updates cache (with name validation)
  - `delete_collection(name)` - Removes documents, schema, and cache entry
  - `list_collections()` - Returns collection names
  - `get_collection(name)` - Returns collection by name
  - `has_collection(name)` - Checks existence
  - `collections_snapshot()` - Returns `CollectionSnapshot` for transaction isolation
  - `load_collections()` - Loads schemas from SystemStore with proper UTF-8 validation
- Improved error handling:
  - Cache update failures after commit now return `CacheUpdateFailedAfterCommit` with clear recovery guidance
  - Serialization errors include collection name for easier debugging
  - Proper UTF-8 validation replaces `from_utf8_lossy` to catch data corruption early
- Added 14 unit tests for collection lifecycle

### `crates/db/src/collection_name.rs` (new)
- `CollectionName` newtype for validated collection names
- Validates: non-empty, no forward slashes, no null bytes
- Prevents invalid names from being persisted

### `crates/db/src/collection_snapshot.rs` (new)
- `CollectionSnapshot` wrapper for immutable collection snapshots
- Provides snapshot isolation semantics for transactions
- Clean API: `get()`, `contains()`, `len()`, `is_empty()`, `names()`, `iter()`

### `crates/db/src/error.rs`
- Added `InvalidCollectionName` error variant
- Added `CacheUpdateFailedAfterCommit` error variant for clear recovery guidance

### `crates/db/src/txn_registry.rs`
- Removed static `collections` field from `DbTransactionRegistry`
- Updated `new()` to take only `Arc<DB<S>>` (removed `schema` parameter)
- Collections are now snapshotted from DB at transaction start time (matches Go behavior)
- Updated to use `CollectionSnapshot` type
- Added 3 new tests for transaction/collection interaction:
  - `test_new_transaction_sees_recently_created_collection`
  - `test_collection_snapshot_isolation_during_deletion`
  - `test_collections_snapshot_is_isolated_from_modifications`

### `crates/db/src/doc_fetcher.rs`
- Updated to use `CollectionSnapshot` instead of `Arc<HashMap<...>>`

### `crates/db/src/collection.rs`
- Added `#[derive(Debug, Clone)]` to `Collection` struct

### `crates/db/src/lib.rs`
- Added exports for `CollectionName` and `CollectionSnapshot`

### `crates/query/tests/transaction_integration_tests.rs`
- Updated tests to use new API

## Test plan

- [x] All 117 db crate tests pass
- [x] All 14 query integration tests pass
- [x] Clippy passes with no warnings
- [x] Code formatted with `cargo fmt`

```bash
cargo test -p db
cargo test -p query --test transaction_integration_tests
cargo clippy -p db -- -D warnings
cargo fmt --all -- --check
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)