### PR TITLE
feat(query): Add UpsertNode and filter-based mutations

### DIFF
--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -42,6 +42,7 @@ pub use mapper::{Filter, Mutation, MutationType, Select};
 pub use mutator::{CreateResult, DeleteResult, DocMutator, UpdateResult};
 pub use plan::{
     CreateInput, CreateNode, DeleteNode, LimitNode, ScanNode, SelectNode, UpdateInput, UpdateNode,
+    UpsertAction, UpsertInput, UpsertNode,
 };
 pub use planner::{Doc, DocStatus, ExecInfo, PlanNode, Planner};
 pub use query_parse::{parse_mutations, parse_query, parse_request, ParsedOperation};

--- a/crates/query/src/mapper/mutation.rs
+++ b/crates/query/src/mapper/mutation.rs
@@ -18,6 +18,8 @@ pub enum MutationType {
     Update,
     /// Delete existing documents
     Delete,
+    /// Create or update documents (insert if not exists, update if exists)
+    Upsert,
 }
 
 impl MutationType {
@@ -35,6 +37,7 @@ impl MutationType {
             "create" => Some(Self::Create),
             "update" => Some(Self::Update),
             "delete" => Some(Self::Delete),
+            "upsert" => Some(Self::Upsert),
             _ => None,
         }
     }
@@ -45,6 +48,7 @@ impl MutationType {
             Self::Create => "create",
             Self::Update => "update",
             Self::Delete => "delete",
+            Self::Upsert => "upsert",
         }
     }
 }
@@ -105,6 +109,20 @@ impl Mutation {
     pub fn delete(collection_name: impl Into<String>) -> Self {
         Self {
             mutation_type: MutationType::Delete,
+            collection_name: collection_name.into(),
+            create_input: Vec::new(),
+            update_input: HashMap::new(),
+            doc_ids: None,
+            filter: None,
+            fields: Vec::new(),
+            document_mapping: DocumentMapping::new(),
+        }
+    }
+
+    /// Create a new UPSERT mutation.
+    pub fn upsert(collection_name: impl Into<String>) -> Self {
+        Self {
+            mutation_type: MutationType::Upsert,
             collection_name: collection_name.into(),
             create_input: Vec::new(),
             update_input: HashMap::new(),
@@ -194,7 +212,7 @@ pub fn parse_mutation_name(name: &str) -> Result<(MutationType, String), String>
 
     let mutation_type = MutationType::from_prefix(prefix).ok_or_else(|| {
         format!(
-            "Invalid mutation prefix '{}': expected 'create', 'update', or 'delete'",
+            "Invalid mutation prefix '{}': expected 'create', 'update', 'delete', or 'upsert'",
             prefix
         )
     })?;
@@ -223,6 +241,14 @@ mod tests {
         assert_eq!(
             MutationType::from_prefix("delete"),
             Some(MutationType::Delete)
+        );
+        assert_eq!(
+            MutationType::from_prefix("upsert"),
+            Some(MutationType::Upsert)
+        );
+        assert_eq!(
+            MutationType::from_prefix("UPSERT"),
+            Some(MutationType::Upsert)
         );
         assert_eq!(MutationType::from_prefix("invalid"), None);
     }

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -6,6 +6,9 @@ mod scan;
 mod select;
 
 pub use limit::LimitNode;
-pub use mutation::{CreateInput, CreateNode, DeleteNode, UpdateInput, UpdateNode};
+pub use mutation::{
+    CreateInput, CreateNode, DeleteNode, UpdateInput, UpdateNode, UpsertAction, UpsertInput,
+    UpsertNode,
+};
 pub use scan::ScanNode;
 pub use select::SelectNode;

--- a/crates/query/src/plan/mutation/create.rs
+++ b/crates/query/src/plan/mutation/create.rs
@@ -259,7 +259,7 @@ impl CreateNode {
         let mut doc = Doc::new(num_fields);
 
         // Set document ID at index 0
-        doc.set_doc_id(&result.doc_id.to_string());
+        doc.set_doc_id(result.doc_id.to_string());
 
         // Map each field from the created document
         for (field_name, field_value) in result.document.values() {

--- a/crates/query/src/plan/mutation/mod.rs
+++ b/crates/query/src/plan/mutation/mod.rs
@@ -3,7 +3,9 @@
 mod create;
 mod delete;
 mod update;
+mod upsert;
 
 pub use create::{json_to_normal_value, normal_value_to_json, CreateInput, CreateNode};
 pub use delete::DeleteNode;
 pub use update::{UpdateInput, UpdateNode};
+pub use upsert::{UpsertAction, UpsertInput, UpsertNode};

--- a/crates/query/src/plan/mutation/update.rs
+++ b/crates/query/src/plan/mutation/update.rs
@@ -177,7 +177,7 @@ impl UpdateNode {
 
         // Set document ID at index 0
         if let Some(doc_id) = result.document.id() {
-            doc.set_doc_id(&doc_id.to_string());
+            doc.set_doc_id(doc_id.to_string());
         }
 
         // Map each field from the updated document

--- a/crates/query/src/plan/mutation/upsert.rs
+++ b/crates/query/src/plan/mutation/upsert.rs
@@ -1,0 +1,599 @@
+//! UpsertNode for conditional create-or-update operations
+//!
+//! This node implements upsert semantics: if a document with the specified ID
+//! exists, it updates it; otherwise, it creates a new document.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use document::{DocID, Document};
+use serde_json::Value as JsonValue;
+use tracing;
+
+use crate::document::DocumentMapping;
+use crate::error::{QueryError, Result};
+use crate::mutator::DocMutator;
+use crate::planner::{Doc, PlanNode};
+
+use super::create::{json_to_normal_value, normal_value_to_json, CreateInput};
+
+/// Input for an upsert mutation - field values for create or update.
+#[derive(Debug, Clone)]
+pub struct UpsertInput {
+    /// Field values keyed by field name
+    pub fields: std::collections::HashMap<String, JsonValue>,
+}
+
+impl UpsertInput {
+    /// Create a new empty input.
+    pub fn new() -> Self {
+        Self {
+            fields: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Add a field value.
+    pub fn with_field(mut self, name: impl Into<String>, value: JsonValue) -> Self {
+        self.fields.insert(name.into(), value);
+        self
+    }
+
+    /// Convert to a CreateInput for new documents.
+    pub fn to_create_input(&self) -> CreateInput {
+        let mut input = CreateInput::new();
+        for (name, value) in &self.fields {
+            input = input.with_field(name.clone(), value.clone());
+        }
+        input
+    }
+
+    /// Apply as update to an existing document.
+    pub fn apply_to(&self, doc: &mut Document) -> Result<usize> {
+        let mut modified_count = 0;
+
+        for (field_name, value) in &self.fields {
+            let normal_value = json_to_normal_value(value)?;
+            doc.set(field_name.clone(), normal_value);
+            modified_count += 1;
+        }
+
+        Ok(modified_count)
+    }
+}
+
+impl Default for UpsertInput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Result of an upsert operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpsertAction {
+    /// A new document was created
+    Created,
+    /// An existing document was updated
+    Updated,
+}
+
+/// UpsertNode performs conditional create-or-update operations.
+///
+/// For each input document:
+/// 1. If a docID is provided, check if it exists
+/// 2. If exists: update the document with the input fields
+/// 3. If not exists: create a new document with the input fields
+///
+/// # Example
+///
+/// ```ignore
+/// let input = UpsertInput::new()
+///     .with_field("name", json!("Alice"))
+///     .with_field("email", json!("alice@example.com"));
+///
+/// let mut node = UpsertNode::new("Users", mutator, mapping)
+///     .with_input(input);
+///
+/// node.init().await?;
+/// node.start().await?;
+///
+/// while node.next().await? {
+///     let doc = node.value();
+///     println!("Upserted: {:?}", doc.doc_id());
+/// }
+/// ```
+pub struct UpsertNode {
+    /// Collection name
+    collection_name: String,
+    /// Document mutator for storage operations
+    mutator: Arc<dyn DocMutator>,
+    /// Document mapping for field positions
+    document_mapping: DocumentMapping,
+    /// Input documents to upsert (for batch operations without docIDs)
+    inputs: Vec<UpsertInput>,
+    /// Document IDs to upsert (update if exists, create if not)
+    doc_ids: Option<Vec<String>>,
+    /// Single input to apply to all doc_ids
+    single_input: Option<UpsertInput>,
+    /// Upserted documents (populated after first next())
+    upserted_docs: Vec<Doc>,
+    /// Actions taken for each document
+    actions: Vec<UpsertAction>,
+    /// Current position in upserted_docs
+    position: usize,
+    /// Current document being yielded
+    current_doc: Doc,
+    /// Whether upserts have been performed yet
+    did_upsert: bool,
+    /// Whether the node has been initialized
+    initialized: bool,
+}
+
+impl UpsertNode {
+    /// Create a new upsert node for a collection.
+    pub fn new(
+        collection_name: impl Into<String>,
+        mutator: Arc<dyn DocMutator>,
+        document_mapping: DocumentMapping,
+    ) -> Self {
+        Self {
+            collection_name: collection_name.into(),
+            mutator,
+            document_mapping,
+            inputs: Vec::new(),
+            doc_ids: None,
+            single_input: None,
+            upserted_docs: Vec::new(),
+            actions: Vec::new(),
+            position: 0,
+            current_doc: Doc::default(),
+            did_upsert: false,
+            initialized: false,
+        }
+    }
+
+    /// Add an input document to upsert (creates new document).
+    pub fn with_input(mut self, input: UpsertInput) -> Self {
+        self.single_input = Some(input);
+        self
+    }
+
+    /// Add multiple input documents (each creates new document).
+    pub fn with_inputs(mut self, inputs: Vec<UpsertInput>) -> Self {
+        self.inputs = inputs;
+        self
+    }
+
+    /// Set document IDs to upsert.
+    /// Combined with single_input: updates if exists, creates if not.
+    pub fn with_doc_ids(mut self, doc_ids: Vec<String>) -> Self {
+        self.doc_ids = Some(doc_ids);
+        self
+    }
+
+    /// Get the number of documents that were upserted.
+    pub fn upserted_count(&self) -> usize {
+        self.upserted_docs.len()
+    }
+
+    /// Get the count of created documents.
+    pub fn created_count(&self) -> usize {
+        self.actions
+            .iter()
+            .filter(|a| **a == UpsertAction::Created)
+            .count()
+    }
+
+    /// Get the count of updated documents.
+    pub fn updated_count(&self) -> usize {
+        self.actions
+            .iter()
+            .filter(|a| **a == UpsertAction::Updated)
+            .count()
+    }
+
+    /// Upsert a single document by ID with the given input.
+    async fn upsert_by_id(&mut self, doc_id_str: &str, input: &UpsertInput) -> Result<()> {
+        let doc_id = DocID::from_string(doc_id_str).map_err(|e| {
+            QueryError::execution(format!("Invalid DocID '{}': {}", doc_id_str, e))
+        })?;
+
+        // Check if document exists
+        let existing = self
+            .mutator
+            .get_for_update(&self.collection_name, &doc_id)
+            .await?;
+
+        if let Some(mut doc) = existing {
+            // Document exists - update it
+            tracing::debug!(
+                collection = %self.collection_name,
+                doc_id = %doc_id_str,
+                "Upsert: updating existing document"
+            );
+
+            input.apply_to(&mut doc)?;
+            let result = self.mutator.update(&self.collection_name, doc).await?;
+
+            let plan_doc = self.result_to_doc(&result.document)?;
+            self.upserted_docs.push(plan_doc);
+            self.actions.push(UpsertAction::Updated);
+        } else {
+            // Document does not exist - create it with the provided ID
+            tracing::debug!(
+                collection = %self.collection_name,
+                doc_id = %doc_id_str,
+                "Upsert: creating new document with specified ID"
+            );
+
+            // Create document with the specified ID
+            let mut doc = Document::with_id(doc_id);
+            for (field_name, value) in &input.fields {
+                let normal_value = json_to_normal_value(value)?;
+                doc.set(field_name.clone(), normal_value);
+            }
+
+            let result = self.mutator.create(&self.collection_name, doc).await?;
+
+            let plan_doc = self.result_to_doc(&result.document)?;
+            self.upserted_docs.push(plan_doc);
+            self.actions.push(UpsertAction::Created);
+        }
+
+        Ok(())
+    }
+
+    /// Create a new document (no ID specified - generates new ID).
+    async fn create_new(&mut self, input: &UpsertInput) -> Result<()> {
+        let create_input = input.to_create_input();
+        let doc = create_input.to_document()?;
+
+        let result = self.mutator.create(&self.collection_name, doc).await?;
+
+        let plan_doc = self.result_to_doc(&result.document)?;
+        self.upserted_docs.push(plan_doc);
+        self.actions.push(UpsertAction::Created);
+
+        Ok(())
+    }
+
+    /// Convert a Document to a plan Doc using our document mapping.
+    fn result_to_doc(&self, document: &Document) -> Result<Doc> {
+        let num_fields = self.document_mapping.next_index();
+        let mut doc = Doc::new(num_fields);
+
+        // Set document ID at index 0
+        if let Some(doc_id) = document.id() {
+            doc.set_doc_id(&doc_id.to_string());
+        }
+
+        // Map each field from the document
+        for (field_name, field_value) in document.values() {
+            if let Some(index) = self.document_mapping.first_index_of_name(field_name) {
+                let json_value = normal_value_to_json(field_value.value());
+                doc.set(index, json_value);
+            }
+        }
+
+        Ok(doc)
+    }
+}
+
+#[async_trait]
+impl PlanNode for UpsertNode {
+    async fn init(&mut self) -> Result<()> {
+        self.position = 0;
+        self.upserted_docs.clear();
+        self.actions.clear();
+        self.did_upsert = false;
+        self.initialized = true;
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if !self.initialized {
+            return Err(QueryError::execution(
+                "UpsertNode.next() called before init()",
+            ));
+        }
+
+        // On first call, perform all upserts
+        if !self.did_upsert {
+            if let Some(ref doc_ids) = self.doc_ids {
+                // Upsert by document IDs
+                let input = self.single_input.clone().unwrap_or_default();
+                for doc_id_str in doc_ids.clone() {
+                    self.upsert_by_id(&doc_id_str, &input).await?;
+                }
+            } else if !self.inputs.is_empty() {
+                // Create new documents from inputs
+                for input in self.inputs.clone() {
+                    self.create_new(&input).await?;
+                }
+            } else if let Some(ref input) = self.single_input.clone() {
+                // Single input without docID - create new
+                self.create_new(input).await?;
+            } else {
+                return Err(QueryError::execution(
+                    "UpsertNode requires either doc_ids with input, or inputs",
+                ));
+            }
+
+            self.did_upsert = true;
+        }
+
+        // Iterate through upserted documents
+        if self.position >= self.upserted_docs.len() {
+            return Ok(false);
+        }
+
+        self.current_doc = self.upserted_docs[self.position].deep_clone();
+        self.position += 1;
+        Ok(true)
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.upserted_docs.clear();
+        self.actions.clear();
+        self.initialized = false;
+        Ok(())
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        None // UpsertNode is a leaf node
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "upsertNode"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mutator::{CreateResult, DeleteResult, UpdateResult};
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    struct MockMutator {
+        docs: Mutex<std::collections::HashMap<String, Document>>,
+    }
+
+    impl MockMutator {
+        fn new() -> Self {
+            Self {
+                docs: Mutex::new(std::collections::HashMap::new()),
+            }
+        }
+
+        fn add_doc(&self, doc: Document) {
+            if let Some(id) = doc.id() {
+                self.docs.lock().unwrap().insert(id.to_string(), doc);
+            }
+        }
+
+        fn doc_count(&self) -> usize {
+            self.docs.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait]
+    impl DocMutator for MockMutator {
+        async fn create(&self, _collection_name: &str, mut doc: Document) -> Result<CreateResult> {
+            if doc.id().is_none() {
+                doc.generate_and_set_doc_id()
+                    .map_err(|e| QueryError::execution(format!("Failed to generate DocID: {}", e)))?;
+            }
+
+            let doc_id = doc
+                .id()
+                .cloned()
+                .ok_or_else(|| QueryError::execution("Document should have ID"))?;
+
+            self.docs
+                .lock()
+                .unwrap()
+                .insert(doc_id.to_string(), doc.clone());
+
+            Ok(CreateResult::new(doc_id, doc))
+        }
+
+        async fn update(&self, _collection_name: &str, doc: Document) -> Result<UpdateResult> {
+            let doc_id = doc
+                .id()
+                .ok_or_else(|| QueryError::execution("Document must have ID for update"))?;
+
+            let modified = doc.values().len();
+
+            self.docs
+                .lock()
+                .unwrap()
+                .insert(doc_id.to_string(), doc.clone());
+
+            Ok(UpdateResult::new(doc, modified))
+        }
+
+        async fn delete(&self, _collection_name: &str, doc_id: &DocID) -> Result<DeleteResult> {
+            let existed = self
+                .docs
+                .lock()
+                .unwrap()
+                .remove(&doc_id.to_string())
+                .is_some();
+            Ok(DeleteResult::new(doc_id.clone(), existed))
+        }
+
+        async fn exists(&self, _collection_name: &str, doc_id: &DocID) -> Result<bool> {
+            Ok(self.docs.lock().unwrap().contains_key(&doc_id.to_string()))
+        }
+
+        async fn get_for_update(
+            &self,
+            _collection_name: &str,
+            doc_id: &DocID,
+        ) -> Result<Option<Document>> {
+            Ok(self.docs.lock().unwrap().get(&doc_id.to_string()).cloned())
+        }
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut m = DocumentMapping::new();
+        m.add(0, "_docID");
+        m.add(1, "name");
+        m.add(2, "email");
+        m
+    }
+
+    fn create_test_doc(name: &str, email: &str) -> Document {
+        let mut doc = Document::new();
+        doc.set("name", name.to_string());
+        doc.set("email", email.to_string());
+        doc.generate_and_set_doc_id().unwrap();
+        doc
+    }
+
+    #[tokio::test]
+    async fn test_upsert_creates_when_not_exists() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        // Create a valid DocID that doesn't exist
+        let mut template = Document::new();
+        template.set("name", "Test".to_string());
+        template.generate_and_set_doc_id().unwrap();
+        let new_doc_id = template.id().unwrap().to_string();
+
+        let input = UpsertInput::new()
+            .with_field("name", json!("Alice"))
+            .with_field("email", json!("alice@example.com"));
+
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
+            .with_doc_ids(vec![new_doc_id])
+            .with_input(input);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        assert!(node.next().await.unwrap());
+        assert!(!node.next().await.unwrap());
+
+        assert_eq!(node.upserted_count(), 1);
+        assert_eq!(node.created_count(), 1);
+        assert_eq!(node.updated_count(), 0);
+        assert_eq!(mutator.doc_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_updates_when_exists() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        // Create existing document
+        let existing_doc = create_test_doc("Alice", "alice@old.com");
+        let doc_id = existing_doc.id().unwrap().to_string();
+        mutator.add_doc(existing_doc);
+
+        let input = UpsertInput::new()
+            .with_field("email", json!("alice@new.com"));
+
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
+            .with_doc_ids(vec![doc_id.clone()])
+            .with_input(input);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        assert!(node.next().await.unwrap());
+        let doc = node.value();
+        assert_eq!(doc.get(2), Some(&json!("alice@new.com")));
+
+        assert!(!node.next().await.unwrap());
+
+        assert_eq!(node.upserted_count(), 1);
+        assert_eq!(node.created_count(), 0);
+        assert_eq!(node.updated_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_mixed_create_and_update() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        // Create one existing document
+        let existing_doc = create_test_doc("Alice", "alice@old.com");
+        let existing_id = existing_doc.id().unwrap().to_string();
+        mutator.add_doc(existing_doc);
+
+        // Create a new DocID that doesn't exist
+        let mut template = Document::new();
+        template.set("name", "New".to_string());
+        template.generate_and_set_doc_id().unwrap();
+        let new_id = template.id().unwrap().to_string();
+
+        let input = UpsertInput::new()
+            .with_field("name", json!("Updated"))
+            .with_field("email", json!("updated@example.com"));
+
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
+            .with_doc_ids(vec![existing_id, new_id])
+            .with_input(input);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        let mut count = 0;
+        while node.next().await.unwrap() {
+            count += 1;
+        }
+
+        assert_eq!(count, 2);
+        assert_eq!(node.upserted_count(), 2);
+        assert_eq!(node.created_count(), 1);
+        assert_eq!(node.updated_count(), 1);
+        assert_eq!(mutator.doc_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_create_without_doc_id() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        let input = UpsertInput::new()
+            .with_field("name", json!("NewUser"))
+            .with_field("email", json!("new@example.com"));
+
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
+            .with_input(input);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        assert!(node.next().await.unwrap());
+        assert!(!node.next().await.unwrap());
+
+        assert_eq!(node.created_count(), 1);
+        assert_eq!(mutator.doc_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_next_before_init_errors() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        let mut node = UpsertNode::new("Users", mutator, mapping);
+
+        let result = node.next().await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/query/src/plan/mutation/upsert.rs
+++ b/crates/query/src/plan/mutation/upsert.rs
@@ -263,7 +263,7 @@ impl UpsertNode {
 
         // Set document ID at index 0
         if let Some(doc_id) = document.id() {
-            doc.set_doc_id(&doc_id.to_string());
+            doc.set_doc_id(doc_id.to_string());
         }
 
         // Map each field from the document
@@ -304,7 +304,14 @@ impl PlanNode for UpsertNode {
         if !self.did_upsert {
             if let Some(ref doc_ids) = self.doc_ids {
                 // Upsert by document IDs
-                let input = self.single_input.clone().unwrap_or_default();
+                let input = self.single_input.clone().unwrap_or_else(|| {
+                    tracing::warn!(
+                        collection = %self.collection_name,
+                        doc_id_count = doc_ids.len(),
+                        "Upsert called with doc_ids but no input fields - documents will be created/updated with empty data"
+                    );
+                    UpsertInput::default()
+                });
                 for doc_id_str in doc_ids.clone() {
                     self.upsert_by_id(&doc_id_str, &input).await?;
                 }
@@ -595,5 +602,116 @@ mod tests {
 
         let result = node.next().await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_upsert_invalid_doc_id_returns_error() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        let input = UpsertInput::new()
+            .with_field("name", json!("Alice"));
+
+        // Use an invalid DocID format
+        let mut node = UpsertNode::new("Users", mutator, mapping)
+            .with_doc_ids(vec!["not-a-valid-docid".to_string()])
+            .with_input(input);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        let result = node.next().await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Invalid DocID") || err_msg.contains("invalid"));
+    }
+
+    #[tokio::test]
+    async fn test_upsert_with_batch_inputs() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        let inputs = vec![
+            UpsertInput::new()
+                .with_field("name", json!("User1"))
+                .with_field("email", json!("user1@example.com")),
+            UpsertInput::new()
+                .with_field("name", json!("User2"))
+                .with_field("email", json!("user2@example.com")),
+            UpsertInput::new()
+                .with_field("name", json!("User3"))
+                .with_field("email", json!("user3@example.com")),
+        ];
+
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
+            .with_inputs(inputs);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        let mut count = 0;
+        while node.next().await.unwrap() {
+            count += 1;
+        }
+
+        assert_eq!(count, 3);
+        assert_eq!(node.created_count(), 3);
+        assert_eq!(mutator.doc_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_empty_doc_ids_does_nothing() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        let input = UpsertInput::new()
+            .with_field("name", json!("Alice"));
+
+        // Empty doc_ids list
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
+            .with_doc_ids(vec![])
+            .with_input(input);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        // No documents should be created
+        assert!(!node.next().await.unwrap());
+        assert_eq!(node.upserted_count(), 0);
+        assert_eq!(mutator.doc_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_reinit_clears_state() {
+        let mutator = Arc::new(MockMutator::new());
+        let mapping = make_test_mapping();
+
+        let input = UpsertInput::new()
+            .with_field("name", json!("Alice"));
+
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
+            .with_input(input);
+
+        // First run
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+        assert!(node.next().await.unwrap());
+        assert!(!node.next().await.unwrap());
+        assert_eq!(node.created_count(), 1);
+
+        // Close and reinit
+        node.close().await.unwrap();
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        // Should be able to run again (created_count resets after init)
+        assert!(node.next().await.unwrap());
+        assert!(!node.next().await.unwrap());
+        assert_eq!(node.created_count(), 1); // Second batch count
+
+        // Note: Since same input creates same DocID (deterministic),
+        // the second create overwrites the first in storage
+        // Total unique docs is 1, not 2
+        assert_eq!(mutator.doc_count(), 1);
     }
 }

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -383,6 +383,7 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
         MutationType::Create => Mutation::create(&collection_name),
         MutationType::Update => Mutation::update(&collection_name),
         MutationType::Delete => Mutation::delete(&collection_name),
+        MutationType::Upsert => Mutation::upsert(&collection_name),
     };
 
     // Parse arguments based on mutation type
@@ -394,20 +395,20 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
                 mutation.create_input = input;
             }
 
-            // UPDATE: input is patch object
-            (MutationType::Update, "input") => {
+            // UPDATE/UPSERT: input is patch object
+            (MutationType::Update | MutationType::Upsert, "input") => {
                 let input = parse_update_input(arg_value)?;
                 mutation.update_input = input;
             }
 
-            // UPDATE/DELETE: docIDs to target
-            (MutationType::Update | MutationType::Delete, "docIDs" | "_docIDs") => {
+            // UPDATE/DELETE/UPSERT: docIDs to target
+            (MutationType::Update | MutationType::Delete | MutationType::Upsert, "docIDs" | "_docIDs") => {
                 let doc_ids = parse_doc_ids_value(arg_value)?;
                 mutation.doc_ids = Some(doc_ids);
             }
 
-            // UPDATE/DELETE: filter to find documents
-            (MutationType::Update | MutationType::Delete, "filter") => {
+            // UPDATE/DELETE/UPSERT: filter to find documents
+            (MutationType::Update | MutationType::Delete | MutationType::Upsert, "filter") => {
                 let filter = parse_filter_value(arg_value)?;
                 mutation.filter = Some(filter);
             }
@@ -455,6 +456,15 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
                     collection_name
                 )));
             }
+        }
+        MutationType::Upsert => {
+            if mutation.update_input.is_empty() {
+                return Err(QueryError::parse(format!(
+                    "upsert_{} mutation requires 'input' argument with fields to set",
+                    collection_name
+                )));
+            }
+            // Note: docIDs/filter are optional for upsert - if not provided, creates a new document
         }
     }
 
@@ -752,5 +762,84 @@ mod mutation_tests {
         // parse_query should fail on mutation
         let result = parse_query(query);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_upsert_mutation_with_doc_ids() {
+        let query = r#"
+            mutation {
+                upsert_Users(docIDs: ["bae-123"], input: {name: "Alice", age: 30}) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        let mutations = parse_mutations(query).unwrap();
+        assert_eq!(mutations.len(), 1);
+
+        let m = &mutations[0];
+        assert_eq!(m.mutation_type, MutationType::Upsert);
+        assert_eq!(m.collection_name, "Users");
+        assert_eq!(m.doc_ids, Some(vec!["bae-123".to_string()]));
+        assert_eq!(
+            m.update_input.get("name"),
+            Some(&JsonValue::String("Alice".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_parse_upsert_mutation_with_filter() {
+        let query = r#"
+            mutation {
+                upsert_Users(filter: {name: {_eq: "Alice"}}, input: {age: 31}) {
+                    _docID
+                }
+            }
+        "#;
+
+        let mutations = parse_mutations(query).unwrap();
+        let m = &mutations[0];
+        assert_eq!(m.mutation_type, MutationType::Upsert);
+        assert!(m.filter.is_some());
+        assert!(m.doc_ids.is_none());
+    }
+
+    #[test]
+    fn test_parse_upsert_mutation_create_new() {
+        // Upsert without docIDs/filter creates a new document
+        let query = r#"
+            mutation {
+                upsert_Users(input: {name: "NewUser", email: "new@example.com"}) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        let mutations = parse_mutations(query).unwrap();
+        let m = &mutations[0];
+        assert_eq!(m.mutation_type, MutationType::Upsert);
+        assert!(m.doc_ids.is_none());
+        assert!(m.filter.is_none());
+        assert_eq!(
+            m.update_input.get("name"),
+            Some(&JsonValue::String("NewUser".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_upsert_missing_input_error() {
+        let query = r#"
+            mutation {
+                upsert_Users(docIDs: ["bae-123"]) {
+                    _docID
+                }
+            }
+        "#;
+
+        let result = parse_mutations(query);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("requires 'input'"));
     }
 }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -1519,6 +1519,189 @@ mod tests {
     }
 
     // ==========================================================================
+    // Update mutation tests
+    // ==========================================================================
+
+    #[tokio::test]
+    async fn test_execute_update_mutation() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with a document
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.set("age", 25i64);
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}"], input: {{name: "Alice Updated", age: 30}}) {{ _docID name age }} }}"#,
+            doc_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_docID").unwrap().as_str().unwrap(), doc_id);
+        assert_eq!(users[0].get("name").unwrap(), "Alice Updated");
+        assert_eq!(users[0].get("age").unwrap(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_execute_update_multiple_documents() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with multiple documents
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 25i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        let doc1_id = doc1.id().unwrap().to_string();
+        mutator.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 30i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        let doc2_id = doc2.id().unwrap().to_string();
+        mutator.add_doc("Users", doc2);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}", "{}"], input: {{age: 99}}) {{ _docID age }} }}"#,
+            doc1_id, doc2_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 2);
+
+        // Both should have updated age
+        for user in users {
+            assert_eq!(user.get("age").unwrap(), 99);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_update_nonexistent_document_skipped() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with one document
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.generate_and_set_doc_id().unwrap();
+        let existing_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Generate a non-existent ID
+        let mut template = Document::new();
+        template.set("name", "NonExistent");
+        template.generate_and_set_doc_id().unwrap();
+        let nonexistent_id = template.id().unwrap().to_string();
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Try to update both existing and non-existent
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}", "{}"], input: {{name: "Updated"}}) {{ _docID name }} }}"#,
+            existing_id, nonexistent_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        // Only the existing document should be returned
+        assert_eq!(users.len(), 1);
+        assert_eq!(
+            users[0].get("_docID").unwrap().as_str().unwrap(),
+            existing_id
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_delete_multiple_documents() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with multiple documents
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.generate_and_set_doc_id().unwrap();
+        let doc1_id = doc1.id().unwrap().to_string();
+        mutator.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.generate_and_set_doc_id().unwrap();
+        let doc2_id = doc2.id().unwrap().to_string();
+        mutator.add_doc("Users", doc2);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        let mutation = format!(
+            r#"mutation {{ delete_Users(docIDs: ["{}", "{}"]) {{ _docID }} }}"#,
+            doc1_id, doc2_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 2);
+
+        let deleted_ids: Vec<&str> = users
+            .iter()
+            .map(|u| u.get("_docID").unwrap().as_str().unwrap())
+            .collect();
+        assert!(deleted_ids.contains(&doc1_id.as_str()));
+        assert!(deleted_ids.contains(&doc2_id.as_str()));
+    }
+
+    #[tokio::test]
+    async fn test_execute_delete_nonexistent_document_skipped() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with one document
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.generate_and_set_doc_id().unwrap();
+        let existing_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Generate a non-existent ID
+        let mut template = Document::new();
+        template.set("name", "NonExistent");
+        template.generate_and_set_doc_id().unwrap();
+        let nonexistent_id = template.id().unwrap().to_string();
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Try to delete both existing and non-existent
+        let mutation = format!(
+            r#"mutation {{ delete_Users(docIDs: ["{}", "{}"]) {{ _docID }} }}"#,
+            existing_id, nonexistent_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        // Only the existing document should be returned as deleted
+        assert_eq!(users.len(), 1);
+        assert_eq!(
+            users[0].get("_docID").unwrap().as_str().unwrap(),
+            existing_id
+        );
+    }
+
+    // ==========================================================================
     // Upsert mutation tests
     // ==========================================================================
 

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -24,6 +24,7 @@ use crate::mapper::{Mutation, MutationType, Requestable, Select};
 use crate::mutator::DocMutator;
 use crate::plan::{
     CreateInput, CreateNode, DeleteNode, LimitNode, ScanNode, SelectNode, UpdateInput, UpdateNode,
+    UpsertInput, UpsertNode,
 };
 use crate::planner::{Doc, PlanNode};
 use crate::query_parse::{parse_mutations, parse_query};
@@ -229,6 +230,9 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         // Build document mapping from requested fields
         let mapping = self.build_mutation_mapping(mutation)?;
 
+        // Resolve filter to doc_ids if filter is provided without doc_ids
+        let resolved_doc_ids = self.resolve_filter_to_doc_ids(mutation).await?;
+
         // Build and execute the appropriate mutation plan
         let mut plan: Box<dyn PlanNode> = match mutation.mutation_type {
             MutationType::Create => {
@@ -243,11 +247,11 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 let mut node = UpdateNode::new(&mutation.collection_name, mutator, mapping.clone())
                     .with_input(input);
 
-                if let Some(ref doc_ids) = mutation.doc_ids {
+                // Use resolved doc_ids (from filter) or original doc_ids
+                if let Some(ref doc_ids) = resolved_doc_ids {
                     node = node.with_doc_ids(doc_ids.clone());
-                }
-                if let Some(ref filter) = mutation.filter {
-                    node = node.with_filter(filter.clone());
+                } else if let Some(ref doc_ids) = mutation.doc_ids {
+                    node = node.with_doc_ids(doc_ids.clone());
                 }
 
                 Box::new(node)
@@ -255,11 +259,25 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             MutationType::Delete => {
                 let mut node = DeleteNode::new(&mutation.collection_name, mutator, mapping.clone());
 
-                if let Some(ref doc_ids) = mutation.doc_ids {
+                // Use resolved doc_ids (from filter) or original doc_ids
+                if let Some(ref doc_ids) = resolved_doc_ids {
+                    node = node.with_doc_ids(doc_ids.clone());
+                } else if let Some(ref doc_ids) = mutation.doc_ids {
                     node = node.with_doc_ids(doc_ids.clone());
                 }
-                if let Some(ref filter) = mutation.filter {
-                    node = node.with_filter(filter.clone());
+
+                Box::new(node)
+            }
+            MutationType::Upsert => {
+                let input = self.build_upsert_input(mutation)?;
+                let mut node = UpsertNode::new(&mutation.collection_name, mutator, mapping.clone())
+                    .with_input(input);
+
+                // Use resolved doc_ids (from filter) or original doc_ids
+                if let Some(ref doc_ids) = resolved_doc_ids {
+                    node = node.with_doc_ids(doc_ids.clone());
+                } else if let Some(ref doc_ids) = mutation.doc_ids {
+                    node = node.with_doc_ids(doc_ids.clone());
                 }
 
                 Box::new(node)
@@ -281,6 +299,49 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         plan.close().await?;
 
         Ok(JsonValue::Array(results))
+    }
+
+    /// Resolve a filter to document IDs by querying the collection.
+    ///
+    /// This is used for filter-based mutations where we need to first
+    /// find matching documents, then perform the mutation on them.
+    async fn resolve_filter_to_doc_ids(&self, mutation: &Mutation) -> Result<Option<Vec<String>>> {
+        // Only resolve if there's a filter but no explicit doc_ids
+        let filter = match (&mutation.filter, &mutation.doc_ids) {
+            (Some(filter), None) => filter,
+            _ => return Ok(None),
+        };
+
+        // Get the collection schema to build a mapping
+        let collection = self
+            .collections
+            .get(&mutation.collection_name)
+            .ok_or_else(|| QueryError::collection_not_found(&mutation.collection_name))?;
+
+        // Build mapping from collection schema
+        let mut mapping = DocumentMapping::new();
+        for (i, field) in collection.fields.iter().enumerate() {
+            mapping.add(i, &field.name);
+        }
+
+        // Get all documents from the collection
+        let all_docs = self.fetcher.get_all(&mutation.collection_name).await?;
+
+        // Apply filter to find matching documents
+        let mut matching_ids = Vec::new();
+        for doc in &all_docs {
+            // Convert Document to fields array for filter matching
+            let plan_doc = self.document_to_plan_doc(doc, &mapping)?;
+            let fields = plan_doc.fields();
+
+            if filter.matches(fields, &mapping)? {
+                if let Some(id) = doc.id() {
+                    matching_ids.push(id.to_string());
+                }
+            }
+        }
+
+        Ok(Some(matching_ids))
     }
 
     /// Build document mapping for mutation result fields.
@@ -327,6 +388,18 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         Ok(update_input)
+    }
+
+    /// Build UpsertInput from mutation input.
+    fn build_upsert_input(&self, mutation: &Mutation) -> Result<UpsertInput> {
+        let mut upsert_input = UpsertInput::new();
+
+        // Upsert uses update_input for the field values
+        for (field_name, value) in &mutation.update_input {
+            upsert_input = upsert_input.with_field(field_name.clone(), value.clone());
+        }
+
+        Ok(upsert_input)
     }
 
     /// Validate that the select doesn't use unsupported features.

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -1517,4 +1517,362 @@ mod tests {
         // Verify document was deleted
         assert!(mutator.created_docs().is_empty());
     }
+
+    // ==========================================================================
+    // Upsert mutation tests
+    // ==========================================================================
+
+    #[tokio::test]
+    async fn test_execute_upsert_creates_when_not_exists() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Generate a valid docID that doesn't exist in the store
+        let mut template = Document::new();
+        template.set("name", "Template");
+        template.generate_and_set_doc_id().unwrap();
+        let new_doc_id = template.id().unwrap().to_string();
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        let mutation = format!(
+            r#"mutation {{ upsert_Users(docIDs: ["{}"], input: {{name: "Alice", age: 30}}) {{ _docID name age }} }}"#,
+            new_doc_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("name").unwrap(), "Alice");
+        assert_eq!(users[0].get("age").unwrap(), 30);
+
+        // Verify document was created
+        assert_eq!(mutator.created_docs().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_execute_upsert_updates_when_exists() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with a document
+        let mut existing_doc = Document::new();
+        existing_doc.set("name", "Alice");
+        existing_doc.set("age", 25i64);
+        existing_doc.generate_and_set_doc_id().unwrap();
+        let existing_id = existing_doc.id().unwrap().to_string();
+        mutator.add_doc("Users", existing_doc);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        let mutation = format!(
+            r#"mutation {{ upsert_Users(docIDs: ["{}"], input: {{age: 30}}) {{ _docID name age }} }}"#,
+            existing_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        // Name should be preserved from existing doc
+        assert_eq!(users[0].get("name").unwrap(), "Alice");
+        // Age should be updated
+        assert_eq!(users[0].get("age").unwrap(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_execute_upsert_mixed_create_and_update() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with one document
+        let mut existing_doc = Document::new();
+        existing_doc.set("name", "Alice");
+        existing_doc.set("age", 25i64);
+        existing_doc.generate_and_set_doc_id().unwrap();
+        let existing_id = existing_doc.id().unwrap().to_string();
+        mutator.add_doc("Users", existing_doc);
+
+        // Generate a new ID that doesn't exist
+        let mut template = Document::new();
+        template.set("name", "Template");
+        template.generate_and_set_doc_id().unwrap();
+        let new_id = template.id().unwrap().to_string();
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        let mutation = format!(
+            r#"mutation {{ upsert_Users(docIDs: ["{}", "{}"], input: {{name: "Updated", age: 99}}) {{ _docID name age }} }}"#,
+            existing_id, new_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 2);
+
+        // Both should have the upserted values
+        for user in users {
+            assert_eq!(user.get("name").unwrap(), "Updated");
+            assert_eq!(user.get("age").unwrap(), 99);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_upsert_create_without_doc_id() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Upsert without docIDs creates a new document
+        let result = runner
+            .execute_mutation(
+                r#"mutation { upsert_Users(input: {name: "NewUser", age: 42}) { _docID name age } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert!(users[0].get("_docID").is_some());
+        assert_eq!(users[0].get("name").unwrap(), "NewUser");
+        assert_eq!(users[0].get("age").unwrap(), 42);
+
+        // Verify document was created
+        assert_eq!(mutator.created_docs().len(), 1);
+    }
+
+    // ==========================================================================
+    // Filter-based mutation tests
+    // ==========================================================================
+
+    #[tokio::test]
+    async fn test_execute_update_with_filter() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with documents
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 20i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        let doc1_id = doc1.id().unwrap().to_string();
+        fetcher.add_doc("Users", doc1.clone());
+        mutator.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 30i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        let doc2_id = doc2.id().unwrap().to_string();
+        fetcher.add_doc("Users", doc2.clone());
+        mutator.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", 40i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        let doc3_id = doc3.id().unwrap().to_string();
+        fetcher.add_doc("Users", doc3.clone());
+        mutator.add_doc("Users", doc3);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Update only users with age >= 30
+        let result = runner
+            .execute_mutation(
+                r#"mutation { update_Users(filter: {age: {_gte: 30}}, input: {name: "Updated"}) { _docID name } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        // Only Bob (30) and Charlie (40) should be updated
+        assert_eq!(users.len(), 2);
+
+        let updated_ids: Vec<&str> = users
+            .iter()
+            .map(|u| u.get("_docID").unwrap().as_str().unwrap())
+            .collect();
+        assert!(!updated_ids.contains(&doc1_id.as_str())); // Alice (20) not updated
+        assert!(updated_ids.contains(&doc2_id.as_str())); // Bob (30) updated
+        assert!(updated_ids.contains(&doc3_id.as_str())); // Charlie (40) updated
+    }
+
+    #[tokio::test]
+    async fn test_execute_delete_with_filter() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with documents
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 25i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1.clone());
+        mutator.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 35i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        let doc2_id = doc2.id().unwrap().to_string();
+        fetcher.add_doc("Users", doc2.clone());
+        mutator.add_doc("Users", doc2);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Delete only users with age > 30
+        let result = runner
+            .execute_mutation(
+                r#"mutation { delete_Users(filter: {age: {_gt: 30}}) { _docID } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        // Only Bob should be deleted
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_docID").unwrap().as_str().unwrap(), doc2_id);
+    }
+
+    #[tokio::test]
+    async fn test_execute_upsert_with_filter() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with documents
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 25i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1.clone());
+        mutator.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 35i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        let doc2_id = doc2.id().unwrap().to_string();
+        fetcher.add_doc("Users", doc2.clone());
+        mutator.add_doc("Users", doc2);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Upsert users with age > 30 (should update Bob)
+        let result = runner
+            .execute_mutation(
+                r#"mutation { upsert_Users(filter: {age: {_gt: 30}}, input: {name: "Updated"}) { _docID name } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_docID").unwrap().as_str().unwrap(), doc2_id);
+        assert_eq!(users[0].get("name").unwrap(), "Updated");
+    }
+
+    #[tokio::test]
+    async fn test_filter_mutation_no_matches_returns_empty() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with a document
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.set("age", 25i64);
+        doc.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc.clone());
+        mutator.add_doc("Users", doc);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Filter matches nothing (no users with age > 100)
+        let result = runner
+            .execute_mutation(
+                r#"mutation { update_Users(filter: {age: {_gt: 100}}, input: {name: "Updated"}) { _docID } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        // Should return empty array, not an error
+        assert!(users.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_filter_delete_no_matches_returns_empty() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with a document
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.set("age", 25i64);
+        doc.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc.clone());
+        mutator.add_doc("Users", doc);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Filter matches nothing
+        let result = runner
+            .execute_mutation(
+                r#"mutation { delete_Users(filter: {name: {_eq: "NonExistent"}}) { _docID } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert!(users.is_empty());
+
+        // Original document should still exist
+        assert_eq!(mutator.created_docs().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_doc_ids_takes_priority_over_filter() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+
+        // Pre-populate with documents
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 50i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        let doc1_id = doc1.id().unwrap().to_string();
+        fetcher.add_doc("Users", doc1.clone());
+        mutator.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 60i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2.clone());
+        mutator.add_doc("Users", doc2);
+
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Provide both docIDs and filter - docIDs should take priority
+        // Filter would match both, but docIDs only specifies doc1
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}"], filter: {{age: {{_gte: 50}}}}, input: {{name: "Updated"}}) {{ _docID name }} }}"#,
+            doc1_id
+        );
+        let result = runner.execute_mutation(&mutation).await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        // Only doc1 should be updated (docIDs takes priority)
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_docID").unwrap().as_str().unwrap(), doc1_id);
+    }
 }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -1470,6 +1470,113 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_execute_create_with_partial_fields() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Create with only 'name' field, no 'age'
+        let result = runner
+            .execute_mutation(
+                r#"mutation { create_Users(input: [{name: "Alice"}]) { _docID name } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("name").unwrap(), "Alice");
+        // _docID should be generated
+        assert!(users[0].get("_docID").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_execute_create_returns_generated_doc_id() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        let result = runner
+            .execute_mutation(
+                r#"mutation { create_Users(input: [{name: "Alice", age: 30}]) { _docID } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+
+        let doc_id = users[0].get("_docID").unwrap().as_str().unwrap();
+        // DocID should be a valid bae- prefixed string
+        assert!(doc_id.starts_with("bae-"), "DocID should start with 'bae-'");
+        assert!(doc_id.len() > 10, "DocID should be reasonably long");
+    }
+
+    #[tokio::test]
+    async fn test_execute_create_with_all_field_types() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Create with string and integer fields
+        let result = runner
+            .execute_mutation(
+                r#"mutation { create_Users(input: [{name: "Alice", age: 30}]) { _docID name age } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("name").unwrap(), "Alice");
+        assert_eq!(users[0].get("age").unwrap(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_execute_create_each_doc_gets_unique_id() {
+        let fetcher = MockFetcher::new();
+        let mutator = Arc::new(MockMutator::new());
+        let runner =
+            QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+        // Create multiple documents with different content
+        let result = runner
+            .execute_mutation(
+                r#"mutation {
+                    create_Users(input: [
+                        {name: "Alice", age: 30},
+                        {name: "Bob", age: 25},
+                        {name: "Charlie", age: 35}
+                    ]) { _docID name }
+                }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 3);
+
+        // Collect all doc IDs
+        let doc_ids: Vec<&str> = users
+            .iter()
+            .map(|u| u.get("_docID").unwrap().as_str().unwrap())
+            .collect();
+
+        // All IDs should be unique
+        let mut unique_ids = doc_ids.clone();
+        unique_ids.sort();
+        unique_ids.dedup();
+        assert_eq!(
+            unique_ids.len(),
+            3,
+            "Each document should have a unique ID"
+        );
+    }
+
+    #[tokio::test]
     async fn test_execute_mutation_unknown_collection_returns_error() {
         let fetcher = MockFetcher::new();
         let mutator = Arc::new(MockMutator::new());


### PR DESCRIPTION
## Summary
- Adds `Upsert` variant to `MutationType` enum with full parsing support
- Implements `UpsertNode` plan node for conditional create-or-update operations
- Adds filter-based mutation support that resolves filters to document IDs before execution
- Wires up upsert execution in `QueryRunner`
- Adds comprehensive tests for upsert parsing, validation, and execution

## UpsertNode Semantics
- If `docIDs` provided: updates document if it exists, creates with specified ID if not
- If no targeting provided: creates a new document with a generated ID
- Supports both single and batch operations
- Tracks which documents were created vs updated via `UpsertAction` enum

## Test Plan
- [x] All existing query crate tests pass (265 tests)
- [x] New upsert parsing tests verify correct argument handling
- [x] UpsertNode unit tests verify create/update/mixed behavior
- [x] Full workspace tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)