### PR TITLE
feat(cli): Integrate HTTP server into defra start

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,11 @@ storage = { path = "../storage" }
 blockstore = { path = "../blockstore" }
 crypto = { path = "../crypto" }
 p2p = { path = "../p2p" }
+defra-http = { path = "../http" }
+query = { path = "../query" }
+db = { path = "../db" }
+schema = { path = "../schema" }
+document = { path = "../document" }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
@@ -25,6 +30,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 # Async runtime
 tokio = { workspace = true }
 futures = { workspace = true }
+async-trait = { workspace = true }
 
 # Serialization
 serde = { workspace = true }
@@ -44,3 +50,9 @@ dirs = "5.0"
 
 # IPLD (for Bitswap type parameters)
 libipld = { workspace = true }
+
+[dev-dependencies]
+# HTTP client for integration tests
+reqwest = { version = "0.12", features = ["json"] }
+tempfile = "3.17"
+portpicker = "0.1"

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -73,7 +73,7 @@ pub struct StartArgs {
     #[arg(long)]
     pub max_txn_retries: Option<u32>,
 
-    /// Specify the datastore to use (supported: badger, memory)
+    /// Specify the datastore to use (supported: badger, rocksdb, memory)
     #[arg(long)]
     pub store: Option<String>,
 
@@ -343,28 +343,11 @@ impl Node {
         info!("Data directory: {}", config.data_path().display());
 
         // Initialize storage, load schemas, and set up P2P
-        // We need to handle both store types with their concrete types
         let (p2p_handle, collections) = match config.datastore.store {
             DatastoreType::Memory => {
                 info!("Using in-memory datastore");
                 let store = Arc::new(storage::MemoryStore::new());
-
-                // Load schemas from storage
-                let database = db::DB::from_arc(store.clone());
-                let collections = db::load_active_collections(&database)
-                    .await
-                    .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?;
-
-                let p2p = if config.net.p2p_disabled {
-                    None
-                } else {
-                    info!("Initializing P2P network");
-                    let blockstore = Arc::new(blockstore::DefraBlockstore::new(store, false));
-                    let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
-                    Some(Self::start_p2p(&config, bitswap_store).await?)
-                };
-
-                (p2p, collections)
+                Self::init_store_and_p2p(store, &config).await?
             }
             DatastoreType::Badger => {
                 info!(
@@ -372,23 +355,7 @@ impl Node {
                     config.data_path().display()
                 );
                 let store = Arc::new(storage::RocksDBStore::open(config.data_path())?);
-
-                // Load schemas from storage
-                let database = db::DB::from_arc(store.clone());
-                let collections = db::load_active_collections(&database)
-                    .await
-                    .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?;
-
-                let p2p = if config.net.p2p_disabled {
-                    None
-                } else {
-                    info!("Initializing P2P network");
-                    let blockstore = Arc::new(blockstore::DefraBlockstore::new(store, false));
-                    let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
-                    Some(Self::start_p2p(&config, bitswap_store).await?)
-                };
-
-                (p2p, collections)
+                Self::init_store_and_p2p(store, &config).await?
             }
         };
 
@@ -425,6 +392,32 @@ impl Node {
             shutdown_tx,
             shutdown_rx,
         })
+    }
+
+    /// Initialize store, load schemas, and optionally start P2P.
+    async fn init_store_and_p2p<S>(
+        store: Arc<S>,
+        config: &Config,
+    ) -> Result<(Option<p2p::P2PHostHandle>, Vec<schema::CollectionVersion>)>
+    where
+        S: storage::corekv::Store + 'static,
+    {
+        // Load schemas from storage
+        let database = db::DB::from_arc(store.clone());
+        let collections = db::load_active_collections(&database)
+            .await
+            .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?;
+
+        let p2p = if config.net.p2p_disabled {
+            None
+        } else {
+            info!("Initializing P2P network");
+            let blockstore = Arc::new(blockstore::DefraBlockstore::new(store, false));
+            let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
+            Some(Self::start_p2p(config, bitswap_store).await?)
+        };
+
+        Ok((p2p, collections))
     }
 
     /// Start P2P networking with the given bitswap store
@@ -559,20 +552,50 @@ impl Node {
             });
         }
 
-        // Wait for shutdown signal
-        self.shutdown_rx.recv().await;
+        // Wait for shutdown signal OR HTTP server crash
+        let mut http_task = http_task;
+        let http_crashed = match &mut http_task {
+            Some(task) => {
+                tokio::select! {
+                    _ = self.shutdown_rx.recv() => false,
+                    result = task => {
+                        match result {
+                            Ok(()) => {
+                                error!("HTTP server exited unexpectedly");
+                            }
+                            Err(e) if e.is_panic() => {
+                                error!("HTTP server panicked: {}", e);
+                            }
+                            Err(e) => {
+                                error!("HTTP server task failed: {}", e);
+                            }
+                        }
+                        true
+                    }
+                }
+            }
+            None => {
+                self.shutdown_rx.recv().await;
+                false
+            }
+        };
 
-        info!("Shutting down DefraDB node...");
-
-        // Shutdown HTTP server
-        // Note: We abort the task since the server doesn't have graceful shutdown yet
-        if let Some(task) = http_task {
-            info!("Stopping HTTP server...");
-            task.abort();
-            // Wait briefly for cleanup
-            match tokio::time::timeout(std::time::Duration::from_secs(1), task).await {
-                Ok(_) => info!("HTTP server stopped"),
-                Err(_) => warn!("HTTP server shutdown timed out"),
+        if http_crashed {
+            info!("Initiating shutdown due to HTTP server failure...");
+        } else {
+            info!("Shutting down DefraDB node...");
+            // Only abort if we're shutting down normally (not due to crash)
+            if let Some(task) = http_task {
+                info!("Stopping HTTP server...");
+                task.abort();
+                match tokio::time::timeout(std::time::Duration::from_secs(1), task).await {
+                    Ok(_) => info!("HTTP server stopped"),
+                    Err(_) => warn!(
+                        timeout_secs = 1,
+                        "HTTP server shutdown timed out - server was forcefully terminated. \
+                         This may occur if requests were still in flight."
+                    ),
+                }
             }
         }
 
@@ -596,6 +619,30 @@ impl Node {
 mod http_integration_tests {
     use super::*;
     use std::time::Duration;
+
+    /// Wait for server to be ready by polling health endpoint with retries.
+    async fn wait_for_server(api_url: &str, max_attempts: u32) {
+        let client = reqwest::Client::new();
+        for attempt in 1..=max_attempts {
+            match client
+                .get(format!("{}/health-check", api_url))
+                .timeout(Duration::from_millis(100))
+                .send()
+                .await
+            {
+                Ok(response) if response.status().is_success() => return,
+                _ => {
+                    if attempt < max_attempts {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                }
+            }
+        }
+        panic!(
+            "Server at {} failed to become ready after {} attempts",
+            api_url, max_attempts
+        );
+    }
 
     /// Create a test config with random port and P2P disabled
     fn test_config(port: u16, temp_dir: &std::path::Path) -> Config {
@@ -651,8 +698,8 @@ mod http_integration_tests {
             node.run().await
         });
 
-        // Give server time to start
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for server to be ready
+        wait_for_server(&api_url, 20).await;
 
         // Test health check endpoint
         let client = reqwest::Client::new();
@@ -690,7 +737,7 @@ mod http_integration_tests {
             node.run().await
         });
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        wait_for_server(&api_url, 20).await;
 
         // Test version endpoint
         let client = reqwest::Client::new();
@@ -725,7 +772,7 @@ mod http_integration_tests {
             node.run().await
         });
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        wait_for_server(&api_url, 20).await;
 
         // Test GraphQL endpoint - expect error since no schema is loaded
         let client = reqwest::Client::new();
@@ -766,7 +813,7 @@ mod http_integration_tests {
             node.run().await
         });
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        wait_for_server(&api_url, 20).await;
 
         // Test schema endpoint - should return empty or minimal schema
         let client = reqwest::Client::new();
@@ -835,7 +882,7 @@ mod http_integration_tests {
             node.run().await
         });
 
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        wait_for_server(&api_url, 20).await;
 
         // Test health check works with RocksDB
         let client = reqwest::Client::new();

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -10,14 +10,38 @@
 
 //! Start command implementation
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use clap::Args;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use crate::config::{Config, DatastoreType};
 use crate::error::{Error, Result};
+
+/// Document fetcher for empty database state.
+///
+/// Returns empty results for all queries. Used when no schemas are loaded.
+struct EmptyFetcher;
+
+#[async_trait]
+impl query::DocFetcher for EmptyFetcher {
+    async fn get_all(&self, _collection_name: &str) -> query::Result<Vec<document::Document>> {
+        Ok(vec![])
+    }
+
+    async fn get_by_ids(
+        &self,
+        _collection_name: &str,
+        doc_ids: &[String],
+    ) -> query::Result<query::FetchByIdsResult> {
+        // All requested IDs are missing since DB is empty
+        Ok(query::FetchByIdsResult::partial(vec![], doc_ids.to_vec()))
+    }
+}
 
 const DEV_MODE_BANNER: &str = r#"
 ******************************************
@@ -297,6 +321,7 @@ mod tests {
 struct Node {
     config: Config,
     p2p_handle: Option<p2p::P2PHostHandle>,
+    http_server: Option<defra_http::Server>,
     shutdown_tx: mpsc::Sender<()>,
     shutdown_rx: mpsc::Receiver<()>,
 }
@@ -344,9 +369,35 @@ impl Node {
 
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
+        // Create HTTP server with empty schema (Phase 1)
+        // Phase 2 will load schemas from storage
+        let http_server = {
+            let api_address: SocketAddr = config
+                .api
+                .address
+                .parse()
+                .map_err(|e: std::net::AddrParseError| {
+                    Error::InvalidApiAddress(config.api.address.clone(), e.to_string())
+                })?;
+
+            let server_config = defra_http::ServerConfig {
+                address: api_address,
+                allowed_origins: config.api.allowed_origins.clone(),
+            };
+
+            // Empty schema - queries will return "collection not found"
+            let collections: Vec<schema::CollectionVersion> = vec![];
+            let executor = query::QueryRunner::new(EmptyFetcher, collections);
+            let server = defra_http::Server::with_config(executor, server_config);
+
+            info!("HTTP server configured on {}", api_address);
+            Some(server)
+        };
+
         Ok(Self {
             config,
             p2p_handle,
+            http_server,
             shutdown_tx,
             shutdown_rx,
         })
@@ -425,6 +476,18 @@ impl Node {
         info!("DefraDB node started");
         info!("API endpoint: http://{}", self.config.api.address);
 
+        // Start HTTP server
+        let http_task: Option<JoinHandle<()>> = if let Some(server) = self.http_server.take() {
+            info!("Starting HTTP server on {}", self.config.api.address);
+            Some(tokio::spawn(async move {
+                if let Err(e) = server.run().await {
+                    error!("HTTP server error: {}", e);
+                }
+            }))
+        } else {
+            None
+        };
+
         // Set up signal handling
         let shutdown_tx = self.shutdown_tx.clone();
 
@@ -477,6 +540,18 @@ impl Node {
 
         info!("Shutting down DefraDB node...");
 
+        // Shutdown HTTP server
+        // Note: We abort the task since the server doesn't have graceful shutdown yet
+        if let Some(task) = http_task {
+            info!("Stopping HTTP server...");
+            task.abort();
+            // Wait briefly for cleanup
+            match tokio::time::timeout(std::time::Duration::from_secs(1), task).await {
+                Ok(_) => info!("HTTP server stopped"),
+                Err(_) => warn!("HTTP server shutdown timed out"),
+            }
+        }
+
         // Shutdown P2P
         // Note: We log but don't return errors here because:
         // 1. The user's intent (stop the node) is still fulfilled
@@ -490,5 +565,198 @@ impl Node {
 
         info!("DefraDB node shutdown complete");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod http_integration_tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Create a test config with random port and P2P disabled
+    fn test_config(port: u16, temp_dir: &std::path::Path) -> Config {
+        Config {
+            rootdir: temp_dir.to_path_buf(),
+            log: crate::config::LogConfig::default(),
+            api: crate::config::ApiConfig {
+                address: format!("127.0.0.1:{}", port),
+                allowed_origins: vec![],
+                pubkey_path: String::new(),
+                privkey_path: String::new(),
+            },
+            datastore: crate::config::DatastoreConfig {
+                store: DatastoreType::Memory,
+                path: String::new(),
+                max_txn_retries: 5,
+                valuelogfilesize: 1 << 30,
+                no_encryption: true,
+                no_signing: true,
+                no_searchable_encryption: true,
+                default_key_type: "ed25519".to_string(),
+            },
+            net: crate::config::NetConfig {
+                p2p_disabled: true, // Disable P2P for HTTP-only tests
+                p2p_addresses: vec![],
+                peers: vec![],
+                pubsub_enabled: false,
+                relay_enabled: false,
+            },
+            keyring: crate::config::KeyringConfig::default(),
+            development: false,
+            secret_file: String::new(),
+            telemetry_disabled: true,
+            replicator_retry_intervals: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_http_server_starts_and_serves_health_check() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let config = test_config(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+
+        // Create node
+        let node = Node::new(config).await.unwrap();
+
+        // Get shutdown sender before moving node
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        // Spawn node in background
+        let node_handle = tokio::spawn(async move {
+            node.run().await
+        });
+
+        // Give server time to start
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Test health check endpoint
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/health-check", api_url))
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to connect to health check");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body = response.text().await.unwrap();
+        assert_eq!(body, "Healthy");
+
+        // Shutdown
+        shutdown_tx.send(()).await.unwrap();
+        let result = tokio::time::timeout(Duration::from_secs(5), node_handle)
+            .await
+            .expect("Node shutdown timed out")
+            .expect("Node task panicked");
+        assert!(result.is_ok(), "Node shutdown failed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn test_http_server_serves_version_endpoint() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let config = test_config(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move {
+            node.run().await
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Test version endpoint
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/api/v0/version", api_url))
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to connect to version endpoint");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert!(body.get("version").is_some(), "Response should contain version");
+        assert!(body.get("commit").is_some(), "Response should contain commit");
+
+        // Shutdown
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
+
+    #[tokio::test]
+    async fn test_http_server_serves_graphql_endpoint() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let config = test_config(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move {
+            node.run().await
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Test GraphQL endpoint - expect error since no schema is loaded
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"query": "{ users { name } }"}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to connect to graphql endpoint");
+
+        // Should return 200 OK even with errors (GraphQL spec)
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+        // With empty schema, we expect an error about collection not found
+        assert!(
+            body.get("errors").is_some() || body.get("data").is_some(),
+            "Response should be valid GraphQL response"
+        );
+
+        // Shutdown
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
+
+    #[tokio::test]
+    async fn test_http_server_schema_endpoint_returns_empty() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let config = test_config(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move {
+            node.run().await
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Test schema endpoint - should return empty or minimal schema
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/api/v0/schema", api_url))
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to connect to schema endpoint");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        // Shutdown
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
     }
 }

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -13,7 +13,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use clap::Args;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -22,35 +21,6 @@ use tracing::{error, info, warn};
 use crate::config::{Config, DatastoreType};
 use crate::error::{Error, Result};
 
-/// Stub document fetcher that returns empty results.
-///
-/// This is a temporary implementation until full database integration is complete.
-/// All queries will return empty results - this is NOT production-ready.
-struct EmptyFetcher;
-
-#[async_trait]
-impl query::DocFetcher for EmptyFetcher {
-    async fn get_all(&self, collection_name: &str) -> query::Result<Vec<document::Document>> {
-        warn!(
-            collection = %collection_name,
-            "EmptyFetcher: returning empty results (DB integration not yet complete)"
-        );
-        Ok(vec![])
-    }
-
-    async fn get_by_ids(
-        &self,
-        collection_name: &str,
-        doc_ids: &[String],
-    ) -> query::Result<query::FetchByIdsResult> {
-        warn!(
-            collection = %collection_name,
-            requested_ids = ?doc_ids,
-            "EmptyFetcher: marking all IDs as missing (DB integration not yet complete)"
-        );
-        Ok(query::FetchByIdsResult::partial(vec![], doc_ids.to_vec()))
-    }
-}
 
 const DEV_MODE_BANNER: &str = r#"
 ******************************************
@@ -342,12 +312,12 @@ impl Node {
         info!("Root directory: {}", config.rootdir.display());
         info!("Data directory: {}", config.data_path().display());
 
-        // Initialize storage, load schemas, and set up P2P
-        let (p2p_handle, collections) = match config.datastore.store {
+        // Initialize storage, database, and set up P2P and HTTP server
+        let (p2p_handle, http_server) = match config.datastore.store {
             DatastoreType::Memory => {
                 info!("Using in-memory datastore");
                 let store = Arc::new(storage::MemoryStore::new());
-                Self::init_store_and_p2p(store, &config).await?
+                Self::init_store_and_server(store, &config).await?
             }
             DatastoreType::Badger => {
                 info!(
@@ -355,15 +325,56 @@ impl Node {
                     config.data_path().display()
                 );
                 let store = Arc::new(storage::RocksDBStore::open(config.data_path())?);
-                Self::init_store_and_p2p(store, &config).await?
+                Self::init_store_and_server(store, &config).await?
             }
         };
 
-        info!("Loaded {} collection schema(s)", collections.len());
-
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
-        // Create HTTP server with loaded schemas
+        Ok(Self {
+            config,
+            p2p_handle,
+            http_server: Some(http_server),
+            shutdown_tx,
+            shutdown_rx,
+        })
+    }
+
+    /// Initialize store, database, P2P, and HTTP server.
+    ///
+    /// This function creates the database, loads collections, sets up the query
+    /// runner with proper transaction support, and returns the HTTP server.
+    async fn init_store_and_server<S>(
+        store: Arc<S>,
+        config: &Config,
+    ) -> Result<(Option<p2p::P2PHostHandle>, defra_http::Server)>
+    where
+        S: storage::corekv::Store + 'static,
+    {
+        // Open database and load collections from storage
+        let database = Arc::new(
+            db::DB::open_from_arc(store.clone())
+                .await
+                .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?,
+        );
+
+        let collection_count = database
+            .list_collections()
+            .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?
+            .len();
+        info!("Loaded {} collection schema(s)", collection_count);
+
+        // Set up P2P if enabled
+        let p2p = if config.net.p2p_disabled {
+            None
+        } else {
+            info!("Initializing P2P network");
+            let blockstore = Arc::new(blockstore::DefraBlockstore::new(store, false));
+            let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
+            Some(Self::start_p2p(config, bitswap_store).await?)
+        };
+
+        // Create HTTP server with database-backed query runner
         let http_server = {
             let api_address: SocketAddr = config
                 .api
@@ -378,46 +389,35 @@ impl Node {
                 allowed_origins: config.api.allowed_origins.clone(),
             };
 
-            let executor = query::QueryRunner::new(EmptyFetcher, collections);
+            // Create auto-committing fetcher for non-transactional queries
+            let fetcher = db::AutoCommitFetcher::new(database.clone());
+
+            // Create transaction registry for explicit transaction support
+            let registry = db::DbTransactionRegistry::new(database.clone());
+
+            // Get collection schemas for the query runner
+            let collections: Vec<schema::CollectionVersion> = database
+                .list_collections()
+                .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?
+                .iter()
+                .filter_map(|name| {
+                    database
+                        .get_collection(name)
+                        .ok()
+                        .flatten()
+                        .map(|c| c.schema().clone())
+                })
+                .collect();
+
+            // Create query runner with transaction support
+            let executor = query::QueryRunner::with_registry(fetcher, collections, registry);
             let server = defra_http::Server::with_config(executor, server_config);
 
             info!("HTTP server configured on {}", api_address);
-            Some(server)
+            server
         };
 
-        Ok(Self {
-            config,
-            p2p_handle,
-            http_server,
-            shutdown_tx,
-            shutdown_rx,
-        })
-    }
-
-    /// Initialize store, load schemas, and optionally start P2P.
-    async fn init_store_and_p2p<S>(
-        store: Arc<S>,
-        config: &Config,
-    ) -> Result<(Option<p2p::P2PHostHandle>, Vec<schema::CollectionVersion>)>
-    where
-        S: storage::corekv::Store + 'static,
-    {
-        // Load schemas from storage
-        let database = db::DB::from_arc(store.clone());
-        let collections = db::load_active_collections(&database)
-            .await
-            .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?;
-
-        let p2p = if config.net.p2p_disabled {
-            None
-        } else {
-            info!("Initializing P2P network");
-            let blockstore = Arc::new(blockstore::DefraBlockstore::new(store, false));
-            let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
-            Some(Self::start_p2p(config, bitswap_store).await?)
-        };
-
-        Ok((p2p, collections))
+        Ok((p2p, http_server))
     }
 
     /// Start P2P networking with the given bitswap store

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -910,4 +910,132 @@ mod http_integration_tests {
         shutdown_tx.send(()).await.unwrap();
         let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
     }
+
+    /// End-to-end test: pre-seed database with documents, query via HTTP
+    #[tokio::test]
+    async fn test_http_graphql_returns_documents_from_database() {
+        use document::NormalValue;
+        use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        // Use the same path that Node will use (rootdir when datastore.path is empty)
+        let data_path = temp_dir.path();
+
+        // Phase 1: Pre-seed database with collection and documents
+        {
+            let store = storage::RocksDBStore::open(data_path).unwrap();
+            let database = db::DB::new(store);
+
+            // Create Users collection
+            let schema = CollectionVersion::new(
+                "Users",
+                "v1",
+                "col-users",
+                vec![
+                    FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                    FieldDescription::new("2", "name", FieldKind::string()),
+                    FieldDescription::new("3", "age", FieldKind::int()),
+                ],
+            );
+            database.create_collection(schema).await.unwrap();
+
+            // Insert test documents
+            let collection = database.get_collection("Users").unwrap().unwrap();
+            let txn = database.new_txn(false).await.unwrap();
+
+            let mut doc1 = document::Document::new();
+            doc1.set("name", NormalValue::String("Alice".to_string()));
+            doc1.set("age", NormalValue::Int(30));
+            doc1.generate_and_set_doc_id().unwrap();
+            collection.create(&txn, &doc1).await.unwrap();
+
+            let mut doc2 = document::Document::new();
+            doc2.set("name", NormalValue::String("Bob".to_string()));
+            doc2.set("age", NormalValue::Int(25));
+            doc2.generate_and_set_doc_id().unwrap();
+            collection.create(&txn, &doc2).await.unwrap();
+
+            txn.commit().await.unwrap();
+            database.close().await.unwrap();
+        }
+
+        // Phase 2: Start server and query via HTTP
+        let config = Config {
+            rootdir: temp_dir.path().to_path_buf(),
+            log: crate::config::LogConfig::default(),
+            api: crate::config::ApiConfig {
+                address: format!("127.0.0.1:{}", port),
+                allowed_origins: vec![],
+                pubkey_path: String::new(),
+                privkey_path: String::new(),
+            },
+            datastore: crate::config::DatastoreConfig {
+                store: DatastoreType::Badger, // Uses RocksDB
+                path: String::new(),
+                max_txn_retries: 5,
+                valuelogfilesize: 1 << 30,
+                no_encryption: true,
+                no_signing: true,
+                no_searchable_encryption: true,
+                default_key_type: "ed25519".to_string(),
+            },
+            net: crate::config::NetConfig {
+                p2p_disabled: true,
+                p2p_addresses: vec![],
+                peers: vec![],
+                pubsub_enabled: false,
+                relay_enabled: false,
+            },
+            keyring: crate::config::KeyringConfig::default(),
+            development: false,
+            secret_file: String::new(),
+            telemetry_disabled: true,
+            replicator_retry_intervals: vec![],
+        };
+
+        let api_url = format!("http://127.0.0.1:{}", port);
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move {
+            node.run().await
+        });
+
+        wait_for_server(&api_url, 20).await;
+
+        // Query documents via GraphQL
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"query": "{ Users { name age } }"}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to query graphql endpoint");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let body: serde_json::Value = response.json().await.unwrap();
+
+        // Verify we got data back (not just errors)
+        let data = body.get("data").expect("Response should have data field");
+        let users = data.get("Users").expect("Data should have Users field");
+        let users_array = users.as_array().expect("Users should be an array");
+
+        assert_eq!(users_array.len(), 2, "Should have 2 users");
+
+        // Verify document contents
+        let names: Vec<&str> = users_array
+            .iter()
+            .filter_map(|u| u.get("name").and_then(|n| n.as_str()))
+            .collect();
+        assert!(names.contains(&"Alice"), "Should contain Alice");
+        assert!(names.contains(&"Bob"), "Should contain Bob");
+
+        // Shutdown
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
 }

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -776,4 +776,84 @@ mod http_integration_tests {
         shutdown_tx.send(()).await.unwrap();
         let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
     }
+
+    /// Create a test config with RocksDB backend
+    fn test_config_rocksdb(port: u16, temp_dir: &std::path::Path) -> Config {
+        Config {
+            rootdir: temp_dir.to_path_buf(),
+            log: crate::config::LogConfig::default(),
+            api: crate::config::ApiConfig {
+                address: format!("127.0.0.1:{}", port),
+                allowed_origins: vec![],
+                pubkey_path: String::new(),
+                privkey_path: String::new(),
+            },
+            datastore: crate::config::DatastoreConfig {
+                store: DatastoreType::Badger, // Use RocksDB backend
+                path: String::new(),
+                max_txn_retries: 5,
+                valuelogfilesize: 1 << 30,
+                no_encryption: true,
+                no_signing: true,
+                no_searchable_encryption: true,
+                default_key_type: "ed25519".to_string(),
+            },
+            net: crate::config::NetConfig {
+                p2p_disabled: true,
+                p2p_addresses: vec![],
+                peers: vec![],
+                pubsub_enabled: false,
+                relay_enabled: false,
+            },
+            keyring: crate::config::KeyringConfig::default(),
+            development: false,
+            secret_file: String::new(),
+            telemetry_disabled: true,
+            replicator_retry_intervals: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_http_server_with_rocksdb_backend() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let config = test_config_rocksdb(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+
+        // Create node with RocksDB backend
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move {
+            node.run().await
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Test health check works with RocksDB
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{}/health-check", api_url))
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to connect to health check");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(response.text().await.unwrap(), "Healthy");
+
+        // Test schema endpoint - should be empty for fresh database
+        let response = client
+            .get(format!("{}/api/v0/schema", api_url))
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to connect to schema endpoint");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        // Shutdown
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
 }

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -333,21 +333,29 @@ impl Node {
         info!("Root directory: {}", config.rootdir.display());
         info!("Data directory: {}", config.data_path().display());
 
-        // Initialize storage and P2P together (P2P needs concrete blockstore type)
-        // We use a helper function to avoid code duplication
-        let p2p_handle = match config.datastore.store {
+        // Initialize storage, load schemas, and set up P2P
+        // We need to handle both store types with their concrete types
+        let (p2p_handle, collections) = match config.datastore.store {
             DatastoreType::Memory => {
                 info!("Using in-memory datastore");
                 let store = Arc::new(storage::MemoryStore::new());
 
-                if config.net.p2p_disabled {
+                // Load schemas from storage
+                let database = db::DB::from_arc(store.clone());
+                let collections = db::load_active_collections(&database)
+                    .await
+                    .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?;
+
+                let p2p = if config.net.p2p_disabled {
                     None
                 } else {
                     info!("Initializing P2P network");
                     let blockstore = Arc::new(blockstore::DefraBlockstore::new(store, false));
                     let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
                     Some(Self::start_p2p(&config, bitswap_store).await?)
-                }
+                };
+
+                (p2p, collections)
             }
             DatastoreType::Badger => {
                 info!(
@@ -356,21 +364,30 @@ impl Node {
                 );
                 let store = Arc::new(storage::RocksDBStore::open(config.data_path())?);
 
-                if config.net.p2p_disabled {
+                // Load schemas from storage
+                let database = db::DB::from_arc(store.clone());
+                let collections = db::load_active_collections(&database)
+                    .await
+                    .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?;
+
+                let p2p = if config.net.p2p_disabled {
                     None
                 } else {
                     info!("Initializing P2P network");
                     let blockstore = Arc::new(blockstore::DefraBlockstore::new(store, false));
                     let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
                     Some(Self::start_p2p(&config, bitswap_store).await?)
-                }
+                };
+
+                (p2p, collections)
             }
         };
 
+        info!("Loaded {} collection schema(s)", collections.len());
+
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
-        // Create HTTP server with empty schema (Phase 1)
-        // Phase 2 will load schemas from storage
+        // Create HTTP server with loaded schemas
         let http_server = {
             let api_address: SocketAddr = config
                 .api
@@ -385,8 +402,8 @@ impl Node {
                 allowed_origins: config.api.allowed_origins.clone(),
             };
 
-            // Empty schema - queries will return "collection not found"
-            let collections: Vec<schema::CollectionVersion> = vec![];
+            // Create QueryRunner with loaded collections
+            // EmptyFetcher is still used since we don't have full DB integration yet
             let executor = query::QueryRunner::new(EmptyFetcher, collections);
             let server = defra_http::Server::with_config(executor, server_config);
 

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -22,23 +22,32 @@ use tracing::{error, info, warn};
 use crate::config::{Config, DatastoreType};
 use crate::error::{Error, Result};
 
-/// Document fetcher for empty database state.
+/// Stub document fetcher that returns empty results.
 ///
-/// Returns empty results for all queries. Used when no schemas are loaded.
+/// This is a temporary implementation until full database integration is complete.
+/// All queries will return empty results - this is NOT production-ready.
 struct EmptyFetcher;
 
 #[async_trait]
 impl query::DocFetcher for EmptyFetcher {
-    async fn get_all(&self, _collection_name: &str) -> query::Result<Vec<document::Document>> {
+    async fn get_all(&self, collection_name: &str) -> query::Result<Vec<document::Document>> {
+        warn!(
+            collection = %collection_name,
+            "EmptyFetcher: returning empty results (DB integration not yet complete)"
+        );
         Ok(vec![])
     }
 
     async fn get_by_ids(
         &self,
-        _collection_name: &str,
+        collection_name: &str,
         doc_ids: &[String],
     ) -> query::Result<query::FetchByIdsResult> {
-        // All requested IDs are missing since DB is empty
+        warn!(
+            collection = %collection_name,
+            requested_ids = ?doc_ids,
+            "EmptyFetcher: marking all IDs as missing (DB integration not yet complete)"
+        );
         Ok(query::FetchByIdsResult::partial(vec![], doc_ids.to_vec()))
     }
 }
@@ -402,8 +411,6 @@ impl Node {
                 allowed_origins: config.api.allowed_origins.clone(),
             };
 
-            // Create QueryRunner with loaded collections
-            // EmptyFetcher is still used since we don't have full DB integration yet
             let executor = query::QueryRunner::new(EmptyFetcher, collections);
             let server = defra_http::Server::with_config(executor, server_config);
 

--- a/crates/db/src/auto_commit_fetcher.rs
+++ b/crates/db/src/auto_commit_fetcher.rs
@@ -1,0 +1,263 @@
+//! Auto-committing document fetcher for non-transactional queries.
+//!
+//! This fetcher wraps a database and automatically creates and commits
+//! a read-only transaction for each query operation. This enables queries
+//! without explicit transaction management while still providing proper
+//! transactional semantics.
+
+use async_trait::async_trait;
+use document::Document;
+use query::runner::{DocFetcher, FetchByIdsResult};
+use std::sync::Arc;
+use storage::corekv::Store;
+use tracing::warn;
+
+use crate::database::DB;
+
+/// Document fetcher that auto-commits transactions for each operation.
+///
+/// This is useful for queries that don't need explicit transaction control.
+/// Each operation creates a new read-only transaction, performs the query,
+/// and commits (or discards on error).
+pub struct AutoCommitFetcher<S: Store> {
+    db: Arc<DB<S>>,
+}
+
+impl<S: Store> AutoCommitFetcher<S> {
+    /// Create a new auto-committing fetcher wrapping the given database.
+    pub fn new(db: Arc<DB<S>>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
+    async fn get_all(&self, collection_name: &str) -> query::error::Result<Vec<Document>> {
+        // Get collection from DB cache
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Create a read-only transaction
+        let txn = self
+            .db
+            .new_txn(true)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("failed to create txn: {}", e)))?;
+
+        // Get the datastore
+        let datastore = txn.datastore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get datastore for collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+
+        // Execute the query
+        let result = collection
+            .get_all_with_datastore(&datastore)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)));
+
+        // Discard the read-only transaction (no changes to commit)
+        if let Err(e) = txn.discard() {
+            warn!(
+                collection = %collection_name,
+                error = %e,
+                "Failed to discard read-only transaction after get_all"
+            );
+        }
+
+        result
+    }
+
+    async fn get_by_ids(
+        &self,
+        collection_name: &str,
+        doc_ids: &[String],
+    ) -> query::error::Result<FetchByIdsResult> {
+        // Get collection from DB cache
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Create a read-only transaction
+        let txn = self
+            .db
+            .new_txn(true)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("failed to create txn: {}", e)))?;
+
+        // Get the datastore
+        let datastore = txn.datastore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get datastore for collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+
+        // Fetch documents
+        let mut docs = Vec::new();
+        let mut missing_ids = Vec::new();
+
+        for id_str in doc_ids {
+            let doc_id = document::DocID::from_string(id_str).map_err(|e| {
+                query::error::QueryError::execution(format!("invalid doc ID '{}': {}", id_str, e))
+            })?;
+
+            match collection
+                .get_with_datastore(&datastore, &doc_id)
+                .await
+                .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?
+            {
+                Some(doc) => docs.push(doc),
+                None => missing_ids.push(id_str.clone()),
+            }
+        }
+
+        // Discard the read-only transaction
+        if let Err(e) = txn.discard() {
+            warn!(
+                collection = %collection_name,
+                error = %e,
+                "Failed to discard read-only transaction after get_by_ids"
+            );
+        }
+
+        if !missing_ids.is_empty() {
+            warn!(
+                collection = %collection_name,
+                requested_count = doc_ids.len(),
+                found_count = docs.len(),
+                missing_count = missing_ids.len(),
+                missing_ids = ?missing_ids,
+                "Some explicitly requested documents were not found"
+            );
+        }
+
+        Ok(FetchByIdsResult::partial(docs, missing_ids))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use document::NormalValue;
+    use query::runner::DocFetcher;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use storage::backends::MemoryStore;
+
+    fn test_schema() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "col-users",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn test_get_all_empty_collection() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        let fetcher = AutoCommitFetcher::new(db);
+        let docs = fetcher.get_all("Users").await.unwrap();
+        assert!(docs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_all_with_documents() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        // Insert some documents
+        let collection = db.get_collection("Users").unwrap().unwrap();
+        let txn = db.new_txn(false).await.unwrap();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", NormalValue::String("Alice".to_string()));
+        doc1.set("age", NormalValue::Int(30));
+        doc1.generate_and_set_doc_id().unwrap();
+        collection.create(&txn, &doc1).await.unwrap();
+
+        let mut doc2 = Document::new();
+        doc2.set("name", NormalValue::String("Bob".to_string()));
+        doc2.set("age", NormalValue::Int(25));
+        doc2.generate_and_set_doc_id().unwrap();
+        collection.create(&txn, &doc2).await.unwrap();
+
+        txn.commit().await.unwrap();
+
+        // Now fetch all
+        let fetcher = AutoCommitFetcher::new(db);
+        let docs = fetcher.get_all("Users").await.unwrap();
+        assert_eq!(docs.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_by_ids_found() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        // Insert a document
+        let collection = db.get_collection("Users").unwrap().unwrap();
+        let txn = db.new_txn(false).await.unwrap();
+
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Alice".to_string()));
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        collection.create(&txn, &doc).await.unwrap();
+        txn.commit().await.unwrap();
+
+        // Fetch by ID
+        let fetcher = AutoCommitFetcher::new(db);
+        let result = fetcher.get_by_ids("Users", &[doc_id]).await.unwrap();
+        assert_eq!(result.docs().len(), 1);
+        assert!(result.missing_ids().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_by_ids_not_found() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        let fetcher = AutoCommitFetcher::new(db);
+        // Use a valid DocID format (bae-<uuid>) that doesn't exist
+        let nonexistent_id = "bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc".to_string();
+        let result = fetcher
+            .get_by_ids("Users", &[nonexistent_id.clone()])
+            .await
+            .unwrap();
+        assert!(result.docs().is_empty());
+        assert_eq!(result.missing_ids().len(), 1);
+        assert_eq!(result.missing_ids()[0], nonexistent_id);
+    }
+
+    #[tokio::test]
+    async fn test_unknown_collection_returns_error() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+
+        let fetcher = AutoCommitFetcher::new(db);
+        let result = fetcher.get_all("NonExistent").await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("collection not found"));
+    }
+}

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -73,6 +73,51 @@ impl<S: Store> DB<S> {
         Ok(db)
     }
 
+    /// Create a new database from an Arc-wrapped store.
+    ///
+    /// Use this when you already have an `Arc<S>` and want to share
+    /// the store between the database and other components (e.g., blockstore).
+    ///
+    /// Note: This creates a DB with an empty collection cache. Use `open_from_arc()`
+    /// to load existing collections from the store.
+    ///
+    /// **Warning:** When multiple DB instances share a store via `from_arc()`,
+    /// transaction IDs may collide if both instances create transactions concurrently.
+    /// This is acceptable for read-heavy workloads but may cause issues with
+    /// concurrent writes from multiple DB instances.
+    pub fn from_arc(store: Arc<S>) -> Self {
+        Self::from_arc_with_options(store, DbOptions::default())
+    }
+
+    /// Create a new database from an Arc-wrapped store with options.
+    ///
+    /// **Warning:** When multiple DB instances share a store via `from_arc()`,
+    /// transaction IDs may collide if both instances create transactions concurrently.
+    pub fn from_arc_with_options(store: Arc<S>, options: DbOptions) -> Self {
+        Self {
+            store,
+            options,
+            txn_id_counter: AtomicU64::new(0),
+            collections: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Open a database from an Arc-wrapped store and load existing collections.
+    ///
+    /// Use this when you already have an `Arc<S>` and want to share
+    /// the store between the database and other components (e.g., blockstore),
+    /// while also loading existing collections from the store.
+    pub async fn open_from_arc(store: Arc<S>) -> Result<Self> {
+        Self::open_from_arc_with_options(store, DbOptions::default()).await
+    }
+
+    /// Open a database from an Arc-wrapped store with options and load existing collections.
+    pub async fn open_from_arc_with_options(store: Arc<S>, options: DbOptions) -> Result<Self> {
+        let db = Self::from_arc_with_options(store, options);
+        db.load_collections().await?;
+        Ok(db)
+    }
+
     /// Get the next transaction ID.
     fn next_txn_id(&self) -> u64 {
         self.txn_id_counter.fetch_add(1, Ordering::SeqCst) + 1

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -1237,4 +1237,71 @@ mod tests {
         assert!(db.has_collection("HiddenCollection").unwrap());
         assert_eq!(db.list_collections().unwrap().len(), 2);
     }
+
+    #[tokio::test]
+    async fn test_db_from_arc_creates_working_database() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::from_arc(store);
+
+        // Verify transactions work
+        let txn = db.new_txn(false).await.unwrap();
+        assert_eq!(txn.id().unwrap(), 1);
+
+        let txn2 = db.new_txn(false).await.unwrap();
+        assert_eq!(txn2.id().unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_db_from_arc_with_options() {
+        let store = Arc::new(MemoryStore::new());
+        let options = DbOptions {
+            max_txn_retries: Some(10),
+            chunk_size: Some(2048),
+        };
+        let db = DB::from_arc_with_options(store, options);
+
+        assert_eq!(db.options().max_txn_retries, Some(10));
+        assert_eq!(db.options().chunk_size, Some(2048));
+    }
+
+    #[tokio::test]
+    async fn test_db_from_arc_shares_store_with_caller() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::from_arc(store.clone());
+
+        // Write via db
+        let txn = db.new_txn(false).await.unwrap();
+        txn.datastore()
+            .unwrap()
+            .set(b"shared_key", b"shared_value")
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        // Verify data is visible via same store (proves Arc sharing works)
+        let db2 = DB::from_arc(store);
+        let txn2 = db2.new_txn(true).await.unwrap();
+        let value = txn2.datastore().unwrap().get(b"shared_key").await.unwrap();
+        assert_eq!(value, Some(b"shared_value".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_db_from_arc_txn_isolation() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::from_arc(store);
+
+        // Write in first transaction
+        let txn1 = db.new_txn(false).await.unwrap();
+        txn1.datastore()
+            .unwrap()
+            .set(b"key", b"value1")
+            .await
+            .unwrap();
+        txn1.commit().await.unwrap();
+
+        // Read in second transaction
+        let txn2 = db.new_txn(true).await.unwrap();
+        let value = txn2.datastore().unwrap().get(b"key").await.unwrap();
+        assert_eq!(value, Some(b"value1".to_vec()));
+    }
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -49,6 +49,7 @@ pub mod database;
 pub mod doc_fetcher;
 pub mod doc_mutator;
 pub mod error;
+pub mod schema_loader;
 pub mod txn;
 pub mod txn_context;
 pub mod txn_registry;
@@ -64,6 +65,7 @@ pub use error::{Error, Result};
 pub use txn::DbTxn;
 pub use txn_context::DbTransactionContext;
 pub use txn_registry::{CleanupResult, DbTransactionRegistry};
+pub use schema_loader::load_active_collections;
 
 // Re-export related crate types for convenience
 pub use datastore::{BasicTxn, NamespaceView};

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -42,6 +42,7 @@
 /// // Commit
 /// txn.commit().await?;
 /// ```
+pub mod auto_commit_fetcher;
 pub mod collection;
 pub mod collection_name;
 pub mod collection_snapshot;
@@ -55,6 +56,7 @@ pub mod txn_context;
 pub mod txn_registry;
 
 // Re-export commonly used types
+pub use auto_commit_fetcher::AutoCommitFetcher;
 pub use collection::Collection;
 pub use collection_name::CollectionName;
 pub use collection_snapshot::CollectionSnapshot;

--- a/crates/db/src/schema_loader.rs
+++ b/crates/db/src/schema_loader.rs
@@ -1,0 +1,179 @@
+//! Schema loading from systemstore.
+//!
+//! This module provides functionality to load collection schemas from the
+//! systemstore on database startup. It matches the Go DefraDB pattern of
+//! storing collection definitions as JSON in the systemstore.
+
+use crate::error::{Error, Result};
+use crate::DB;
+use schema::CollectionVersion;
+use storage::corekv::{IterOptions, Iterator, Key, Store};
+use storage::keys::systemstore::{CollectionKey, CollectionNameKey};
+
+/// Load all active collections from the systemstore.
+///
+/// This iterates over `/collection/name/*` keys to find all collection names,
+/// then looks up each collection's full definition from `/collection/id/<id>`.
+///
+/// Returns an empty Vec if no collections are stored (new database).
+pub async fn load_active_collections<S: Store>(db: &DB<S>) -> Result<Vec<CollectionVersion>> {
+    let txn = db.new_txn(true).await?;
+    let systemstore = txn.systemstore()?;
+
+    let mut collections = Vec::new();
+
+    // Iterate over all collection name mappings
+    let prefix = CollectionNameKey::name_prefix();
+    let opts = IterOptions::new().with_prefix(prefix);
+    let mut iter = systemstore.iterator(opts).await.map_err(Error::Storage)?;
+
+    while let Some(kv) = iter.next().await.map_err(Error::Storage)? {
+        // The value at /collection/name/<name> is the collection ID
+        let collection_id = String::from_utf8(kv.value)
+            .map_err(|e| Error::Other(format!("Invalid collection ID encoding: {}", e)))?;
+
+        // Look up the full collection definition
+        let collection_key = CollectionKey::new(&collection_id);
+        let collection_json = systemstore
+            .get(&collection_key.bytes())
+            .await
+            .map_err(Error::Storage)?
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "Collection definition not found for ID: {}",
+                    collection_id
+                ))
+            })?;
+
+        // Deserialize the collection
+        let collection: CollectionVersion =
+            serde_json::from_slice(&collection_json).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to deserialize collection {}: {}",
+                    collection_id, e
+                ))
+            })?;
+
+        collections.push(collection);
+    }
+
+    iter.close().await.map_err(Error::Storage)?;
+
+    // Read-only transaction - no need to commit or discard explicitly
+    // The transaction will be cleaned up when it's dropped
+    drop(txn);
+
+    tracing::info!(
+        "Loaded {} collection(s) from systemstore",
+        collections.len()
+    );
+
+    Ok(collections)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DB;
+    use datastore::BasicTxn;
+    use storage::backends::MemoryStore;
+    use storage::corekv::Key;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_load_empty_database() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        let collections = load_active_collections(&db).await.unwrap();
+        assert!(collections.is_empty(), "New database should have no collections");
+    }
+
+    #[tokio::test]
+    async fn test_load_single_collection() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::new((*store).clone());
+
+        // Manually insert a collection into systemstore
+        let collection = CollectionVersion::new("users", "bafytest123", "bafytest123", vec![]);
+
+        // Store collection definition
+        let collection_json = serde_json::to_vec(&collection).unwrap();
+        let collection_key = CollectionKey::new(&collection.version_id);
+        let name_key = CollectionNameKey::new(&collection.name);
+
+        {
+            let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+            let txn = crate::txn::DbTxn::new(basic_txn, store.clone());
+
+            // Store the collection definition at /collection/id/<id>
+            txn.systemstore()
+                .unwrap()
+                .set(&collection_key.bytes(), &collection_json)
+                .await
+                .unwrap();
+
+            // Store the name -> id mapping at /collection/name/<name>
+            txn.systemstore()
+                .unwrap()
+                .set(&name_key.bytes(), collection.version_id.as_bytes())
+                .await
+                .unwrap();
+
+            txn.commit().await.unwrap();
+        }
+
+        // Now load collections
+        let loaded = load_active_collections(&db).await.unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "users");
+        assert_eq!(loaded[0].version_id, "bafytest123");
+    }
+
+    #[tokio::test]
+    async fn test_load_multiple_collections() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::new((*store).clone());
+
+        let collections = vec![
+            ("users", "bafyuser123"),
+            ("posts", "bafypost456"),
+            ("comments", "bafycomment789"),
+        ];
+
+        {
+            let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+            let txn = crate::txn::DbTxn::new(basic_txn, store.clone());
+
+            for (name, id) in &collections {
+                let collection = CollectionVersion::new(*name, *id, *id, vec![]);
+
+                let collection_json = serde_json::to_vec(&collection).unwrap();
+                let collection_key = CollectionKey::new(*id);
+                let name_key = CollectionNameKey::new(*name);
+
+                txn.systemstore()
+                    .unwrap()
+                    .set(&collection_key.bytes(), &collection_json)
+                    .await
+                    .unwrap();
+                txn.systemstore()
+                    .unwrap()
+                    .set(&name_key.bytes(), id.as_bytes())
+                    .await
+                    .unwrap();
+            }
+
+            txn.commit().await.unwrap();
+        }
+
+        let loaded = load_active_collections(&db).await.unwrap();
+        assert_eq!(loaded.len(), 3);
+
+        // Verify all collections were loaded
+        let names: Vec<&str> = loaded.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"users"));
+        assert!(names.contains(&"posts"));
+        assert!(names.contains(&"comments"));
+    }
+}

--- a/crates/db/src/schema_loader.rs
+++ b/crates/db/src/schema_loader.rs
@@ -16,52 +16,85 @@ use storage::keys::systemstore::{CollectionKey, CollectionNameKey};
 /// then looks up each collection's full definition from `/collection/id/<id>`.
 ///
 /// Returns an empty Vec if no collections are stored (new database).
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - A collection name exists but its definition is missing (inconsistent state)
+/// - A collection definition cannot be deserialized (corrupt data)
+/// - Storage operations fail
 pub async fn load_active_collections<S: Store>(db: &DB<S>) -> Result<Vec<CollectionVersion>> {
     let txn = db.new_txn(true).await?;
     let systemstore = txn.systemstore()?;
 
     let mut collections = Vec::new();
+    let mut load_error: Option<Error> = None;
 
     // Iterate over all collection name mappings
     let prefix = CollectionNameKey::name_prefix();
     let opts = IterOptions::new().with_prefix(prefix);
     let mut iter = systemstore.iterator(opts).await.map_err(Error::Storage)?;
 
-    while let Some(kv) = iter.next().await.map_err(Error::Storage)? {
-        // The value at /collection/name/<name> is the collection ID
-        let collection_id = String::from_utf8(kv.value)
-            .map_err(|e| Error::Other(format!("Invalid collection ID encoding: {}", e)))?;
+    // Process iterator, capturing any error for later
+    loop {
+        match iter.next().await {
+            Ok(Some(kv)) => {
+                // The value at /collection/name/<name> is the collection ID
+                let collection_id = match String::from_utf8(kv.value) {
+                    Ok(id) => id,
+                    Err(e) => {
+                        load_error =
+                            Some(Error::Other(format!("Invalid collection ID encoding: {}", e)));
+                        break;
+                    }
+                };
 
-        // Look up the full collection definition
-        let collection_key = CollectionKey::new(&collection_id);
-        let collection_json = systemstore
-            .get(&collection_key.bytes())
-            .await
-            .map_err(Error::Storage)?
-            .ok_or_else(|| {
-                Error::Other(format!(
-                    "Collection definition not found for ID: {}",
-                    collection_id
-                ))
-            })?;
+                // Look up the full collection definition
+                let collection_key = CollectionKey::new(&collection_id);
+                let collection_json = match systemstore.get(&collection_key.bytes()).await {
+                    Ok(Some(json)) => json,
+                    Ok(None) => {
+                        load_error = Some(Error::Other(format!(
+                            "Collection definition not found for ID: {}",
+                            collection_id
+                        )));
+                        break;
+                    }
+                    Err(e) => {
+                        load_error = Some(Error::Storage(e));
+                        break;
+                    }
+                };
 
-        // Deserialize the collection
-        let collection: CollectionVersion =
-            serde_json::from_slice(&collection_json).map_err(|e| {
-                Error::Other(format!(
-                    "Failed to deserialize collection {}: {}",
-                    collection_id, e
-                ))
-            })?;
-
-        collections.push(collection);
+                // Deserialize the collection
+                match serde_json::from_slice::<CollectionVersion>(&collection_json) {
+                    Ok(collection) => collections.push(collection),
+                    Err(e) => {
+                        load_error = Some(Error::Other(format!(
+                            "Failed to deserialize collection {}: {}",
+                            collection_id, e
+                        )));
+                        break;
+                    }
+                }
+            }
+            Ok(None) => break, // End of iteration
+            Err(e) => {
+                load_error = Some(Error::Storage(e));
+                break;
+            }
+        }
     }
 
-    iter.close().await.map_err(Error::Storage)?;
+    // Always close the iterator, log if cleanup fails
+    if let Err(e) = iter.close().await {
+        tracing::warn!(error = %e, "Failed to close iterator during schema loading");
+    }
 
-    // Read-only transaction - no need to commit or discard explicitly
-    // The transaction will be cleaned up when it's dropped
-    drop(txn);
+    // Return error if any occurred during loading
+    if let Some(err) = load_error {
+        return Err(err);
+    }
 
     tracing::info!(
         "Loaded {} collection(s) from systemstore",
@@ -175,5 +208,75 @@ mod tests {
         assert!(names.contains(&"users"));
         assert!(names.contains(&"posts"));
         assert!(names.contains(&"comments"));
+    }
+
+    #[tokio::test]
+    async fn test_load_missing_collection_definition_returns_error() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::new((*store).clone());
+
+        // Store only the name mapping, NOT the collection definition
+        {
+            let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+            let txn = crate::txn::DbTxn::new(basic_txn, store.clone());
+
+            let name_key = CollectionNameKey::new("orphan_collection");
+            txn.systemstore()
+                .unwrap()
+                .set(&name_key.bytes(), b"missing_id_123")
+                .await
+                .unwrap();
+
+            txn.commit().await.unwrap();
+        }
+
+        let result = load_active_collections(&db).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not found"),
+            "Error should mention 'not found', got: {}",
+            err_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_load_invalid_json_collection_returns_error() {
+        let store = Arc::new(MemoryStore::new());
+        let db = DB::new((*store).clone());
+
+        // Store name mapping pointing to invalid JSON
+        {
+            let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+            let txn = crate::txn::DbTxn::new(basic_txn, store.clone());
+
+            let name_key = CollectionNameKey::new("bad_collection");
+            let collection_key = CollectionKey::new("bad_id_456");
+
+            // Store name -> id mapping
+            txn.systemstore()
+                .unwrap()
+                .set(&name_key.bytes(), b"bad_id_456")
+                .await
+                .unwrap();
+
+            // Store invalid JSON as collection definition
+            txn.systemstore()
+                .unwrap()
+                .set(&collection_key.bytes(), b"{ invalid json }")
+                .await
+                .unwrap();
+
+            txn.commit().await.unwrap();
+        }
+
+        let result = load_active_collections(&db).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("deserialize"),
+            "Error should mention 'deserialize', got: {}",
+            err_msg
+        );
     }
 }

--- a/crates/query/src/plan/mutation/create.rs
+++ b/crates/query/src/plan/mutation/create.rs
@@ -259,7 +259,7 @@ impl CreateNode {
         let mut doc = Doc::new(num_fields);
 
         // Set document ID at index 0
-        doc.set_doc_id(&result.doc_id.to_string());
+        doc.set_doc_id(result.doc_id.to_string());
 
         // Map each field from the created document
         for (field_name, field_value) in result.document.values() {

--- a/crates/query/src/plan/mutation/update.rs
+++ b/crates/query/src/plan/mutation/update.rs
@@ -177,7 +177,7 @@ impl UpdateNode {
 
         // Set document ID at index 0
         if let Some(doc_id) = result.document.id() {
-            doc.set_doc_id(&doc_id.to_string());
+            doc.set_doc_id(doc_id.to_string());
         }
 
         // Map each field from the updated document


### PR DESCRIPTION
## Summary

Integrates the HTTP server from `crates/http/` into the CLI's `defra start` command with full database-backed query execution.

**Rebased onto:** `feat/query-mutations` (PR #63) and `feat/collection-lifecycle` (PR #58)

## Changes

### Phase 1: HTTP Server Integration
- Add `defra-http`, `query`, `db`, `schema`, `document` dependencies to CLI
- Initialize HTTP server in `Node::new()` with `QueryRunner`
- Spawn HTTP server task in `Node::run()` with crash detection and shutdown propagation
- HTTP server failures now trigger graceful node shutdown via `tokio::select!`

### Phase 2: Schema Loading from Storage
- Add `schema_loader` module in db crate with `load_active_collections()` function
- Add `DB::from_arc()` and `DB::open_from_arc()` to create database from shared `Arc<Store>`
- Load schemas from systemstore on startup before initializing HTTP server

### Phase 3: Database-Backed Query Execution
- Add `AutoCommitFetcher` to db crate for non-transactional queries
  - Creates/commits read-only transactions automatically per query
  - Enables HTTP queries to fetch real documents from the database
- Wire up `DbTransactionRegistry` for explicit transaction support
- Replace `EmptyFetcher` stub with real database integration
- Queries now fetch actual documents from storage

### Code Quality Improvements
- Extract `init_store_and_server()` helper to reduce duplication between Memory/RocksDB paths
- Add `wait_for_server()` test helper with health-check polling
- Document txn ID collision risk in `DB::from_arc()` docstring
- Add `rocksdb` alias to `--store` CLI help text
- Fix clippy warnings in query crate mutation nodes

### Tests Added
- 6 HTTP integration tests:
  - Health check, version, GraphQL, schema endpoints
  - RocksDB backend startup
  - **End-to-end: pre-seed DB, query via HTTP, verify documents returned**
- 4 unit tests for `DB::from_arc()` methods
- 5 unit tests for `AutoCommitFetcher`
- 2 error path tests for schema loader

## Current Behavior

| Endpoint | Response |
|----------|----------|
| `GET /health-check` | "Healthy" |
| `GET /api/v0/version` | Version info JSON |
| `GET /api/v0/schema` | Loaded collection schemas |
| `POST /api/v0/graphql` | **Executes queries against actual database** |

## Test Results

```
cli: 55 tests passing (including end-to-end integration test)
db:  149 tests passing
```

## Architecture

```
HTTP Request
    ↓
defra-http::Server
    ↓
query::QueryRunner
    ├── AutoCommitFetcher (non-transactional queries)
    │   └── Creates read-only txn per query
    └── DbTransactionRegistry (explicit transactions)
        └── begin/commit/rollback API
    ↓
db::DB
    ↓
storage::Store (Memory or RocksDB)
```

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)