### PR TITLE
feat(db): Implement transaction-scoped collection caching

### DIFF
--- a/crates/db/src/collection_cache.rs
+++ b/crates/db/src/collection_cache.rs
@@ -1,0 +1,209 @@
+//! Transaction-scoped collection cache.
+//!
+//! This module provides a per-transaction cache for collection metadata,
+//! matching the Go DefraDB pattern. Each transaction gets its own cache
+//! that is populated lazily from the SystemStore.
+
+use std::collections::HashMap;
+
+use crate::collection::Collection;
+
+/// A transaction-scoped cache for collection metadata.
+///
+/// This cache lives within a transaction and provides:
+/// - O(1) lookups by collection name
+/// - Lazy loading from SystemStore on cache miss
+/// - Isolation between transactions (each txn has its own cache)
+///
+/// The cache is populated lazily - individual collections are loaded on
+/// first access, and the full collection list is loaded when needed.
+#[derive(Debug, Clone)]
+pub struct CollectionCache {
+    /// Collections indexed by name
+    by_name: HashMap<String, Collection>,
+
+    /// Whether the full collection set has been loaded from store
+    is_fully_populated: bool,
+}
+
+impl CollectionCache {
+    /// Create a new empty collection cache.
+    pub fn new() -> Self {
+        Self {
+            by_name: HashMap::new(),
+            is_fully_populated: false,
+        }
+    }
+
+    /// Get a collection by name.
+    ///
+    /// Returns `None` if the collection is not in the cache.
+    /// Note: A `None` result does not mean the collection doesn't exist -
+    /// it may not have been loaded yet. Use the transaction's lazy loading
+    /// methods to check the store.
+    pub fn get(&self, name: &str) -> Option<&Collection> {
+        self.by_name.get(name)
+    }
+
+    /// Check if a collection exists in the cache.
+    pub fn contains(&self, name: &str) -> bool {
+        self.by_name.contains_key(name)
+    }
+
+    /// Add a collection to the cache.
+    pub fn add(&mut self, name: String, collection: Collection) {
+        self.by_name.insert(name, collection);
+    }
+
+    /// Remove a collection from the cache.
+    ///
+    /// Returns the removed collection if it existed.
+    pub fn remove(&mut self, name: &str) -> Option<Collection> {
+        self.by_name.remove(name)
+    }
+
+    /// Get all collection names in the cache.
+    pub fn names(&self) -> Vec<String> {
+        self.by_name.keys().cloned().collect()
+    }
+
+    /// Get the number of collections in the cache.
+    pub fn len(&self) -> usize {
+        self.by_name.len()
+    }
+
+    /// Check if the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+
+    /// Check if the cache has been fully populated from the store.
+    pub fn is_fully_populated(&self) -> bool {
+        self.is_fully_populated
+    }
+
+    /// Mark the cache as fully populated.
+    ///
+    /// Call this after loading all collections from the store.
+    pub fn mark_fully_populated(&mut self) {
+        self.is_fully_populated = true;
+    }
+
+    /// Populate the cache with a full set of collections.
+    ///
+    /// This replaces any existing cache contents and marks the cache
+    /// as fully populated.
+    pub fn populate(&mut self, collections: HashMap<String, Collection>) {
+        self.by_name = collections;
+        self.is_fully_populated = true;
+    }
+
+    /// Get an iterator over the collections.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Collection)> {
+        self.by_name.iter()
+    }
+
+    /// Convert the cache into a HashMap.
+    pub fn into_inner(self) -> HashMap<String, Collection> {
+        self.by_name
+    }
+}
+
+impl Default for CollectionCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+    fn test_collection(name: &str) -> Collection {
+        Collection::new(CollectionVersion::new(
+            name,
+            "v1",
+            &format!("col-{}", name.to_lowercase()),
+            vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+        ))
+    }
+
+    #[test]
+    fn test_cache_new_is_empty() {
+        let cache = CollectionCache::new();
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+        assert!(!cache.is_fully_populated());
+    }
+
+    #[test]
+    fn test_cache_add_and_get() {
+        let mut cache = CollectionCache::new();
+        let col = test_collection("Users");
+
+        cache.add("Users".to_string(), col);
+
+        assert!(cache.contains("Users"));
+        assert!(!cache.contains("Posts"));
+        assert_eq!(cache.len(), 1);
+
+        let retrieved = cache.get("Users");
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().name(), "Users");
+    }
+
+    #[test]
+    fn test_cache_remove() {
+        let mut cache = CollectionCache::new();
+        cache.add("Users".to_string(), test_collection("Users"));
+        cache.add("Posts".to_string(), test_collection("Posts"));
+
+        assert_eq!(cache.len(), 2);
+
+        let removed = cache.remove("Users");
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().name(), "Users");
+        assert_eq!(cache.len(), 1);
+        assert!(!cache.contains("Users"));
+        assert!(cache.contains("Posts"));
+    }
+
+    #[test]
+    fn test_cache_names() {
+        let mut cache = CollectionCache::new();
+        cache.add("Users".to_string(), test_collection("Users"));
+        cache.add("Posts".to_string(), test_collection("Posts"));
+
+        let mut names = cache.names();
+        names.sort();
+        assert_eq!(names, vec!["Posts", "Users"]);
+    }
+
+    #[test]
+    fn test_cache_populate() {
+        let mut cache = CollectionCache::new();
+        assert!(!cache.is_fully_populated());
+
+        let mut collections = HashMap::new();
+        collections.insert("Users".to_string(), test_collection("Users"));
+        collections.insert("Posts".to_string(), test_collection("Posts"));
+
+        cache.populate(collections);
+
+        assert!(cache.is_fully_populated());
+        assert_eq!(cache.len(), 2);
+        assert!(cache.contains("Users"));
+        assert!(cache.contains("Posts"));
+    }
+
+    #[test]
+    fn test_cache_mark_fully_populated() {
+        let mut cache = CollectionCache::new();
+        cache.add("Users".to_string(), test_collection("Users"));
+
+        assert!(!cache.is_fully_populated());
+        cache.mark_fully_populated();
+        assert!(cache.is_fully_populated());
+    }
+}

--- a/crates/db/src/collection_cache.rs
+++ b/crates/db/src/collection_cache.rs
@@ -11,7 +11,7 @@ use crate::collection::Collection;
 /// A transaction-scoped cache for collection metadata.
 ///
 /// This cache lives within a transaction and provides:
-/// - O(1) lookups by collection name
+/// - O(1) average-case lookups by collection name (HashMap-backed)
 /// - Lazy loading from SystemStore on cache miss
 /// - Isolation between transactions (each txn has its own cache)
 ///
@@ -46,20 +46,32 @@ impl CollectionCache {
     }
 
     /// Check if a collection exists in the cache.
+    ///
+    /// Note: `false` does not mean the collection doesn't exist - it may
+    /// not have been loaded yet.
     pub fn contains(&self, name: &str) -> bool {
         self.by_name.contains_key(name)
     }
 
-    /// Add a collection to the cache.
-    pub fn add(&mut self, name: String, collection: Collection) {
-        self.by_name.insert(name, collection);
+    /// Add a collection to the cache, keyed by its name.
+    ///
+    /// The key is derived from `collection.name()` to prevent key-name mismatches.
+    pub fn add(&mut self, collection: Collection) {
+        self.by_name
+            .insert(collection.name().to_string(), collection);
     }
 
     /// Remove a collection from the cache.
     ///
     /// Returns the removed collection if it existed.
+    /// Note: This resets the `is_fully_populated` flag since the cache
+    /// no longer contains all collections.
     pub fn remove(&mut self, name: &str) -> Option<Collection> {
-        self.by_name.remove(name)
+        let removed = self.by_name.remove(name);
+        if removed.is_some() {
+            self.is_fully_populated = false;
+        }
+        removed
     }
 
     /// Get all collection names in the cache.
@@ -82,30 +94,16 @@ impl CollectionCache {
         self.is_fully_populated
     }
 
-    /// Mark the cache as fully populated.
-    ///
-    /// Call this after loading all collections from the store.
-    pub fn mark_fully_populated(&mut self) {
-        self.is_fully_populated = true;
-    }
-
     /// Populate the cache with a full set of collections.
     ///
-    /// This replaces any existing cache contents and marks the cache
-    /// as fully populated.
-    pub fn populate(&mut self, collections: HashMap<String, Collection>) {
-        self.by_name = collections;
+    /// This replaces any existing cache contents, marks the cache as fully
+    /// populated, and derives keys from each collection's name.
+    pub fn populate(&mut self, collections: impl IntoIterator<Item = Collection>) {
+        self.by_name = collections
+            .into_iter()
+            .map(|c| (c.name().to_string(), c))
+            .collect();
         self.is_fully_populated = true;
-    }
-
-    /// Get an iterator over the collections.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Collection)> {
-        self.by_name.iter()
-    }
-
-    /// Convert the cache into a HashMap.
-    pub fn into_inner(self) -> HashMap<String, Collection> {
-        self.by_name
     }
 }
 
@@ -142,7 +140,7 @@ mod tests {
         let mut cache = CollectionCache::new();
         let col = test_collection("Users");
 
-        cache.add("Users".to_string(), col);
+        cache.add(col);
 
         assert!(cache.contains("Users"));
         assert!(!cache.contains("Posts"));
@@ -156,8 +154,8 @@ mod tests {
     #[test]
     fn test_cache_remove() {
         let mut cache = CollectionCache::new();
-        cache.add("Users".to_string(), test_collection("Users"));
-        cache.add("Posts".to_string(), test_collection("Posts"));
+        cache.add(test_collection("Users"));
+        cache.add(test_collection("Posts"));
 
         assert_eq!(cache.len(), 2);
 
@@ -170,10 +168,26 @@ mod tests {
     }
 
     #[test]
+    fn test_cache_remove_resets_fully_populated() {
+        let mut cache = CollectionCache::new();
+        cache.populate(vec![test_collection("Users"), test_collection("Posts")]);
+
+        assert!(cache.is_fully_populated());
+        assert_eq!(cache.len(), 2);
+
+        cache.remove("Users");
+
+        assert!(
+            !cache.is_fully_populated(),
+            "Cache should no longer be fully populated after remove"
+        );
+    }
+
+    #[test]
     fn test_cache_names() {
         let mut cache = CollectionCache::new();
-        cache.add("Users".to_string(), test_collection("Users"));
-        cache.add("Posts".to_string(), test_collection("Posts"));
+        cache.add(test_collection("Users"));
+        cache.add(test_collection("Posts"));
 
         let mut names = cache.names();
         names.sort();
@@ -185,25 +199,11 @@ mod tests {
         let mut cache = CollectionCache::new();
         assert!(!cache.is_fully_populated());
 
-        let mut collections = HashMap::new();
-        collections.insert("Users".to_string(), test_collection("Users"));
-        collections.insert("Posts".to_string(), test_collection("Posts"));
-
-        cache.populate(collections);
+        cache.populate(vec![test_collection("Users"), test_collection("Posts")]);
 
         assert!(cache.is_fully_populated());
         assert_eq!(cache.len(), 2);
         assert!(cache.contains("Users"));
         assert!(cache.contains("Posts"));
-    }
-
-    #[test]
-    fn test_cache_mark_fully_populated() {
-        let mut cache = CollectionCache::new();
-        cache.add("Users".to_string(), test_collection("Users"));
-
-        assert!(!cache.is_fully_populated());
-        cache.mark_fully_populated();
-        assert!(cache.is_fully_populated());
     }
 }

--- a/crates/db/src/collection_loader.rs
+++ b/crates/db/src/collection_loader.rs
@@ -1,0 +1,51 @@
+//! Shared collection loading utilities.
+//!
+//! This module provides common functions for loading collections from the SystemStore,
+//! used by both DbDocFetcher and DbDocMutator.
+
+use datastore::NamespaceView;
+use schema::CollectionVersion;
+use storage::corekv::Key;
+use storage::keys::systemstore::CollectionNameKey;
+use tracing::error;
+
+use crate::collection::Collection;
+
+/// Load a collection from the systemstore by name.
+///
+/// This is a standalone async function that doesn't hold any locks,
+/// allowing it to be called outside the mutex lock scope.
+///
+/// Returns `Ok(Some(collection))` if found, `Ok(None)` if not found,
+/// or an error if storage/deserialization fails.
+pub(crate) async fn load_collection_from_systemstore(
+    systemstore: &NamespaceView,
+    name: &str,
+) -> query::error::Result<Option<Collection>> {
+    let key = CollectionNameKey::new(name);
+
+    match systemstore.get(&key.bytes()).await.map_err(|e| {
+        error!(
+            error = ?e,
+            collection_name = %name,
+            "Storage error while loading collection from systemstore"
+        );
+        query::error::QueryError::execution(format!("storage error: {}", e))
+    })? {
+        Some(data) => {
+            let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
+                error!(
+                    error = ?e,
+                    collection_name = %name,
+                    "Failed to deserialize schema for collection"
+                );
+                query::error::QueryError::execution(format!(
+                    "failed to deserialize schema for collection '{}': {}",
+                    name, e
+                ))
+            })?;
+            Ok(Some(Collection::new(schema)))
+        }
+        None => Ok(None),
+    }
+}

--- a/crates/db/src/collection_loader.rs
+++ b/crates/db/src/collection_loader.rs
@@ -3,13 +3,17 @@
 //! This module provides common functions for loading collections from the SystemStore,
 //! used by both DbDocFetcher and DbDocMutator.
 
+use std::sync::Arc;
+
 use datastore::NamespaceView;
 use schema::CollectionVersion;
-use storage::corekv::Key;
+use storage::corekv::{Key, Store};
 use storage::keys::systemstore::CollectionNameKey;
-use tracing::error;
+use tokio::sync::Mutex as TokioMutex;
+use tracing::{error, warn};
 
 use crate::collection::Collection;
+use crate::txn::DbTxn;
 
 /// Load a collection from the systemstore by name.
 ///
@@ -48,4 +52,67 @@ pub(crate) async fn load_collection_from_systemstore(
         }
         None => Ok(None),
     }
+}
+
+/// Get a collection by name with lazy loading from the SystemStore.
+///
+/// This function checks the transaction's cache first. On cache miss, it loads
+/// the collection from the SystemStore and adds it to the cache.
+///
+/// Returns the collection and datastore for document operations.
+pub(crate) async fn get_collection_with_lazy_load<S: Store + 'static>(
+    txn: &Arc<TokioMutex<Option<DbTxn<S>>>>,
+    collection_name: &str,
+) -> query::error::Result<(Collection, NamespaceView)> {
+    // Extract what we need from the transaction while holding the lock briefly
+    let (collection_opt, systemstore, datastore) = {
+        let txn_guard = txn.lock().await;
+        let db_txn = txn_guard.as_ref().ok_or_else(|| {
+            query::error::QueryError::execution("transaction already consumed")
+        })?;
+        let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
+        let systemstore = db_txn.systemstore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get systemstore for collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+        let datastore = db_txn.datastore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get datastore for collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+        (collection_opt, systemstore, datastore)
+    };
+
+    // Return cached collection if found
+    let collection = if let Some(col) = collection_opt {
+        col
+    } else {
+        // Cache miss: load from SystemStore
+        let loaded = load_collection_from_systemstore(&systemstore, collection_name).await?;
+        let collection = loaded
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Add to cache - warn if transaction was consumed during load
+        {
+            let mut txn_guard = txn.lock().await;
+            match txn_guard.as_mut() {
+                Some(db_txn) => {
+                    db_txn.cache_collection(collection.clone());
+                }
+                None => {
+                    warn!(
+                        collection_name = %collection_name,
+                        "Transaction was consumed during collection load - cache not updated"
+                    );
+                }
+            }
+        }
+
+        collection
+    };
+
+    Ok((collection, datastore))
 }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -1196,6 +1196,102 @@ mod tests {
         );
     }
 
+    /// Documents the transaction-level caching behavior.
+    ///
+    /// The collection cache is per-transaction and uses lazy loading:
+    /// - Collections are NOT pre-loaded when a transaction starts
+    /// - Collections are loaded from the store on first access
+    /// - Once cached, the same collection instance is reused within the transaction
+    ///
+    /// Note: The underlying storage layer (MemoryStore) provides its own snapshot
+    /// isolation, so a transaction won't see changes committed after it started.
+    /// The "not true snapshot isolation" comment in the doc refers to the cache
+    /// behavior specifically - if you start a transaction and don't access a
+    /// collection, it's not snapshotted. But storage-level isolation still applies.
+    #[tokio::test]
+    async fn test_transaction_cache_lazy_loading_behavior() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+
+        // Create collection first
+        db.create_collection(test_users_schema()).await.unwrap();
+
+        // Start transaction A
+        let txn_a = db.new_txn(true).await.unwrap();
+
+        // Cache starts empty - collections are NOT pre-loaded
+        assert!(
+            txn_a.collection_cache().is_empty(),
+            "Transaction starts with empty cache (lazy loading)"
+        );
+
+        // First access loads from store and caches
+        {
+            let systemstore = txn_a.systemstore().unwrap();
+            let key = storage::keys::systemstore::CollectionNameKey::new("Users");
+            let data = systemstore
+                .get(&storage::corekv::Key::bytes(&key))
+                .await
+                .unwrap();
+            assert!(data.is_some(), "Collection should be loadable from store");
+        }
+
+        // The cache loading happens through DbDocFetcher/DbDocMutator's
+        // get_collection_with_lazy_load function, which:
+        // 1. Checks the transaction's cache first
+        // 2. On miss, loads from store and adds to cache
+        // 3. On subsequent accesses, returns cached version
+
+        txn_a.discard().unwrap();
+    }
+
+    /// Verifies that the storage layer provides snapshot isolation,
+    /// preventing transactions from seeing changes committed after they started.
+    #[tokio::test]
+    async fn test_storage_snapshot_isolation() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+
+        // Start transaction A BEFORE any collections exist
+        let txn_a = db.new_txn(true).await.unwrap();
+
+        // Create collection in a separate transaction
+        db.create_collection(test_users_schema()).await.unwrap();
+
+        // Transaction A (started before collection existed) should NOT see
+        // the new collection due to storage-level snapshot isolation
+        {
+            let systemstore = txn_a.systemstore().unwrap();
+            let key = storage::keys::systemstore::CollectionNameKey::new("Users");
+            let data = systemstore
+                .get(&storage::corekv::Key::bytes(&key))
+                .await
+                .unwrap();
+            assert!(
+                data.is_none(),
+                "Storage snapshot isolation: txn A should NOT see collection created after it started"
+            );
+        }
+
+        txn_a.discard().unwrap();
+
+        // New transaction SHOULD see the collection
+        let txn_b = db.new_txn(true).await.unwrap();
+        {
+            let systemstore = txn_b.systemstore().unwrap();
+            let key = storage::keys::systemstore::CollectionNameKey::new("Users");
+            let data = systemstore
+                .get(&storage::corekv::Key::bytes(&key))
+                .await
+                .unwrap();
+            assert!(
+                data.is_some(),
+                "New transaction should see previously committed collection"
+            );
+        }
+        txn_b.discard().unwrap();
+    }
+
     #[tokio::test]
     async fn test_reload_cache_recovers_from_inconsistency() {
         // Test that reload_cache() can recover from cache-store inconsistency

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -320,7 +320,7 @@ impl<S: Store> DB<S> {
             .map_err(Error::Storage)?;
 
         // Update txn-local cache
-        txn.cache_collection(name, Collection::new(schema));
+        txn.cache_collection(Collection::new(schema));
 
         Ok(())
     }
@@ -343,8 +343,7 @@ impl<S: Store> DB<S> {
             Ok(()) => {
                 txn.commit().await?;
 
-                // Update process-wide cache for backward compatibility
-                // This will be removed once all callers use transaction-scoped caching
+                // Update process-wide cache for callers not using transaction-scoped caching
                 let mut cache = self.collections.write().map_err(|e| {
                     tracing::error!(
                         error = ?e,
@@ -468,8 +467,7 @@ impl<S: Store> DB<S> {
             Ok(()) => {
                 txn.commit().await?;
 
-                // Update process-wide cache for backward compatibility
-                // This will be removed once all callers use transaction-scoped caching
+                // Update process-wide cache for callers not using transaction-scoped caching
                 let mut cache = self.collections.write().map_err(|e| {
                     tracing::error!(
                         error = ?e,

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -283,204 +283,229 @@ impl<S: Store> DB<S> {
         self.load_collections().await
     }
 
-    /// Create a new collection with schema persistence.
+    /// Create a new collection within an existing transaction.
     ///
-    /// Uses store-level atomicity to prevent duplicates - checks existence within
-    /// the transaction before writing.
+    /// The collection is written to the store and added to the transaction's cache.
+    /// The caller is responsible for committing or discarding the transaction.
     ///
     /// # Errors
     ///
     /// - `InvalidCollectionName` if the collection name is invalid
     /// - `CollectionAlreadyExists` if a collection with this name already exists
-    /// - `CacheUpdateFailedAfterCommit` if the schema was persisted but cache update failed
-    pub async fn create_collection(&self, schema: CollectionVersion) -> Result<()> {
+    pub async fn create_collection_with_txn(
+        &self,
+        txn: &mut DbTxn<S>,
+        schema: CollectionVersion,
+    ) -> Result<()> {
         // Validate collection name
         let collection_name = CollectionName::new(&schema.name)?;
         let name = collection_name.as_str().to_string();
 
-        let txn = self.new_txn(false).await?;
-        let key = CollectionNameKey::new(&name);
-
-        // Check if collection exists in store (must drop systemstore before discard)
-        let exists = {
-            let systemstore = txn.systemstore()?;
-            systemstore
-                .get(&key.bytes())
-                .await
-                .map_err(Error::Storage)?
-                .is_some()
-        };
-
-        if exists {
-            if let Err(discard_err) = txn.discard() {
-                tracing::error!(
-                    error = %discard_err,
-                    collection_name = %name,
-                    "Transaction discard failed while handling CollectionAlreadyExists"
-                );
-            }
+        // Check if collection exists in txn cache or store
+        if txn.get_collection(&name).await?.is_some() {
             return Err(Error::CollectionAlreadyExists(name));
         }
 
-        // Write schema to store
-        {
-            let systemstore = txn.systemstore()?;
-            let data = serde_json::to_vec(&schema).map_err(|e| {
-                Error::Serialization(format!(
-                    "failed to serialize schema for collection '{}': {}",
-                    name, e
-                ))
-            })?;
-            systemstore
-                .set(&key.bytes(), &data)
-                .await
-                .map_err(Error::Storage)?;
+        // Write schema to store (within txn)
+        let key = CollectionNameKey::new(&name);
+        let data = serde_json::to_vec(&schema).map_err(|e| {
+            Error::Serialization(format!(
+                "failed to serialize schema for collection '{}': {}",
+                name, e
+            ))
+        })?;
+        txn.systemstore()?
+            .set(&key.bytes(), &data)
+            .await
+            .map_err(Error::Storage)?;
+
+        // Update txn-local cache
+        txn.cache_collection(name, Collection::new(schema));
+
+        Ok(())
+    }
+
+    /// Create a new collection with schema persistence.
+    ///
+    /// This is a convenience method that creates its own transaction.
+    /// For multi-operation transactions, use `create_collection_with_txn`.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidCollectionName` if the collection name is invalid
+    /// - `CollectionAlreadyExists` if a collection with this name already exists
+    pub async fn create_collection(&self, schema: CollectionVersion) -> Result<()> {
+        let name = schema.name.clone();
+        let collection = Collection::new(schema.clone());
+
+        let mut txn = self.new_txn(false).await?;
+        match self.create_collection_with_txn(&mut txn, schema).await {
+            Ok(()) => {
+                txn.commit().await?;
+
+                // Update process-wide cache for backward compatibility
+                // This will be removed once all callers use transaction-scoped caching
+                let mut cache = self.collections.write().map_err(|e| {
+                    tracing::error!(
+                        error = ?e,
+                        collection_name = %name,
+                        "Collection cache lock poisoned during create"
+                    );
+                    Error::CacheUpdateFailedAfterCommit(name.clone())
+                })?;
+                cache.insert(name, collection);
+                Ok(())
+            }
+            Err(e) => {
+                if let Err(discard_err) = txn.discard() {
+                    tracing::warn!(
+                        error = %discard_err,
+                        original_error = %e,
+                        "Transaction discard failed after create_collection error"
+                    );
+                }
+                Err(e)
+            }
         }
+    }
 
-        txn.commit().await?;
+    /// Delete a collection and all its documents within an existing transaction.
+    ///
+    /// The collection is deleted from the store and removed from the transaction's cache.
+    /// The caller is responsible for committing or discarding the transaction.
+    ///
+    /// # Errors
+    ///
+    /// - `CollectionNotFound` if the collection does not exist
+    pub async fn delete_collection_with_txn(&self, txn: &mut DbTxn<S>, name: &str) -> Result<()> {
+        // Get collection from txn cache/store
+        let collection = txn
+            .get_collection(name)
+            .await?
+            .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?;
+        let collection_id = collection.collection_id().to_string();
 
-        // Update cache after successful commit.
-        // If this fails, the collection IS persisted but not in cache.
-        // Call reload_cache() or restart to recover.
-        let mut cache = self.collections.write().map_err(|e| {
+        // Delete schema from store
+        let schema_key = CollectionNameKey::new(name);
+        txn.systemstore()?
+            .delete(&schema_key.bytes())
+            .await
+            .map_err(Error::Storage)?;
+
+        // Delete documents
+        let datastore = txn.datastore()?;
+        let doc_prefix = format!("/d/{}/", collection_id);
+        let opts = IterOptions::new().with_prefix(doc_prefix.as_bytes().to_vec());
+
+        let mut iter = datastore.iterator(opts).await.map_err(|e| {
             tracing::error!(
                 error = ?e,
                 collection_name = %name,
-                "Collection cache lock poisoned during create - collection WAS persisted to store. Call reload_cache() or restart to recover."
+                "Failed to create iterator for document deletion"
             );
-            Error::CacheUpdateFailedAfterCommit(name.clone())
+            Error::Storage(e)
         })?;
-        cache.insert(name, Collection::new(schema));
+        let mut keys_to_delete = Vec::new();
+
+        while let Some(pair) = iter.next().await.map_err(|e| {
+            tracing::error!(
+                error = ?e,
+                collection_name = %name,
+                documents_found = keys_to_delete.len(),
+                "Failed to iterate documents during collection deletion"
+            );
+            Error::Storage(e)
+        })? {
+            keys_to_delete.push(pair.key.clone());
+        }
+        iter.close().await.map_err(|e| {
+            tracing::error!(
+                error = ?e,
+                collection_name = %name,
+                "Failed to close iterator during collection deletion"
+            );
+            Error::Storage(e)
+        })?;
+
+        tracing::debug!(
+            collection_name = %name,
+            documents_to_delete = keys_to_delete.len(),
+            "Deleting documents for collection"
+        );
+
+        for (i, key) in keys_to_delete.iter().enumerate() {
+            datastore.delete(key).await.map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    collection_name = %name,
+                    documents_deleted = i,
+                    documents_total = keys_to_delete.len(),
+                    "Failed to delete document during collection deletion"
+                );
+                Error::Storage(e)
+            })?;
+        }
+
+        // Update txn-local cache
+        txn.uncache_collection(name);
 
         Ok(())
     }
 
     /// Delete a collection and all its documents.
     ///
-    /// Checks store for existence within transaction for atomic delete.
+    /// This is a convenience method that creates its own transaction.
+    /// For multi-operation transactions, use `delete_collection_with_txn`.
     ///
     /// # Errors
     ///
     /// - `CollectionNotFound` if the collection does not exist
-    /// - `CacheUpdateFailedAfterCommit` if the collection was deleted but cache update failed
     pub async fn delete_collection(&self, name: &str) -> Result<()> {
-        // Get collection_id from cache (read lock, released before async ops)
-        let collection_id = {
-            let cache = self.collections.read().map_err(|e| {
-                tracing::error!(error = ?e, "Collection cache lock poisoned during delete");
-                Error::LockPoisoned("collection cache lock poisoned during delete".into())
-            })?;
-            cache
-                .get(name)
-                .map(|c| c.collection_id().to_string())
-                .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?
-        };
+        let name_owned = name.to_string();
 
-        let txn = self.new_txn(false).await?;
-        let schema_key = CollectionNameKey::new(name);
+        let mut txn = self.new_txn(false).await?;
+        match self.delete_collection_with_txn(&mut txn, name).await {
+            Ok(()) => {
+                txn.commit().await?;
 
-        // Verify collection still exists in store (must drop systemstore before discard)
-        let exists = {
-            let systemstore = txn.systemstore()?;
-            systemstore
-                .get(&schema_key.bytes())
-                .await
-                .map_err(Error::Storage)?
-                .is_some()
-        };
-
-        if !exists {
-            if let Err(discard_err) = txn.discard() {
-                tracing::error!(
-                    error = %discard_err,
-                    collection_name = %name,
-                    "Transaction discard failed while handling CollectionNotFound"
-                );
-            }
-            return Err(Error::CollectionNotFound(name.to_string()));
-        }
-
-        // Delete schema and documents
-        {
-            let systemstore = txn.systemstore()?;
-            systemstore
-                .delete(&schema_key.bytes())
-                .await
-                .map_err(Error::Storage)?;
-
-            let datastore = txn.datastore()?;
-            let doc_prefix = format!("/d/{}/", collection_id);
-            let opts = IterOptions::new().with_prefix(doc_prefix.as_bytes().to_vec());
-
-            let mut iter = datastore.iterator(opts).await.map_err(|e| {
-                tracing::error!(
-                    error = ?e,
-                    collection_name = %name,
-                    "Failed to create iterator for document deletion"
-                );
-                Error::Storage(e)
-            })?;
-            let mut keys_to_delete = Vec::new();
-
-            while let Some(pair) = iter.next().await.map_err(|e| {
-                tracing::error!(
-                    error = ?e,
-                    collection_name = %name,
-                    documents_found = keys_to_delete.len(),
-                    "Failed to iterate documents during collection deletion"
-                );
-                Error::Storage(e)
-            })? {
-                keys_to_delete.push(pair.key.clone());
-            }
-            iter.close().await.map_err(|e| {
-                tracing::error!(
-                    error = ?e,
-                    collection_name = %name,
-                    "Failed to close iterator during collection deletion"
-                );
-                Error::Storage(e)
-            })?;
-
-            tracing::debug!(
-                collection_name = %name,
-                documents_to_delete = keys_to_delete.len(),
-                "Deleting documents for collection"
-            );
-
-            for (i, key) in keys_to_delete.iter().enumerate() {
-                datastore.delete(key).await.map_err(|e| {
+                // Update process-wide cache for backward compatibility
+                // This will be removed once all callers use transaction-scoped caching
+                let mut cache = self.collections.write().map_err(|e| {
                     tracing::error!(
                         error = ?e,
-                        collection_name = %name,
-                        documents_deleted = i,
-                        documents_total = keys_to_delete.len(),
-                        "Failed to delete document during collection deletion"
+                        collection_name = %name_owned,
+                        "Collection cache lock poisoned during delete"
                     );
-                    Error::Storage(e)
+                    Error::CacheUpdateFailedAfterCommit(name_owned.clone())
                 })?;
+                cache.remove(&name_owned);
+                Ok(())
+            }
+            Err(e) => {
+                if let Err(discard_err) = txn.discard() {
+                    tracing::warn!(
+                        error = %discard_err,
+                        original_error = %e,
+                        "Transaction discard failed after delete_collection error"
+                    );
+                }
+                Err(e)
             }
         }
+    }
 
-        txn.commit().await?;
-
-        // Update cache after successful commit.
-        // If this fails, the collection IS deleted but still in cache.
-        // Call reload_cache() or restart to recover.
-        let mut cache = self.collections.write().map_err(|e| {
-            tracing::error!(
-                error = ?e,
-                collection_name = %name,
-                "Collection cache lock poisoned during delete - collection WAS deleted from store. Call reload_cache() or restart to recover."
-            );
-            Error::CacheUpdateFailedAfterCommit(name.to_string())
-        })?;
-        cache.remove(name);
-
-        Ok(())
+    /// List all collection names using the transaction's cache.
+    ///
+    /// This loads all collections from the store into the transaction cache
+    /// if they haven't been loaded yet.
+    pub async fn list_collections_with_txn(&self, txn: &mut DbTxn<S>) -> Result<Vec<String>> {
+        txn.load_all_collections().await?;
+        Ok(txn.collection_cache().names())
     }
 
     /// List all collection names.
+    ///
+    /// Uses the process-wide cache. For transaction-scoped access, use `list_collections_with_txn`.
     pub fn list_collections(&self) -> Result<Vec<String>> {
         let cache = self.collections.read().map_err(|e| {
             tracing::error!(error = ?e, "Collection cache lock poisoned during list");
@@ -489,7 +514,21 @@ impl<S: Store> DB<S> {
         Ok(cache.keys().cloned().collect())
     }
 
+    /// Get a collection by name using the transaction's cache.
+    ///
+    /// This performs lazy loading - the collection is loaded from the store
+    /// on first access within the transaction.
+    pub async fn get_collection_with_txn(
+        &self,
+        txn: &mut DbTxn<S>,
+        name: &str,
+    ) -> Result<Option<Collection>> {
+        txn.get_collection(name).await.map(|opt| opt.cloned())
+    }
+
     /// Get a collection by name.
+    ///
+    /// Uses the process-wide cache. For transaction-scoped access, use `get_collection_with_txn`.
     pub fn get_collection(&self, name: &str) -> Result<Option<Collection>> {
         let cache = self
             .collections
@@ -501,7 +540,17 @@ impl<S: Store> DB<S> {
         Ok(cache.get(name).cloned())
     }
 
+    /// Check if a collection exists using the transaction's cache.
+    ///
+    /// This performs lazy loading - the collection is loaded from the store
+    /// on first access within the transaction.
+    pub async fn has_collection_with_txn(&self, txn: &mut DbTxn<S>, name: &str) -> Result<bool> {
+        Ok(txn.get_collection(name).await?.is_some())
+    }
+
     /// Check if a collection exists.
+    ///
+    /// Uses the process-wide cache. For transaction-scoped access, use `has_collection_with_txn`.
     pub fn has_collection(&self, name: &str) -> Result<bool> {
         let cache = self
             .collections

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -1,7 +1,6 @@
 //! Document fetcher for transaction-scoped queries.
 
 use async_trait::async_trait;
-use datastore::NamespaceView;
 use document::Document;
 use query::runner::{DocFetcher, FetchByIdsResult};
 use std::sync::Arc;
@@ -9,8 +8,7 @@ use storage::corekv::Store;
 use tokio::sync::Mutex as TokioMutex;
 use tracing::warn;
 
-use crate::collection::Collection;
-use crate::collection_loader::load_collection_from_systemstore;
+use crate::collection_loader::get_collection_with_lazy_load;
 use crate::txn::DbTxn;
 
 /// Document fetcher that uses a database transaction.
@@ -74,69 +72,10 @@ impl<S: Store> DbDocFetcher<S> {
     }
 }
 
-impl<S: Store + 'static> DbDocFetcher<S> {
-    /// Get a collection by name with lazy loading from the SystemStore.
-    ///
-    /// Returns the collection and datastore for document operations.
-    async fn get_collection(
-        &self,
-        collection_name: &str,
-    ) -> query::error::Result<(Collection, NamespaceView)> {
-        let (collection_opt, systemstore, datastore) = {
-            let txn_guard = self.txn.lock().await;
-            let db_txn = txn_guard.as_ref().ok_or_else(|| {
-                query::error::QueryError::execution("transaction already consumed")
-            })?;
-            let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
-            let systemstore = db_txn.systemstore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get systemstore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
-            let datastore = db_txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
-            (collection_opt, systemstore, datastore)
-        };
-
-        let collection = if let Some(col) = collection_opt {
-            col
-        } else {
-            let loaded = load_collection_from_systemstore(&systemstore, collection_name).await?;
-            let collection = loaded
-                .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-
-            // Add to cache - warn if transaction was consumed during load
-            {
-                let mut txn_guard = self.txn.lock().await;
-                match txn_guard.as_mut() {
-                    Some(db_txn) => {
-                        db_txn.cache_collection(collection.clone());
-                    }
-                    None => {
-                        warn!(
-                            collection_name = %collection_name,
-                            "Transaction was consumed during collection load - cache not updated"
-                        );
-                    }
-                }
-            }
-
-            collection
-        };
-
-        Ok((collection, datastore))
-    }
-}
-
 #[async_trait]
 impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
     async fn get_all(&self, collection_name: &str) -> query::error::Result<Vec<Document>> {
-        let (collection, datastore) = self.get_collection(collection_name).await?;
+        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .get_all_with_datastore(&datastore)
@@ -149,7 +88,7 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         collection_name: &str,
         doc_ids: &[String],
     ) -> query::error::Result<FetchByIdsResult> {
-        let (collection, datastore) = self.get_collection(collection_name).await?;
+        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         let mut docs = Vec::new();
         let mut missing_ids = Vec::new();

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -1,20 +1,51 @@
 //! Document fetcher for transaction-scoped queries.
 
 use async_trait::async_trait;
+use datastore::NamespaceView;
 use document::Document;
 use query::runner::{DocFetcher, FetchByIdsResult};
+use schema::CollectionVersion;
 use std::sync::Arc;
-use storage::corekv::Store;
+use storage::corekv::{Key, Store};
+use storage::keys::systemstore::CollectionNameKey;
 use tokio::sync::Mutex as TokioMutex;
 use tracing::warn;
 
-use crate::collection_snapshot::CollectionSnapshot;
+use crate::collection::Collection;
 use crate::txn::DbTxn;
+
+/// Load a collection from the systemstore by name.
+///
+/// This is a standalone async function that doesn't hold any locks,
+/// allowing it to be called outside the mutex lock scope.
+async fn load_collection_from_systemstore(
+    systemstore: &NamespaceView,
+    name: &str,
+) -> query::error::Result<Option<Collection>> {
+    let key = CollectionNameKey::new(name);
+
+    match systemstore
+        .get(&key.bytes())
+        .await
+        .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?
+    {
+        Some(data) => {
+            let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to deserialize schema for collection '{}': {}",
+                    name, e
+                ))
+            })?;
+            Ok(Some(Collection::new(schema)))
+        }
+        None => Ok(None),
+    }
+}
 
 /// Document fetcher that uses a database transaction.
 ///
-/// This fetcher holds a reference to an active transaction and a collection
-/// snapshot, allowing it to fetch documents within the transaction context.
+/// This fetcher holds a reference to an active transaction and uses the
+/// transaction's collection cache with lazy loading for snapshot isolation.
 ///
 /// # Ownership Model
 ///
@@ -26,17 +57,23 @@ use crate::txn::DbTxn;
 ///
 /// After `take_txn()` is called, all fetcher operations will return an error
 /// indicating the transaction was consumed. Use `is_consumed()` to check state.
+///
+/// # Collection Access
+///
+/// Collections are loaded lazily from the SystemStore on first access within
+/// the transaction. This provides snapshot isolation - the transaction sees
+/// collections as they existed when first accessed, not at transaction start.
 pub struct DbDocFetcher<S: Store> {
     txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
-    collections: CollectionSnapshot,
 }
 
 impl<S: Store> DbDocFetcher<S> {
     /// Create a new transaction-scoped document fetcher.
-    pub(crate) fn new(txn: DbTxn<S>, collections: CollectionSnapshot) -> Self {
+    ///
+    /// Collections will be loaded lazily from the transaction's cache.
+    pub(crate) fn new(txn: DbTxn<S>) -> Self {
         Self {
             txn: Arc::new(TokioMutex::new(Some(txn))),
-            collections,
         }
     }
 
@@ -62,37 +99,53 @@ impl<S: Store> DbDocFetcher<S> {
     pub(crate) fn shared_txn(&self) -> Arc<TokioMutex<Option<DbTxn<S>>>> {
         self.txn.clone()
     }
-
-    /// Get a reference to the collection snapshot.
-    pub(crate) fn collections(&self) -> &CollectionSnapshot {
-        &self.collections
-    }
 }
 
 #[async_trait]
 impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
     async fn get_all(&self, collection_name: &str) -> query::error::Result<Vec<Document>> {
-        let collection = self
-            .collections
-            .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?
-            .clone();
-
-        // Extract the datastore while holding the lock, then release the lock
-        // before awaiting. The datastore is Send + Sync so this is safe.
-        let datastore = {
+        // Step 1: Check if collection is in cache (sync, no await while holding lock)
+        let (collection_opt, systemstore, datastore) = {
             let txn_guard = self.txn.lock().await;
             let db_txn = txn_guard.as_ref().ok_or_else(|| {
                 query::error::QueryError::execution("transaction already consumed")
             })?;
-            db_txn.datastore().map_err(|e| {
+            let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
+            let systemstore = db_txn.systemstore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get systemstore for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
+            let datastore = db_txn.datastore().map_err(|e| {
                 query::error::QueryError::execution(format!(
                     "failed to get datastore for collection '{}': {}",
                     collection_name, e
                 ))
-            })?
+            })?;
+            (collection_opt, systemstore, datastore)
+        }; // Lock released here
+
+        // Step 2: If not in cache, load from store (no lock held during await)
+        let collection = if let Some(col) = collection_opt {
+            col
+        } else {
+            let loaded = load_collection_from_systemstore(&systemstore, collection_name).await?;
+            let collection = loaded
+                .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+            // Add to cache
+            {
+                let mut txn_guard = self.txn.lock().await;
+                if let Some(db_txn) = txn_guard.as_mut() {
+                    db_txn.cache_collection(collection_name.to_string(), collection.clone());
+                }
+            }
+
+            collection
         };
 
+        // Step 3: Fetch documents (no lock held)
         collection
             .get_all_with_datastore(&datastore)
             .await
@@ -104,27 +157,48 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         collection_name: &str,
         doc_ids: &[String],
     ) -> query::error::Result<FetchByIdsResult> {
-        let collection = self
-            .collections
-            .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?
-            .clone();
-
-        // Extract the datastore while holding the lock, then release the lock
-        // before awaiting. The datastore is Send + Sync so this is safe.
-        let datastore = {
+        // Step 1: Check if collection is in cache (sync, no await while holding lock)
+        let (collection_opt, systemstore, datastore) = {
             let txn_guard = self.txn.lock().await;
             let db_txn = txn_guard.as_ref().ok_or_else(|| {
                 query::error::QueryError::execution("transaction already consumed")
             })?;
-            db_txn.datastore().map_err(|e| {
+            let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
+            let systemstore = db_txn.systemstore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get systemstore for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
+            let datastore = db_txn.datastore().map_err(|e| {
                 query::error::QueryError::execution(format!(
                     "failed to get datastore for collection '{}': {}",
                     collection_name, e
                 ))
-            })?
+            })?;
+            (collection_opt, systemstore, datastore)
+        }; // Lock released here
+
+        // Step 2: If not in cache, load from store (no lock held during await)
+        let collection = if let Some(col) = collection_opt {
+            col
+        } else {
+            let loaded = load_collection_from_systemstore(&systemstore, collection_name).await?;
+            let collection = loaded
+                .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+            // Add to cache
+            {
+                let mut txn_guard = self.txn.lock().await;
+                if let Some(db_txn) = txn_guard.as_mut() {
+                    db_txn.cache_collection(collection_name.to_string(), collection.clone());
+                }
+            }
+
+            collection
         };
 
+        // Step 3: Fetch documents (no lock held)
         let mut docs = Vec::new();
         let mut missing_ids = Vec::new();
 

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -4,48 +4,19 @@ use async_trait::async_trait;
 use datastore::NamespaceView;
 use document::Document;
 use query::runner::{DocFetcher, FetchByIdsResult};
-use schema::CollectionVersion;
 use std::sync::Arc;
-use storage::corekv::{Key, Store};
-use storage::keys::systemstore::CollectionNameKey;
+use storage::corekv::Store;
 use tokio::sync::Mutex as TokioMutex;
 use tracing::warn;
 
 use crate::collection::Collection;
+use crate::collection_loader::load_collection_from_systemstore;
 use crate::txn::DbTxn;
-
-/// Load a collection from the systemstore by name.
-///
-/// This is a standalone async function that doesn't hold any locks,
-/// allowing it to be called outside the mutex lock scope.
-async fn load_collection_from_systemstore(
-    systemstore: &NamespaceView,
-    name: &str,
-) -> query::error::Result<Option<Collection>> {
-    let key = CollectionNameKey::new(name);
-
-    match systemstore
-        .get(&key.bytes())
-        .await
-        .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?
-    {
-        Some(data) => {
-            let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to deserialize schema for collection '{}': {}",
-                    name, e
-                ))
-            })?;
-            Ok(Some(Collection::new(schema)))
-        }
-        None => Ok(None),
-    }
-}
 
 /// Document fetcher that uses a database transaction.
 ///
 /// This fetcher holds a reference to an active transaction and uses the
-/// transaction's collection cache with lazy loading for snapshot isolation.
+/// transaction's collection cache with lazy loading.
 ///
 /// # Ownership Model
 ///
@@ -61,8 +32,10 @@ async fn load_collection_from_systemstore(
 /// # Collection Access
 ///
 /// Collections are loaded lazily from the SystemStore on first access within
-/// the transaction. This provides snapshot isolation - the transaction sees
-/// collections as they existed when first accessed, not at transaction start.
+/// the transaction. Once loaded, the collection metadata is cached for the
+/// duration of the transaction. Note: This provides transaction-level caching,
+/// not true snapshot isolation - if collections are accessed at different times,
+/// they reflect the store state at the time of first access.
 pub struct DbDocFetcher<S: Store> {
     txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
 }
@@ -101,10 +74,14 @@ impl<S: Store> DbDocFetcher<S> {
     }
 }
 
-#[async_trait]
-impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
-    async fn get_all(&self, collection_name: &str) -> query::error::Result<Vec<Document>> {
-        // Step 1: Check if collection is in cache (sync, no await while holding lock)
+impl<S: Store + 'static> DbDocFetcher<S> {
+    /// Get a collection by name with lazy loading from the SystemStore.
+    ///
+    /// Returns the collection and datastore for document operations.
+    async fn get_collection(
+        &self,
+        collection_name: &str,
+    ) -> query::error::Result<(Collection, NamespaceView)> {
         let (collection_opt, systemstore, datastore) = {
             let txn_guard = self.txn.lock().await;
             let db_txn = txn_guard.as_ref().ok_or_else(|| {
@@ -124,9 +101,8 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                 ))
             })?;
             (collection_opt, systemstore, datastore)
-        }; // Lock released here
+        };
 
-        // Step 2: If not in cache, load from store (no lock held during await)
         let collection = if let Some(col) = collection_opt {
             col
         } else {
@@ -134,18 +110,34 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
             let collection = loaded
                 .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
-            // Add to cache
+            // Add to cache - warn if transaction was consumed during load
             {
                 let mut txn_guard = self.txn.lock().await;
-                if let Some(db_txn) = txn_guard.as_mut() {
-                    db_txn.cache_collection(collection_name.to_string(), collection.clone());
+                match txn_guard.as_mut() {
+                    Some(db_txn) => {
+                        db_txn.cache_collection(collection.clone());
+                    }
+                    None => {
+                        warn!(
+                            collection_name = %collection_name,
+                            "Transaction was consumed during collection load - cache not updated"
+                        );
+                    }
                 }
             }
 
             collection
         };
 
-        // Step 3: Fetch documents (no lock held)
+        Ok((collection, datastore))
+    }
+}
+
+#[async_trait]
+impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
+    async fn get_all(&self, collection_name: &str) -> query::error::Result<Vec<Document>> {
+        let (collection, datastore) = self.get_collection(collection_name).await?;
+
         collection
             .get_all_with_datastore(&datastore)
             .await
@@ -157,48 +149,8 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         collection_name: &str,
         doc_ids: &[String],
     ) -> query::error::Result<FetchByIdsResult> {
-        // Step 1: Check if collection is in cache (sync, no await while holding lock)
-        let (collection_opt, systemstore, datastore) = {
-            let txn_guard = self.txn.lock().await;
-            let db_txn = txn_guard.as_ref().ok_or_else(|| {
-                query::error::QueryError::execution("transaction already consumed")
-            })?;
-            let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
-            let systemstore = db_txn.systemstore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get systemstore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
-            let datastore = db_txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
-            (collection_opt, systemstore, datastore)
-        }; // Lock released here
+        let (collection, datastore) = self.get_collection(collection_name).await?;
 
-        // Step 2: If not in cache, load from store (no lock held during await)
-        let collection = if let Some(col) = collection_opt {
-            col
-        } else {
-            let loaded = load_collection_from_systemstore(&systemstore, collection_name).await?;
-            let collection = loaded
-                .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-
-            // Add to cache
-            {
-                let mut txn_guard = self.txn.lock().await;
-                if let Some(db_txn) = txn_guard.as_mut() {
-                    db_txn.cache_collection(collection_name.to_string(), collection.clone());
-                }
-            }
-
-            collection
-        };
-
-        // Step 3: Fetch documents (no lock held)
         let mut docs = Vec::new();
         let mut missing_ids = Vec::new();
 

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -1,19 +1,50 @@
 //! Document mutator for transaction-scoped mutations.
 
 use async_trait::async_trait;
+use datastore::NamespaceView;
 use document::{DocID, Document};
 use query::mutator::{CreateResult, DeleteResult, DocMutator, UpdateResult};
+use schema::CollectionVersion;
 use std::sync::Arc;
-use storage::corekv::Store;
+use storage::corekv::{Key, Store};
+use storage::keys::systemstore::CollectionNameKey;
 use tokio::sync::Mutex as TokioMutex;
 
-use crate::collection_snapshot::CollectionSnapshot;
+use crate::collection::Collection;
 use crate::txn::DbTxn;
+
+/// Load a collection from the systemstore by name.
+///
+/// This is a standalone async function that doesn't hold any locks,
+/// allowing it to be called outside the mutex lock scope.
+async fn load_collection_from_systemstore(
+    systemstore: &NamespaceView,
+    name: &str,
+) -> query::error::Result<Option<Collection>> {
+    let key = CollectionNameKey::new(name);
+
+    match systemstore
+        .get(&key.bytes())
+        .await
+        .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?
+    {
+        Some(data) => {
+            let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to deserialize schema for collection '{}': {}",
+                    name, e
+                ))
+            })?;
+            Ok(Some(Collection::new(schema)))
+        }
+        None => Ok(None),
+    }
+}
 
 /// Document mutator that uses a database transaction.
 ///
-/// This mutator holds a reference to an active transaction and collection
-/// snapshot, allowing it to perform mutations within the transaction context.
+/// This mutator holds a reference to an active transaction and uses the
+/// transaction's collection cache with lazy loading for snapshot isolation.
 ///
 /// # Ownership Model
 ///
@@ -29,17 +60,23 @@ use crate::txn::DbTxn;
 ///
 /// After `take_txn()` is called, all mutator operations will return an error
 /// indicating the transaction was consumed. Use `is_consumed()` to check state.
+///
+/// # Collection Access
+///
+/// Collections are loaded lazily from the SystemStore on first access within
+/// the transaction. This provides snapshot isolation - the transaction sees
+/// collections as they existed when first accessed, not at transaction start.
 pub struct DbDocMutator<S: Store> {
     txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
-    collections: CollectionSnapshot,
 }
 
 impl<S: Store> DbDocMutator<S> {
     /// Create a new transaction-scoped document mutator.
-    pub fn new(txn: DbTxn<S>, collections: CollectionSnapshot) -> Self {
+    ///
+    /// Collections will be loaded lazily from the transaction's cache.
+    pub fn new(txn: DbTxn<S>) -> Self {
         Self {
             txn: Arc::new(TokioMutex::new(Some(txn))),
-            collections,
         }
     }
 
@@ -47,11 +84,8 @@ impl<S: Store> DbDocMutator<S> {
     ///
     /// This is used by `DbTransactionContext` to create a mutator that shares
     /// the same transaction as the `DbDocFetcher`.
-    pub(crate) fn from_shared_txn(
-        txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
-        collections: CollectionSnapshot,
-    ) -> Self {
-        Self { txn, collections }
+    pub(crate) fn from_shared_txn(txn: Arc<TokioMutex<Option<DbTxn<S>>>>) -> Self {
+        Self { txn }
     }
 
     /// Take the transaction out of the mutator (for commit/rollback).
@@ -69,6 +103,55 @@ impl<S: Store> DbDocMutator<S> {
     pub async fn is_consumed(&self) -> bool {
         self.txn.lock().await.is_none()
     }
+
+    /// Get a collection by name, loading from the transaction's cache with lazy loading.
+    async fn get_collection(
+        &self,
+        collection_name: &str,
+    ) -> query::error::Result<(Collection, NamespaceView)> {
+        // Step 1: Check if collection is in cache
+        let (collection_opt, systemstore, datastore) = {
+            let txn_guard = self.txn.lock().await;
+            let db_txn = txn_guard.as_ref().ok_or_else(|| {
+                query::error::QueryError::execution("transaction already consumed")
+            })?;
+            let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
+            let systemstore = db_txn.systemstore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get systemstore for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
+            let datastore = db_txn.datastore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get datastore for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
+            (collection_opt, systemstore, datastore)
+        }; // Lock released here
+
+        // Step 2: If not in cache, load from store
+        let collection = if let Some(col) = collection_opt {
+            col
+        } else {
+            let loaded = load_collection_from_systemstore(&systemstore, collection_name).await?;
+            let collection = loaded
+                .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+            // Add to cache
+            {
+                let mut txn_guard = self.txn.lock().await;
+                if let Some(db_txn) = txn_guard.as_mut() {
+                    db_txn.cache_collection(collection_name.to_string(), collection.clone());
+                }
+            }
+
+            collection
+        };
+
+        Ok((collection, datastore))
+    }
 }
 
 #[async_trait]
@@ -78,10 +161,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         mut doc: Document,
     ) -> query::error::Result<CreateResult> {
-        let collection = self
-            .collections
-            .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+        let (collection, datastore) = self.get_collection(collection_name).await?;
 
         // Generate document ID if not present
         if doc.id().is_none() {
@@ -93,21 +173,6 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         let doc_id = doc.id().cloned().ok_or_else(|| {
             query::error::QueryError::execution("document should have ID after generation")
         })?;
-
-        // Extract the datastore while holding the lock, then release the lock
-        // before awaiting. The datastore is Send + Sync so this is safe.
-        let datastore = {
-            let txn_guard = self.txn.lock().await;
-            let db_txn = txn_guard.as_ref().ok_or_else(|| {
-                query::error::QueryError::execution("transaction already consumed")
-            })?;
-            db_txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?
-        };
 
         collection
             .create_with_datastore(&datastore, &doc)
@@ -122,24 +187,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc: Document,
     ) -> query::error::Result<UpdateResult> {
-        let collection = self
-            .collections
-            .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-
-        // Extract the datastore while holding the lock
-        let datastore = {
-            let txn_guard = self.txn.lock().await;
-            let db_txn = txn_guard.as_ref().ok_or_else(|| {
-                query::error::QueryError::execution("transaction already consumed")
-            })?;
-            db_txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?
-        };
+        let (collection, datastore) = self.get_collection(collection_name).await?;
 
         collection
             .update_with_datastore(&datastore, &doc)
@@ -157,24 +205,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<DeleteResult> {
-        let collection = self
-            .collections
-            .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-
-        // Extract the datastore while holding the lock
-        let datastore = {
-            let txn_guard = self.txn.lock().await;
-            let db_txn = txn_guard.as_ref().ok_or_else(|| {
-                query::error::QueryError::execution("transaction already consumed")
-            })?;
-            db_txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?
-        };
+        let (collection, datastore) = self.get_collection(collection_name).await?;
 
         let existed = collection
             .delete_with_datastore(&datastore, doc_id)
@@ -185,24 +216,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
     }
 
     async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {
-        let collection = self
-            .collections
-            .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-
-        // Extract the datastore while holding the lock
-        let datastore = {
-            let txn_guard = self.txn.lock().await;
-            let db_txn = txn_guard.as_ref().ok_or_else(|| {
-                query::error::QueryError::execution("transaction already consumed")
-            })?;
-            db_txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?
-        };
+        let (collection, datastore) = self.get_collection(collection_name).await?;
 
         collection
             .exists_with_datastore(&datastore, doc_id)
@@ -215,24 +229,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<Option<Document>> {
-        let collection = self
-            .collections
-            .get(collection_name)
-            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-
-        // Extract the datastore while holding the lock
-        let datastore = {
-            let txn_guard = self.txn.lock().await;
-            let db_txn = txn_guard.as_ref().ok_or_else(|| {
-                query::error::QueryError::execution("transaction already consumed")
-            })?;
-            db_txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?
-        };
+        let (collection, datastore) = self.get_collection(collection_name).await?;
 
         collection
             .get_with_datastore(&datastore, doc_id)
@@ -246,34 +243,33 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::collection::Collection;
     use crate::database::DB;
     use document::NormalValue;
     use schema::{CollectionVersion, FieldDescription, FieldKind};
-    use std::collections::HashMap;
     use storage::backends::MemoryStore;
 
-    fn test_collections() -> CollectionSnapshot {
+    fn test_schema() -> CollectionVersion {
         let fields = vec![
             FieldDescription::new("1", "_docID", FieldKind::doc_id()),
             FieldDescription::new("2", "name", FieldKind::string()),
             FieldDescription::new("3", "age", FieldKind::int()),
         ];
-        let col = Collection::new(CollectionVersion::new("Users", "v1", "col-users", fields));
+        CollectionVersion::new("Users", "v1", "col-users", fields)
+    }
 
-        let mut map = HashMap::new();
-        map.insert("Users".to_string(), col);
-        CollectionSnapshot::new(map)
+    async fn setup_db_with_collection() -> DB<MemoryStore> {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+        db.create_collection(test_schema()).await.unwrap();
+        db
     }
 
     #[tokio::test]
     async fn test_create_document() {
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         // Create a document
         let mut doc = Document::new();
@@ -293,20 +289,18 @@ mod tests {
 
         // Verify the document was persisted
         let txn = db.new_txn(true).await.unwrap();
-        let read_mutator = DbDocMutator::new(txn, collections);
+        let read_mutator = DbDocMutator::new(txn);
         let exists = read_mutator.exists("Users", &result.doc_id).await.unwrap();
         assert!(exists);
     }
 
     #[tokio::test]
     async fn test_delete_document() {
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         // First create a document
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         let mut doc = Document::new();
         doc.set("name", NormalValue::String("Bob".to_string()));
@@ -318,7 +312,7 @@ mod tests {
 
         // Now delete it
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         let delete_result = mutator.delete("Users", &doc_id).await.unwrap();
         assert!(delete_result.existed);
@@ -328,20 +322,18 @@ mod tests {
 
         // Verify it's gone
         let txn = db.new_txn(true).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections);
+        let mutator = DbDocMutator::new(txn);
         let exists = mutator.exists("Users", &doc_id).await.unwrap();
         assert!(!exists);
     }
 
     #[tokio::test]
     async fn test_update_document() {
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         // First create a document
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         let mut doc = Document::new();
         doc.set("name", NormalValue::String("Charlie".to_string()));
@@ -354,7 +346,7 @@ mod tests {
 
         // Now update it
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         let mut updated_doc = Document::with_id(doc_id.clone());
         updated_doc.set("name", NormalValue::String("Charles".to_string()));
@@ -368,7 +360,7 @@ mod tests {
 
         // Verify the update
         let txn = db.new_txn(true).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections);
+        let mutator = DbDocMutator::new(txn);
         let fetched = mutator.get_for_update("Users", &doc_id).await.unwrap();
         assert!(fetched.is_some());
         assert_eq!(
@@ -379,13 +371,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_for_update() {
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         // First create a document
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         let mut doc = Document::new();
         doc.set("name", NormalValue::String("Diana".to_string()));
@@ -397,7 +387,7 @@ mod tests {
 
         // Get for update
         let txn = db.new_txn(true).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections);
+        let mutator = DbDocMutator::new(txn);
 
         let fetched = mutator.get_for_update("Users", &doc_id).await.unwrap();
         assert!(fetched.is_some());
@@ -411,10 +401,10 @@ mod tests {
     async fn test_unknown_collection_returns_error() {
         let store = MemoryStore::new();
         let db = DB::new(store);
-        let collections = test_collections();
+        // Don't create any collections
 
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections);
+        let mutator = DbDocMutator::new(txn);
 
         let doc = Document::new();
         let result = mutator.create("NonExistent", doc).await;
@@ -427,12 +417,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_consumed_transaction_returns_error() {
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections);
+        let mutator = DbDocMutator::new(txn);
 
         // Consume the transaction
         let txn = mutator.take_txn().await.unwrap();
@@ -450,13 +438,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_rollback_reverts_mutations() {
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         // Create a document in a transaction
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         let mut doc = Document::new();
         doc.set("name", NormalValue::String("RollbackTest".to_string()));
@@ -473,7 +459,7 @@ mod tests {
 
         // Verify document does NOT exist after rollback
         let txn = db.new_txn(true).await.unwrap();
-        let read_mutator = DbDocMutator::new(txn, collections);
+        let read_mutator = DbDocMutator::new(txn);
         let exists_after_rollback = read_mutator.exists("Users", &doc_id).await.unwrap();
         assert!(
             !exists_after_rollback,
@@ -483,13 +469,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_mutation_rollback() {
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         // Create first document successfully
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         let mut doc1 = Document::new();
         doc1.set("name", NormalValue::String("Doc1".to_string()));
@@ -510,7 +494,7 @@ mod tests {
 
         // Verify NEITHER document exists after rollback
         let txn = db.new_txn(true).await.unwrap();
-        let read_mutator = DbDocMutator::new(txn, collections);
+        let read_mutator = DbDocMutator::new(txn);
         assert!(
             !read_mutator.exists("Users", &doc1_id).await.unwrap(),
             "Doc1 should not exist after rollback"
@@ -525,12 +509,10 @@ mod tests {
     async fn test_concurrent_mutations_are_serialized() {
         use std::sync::Arc;
 
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = Arc::new(DbDocMutator::new(txn, collections.clone()));
+        let mutator = Arc::new(DbDocMutator::new(txn));
 
         // Spawn multiple concurrent create operations
         let m1 = mutator.clone();
@@ -574,7 +556,7 @@ mod tests {
         txn.commit().await.unwrap();
 
         let txn = db.new_txn(true).await.unwrap();
-        let read_mutator = DbDocMutator::new(txn, collections);
+        let read_mutator = DbDocMutator::new(txn);
         assert!(read_mutator.exists("Users", &doc1_id).await.unwrap());
         assert!(read_mutator.exists("Users", &doc2_id).await.unwrap());
         assert!(read_mutator.exists("Users", &doc3_id).await.unwrap());
@@ -584,13 +566,11 @@ mod tests {
     async fn test_concurrent_read_write_operations() {
         use std::sync::Arc;
 
-        let store = MemoryStore::new();
-        let db = DB::new(store);
-        let collections = test_collections();
+        let db = setup_db_with_collection().await;
 
         // First create a document
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = DbDocMutator::new(txn, collections.clone());
+        let mutator = DbDocMutator::new(txn);
 
         let mut doc = Document::new();
         doc.set("name", NormalValue::String("ReadWriteTest".to_string()));
@@ -602,7 +582,7 @@ mod tests {
 
         // Now test concurrent read and write operations
         let txn = db.new_txn(false).await.unwrap();
-        let mutator = Arc::new(DbDocMutator::new(txn, collections.clone()));
+        let mutator = Arc::new(DbDocMutator::new(txn));
 
         let m1 = mutator.clone();
         let m2 = mutator.clone();

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -4,47 +4,19 @@ use async_trait::async_trait;
 use datastore::NamespaceView;
 use document::{DocID, Document};
 use query::mutator::{CreateResult, DeleteResult, DocMutator, UpdateResult};
-use schema::CollectionVersion;
 use std::sync::Arc;
-use storage::corekv::{Key, Store};
-use storage::keys::systemstore::CollectionNameKey;
+use storage::corekv::Store;
 use tokio::sync::Mutex as TokioMutex;
+use tracing::warn;
 
 use crate::collection::Collection;
+use crate::collection_loader::load_collection_from_systemstore;
 use crate::txn::DbTxn;
-
-/// Load a collection from the systemstore by name.
-///
-/// This is a standalone async function that doesn't hold any locks,
-/// allowing it to be called outside the mutex lock scope.
-async fn load_collection_from_systemstore(
-    systemstore: &NamespaceView,
-    name: &str,
-) -> query::error::Result<Option<Collection>> {
-    let key = CollectionNameKey::new(name);
-
-    match systemstore
-        .get(&key.bytes())
-        .await
-        .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))?
-    {
-        Some(data) => {
-            let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to deserialize schema for collection '{}': {}",
-                    name, e
-                ))
-            })?;
-            Ok(Some(Collection::new(schema)))
-        }
-        None => Ok(None),
-    }
-}
 
 /// Document mutator that uses a database transaction.
 ///
 /// This mutator holds a reference to an active transaction and uses the
-/// transaction's collection cache with lazy loading for snapshot isolation.
+/// transaction's collection cache with lazy loading.
 ///
 /// # Ownership Model
 ///
@@ -64,8 +36,10 @@ async fn load_collection_from_systemstore(
 /// # Collection Access
 ///
 /// Collections are loaded lazily from the SystemStore on first access within
-/// the transaction. This provides snapshot isolation - the transaction sees
-/// collections as they existed when first accessed, not at transaction start.
+/// the transaction. Once loaded, the collection metadata is cached for the
+/// duration of the transaction. Note: This provides transaction-level caching,
+/// not true snapshot isolation - if collections are accessed at different times,
+/// they reflect the store state at the time of first access.
 pub struct DbDocMutator<S: Store> {
     txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
 }
@@ -109,7 +83,6 @@ impl<S: Store> DbDocMutator<S> {
         &self,
         collection_name: &str,
     ) -> query::error::Result<(Collection, NamespaceView)> {
-        // Step 1: Check if collection is in cache
         let (collection_opt, systemstore, datastore) = {
             let txn_guard = self.txn.lock().await;
             let db_txn = txn_guard.as_ref().ok_or_else(|| {
@@ -129,9 +102,8 @@ impl<S: Store> DbDocMutator<S> {
                 ))
             })?;
             (collection_opt, systemstore, datastore)
-        }; // Lock released here
+        };
 
-        // Step 2: If not in cache, load from store
         let collection = if let Some(col) = collection_opt {
             col
         } else {
@@ -139,11 +111,19 @@ impl<S: Store> DbDocMutator<S> {
             let collection = loaded
                 .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
-            // Add to cache
+            // Add to cache - warn if transaction was consumed during load
             {
                 let mut txn_guard = self.txn.lock().await;
-                if let Some(db_txn) = txn_guard.as_mut() {
-                    db_txn.cache_collection(collection_name.to_string(), collection.clone());
+                match txn_guard.as_mut() {
+                    Some(db_txn) => {
+                        db_txn.cache_collection(collection.clone());
+                    }
+                    None => {
+                        warn!(
+                            collection_name = %collection_name,
+                            "Transaction was consumed during collection load - cache not updated"
+                        );
+                    }
                 }
             }
 

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -1,16 +1,13 @@
 //! Document mutator for transaction-scoped mutations.
 
 use async_trait::async_trait;
-use datastore::NamespaceView;
 use document::{DocID, Document};
 use query::mutator::{CreateResult, DeleteResult, DocMutator, UpdateResult};
 use std::sync::Arc;
 use storage::corekv::Store;
 use tokio::sync::Mutex as TokioMutex;
-use tracing::warn;
 
-use crate::collection::Collection;
-use crate::collection_loader::load_collection_from_systemstore;
+use crate::collection_loader::get_collection_with_lazy_load;
 use crate::txn::DbTxn;
 
 /// Document mutator that uses a database transaction.
@@ -77,61 +74,6 @@ impl<S: Store> DbDocMutator<S> {
     pub async fn is_consumed(&self) -> bool {
         self.txn.lock().await.is_none()
     }
-
-    /// Get a collection by name, loading from the transaction's cache with lazy loading.
-    async fn get_collection(
-        &self,
-        collection_name: &str,
-    ) -> query::error::Result<(Collection, NamespaceView)> {
-        let (collection_opt, systemstore, datastore) = {
-            let txn_guard = self.txn.lock().await;
-            let db_txn = txn_guard.as_ref().ok_or_else(|| {
-                query::error::QueryError::execution("transaction already consumed")
-            })?;
-            let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
-            let systemstore = db_txn.systemstore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get systemstore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
-            let datastore = db_txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
-            (collection_opt, systemstore, datastore)
-        };
-
-        let collection = if let Some(col) = collection_opt {
-            col
-        } else {
-            let loaded = load_collection_from_systemstore(&systemstore, collection_name).await?;
-            let collection = loaded
-                .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-
-            // Add to cache - warn if transaction was consumed during load
-            {
-                let mut txn_guard = self.txn.lock().await;
-                match txn_guard.as_mut() {
-                    Some(db_txn) => {
-                        db_txn.cache_collection(collection.clone());
-                    }
-                    None => {
-                        warn!(
-                            collection_name = %collection_name,
-                            "Transaction was consumed during collection load - cache not updated"
-                        );
-                    }
-                }
-            }
-
-            collection
-        };
-
-        Ok((collection, datastore))
-    }
 }
 
 #[async_trait]
@@ -141,7 +83,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         mut doc: Document,
     ) -> query::error::Result<CreateResult> {
-        let (collection, datastore) = self.get_collection(collection_name).await?;
+        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         // Generate document ID if not present
         if doc.id().is_none() {
@@ -167,7 +109,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc: Document,
     ) -> query::error::Result<UpdateResult> {
-        let (collection, datastore) = self.get_collection(collection_name).await?;
+        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .update_with_datastore(&datastore, &doc)
@@ -185,7 +127,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<DeleteResult> {
-        let (collection, datastore) = self.get_collection(collection_name).await?;
+        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         let existed = collection
             .delete_with_datastore(&datastore, doc_id)
@@ -196,7 +138,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
     }
 
     async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {
-        let (collection, datastore) = self.get_collection(collection_name).await?;
+        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .exists_with_datastore(&datastore, doc_id)
@@ -209,7 +151,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<Option<Document>> {
-        let (collection, datastore) = self.get_collection(collection_name).await?;
+        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .get_with_datastore(&datastore, doc_id)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -43,6 +43,7 @@
 /// txn.commit().await?;
 /// ```
 pub mod collection;
+pub mod collection_cache;
 pub mod collection_name;
 pub mod collection_snapshot;
 pub mod database;
@@ -55,6 +56,7 @@ pub mod txn_registry;
 
 // Re-export commonly used types
 pub use collection::Collection;
+pub use collection_cache::CollectionCache;
 pub use collection_name::CollectionName;
 pub use collection_snapshot::CollectionSnapshot;
 pub use database::{DbOptions, DB};

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -44,6 +44,7 @@
 /// ```
 pub mod collection;
 pub mod collection_cache;
+pub(crate) mod collection_loader;
 pub mod collection_name;
 pub mod collection_snapshot;
 pub mod database;

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -2,16 +2,23 @@
 ///
 /// DbTxn wraps a BasicTxn and adds:
 /// - Explicit/implicit transaction handling
+/// - Transaction-scoped collection cache (lazy loading)
 /// - Reference to the database for collection operations
+use crate::collection::Collection;
+use crate::collection_cache::CollectionCache;
 use crate::error::{Error, Result};
 use datastore::{BasicTxn, NamespaceView, RootView, TxnCallback};
+use schema::CollectionVersion;
+use std::collections::HashMap;
 use std::sync::Arc;
-use storage::corekv::Store;
+use storage::corekv::{IterOptions, Key, Store};
+use storage::keys::systemstore::CollectionNameKey;
 
 /// Database transaction wrapper.
 ///
 /// This wraps a BasicTxn and provides:
 /// - Explicit/implicit transaction handling
+/// - Transaction-scoped collection cache with lazy loading
 /// - Access to the underlying store for collection operations
 ///
 /// Explicit transactions are created by the user and must be explicitly
@@ -24,11 +31,16 @@ use storage::corekv::Store;
 /// Transaction liveness is tracked by the `txn` field:
 /// - `Some(txn)` = transaction is active
 /// - `None` = transaction has been committed or discarded
+///
+/// The collection cache is populated lazily from the SystemStore on first
+/// access, matching the Go DefraDB pattern for transaction isolation.
 pub struct DbTxn<S: Store> {
     /// The underlying BasicTxn. `None` after commit/discard.
     txn: Option<BasicTxn>,
     /// Whether this is an explicit transaction.
     explicit: bool,
+    /// Transaction-scoped collection cache (lazy loading from SystemStore).
+    collection_cache: CollectionCache,
     /// Phantom data for the store type.
     _marker: std::marker::PhantomData<S>,
 }
@@ -39,6 +51,7 @@ impl<S: Store> DbTxn<S> {
         Self {
             txn: Some(txn),
             explicit: false,
+            collection_cache: CollectionCache::new(),
             _marker: std::marker::PhantomData,
         }
     }
@@ -48,6 +61,7 @@ impl<S: Store> DbTxn<S> {
         Self {
             txn: Some(txn),
             explicit: true,
+            collection_cache: CollectionCache::new(),
             _marker: std::marker::PhantomData,
         }
     }
@@ -187,6 +201,158 @@ impl<S: Store> DbTxn<S> {
             Err(Error::TxnNotActive)
         }
     }
+
+    // =========================================================================
+    // Collection Cache Methods (Transaction-scoped caching)
+    // =========================================================================
+
+    /// Get a collection by name, loading from SystemStore if not in cache.
+    ///
+    /// This implements lazy loading - collections are loaded on first access.
+    /// Returns `None` if the collection doesn't exist in the store.
+    ///
+    /// Note: This method is structured to avoid holding `&mut self` across awaits,
+    /// which allows futures using this method to be `Send`.
+    pub async fn get_collection(&mut self, name: &str) -> Result<Option<&Collection>> {
+        // Check cache first
+        if self.collection_cache.contains(name) {
+            return Ok(self.collection_cache.get(name));
+        }
+
+        // Cache miss: extract systemstore synchronously, then do async operation
+        let systemstore = self.systemstore()?;
+        let key = CollectionNameKey::new(name);
+
+        // Load from store (no &self held during this await)
+        let maybe_data = systemstore
+            .get(&key.bytes())
+            .await
+            .map_err(Error::Storage)?;
+
+        // Process result and update cache
+        if let Some(data) = maybe_data {
+            let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    collection_name = %name,
+                    "Failed to deserialize schema for collection"
+                );
+                Error::Serialization(format!(
+                    "failed to deserialize schema for collection '{}': {}",
+                    name, e
+                ))
+            })?;
+            self.collection_cache
+                .add(name.to_string(), Collection::new(schema));
+            return Ok(self.collection_cache.get(name));
+        }
+
+        Ok(None)
+    }
+
+    /// Load all collections from SystemStore into the cache.
+    ///
+    /// This is called when listing collections or when we need to iterate
+    /// over all collections. After calling this, `is_fully_populated()` returns true.
+    pub async fn load_all_collections(&mut self) -> Result<()> {
+        if self.collection_cache.is_fully_populated() {
+            return Ok(());
+        }
+
+        let prefix = CollectionNameKey::name_prefix();
+        let mut collections = HashMap::new();
+
+        let systemstore = self.systemstore()?;
+        let opts = IterOptions::new().with_prefix(prefix.clone());
+
+        let mut iter = systemstore.iterator(opts).await.map_err(|e| {
+            tracing::error!(error = ?e, "Failed to create iterator during collection load");
+            Error::Storage(e)
+        })?;
+
+        while let Some(pair) = iter.next().await.map_err(|e| {
+            tracing::error!(error = ?e, "Failed to iterate collections during load");
+            Error::Storage(e)
+        })? {
+            // Validate UTF-8 in key
+            let key_str = String::from_utf8(pair.key.to_vec()).map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    key_bytes = ?&pair.key[..pair.key.len().min(50)],
+                    "Collection key contains invalid UTF-8"
+                );
+                Error::Serialization(format!("collection key contains invalid UTF-8: {}", e))
+            })?;
+
+            let prefix_str = String::from_utf8(prefix.clone()).map_err(|e| {
+                Error::Other(format!("internal error: prefix is not valid UTF-8: {}", e))
+            })?;
+
+            let name = key_str
+                .strip_prefix(&prefix_str)
+                .ok_or_else(|| {
+                    Error::Other(format!(
+                        "collection key '{}' does not match expected prefix '{}'",
+                        key_str, prefix_str
+                    ))
+                })?
+                .to_string();
+
+            let schema: CollectionVersion = serde_json::from_slice(&pair.value).map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    collection_name = %name,
+                    "Failed to deserialize schema for collection"
+                );
+                Error::Serialization(format!(
+                    "failed to deserialize schema for collection '{}': {}",
+                    name, e
+                ))
+            })?;
+
+            collections.insert(name, Collection::new(schema));
+        }
+
+        iter.close().await.map_err(|e| {
+            tracing::error!(error = ?e, "Failed to close iterator during collection load");
+            Error::Storage(e)
+        })?;
+
+        self.collection_cache.populate(collections);
+        Ok(())
+    }
+
+    /// Add a collection to the transaction-scoped cache.
+    ///
+    /// Called by create_collection to update the cache after writing to store.
+    pub fn cache_collection(&mut self, name: String, collection: Collection) {
+        self.collection_cache.add(name, collection);
+    }
+
+    /// Remove a collection from the transaction-scoped cache.
+    ///
+    /// Called by delete_collection to update the cache after writing to store.
+    pub fn uncache_collection(&mut self, name: &str) {
+        self.collection_cache.remove(name);
+    }
+
+    /// Get the collection cache.
+    ///
+    /// Use this for read-only access to iterate over cached collections.
+    pub fn collection_cache(&self) -> &CollectionCache {
+        &self.collection_cache
+    }
+
+    /// Get mutable access to the collection cache.
+    ///
+    /// Use this for advanced cache manipulation (e.g., populate from snapshot).
+    pub fn collection_cache_mut(&mut self) -> &mut CollectionCache {
+        &mut self.collection_cache
+    }
+
+    // =========================================================================
+    // Transaction Lifecycle Methods
+    // =========================================================================
 
     /// Commit the transaction.
     ///

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -9,7 +9,6 @@ use crate::collection_cache::CollectionCache;
 use crate::error::{Error, Result};
 use datastore::{BasicTxn, NamespaceView, RootView, TxnCallback};
 use schema::CollectionVersion;
-use std::collections::HashMap;
 use std::sync::Arc;
 use storage::corekv::{IterOptions, Key, Store};
 use storage::keys::systemstore::CollectionNameKey;
@@ -242,8 +241,7 @@ impl<S: Store> DbTxn<S> {
                     name, e
                 ))
             })?;
-            self.collection_cache
-                .add(name.to_string(), Collection::new(schema));
+            self.collection_cache.add(Collection::new(schema));
             return Ok(self.collection_cache.get(name));
         }
 
@@ -260,7 +258,7 @@ impl<S: Store> DbTxn<S> {
         }
 
         let prefix = CollectionNameKey::name_prefix();
-        let mut collections = HashMap::new();
+        let mut collections = Vec::new();
 
         let systemstore = self.systemstore()?;
         let opts = IterOptions::new().with_prefix(prefix.clone());
@@ -302,7 +300,9 @@ impl<S: Store> DbTxn<S> {
                 tracing::error!(
                     error = ?e,
                     collection_name = %name,
-                    "Failed to deserialize schema for collection"
+                    "Failed to deserialize schema for collection '{}': {}",
+                    name,
+                    e
                 );
                 Error::Serialization(format!(
                     "failed to deserialize schema for collection '{}': {}",
@@ -310,7 +310,7 @@ impl<S: Store> DbTxn<S> {
                 ))
             })?;
 
-            collections.insert(name, Collection::new(schema));
+            collections.push(Collection::new(schema));
         }
 
         iter.close().await.map_err(|e| {
@@ -324,9 +324,9 @@ impl<S: Store> DbTxn<S> {
 
     /// Add a collection to the transaction-scoped cache.
     ///
-    /// Called by create_collection to update the cache after writing to store.
-    pub fn cache_collection(&mut self, name: String, collection: Collection) {
-        self.collection_cache.add(name, collection);
+    /// The key is derived from the collection's name to prevent key-name mismatches.
+    pub fn cache_collection(&mut self, collection: Collection) {
+        self.collection_cache.add(collection);
     }
 
     /// Remove a collection from the transaction-scoped cache.

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -68,10 +68,7 @@ impl<S: Store + 'static> DbTransactionContext<S> {
     /// Should only be called on non-readonly transactions. Attempting to mutate
     /// via the returned mutator on a readonly transaction will fail.
     pub fn doc_mutator(&self) -> Arc<dyn DocMutator> {
-        Arc::new(DbDocMutator::from_shared_txn(
-            self.fetcher.shared_txn(),
-            self.fetcher.collections().clone(),
-        ))
+        Arc::new(DbDocMutator::from_shared_txn(self.fetcher.shared_txn()))
     }
 }
 

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -262,9 +262,8 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .map_err(|e| TransactionError::execution(format!("storage error: {}", e)))?;
 
         // Transaction-scoped collection caching: collections are loaded lazily
-        // from the SystemStore on first access within the transaction. This provides
-        // snapshot isolation - the transaction sees collections as they existed
-        // when first accessed, not at transaction start.
+        // from the SystemStore on first access within the transaction. Once loaded,
+        // the collection metadata is cached for the transaction's duration.
         let fetcher = Arc::new(DbDocFetcher::new(db_txn));
         let ctx = Arc::new(DbTransactionContext::new(txn_id.clone(), readonly, fetcher));
 

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -27,7 +27,6 @@ use storage::corekv::Store;
 use tracing::{error, warn};
 
 use crate::collection::Collection;
-use crate::collection_snapshot::CollectionSnapshot;
 use crate::database::DB;
 use crate::doc_fetcher::DbDocFetcher;
 use crate::error::{Error, Result};
@@ -98,12 +97,18 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         &self.db
     }
 
-    /// Get a snapshot of all collections from the DB.
-    pub fn collections(&self) -> Result<CollectionSnapshot> {
-        self.db.collections_snapshot()
+    /// Get all collection names from the DB.
+    ///
+    /// Uses the process-wide cache. For transaction-scoped access,
+    /// use the transaction's collection cache directly.
+    pub fn collection_names(&self) -> Result<Vec<String>> {
+        self.db.list_collections()
     }
 
     /// Get a collection by name from the DB.
+    ///
+    /// Uses the process-wide cache. For transaction-scoped access,
+    /// use the transaction's collection cache directly.
     pub fn collection(&self, name: &str) -> Result<Option<Collection>> {
         self.db.get_collection(name)
     }
@@ -256,12 +261,11 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .await
             .map_err(|e| TransactionError::execution(format!("storage error: {}", e)))?;
 
-        // Snapshot collections at transaction start for snapshot isolation -
-        // the transaction sees a consistent view of collections throughout its lifetime
-        let collections = self.db.collections_snapshot().map_err(|e| {
-            TransactionError::execution(format!("failed to snapshot collections: {}", e))
-        })?;
-        let fetcher = Arc::new(DbDocFetcher::new(db_txn, collections));
+        // Transaction-scoped collection caching: collections are loaded lazily
+        // from the SystemStore on first access within the transaction. This provides
+        // snapshot isolation - the transaction sees collections as they existed
+        // when first accessed, not at transaction start.
+        let fetcher = Arc::new(DbDocFetcher::new(db_txn));
         let ctx = Arc::new(DbTransactionContext::new(txn_id.clone(), readonly, fetcher));
 
         self.transactions
@@ -1183,9 +1187,9 @@ mod tests {
 
         // New transaction should see the collection
         let txn_id = registry.begin(true).await.unwrap();
-        let collections = registry.collections().unwrap();
+        let collection_names = registry.collection_names().unwrap();
         assert!(
-            collections.contains("NewCollection"),
+            collection_names.contains(&"NewCollection".to_string()),
             "New transaction should see recently created collection"
         );
 

--- a/crates/query/src/plan/mutation/create.rs
+++ b/crates/query/src/plan/mutation/create.rs
@@ -259,7 +259,7 @@ impl CreateNode {
         let mut doc = Doc::new(num_fields);
 
         // Set document ID at index 0
-        doc.set_doc_id(&result.doc_id.to_string());
+        doc.set_doc_id(result.doc_id.to_string());
 
         // Map each field from the created document
         for (field_name, field_value) in result.document.values() {

--- a/crates/query/src/plan/mutation/update.rs
+++ b/crates/query/src/plan/mutation/update.rs
@@ -177,7 +177,7 @@ impl UpdateNode {
 
         // Set document ID at index 0
         if let Some(doc_id) = result.document.id() {
-            doc.set_doc_id(&doc_id.to_string());
+            doc.set_doc_id(doc_id.to_string());
         }
 
         // Map each field from the updated document


### PR DESCRIPTION
## Summary

- Refactors collection caching from process-wide `RwLock<HashMap>` to transaction-scoped caching
- Eliminates race condition window between commit and cache update
- Matches the Go DefraDB pattern for collection caching

## Changes

- **New `CollectionCache` type** (`collection_cache.rs`): Transaction-scoped cache with lazy loading support
- **Updated `DbTxn`**: Added `get_collection()`, `load_all_collections()`, `cache_collection()`, `uncache_collection()` methods
- **Updated `DB`**: Added `_with_txn` variants for collection operations (create, delete, get, list, has)
- **Updated `DbDocFetcher`**: Uses transaction cache with lazy loading instead of `CollectionSnapshot`
- **Updated `DbDocMutator`**: Uses transaction cache instead of `CollectionSnapshot`
- **Updated `DbTransactionRegistry`**: No longer snapshots collections at `begin()`

## Architecture

Before (race condition possible):
```
DB struct
└── collections: RwLock<HashMap>  ← Process-wide, shared
    └── Race window: commit succeeds but cache update can fail
```

After (transaction-scoped):
```
Transaction
└── collection_cache: CollectionCache  ← Per-transaction, isolated
    ├── Lazy loading from SystemStore on cache miss
    └── Discarded with transaction (no race window)
```

## Test plan

- [x] All 141 tests pass
- [x] Clippy passes
- [x] Code formatted

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)