### PR TITLE
feat(http): Wire up GraphQL mutations and add transaction endpoints

### DIFF
--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -1036,4 +1036,588 @@ mod http_integration_tests {
         shutdown_tx.send(()).await.unwrap();
         let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
     }
+
+    // =========================================================================
+    // Integration tests for Issue #67: GraphQL Mutations
+    // =========================================================================
+
+    /// Test creating a document via GraphQL mutation through HTTP
+    #[tokio::test]
+    async fn test_http_graphql_create_mutation() {
+        use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let data_path = temp_dir.path();
+
+        // Phase 1: Pre-seed database with collection (no documents)
+        {
+            let store = storage::RocksDBStore::open(data_path).unwrap();
+            let database = db::DB::new(store);
+
+            let schema = CollectionVersion::new(
+                "Users",
+                "v1",
+                "col-users",
+                vec![
+                    FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                    FieldDescription::new("2", "name", FieldKind::string()),
+                    FieldDescription::new("3", "age", FieldKind::int()),
+                ],
+            );
+            database.create_collection(schema).await.unwrap();
+            database.close().await.unwrap();
+        }
+
+        // Phase 2: Start server and create document via mutation
+        let config = test_config_rocksdb(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move { node.run().await });
+        wait_for_server(&api_url, 20).await;
+
+        let client = reqwest::Client::new();
+
+        // Create a document via mutation
+        let create_mutation = r#"{
+            "query": "mutation { create_Users(input: {name: \"Charlie\", age: 35}) { _docID name age } }"
+        }"#;
+
+        let response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(create_mutation)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .expect("Failed to execute create mutation");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+
+        // Verify mutation succeeded
+        // Note: Response uses collection name "Users" as key, not "create_Users"
+        let data = body.get("data").expect("Response should have data field");
+        let created_array = data
+            .get("Users")
+            .and_then(|u| u.as_array())
+            .expect("Data should have Users array");
+        assert_eq!(created_array.len(), 1, "Should have created 1 document");
+        let created = &created_array[0];
+        assert_eq!(created.get("name").and_then(|n| n.as_str()), Some("Charlie"));
+        assert_eq!(created.get("age").and_then(|n| n.as_i64()), Some(35));
+        let doc_id = created
+            .get("_docID")
+            .and_then(|d| d.as_str())
+            .expect("Should return _docID");
+        assert!(doc_id.starts_with("bae-"), "DocID should start with bae-");
+
+        // Verify document persisted by querying it back
+        let query_response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"query": "{ Users { name age } }"}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to query users");
+
+        let query_body: serde_json::Value = query_response.json().await.unwrap();
+        let users = query_body["data"]["Users"]
+            .as_array()
+            .expect("Should have Users array");
+        assert_eq!(users.len(), 1, "Should have exactly 1 user");
+        assert_eq!(users[0]["name"].as_str(), Some("Charlie"));
+
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
+
+    /// Test updating a document via GraphQL mutation through HTTP
+    #[tokio::test]
+    async fn test_http_graphql_update_mutation() {
+        use document::NormalValue;
+        use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let data_path = temp_dir.path();
+
+        // Phase 1: Pre-seed database with a document
+        let doc_id: String;
+        {
+            let store = storage::RocksDBStore::open(data_path).unwrap();
+            let database = db::DB::new(store);
+
+            let schema = CollectionVersion::new(
+                "Users",
+                "v1",
+                "col-users",
+                vec![
+                    FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                    FieldDescription::new("2", "name", FieldKind::string()),
+                    FieldDescription::new("3", "age", FieldKind::int()),
+                ],
+            );
+            database.create_collection(schema).await.unwrap();
+
+            let collection = database.get_collection("Users").unwrap().unwrap();
+            let txn = database.new_txn(false).await.unwrap();
+
+            let mut doc = document::Document::new();
+            doc.set("name", NormalValue::String("Diana".to_string()));
+            doc.set("age", NormalValue::Int(28));
+            doc.generate_and_set_doc_id().unwrap();
+            doc_id = doc.id().unwrap().to_string();
+            collection.create(&txn, &doc).await.unwrap();
+
+            txn.commit().await.unwrap();
+            database.close().await.unwrap();
+        }
+
+        // Phase 2: Start server and update the document
+        let config = test_config_rocksdb(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move { node.run().await });
+        wait_for_server(&api_url, 20).await;
+
+        let client = reqwest::Client::new();
+
+        // Update the document
+        let update_mutation = format!(
+            r#"{{"query": "mutation {{ update_Users(docIDs: [\"{}\"], input: {{age: 29}}) {{ _docID name age }} }}"}}"#,
+            doc_id
+        );
+
+        let response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(update_mutation)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .expect("Failed to execute update mutation");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+
+        // Debug: print full response
+        println!("Update mutation response: {}", serde_json::to_string_pretty(&body).unwrap());
+
+        // Verify mutation succeeded
+        // Note: Response uses collection name "Users" as key, not "update_Users"
+        let data = body.get("data").expect("Response should have data field");
+        let updated = data
+            .get("Users")
+            .and_then(|u| u.as_array())
+            .expect("Users should be an array");
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0]["age"].as_i64(), Some(29));
+        assert_eq!(updated[0]["name"].as_str(), Some("Diana"));
+
+        // Verify persistence
+        let query_response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"query": "{ Users { name age } }"}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        let query_body: serde_json::Value = query_response.json().await.unwrap();
+        let users = query_body["data"]["Users"].as_array().unwrap();
+        assert_eq!(users[0]["age"].as_i64(), Some(29));
+
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
+
+    /// Test deleting a document via GraphQL mutation through HTTP
+    #[tokio::test]
+    async fn test_http_graphql_delete_mutation() {
+        use document::NormalValue;
+        use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let data_path = temp_dir.path();
+
+        // Phase 1: Pre-seed database with two documents
+        let doc_id_to_delete: String;
+        {
+            let store = storage::RocksDBStore::open(data_path).unwrap();
+            let database = db::DB::new(store);
+
+            let schema = CollectionVersion::new(
+                "Users",
+                "v1",
+                "col-users",
+                vec![
+                    FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                    FieldDescription::new("2", "name", FieldKind::string()),
+                    FieldDescription::new("3", "age", FieldKind::int()),
+                ],
+            );
+            database.create_collection(schema).await.unwrap();
+
+            let collection = database.get_collection("Users").unwrap().unwrap();
+            let txn = database.new_txn(false).await.unwrap();
+
+            let mut doc1 = document::Document::new();
+            doc1.set("name", NormalValue::String("Eve".to_string()));
+            doc1.set("age", NormalValue::Int(22));
+            doc1.generate_and_set_doc_id().unwrap();
+            doc_id_to_delete = doc1.id().unwrap().to_string();
+            collection.create(&txn, &doc1).await.unwrap();
+
+            let mut doc2 = document::Document::new();
+            doc2.set("name", NormalValue::String("Frank".to_string()));
+            doc2.set("age", NormalValue::Int(40));
+            doc2.generate_and_set_doc_id().unwrap();
+            collection.create(&txn, &doc2).await.unwrap();
+
+            txn.commit().await.unwrap();
+            database.close().await.unwrap();
+        }
+
+        // Phase 2: Start server and delete one document
+        let config = test_config_rocksdb(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move { node.run().await });
+        wait_for_server(&api_url, 20).await;
+
+        let client = reqwest::Client::new();
+
+        // Delete the first document
+        let delete_mutation = format!(
+            r#"{{"query": "mutation {{ delete_Users(docIDs: [\"{}\"]) {{ _docID }} }}"}}"#,
+            doc_id_to_delete
+        );
+
+        let response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(delete_mutation)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .expect("Failed to execute delete mutation");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        // Verify only one document remains
+        let query_response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"query": "{ Users { name } }"}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        let query_body: serde_json::Value = query_response.json().await.unwrap();
+        let users = query_body["data"]["Users"].as_array().unwrap();
+        assert_eq!(users.len(), 1, "Should have only 1 user after deletion");
+        assert_eq!(users[0]["name"].as_str(), Some("Frank"));
+
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
+
+    // =========================================================================
+    // Integration tests for Issue #68: Transaction HTTP Endpoints
+    // =========================================================================
+
+    /// Test transaction begin endpoint
+    #[tokio::test]
+    async fn test_http_transaction_begin() {
+        use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let data_path = temp_dir.path();
+
+        // Pre-seed database with collection
+        {
+            let store = storage::RocksDBStore::open(data_path).unwrap();
+            let database = db::DB::new(store);
+            let schema = CollectionVersion::new(
+                "Users",
+                "v1",
+                "col-users",
+                vec![
+                    FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                    FieldDescription::new("2", "name", FieldKind::string()),
+                ],
+            );
+            database.create_collection(schema).await.unwrap();
+            database.close().await.unwrap();
+        }
+
+        let config = test_config_rocksdb(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move { node.run().await });
+        wait_for_server(&api_url, 20).await;
+
+        let client = reqwest::Client::new();
+
+        // Begin a transaction
+        let response = client
+            .post(format!("{}/api/v0/tx/begin", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"readonly": false}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .expect("Failed to begin transaction");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+        let txn_id = body
+            .get("txn_id")
+            .and_then(|t| t.as_str())
+            .expect("Should return txn_id");
+        assert!(!txn_id.is_empty(), "Transaction ID should not be empty");
+
+        // Begin a read-only transaction
+        let response = client
+            .post(format!("{}/api/v0/tx/begin", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"readonly": true}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+        let readonly_txn_id = body.get("txn_id").and_then(|t| t.as_str()).unwrap();
+        assert_ne!(txn_id, readonly_txn_id, "Should get different transaction IDs");
+
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
+
+    /// Test full transaction lifecycle: begin, query, commit
+    #[tokio::test]
+    async fn test_http_transaction_commit_flow() {
+        use document::NormalValue;
+        use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let data_path = temp_dir.path();
+
+        // Pre-seed database with collection and document
+        {
+            let store = storage::RocksDBStore::open(data_path).unwrap();
+            let database = db::DB::new(store);
+            let schema = CollectionVersion::new(
+                "Users",
+                "v1",
+                "col-users",
+                vec![
+                    FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                    FieldDescription::new("2", "name", FieldKind::string()),
+                    FieldDescription::new("3", "age", FieldKind::int()),
+                ],
+            );
+            database.create_collection(schema).await.unwrap();
+
+            let collection = database.get_collection("Users").unwrap().unwrap();
+            let txn = database.new_txn(false).await.unwrap();
+            let mut doc = document::Document::new();
+            doc.set("name", NormalValue::String("Grace".to_string()));
+            doc.set("age", NormalValue::Int(33));
+            doc.generate_and_set_doc_id().unwrap();
+            collection.create(&txn, &doc).await.unwrap();
+            txn.commit().await.unwrap();
+            database.close().await.unwrap();
+        }
+
+        let config = test_config_rocksdb(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move { node.run().await });
+        wait_for_server(&api_url, 20).await;
+
+        let client = reqwest::Client::new();
+
+        // Step 1: Begin a transaction
+        let begin_response = client
+            .post(format!("{}/api/v0/tx/begin", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"readonly": true}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        let begin_body: serde_json::Value = begin_response.json().await.unwrap();
+        let txn_id = begin_body["txn_id"].as_str().unwrap();
+
+        // Step 2: Query within the transaction
+        let query_body = format!(
+            r#"{{"query": "{{ Users {{ name age }} }}", "txn_id": "{}"}}"#,
+            txn_id
+        );
+        let query_response = client
+            .post(format!("{}/api/v0/graphql", api_url))
+            .header("content-type", "application/json")
+            .body(query_body)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(query_response.status(), reqwest::StatusCode::OK);
+        let query_result: serde_json::Value = query_response.json().await.unwrap();
+        let users = query_result["data"]["Users"].as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0]["name"].as_str(), Some("Grace"));
+
+        // Step 3: Commit the transaction
+        let commit_body = format!(r#"{{"txn_id": "{}"}}"#, txn_id);
+        let commit_response = client
+            .post(format!("{}/api/v0/tx/commit", api_url))
+            .header("content-type", "application/json")
+            .body(commit_body)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(commit_response.status(), reqwest::StatusCode::OK);
+        let commit_body: serde_json::Value = commit_response.json().await.unwrap();
+        assert_eq!(commit_body["status"].as_str(), Some("committed"));
+
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
+
+    /// Test transaction rollback
+    #[tokio::test]
+    async fn test_http_transaction_rollback() {
+        use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+        let data_path = temp_dir.path();
+
+        // Pre-seed database with collection
+        {
+            let store = storage::RocksDBStore::open(data_path).unwrap();
+            let database = db::DB::new(store);
+            let schema = CollectionVersion::new(
+                "Users",
+                "v1",
+                "col-users",
+                vec![
+                    FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                    FieldDescription::new("2", "name", FieldKind::string()),
+                ],
+            );
+            database.create_collection(schema).await.unwrap();
+            database.close().await.unwrap();
+        }
+
+        let config = test_config_rocksdb(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move { node.run().await });
+        wait_for_server(&api_url, 20).await;
+
+        let client = reqwest::Client::new();
+
+        // Begin a transaction
+        let begin_response = client
+            .post(format!("{}/api/v0/tx/begin", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"readonly": false}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        let begin_body: serde_json::Value = begin_response.json().await.unwrap();
+        let txn_id = begin_body["txn_id"].as_str().unwrap();
+
+        // Rollback the transaction
+        let rollback_body = format!(r#"{{"txn_id": "{}"}}"#, txn_id);
+        let rollback_response = client
+            .post(format!("{}/api/v0/tx/rollback", api_url))
+            .header("content-type", "application/json")
+            .body(rollback_body)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(rollback_response.status(), reqwest::StatusCode::OK);
+        let rollback_result: serde_json::Value = rollback_response.json().await.unwrap();
+        assert_eq!(rollback_result["status"].as_str(), Some("rolled_back"));
+
+        // Verify the transaction is no longer valid (double rollback should fail)
+        let double_rollback = client
+            .post(format!("{}/api/v0/tx/rollback", api_url))
+            .header("content-type", "application/json")
+            .body(format!(r#"{{"txn_id": "{}"}}"#, txn_id))
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(double_rollback.status(), reqwest::StatusCode::BAD_REQUEST);
+
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
+
+    /// Test invalid transaction ID returns error
+    #[tokio::test]
+    async fn test_http_transaction_invalid_id() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let port = portpicker::pick_unused_port().expect("No free ports");
+
+        let config = test_config(port, temp_dir.path());
+        let api_url = format!("http://127.0.0.1:{}", port);
+        let node = Node::new(config).await.unwrap();
+        let shutdown_tx = node.shutdown_tx.clone();
+
+        let node_handle = tokio::spawn(async move { node.run().await });
+        wait_for_server(&api_url, 20).await;
+
+        let client = reqwest::Client::new();
+
+        // Try to commit a non-existent transaction
+        let response = client
+            .post(format!("{}/api/v0/tx/commit", api_url))
+            .header("content-type", "application/json")
+            .body(r#"{"txn_id": "nonexistent-txn-id"}"#)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+
+        shutdown_tx.send(()).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), node_handle).await;
+    }
 }

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -21,7 +21,6 @@ use tracing::{error, info, warn};
 use crate::config::{Config, DatastoreType};
 use crate::error::{Error, Result};
 
-
 const DEV_MODE_BANNER: &str = r#"
 ******************************************
 **     DEVELOPMENT MODE IS ENABLED      **
@@ -376,13 +375,14 @@ impl Node {
 
         // Create HTTP server with database-backed query runner
         let http_server = {
-            let api_address: SocketAddr = config
-                .api
-                .address
-                .parse()
-                .map_err(|e: std::net::AddrParseError| {
-                    Error::InvalidApiAddress(config.api.address.clone(), e.to_string())
-                })?;
+            let api_address: SocketAddr =
+                config
+                    .api
+                    .address
+                    .parse()
+                    .map_err(|e: std::net::AddrParseError| {
+                        Error::InvalidApiAddress(config.api.address.clone(), e.to_string())
+                    })?;
 
             let server_config = defra_http::ServerConfig {
                 address: api_address,
@@ -391,6 +391,9 @@ impl Node {
 
             // Create auto-committing fetcher for non-transactional queries
             let fetcher = db::AutoCommitFetcher::new(database.clone());
+
+            // Create auto-committing mutator for non-transactional mutations
+            let mutator = std::sync::Arc::new(db::AutoCommitMutator::new(database.clone()));
 
             // Create transaction registry for explicit transaction support
             let registry = db::DbTransactionRegistry::new(database.clone());
@@ -409,8 +412,9 @@ impl Node {
                 })
                 .collect();
 
-            // Create query runner with transaction support
-            let executor = query::QueryRunner::with_registry(fetcher, collections, registry);
+            // Create query runner with transaction and mutation support
+            let executor = query::QueryRunner::with_registry(fetcher, collections, registry)
+                .with_mutator(mutator);
             let server = defra_http::Server::with_config(executor, server_config);
 
             info!("HTTP server configured on {}", api_address);
@@ -694,9 +698,7 @@ mod http_integration_tests {
         let shutdown_tx = node.shutdown_tx.clone();
 
         // Spawn node in background
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         // Wait for server to be ready
         wait_for_server(&api_url, 20).await;
@@ -733,9 +735,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 
@@ -750,8 +750,14 @@ mod http_integration_tests {
 
         assert_eq!(response.status(), reqwest::StatusCode::OK);
         let body: serde_json::Value = response.json().await.unwrap();
-        assert!(body.get("version").is_some(), "Response should contain version");
-        assert!(body.get("commit").is_some(), "Response should contain commit");
+        assert!(
+            body.get("version").is_some(),
+            "Response should contain version"
+        );
+        assert!(
+            body.get("commit").is_some(),
+            "Response should contain commit"
+        );
 
         // Shutdown
         shutdown_tx.send(()).await.unwrap();
@@ -768,9 +774,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 
@@ -809,9 +813,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 
@@ -878,9 +880,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 
@@ -998,9 +998,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 

--- a/crates/db/src/auto_commit_fetcher.rs
+++ b/crates/db/src/auto_commit_fetcher.rs
@@ -41,11 +41,9 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
         // Create a read-only transaction
-        let txn = self
-            .db
-            .new_txn(true)
-            .await
-            .map_err(|e| query::error::QueryError::execution(format!("failed to create txn: {}", e)))?;
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
 
         // Get the datastore
         let datastore = txn.datastore().map_err(|e| {
@@ -86,11 +84,9 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
         // Create a read-only transaction
-        let txn = self
-            .db
-            .new_txn(true)
-            .await
-            .map_err(|e| query::error::QueryError::execution(format!("failed to create txn: {}", e)))?;
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
 
         // Get the datastore
         let datastore = txn.datastore().map_err(|e| {

--- a/crates/db/src/auto_commit_mutator.rs
+++ b/crates/db/src/auto_commit_mutator.rs
@@ -1,0 +1,503 @@
+//! Auto-committing document mutator for non-transactional mutations.
+//!
+//! This mutator wraps a database and automatically creates and commits
+//! a write transaction for each mutation operation. This enables mutations
+//! without explicit transaction management while still providing proper
+//! transactional semantics per operation.
+
+use async_trait::async_trait;
+use document::{DocID, Document};
+use query::mutator::{CreateResult, DeleteResult, DocMutator, UpdateResult};
+use std::sync::Arc;
+use storage::corekv::Store;
+use tracing::warn;
+
+use crate::database::DB;
+
+/// Document mutator that auto-commits transactions for each operation.
+///
+/// This is useful for mutations that don't need explicit transaction control.
+/// Each operation creates a new write transaction, performs the mutation,
+/// and commits (or discards on error).
+///
+/// # Transaction Semantics
+///
+/// Each mutation is atomic: it either succeeds entirely or fails without
+/// partial changes. However, multiple mutations are NOT atomic with respect
+/// to each other - if you need multiple operations to be atomic, use
+/// `DbDocMutator` with explicit transaction management instead.
+pub struct AutoCommitMutator<S: Store> {
+    db: Arc<DB<S>>,
+}
+
+impl<S: Store> AutoCommitMutator<S> {
+    /// Create a new auto-committing mutator wrapping the given database.
+    pub fn new(db: Arc<DB<S>>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
+    async fn create(
+        &self,
+        collection_name: &str,
+        mut doc: Document,
+    ) -> query::error::Result<CreateResult> {
+        // Get collection from DB cache
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Create a write transaction
+        let txn = self.db.new_txn(false).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        // Generate document ID if not present
+        if doc.id().is_none() {
+            doc.generate_and_set_doc_id().map_err(|e| {
+                query::error::QueryError::execution(format!("failed to generate DocID: {}", e))
+            })?;
+        }
+
+        let doc_id = doc.id().cloned().ok_or_else(|| {
+            query::error::QueryError::execution("document should have ID after generation")
+        })?;
+
+        // Execute the mutation in a block to drop datastore before commit
+        let result = {
+            let datastore = txn.datastore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get datastore for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
+
+            collection
+                .create_with_datastore(&datastore, &doc)
+                .await
+                .map_err(|e| query::error::QueryError::execution(format!("create error: {}", e)))
+        };
+
+        match result {
+            Ok(_returned_doc_id) => {
+                // Commit the transaction (datastore reference is now dropped)
+                if let Err(e) = txn.commit().await {
+                    warn!(
+                        collection = %collection_name,
+                        error = %e,
+                        "Failed to commit transaction after create"
+                    );
+                    return Err(query::error::QueryError::execution(format!(
+                        "commit error: {}",
+                        e
+                    )));
+                }
+                Ok(CreateResult::new(doc_id, doc))
+            }
+            Err(e) => {
+                // Discard the transaction on error
+                if let Err(discard_err) = txn.discard() {
+                    warn!(
+                        collection = %collection_name,
+                        error = %discard_err,
+                        "Failed to discard transaction after create error"
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn update(
+        &self,
+        collection_name: &str,
+        doc: Document,
+    ) -> query::error::Result<UpdateResult> {
+        // Get collection from DB cache
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Create a write transaction
+        let txn = self.db.new_txn(false).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        // Execute the mutation in a block to drop datastore before commit
+        let result = {
+            let datastore = txn.datastore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get datastore for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
+
+            collection
+                .update_with_datastore(&datastore, &doc)
+                .await
+                .map_err(|e| query::error::QueryError::execution(format!("update error: {}", e)))
+        };
+
+        match result {
+            Ok(()) => {
+                // Commit the transaction (datastore reference is now dropped)
+                if let Err(e) = txn.commit().await {
+                    warn!(
+                        collection = %collection_name,
+                        error = %e,
+                        "Failed to commit transaction after update"
+                    );
+                    return Err(query::error::QueryError::execution(format!(
+                        "commit error: {}",
+                        e
+                    )));
+                }
+
+                // Count modified fields
+                let fields_modified = doc.values().len();
+                Ok(UpdateResult::new(doc, fields_modified))
+            }
+            Err(e) => {
+                // Discard the transaction on error
+                if let Err(discard_err) = txn.discard() {
+                    warn!(
+                        collection = %collection_name,
+                        error = %discard_err,
+                        "Failed to discard transaction after update error"
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn delete(
+        &self,
+        collection_name: &str,
+        doc_id: &DocID,
+    ) -> query::error::Result<DeleteResult> {
+        // Get collection from DB cache
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Create a write transaction
+        let txn = self.db.new_txn(false).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        // Execute the mutation in a block to drop datastore before commit
+        let result = {
+            let datastore = txn.datastore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get datastore for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
+
+            collection
+                .delete_with_datastore(&datastore, doc_id)
+                .await
+                .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))
+        };
+
+        match result {
+            Ok(existed) => {
+                // Commit the transaction (datastore reference is now dropped)
+                if let Err(e) = txn.commit().await {
+                    warn!(
+                        collection = %collection_name,
+                        error = %e,
+                        "Failed to commit transaction after delete"
+                    );
+                    return Err(query::error::QueryError::execution(format!(
+                        "commit error: {}",
+                        e
+                    )));
+                }
+                Ok(DeleteResult::new(doc_id.clone(), existed))
+            }
+            Err(e) => {
+                // Discard the transaction on error
+                if let Err(discard_err) = txn.discard() {
+                    warn!(
+                        collection = %collection_name,
+                        error = %discard_err,
+                        "Failed to discard transaction after delete error"
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {
+        // Get collection from DB cache
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Create a read-only transaction (exists is read-only)
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        // Get the datastore
+        let datastore = txn.datastore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get datastore for collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+
+        // Execute the check
+        let result = collection
+            .exists_with_datastore(&datastore, doc_id)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("exists error: {}", e)));
+
+        // Discard the read-only transaction
+        if let Err(e) = txn.discard() {
+            warn!(
+                collection = %collection_name,
+                error = %e,
+                "Failed to discard read-only transaction after exists"
+            );
+        }
+
+        result
+    }
+
+    async fn get_for_update(
+        &self,
+        collection_name: &str,
+        doc_id: &DocID,
+    ) -> query::error::Result<Option<Document>> {
+        // Get collection from DB cache
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Create a read-only transaction (get_for_update is read-only)
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        // Get the datastore
+        let datastore = txn.datastore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get datastore for collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+
+        // Execute the fetch
+        let result = collection
+            .get_with_datastore(&datastore, doc_id)
+            .await
+            .map_err(|e| {
+                query::error::QueryError::execution(format!("get_for_update error: {}", e))
+            });
+
+        // Discard the read-only transaction
+        if let Err(e) = txn.discard() {
+            warn!(
+                collection = %collection_name,
+                error = %e,
+                "Failed to discard read-only transaction after get_for_update"
+            );
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use document::NormalValue;
+    use query::mutator::DocMutator;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use storage::backends::MemoryStore;
+
+    fn test_schema() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "col-users",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn test_create_document() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        let mutator = AutoCommitMutator::new(db.clone());
+
+        // Create a document
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Alice".to_string()));
+        doc.set("age", NormalValue::Int(30));
+
+        let result = mutator.create("Users", doc).await.unwrap();
+        assert!(!result.doc_id.to_string().is_empty());
+        assert_eq!(
+            result.document.get("name").and_then(|v| v.as_str()),
+            Some("Alice")
+        );
+
+        // Verify document persisted
+        let exists = mutator.exists("Users", &result.doc_id).await.unwrap();
+        assert!(exists);
+    }
+
+    #[tokio::test]
+    async fn test_update_document() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        let mutator = AutoCommitMutator::new(db);
+
+        // First create a document
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Bob".to_string()));
+        doc.set("age", NormalValue::Int(25));
+        let result = mutator.create("Users", doc).await.unwrap();
+        let doc_id = result.doc_id.clone();
+
+        // Update the document
+        let mut updated_doc = Document::with_id(doc_id.clone());
+        updated_doc.set("name", NormalValue::String("Robert".to_string()));
+        updated_doc.set("age", NormalValue::Int(26));
+
+        let update_result = mutator.update("Users", updated_doc).await.unwrap();
+        assert!(update_result.fields_modified > 0);
+
+        // Verify update
+        let fetched = mutator.get_for_update("Users", &doc_id).await.unwrap();
+        assert_eq!(
+            fetched.unwrap().get("name").and_then(|v| v.as_str()),
+            Some("Robert")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_document() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        let mutator = AutoCommitMutator::new(db);
+
+        // First create a document
+        let mut doc = Document::new();
+        doc.set("name", NormalValue::String("Charlie".to_string()));
+        let result = mutator.create("Users", doc).await.unwrap();
+        let doc_id = result.doc_id.clone();
+
+        // Verify it exists
+        assert!(mutator.exists("Users", &doc_id).await.unwrap());
+
+        // Delete it
+        let delete_result = mutator.delete("Users", &doc_id).await.unwrap();
+        assert!(delete_result.existed);
+
+        // Verify it's gone
+        assert!(!mutator.exists("Users", &doc_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent_document() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        let mutator = AutoCommitMutator::new(db);
+
+        // Try to delete a document that doesn't exist
+        let nonexistent_id =
+            DocID::from_string("bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc").unwrap();
+        let delete_result = mutator.delete("Users", &nonexistent_id).await.unwrap();
+        assert!(!delete_result.existed);
+    }
+
+    #[tokio::test]
+    async fn test_get_for_update_nonexistent() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        let mutator = AutoCommitMutator::new(db);
+
+        let nonexistent_id =
+            DocID::from_string("bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc").unwrap();
+        let result = mutator
+            .get_for_update("Users", &nonexistent_id)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_unknown_collection_returns_error() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+
+        let mutator = AutoCommitMutator::new(db);
+        let doc = Document::new();
+        let result = mutator.create("NonExistent", doc).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("collection not found"));
+    }
+
+    #[tokio::test]
+    async fn test_each_mutation_is_independent() {
+        let store = MemoryStore::new();
+        let db = Arc::new(DB::new(store));
+        db.create_collection(test_schema()).await.unwrap();
+
+        let mutator = AutoCommitMutator::new(db);
+
+        // Create first document
+        let mut doc1 = Document::new();
+        doc1.set("name", NormalValue::String("Doc1".to_string()));
+        let result1 = mutator.create("Users", doc1).await.unwrap();
+
+        // Create second document
+        let mut doc2 = Document::new();
+        doc2.set("name", NormalValue::String("Doc2".to_string()));
+        let result2 = mutator.create("Users", doc2).await.unwrap();
+
+        // Both should exist independently
+        assert!(mutator.exists("Users", &result1.doc_id).await.unwrap());
+        assert!(mutator.exists("Users", &result2.doc_id).await.unwrap());
+
+        // Deleting one doesn't affect the other
+        mutator.delete("Users", &result1.doc_id).await.unwrap();
+        assert!(!mutator.exists("Users", &result1.doc_id).await.unwrap());
+        assert!(mutator.exists("Users", &result2.doc_id).await.unwrap());
+    }
+}

--- a/crates/db/src/collection.rs
+++ b/crates/db/src/collection.rs
@@ -84,8 +84,10 @@ impl Collection {
 
         match data {
             Some(bytes) => {
-                let doc =
+                let mut doc =
                     Document::from_cbor(&bytes).map_err(|e| Error::Serialization(e.to_string()))?;
+                // Set the document ID (stored as part of the key, not in the serialized document)
+                doc.set_id(doc_id.clone());
                 Ok(Some(doc))
             }
             None => Ok(None),
@@ -189,13 +191,22 @@ impl Collection {
             .map_err(Error::Storage)?;
 
         while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
-            let doc = Document::from_cbor(&pair.value).map_err(|e| {
+            let mut doc = Document::from_cbor(&pair.value).map_err(|e| {
                 Error::Serialization(format!(
                     "failed to deserialize document at key {:?}: {}",
                     String::from_utf8_lossy(&pair.key),
                     e
                 ))
             })?;
+
+            // Extract doc_id from key (format: /d/<collection_id>/<doc_id>)
+            // Find the last '/' and extract the doc_id string after it
+            if let Some(pos) = pair.key.iter().rposition(|&b| b == b'/') {
+                let doc_id_str = String::from_utf8_lossy(&pair.key[pos + 1..]);
+                if let Ok(doc_id) = doc_id_str.parse::<DocID>() {
+                    doc.set_id(doc_id);
+                }
+            }
 
             // Callback returns true to continue, false to stop
             if !callback(doc).await? {
@@ -238,8 +249,10 @@ impl Collection {
 
         match data {
             Some(bytes) => {
-                let doc =
+                let mut doc =
                     Document::from_cbor(&bytes).map_err(|e| Error::Serialization(e.to_string()))?;
+                // Set the document ID (stored as part of the key, not in the serialized document)
+                doc.set_id(doc_id.clone());
                 Ok(Some(doc))
             }
             None => Ok(None),
@@ -258,13 +271,23 @@ impl Collection {
 
         let mut docs = Vec::new();
         while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
-            let doc = Document::from_cbor(&pair.value).map_err(|e| {
+            let mut doc = Document::from_cbor(&pair.value).map_err(|e| {
                 Error::Serialization(format!(
                     "failed to deserialize document at key {:?}: {}",
                     String::from_utf8_lossy(&pair.key),
                     e
                 ))
             })?;
+
+            // Extract doc_id from key (format: /d/<collection_id>/<doc_id>)
+            // Find the last '/' and extract the doc_id string after it
+            if let Some(pos) = pair.key.iter().rposition(|&b| b == b'/') {
+                let doc_id_str = String::from_utf8_lossy(&pair.key[pos + 1..]);
+                if let Ok(doc_id) = doc_id_str.parse::<DocID>() {
+                    doc.set_id(doc_id);
+                }
+            }
+
             docs.push(doc);
         }
 

--- a/crates/db/src/collection_loader.rs
+++ b/crates/db/src/collection_loader.rs
@@ -67,9 +67,9 @@ pub(crate) async fn get_collection_with_lazy_load<S: Store + 'static>(
     // Extract what we need from the transaction while holding the lock briefly
     let (collection_opt, systemstore, datastore) = {
         let txn_guard = txn.lock().await;
-        let db_txn = txn_guard.as_ref().ok_or_else(|| {
-            query::error::QueryError::execution("transaction already consumed")
-        })?;
+        let db_txn = txn_guard
+            .as_ref()
+            .ok_or_else(|| query::error::QueryError::execution("transaction already consumed"))?;
         let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
         let systemstore = db_txn.systemstore().map_err(|e| {
             query::error::QueryError::execution(format!(

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -75,7 +75,8 @@ impl<S: Store> DbDocFetcher<S> {
 #[async_trait]
 impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
     async fn get_all(&self, collection_name: &str) -> query::error::Result<Vec<Document>> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .get_all_with_datastore(&datastore)
@@ -88,7 +89,8 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         collection_name: &str,
         doc_ids: &[String],
     ) -> query::error::Result<FetchByIdsResult> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         let mut docs = Vec::new();
         let mut missing_ids = Vec::new();

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -83,7 +83,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         mut doc: Document,
     ) -> query::error::Result<CreateResult> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         // Generate document ID if not present
         if doc.id().is_none() {
@@ -109,7 +110,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc: Document,
     ) -> query::error::Result<UpdateResult> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .update_with_datastore(&datastore, &doc)
@@ -127,7 +129,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<DeleteResult> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         let existed = collection
             .delete_with_datastore(&datastore, doc_id)
@@ -138,7 +141,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
     }
 
     async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .exists_with_datastore(&datastore, doc_id)
@@ -151,7 +155,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<Option<Document>> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .get_with_datastore(&datastore, doc_id)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -43,6 +43,7 @@
 /// txn.commit().await?;
 /// ```
 pub mod auto_commit_fetcher;
+pub mod auto_commit_mutator;
 pub mod collection;
 pub mod collection_cache;
 pub(crate) mod collection_loader;
@@ -59,6 +60,7 @@ pub mod txn_registry;
 
 // Re-export commonly used types
 pub use auto_commit_fetcher::AutoCommitFetcher;
+pub use auto_commit_mutator::AutoCommitMutator;
 pub use collection::Collection;
 pub use collection_cache::CollectionCache;
 pub use collection_name::CollectionName;
@@ -67,10 +69,10 @@ pub use database::{DbOptions, DB};
 pub use doc_fetcher::DbDocFetcher;
 pub use doc_mutator::DbDocMutator;
 pub use error::{Error, Result};
+pub use schema_loader::load_active_collections;
 pub use txn::DbTxn;
 pub use txn_context::DbTransactionContext;
 pub use txn_registry::{CleanupResult, DbTransactionRegistry};
-pub use schema_loader::load_active_collections;
 
 // Re-export related crate types for convenience
 pub use datastore::{BasicTxn, NamespaceView};

--- a/crates/db/src/schema_loader.rs
+++ b/crates/db/src/schema_loader.rs
@@ -43,8 +43,10 @@ pub async fn load_active_collections<S: Store>(db: &DB<S>) -> Result<Vec<Collect
                 let collection_id = match String::from_utf8(kv.value) {
                     Ok(id) => id,
                     Err(e) => {
-                        load_error =
-                            Some(Error::Other(format!("Invalid collection ID encoding: {}", e)));
+                        load_error = Some(Error::Other(format!(
+                            "Invalid collection ID encoding: {}",
+                            e
+                        )));
                         break;
                     }
                 };
@@ -109,9 +111,9 @@ mod tests {
     use super::*;
     use crate::DB;
     use datastore::BasicTxn;
+    use std::sync::Arc;
     use storage::backends::MemoryStore;
     use storage::corekv::Key;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_load_empty_database() {
@@ -119,7 +121,10 @@ mod tests {
         let db = DB::new(store);
 
         let collections = load_active_collections(&db).await.unwrap();
-        assert!(collections.is_empty(), "New database should have no collections");
+        assert!(
+            collections.is_empty(),
+            "New database should have no collections"
+        );
     }
 
     #[tokio::test]

--- a/crates/http/src/handlers.rs
+++ b/crates/http/src/handlers.rs
@@ -127,6 +127,211 @@ fn categorize_schema_error(e: &query::error::QueryError) -> String {
     }
 }
 
+// ============================================================================
+// Transaction Endpoints
+// ============================================================================
+
+/// Request body for beginning a transaction.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct TxBeginRequest {
+    /// If true, the transaction is read-only.
+    #[serde(default)]
+    pub readonly: bool,
+}
+
+/// Response from beginning a transaction.
+#[derive(Debug, Clone, Serialize)]
+pub struct TxBeginResponse {
+    /// The transaction ID.
+    pub txn_id: String,
+}
+
+/// Request body for commit/rollback operations.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TxRequest {
+    /// The transaction ID.
+    pub txn_id: String,
+}
+
+/// Response for successful transaction operations.
+#[derive(Debug, Clone, Serialize)]
+pub struct TxSuccessResponse {
+    /// Status message.
+    pub status: String,
+}
+
+/// Begin a new transaction.
+///
+/// POST /api/v0/tx/begin
+pub async fn tx_begin(
+    State(state): State<AppState>,
+    Json(request): Json<TxBeginRequest>,
+) -> impl IntoResponse {
+    match state.executor.begin_txn(request.readonly).await {
+        Ok(handle) => {
+            tracing::info!(txn_id = %handle, readonly = request.readonly, "Transaction started");
+            (
+                StatusCode::OK,
+                Json(TxBeginResponse {
+                    txn_id: handle.to_string(),
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to begin transaction");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(crate::error::ErrorResponse {
+                    error: format!("Failed to begin transaction: {}", e),
+                }),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Commit a transaction.
+///
+/// POST /api/v0/tx/commit
+pub async fn tx_commit(
+    State(state): State<AppState>,
+    Json(request): Json<TxRequest>,
+) -> impl IntoResponse {
+    let handle = match request.txn_id.parse() {
+        Ok(h) => h,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(crate::error::ErrorResponse {
+                    error: format!("Invalid transaction ID: {}", request.txn_id),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    match state.executor.commit_txn(&handle).await {
+        Ok(()) => {
+            tracing::info!(txn_id = %handle, "Transaction committed");
+            (
+                StatusCode::OK,
+                Json(TxSuccessResponse {
+                    status: "committed".to_string(),
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(txn_id = %handle, error = %e, "Failed to commit transaction");
+            (
+                StatusCode::BAD_REQUEST,
+                Json(crate::error::ErrorResponse {
+                    error: format!("Failed to commit transaction: {}", e),
+                }),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Rollback a transaction.
+///
+/// POST /api/v0/tx/rollback
+pub async fn tx_rollback(
+    State(state): State<AppState>,
+    Json(request): Json<TxRequest>,
+) -> impl IntoResponse {
+    let handle = match request.txn_id.parse() {
+        Ok(h) => h,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(crate::error::ErrorResponse {
+                    error: format!("Invalid transaction ID: {}", request.txn_id),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    match state.executor.rollback_txn(&handle).await {
+        Ok(()) => {
+            tracing::info!(txn_id = %handle, "Transaction rolled back");
+            (
+                StatusCode::OK,
+                Json(TxSuccessResponse {
+                    status: "rolled_back".to_string(),
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(txn_id = %handle, error = %e, "Failed to rollback transaction");
+            (
+                StatusCode::BAD_REQUEST,
+                Json(crate::error::ErrorResponse {
+                    error: format!("Failed to rollback transaction: {}", e),
+                }),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Extended GraphQL request with optional transaction ID.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TransactionalQueryRequest {
+    /// The GraphQL query string.
+    pub query: String,
+
+    /// Optional operation name.
+    #[serde(rename = "operationName")]
+    pub operation_name: Option<String>,
+
+    /// Optional variables.
+    pub variables: Option<JsonValue>,
+
+    /// Optional transaction ID for executing within a transaction.
+    pub txn_id: Option<String>,
+}
+
+/// GraphQL POST request handler with optional transaction support.
+///
+/// If txn_id is provided, executes within the specified transaction.
+/// Otherwise, executes with auto-commit semantics.
+pub async fn graphql_transactional(
+    State(state): State<AppState>,
+    Json(request): Json<TransactionalQueryRequest>,
+) -> Json<QueryResponse> {
+    let query_request = QueryRequest {
+        query: request.query,
+        operation_name: request.operation_name,
+        variables: request.variables,
+    };
+
+    let response = match request.txn_id {
+        Some(txn_id_str) => {
+            let handle = match txn_id_str.parse() {
+                Ok(h) => h,
+                Err(_) => {
+                    return Json(QueryResponse::error(format!(
+                        "Invalid transaction ID: {}",
+                        txn_id_str
+                    )));
+                }
+            };
+            state.executor.execute_in_txn(query_request, &handle).await
+        }
+        None => state.executor.execute(query_request).await,
+    };
+
+    if response.has_errors() {
+        tracing::warn!(errors = ?response.errors, "GraphQL query returned errors");
+    }
+    Json(response)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,5 +435,141 @@ mod tests {
         let response = schema(State(state)).await;
         let response = response.into_response();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    // ==========================================================================
+    // Transaction endpoint tests
+    // ==========================================================================
+
+    #[tokio::test]
+    async fn test_tx_begin() {
+        let state = AppState {
+            executor: Arc::new(MockQueryExecutor::new()),
+        };
+        let request = TxBeginRequest { readonly: false };
+
+        let response = tx_begin(State(state), Json(request)).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_tx_begin_readonly() {
+        let state = AppState {
+            executor: Arc::new(MockQueryExecutor::new()),
+        };
+        let request = TxBeginRequest { readonly: true };
+
+        let response = tx_begin(State(state), Json(request)).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_tx_begin_failure() {
+        let state = AppState {
+            executor: Arc::new(FailingMockExecutor::with_schema_error("unused")),
+        };
+        let request = TxBeginRequest { readonly: false };
+
+        let response = tx_begin(State(state), Json(request)).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn test_tx_commit() {
+        let state = AppState {
+            executor: Arc::new(MockQueryExecutor::new()),
+        };
+        let request = TxRequest {
+            txn_id: "mock-txn-001".to_string(),
+        };
+
+        let response = tx_commit(State(state), Json(request)).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_tx_rollback() {
+        let state = AppState {
+            executor: Arc::new(MockQueryExecutor::new()),
+        };
+        let request = TxRequest {
+            txn_id: "mock-txn-001".to_string(),
+        };
+
+        let response = tx_rollback(State(state), Json(request)).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_tx_commit_invalid_id() {
+        let state = AppState {
+            executor: Arc::new(MockQueryExecutor::new()),
+        };
+        // Empty string is invalid
+        let request = TxRequest {
+            txn_id: "".to_string(),
+        };
+
+        let response = tx_commit(State(state), Json(request)).await;
+        let response = response.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_graphql_transactional_without_txn() {
+        let state = AppState {
+            executor: Arc::new(MockQueryExecutor::new()),
+        };
+        let request = TransactionalQueryRequest {
+            query: "{ users { name } }".to_string(),
+            operation_name: None,
+            variables: None,
+            txn_id: None,
+        };
+
+        let response = graphql_transactional(State(state), Json(request)).await;
+        assert!(response.data.is_some());
+        assert!(!response.has_errors());
+    }
+
+    #[tokio::test]
+    async fn test_graphql_transactional_with_txn() {
+        let state = AppState {
+            executor: Arc::new(MockQueryExecutor::new()),
+        };
+        let request = TransactionalQueryRequest {
+            query: "{ users { name } }".to_string(),
+            operation_name: None,
+            variables: None,
+            txn_id: Some("mock-txn-001".to_string()),
+        };
+
+        let response = graphql_transactional(State(state), Json(request)).await;
+        assert!(response.data.is_some());
+        assert!(!response.has_errors());
+    }
+
+    #[tokio::test]
+    async fn test_graphql_transactional_invalid_txn_id() {
+        let state = AppState {
+            executor: Arc::new(MockQueryExecutor::new()),
+        };
+        let request = TransactionalQueryRequest {
+            query: "{ users { name } }".to_string(),
+            operation_name: None,
+            variables: None,
+            txn_id: Some("".to_string()), // Empty string is invalid
+        };
+
+        let response = graphql_transactional(State(state), Json(request)).await;
+        assert!(response.has_errors());
+        assert!(response.errors[0]
+            .message
+            .contains("Invalid transaction ID"));
     }
 }

--- a/crates/http/src/router.rs
+++ b/crates/http/src/router.rs
@@ -32,12 +32,20 @@ pub fn create_router(executor: Arc<dyn QueryExecutor>) -> Router {
     // Health check at root level (matches Go DefraDB)
     let root_routes = Router::new().route("/health-check", get(handlers::health_check));
 
+    // Transaction routes
+    let tx_routes = Router::new()
+        .route("/begin", post(handlers::tx_begin))
+        .route("/commit", post(handlers::tx_commit))
+        .route("/rollback", post(handlers::tx_rollback));
+
     // API v0 routes
     let api_routes = Router::new()
-        .route("/graphql", post(handlers::graphql))
+        // Use the transactional handler which supports optional txn_id
+        .route("/graphql", post(handlers::graphql_transactional))
         .route("/graphql", get(handlers::graphql_get))
         .route("/schema", get(handlers::schema))
         .route("/version", get(handlers::version))
+        .nest("/tx", tx_routes)
         .with_state(state);
 
     root_routes.nest("/api/v0", api_routes)

--- a/crates/query/src/plan/mutation/upsert.rs
+++ b/crates/query/src/plan/mutation/upsert.rs
@@ -193,9 +193,8 @@ impl UpsertNode {
 
     /// Upsert a single document by ID with the given input.
     async fn upsert_by_id(&mut self, doc_id_str: &str, input: &UpsertInput) -> Result<()> {
-        let doc_id = DocID::from_string(doc_id_str).map_err(|e| {
-            QueryError::execution(format!("Invalid DocID '{}': {}", doc_id_str, e))
-        })?;
+        let doc_id = DocID::from_string(doc_id_str)
+            .map_err(|e| QueryError::execution(format!("Invalid DocID '{}': {}", doc_id_str, e)))?;
 
         // Check if document exists
         let existing = self
@@ -399,8 +398,9 @@ mod tests {
     impl DocMutator for MockMutator {
         async fn create(&self, _collection_name: &str, mut doc: Document) -> Result<CreateResult> {
             if doc.id().is_none() {
-                doc.generate_and_set_doc_id()
-                    .map_err(|e| QueryError::execution(format!("Failed to generate DocID: {}", e)))?;
+                doc.generate_and_set_doc_id().map_err(|e| {
+                    QueryError::execution(format!("Failed to generate DocID: {}", e))
+                })?;
             }
 
             let doc_id = doc
@@ -511,8 +511,7 @@ mod tests {
         let doc_id = existing_doc.id().unwrap().to_string();
         mutator.add_doc(existing_doc);
 
-        let input = UpsertInput::new()
-            .with_field("email", json!("alice@new.com"));
+        let input = UpsertInput::new().with_field("email", json!("alice@new.com"));
 
         let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
             .with_doc_ids(vec![doc_id.clone()])
@@ -580,8 +579,7 @@ mod tests {
             .with_field("name", json!("NewUser"))
             .with_field("email", json!("new@example.com"));
 
-        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
-            .with_input(input);
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping).with_input(input);
 
         node.init().await.unwrap();
         node.start().await.unwrap();
@@ -609,8 +607,7 @@ mod tests {
         let mutator = Arc::new(MockMutator::new());
         let mapping = make_test_mapping();
 
-        let input = UpsertInput::new()
-            .with_field("name", json!("Alice"));
+        let input = UpsertInput::new().with_field("name", json!("Alice"));
 
         // Use an invalid DocID format
         let mut node = UpsertNode::new("Users", mutator, mapping)
@@ -643,8 +640,7 @@ mod tests {
                 .with_field("email", json!("user3@example.com")),
         ];
 
-        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
-            .with_inputs(inputs);
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping).with_inputs(inputs);
 
         node.init().await.unwrap();
         node.start().await.unwrap();
@@ -664,8 +660,7 @@ mod tests {
         let mutator = Arc::new(MockMutator::new());
         let mapping = make_test_mapping();
 
-        let input = UpsertInput::new()
-            .with_field("name", json!("Alice"));
+        let input = UpsertInput::new().with_field("name", json!("Alice"));
 
         // Empty doc_ids list
         let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
@@ -686,11 +681,9 @@ mod tests {
         let mutator = Arc::new(MockMutator::new());
         let mapping = make_test_mapping();
 
-        let input = UpsertInput::new()
-            .with_field("name", json!("Alice"));
+        let input = UpsertInput::new().with_field("name", json!("Alice"));
 
-        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
-            .with_input(input);
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping).with_input(input);
 
         // First run
         node.init().await.unwrap();

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -402,7 +402,10 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
             }
 
             // UPDATE/DELETE/UPSERT: docIDs to target
-            (MutationType::Update | MutationType::Delete | MutationType::Upsert, "docIDs" | "_docIDs") => {
+            (
+                MutationType::Update | MutationType::Delete | MutationType::Upsert,
+                "docIDs" | "_docIDs",
+            ) => {
                 let doc_ids = parse_doc_ids_value(arg_value)?;
                 mutation.doc_ids = Some(doc_ids);
             }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -27,7 +27,7 @@ use crate::plan::{
     UpsertInput, UpsertNode,
 };
 use crate::planner::{Doc, PlanNode};
-use crate::query_parse::{parse_mutations, parse_query};
+use crate::query_parse::{parse_mutations, parse_query, parse_request, ParsedOperation};
 use crate::txn::{
     GetTransactionResult, NoOpTransactionRegistry, TransactionHandle, TransactionRegistry,
 };
@@ -551,7 +551,28 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 #[async_trait]
 impl<F: DocFetcher, R: TransactionRegistry> QueryExecutor for QueryRunner<F, R> {
     async fn execute(&self, request: QueryRequest) -> QueryResponse {
-        match self.execute_query(&request.query).await {
+        // First, parse the request to determine if it's a query or mutation
+        let parsed = match parse_request(&request.query) {
+            Ok(p) => p,
+            Err(e) => {
+                return QueryResponse {
+                    data: None,
+                    errors: vec![QueryResponseError {
+                        message: format!("parse error: {}", e),
+                        path: None,
+                        locations: None,
+                    }],
+                };
+            }
+        };
+
+        // Route to appropriate handler based on operation type
+        let result = match parsed {
+            ParsedOperation::Query(_) => self.execute_query(&request.query).await,
+            ParsedOperation::Mutation(_) => self.execute_mutation(&request.query).await,
+        };
+
+        match result {
             Ok(data) => QueryResponse {
                 data: Some(data),
                 errors: vec![],

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -1569,11 +1569,7 @@ mod tests {
         let mut unique_ids = doc_ids.clone();
         unique_ids.sort();
         unique_ids.dedup();
-        assert_eq!(
-            unique_ids.len(),
-            3,
-            "Each document should have a unique ID"
-        );
+        assert_eq!(unique_ids.len(), 3, "Each document should have a unique ID");
     }
 
     #[tokio::test]
@@ -2018,9 +2014,7 @@ mod tests {
 
         // Delete only users with age > 30
         let result = runner
-            .execute_mutation(
-                r#"mutation { delete_Users(filter: {age: {_gt: 30}}) { _docID } }"#,
-            )
+            .execute_mutation(r#"mutation { delete_Users(filter: {age: {_gt: 30}}) { _docID } }"#)
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary

- **Issue #67**: Wire up GraphQL mutations by connecting `AutoCommitMutator` to the HTTP server
- **Issue #68**: Add transaction HTTP endpoints for explicit transaction management

### Changes

**GraphQL Mutations (Issue #67)**
- Created `AutoCommitMutator` in `crates/db/src/auto_commit_mutator.rs`
- Each mutation (create/update/delete) automatically creates and commits its own transaction
- Wired to `QueryRunner` via `.with_mutator()` in `start.rs`

**Transaction Endpoints (Issue #68)**
- `POST /api/v0/tx/begin` → returns `{ "txn_id": "..." }` (supports `readonly` flag)
- `POST /api/v0/tx/commit` with `{ "txn_id": "..." }`
- `POST /api/v0/tx/rollback` with `{ "txn_id": "..." }`
- `POST /api/v0/graphql` now accepts optional `txn_id` for transactional queries

## Test plan

- [x] All existing tests pass (164+ tests)
- [x] New `AutoCommitMutator` unit tests (8 tests)
- [x] New transaction handler unit tests (9 tests)
- [x] `cargo clippy --all -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

Closes #67, Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)