### PR TITLE
feat(query): Add COUNT aggregate and GROUP BY support

### DIFF
--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -21,7 +21,6 @@ use tracing::{error, info, warn};
 use crate::config::{Config, DatastoreType};
 use crate::error::{Error, Result};
 
-
 const DEV_MODE_BANNER: &str = r#"
 ******************************************
 **     DEVELOPMENT MODE IS ENABLED      **
@@ -376,13 +375,14 @@ impl Node {
 
         // Create HTTP server with database-backed query runner
         let http_server = {
-            let api_address: SocketAddr = config
-                .api
-                .address
-                .parse()
-                .map_err(|e: std::net::AddrParseError| {
-                    Error::InvalidApiAddress(config.api.address.clone(), e.to_string())
-                })?;
+            let api_address: SocketAddr =
+                config
+                    .api
+                    .address
+                    .parse()
+                    .map_err(|e: std::net::AddrParseError| {
+                        Error::InvalidApiAddress(config.api.address.clone(), e.to_string())
+                    })?;
 
             let server_config = defra_http::ServerConfig {
                 address: api_address,
@@ -694,9 +694,7 @@ mod http_integration_tests {
         let shutdown_tx = node.shutdown_tx.clone();
 
         // Spawn node in background
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         // Wait for server to be ready
         wait_for_server(&api_url, 20).await;
@@ -733,9 +731,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 
@@ -750,8 +746,14 @@ mod http_integration_tests {
 
         assert_eq!(response.status(), reqwest::StatusCode::OK);
         let body: serde_json::Value = response.json().await.unwrap();
-        assert!(body.get("version").is_some(), "Response should contain version");
-        assert!(body.get("commit").is_some(), "Response should contain commit");
+        assert!(
+            body.get("version").is_some(),
+            "Response should contain version"
+        );
+        assert!(
+            body.get("commit").is_some(),
+            "Response should contain commit"
+        );
 
         // Shutdown
         shutdown_tx.send(()).await.unwrap();
@@ -768,9 +770,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 
@@ -809,9 +809,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 
@@ -878,9 +876,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 
@@ -998,9 +994,7 @@ mod http_integration_tests {
         let node = Node::new(config).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
-        let node_handle = tokio::spawn(async move {
-            node.run().await
-        });
+        let node_handle = tokio::spawn(async move { node.run().await });
 
         wait_for_server(&api_url, 20).await;
 

--- a/crates/db/src/auto_commit_fetcher.rs
+++ b/crates/db/src/auto_commit_fetcher.rs
@@ -41,11 +41,9 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
         // Create a read-only transaction
-        let txn = self
-            .db
-            .new_txn(true)
-            .await
-            .map_err(|e| query::error::QueryError::execution(format!("failed to create txn: {}", e)))?;
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
 
         // Get the datastore
         let datastore = txn.datastore().map_err(|e| {
@@ -86,11 +84,9 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
 
         // Create a read-only transaction
-        let txn = self
-            .db
-            .new_txn(true)
-            .await
-            .map_err(|e| query::error::QueryError::execution(format!("failed to create txn: {}", e)))?;
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
 
         // Get the datastore
         let datastore = txn.datastore().map_err(|e| {

--- a/crates/db/src/collection_loader.rs
+++ b/crates/db/src/collection_loader.rs
@@ -67,9 +67,9 @@ pub(crate) async fn get_collection_with_lazy_load<S: Store + 'static>(
     // Extract what we need from the transaction while holding the lock briefly
     let (collection_opt, systemstore, datastore) = {
         let txn_guard = txn.lock().await;
-        let db_txn = txn_guard.as_ref().ok_or_else(|| {
-            query::error::QueryError::execution("transaction already consumed")
-        })?;
+        let db_txn = txn_guard
+            .as_ref()
+            .ok_or_else(|| query::error::QueryError::execution("transaction already consumed"))?;
         let collection_opt = db_txn.collection_cache().get(collection_name).cloned();
         let systemstore = db_txn.systemstore().map_err(|e| {
             query::error::QueryError::execution(format!(

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -75,7 +75,8 @@ impl<S: Store> DbDocFetcher<S> {
 #[async_trait]
 impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
     async fn get_all(&self, collection_name: &str) -> query::error::Result<Vec<Document>> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .get_all_with_datastore(&datastore)
@@ -88,7 +89,8 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         collection_name: &str,
         doc_ids: &[String],
     ) -> query::error::Result<FetchByIdsResult> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         let mut docs = Vec::new();
         let mut missing_ids = Vec::new();

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -83,7 +83,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         mut doc: Document,
     ) -> query::error::Result<CreateResult> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         // Generate document ID if not present
         if doc.id().is_none() {
@@ -109,7 +110,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc: Document,
     ) -> query::error::Result<UpdateResult> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .update_with_datastore(&datastore, &doc)
@@ -127,7 +129,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<DeleteResult> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         let existed = collection
             .delete_with_datastore(&datastore, doc_id)
@@ -138,7 +141,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
     }
 
     async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .exists_with_datastore(&datastore, doc_id)
@@ -151,7 +155,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<Option<Document>> {
-        let (collection, datastore) = get_collection_with_lazy_load(&self.txn, collection_name).await?;
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
         collection
             .get_with_datastore(&datastore, doc_id)

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -67,10 +67,10 @@ pub use database::{DbOptions, DB};
 pub use doc_fetcher::DbDocFetcher;
 pub use doc_mutator::DbDocMutator;
 pub use error::{Error, Result};
+pub use schema_loader::load_active_collections;
 pub use txn::DbTxn;
 pub use txn_context::DbTransactionContext;
 pub use txn_registry::{CleanupResult, DbTransactionRegistry};
-pub use schema_loader::load_active_collections;
 
 // Re-export related crate types for convenience
 pub use datastore::{BasicTxn, NamespaceView};

--- a/crates/db/src/schema_loader.rs
+++ b/crates/db/src/schema_loader.rs
@@ -43,8 +43,10 @@ pub async fn load_active_collections<S: Store>(db: &DB<S>) -> Result<Vec<Collect
                 let collection_id = match String::from_utf8(kv.value) {
                     Ok(id) => id,
                     Err(e) => {
-                        load_error =
-                            Some(Error::Other(format!("Invalid collection ID encoding: {}", e)));
+                        load_error = Some(Error::Other(format!(
+                            "Invalid collection ID encoding: {}",
+                            e
+                        )));
                         break;
                     }
                 };
@@ -109,9 +111,9 @@ mod tests {
     use super::*;
     use crate::DB;
     use datastore::BasicTxn;
+    use std::sync::Arc;
     use storage::backends::MemoryStore;
     use storage::corekv::Key;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_load_empty_database() {
@@ -119,7 +121,10 @@ mod tests {
         let db = DB::new(store);
 
         let collections = load_active_collections(&db).await.unwrap();
-        assert!(collections.is_empty(), "New database should have no collections");
+        assert!(
+            collections.is_empty(),
+            "New database should have no collections"
+        );
     }
 
     #[tokio::test]

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -124,6 +124,43 @@ impl Filter {
         self.conditions.is_empty()
     }
 
+    /// Get all field names referenced by this filter
+    pub fn referenced_fields(&self) -> Vec<String> {
+        let mut fields = Vec::new();
+        Self::collect_fields(&self.conditions, &mut fields);
+        fields
+    }
+
+    fn collect_fields(conditions: &HashMap<String, JsonValue>, fields: &mut Vec<String>) {
+        for (key, value) in conditions {
+            // Skip logical operators
+            if FilterOp::parse(key).is_some() {
+                match value {
+                    JsonValue::Array(arr) => {
+                        for item in arr {
+                            if let JsonValue::Object(obj) = item {
+                                let nested: HashMap<String, JsonValue> =
+                                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                                Self::collect_fields(&nested, fields);
+                            }
+                        }
+                    }
+                    JsonValue::Object(obj) => {
+                        let nested: HashMap<String, JsonValue> =
+                            obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                        Self::collect_fields(&nested, fields);
+                    }
+                    _ => {}
+                }
+            } else {
+                // This is a field name
+                if !fields.contains(key) {
+                    fields.push(key.clone());
+                }
+            }
+        }
+    }
+
     /// Evaluate the filter against document fields
     pub fn matches(&self, fields: &[Option<JsonValue>], mapping: &DocumentMapping) -> Result<bool> {
         if self.conditions.is_empty() {

--- a/crates/query/src/mapper/types.rs
+++ b/crates/query/src/mapper/types.rs
@@ -204,6 +204,8 @@ pub struct Aggregate {
     pub targets: Vec<AggregateTarget>,
     /// Optional filter for the aggregate
     pub filter: Option<Filter>,
+    /// Optional alias for output
+    pub alias: Option<String>,
 }
 
 impl Aggregate {
@@ -212,6 +214,7 @@ impl Aggregate {
             aggregate_type: AggregateType::Count,
             targets: Vec::new(),
             filter: None,
+            alias: None,
         }
     }
 
@@ -220,6 +223,7 @@ impl Aggregate {
             aggregate_type: AggregateType::Sum,
             targets: vec![target],
             filter: None,
+            alias: None,
         }
     }
 
@@ -228,6 +232,7 @@ impl Aggregate {
             aggregate_type: AggregateType::Average,
             targets: vec![target],
             filter: None,
+            alias: None,
         }
     }
 
@@ -236,6 +241,7 @@ impl Aggregate {
             aggregate_type: AggregateType::Min,
             targets: vec![target],
             filter: None,
+            alias: None,
         }
     }
 
@@ -244,12 +250,30 @@ impl Aggregate {
             aggregate_type: AggregateType::Max,
             targets: vec![target],
             filter: None,
+            alias: None,
         }
     }
 
     pub fn with_filter(mut self, filter: Filter) -> Self {
         self.filter = Some(filter);
         self
+    }
+
+    pub fn with_target(mut self, target: AggregateTarget) -> Self {
+        self.targets.push(target);
+        self
+    }
+
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+
+    /// Get the output name (alias if set, otherwise the aggregate type name)
+    pub fn output_name(&self) -> &str {
+        self.alias
+            .as_deref()
+            .unwrap_or_else(|| self.aggregate_type.as_str())
     }
 }
 

--- a/crates/query/src/plan/alldocs.rs
+++ b/crates/query/src/plan/alldocs.rs
@@ -1,0 +1,204 @@
+//! AllDocsNode for providing all documents as a single group
+//!
+//! Used to enable multiple aggregates without GROUP BY by buffering
+//! all documents and making them available via `current_group_docs()`.
+
+use async_trait::async_trait;
+
+use crate::document::DocumentMapping;
+use crate::error::Result;
+use crate::planner::{Doc, PlanNode};
+
+/// AllDocsNode buffers all documents and yields them once as a single group.
+///
+/// This node enables multiple aggregates to work correctly without GROUP BY:
+/// - During `start()`, it buffers all documents from the source
+/// - It yields a single "group" containing all documents
+/// - `current_group_docs()` returns all buffered documents
+///
+/// Without this node, chained aggregates would each consume the previous
+/// aggregate's result instead of sharing access to the original documents.
+pub struct AllDocsNode {
+    source: Box<dyn PlanNode>,
+    document_mapping: DocumentMapping,
+    /// All documents buffered from source
+    docs: Vec<Doc>,
+    /// Current representative document
+    current_doc: Doc,
+    /// Whether start() has been called
+    started: bool,
+    /// Whether we've yielded the single result
+    done: bool,
+}
+
+impl AllDocsNode {
+    /// Create a new AllDocsNode wrapping a source
+    pub fn new(source: Box<dyn PlanNode>, document_mapping: DocumentMapping) -> Self {
+        Self {
+            source,
+            document_mapping,
+            docs: Vec::new(),
+            current_doc: Doc::default(),
+            started: false,
+            done: false,
+        }
+    }
+}
+
+#[async_trait]
+impl PlanNode for AllDocsNode {
+    async fn init(&mut self) -> Result<()> {
+        self.docs.clear();
+        self.done = false;
+        self.started = false;
+        self.source.init().await
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        self.source.start().await?;
+        self.started = true;
+
+        // Buffer all documents from source
+        while self.source.next().await? {
+            self.docs.push(self.source.value().deep_clone());
+        }
+
+        // Set representative document (first doc or empty)
+        if !self.docs.is_empty() {
+            self.current_doc = self.docs[0].deep_clone();
+        }
+
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if !self.started {
+            self.start().await?;
+        }
+
+        if self.done {
+            return Ok(false);
+        }
+
+        self.done = true;
+        Ok(true)
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.source.close().await
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        Some(self.source.as_ref())
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "allDocsNode"
+    }
+
+    fn current_group_docs(&self) -> Option<&[Doc]> {
+        Some(&self.docs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::ScanNode;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    fn make_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    fn make_test_docs() -> Vec<Doc> {
+        vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                Some(json!(25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(35)),
+            ]),
+        ]
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "age");
+        mapping
+    }
+
+    #[tokio::test]
+    async fn test_alldocs_buffers_all_documents() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        let docs = make_test_docs();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut node = AllDocsNode::new(Box::new(scan), mapping);
+
+        node.init().await.unwrap();
+
+        // Should yield exactly once
+        assert!(node.next().await.unwrap());
+
+        // current_group_docs should return all 3 docs
+        let group_docs = node.current_group_docs().unwrap();
+        assert_eq!(group_docs.len(), 3);
+
+        // Should not yield again
+        assert!(!node.next().await.unwrap());
+
+        node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_alldocs_empty_source() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+        let mut node = AllDocsNode::new(Box::new(scan), mapping);
+
+        node.init().await.unwrap();
+
+        // Should yield once with empty group
+        assert!(node.next().await.unwrap());
+
+        let group_docs = node.current_group_docs().unwrap();
+        assert_eq!(group_docs.len(), 0);
+
+        assert!(!node.next().await.unwrap());
+
+        node.close().await.unwrap();
+    }
+}

--- a/crates/query/src/plan/average.rs
+++ b/crates/query/src/plan/average.rs
@@ -1,0 +1,477 @@
+//! AverageNode for computing AVG aggregate
+
+use async_trait::async_trait;
+use serde_json::Value as JsonValue;
+
+use crate::document::DocumentMapping;
+use crate::error::Result;
+use crate::planner::{Doc, PlanNode};
+
+/// AverageNode computes the average of a numeric field from its source.
+///
+/// Operates in two modes:
+/// - Without GROUP BY: Computes average of all documents and yields a single result
+/// - With GROUP BY: For each group, adds the average to the document
+///
+/// Null values are skipped. Returns 0.0 if no values to average.
+/// Always returns f64 for precision.
+pub struct AverageNode {
+    source: Box<dyn PlanNode>,
+    document_mapping: DocumentMapping,
+    /// Index of the field to average
+    field_index: usize,
+    /// Index in the document where average result should be stored
+    aggregate_index: usize,
+    /// The running sum (for non-grouped mode)
+    sum: f64,
+    /// The running count (for non-grouped mode)
+    count: i64,
+    /// Current document with average result
+    current_doc: Doc,
+    /// Whether we've already yielded the result (for non-grouped mode)
+    done: bool,
+    /// Whether start() has been called
+    started: bool,
+    /// Whether we're in grouped mode (source provides group docs)
+    grouped_mode: bool,
+}
+
+impl AverageNode {
+    /// Create a new AverageNode wrapping a source
+    pub fn new(
+        source: Box<dyn PlanNode>,
+        document_mapping: DocumentMapping,
+        field_index: usize,
+        aggregate_index: usize,
+    ) -> Self {
+        Self {
+            source,
+            document_mapping,
+            field_index,
+            aggregate_index,
+            sum: 0.0,
+            count: 0,
+            current_doc: Doc::default(),
+            done: false,
+            started: false,
+            grouped_mode: false,
+        }
+    }
+
+    /// Extract numeric value from JSON, returning None for nulls
+    fn extract_numeric(value: Option<&JsonValue>) -> Option<f64> {
+        match value {
+            Some(JsonValue::Number(n)) => n.as_f64(),
+            _ => None,
+        }
+    }
+
+    /// Compute average of a slice of documents
+    fn compute_average(&self, docs: &[Doc]) -> f64 {
+        let mut sum = 0.0;
+        let mut count = 0i64;
+
+        for doc in docs {
+            if doc.hidden {
+                continue;
+            }
+            if let Some(val) = Self::extract_numeric(doc.get(self.field_index)) {
+                sum += val;
+                count += 1;
+            }
+        }
+
+        if count == 0 {
+            0.0
+        } else {
+            sum / count as f64
+        }
+    }
+
+    /// Convert average to JSON value (always f64)
+    fn avg_to_json(avg: f64) -> JsonValue {
+        JsonValue::Number(serde_json::Number::from_f64(avg).unwrap_or_else(|| 0.into()))
+    }
+}
+
+#[async_trait]
+impl PlanNode for AverageNode {
+    async fn init(&mut self) -> Result<()> {
+        self.sum = 0.0;
+        self.count = 0;
+        self.done = false;
+        self.started = false;
+        self.grouped_mode = false;
+        self.source.init().await
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        self.source.start().await?;
+        self.started = true;
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if !self.started {
+            self.start().await?;
+        }
+
+        // Try to get next from source
+        if !self.source.next().await? {
+            // No more source documents
+            if !self.grouped_mode && !self.done {
+                // Non-grouped mode: Return the single result
+                self.done = true;
+                let avg = if self.count == 0 {
+                    0.0
+                } else {
+                    self.sum / self.count as f64
+                };
+                let num_fields = self
+                    .document_mapping
+                    .next_index()
+                    .max(self.aggregate_index + 1);
+                let mut doc = Doc::new(num_fields);
+                doc.set(self.aggregate_index, Self::avg_to_json(avg));
+                self.current_doc = doc;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        // Check if source provides group docs
+        if let Some(group_docs) = self.source.current_group_docs() {
+            // Grouped mode: compute average for this group
+            self.grouped_mode = true;
+            let group_avg = self.compute_average(group_docs);
+
+            // Clone the current doc from source and add the average
+            let mut doc = self.source.value().deep_clone();
+            if doc.num_fields() <= self.aggregate_index {
+                doc.set(self.aggregate_index, JsonValue::Null);
+            }
+            doc.set(self.aggregate_index, Self::avg_to_json(group_avg));
+            self.current_doc = doc;
+            return Ok(true);
+        }
+
+        // Non-grouped mode: accumulate sum and count
+        let doc = self.source.value();
+        if !doc.hidden {
+            if let Some(val) = Self::extract_numeric(doc.get(self.field_index)) {
+                self.sum += val;
+                self.count += 1;
+            }
+        }
+
+        // Continue iterating
+        Box::pin(self.next()).await
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.source.close().await
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        Some(self.source.as_ref())
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "averageNode"
+    }
+
+    fn current_group_docs(&self) -> Option<&[Doc]> {
+        // Pass through from source for stacked aggregates
+        self.source.current_group_docs()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::ScanNode;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    fn make_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    fn make_test_docs() -> Vec<Doc> {
+        vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                Some(json!(20)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(40)),
+            ]),
+        ]
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "age");
+        mapping.add(3, "_avg");
+        mapping.add_render_key(3, "_avg");
+        mapping
+    }
+
+    #[tokio::test]
+    async fn test_average_integer_field() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        let docs = make_test_docs();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut avg_node = AverageNode::new(Box::new(scan), mapping, 2, 3);
+
+        avg_node.init().await.unwrap();
+
+        assert!(avg_node.next().await.unwrap());
+        let result = avg_node.value();
+        // (30 + 20 + 40) / 3 = 30
+        let avg_val = result.get(3).unwrap().as_f64().unwrap();
+        assert!((avg_val - 30.0).abs() < 0.001);
+
+        assert!(!avg_node.next().await.unwrap());
+        avg_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_average_empty_source() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+        let mut avg_node = AverageNode::new(Box::new(scan), mapping, 2, 3);
+
+        avg_node.init().await.unwrap();
+
+        assert!(avg_node.next().await.unwrap());
+        let result = avg_node.value();
+        // Should return 0.0 for empty
+        let avg_val = result.get(3).unwrap().as_f64().unwrap();
+        assert!((avg_val - 0.0).abs() < 0.001);
+
+        avg_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_average_with_nulls() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                None, // null age
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(40)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut avg_node = AverageNode::new(Box::new(scan), mapping, 2, 3);
+
+        avg_node.init().await.unwrap();
+
+        assert!(avg_node.next().await.unwrap());
+        let result = avg_node.value();
+        // (30 + 40) / 2 = 35 (null skipped)
+        let avg_val = result.get(3).unwrap().as_f64().unwrap();
+        assert!((avg_val - 35.0).abs() < 0.001);
+
+        avg_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_average_float_field() {
+        let collection = CollectionVersion::new(
+            "Products",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "price", FieldKind::float64()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "price");
+        mapping.add(3, "_avg");
+        mapping.add_render_key(3, "_avg");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Item A")),
+                Some(json!(10.0)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Item B")),
+                Some(json!(20.0)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Item C")),
+                Some(json!(30.0)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut avg_node = AverageNode::new(Box::new(scan), mapping, 2, 3);
+
+        avg_node.init().await.unwrap();
+
+        assert!(avg_node.next().await.unwrap());
+        let result = avg_node.value();
+        // (10 + 20 + 30) / 3 = 20
+        let avg_val = result.get(3).unwrap().as_f64().unwrap();
+        assert!((avg_val - 20.0).abs() < 0.001);
+
+        avg_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_average_skips_hidden_docs() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let mut docs = make_test_docs();
+        docs[1].hidden = true; // Hide Bob (age 20)
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut avg_node = AverageNode::new(Box::new(scan), mapping, 2, 3);
+
+        avg_node.init().await.unwrap();
+
+        assert!(avg_node.next().await.unwrap());
+        let result = avg_node.value();
+        // (30 + 40) / 2 = 35 (20 skipped)
+        let avg_val = result.get(3).unwrap().as_f64().unwrap();
+        assert!((avg_val - 35.0).abs() < 0.001);
+
+        avg_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_average_with_groupby() {
+        use crate::mapper::GroupBy;
+        use crate::plan::GroupByNode;
+
+        let collection = CollectionVersion::new(
+            "Employees",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "department", FieldKind::string()),
+                FieldDescription::new("3", "salary", FieldKind::int()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "department");
+        mapping.add(2, "salary");
+        mapping.add(3, "_avg");
+        mapping.add_render_key(1, "department");
+        mapping.add_render_key(3, "_avg");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Engineering")),
+                Some(json!(100)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Sales")),
+                Some(json!(80)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Engineering")),
+                Some(json!(120)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc4")),
+                Some(json!("Sales")),
+                Some(json!(100)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let groupby_node = GroupByNode::new(Box::new(scan), group_by, mapping.clone());
+        let mut avg_node = AverageNode::new(Box::new(groupby_node), mapping, 2, 3);
+
+        avg_node.init().await.unwrap();
+
+        let mut results = Vec::new();
+        while avg_node.next().await.unwrap() {
+            results.push(avg_node.value().deep_clone());
+        }
+
+        assert_eq!(results.len(), 2);
+
+        // Find Engineering group (100 + 120) / 2 = 110
+        let eng = results
+            .iter()
+            .find(|d| d.get(1).and_then(|v| v.as_str()) == Some("Engineering"))
+            .unwrap();
+        let eng_avg = eng.get(3).unwrap().as_f64().unwrap();
+        assert!((eng_avg - 110.0).abs() < 0.001);
+
+        // Find Sales group (80 + 100) / 2 = 90
+        let sales = results
+            .iter()
+            .find(|d| d.get(1).and_then(|v| v.as_str()) == Some("Sales"))
+            .unwrap();
+        let sales_avg = sales.get(3).unwrap().as_f64().unwrap();
+        assert!((sales_avg - 90.0).abs() < 0.001);
+
+        avg_node.close().await.unwrap();
+    }
+}

--- a/crates/query/src/plan/average.rs
+++ b/crates/query/src/plan/average.rs
@@ -13,7 +13,7 @@ use crate::planner::{Doc, PlanNode};
 /// - Without GROUP BY: Computes average of all documents and yields a single result
 /// - With GROUP BY: For each group, adds the average to the document
 ///
-/// Null values are skipped. Returns 0.0 if no values to average.
+/// Null values are skipped. Returns null if no values to average (SQL semantics).
 /// Always returns f64 for precision.
 pub struct AverageNode {
     source: Box<dyn PlanNode>,
@@ -25,7 +25,7 @@ pub struct AverageNode {
     /// The running sum (for non-grouped mode)
     sum: f64,
     /// The running count (for non-grouped mode)
-    count: i64,
+    count: usize,
     /// Current document with average result
     current_doc: Doc,
     /// Whether we've already yielded the result (for non-grouped mode)
@@ -67,9 +67,10 @@ impl AverageNode {
     }
 
     /// Compute average of a slice of documents
-    fn compute_average(&self, docs: &[Doc]) -> f64 {
+    /// Returns None if no values (SQL semantics: AVG of empty set is NULL)
+    fn compute_average(&self, docs: &[Doc]) -> Option<f64> {
         let mut sum = 0.0;
-        let mut count = 0i64;
+        let mut count = 0usize;
 
         for doc in docs {
             if doc.hidden {
@@ -82,15 +83,25 @@ impl AverageNode {
         }
 
         if count == 0 {
-            0.0
+            None
         } else {
-            sum / count as f64
+            Some(sum / count as f64)
         }
     }
 
-    /// Convert average to JSON value (always f64)
-    fn avg_to_json(avg: f64) -> JsonValue {
-        JsonValue::Number(serde_json::Number::from_f64(avg).unwrap_or_else(|| 0.into()))
+    /// Convert average to JSON value (null for empty, f64 otherwise)
+    /// Returns Null for NaN/Infinity to prevent silent data corruption
+    fn avg_to_json(avg: Option<f64>) -> JsonValue {
+        match avg {
+            None => JsonValue::Null,
+            Some(val) => {
+                // NaN and Infinity cannot be represented in JSON - return null
+                // This is safer than silently returning 0
+                serde_json::Number::from_f64(val)
+                    .map(JsonValue::Number)
+                    .unwrap_or(JsonValue::Null)
+            }
+        }
     }
 }
 
@@ -116,56 +127,57 @@ impl PlanNode for AverageNode {
             self.start().await?;
         }
 
-        // Try to get next from source
-        if !self.source.next().await? {
-            // No more source documents
-            if !self.grouped_mode && !self.done {
-                // Non-grouped mode: Return the single result
-                self.done = true;
-                let avg = if self.count == 0 {
-                    0.0
-                } else {
-                    self.sum / self.count as f64
-                };
-                let num_fields = self
-                    .document_mapping
-                    .next_index()
-                    .max(self.aggregate_index + 1);
-                let mut doc = Doc::new(num_fields);
-                doc.set(self.aggregate_index, Self::avg_to_json(avg));
+        loop {
+            // Try to get next from source
+            if !self.source.next().await? {
+                // No more source documents
+                if !self.grouped_mode && !self.done {
+                    // Non-grouped mode: Return the single result
+                    self.done = true;
+                    let avg = if self.count == 0 {
+                        None
+                    } else {
+                        Some(self.sum / self.count as f64)
+                    };
+                    let num_fields = self
+                        .document_mapping
+                        .next_index()
+                        .max(self.aggregate_index + 1);
+                    let mut doc = Doc::new(num_fields);
+                    doc.set(self.aggregate_index, Self::avg_to_json(avg));
+                    self.current_doc = doc;
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+
+            // Check if source provides group docs
+            if let Some(group_docs) = self.source.current_group_docs() {
+                // Grouped mode: compute average for this group
+                self.grouped_mode = true;
+                let group_avg = self.compute_average(group_docs);
+
+                // Clone the current doc from source and add the average
+                let mut doc = self.source.value().deep_clone();
+                if doc.num_fields() <= self.aggregate_index {
+                    doc.set(self.aggregate_index, JsonValue::Null);
+                }
+                doc.set(self.aggregate_index, Self::avg_to_json(group_avg));
                 self.current_doc = doc;
                 return Ok(true);
             }
-            return Ok(false);
-        }
 
-        // Check if source provides group docs
-        if let Some(group_docs) = self.source.current_group_docs() {
-            // Grouped mode: compute average for this group
-            self.grouped_mode = true;
-            let group_avg = self.compute_average(group_docs);
-
-            // Clone the current doc from source and add the average
-            let mut doc = self.source.value().deep_clone();
-            if doc.num_fields() <= self.aggregate_index {
-                doc.set(self.aggregate_index, JsonValue::Null);
+            // Non-grouped mode: accumulate sum and count
+            let doc = self.source.value();
+            if !doc.hidden {
+                if let Some(val) = Self::extract_numeric(doc.get(self.field_index)) {
+                    self.sum += val;
+                    self.count += 1;
+                }
             }
-            doc.set(self.aggregate_index, Self::avg_to_json(group_avg));
-            self.current_doc = doc;
-            return Ok(true);
-        }
 
-        // Non-grouped mode: accumulate sum and count
-        let doc = self.source.value();
-        if !doc.hidden {
-            if let Some(val) = Self::extract_numeric(doc.get(self.field_index)) {
-                self.sum += val;
-                self.count += 1;
-            }
+            // Continue iterating (loop continues)
         }
-
-        // Continue iterating
-        Box::pin(self.next()).await
     }
 
     fn value(&self) -> &Doc {
@@ -277,9 +289,8 @@ mod tests {
 
         assert!(avg_node.next().await.unwrap());
         let result = avg_node.value();
-        // Should return 0.0 for empty
-        let avg_val = result.get(3).unwrap().as_f64().unwrap();
-        assert!((avg_val - 0.0).abs() < 0.001);
+        // Should return null for empty set (SQL semantics)
+        assert_eq!(result.get(3), Some(&JsonValue::Null));
 
         avg_node.close().await.unwrap();
     }

--- a/crates/query/src/plan/count.rs
+++ b/crates/query/src/plan/count.rs
@@ -1,0 +1,327 @@
+//! CountNode for computing COUNT aggregate
+
+use async_trait::async_trait;
+use serde_json::Value as JsonValue;
+
+use crate::document::DocumentMapping;
+use crate::error::Result;
+use crate::planner::{Doc, PlanNode};
+
+/// CountNode computes the count of documents from its source.
+///
+/// Operates in two modes:
+/// - Without GROUP BY: Counts all documents and yields a single result
+/// - With GROUP BY: For each group, adds the group count to the document
+///
+/// When the source is a GroupByNode, CountNode operates in pass-through mode:
+/// it iterates through groups and adds the count for each group's documents.
+pub struct CountNode {
+    source: Box<dyn PlanNode>,
+    document_mapping: DocumentMapping,
+    /// Index in the document where count result should be stored
+    aggregate_index: usize,
+    /// The computed count value (for non-grouped mode)
+    count: i64,
+    /// Current document with count result
+    current_doc: Doc,
+    /// Whether we've already yielded the result (for non-grouped mode)
+    done: bool,
+    /// Whether start() has been called
+    started: bool,
+    /// Whether we're in grouped mode (source provides group docs)
+    grouped_mode: bool,
+}
+
+impl CountNode {
+    /// Create a new CountNode wrapping a source
+    pub fn new(
+        source: Box<dyn PlanNode>,
+        document_mapping: DocumentMapping,
+        aggregate_index: usize,
+    ) -> Self {
+        Self {
+            source,
+            document_mapping,
+            aggregate_index,
+            count: 0,
+            current_doc: Doc::default(),
+            done: false,
+            started: false,
+            grouped_mode: false,
+        }
+    }
+}
+
+#[async_trait]
+impl PlanNode for CountNode {
+    async fn init(&mut self) -> Result<()> {
+        self.count = 0;
+        self.done = false;
+        self.started = false;
+        self.grouped_mode = false;
+        self.source.init().await
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        self.source.start().await?;
+        self.started = true;
+
+        // Check if we're in grouped mode by testing if source provides group docs
+        // We can't detect this until we call next() on the source, so we'll check later
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if !self.started {
+            self.start().await?;
+        }
+
+        // Try to get next from source
+        if !self.source.next().await? {
+            // No more source documents
+            if !self.grouped_mode && !self.done {
+                // Non-grouped mode: We counted during iteration, return the single result
+                self.done = true;
+                let num_fields = self
+                    .document_mapping
+                    .next_index()
+                    .max(self.aggregate_index + 1);
+                let mut doc = Doc::new(num_fields);
+                doc.set(self.aggregate_index, JsonValue::Number(self.count.into()));
+                self.current_doc = doc;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        // Check if source provides group docs
+        if let Some(group_docs) = self.source.current_group_docs() {
+            // Grouped mode: count docs in this group
+            self.grouped_mode = true;
+            let group_count = group_docs.iter().filter(|d| !d.hidden).count() as i64;
+
+            // Clone the current doc from source and add the count
+            let mut doc = self.source.value().deep_clone();
+            // Ensure doc has enough fields
+            if doc.num_fields() <= self.aggregate_index {
+                doc.set(self.aggregate_index, JsonValue::Null);
+            }
+            doc.set(self.aggregate_index, JsonValue::Number(group_count.into()));
+            self.current_doc = doc;
+            return Ok(true);
+        }
+
+        // Non-grouped mode: count this doc
+        let doc = self.source.value();
+        if !doc.hidden {
+            self.count += 1;
+        }
+
+        // Continue iterating to count all docs
+        // We'll return the result after all docs are counted (when source returns false)
+        Box::pin(self.next()).await
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.source.close().await
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        Some(self.source.as_ref())
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "countNode"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::ScanNode;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    fn make_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    fn make_test_docs() -> Vec<Doc> {
+        vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                Some(json!(25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(35)),
+            ]),
+        ]
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "age");
+        mapping.add(3, "_count");
+        mapping.add_render_key(3, "_count");
+        mapping
+    }
+
+    #[tokio::test]
+    async fn test_count_all_documents() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        let docs = make_test_docs();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut count_node = CountNode::new(Box::new(scan), mapping, 3);
+
+        count_node.init().await.unwrap();
+
+        // Should return exactly one result
+        assert!(count_node.next().await.unwrap());
+        let result = count_node.value();
+        assert_eq!(result.get(3), Some(&json!(3)));
+
+        // Should return false on second call
+        assert!(!count_node.next().await.unwrap());
+
+        count_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_count_empty_source() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+        let mut count_node = CountNode::new(Box::new(scan), mapping, 3);
+
+        count_node.init().await.unwrap();
+
+        assert!(count_node.next().await.unwrap());
+        let result = count_node.value();
+        assert_eq!(result.get(3), Some(&json!(0)));
+
+        count_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_count_skips_hidden_docs() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        // Create docs with one hidden
+        let mut docs = make_test_docs();
+        docs[1].hidden = true;
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut count_node = CountNode::new(Box::new(scan), mapping, 3);
+
+        count_node.init().await.unwrap();
+
+        assert!(count_node.next().await.unwrap());
+        let result = count_node.value();
+        assert_eq!(result.get(3), Some(&json!(2))); // 3 docs - 1 hidden = 2
+
+        count_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_count_with_groupby() {
+        use crate::mapper::GroupBy;
+        use crate::plan::GroupByNode;
+
+        let collection = CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "department", FieldKind::string()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "department");
+        mapping.add(3, "_count");
+        mapping.add_render_key(0, "_docID");
+        mapping.add_render_key(1, "name");
+        mapping.add_render_key(2, "department");
+        mapping.add_render_key(3, "_count");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!("Engineering")),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                Some(json!("Sales")),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!("Engineering")),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc4")),
+                Some(json!("Diana")),
+                Some(json!("Sales")),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let groupby_node = GroupByNode::new(Box::new(scan), group_by, mapping.clone());
+        let mut count_node = CountNode::new(Box::new(groupby_node), mapping, 3);
+
+        count_node.init().await.unwrap();
+
+        // Should get 2 groups
+        let mut results = Vec::new();
+        while count_node.next().await.unwrap() {
+            results.push(count_node.value().deep_clone());
+        }
+
+        assert_eq!(results.len(), 2);
+
+        // Each group should have count 2
+        for result in &results {
+            assert_eq!(result.get(3), Some(&json!(2)));
+        }
+
+        count_node.close().await.unwrap();
+    }
+}

--- a/crates/query/src/plan/count.rs
+++ b/crates/query/src/plan/count.rs
@@ -141,6 +141,11 @@ impl PlanNode for CountNode {
     fn kind(&self) -> &'static str {
         "countNode"
     }
+
+    fn current_group_docs(&self) -> Option<&[Doc]> {
+        // Pass through from source for stacked aggregates
+        self.source.current_group_docs()
+    }
 }
 
 #[cfg(test)]

--- a/crates/query/src/plan/count.rs
+++ b/crates/query/src/plan/count.rs
@@ -76,50 +76,50 @@ impl PlanNode for CountNode {
             self.start().await?;
         }
 
-        // Try to get next from source
-        if !self.source.next().await? {
-            // No more source documents
-            if !self.grouped_mode && !self.done {
-                // Non-grouped mode: We counted during iteration, return the single result
-                self.done = true;
-                let num_fields = self
-                    .document_mapping
-                    .next_index()
-                    .max(self.aggregate_index + 1);
-                let mut doc = Doc::new(num_fields);
-                doc.set(self.aggregate_index, JsonValue::Number(self.count.into()));
+        loop {
+            // Try to get next from source
+            if !self.source.next().await? {
+                // No more source documents
+                if !self.grouped_mode && !self.done {
+                    // Non-grouped mode: We counted during iteration, return the single result
+                    self.done = true;
+                    let num_fields = self
+                        .document_mapping
+                        .next_index()
+                        .max(self.aggregate_index + 1);
+                    let mut doc = Doc::new(num_fields);
+                    doc.set(self.aggregate_index, JsonValue::Number(self.count.into()));
+                    self.current_doc = doc;
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+
+            // Check if source provides group docs
+            if let Some(group_docs) = self.source.current_group_docs() {
+                // Grouped mode: count docs in this group
+                self.grouped_mode = true;
+                let group_count = group_docs.iter().filter(|d| !d.hidden).count() as i64;
+
+                // Clone the current doc from source and add the count
+                let mut doc = self.source.value().deep_clone();
+                // Ensure doc has enough fields
+                if doc.num_fields() <= self.aggregate_index {
+                    doc.set(self.aggregate_index, JsonValue::Null);
+                }
+                doc.set(self.aggregate_index, JsonValue::Number(group_count.into()));
                 self.current_doc = doc;
                 return Ok(true);
             }
-            return Ok(false);
-        }
 
-        // Check if source provides group docs
-        if let Some(group_docs) = self.source.current_group_docs() {
-            // Grouped mode: count docs in this group
-            self.grouped_mode = true;
-            let group_count = group_docs.iter().filter(|d| !d.hidden).count() as i64;
-
-            // Clone the current doc from source and add the count
-            let mut doc = self.source.value().deep_clone();
-            // Ensure doc has enough fields
-            if doc.num_fields() <= self.aggregate_index {
-                doc.set(self.aggregate_index, JsonValue::Null);
+            // Non-grouped mode: count this doc
+            let doc = self.source.value();
+            if !doc.hidden {
+                self.count += 1;
             }
-            doc.set(self.aggregate_index, JsonValue::Number(group_count.into()));
-            self.current_doc = doc;
-            return Ok(true);
-        }
 
-        // Non-grouped mode: count this doc
-        let doc = self.source.value();
-        if !doc.hidden {
-            self.count += 1;
+            // Continue iterating to count all docs (loop continues)
         }
-
-        // Continue iterating to count all docs
-        // We'll return the result after all docs are counted (when source returns false)
-        Box::pin(self.next()).await
     }
 
     fn value(&self) -> &Doc {

--- a/crates/query/src/plan/groupby.rs
+++ b/crates/query/src/plan/groupby.rs
@@ -1,0 +1,388 @@
+//! GroupByNode for grouping query results
+
+use async_trait::async_trait;
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+
+use crate::document::DocumentMapping;
+use crate::error::Result;
+use crate::mapper::GroupBy;
+use crate::planner::{Doc, PlanNode};
+
+/// A group of documents with the same group key
+#[derive(Debug)]
+pub struct DocumentGroup {
+    /// The documents in this group
+    pub docs: Vec<Doc>,
+    /// The representative document (first doc) for this group
+    pub representative: Doc,
+}
+
+impl DocumentGroup {
+    fn new(first_doc: Doc) -> Self {
+        Self {
+            representative: first_doc.deep_clone(),
+            docs: vec![first_doc],
+        }
+    }
+
+    fn add(&mut self, doc: Doc) {
+        self.docs.push(doc);
+    }
+}
+
+/// GroupByNode groups documents by specified fields.
+///
+/// This node buffers all documents from its source during `start()`,
+/// groups them by the specified fields, then yields one document per group.
+/// Each yielded document is the representative (first) document from each group.
+///
+/// Follows Go DefraDB pattern:
+/// - Group key is generated from field values (format: `{index}_{value}_`)
+/// - Groups are stored in insertion order (first group created is first yielded)
+/// - Hidden documents are included in grouping
+pub struct GroupByNode {
+    source: Box<dyn PlanNode>,
+    group_by: GroupBy,
+    document_mapping: DocumentMapping,
+    /// Groups keyed by their group key string
+    groups: Vec<(String, DocumentGroup)>,
+    /// Current position in groups
+    position: usize,
+    /// Current document
+    current_doc: Doc,
+    /// Whether start() has been called
+    started: bool,
+}
+
+impl GroupByNode {
+    /// Create a new GroupByNode
+    pub fn new(
+        source: Box<dyn PlanNode>,
+        group_by: GroupBy,
+        document_mapping: DocumentMapping,
+    ) -> Self {
+        Self {
+            source,
+            group_by,
+            document_mapping,
+            groups: Vec::new(),
+            position: 0,
+            current_doc: Doc::default(),
+            started: false,
+        }
+    }
+
+    /// Get the groups (for aggregation nodes to access)
+    pub fn groups(&self) -> &[(String, DocumentGroup)] {
+        &self.groups
+    }
+
+    /// Generate a group key from document field values
+    /// Format: `{field_index}_{field_value}_` for each GROUP BY field
+    fn generate_key(&self, doc: &Doc) -> String {
+        let mut key = String::new();
+        for field_name in &self.group_by.fields {
+            if let Some(index) = self.document_mapping.first_index_of_name(field_name) {
+                key.push_str(&format!("{}_", index));
+                let value = doc.get(index);
+                key.push_str(&format!("{}_", Self::value_to_key(value)));
+            }
+        }
+        key
+    }
+
+    /// Convert a JSON value to a string key component
+    fn value_to_key(value: Option<&JsonValue>) -> String {
+        match value {
+            None | Some(JsonValue::Null) => "null".to_string(),
+            Some(JsonValue::Bool(b)) => b.to_string(),
+            Some(JsonValue::Number(n)) => n.to_string(),
+            Some(JsonValue::String(s)) => s.clone(),
+            Some(JsonValue::Array(arr)) => {
+                format!(
+                    "[{}]",
+                    arr.iter()
+                        .map(|v| Self::value_to_key(Some(v)))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+            Some(JsonValue::Object(obj)) => {
+                format!(
+                    "{{{}}}",
+                    obj.iter()
+                        .map(|(k, v)| format!("{}:{}", k, Self::value_to_key(Some(v))))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl PlanNode for GroupByNode {
+    async fn init(&mut self) -> Result<()> {
+        self.groups.clear();
+        self.position = 0;
+        self.started = false;
+        self.source.init().await
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        self.source.start().await?;
+        self.started = true;
+
+        // Buffer all documents and group them
+        let mut group_map: HashMap<String, usize> = HashMap::new();
+
+        while self.source.next().await? {
+            let doc = self.source.value().deep_clone();
+            let key = self.generate_key(&doc);
+
+            if let Some(&idx) = group_map.get(&key) {
+                self.groups[idx].1.add(doc);
+            } else {
+                let idx = self.groups.len();
+                group_map.insert(key.clone(), idx);
+                self.groups.push((key, DocumentGroup::new(doc)));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if !self.started {
+            self.start().await?;
+        }
+
+        if self.position >= self.groups.len() {
+            return Ok(false);
+        }
+
+        // Return the representative document for the current group
+        self.current_doc = self.groups[self.position].1.representative.deep_clone();
+        self.position += 1;
+        Ok(true)
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.source.close().await
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        Some(self.source.as_ref())
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "groupByNode"
+    }
+
+    fn current_group_docs(&self) -> Option<&[Doc]> {
+        // Position is incremented after next(), so position-1 is the current group
+        if self.position > 0 && self.position <= self.groups.len() {
+            Some(&self.groups[self.position - 1].1.docs)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::ScanNode;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    fn make_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "department", FieldKind::string()),
+                FieldDescription::new("4", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "department");
+        mapping.add(3, "age");
+        mapping.add_render_key(0, "_docID");
+        mapping.add_render_key(1, "name");
+        mapping.add_render_key(2, "department");
+        mapping.add_render_key(3, "age");
+        mapping
+    }
+
+    fn make_test_docs() -> Vec<Doc> {
+        vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!("Engineering")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                Some(json!("Sales")),
+                Some(json!(25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!("Engineering")),
+                Some(json!(35)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc4")),
+                Some(json!("Diana")),
+                Some(json!("Sales")),
+                Some(json!(28)),
+            ]),
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_group_by_single_field() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        let docs = make_test_docs();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let mut node = GroupByNode::new(Box::new(scan), group_by, mapping);
+
+        node.init().await.unwrap();
+
+        // Should get 2 groups (Engineering and Sales)
+        assert!(node.next().await.unwrap());
+        let doc1 = node.value().deep_clone();
+
+        assert!(node.next().await.unwrap());
+        let doc2 = node.value().deep_clone();
+
+        // No more groups
+        assert!(!node.next().await.unwrap());
+
+        // Get department values
+        let dept1 = doc1.get(2).and_then(|v| v.as_str()).unwrap();
+        let dept2 = doc2.get(2).and_then(|v| v.as_str()).unwrap();
+
+        // Both Engineering and Sales should be present
+        let depts: Vec<&str> = vec![dept1, dept2];
+        assert!(depts.contains(&"Engineering"));
+        assert!(depts.contains(&"Sales"));
+
+        node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_group_by_preserves_groups() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        let docs = make_test_docs();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let mut node = GroupByNode::new(Box::new(scan), group_by, mapping);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        // Check that groups have correct document counts
+        assert_eq!(node.groups().len(), 2);
+
+        // Find Engineering group
+        let eng_group = node
+            .groups()
+            .iter()
+            .find(|(_, g)| g.representative.get(2).and_then(|v| v.as_str()) == Some("Engineering"));
+        assert!(eng_group.is_some());
+        assert_eq!(eng_group.unwrap().1.docs.len(), 2); // Alice and Charlie
+
+        // Find Sales group
+        let sales_group = node
+            .groups()
+            .iter()
+            .find(|(_, g)| g.representative.get(2).and_then(|v| v.as_str()) == Some("Sales"));
+        assert!(sales_group.is_some());
+        assert_eq!(sales_group.unwrap().1.docs.len(), 2); // Bob and Diana
+
+        node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_group_by_empty_source() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let mut node = GroupByNode::new(Box::new(scan), group_by, mapping);
+
+        node.init().await.unwrap();
+
+        // No groups from empty source
+        assert!(!node.next().await.unwrap());
+
+        node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_group_by_handles_null_values() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!("Engineering")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                None, // null department
+                Some(json!(25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                None, // null department
+                Some(json!(35)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let mut node = GroupByNode::new(Box::new(scan), group_by, mapping);
+
+        node.init().await.unwrap();
+        node.start().await.unwrap();
+
+        // Should have 2 groups: Engineering and null
+        assert_eq!(node.groups().len(), 2);
+
+        node.close().await.unwrap();
+    }
+}

--- a/crates/query/src/plan/groupby.rs
+++ b/crates/query/src/plan/groupby.rs
@@ -5,7 +5,7 @@ use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 
 use crate::document::DocumentMapping;
-use crate::error::Result;
+use crate::error::{QueryError, Result};
 use crate::mapper::GroupBy;
 use crate::planner::{Doc, PlanNode};
 
@@ -80,16 +80,24 @@ impl GroupByNode {
 
     /// Generate a group key from document field values
     /// Format: `{field_index}_{field_value}_` for each GROUP BY field
-    fn generate_key(&self, doc: &Doc) -> String {
+    /// Returns an error if any GROUP BY field is not found in the document mapping
+    fn generate_key(&self, doc: &Doc) -> Result<String> {
         let mut key = String::new();
         for field_name in &self.group_by.fields {
-            if let Some(index) = self.document_mapping.first_index_of_name(field_name) {
-                key.push_str(&format!("{}_", index));
-                let value = doc.get(index);
-                key.push_str(&format!("{}_", Self::value_to_key(value)));
-            }
+            let index = self
+                .document_mapping
+                .first_index_of_name(field_name)
+                .ok_or_else(|| {
+                    QueryError::unknown_field(format!(
+                        "GROUP BY field '{}' not found in document mapping",
+                        field_name
+                    ))
+                })?;
+            key.push_str(&format!("{}_", index));
+            let value = doc.get(index);
+            key.push_str(&format!("{}_", Self::value_to_key(value)));
         }
-        key
+        Ok(key)
     }
 
     /// Convert a JSON value to a string key component
@@ -139,7 +147,7 @@ impl PlanNode for GroupByNode {
 
         while self.source.next().await? {
             let doc = self.source.value().deep_clone();
-            let key = self.generate_key(&doc);
+            let key = self.generate_key(&doc)?;
 
             if let Some(&idx) = group_map.get(&key) {
                 self.groups[idx].1.add(doc);

--- a/crates/query/src/plan/max.rs
+++ b/crates/query/src/plan/max.rs
@@ -1,0 +1,461 @@
+//! MaxNode for computing MAX aggregate
+
+use async_trait::async_trait;
+use serde_json::Value as JsonValue;
+
+use crate::document::DocumentMapping;
+use crate::error::Result;
+use crate::planner::{Doc, PlanNode};
+
+/// MaxNode computes the maximum of a numeric field from its source.
+///
+/// Operates in two modes:
+/// - Without GROUP BY: Finds max of all documents and yields a single result
+/// - With GROUP BY: For each group, adds the max to the document
+///
+/// Null values are skipped. Returns null if no values found.
+pub struct MaxNode {
+    source: Box<dyn PlanNode>,
+    document_mapping: DocumentMapping,
+    /// Index of the field to find max
+    field_index: usize,
+    /// Index in the document where max result should be stored
+    aggregate_index: usize,
+    /// The current maximum value (for non-grouped mode)
+    max: Option<f64>,
+    /// Whether we've seen any float values
+    has_float: bool,
+    /// Current document with max result
+    current_doc: Doc,
+    /// Whether we've already yielded the result (for non-grouped mode)
+    done: bool,
+    /// Whether start() has been called
+    started: bool,
+    /// Whether we're in grouped mode (source provides group docs)
+    grouped_mode: bool,
+}
+
+impl MaxNode {
+    /// Create a new MaxNode wrapping a source
+    pub fn new(
+        source: Box<dyn PlanNode>,
+        document_mapping: DocumentMapping,
+        field_index: usize,
+        aggregate_index: usize,
+    ) -> Self {
+        Self {
+            source,
+            document_mapping,
+            field_index,
+            aggregate_index,
+            max: None,
+            has_float: false,
+            current_doc: Doc::default(),
+            done: false,
+            started: false,
+            grouped_mode: false,
+        }
+    }
+
+    /// Extract numeric value from JSON, returning None for nulls
+    fn extract_numeric(value: Option<&JsonValue>) -> Option<(f64, bool)> {
+        match value {
+            Some(JsonValue::Number(n)) => n
+                .as_i64()
+                .map(|i| (i as f64, false))
+                .or_else(|| n.as_f64().map(|f| (f, true))),
+            _ => None,
+        }
+    }
+
+    /// Compute max of a slice of documents
+    fn compute_max(&self, docs: &[Doc]) -> (Option<f64>, bool) {
+        let mut max: Option<f64> = None;
+        let mut has_float = false;
+
+        for doc in docs {
+            if doc.hidden {
+                continue;
+            }
+            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                max = Some(match max {
+                    None => val,
+                    Some(current) => current.max(val),
+                });
+                has_float = has_float || is_float;
+            }
+        }
+
+        (max, has_float)
+    }
+
+    /// Convert max to JSON value
+    fn max_to_json(max: Option<f64>, has_float: bool) -> JsonValue {
+        match max {
+            None => JsonValue::Null,
+            Some(val) if has_float => {
+                JsonValue::Number(serde_json::Number::from_f64(val).unwrap_or_else(|| 0.into()))
+            }
+            Some(val) => JsonValue::Number((val as i64).into()),
+        }
+    }
+}
+
+#[async_trait]
+impl PlanNode for MaxNode {
+    async fn init(&mut self) -> Result<()> {
+        self.max = None;
+        self.has_float = false;
+        self.done = false;
+        self.started = false;
+        self.grouped_mode = false;
+        self.source.init().await
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        self.source.start().await?;
+        self.started = true;
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if !self.started {
+            self.start().await?;
+        }
+
+        // Try to get next from source
+        if !self.source.next().await? {
+            // No more source documents
+            if !self.grouped_mode && !self.done {
+                // Non-grouped mode: Return the single result
+                self.done = true;
+                let num_fields = self
+                    .document_mapping
+                    .next_index()
+                    .max(self.aggregate_index + 1);
+                let mut doc = Doc::new(num_fields);
+                doc.set(
+                    self.aggregate_index,
+                    Self::max_to_json(self.max, self.has_float),
+                );
+                self.current_doc = doc;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        // Check if source provides group docs
+        if let Some(group_docs) = self.source.current_group_docs() {
+            // Grouped mode: find max in this group
+            self.grouped_mode = true;
+            let (group_max, group_has_float) = self.compute_max(group_docs);
+
+            // Clone the current doc from source and add the max
+            let mut doc = self.source.value().deep_clone();
+            if doc.num_fields() <= self.aggregate_index {
+                doc.set(self.aggregate_index, JsonValue::Null);
+            }
+            doc.set(
+                self.aggregate_index,
+                Self::max_to_json(group_max, group_has_float),
+            );
+            self.current_doc = doc;
+            return Ok(true);
+        }
+
+        // Non-grouped mode: track maximum
+        let doc = self.source.value();
+        if !doc.hidden {
+            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                self.max = Some(match self.max {
+                    None => val,
+                    Some(current) => current.max(val),
+                });
+                self.has_float = self.has_float || is_float;
+            }
+        }
+
+        // Continue iterating
+        Box::pin(self.next()).await
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.source.close().await
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        Some(self.source.as_ref())
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "maxNode"
+    }
+
+    fn current_group_docs(&self) -> Option<&[Doc]> {
+        // Pass through from source for stacked aggregates
+        self.source.current_group_docs()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::ScanNode;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    fn make_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    fn make_test_docs() -> Vec<Doc> {
+        vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                Some(json!(25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(35)),
+            ]),
+        ]
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "age");
+        mapping.add(3, "_max");
+        mapping.add_render_key(3, "_max");
+        mapping
+    }
+
+    #[tokio::test]
+    async fn test_max_integer_field() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        let docs = make_test_docs();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut max_node = MaxNode::new(Box::new(scan), mapping, 2, 3);
+
+        max_node.init().await.unwrap();
+
+        assert!(max_node.next().await.unwrap());
+        let result = max_node.value();
+        // max(30, 25, 35) = 35
+        assert_eq!(result.get(3), Some(&json!(35)));
+
+        assert!(!max_node.next().await.unwrap());
+        max_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_max_empty_source() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+        let mut max_node = MaxNode::new(Box::new(scan), mapping, 2, 3);
+
+        max_node.init().await.unwrap();
+
+        assert!(max_node.next().await.unwrap());
+        let result = max_node.value();
+        // Should return null for empty
+        assert_eq!(result.get(3), Some(&JsonValue::Null));
+
+        max_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_max_with_nulls() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                None, // null age
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(35)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut max_node = MaxNode::new(Box::new(scan), mapping, 2, 3);
+
+        max_node.init().await.unwrap();
+
+        assert!(max_node.next().await.unwrap());
+        let result = max_node.value();
+        // max(30, 35) = 35 (null skipped)
+        assert_eq!(result.get(3), Some(&json!(35)));
+
+        max_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_max_float_field() {
+        let collection = CollectionVersion::new(
+            "Products",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "price", FieldKind::float64()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "price");
+        mapping.add(3, "_max");
+        mapping.add_render_key(3, "_max");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Item A")),
+                Some(json!(10.5)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Item B")),
+                Some(json!(5.25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Item C")),
+                Some(json!(15.75)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut max_node = MaxNode::new(Box::new(scan), mapping, 2, 3);
+
+        max_node.init().await.unwrap();
+
+        assert!(max_node.next().await.unwrap());
+        let result = max_node.value();
+        // max(10.5, 5.25, 15.75) = 15.75
+        let max_val = result.get(3).unwrap().as_f64().unwrap();
+        assert!((max_val - 15.75).abs() < 0.001);
+
+        max_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_max_with_groupby() {
+        use crate::mapper::GroupBy;
+        use crate::plan::GroupByNode;
+
+        let collection = CollectionVersion::new(
+            "Sales",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "department", FieldKind::string()),
+                FieldDescription::new("3", "amount", FieldKind::int()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "department");
+        mapping.add(2, "amount");
+        mapping.add(3, "_max");
+        mapping.add_render_key(1, "department");
+        mapping.add_render_key(3, "_max");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Engineering")),
+                Some(json!(100)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Sales")),
+                Some(json!(200)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Engineering")),
+                Some(json!(150)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc4")),
+                Some(json!("Sales")),
+                Some(json!(250)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let groupby_node = GroupByNode::new(Box::new(scan), group_by, mapping.clone());
+        let mut max_node = MaxNode::new(Box::new(groupby_node), mapping, 2, 3);
+
+        max_node.init().await.unwrap();
+
+        let mut results = Vec::new();
+        while max_node.next().await.unwrap() {
+            results.push(max_node.value().deep_clone());
+        }
+
+        assert_eq!(results.len(), 2);
+
+        // Find Engineering group (max of 100, 150 = 150)
+        let eng = results
+            .iter()
+            .find(|d| d.get(1).and_then(|v| v.as_str()) == Some("Engineering"))
+            .unwrap();
+        assert_eq!(eng.get(3), Some(&json!(150)));
+
+        // Find Sales group (max of 200, 250 = 250)
+        let sales = results
+            .iter()
+            .find(|d| d.get(1).and_then(|v| v.as_str()) == Some("Sales"))
+            .unwrap();
+        assert_eq!(sales.get(3), Some(&json!(250)));
+
+        max_node.close().await.unwrap();
+    }
+}

--- a/crates/query/src/plan/max.rs
+++ b/crates/query/src/plan/max.rs
@@ -90,11 +90,15 @@ impl MaxNode {
     }
 
     /// Convert max to JSON value
+    /// Returns Null for NaN/Infinity to prevent silent data corruption
     fn max_to_json(max: Option<f64>, has_float: bool) -> JsonValue {
         match max {
             None => JsonValue::Null,
             Some(val) if has_float => {
-                JsonValue::Number(serde_json::Number::from_f64(val).unwrap_or_else(|| 0.into()))
+                // NaN and Infinity cannot be represented in JSON - return null
+                serde_json::Number::from_f64(val)
+                    .map(JsonValue::Number)
+                    .unwrap_or(JsonValue::Null)
             }
             Some(val) => JsonValue::Number((val as i64).into()),
         }
@@ -123,60 +127,61 @@ impl PlanNode for MaxNode {
             self.start().await?;
         }
 
-        // Try to get next from source
-        if !self.source.next().await? {
-            // No more source documents
-            if !self.grouped_mode && !self.done {
-                // Non-grouped mode: Return the single result
-                self.done = true;
-                let num_fields = self
-                    .document_mapping
-                    .next_index()
-                    .max(self.aggregate_index + 1);
-                let mut doc = Doc::new(num_fields);
+        loop {
+            // Try to get next from source
+            if !self.source.next().await? {
+                // No more source documents
+                if !self.grouped_mode && !self.done {
+                    // Non-grouped mode: Return the single result
+                    self.done = true;
+                    let num_fields = self
+                        .document_mapping
+                        .next_index()
+                        .max(self.aggregate_index + 1);
+                    let mut doc = Doc::new(num_fields);
+                    doc.set(
+                        self.aggregate_index,
+                        Self::max_to_json(self.max, self.has_float),
+                    );
+                    self.current_doc = doc;
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+
+            // Check if source provides group docs
+            if let Some(group_docs) = self.source.current_group_docs() {
+                // Grouped mode: find max in this group
+                self.grouped_mode = true;
+                let (group_max, group_has_float) = self.compute_max(group_docs);
+
+                // Clone the current doc from source and add the max
+                let mut doc = self.source.value().deep_clone();
+                if doc.num_fields() <= self.aggregate_index {
+                    doc.set(self.aggregate_index, JsonValue::Null);
+                }
                 doc.set(
                     self.aggregate_index,
-                    Self::max_to_json(self.max, self.has_float),
+                    Self::max_to_json(group_max, group_has_float),
                 );
                 self.current_doc = doc;
                 return Ok(true);
             }
-            return Ok(false);
-        }
 
-        // Check if source provides group docs
-        if let Some(group_docs) = self.source.current_group_docs() {
-            // Grouped mode: find max in this group
-            self.grouped_mode = true;
-            let (group_max, group_has_float) = self.compute_max(group_docs);
-
-            // Clone the current doc from source and add the max
-            let mut doc = self.source.value().deep_clone();
-            if doc.num_fields() <= self.aggregate_index {
-                doc.set(self.aggregate_index, JsonValue::Null);
+            // Non-grouped mode: track maximum
+            let doc = self.source.value();
+            if !doc.hidden {
+                if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                    self.max = Some(match self.max {
+                        None => val,
+                        Some(current) => current.max(val),
+                    });
+                    self.has_float = self.has_float || is_float;
+                }
             }
-            doc.set(
-                self.aggregate_index,
-                Self::max_to_json(group_max, group_has_float),
-            );
-            self.current_doc = doc;
-            return Ok(true);
-        }
 
-        // Non-grouped mode: track maximum
-        let doc = self.source.value();
-        if !doc.hidden {
-            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
-                self.max = Some(match self.max {
-                    None => val,
-                    Some(current) => current.max(val),
-                });
-                self.has_float = self.has_float || is_float;
-            }
+            // Continue iterating (loop continues)
         }
-
-        // Continue iterating
-        Box::pin(self.next()).await
     }
 
     fn value(&self) -> &Doc {

--- a/crates/query/src/plan/min.rs
+++ b/crates/query/src/plan/min.rs
@@ -90,11 +90,15 @@ impl MinNode {
     }
 
     /// Convert min to JSON value
+    /// Returns Null for NaN/Infinity to prevent silent data corruption
     fn min_to_json(min: Option<f64>, has_float: bool) -> JsonValue {
         match min {
             None => JsonValue::Null,
             Some(val) if has_float => {
-                JsonValue::Number(serde_json::Number::from_f64(val).unwrap_or_else(|| 0.into()))
+                // NaN and Infinity cannot be represented in JSON - return null
+                serde_json::Number::from_f64(val)
+                    .map(JsonValue::Number)
+                    .unwrap_or(JsonValue::Null)
             }
             Some(val) => JsonValue::Number((val as i64).into()),
         }
@@ -123,60 +127,61 @@ impl PlanNode for MinNode {
             self.start().await?;
         }
 
-        // Try to get next from source
-        if !self.source.next().await? {
-            // No more source documents
-            if !self.grouped_mode && !self.done {
-                // Non-grouped mode: Return the single result
-                self.done = true;
-                let num_fields = self
-                    .document_mapping
-                    .next_index()
-                    .max(self.aggregate_index + 1);
-                let mut doc = Doc::new(num_fields);
+        loop {
+            // Try to get next from source
+            if !self.source.next().await? {
+                // No more source documents
+                if !self.grouped_mode && !self.done {
+                    // Non-grouped mode: Return the single result
+                    self.done = true;
+                    let num_fields = self
+                        .document_mapping
+                        .next_index()
+                        .max(self.aggregate_index + 1);
+                    let mut doc = Doc::new(num_fields);
+                    doc.set(
+                        self.aggregate_index,
+                        Self::min_to_json(self.min, self.has_float),
+                    );
+                    self.current_doc = doc;
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+
+            // Check if source provides group docs
+            if let Some(group_docs) = self.source.current_group_docs() {
+                // Grouped mode: find min in this group
+                self.grouped_mode = true;
+                let (group_min, group_has_float) = self.compute_min(group_docs);
+
+                // Clone the current doc from source and add the min
+                let mut doc = self.source.value().deep_clone();
+                if doc.num_fields() <= self.aggregate_index {
+                    doc.set(self.aggregate_index, JsonValue::Null);
+                }
                 doc.set(
                     self.aggregate_index,
-                    Self::min_to_json(self.min, self.has_float),
+                    Self::min_to_json(group_min, group_has_float),
                 );
                 self.current_doc = doc;
                 return Ok(true);
             }
-            return Ok(false);
-        }
 
-        // Check if source provides group docs
-        if let Some(group_docs) = self.source.current_group_docs() {
-            // Grouped mode: find min in this group
-            self.grouped_mode = true;
-            let (group_min, group_has_float) = self.compute_min(group_docs);
-
-            // Clone the current doc from source and add the min
-            let mut doc = self.source.value().deep_clone();
-            if doc.num_fields() <= self.aggregate_index {
-                doc.set(self.aggregate_index, JsonValue::Null);
+            // Non-grouped mode: track minimum
+            let doc = self.source.value();
+            if !doc.hidden {
+                if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                    self.min = Some(match self.min {
+                        None => val,
+                        Some(current) => current.min(val),
+                    });
+                    self.has_float = self.has_float || is_float;
+                }
             }
-            doc.set(
-                self.aggregate_index,
-                Self::min_to_json(group_min, group_has_float),
-            );
-            self.current_doc = doc;
-            return Ok(true);
-        }
 
-        // Non-grouped mode: track minimum
-        let doc = self.source.value();
-        if !doc.hidden {
-            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
-                self.min = Some(match self.min {
-                    None => val,
-                    Some(current) => current.min(val),
-                });
-                self.has_float = self.has_float || is_float;
-            }
+            // Continue iterating (loop continues)
         }
-
-        // Continue iterating
-        Box::pin(self.next()).await
     }
 
     fn value(&self) -> &Doc {

--- a/crates/query/src/plan/min.rs
+++ b/crates/query/src/plan/min.rs
@@ -1,0 +1,461 @@
+//! MinNode for computing MIN aggregate
+
+use async_trait::async_trait;
+use serde_json::Value as JsonValue;
+
+use crate::document::DocumentMapping;
+use crate::error::Result;
+use crate::planner::{Doc, PlanNode};
+
+/// MinNode computes the minimum of a numeric field from its source.
+///
+/// Operates in two modes:
+/// - Without GROUP BY: Finds min of all documents and yields a single result
+/// - With GROUP BY: For each group, adds the min to the document
+///
+/// Null values are skipped. Returns null if no values found.
+pub struct MinNode {
+    source: Box<dyn PlanNode>,
+    document_mapping: DocumentMapping,
+    /// Index of the field to find min
+    field_index: usize,
+    /// Index in the document where min result should be stored
+    aggregate_index: usize,
+    /// The current minimum value (for non-grouped mode)
+    min: Option<f64>,
+    /// Whether we've seen any float values
+    has_float: bool,
+    /// Current document with min result
+    current_doc: Doc,
+    /// Whether we've already yielded the result (for non-grouped mode)
+    done: bool,
+    /// Whether start() has been called
+    started: bool,
+    /// Whether we're in grouped mode (source provides group docs)
+    grouped_mode: bool,
+}
+
+impl MinNode {
+    /// Create a new MinNode wrapping a source
+    pub fn new(
+        source: Box<dyn PlanNode>,
+        document_mapping: DocumentMapping,
+        field_index: usize,
+        aggregate_index: usize,
+    ) -> Self {
+        Self {
+            source,
+            document_mapping,
+            field_index,
+            aggregate_index,
+            min: None,
+            has_float: false,
+            current_doc: Doc::default(),
+            done: false,
+            started: false,
+            grouped_mode: false,
+        }
+    }
+
+    /// Extract numeric value from JSON, returning None for nulls
+    fn extract_numeric(value: Option<&JsonValue>) -> Option<(f64, bool)> {
+        match value {
+            Some(JsonValue::Number(n)) => n
+                .as_i64()
+                .map(|i| (i as f64, false))
+                .or_else(|| n.as_f64().map(|f| (f, true))),
+            _ => None,
+        }
+    }
+
+    /// Compute min of a slice of documents
+    fn compute_min(&self, docs: &[Doc]) -> (Option<f64>, bool) {
+        let mut min: Option<f64> = None;
+        let mut has_float = false;
+
+        for doc in docs {
+            if doc.hidden {
+                continue;
+            }
+            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                min = Some(match min {
+                    None => val,
+                    Some(current) => current.min(val),
+                });
+                has_float = has_float || is_float;
+            }
+        }
+
+        (min, has_float)
+    }
+
+    /// Convert min to JSON value
+    fn min_to_json(min: Option<f64>, has_float: bool) -> JsonValue {
+        match min {
+            None => JsonValue::Null,
+            Some(val) if has_float => {
+                JsonValue::Number(serde_json::Number::from_f64(val).unwrap_or_else(|| 0.into()))
+            }
+            Some(val) => JsonValue::Number((val as i64).into()),
+        }
+    }
+}
+
+#[async_trait]
+impl PlanNode for MinNode {
+    async fn init(&mut self) -> Result<()> {
+        self.min = None;
+        self.has_float = false;
+        self.done = false;
+        self.started = false;
+        self.grouped_mode = false;
+        self.source.init().await
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        self.source.start().await?;
+        self.started = true;
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if !self.started {
+            self.start().await?;
+        }
+
+        // Try to get next from source
+        if !self.source.next().await? {
+            // No more source documents
+            if !self.grouped_mode && !self.done {
+                // Non-grouped mode: Return the single result
+                self.done = true;
+                let num_fields = self
+                    .document_mapping
+                    .next_index()
+                    .max(self.aggregate_index + 1);
+                let mut doc = Doc::new(num_fields);
+                doc.set(
+                    self.aggregate_index,
+                    Self::min_to_json(self.min, self.has_float),
+                );
+                self.current_doc = doc;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        // Check if source provides group docs
+        if let Some(group_docs) = self.source.current_group_docs() {
+            // Grouped mode: find min in this group
+            self.grouped_mode = true;
+            let (group_min, group_has_float) = self.compute_min(group_docs);
+
+            // Clone the current doc from source and add the min
+            let mut doc = self.source.value().deep_clone();
+            if doc.num_fields() <= self.aggregate_index {
+                doc.set(self.aggregate_index, JsonValue::Null);
+            }
+            doc.set(
+                self.aggregate_index,
+                Self::min_to_json(group_min, group_has_float),
+            );
+            self.current_doc = doc;
+            return Ok(true);
+        }
+
+        // Non-grouped mode: track minimum
+        let doc = self.source.value();
+        if !doc.hidden {
+            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                self.min = Some(match self.min {
+                    None => val,
+                    Some(current) => current.min(val),
+                });
+                self.has_float = self.has_float || is_float;
+            }
+        }
+
+        // Continue iterating
+        Box::pin(self.next()).await
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.source.close().await
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        Some(self.source.as_ref())
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "minNode"
+    }
+
+    fn current_group_docs(&self) -> Option<&[Doc]> {
+        // Pass through from source for stacked aggregates
+        self.source.current_group_docs()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::ScanNode;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    fn make_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    fn make_test_docs() -> Vec<Doc> {
+        vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                Some(json!(25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(35)),
+            ]),
+        ]
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "age");
+        mapping.add(3, "_min");
+        mapping.add_render_key(3, "_min");
+        mapping
+    }
+
+    #[tokio::test]
+    async fn test_min_integer_field() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        let docs = make_test_docs();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut min_node = MinNode::new(Box::new(scan), mapping, 2, 3);
+
+        min_node.init().await.unwrap();
+
+        assert!(min_node.next().await.unwrap());
+        let result = min_node.value();
+        // min(30, 25, 35) = 25
+        assert_eq!(result.get(3), Some(&json!(25)));
+
+        assert!(!min_node.next().await.unwrap());
+        min_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_min_empty_source() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+        let mut min_node = MinNode::new(Box::new(scan), mapping, 2, 3);
+
+        min_node.init().await.unwrap();
+
+        assert!(min_node.next().await.unwrap());
+        let result = min_node.value();
+        // Should return null for empty
+        assert_eq!(result.get(3), Some(&JsonValue::Null));
+
+        min_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_min_with_nulls() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                None, // null age
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(35)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut min_node = MinNode::new(Box::new(scan), mapping, 2, 3);
+
+        min_node.init().await.unwrap();
+
+        assert!(min_node.next().await.unwrap());
+        let result = min_node.value();
+        // min(30, 35) = 30 (null skipped)
+        assert_eq!(result.get(3), Some(&json!(30)));
+
+        min_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_min_float_field() {
+        let collection = CollectionVersion::new(
+            "Products",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "price", FieldKind::float64()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "price");
+        mapping.add(3, "_min");
+        mapping.add_render_key(3, "_min");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Item A")),
+                Some(json!(10.5)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Item B")),
+                Some(json!(5.25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Item C")),
+                Some(json!(15.75)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut min_node = MinNode::new(Box::new(scan), mapping, 2, 3);
+
+        min_node.init().await.unwrap();
+
+        assert!(min_node.next().await.unwrap());
+        let result = min_node.value();
+        // min(10.5, 5.25, 15.75) = 5.25
+        let min_val = result.get(3).unwrap().as_f64().unwrap();
+        assert!((min_val - 5.25).abs() < 0.001);
+
+        min_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_min_with_groupby() {
+        use crate::mapper::GroupBy;
+        use crate::plan::GroupByNode;
+
+        let collection = CollectionVersion::new(
+            "Sales",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "department", FieldKind::string()),
+                FieldDescription::new("3", "amount", FieldKind::int()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "department");
+        mapping.add(2, "amount");
+        mapping.add(3, "_min");
+        mapping.add_render_key(1, "department");
+        mapping.add_render_key(3, "_min");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Engineering")),
+                Some(json!(100)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Sales")),
+                Some(json!(200)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Engineering")),
+                Some(json!(50)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc4")),
+                Some(json!("Sales")),
+                Some(json!(150)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let groupby_node = GroupByNode::new(Box::new(scan), group_by, mapping.clone());
+        let mut min_node = MinNode::new(Box::new(groupby_node), mapping, 2, 3);
+
+        min_node.init().await.unwrap();
+
+        let mut results = Vec::new();
+        while min_node.next().await.unwrap() {
+            results.push(min_node.value().deep_clone());
+        }
+
+        assert_eq!(results.len(), 2);
+
+        // Find Engineering group (min of 100, 50 = 50)
+        let eng = results
+            .iter()
+            .find(|d| d.get(1).and_then(|v| v.as_str()) == Some("Engineering"))
+            .unwrap();
+        assert_eq!(eng.get(3), Some(&json!(50)));
+
+        // Find Sales group (min of 200, 150 = 150)
+        let sales = results
+            .iter()
+            .find(|d| d.get(1).and_then(|v| v.as_str()) == Some("Sales"))
+            .unwrap();
+        assert_eq!(sales.get(3), Some(&json!(150)));
+
+        min_node.close().await.unwrap();
+    }
+}

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -1,11 +1,15 @@
 //! Query plan nodes implementing the Volcano Iterator Model
 
+mod count;
+mod groupby;
 mod limit;
 pub mod mutation;
 mod orderby;
 mod scan;
 mod select;
 
+pub use count::CountNode;
+pub use groupby::{DocumentGroup, GroupByNode};
 pub use limit::LimitNode;
 pub use mutation::{
     CreateInput, CreateNode, DeleteNode, UpdateInput, UpdateNode, UpsertAction, UpsertInput,

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -1,5 +1,6 @@
 //! Query plan nodes implementing the Volcano Iterator Model
 
+mod alldocs;
 mod average;
 mod count;
 mod groupby;
@@ -12,6 +13,7 @@ mod scan;
 mod select;
 mod sum;
 
+pub use alldocs::AllDocsNode;
 pub use average::AverageNode;
 pub use count::CountNode;
 pub use groupby::{DocumentGroup, GroupByNode};

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -1,16 +1,23 @@
 //! Query plan nodes implementing the Volcano Iterator Model
 
+mod average;
 mod count;
 mod groupby;
 mod limit;
+mod max;
+mod min;
 pub mod mutation;
 mod orderby;
 mod scan;
 mod select;
+mod sum;
 
+pub use average::AverageNode;
 pub use count::CountNode;
 pub use groupby::{DocumentGroup, GroupByNode};
 pub use limit::LimitNode;
+pub use max::MaxNode;
+pub use min::MinNode;
 pub use mutation::{
     CreateInput, CreateNode, DeleteNode, UpdateInput, UpdateNode, UpsertAction, UpsertInput,
     UpsertNode,
@@ -18,3 +25,4 @@ pub use mutation::{
 pub use orderby::OrderByNode;
 pub use scan::ScanNode;
 pub use select::SelectNode;
+pub use sum::SumNode;

--- a/crates/query/src/plan/mutation/upsert.rs
+++ b/crates/query/src/plan/mutation/upsert.rs
@@ -193,9 +193,8 @@ impl UpsertNode {
 
     /// Upsert a single document by ID with the given input.
     async fn upsert_by_id(&mut self, doc_id_str: &str, input: &UpsertInput) -> Result<()> {
-        let doc_id = DocID::from_string(doc_id_str).map_err(|e| {
-            QueryError::execution(format!("Invalid DocID '{}': {}", doc_id_str, e))
-        })?;
+        let doc_id = DocID::from_string(doc_id_str)
+            .map_err(|e| QueryError::execution(format!("Invalid DocID '{}': {}", doc_id_str, e)))?;
 
         // Check if document exists
         let existing = self
@@ -399,8 +398,9 @@ mod tests {
     impl DocMutator for MockMutator {
         async fn create(&self, _collection_name: &str, mut doc: Document) -> Result<CreateResult> {
             if doc.id().is_none() {
-                doc.generate_and_set_doc_id()
-                    .map_err(|e| QueryError::execution(format!("Failed to generate DocID: {}", e)))?;
+                doc.generate_and_set_doc_id().map_err(|e| {
+                    QueryError::execution(format!("Failed to generate DocID: {}", e))
+                })?;
             }
 
             let doc_id = doc
@@ -511,8 +511,7 @@ mod tests {
         let doc_id = existing_doc.id().unwrap().to_string();
         mutator.add_doc(existing_doc);
 
-        let input = UpsertInput::new()
-            .with_field("email", json!("alice@new.com"));
+        let input = UpsertInput::new().with_field("email", json!("alice@new.com"));
 
         let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
             .with_doc_ids(vec![doc_id.clone()])
@@ -580,8 +579,7 @@ mod tests {
             .with_field("name", json!("NewUser"))
             .with_field("email", json!("new@example.com"));
 
-        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
-            .with_input(input);
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping).with_input(input);
 
         node.init().await.unwrap();
         node.start().await.unwrap();
@@ -609,8 +607,7 @@ mod tests {
         let mutator = Arc::new(MockMutator::new());
         let mapping = make_test_mapping();
 
-        let input = UpsertInput::new()
-            .with_field("name", json!("Alice"));
+        let input = UpsertInput::new().with_field("name", json!("Alice"));
 
         // Use an invalid DocID format
         let mut node = UpsertNode::new("Users", mutator, mapping)
@@ -643,8 +640,7 @@ mod tests {
                 .with_field("email", json!("user3@example.com")),
         ];
 
-        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
-            .with_inputs(inputs);
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping).with_inputs(inputs);
 
         node.init().await.unwrap();
         node.start().await.unwrap();
@@ -664,8 +660,7 @@ mod tests {
         let mutator = Arc::new(MockMutator::new());
         let mapping = make_test_mapping();
 
-        let input = UpsertInput::new()
-            .with_field("name", json!("Alice"));
+        let input = UpsertInput::new().with_field("name", json!("Alice"));
 
         // Empty doc_ids list
         let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
@@ -686,11 +681,9 @@ mod tests {
         let mutator = Arc::new(MockMutator::new());
         let mapping = make_test_mapping();
 
-        let input = UpsertInput::new()
-            .with_field("name", json!("Alice"));
+        let input = UpsertInput::new().with_field("name", json!("Alice"));
 
-        let mut node = UpsertNode::new("Users", mutator.clone(), mapping)
-            .with_input(input);
+        let mut node = UpsertNode::new("Users", mutator.clone(), mapping).with_input(input);
 
         // First run
         node.init().await.unwrap();

--- a/crates/query/src/plan/orderby.rs
+++ b/crates/query/src/plan/orderby.rs
@@ -122,7 +122,6 @@ impl OrderByNode {
         }
     }
 
-
     /// Static version of compare_docs that doesn't require &self
     fn compare_docs_static(
         a: &Doc,
@@ -186,7 +185,11 @@ impl PlanNode for OrderByNode {
         for condition in &self.order_by.conditions {
             if !condition.fields.is_empty() {
                 let field_name = &condition.fields[0];
-                if self.document_mapping.first_index_of_name(field_name).is_none() {
+                if self
+                    .document_mapping
+                    .first_index_of_name(field_name)
+                    .is_none()
+                {
                     return Err(QueryError::execution(format!(
                         "ORDER BY field '{}' does not exist in the document schema",
                         field_name
@@ -207,9 +210,8 @@ impl PlanNode for OrderByNode {
         let mapping = &self.document_mapping;
 
         // Sort the buffer using stable sort (preserves order of equal elements)
-        self.buffer.sort_by(|a, b| {
-            Self::compare_docs_static(a, b, order_by, mapping)
-        });
+        self.buffer
+            .sort_by(|a, b| Self::compare_docs_static(a, b, order_by, mapping));
 
         Ok(())
     }
@@ -301,8 +303,8 @@ mod tests {
             make_doc("doc3", "Bob", 35),
         ];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("name", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("name", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -332,8 +334,8 @@ mod tests {
             make_doc("doc3", "Bob", 35),
         ];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("name", OrderDirection::Desc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("name", OrderDirection::Desc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -363,8 +365,8 @@ mod tests {
             make_doc("doc3", "Charlie", 35),
         ];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("age", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("age", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -435,8 +437,8 @@ mod tests {
             make_doc("doc3", "Charlie", 25),
         ];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("age", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("age", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -470,8 +472,8 @@ mod tests {
             make_doc("doc3", "Charlie", 25),
         ];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("age", OrderDirection::Desc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("age", OrderDirection::Desc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -499,8 +501,8 @@ mod tests {
         let collection = make_test_collection();
         let mapping = make_test_mapping();
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("name", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("name", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -518,8 +520,8 @@ mod tests {
 
         let docs = vec![make_doc("doc1", "Alice", 30)];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("name", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("name", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -544,8 +546,8 @@ mod tests {
             make_doc("doc3", "Charlie", 35),
         ];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("name", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("name", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -576,8 +578,8 @@ mod tests {
             make_doc("doc3", "Alice", 30),
         ];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("name", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("name", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -675,14 +677,13 @@ mod tests {
         let collection = make_test_collection();
         let mapping = make_test_mapping();
 
-        let docs = vec![
-            make_doc("doc1", "Alice", 30),
-            make_doc("doc2", "Bob", 25),
-        ];
+        let docs = vec![make_doc("doc1", "Alice", 30), make_doc("doc2", "Bob", 25)];
 
         // Order by a field that doesn't exist in the mapping
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("nonexistent_field", OrderDirection::Asc));
+        let order_by = OrderBy::new().with_condition(OrderCondition::new(
+            "nonexistent_field",
+            OrderDirection::Asc,
+        ));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -693,7 +694,8 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            err.to_string().contains("ORDER BY field 'nonexistent_field' does not exist"),
+            err.to_string()
+                .contains("ORDER BY field 'nonexistent_field' does not exist"),
             "Expected error about nonexistent field, got: {}",
             err
         );
@@ -714,8 +716,8 @@ mod tests {
         ];
 
         // Order by age - all ages are equal, so stable sort should preserve order
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("age", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("age", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
@@ -749,8 +751,8 @@ mod tests {
             make_doc("doc4", "Diana", 25),
         ];
 
-        let order_by = OrderBy::new()
-            .with_condition(OrderCondition::new("age", OrderDirection::Asc));
+        let order_by =
+            OrderBy::new().with_condition(OrderCondition::new("age", OrderDirection::Asc));
 
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
         let mut orderby = OrderByNode::new(Box::new(scan), order_by, mapping);

--- a/crates/query/src/plan/sum.rs
+++ b/crates/query/src/plan/sum.rs
@@ -88,9 +88,13 @@ impl SumNode {
     }
 
     /// Convert sum to JSON value (int if no floats, float otherwise)
+    /// Returns Null for NaN/Infinity to prevent silent data corruption
     fn sum_to_json(sum: f64, has_float: bool) -> JsonValue {
         if has_float {
-            JsonValue::Number(serde_json::Number::from_f64(sum).unwrap_or_else(|| 0.into()))
+            // NaN and Infinity cannot be represented in JSON - return null
+            serde_json::Number::from_f64(sum)
+                .map(JsonValue::Number)
+                .unwrap_or(JsonValue::Null)
         } else {
             JsonValue::Number((sum as i64).into())
         }
@@ -119,57 +123,58 @@ impl PlanNode for SumNode {
             self.start().await?;
         }
 
-        // Try to get next from source
-        if !self.source.next().await? {
-            // No more source documents
-            if !self.grouped_mode && !self.done {
-                // Non-grouped mode: Return the single result
-                self.done = true;
-                let num_fields = self
-                    .document_mapping
-                    .next_index()
-                    .max(self.aggregate_index + 1);
-                let mut doc = Doc::new(num_fields);
+        loop {
+            // Try to get next from source
+            if !self.source.next().await? {
+                // No more source documents
+                if !self.grouped_mode && !self.done {
+                    // Non-grouped mode: Return the single result
+                    self.done = true;
+                    let num_fields = self
+                        .document_mapping
+                        .next_index()
+                        .max(self.aggregate_index + 1);
+                    let mut doc = Doc::new(num_fields);
+                    doc.set(
+                        self.aggregate_index,
+                        Self::sum_to_json(self.sum, self.has_float),
+                    );
+                    self.current_doc = doc;
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+
+            // Check if source provides group docs
+            if let Some(group_docs) = self.source.current_group_docs() {
+                // Grouped mode: sum field values in this group
+                self.grouped_mode = true;
+                let (group_sum, group_has_float) = self.compute_sum(group_docs);
+
+                // Clone the current doc from source and add the sum
+                let mut doc = self.source.value().deep_clone();
+                if doc.num_fields() <= self.aggregate_index {
+                    doc.set(self.aggregate_index, JsonValue::Null);
+                }
                 doc.set(
                     self.aggregate_index,
-                    Self::sum_to_json(self.sum, self.has_float),
+                    Self::sum_to_json(group_sum, group_has_float),
                 );
                 self.current_doc = doc;
                 return Ok(true);
             }
-            return Ok(false);
-        }
 
-        // Check if source provides group docs
-        if let Some(group_docs) = self.source.current_group_docs() {
-            // Grouped mode: sum field values in this group
-            self.grouped_mode = true;
-            let (group_sum, group_has_float) = self.compute_sum(group_docs);
-
-            // Clone the current doc from source and add the sum
-            let mut doc = self.source.value().deep_clone();
-            if doc.num_fields() <= self.aggregate_index {
-                doc.set(self.aggregate_index, JsonValue::Null);
+            // Non-grouped mode: accumulate sum
+            let doc = self.source.value();
+            if !doc.hidden {
+                if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                    self.sum += val;
+                    self.has_float = self.has_float || is_float;
+                }
             }
-            doc.set(
-                self.aggregate_index,
-                Self::sum_to_json(group_sum, group_has_float),
-            );
-            self.current_doc = doc;
-            return Ok(true);
-        }
 
-        // Non-grouped mode: accumulate sum
-        let doc = self.source.value();
-        if !doc.hidden {
-            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
-                self.sum += val;
-                self.has_float = self.has_float || is_float;
-            }
+            // Continue iterating to sum all docs (loop continues)
         }
-
-        // Continue iterating to sum all docs
-        Box::pin(self.next()).await
     }
 
     fn value(&self) -> &Doc {

--- a/crates/query/src/plan/sum.rs
+++ b/crates/query/src/plan/sum.rs
@@ -1,0 +1,470 @@
+//! SumNode for computing SUM aggregate
+
+use async_trait::async_trait;
+use serde_json::Value as JsonValue;
+
+use crate::document::DocumentMapping;
+use crate::error::Result;
+use crate::planner::{Doc, PlanNode};
+
+/// SumNode computes the sum of a numeric field from its source.
+///
+/// Operates in two modes:
+/// - Without GROUP BY: Sums all documents and yields a single result
+/// - With GROUP BY: For each group, adds the sum to the document
+///
+/// Null values are skipped. Returns 0 if no values to sum.
+/// Returns f64 if any values are floats, i64 if all integers.
+pub struct SumNode {
+    source: Box<dyn PlanNode>,
+    document_mapping: DocumentMapping,
+    /// Index of the field to sum
+    field_index: usize,
+    /// Index in the document where sum result should be stored
+    aggregate_index: usize,
+    /// The computed sum value as float (for non-grouped mode)
+    sum: f64,
+    /// Whether we've seen any float values
+    has_float: bool,
+    /// Current document with sum result
+    current_doc: Doc,
+    /// Whether we've already yielded the result (for non-grouped mode)
+    done: bool,
+    /// Whether start() has been called
+    started: bool,
+    /// Whether we're in grouped mode (source provides group docs)
+    grouped_mode: bool,
+}
+
+impl SumNode {
+    /// Create a new SumNode wrapping a source
+    pub fn new(
+        source: Box<dyn PlanNode>,
+        document_mapping: DocumentMapping,
+        field_index: usize,
+        aggregate_index: usize,
+    ) -> Self {
+        Self {
+            source,
+            document_mapping,
+            field_index,
+            aggregate_index,
+            sum: 0.0,
+            has_float: false,
+            current_doc: Doc::default(),
+            done: false,
+            started: false,
+            grouped_mode: false,
+        }
+    }
+
+    /// Extract numeric value from JSON, returning None for nulls
+    fn extract_numeric(value: Option<&JsonValue>) -> Option<(f64, bool)> {
+        match value {
+            Some(JsonValue::Number(n)) => n
+                .as_i64()
+                .map(|i| (i as f64, false))
+                .or_else(|| n.as_f64().map(|f| (f, true))),
+            _ => None,
+        }
+    }
+
+    /// Compute sum of a slice of documents
+    fn compute_sum(&self, docs: &[Doc]) -> (f64, bool) {
+        let mut sum = 0.0;
+        let mut has_float = false;
+
+        for doc in docs {
+            if doc.hidden {
+                continue;
+            }
+            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                sum += val;
+                has_float = has_float || is_float;
+            }
+        }
+
+        (sum, has_float)
+    }
+
+    /// Convert sum to JSON value (int if no floats, float otherwise)
+    fn sum_to_json(sum: f64, has_float: bool) -> JsonValue {
+        if has_float {
+            JsonValue::Number(serde_json::Number::from_f64(sum).unwrap_or_else(|| 0.into()))
+        } else {
+            JsonValue::Number((sum as i64).into())
+        }
+    }
+}
+
+#[async_trait]
+impl PlanNode for SumNode {
+    async fn init(&mut self) -> Result<()> {
+        self.sum = 0.0;
+        self.has_float = false;
+        self.done = false;
+        self.started = false;
+        self.grouped_mode = false;
+        self.source.init().await
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        self.source.start().await?;
+        self.started = true;
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if !self.started {
+            self.start().await?;
+        }
+
+        // Try to get next from source
+        if !self.source.next().await? {
+            // No more source documents
+            if !self.grouped_mode && !self.done {
+                // Non-grouped mode: Return the single result
+                self.done = true;
+                let num_fields = self
+                    .document_mapping
+                    .next_index()
+                    .max(self.aggregate_index + 1);
+                let mut doc = Doc::new(num_fields);
+                doc.set(
+                    self.aggregate_index,
+                    Self::sum_to_json(self.sum, self.has_float),
+                );
+                self.current_doc = doc;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        // Check if source provides group docs
+        if let Some(group_docs) = self.source.current_group_docs() {
+            // Grouped mode: sum field values in this group
+            self.grouped_mode = true;
+            let (group_sum, group_has_float) = self.compute_sum(group_docs);
+
+            // Clone the current doc from source and add the sum
+            let mut doc = self.source.value().deep_clone();
+            if doc.num_fields() <= self.aggregate_index {
+                doc.set(self.aggregate_index, JsonValue::Null);
+            }
+            doc.set(
+                self.aggregate_index,
+                Self::sum_to_json(group_sum, group_has_float),
+            );
+            self.current_doc = doc;
+            return Ok(true);
+        }
+
+        // Non-grouped mode: accumulate sum
+        let doc = self.source.value();
+        if !doc.hidden {
+            if let Some((val, is_float)) = Self::extract_numeric(doc.get(self.field_index)) {
+                self.sum += val;
+                self.has_float = self.has_float || is_float;
+            }
+        }
+
+        // Continue iterating to sum all docs
+        Box::pin(self.next()).await
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.source.close().await
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        Some(self.source.as_ref())
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "sumNode"
+    }
+
+    fn current_group_docs(&self) -> Option<&[Doc]> {
+        // Pass through from source for stacked aggregates
+        self.source.current_group_docs()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::ScanNode;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    fn make_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+    }
+
+    fn make_test_docs() -> Vec<Doc> {
+        vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                Some(json!(25)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(35)),
+            ]),
+        ]
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "age");
+        mapping.add(3, "_sum");
+        mapping.add_render_key(3, "_sum");
+        mapping
+    }
+
+    #[tokio::test]
+    async fn test_sum_integer_field() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        let docs = make_test_docs();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        // field_index=2 is "age", aggregate_index=3 is where result goes
+        let mut sum_node = SumNode::new(Box::new(scan), mapping, 2, 3);
+
+        sum_node.init().await.unwrap();
+
+        assert!(sum_node.next().await.unwrap());
+        let result = sum_node.value();
+        // 30 + 25 + 35 = 90
+        assert_eq!(result.get(3), Some(&json!(90)));
+
+        assert!(!sum_node.next().await.unwrap());
+        sum_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sum_empty_source() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+        let mut sum_node = SumNode::new(Box::new(scan), mapping, 2, 3);
+
+        sum_node.init().await.unwrap();
+
+        assert!(sum_node.next().await.unwrap());
+        let result = sum_node.value();
+        assert_eq!(result.get(3), Some(&json!(0)));
+
+        sum_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sum_with_nulls() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Alice")),
+                Some(json!(30)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Bob")),
+                None, // null age
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Charlie")),
+                Some(json!(35)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut sum_node = SumNode::new(Box::new(scan), mapping, 2, 3);
+
+        sum_node.init().await.unwrap();
+
+        assert!(sum_node.next().await.unwrap());
+        let result = sum_node.value();
+        // 30 + 35 = 65 (null skipped)
+        assert_eq!(result.get(3), Some(&json!(65)));
+
+        sum_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sum_float_field() {
+        let collection = CollectionVersion::new(
+            "Products",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "price", FieldKind::float64()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping.add(2, "price");
+        mapping.add(3, "_sum");
+        mapping.add_render_key(3, "_sum");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Item A")),
+                Some(json!(10.5)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Item B")),
+                Some(json!(20.25)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut sum_node = SumNode::new(Box::new(scan), mapping, 2, 3);
+
+        sum_node.init().await.unwrap();
+
+        assert!(sum_node.next().await.unwrap());
+        let result = sum_node.value();
+        // 10.5 + 20.25 = 30.75
+        let sum_val = result.get(3).unwrap().as_f64().unwrap();
+        assert!((sum_val - 30.75).abs() < 0.001);
+
+        sum_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sum_skips_hidden_docs() {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+
+        let mut docs = make_test_docs();
+        docs[1].hidden = true; // Hide Bob (age 25)
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let mut sum_node = SumNode::new(Box::new(scan), mapping, 2, 3);
+
+        sum_node.init().await.unwrap();
+
+        assert!(sum_node.next().await.unwrap());
+        let result = sum_node.value();
+        // 30 + 35 = 65 (25 skipped)
+        assert_eq!(result.get(3), Some(&json!(65)));
+
+        sum_node.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_sum_with_groupby() {
+        use crate::mapper::GroupBy;
+        use crate::plan::GroupByNode;
+
+        let collection = CollectionVersion::new(
+            "Sales",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "department", FieldKind::string()),
+                FieldDescription::new("3", "amount", FieldKind::int()),
+            ],
+        );
+
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "department");
+        mapping.add(2, "amount");
+        mapping.add(3, "_sum");
+        mapping.add_render_key(1, "department");
+        mapping.add_render_key(3, "_sum");
+
+        let docs = vec![
+            Doc::with_fields(vec![
+                Some(json!("doc1")),
+                Some(json!("Engineering")),
+                Some(json!(100)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc2")),
+                Some(json!("Sales")),
+                Some(json!(200)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc3")),
+                Some(json!("Engineering")),
+                Some(json!(150)),
+            ]),
+            Doc::with_fields(vec![
+                Some(json!("doc4")),
+                Some(json!("Sales")),
+                Some(json!(300)),
+            ]),
+        ];
+
+        let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+        let group_by = GroupBy::new(vec!["department".to_string()]);
+        let groupby_node = GroupByNode::new(Box::new(scan), group_by, mapping.clone());
+        let mut sum_node = SumNode::new(Box::new(groupby_node), mapping, 2, 3);
+
+        sum_node.init().await.unwrap();
+
+        let mut results = Vec::new();
+        while sum_node.next().await.unwrap() {
+            results.push(sum_node.value().deep_clone());
+        }
+
+        assert_eq!(results.len(), 2);
+
+        // Find Engineering group (100 + 150 = 250)
+        let eng = results
+            .iter()
+            .find(|d| d.get(1).and_then(|v| v.as_str()) == Some("Engineering"))
+            .unwrap();
+        assert_eq!(eng.get(3), Some(&json!(250)));
+
+        // Find Sales group (200 + 300 = 500)
+        let sales = results
+            .iter()
+            .find(|d| d.get(1).and_then(|v| v.as_str()) == Some("Sales"))
+            .unwrap();
+        assert_eq!(sales.get(3), Some(&json!(500)));
+
+        sum_node.close().await.unwrap();
+    }
+}

--- a/crates/query/src/planner/traits.rs
+++ b/crates/query/src/planner/traits.rs
@@ -153,6 +153,14 @@ pub trait PlanNode: Send + Sync {
 
     /// Get the node type name (for debugging/explain).
     fn kind(&self) -> &'static str;
+
+    /// Get the documents in the current group (for GROUP BY aggregation).
+    ///
+    /// Returns Some(&[Doc]) if this node is a GroupByNode and is positioned on a group,
+    /// None otherwise. Default implementation returns None.
+    fn current_group_docs(&self) -> Option<&[Doc]> {
+        None
+    }
 }
 
 /// Execution statistics for plan nodes

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -11,8 +11,9 @@ use std::collections::{BTreeMap, HashMap};
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
 use crate::mapper::{
-    parse_mutation_name, Field as SelectField, Filter, GroupBy, Limit, Mutation, MutationType,
-    OrderBy, OrderCondition, OrderDirection, Requestable, Select,
+    parse_mutation_name, Aggregate, AggregateTarget, AggregateType, Field as SelectField, Filter,
+    GroupBy, Limit, Mutation, MutationType, OrderBy, OrderCondition, OrderDirection, Requestable,
+    Select,
 };
 
 /// Result of parsing a GraphQL request.
@@ -204,8 +205,22 @@ fn parse_selection_set(
                 let field_name = field.name.clone();
                 let alias = field.alias.clone();
 
-                // Check if this is a nested selection (relation)
-                if !field.selection_set.items.is_empty() {
+                // Check if this is an aggregate field (_count, _sum, _avg, _min, _max)
+                if let Some(agg_type) = AggregateType::parse(&field_name) {
+                    let mut aggregate = parse_aggregate_field(field, agg_type)?;
+
+                    // Set alias if provided
+                    if let Some(ref a) = alias {
+                        aggregate = aggregate.with_alias(a.clone());
+                    }
+
+                    // Add to document mapping
+                    let index = mapping.next_index();
+                    mapping.add(index, agg_type.as_str());
+                    mapping.add_render_key(index, aggregate.output_name());
+
+                    fields.push(Requestable::Aggregate(aggregate));
+                } else if !field.selection_set.items.is_empty() {
                     // This is a nested select (relation)
                     let nested = parse_field_to_select(field)?;
                     fields.push(Requestable::Select(Box::new(nested)));
@@ -345,6 +360,67 @@ fn parse_group_by_value(value: &Value<'_, String>) -> Result<GroupBy> {
     }
 }
 
+/// Parse an aggregate field into an Aggregate.
+///
+/// Handles aggregate functions like `_count`, `_sum(field: "age")`, etc.
+fn parse_aggregate_field(field: &Field<'_, String>, agg_type: AggregateType) -> Result<Aggregate> {
+    let mut target_field: Option<String> = None;
+
+    // Parse arguments (e.g., `field: "age"` for _sum)
+    for (arg_name, arg_value) in &field.arguments {
+        match arg_name.as_str() {
+            "field" => {
+                target_field = Some(match arg_value {
+                    Value::String(s) => s.clone(),
+                    Value::Enum(s) => s.clone(),
+                    _ => return Err(QueryError::parse("field argument must be a string")),
+                });
+            }
+            _ => {
+                return Err(QueryError::parse(format!(
+                    "unknown argument '{}' on aggregate '{}'. Valid arguments are: field",
+                    arg_name,
+                    agg_type.as_str()
+                )));
+            }
+        }
+    }
+
+    // Create the appropriate aggregate
+    let aggregate = match agg_type {
+        AggregateType::Count => {
+            // _count can work without a field argument (counts all docs)
+            if let Some(field_name) = target_field {
+                Aggregate::count().with_target(AggregateTarget::with_field("", field_name))
+            } else {
+                Aggregate::count()
+            }
+        }
+        AggregateType::Sum => {
+            let field_name = target_field
+                .ok_or_else(|| QueryError::parse("_sum requires a 'field' argument"))?;
+            Aggregate::sum(AggregateTarget::with_field("", field_name))
+        }
+        AggregateType::Average => {
+            let field_name = target_field
+                .ok_or_else(|| QueryError::parse("_avg requires a 'field' argument"))?;
+            Aggregate::avg(AggregateTarget::with_field("", field_name))
+        }
+        AggregateType::Min => {
+            let field_name = target_field
+                .ok_or_else(|| QueryError::parse("_min requires a 'field' argument"))?;
+            Aggregate::min(AggregateTarget::with_field("", field_name))
+        }
+        AggregateType::Max => {
+            let field_name = target_field
+                .ok_or_else(|| QueryError::parse("_max requires a 'field' argument"))?;
+            Aggregate::max(AggregateTarget::with_field("", field_name))
+        }
+    };
+
+    Ok(aggregate)
+}
+
 /// Parse docIDs argument into vector of strings.
 fn parse_doc_ids_value(value: &Value<'_, String>) -> Result<Vec<String>> {
     match value {
@@ -402,7 +478,10 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
             }
 
             // UPDATE/DELETE/UPSERT: docIDs to target
-            (MutationType::Update | MutationType::Delete | MutationType::Upsert, "docIDs" | "_docIDs") => {
+            (
+                MutationType::Update | MutationType::Delete | MutationType::Upsert,
+                "docIDs" | "_docIDs",
+            ) => {
                 let doc_ids = parse_doc_ids_value(arg_value)?;
                 mutation.doc_ids = Some(doc_ids);
             }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -23,8 +23,9 @@ use crate::json_convert::normal_value_to_json;
 use crate::mapper::{AggregateType, Mutation, MutationType, Requestable, Select};
 use crate::mutator::DocMutator;
 use crate::plan::{
-    CountNode, CreateInput, CreateNode, DeleteNode, GroupByNode, LimitNode, OrderByNode, ScanNode,
-    SelectNode, UpdateInput, UpdateNode, UpsertInput, UpsertNode,
+    AverageNode, CountNode, CreateInput, CreateNode, DeleteNode, GroupByNode, LimitNode, MaxNode,
+    MinNode, OrderByNode, ScanNode, SelectNode, SumNode, UpdateInput, UpdateNode, UpsertInput,
+    UpsertNode,
 };
 use crate::planner::{Doc, PlanNode};
 use crate::query_parse::{parse_mutations, parse_query};
@@ -410,26 +411,14 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             ));
         }
 
-        // Check for nested selections and unsupported aggregates
+        // Check for nested selections
         for field in &select.fields {
-            match field {
-                Requestable::Select(nested) => {
-                    return Err(QueryError::execution(format!(
-                        "nested selections (relations) are not yet implemented; \
-                         remove the nested '{}' selection",
-                        nested.collection_name
-                    )));
-                }
-                Requestable::Aggregate(agg) => {
-                    // Only _count is supported for now
-                    if agg.aggregate_type != AggregateType::Count {
-                        return Err(QueryError::execution(format!(
-                            "'{}' aggregate is not yet implemented; only _count is supported",
-                            agg.aggregate_type.as_str()
-                        )));
-                    }
-                }
-                Requestable::Field(_) => {}
+            if let Requestable::Select(nested) = field {
+                return Err(QueryError::execution(format!(
+                    "nested selections (relations) are not yet implemented; \
+                     remove the nested '{}' selection",
+                    nested.collection_name
+                )));
             }
         }
 
@@ -484,6 +473,21 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                     let index = mapping.next_index();
                     mapping.add(index, field_name);
                     // Don't add render_key - they may or may not be selected
+                }
+            }
+        }
+
+        // Add aggregate target fields (needed for aggregation but not rendered)
+        for requestable in &select.fields {
+            if let Requestable::Aggregate(agg) = requestable {
+                for target in &agg.targets {
+                    if let Some(ref field_name) = target.field_name {
+                        if mapping.first_index_of_name(field_name).is_none() {
+                            let index = mapping.next_index();
+                            mapping.add(index, field_name);
+                            // Don't add render_key - we don't want to output these fields
+                        }
+                    }
                 }
             }
         }
@@ -573,16 +577,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             }
 
             // Add aggregate nodes
-            for field in &select.fields {
-                if let Requestable::Aggregate(agg) = field {
-                    if agg.aggregate_type == AggregateType::Count {
-                        let agg_index = mapping
-                            .first_index_of_name("_count")
-                            .unwrap_or_else(|| mapping.next_index());
-                        plan = Box::new(CountNode::new(plan, mapping.clone(), agg_index));
-                    }
-                }
-            }
+            plan = Self::add_aggregate_nodes(plan, select, &mapping)?;
 
             // Add OrderByNode for sorting (after grouping/aggregation)
             if let Some(ref order_by) = select.order_by {
@@ -608,18 +603,68 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 
             // Add aggregate nodes
             // Without GROUP BY, aggregates return a single row for the entire result
-            for field in &select.fields {
-                if let Requestable::Aggregate(agg) = field {
-                    if agg.aggregate_type == AggregateType::Count {
-                        let agg_index = mapping
-                            .first_index_of_name("_count")
-                            .unwrap_or_else(|| mapping.next_index());
+            plan = Self::add_aggregate_nodes(plan, select, &mapping)?;
+        }
+
+        Ok(plan)
+    }
+
+    /// Add aggregate nodes to the plan based on the select's aggregate fields.
+    fn add_aggregate_nodes(
+        mut plan: Box<dyn PlanNode>,
+        select: &Select,
+        mapping: &DocumentMapping,
+    ) -> Result<Box<dyn PlanNode>> {
+        for field in &select.fields {
+            if let Requestable::Aggregate(agg) = field {
+                // Get the index where the aggregate result should be stored
+                // Use the aggregate type name for lookup (that's how it's registered in mapping)
+                let agg_type_name = agg.aggregate_type.as_str();
+                let agg_index = mapping
+                    .first_index_of_name(agg_type_name)
+                    .unwrap_or_else(|| mapping.next_index());
+
+                // For aggregates that operate on a field, get the field index
+                let field_index = if !agg.targets.is_empty() && agg.targets[0].field_name.is_some()
+                {
+                    let target_field = agg.targets[0].field_name.as_ref().unwrap();
+                    mapping.first_index_of_name(target_field).ok_or_else(|| {
+                        QueryError::execution(format!(
+                            "aggregate target field '{}' not found in mapping",
+                            target_field
+                        ))
+                    })?
+                } else {
+                    0 // Not used for count
+                };
+
+                match agg.aggregate_type {
+                    AggregateType::Count => {
                         plan = Box::new(CountNode::new(plan, mapping.clone(), agg_index));
+                    }
+                    AggregateType::Sum => {
+                        plan =
+                            Box::new(SumNode::new(plan, mapping.clone(), field_index, agg_index));
+                    }
+                    AggregateType::Average => {
+                        plan = Box::new(AverageNode::new(
+                            plan,
+                            mapping.clone(),
+                            field_index,
+                            agg_index,
+                        ));
+                    }
+                    AggregateType::Min => {
+                        plan =
+                            Box::new(MinNode::new(plan, mapping.clone(), field_index, agg_index));
+                    }
+                    AggregateType::Max => {
+                        plan =
+                            Box::new(MaxNode::new(plan, mapping.clone(), field_index, agg_index));
                     }
                 }
             }
         }
-
         Ok(plan)
     }
 
@@ -2592,19 +2637,175 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unsupported_aggregate_returns_error() {
+    async fn test_sum_aggregate() {
         let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 25i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", 35i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
         let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
 
-        // _sum is not yet implemented
         let result = runner
             .execute_query(r#"{ Users { _sum(field: "age") } }"#)
-            .await;
+            .await
+            .unwrap();
 
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("'_sum' aggregate is not yet implemented"));
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        // 30 + 25 + 35 = 90
+        assert_eq!(users[0].get("_sum").unwrap(), 90);
+    }
+
+    #[tokio::test]
+    async fn test_avg_aggregate() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 20i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", 40i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner
+            .execute_query(r#"{ Users { _avg(field: "age") } }"#)
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        // (30 + 20 + 40) / 3 = 30
+        let avg = users[0].get("_avg").unwrap().as_f64().unwrap();
+        assert!((avg - 30.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_min_max_aggregate() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 25i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", 35i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        // Test min
+        let result = runner
+            .execute_query(r#"{ Users { _min(field: "age") } }"#)
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_min").unwrap(), 25);
+
+        // Test max
+        let result = runner
+            .execute_query(r#"{ Users { _max(field: "age") } }"#)
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_max").unwrap(), 35);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_aggregates_with_groupby() {
+        let fetcher = MockFetcher::new();
+
+        // Create docs in two groups
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Alice");
+        doc2.set("age", 20i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Bob");
+        doc3.set("age", 25i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        // Use GROUP BY so multiple aggregates work correctly
+        let result = runner
+            .execute_query(
+                r#"{ Users(groupBy: [name]) { name _count _sum(field: "age") _avg(field: "age") } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 2);
+
+        // Find Alice group: 2 docs, sum=50, avg=25
+        let alice = users
+            .iter()
+            .find(|u| u["name"].as_str() == Some("Alice"))
+            .unwrap();
+        assert_eq!(alice.get("_count").unwrap(), 2);
+        assert_eq!(alice.get("_sum").unwrap(), 50);
+        let alice_avg = alice.get("_avg").unwrap().as_f64().unwrap();
+        assert!((alice_avg - 25.0).abs() < 0.001);
+
+        // Find Bob group: 1 doc, sum=25, avg=25
+        let bob = users
+            .iter()
+            .find(|u| u["name"].as_str() == Some("Bob"))
+            .unwrap();
+        assert_eq!(bob.get("_count").unwrap(), 1);
+        assert_eq!(bob.get("_sum").unwrap(), 25);
+        let bob_avg = bob.get("_avg").unwrap().as_f64().unwrap();
+        assert!((bob_avg - 25.0).abs() < 0.001);
     }
 }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -20,11 +20,11 @@ use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result, TransactionError};
 use crate::executor::{QueryExecutor, QueryRequest, QueryResponse, QueryResponseError};
 use crate::json_convert::normal_value_to_json;
-use crate::mapper::{Mutation, MutationType, Requestable, Select};
+use crate::mapper::{AggregateType, Mutation, MutationType, Requestable, Select};
 use crate::mutator::DocMutator;
 use crate::plan::{
-    CreateInput, CreateNode, DeleteNode, LimitNode, OrderByNode, ScanNode, SelectNode, UpdateInput,
-    UpdateNode, UpsertInput, UpsertNode,
+    CountNode, CreateInput, CreateNode, DeleteNode, GroupByNode, LimitNode, OrderByNode, ScanNode,
+    SelectNode, UpdateInput, UpdateNode, UpsertInput, UpsertNode,
 };
 use crate::planner::{Doc, PlanNode};
 use crate::query_parse::{parse_mutations, parse_query};
@@ -404,25 +404,32 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 
     /// Validate that the select doesn't use unsupported features.
     fn validate_select(&self, select: &Select) -> Result<()> {
-        if select.group_by.is_some() {
-            return Err(QueryError::execution(
-                "grouping is not yet implemented; remove the 'groupBy' argument",
-            ));
-        }
         if select.cid.is_some() {
             return Err(QueryError::execution(
                 "CID-based queries are not yet implemented; remove the 'cid' argument",
             ));
         }
 
-        // Check for nested selections (relations)
+        // Check for nested selections and unsupported aggregates
         for field in &select.fields {
-            if let Requestable::Select(nested) = field {
-                return Err(QueryError::execution(format!(
-                    "nested selections (relations) are not yet implemented; \
-                     remove the nested '{}' selection",
-                    nested.collection_name
-                )));
+            match field {
+                Requestable::Select(nested) => {
+                    return Err(QueryError::execution(format!(
+                        "nested selections (relations) are not yet implemented; \
+                         remove the nested '{}' selection",
+                        nested.collection_name
+                    )));
+                }
+                Requestable::Aggregate(agg) => {
+                    // Only _count is supported for now
+                    if agg.aggregate_type != AggregateType::Count {
+                        return Err(QueryError::execution(format!(
+                            "'{}' aggregate is not yet implemented; only _count is supported",
+                            agg.aggregate_type.as_str()
+                        )));
+                    }
+                }
+                Requestable::Field(_) => {}
             }
         }
 
@@ -437,11 +444,48 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     ) -> Result<DocumentMapping> {
         let mut mapping = DocumentMapping::new();
 
-        // Add requested fields
-        for field in select.requested_fields() {
-            let index = mapping.next_index();
-            mapping.add(index, &field.name);
-            mapping.add_render_key(index, field.output_name());
+        // Add requested fields and aggregates
+        for requestable in &select.fields {
+            match requestable {
+                Requestable::Field(field) => {
+                    let index = mapping.next_index();
+                    mapping.add(index, &field.name);
+                    mapping.add_render_key(index, field.output_name());
+                }
+                Requestable::Aggregate(agg) => {
+                    let index = mapping.next_index();
+                    let name = agg.aggregate_type.as_str();
+                    mapping.add(index, name);
+                    // Use alias if provided, otherwise use the aggregate name
+                    mapping.add_render_key(index, agg.output_name());
+                }
+                Requestable::Select(_) => {
+                    // Nested selections will be handled when relations are implemented
+                }
+            }
+        }
+
+        // Add fields referenced by the filter (but not selected)
+        // These are needed for filter evaluation but won't be rendered
+        if let Some(ref filter) = select.filter {
+            for field_name in filter.referenced_fields() {
+                if mapping.first_index_of_name(&field_name).is_none() {
+                    let index = mapping.next_index();
+                    mapping.add(index, &field_name);
+                    // Don't add render_key - we don't want to output these fields
+                }
+            }
+        }
+
+        // Add GROUP BY fields (they need to be in mapping for grouping)
+        if let Some(ref group_by) = select.group_by {
+            for field_name in &group_by.fields {
+                if mapping.first_index_of_name(field_name).is_none() {
+                    let index = mapping.next_index();
+                    mapping.add(index, field_name);
+                    // Don't add render_key - they may or may not be selected
+                }
+            }
         }
 
         // If no fields specified, add all from collection
@@ -517,14 +561,63 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             plan = Box::new(select_node);
         }
 
-        // Add OrderByNode for sorting (after filtering, before limit)
-        if let Some(ref order_by) = select.order_by {
-            plan = Box::new(OrderByNode::new(plan, order_by.clone(), mapping.clone()));
-        }
+        // Check if we have GROUP BY
+        let has_group_by = select.group_by.is_some();
 
-        // Add LimitNode if needed
-        if let Some(ref limit) = select.limit {
-            plan = Box::new(LimitNode::new(plan, limit.limit, limit.offset));
+        if has_group_by {
+            // WITH GROUP BY: GroupByNode → Aggregates → OrderBy → Limit
+
+            // Add GroupByNode
+            if let Some(ref group_by) = select.group_by {
+                plan = Box::new(GroupByNode::new(plan, group_by.clone(), mapping.clone()));
+            }
+
+            // Add aggregate nodes
+            for field in &select.fields {
+                if let Requestable::Aggregate(agg) = field {
+                    if agg.aggregate_type == AggregateType::Count {
+                        let agg_index = mapping
+                            .first_index_of_name("_count")
+                            .unwrap_or_else(|| mapping.next_index());
+                        plan = Box::new(CountNode::new(plan, mapping.clone(), agg_index));
+                    }
+                }
+            }
+
+            // Add OrderByNode for sorting (after grouping/aggregation)
+            if let Some(ref order_by) = select.order_by {
+                plan = Box::new(OrderByNode::new(plan, order_by.clone(), mapping.clone()));
+            }
+
+            // Add LimitNode
+            if let Some(ref limit) = select.limit {
+                plan = Box::new(LimitNode::new(plan, limit.limit, limit.offset));
+            }
+        } else {
+            // WITHOUT GROUP BY: OrderBy → Limit → Aggregates
+
+            // Add OrderByNode for sorting (after filtering, before limit)
+            if let Some(ref order_by) = select.order_by {
+                plan = Box::new(OrderByNode::new(plan, order_by.clone(), mapping.clone()));
+            }
+
+            // Add LimitNode
+            if let Some(ref limit) = select.limit {
+                plan = Box::new(LimitNode::new(plan, limit.limit, limit.offset));
+            }
+
+            // Add aggregate nodes
+            // Without GROUP BY, aggregates return a single row for the entire result
+            for field in &select.fields {
+                if let Requestable::Aggregate(agg) = field {
+                    if agg.aggregate_type == AggregateType::Count {
+                        let agg_index = mapping
+                            .first_index_of_name("_count")
+                            .unwrap_or_else(|| mapping.next_index());
+                        plan = Box::new(CountNode::new(plan, mapping.clone(), agg_index));
+                    }
+                }
+            }
         }
 
         Ok(plan)
@@ -1103,19 +1196,91 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_group_by_returns_error() {
+    async fn test_group_by_single_field() {
         let fetcher = MockFetcher::new();
+
+        // Add test documents with same names (will group together)
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 25i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Alice");
+        doc3.set("age", 35i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
         let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
 
         let result = runner
             .execute_query("{ Users(groupBy: [name]) { name } }")
-            .await;
+            .await
+            .unwrap();
 
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("grouping is not yet implemented"));
+        let users = result["Users"].as_array().unwrap();
+        // Should get 2 groups: Alice and Bob
+        assert_eq!(users.len(), 2);
+
+        let names: Vec<&str> = users.iter().map(|u| u["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"Alice"));
+        assert!(names.contains(&"Bob"));
+    }
+
+    #[tokio::test]
+    async fn test_group_by_with_count() {
+        let fetcher = MockFetcher::new();
+
+        // Add test documents: 2 in Engineering, 2 in Sales
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 25i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Alice");
+        doc3.set("age", 35i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner
+            .execute_query("{ Users(groupBy: [name]) { name _count } }")
+            .await
+            .unwrap();
+
+        let users = result["Users"].as_array().unwrap();
+        // Should get 2 groups: Alice (count 2) and Bob (count 1)
+        assert_eq!(users.len(), 2);
+
+        // Find Alice group and verify count
+        let alice = users
+            .iter()
+            .find(|u| u["name"].as_str() == Some("Alice"))
+            .unwrap();
+        assert_eq!(alice["_count"].as_i64(), Some(2));
+
+        // Find Bob group and verify count
+        let bob = users
+            .iter()
+            .find(|u| u["name"].as_str() == Some("Bob"))
+            .unwrap();
+        assert_eq!(bob["_count"].as_i64(), Some(1));
     }
 
     #[tokio::test]
@@ -1727,11 +1892,7 @@ mod tests {
         let mut unique_ids = doc_ids.clone();
         unique_ids.sort();
         unique_ids.dedup();
-        assert_eq!(
-            unique_ids.len(),
-            3,
-            "Each document should have a unique ID"
-        );
+        assert_eq!(unique_ids.len(), 3, "Each document should have a unique ID");
     }
 
     #[tokio::test]
@@ -2176,9 +2337,7 @@ mod tests {
 
         // Delete only users with age > 30
         let result = runner
-            .execute_mutation(
-                r#"mutation { delete_Users(filter: {age: {_gt: 30}}) { _docID } }"#,
-            )
+            .execute_mutation(r#"mutation { delete_Users(filter: {age: {_gt: 30}}) { _docID } }"#)
             .await
             .unwrap();
 
@@ -2322,5 +2481,130 @@ mod tests {
         // Only doc1 should be updated (docIDs takes priority)
         assert_eq!(users.len(), 1);
         assert_eq!(users[0].get("_docID").unwrap().as_str().unwrap(), doc1_id);
+    }
+
+    // =============================================================================
+    // Aggregation Tests
+    // =============================================================================
+
+    #[tokio::test]
+    async fn test_count_all_documents() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 25i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", 35i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner.execute_query("{ Users { _count } }").await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_count").unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_count_with_alias() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner
+            .execute_query("{ Users { total: _count } }")
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("total").unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_count_with_filter() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 25i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", 35i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner
+            .execute_query(r#"{ Users(filter: {age: {_gte: 30}}) { _count } }"#)
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        // Should count only Alice and Charlie (age >= 30)
+        assert_eq!(users[0].get("_count").unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_count_empty_collection() {
+        let fetcher = MockFetcher::new();
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner.execute_query("{ Users { _count } }").await.unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_count").unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_aggregate_returns_error() {
+        let fetcher = MockFetcher::new();
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        // _sum is not yet implemented
+        let result = runner
+            .execute_query(r#"{ Users { _sum(field: "age") } }"#)
+            .await;
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("'_sum' aggregate is not yet implemented"));
     }
 }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -23,9 +23,9 @@ use crate::json_convert::normal_value_to_json;
 use crate::mapper::{AggregateType, Mutation, MutationType, Requestable, Select};
 use crate::mutator::DocMutator;
 use crate::plan::{
-    AverageNode, CountNode, CreateInput, CreateNode, DeleteNode, GroupByNode, LimitNode, MaxNode,
-    MinNode, OrderByNode, ScanNode, SelectNode, SumNode, UpdateInput, UpdateNode, UpsertInput,
-    UpsertNode,
+    AllDocsNode, AverageNode, CountNode, CreateInput, CreateNode, DeleteNode, GroupByNode,
+    LimitNode, MaxNode, MinNode, OrderByNode, ScanNode, SelectNode, SumNode, UpdateInput,
+    UpdateNode, UpsertInput, UpsertNode,
 };
 use crate::planner::{Doc, PlanNode};
 use crate::query_parse::{parse_mutations, parse_query};
@@ -130,8 +130,8 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             .get(&select.collection_name)
             .ok_or_else(|| QueryError::collection_not_found(&select.collection_name))?;
 
-        // Validate unsupported features
-        self.validate_select(select)?;
+        // Validate unsupported features and field references
+        self.validate_select(select, collection)?;
 
         // Fetch documents from storage
         let docs = if let Some(ref doc_ids) = select.doc_ids {
@@ -404,7 +404,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     }
 
     /// Validate that the select doesn't use unsupported features.
-    fn validate_select(&self, select: &Select) -> Result<()> {
+    fn validate_select(&self, select: &Select, collection: &CollectionVersion) -> Result<()> {
         if select.cid.is_some() {
             return Err(QueryError::execution(
                 "CID-based queries are not yet implemented; remove the 'cid' argument",
@@ -419,6 +419,39 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                      remove the nested '{}' selection",
                     nested.collection_name
                 )));
+            }
+        }
+
+        // Helper to check if a field exists in the collection schema
+        let field_exists = |name: &str| -> bool {
+            name == "_docID" || collection.fields.iter().any(|f| f.name == name)
+        };
+
+        // Validate aggregate target fields exist in schema
+        for requestable in &select.fields {
+            if let Requestable::Aggregate(agg) = requestable {
+                for target in &agg.targets {
+                    if let Some(ref field_name) = target.field_name {
+                        if !field_exists(field_name) {
+                            return Err(QueryError::unknown_field(format!(
+                                "aggregate target field '{}' not found in collection '{}'",
+                                field_name, select.collection_name
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Validate GROUP BY fields exist in schema
+        if let Some(ref group_by) = select.group_by {
+            for field_name in &group_by.fields {
+                if !field_exists(field_name) {
+                    return Err(QueryError::unknown_field(format!(
+                        "GROUP BY field '{}' not found in collection '{}'",
+                        field_name, select.collection_name
+                    )));
+                }
             }
         }
 
@@ -589,7 +622,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 plan = Box::new(LimitNode::new(plan, limit.limit, limit.offset));
             }
         } else {
-            // WITHOUT GROUP BY: OrderBy → Limit → Aggregates
+            // WITHOUT GROUP BY: OrderBy → Limit → [AllDocs if multiple aggs] → Aggregates
 
             // Add OrderByNode for sorting (after filtering, before limit)
             if let Some(ref order_by) = select.order_by {
@@ -599,6 +632,19 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             // Add LimitNode
             if let Some(ref limit) = select.limit {
                 plan = Box::new(LimitNode::new(plan, limit.limit, limit.offset));
+            }
+
+            // Count aggregates to determine if we need AllDocsNode
+            let aggregate_count = select
+                .fields
+                .iter()
+                .filter(|f| matches!(f, Requestable::Aggregate(_)))
+                .count();
+
+            // If there are multiple aggregates, wrap in AllDocsNode so they all
+            // can access the original documents via current_group_docs()
+            if aggregate_count > 1 {
+                plan = Box::new(AllDocsNode::new(plan, mapping.clone()));
             }
 
             // Add aggregate nodes
@@ -620,9 +666,12 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 // Get the index where the aggregate result should be stored
                 // Use the aggregate type name for lookup (that's how it's registered in mapping)
                 let agg_type_name = agg.aggregate_type.as_str();
-                let agg_index = mapping
-                    .first_index_of_name(agg_type_name)
-                    .unwrap_or_else(|| mapping.next_index());
+                let agg_index = mapping.first_index_of_name(agg_type_name).ok_or_else(|| {
+                    QueryError::internal(format!(
+                        "aggregate '{}' not found in document mapping - this is a bug",
+                        agg_type_name
+                    ))
+                })?;
 
                 // For aggregates that operate on a field, get the field index
                 let field_index = if !agg.targets.is_empty() && agg.targets[0].field_name.is_some()
@@ -2807,5 +2856,338 @@ mod tests {
         assert_eq!(bob.get("_sum").unwrap(), 25);
         let bob_avg = bob.get("_avg").unwrap().as_f64().unwrap();
         assert!((bob_avg - 25.0).abs() < 0.001);
+    }
+
+    // ==========================================================================
+    // Edge Case Tests
+    // ==========================================================================
+
+    #[tokio::test]
+    async fn test_aggregate_on_nonexistent_field_returns_error() {
+        let fetcher = MockFetcher::new();
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner
+            .execute_query(r#"{ Users { _sum(field: "nonexistent_field") } }"#)
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_groupby_unknown_field_returns_error() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner
+            .execute_query(r#"{ Users(groupBy: [unknown_field]) { name } }"#)
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_with_negative_numbers() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", -50i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 100i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", -25i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        // Sum: -50 + 100 + (-25) = 25
+        let result = runner
+            .execute_query(r#"{ Users { _sum(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users[0].get("_sum").unwrap(), 25);
+
+        // Min: -50
+        let result = runner
+            .execute_query(r#"{ Users { _min(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users[0].get("_min").unwrap(), -50);
+
+        // Max: 100
+        let result = runner
+            .execute_query(r#"{ Users { _max(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users[0].get("_max").unwrap(), 100);
+
+        // Avg: 25 / 3 ≈ 8.33
+        let result = runner
+            .execute_query(r#"{ Users { _avg(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        let avg = users[0].get("_avg").unwrap().as_f64().unwrap();
+        assert!((avg - 8.333).abs() < 0.01);
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_mixed_int_and_float() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 10i64); // int
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 20.5f64); // float
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        // Sum should return float since one value is float: 10 + 20.5 = 30.5
+        let result = runner
+            .execute_query(r#"{ Users { _sum(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        let sum = users[0].get("_sum").unwrap().as_f64().unwrap();
+        assert!((sum - 30.5).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_aggregates_without_groupby() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 20i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", 40i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner
+            .execute_query(
+                r#"{ Users { _count _sum(field: "age") _min(field: "age") _max(field: "age") } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1); // Single aggregated result
+
+        assert_eq!(users[0].get("_count").unwrap(), 3);
+        assert_eq!(users[0].get("_sum").unwrap(), 90);
+        assert_eq!(users[0].get("_min").unwrap(), 20);
+        assert_eq!(users[0].get("_max").unwrap(), 40);
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_on_string_field_returns_zero() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 25i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        // SUM on string field returns 0 (skips non-numeric values)
+        let result = runner
+            .execute_query(r#"{ Users { _sum(field: "name") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users[0].get("_sum").unwrap(), 0);
+
+        // MIN on string field returns null
+        let result = runner
+            .execute_query(r#"{ Users { _min(field: "name") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert!(users[0].get("_min").unwrap().is_null());
+
+        // AVG on string field returns null (SQL semantics for empty set)
+        let result = runner
+            .execute_query(r#"{ Users { _avg(field: "name") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert!(users[0].get("_avg").unwrap().is_null());
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_empty_collection_semantics() {
+        let fetcher = MockFetcher::new();
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        // COUNT on empty: 0
+        let result = runner
+            .execute_query(r#"{ Users { _count } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].get("_count").unwrap(), 0);
+
+        // SUM on empty: 0 (no values to sum)
+        let result = runner
+            .execute_query(r#"{ Users { _sum(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users[0].get("_sum").unwrap(), 0);
+
+        // AVG on empty: null (SQL semantics)
+        let result = runner
+            .execute_query(r#"{ Users { _avg(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert!(users[0].get("_avg").unwrap().is_null());
+
+        // MIN on empty: null
+        let result = runner
+            .execute_query(r#"{ Users { _min(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert!(users[0].get("_min").unwrap().is_null());
+
+        // MAX on empty: null
+        let result = runner
+            .execute_query(r#"{ Users { _max(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert!(users[0].get("_max").unwrap().is_null());
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_with_filter() {
+        let fetcher = MockFetcher::new();
+
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Bob");
+        doc2.set("age", 20i64);
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let mut doc3 = Document::new();
+        doc3.set("name", "Charlie");
+        doc3.set("age", 40i64);
+        doc3.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc3);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        // SUM with filter: only age >= 30 (30 + 40 = 70)
+        let result = runner
+            .execute_query(r#"{ Users(filter: {age: {_gte: 30}}) { _sum(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users[0].get("_sum").unwrap(), 70);
+
+        // AVG with filter: (30 + 40) / 2 = 35
+        let result = runner
+            .execute_query(r#"{ Users(filter: {age: {_gte: 30}}) { _avg(field: "age") } }"#)
+            .await
+            .unwrap();
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        let avg = users[0].get("_avg").unwrap().as_f64().unwrap();
+        assert!((avg - 35.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_groupby_all_null_values_in_field() {
+        let fetcher = MockFetcher::new();
+
+        // Both docs have null age
+        let mut doc1 = Document::new();
+        doc1.set("name", "Alice");
+        // age is null (not set)
+        doc1.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("name", "Alice");
+        // age is null (not set)
+        doc2.generate_and_set_doc_id().unwrap();
+        fetcher.add_doc("Users", doc2);
+
+        let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
+
+        let result = runner
+            .execute_query(
+                r#"{ Users(groupBy: [name]) { name _sum(field: "age") _avg(field: "age") } }"#,
+            )
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1);
+
+        let alice = &users[0];
+        // SUM of no values is 0
+        assert_eq!(alice.get("_sum").unwrap(), 0);
+        // AVG of no values is null (SQL semantics)
+        assert!(alice.get("_avg").unwrap().is_null());
     }
 }


### PR DESCRIPTION
## Summary

- Implement Phase 1 (basic `_count`) and Phase 2 (`GROUP BY` + count) of aggregation support
- Add `CountNode` for counting documents (single result or per-group)
- Add `GroupByNode` for grouping documents by field values
- Add aggregate parsing for `_count`, `_sum`, `_avg`, `_min`, `_max` (only `_count` implemented so far)
- Add `current_group_docs()` to `PlanNode` trait for aggregate access to group data

## Test plan

- [x] `test_count_all_documents` - basic count returns total
- [x] `test_count_empty_collection` - count on empty returns 0
- [x] `test_count_with_alias` - `total: _count` works
- [x] `test_count_with_filter` - count respects WHERE filter
- [x] `test_group_by_single_field` - GROUP BY returns one row per group
- [x] `test_group_by_with_count` - GROUP BY + _count returns correct counts per group
- [x] All 324 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)