### PR TITLE
feat(storage): Add index query execution layer (Phase 2a)

### DIFF
--- a/crates/storage/src/index/eq_iterator.rs
+++ b/crates/storage/src/index/eq_iterator.rs
@@ -11,7 +11,7 @@
 //! Exact match iterator for index lookups
 //!
 //! Provides iteration over index entries that exactly match specific field values.
-//! Maps to Go's `eqSingleIndexIterator` and supports both unique and non-unique indexes.
+//! Supports both unique and non-unique indexes.
 
 use async_trait::async_trait;
 use document::NormalValue;
@@ -36,11 +36,10 @@ pub struct ExactMatchIterator {
     key_prefix: Vec<u8>,
     /// The exact field values being matched
     values: Vec<NormalValue>,
-    /// Whether this is a unique index (reserved for future use in value decoding)
-    #[allow(dead_code)]
-    is_unique: bool,
     /// Single result for unique index direct lookup (consumed on first next())
     unique_result: Option<IndexEntry>,
+    /// Cached copy of unique_result for reset() support
+    cached_unique_result: Option<IndexEntry>,
     /// Whether the iterator has been exhausted
     exhausted: bool,
 }
@@ -66,8 +65,8 @@ impl ExactMatchIterator {
             inner: Some(inner),
             key_prefix,
             values: values.to_vec(),
-            is_unique: false,
             unique_result: None,
+            cached_unique_result: None,
             exhausted: false,
         })
     }
@@ -98,8 +97,8 @@ impl ExactMatchIterator {
                 inner: Some(inner),
                 key_prefix,
                 values: values.to_vec(),
-                is_unique: true,
                 unique_result: None,
+                cached_unique_result: None,
                 exhausted: false,
             })
         } else {
@@ -116,7 +115,7 @@ impl ExactMatchIterator {
                 inner: None, // No iterator needed for direct lookup
                 key_prefix,
                 values: values.to_vec(),
-                is_unique: true,
+                cached_unique_result: unique_result.clone(),
                 unique_result,
                 exhausted: false,
             })
@@ -180,6 +179,10 @@ impl IndexIterator for ExactMatchIterator {
     async fn reset(&mut self) -> Result<()> {
         if let Some(ref mut iter) = self.inner {
             iter.reset().await?;
+        }
+        // Restore unique_result from cache for unique index direct lookups
+        if self.cached_unique_result.is_some() && self.unique_result.is_none() {
+            self.unique_result = self.cached_unique_result.clone();
         }
         self.exhausted = false;
         Ok(())

--- a/crates/storage/src/index/eq_iterator.rs
+++ b/crates/storage/src/index/eq_iterator.rs
@@ -1,0 +1,398 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//! Exact match iterator for index lookups
+//!
+//! Provides iteration over index entries that exactly match specific field values.
+//! Maps to Go's `eqSingleIndexIterator` and supports both unique and non-unique indexes.
+
+use async_trait::async_trait;
+use document::NormalValue;
+use schema::IndexDescription;
+
+use super::iterator::{IndexEntry, IndexIterator};
+use crate::corekv::{IterOptions, Iterator, Reader, Result};
+use crate::keys::datastore::IndexedField;
+use crate::keys::IndexDataStoreKey;
+
+/// Iterator for exact match queries on an index.
+///
+/// For SimpleIndex: scans all entries with the exact encoded value prefix,
+/// extracting document IDs from the key suffix.
+///
+/// For UniqueIndex: performs a direct lookup for non-NULL values (single result),
+/// or prefix scan for NULL values (multiple results allowed).
+pub struct ExactMatchIterator {
+    /// The underlying KV iterator (None after exhaustion or for unique index after first result)
+    inner: Option<Box<dyn Iterator>>,
+    /// The key prefix (encoded field values without doc_id)
+    key_prefix: Vec<u8>,
+    /// The exact field values being matched
+    values: Vec<NormalValue>,
+    /// Whether this is a unique index (reserved for future use in value decoding)
+    #[allow(dead_code)]
+    is_unique: bool,
+    /// Single result for unique index direct lookup (consumed on first next())
+    unique_result: Option<IndexEntry>,
+    /// Whether the iterator has been exhausted
+    exhausted: bool,
+}
+
+impl ExactMatchIterator {
+    /// Create a new exact match iterator for a simple (non-unique) index.
+    ///
+    /// Scans all index entries with the given field values.
+    pub async fn new_simple<R: Reader + Send + ?Sized>(
+        txn: &R,
+        collection_short_id: u32,
+        desc: &IndexDescription,
+        values: &[NormalValue],
+    ) -> Result<Self> {
+        let fields = build_indexed_fields(values, desc);
+        let key_prefix =
+            IndexDataStoreKey::new(collection_short_id, desc.id, fields).try_bytes()?;
+
+        let opts = IterOptions::default().with_prefix(key_prefix.clone());
+        let inner = txn.iterator(opts).await?;
+
+        Ok(Self {
+            inner: Some(inner),
+            key_prefix,
+            values: values.to_vec(),
+            is_unique: false,
+            unique_result: None,
+            exhausted: false,
+        })
+    }
+
+    /// Create a new exact match iterator for a unique index.
+    ///
+    /// For non-NULL values: performs direct key lookup (single result).
+    /// For NULL values: performs prefix scan (multiple results allowed).
+    pub async fn new_unique<R: Reader + Send + ?Sized>(
+        txn: &R,
+        collection_short_id: u32,
+        desc: &IndexDescription,
+        values: &[NormalValue],
+    ) -> Result<Self> {
+        let fields = build_indexed_fields(values, desc);
+        let key_prefix =
+            IndexDataStoreKey::new(collection_short_id, desc.id, fields).try_bytes()?;
+
+        // Check if any value is nil - if so, use prefix scan like SimpleIndex
+        let has_nil = values.iter().any(|v| v.is_nil());
+
+        if has_nil {
+            // NULL values: use prefix scan (multiple documents can have NULL)
+            let opts = IterOptions::default().with_prefix(key_prefix.clone());
+            let inner = txn.iterator(opts).await?;
+
+            Ok(Self {
+                inner: Some(inner),
+                key_prefix,
+                values: values.to_vec(),
+                is_unique: true,
+                unique_result: None,
+                exhausted: false,
+            })
+        } else {
+            // Non-NULL values: direct lookup, doc_id stored in value
+            let unique_result = if let Some(value_bytes) = txn.get(&key_prefix).await? {
+                let doc_id = String::from_utf8(value_bytes)
+                    .map_err(|e| crate::corekv::Error::Other(e.to_string()))?;
+                Some(IndexEntry::new(doc_id, values.to_vec()))
+            } else {
+                None
+            };
+
+            Ok(Self {
+                inner: None, // No iterator needed for direct lookup
+                key_prefix,
+                values: values.to_vec(),
+                is_unique: true,
+                unique_result,
+                exhausted: false,
+            })
+        }
+    }
+
+    /// Extract the document ID from an index key.
+    ///
+    /// For simple index keys, the doc_id is appended after the encoded field values.
+    fn extract_doc_id(&self, key: &[u8]) -> Result<String> {
+        // The key is: [prefix_bytes][doc_id_bytes]
+        // where prefix_bytes is what we already have in key_prefix
+        if key.len() <= self.key_prefix.len() {
+            return Err(crate::corekv::Error::Other(
+                "index key too short to contain doc_id".to_string(),
+            ));
+        }
+        let doc_id_bytes = &key[self.key_prefix.len()..];
+        String::from_utf8(doc_id_bytes.to_vec())
+            .map_err(|e| crate::corekv::Error::Other(format!("invalid doc_id in index key: {}", e)))
+    }
+}
+
+#[async_trait]
+impl IndexIterator for ExactMatchIterator {
+    async fn next(&mut self) -> Result<Option<IndexEntry>> {
+        if self.exhausted {
+            return Ok(None);
+        }
+
+        // Check for single unique result first
+        if let Some(entry) = self.unique_result.take() {
+            self.exhausted = true;
+            return Ok(Some(entry));
+        }
+
+        // Use the inner iterator if available
+        if let Some(ref mut iter) = self.inner {
+            if let Some(kv) = iter.next().await? {
+                // For unique index with NULL: doc_id is in key suffix
+                // For simple index: doc_id is in key suffix
+                // For unique index without NULL: handled above via unique_result
+                let doc_id = self.extract_doc_id(&kv.key)?;
+                return Ok(Some(IndexEntry::new(doc_id, self.values.clone())));
+            }
+        }
+
+        self.exhausted = true;
+        Ok(None)
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        if let Some(ref mut iter) = self.inner {
+            iter.close().await?;
+        }
+        self.inner = None;
+        self.exhausted = true;
+        Ok(())
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        if let Some(ref mut iter) = self.inner {
+            iter.reset().await?;
+        }
+        self.exhausted = false;
+        Ok(())
+    }
+}
+
+/// Build IndexedField structs from values and index description.
+fn build_indexed_fields(values: &[NormalValue], desc: &IndexDescription) -> Vec<IndexedField> {
+    values
+        .iter()
+        .zip(desc.fields.iter())
+        .map(|(value, field_desc)| IndexedField::new(value.clone(), field_desc.descending))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::MemoryStore;
+    use crate::corekv::Store;
+    use crate::index::{CollectionIndex, SimpleIndex, UniqueIndex};
+    use schema::IndexedFieldDescription;
+
+    fn test_index_description(unique: bool) -> IndexDescription {
+        IndexDescription {
+            id: 1,
+            name: "test_index".to_string(),
+            unique,
+            fields: vec![IndexedFieldDescription {
+                name: "name".to_string(),
+                descending: false,
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_exact_match_simple_single_result() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = test_index_description(false);
+        let index = SimpleIndex::new(1, desc.clone());
+
+        index
+            .save(
+                &mut txn,
+                "doc1",
+                &[NormalValue::String("alice".to_string())],
+            )
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = ExactMatchIterator::new_simple(
+            txn.as_ref(),
+            1,
+            &desc,
+            &[NormalValue::String("alice".to_string())],
+        )
+        .await
+        .unwrap();
+
+        let entry = iter.next().await.unwrap();
+        assert!(entry.is_some());
+        let entry = entry.unwrap();
+        assert_eq!(entry.doc_id, "doc1");
+
+        let entry = iter.next().await.unwrap();
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_exact_match_simple_multiple_results() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = test_index_description(false);
+        let index = SimpleIndex::new(1, desc.clone());
+
+        // Same value, multiple documents
+        index
+            .save(
+                &mut txn,
+                "doc1",
+                &[NormalValue::String("alice".to_string())],
+            )
+            .await
+            .unwrap();
+        index
+            .save(
+                &mut txn,
+                "doc2",
+                &[NormalValue::String("alice".to_string())],
+            )
+            .await
+            .unwrap();
+        index
+            .save(&mut txn, "doc3", &[NormalValue::String("bob".to_string())])
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = ExactMatchIterator::new_simple(
+            txn.as_ref(),
+            1,
+            &desc,
+            &[NormalValue::String("alice".to_string())],
+        )
+        .await
+        .unwrap();
+
+        let entries = iter.collect_all().await.unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|e| e.doc_id == "doc1"));
+        assert!(entries.iter().any(|e| e.doc_id == "doc2"));
+    }
+
+    #[tokio::test]
+    async fn test_exact_match_unique_single_result() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = test_index_description(true);
+        let index = UniqueIndex::new(1, desc.clone());
+
+        index
+            .save(
+                &mut txn,
+                "doc1",
+                &[NormalValue::String("alice".to_string())],
+            )
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = ExactMatchIterator::new_unique(
+            txn.as_ref(),
+            1,
+            &desc,
+            &[NormalValue::String("alice".to_string())],
+        )
+        .await
+        .unwrap();
+
+        let entry = iter.next().await.unwrap();
+        assert!(entry.is_some());
+        let entry = entry.unwrap();
+        assert_eq!(entry.doc_id, "doc1");
+
+        let entry = iter.next().await.unwrap();
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_exact_match_unique_not_found() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = test_index_description(true);
+        let index = UniqueIndex::new(1, desc.clone());
+
+        index
+            .save(
+                &mut txn,
+                "doc1",
+                &[NormalValue::String("alice".to_string())],
+            )
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = ExactMatchIterator::new_unique(
+            txn.as_ref(),
+            1,
+            &desc,
+            &[NormalValue::String("bob".to_string())],
+        )
+        .await
+        .unwrap();
+
+        let entry = iter.next().await.unwrap();
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_exact_match_unique_null_multiple() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = test_index_description(true);
+        let index = UniqueIndex::new(1, desc.clone());
+
+        // Multiple documents with NULL - allowed for unique index
+        index
+            .save(&mut txn, "doc1", &[NormalValue::Null])
+            .await
+            .unwrap();
+        index
+            .save(&mut txn, "doc2", &[NormalValue::Null])
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = ExactMatchIterator::new_unique(txn.as_ref(), 1, &desc, &[NormalValue::Null])
+            .await
+            .unwrap();
+
+        let entries = iter.collect_all().await.unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+}

--- a/crates/storage/src/index/iterator.rs
+++ b/crates/storage/src/index/iterator.rs
@@ -53,11 +53,11 @@ impl IndexEntry {
 /// Bound for range queries on an index field.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Bound {
-    /// Include values equal to or greater than (for forward) or equal to or less than (for reverse)
+    /// Include the bound value in the range (>=, <=)
     Inclusive(NormalValue),
-    /// Exclude values equal to the bound
+    /// Exclude the bound value from the range (>, <)
     Exclusive(NormalValue),
-    /// No bound (unbounded)
+    /// No bound (unbounded in this direction)
     Unbounded,
 }
 

--- a/crates/storage/src/index/iterator.rs
+++ b/crates/storage/src/index/iterator.rs
@@ -1,0 +1,200 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//! Index iterator traits and types for scanning index entries
+//!
+//! This module provides the core abstractions for iterating over index entries:
+//! - `IndexEntry`: A single index entry containing document ID and field values
+//! - `IndexIterator`: Trait for iterating over index entries
+//! - Bound types for configuring range queries
+
+use async_trait::async_trait;
+use document::NormalValue;
+
+use crate::corekv::Result;
+
+/// A single entry from an index scan.
+///
+/// Contains the document ID and the indexed field values for that document.
+/// The values are in the same order as the index field definitions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IndexEntry {
+    /// The document ID this entry points to
+    pub doc_id: String,
+    /// The indexed field values in field order
+    pub values: Vec<NormalValue>,
+}
+
+impl IndexEntry {
+    /// Create a new index entry
+    pub fn new(doc_id: impl Into<String>, values: Vec<NormalValue>) -> Self {
+        Self {
+            doc_id: doc_id.into(),
+            values,
+        }
+    }
+
+    /// Create an index entry with a single value
+    pub fn single(doc_id: impl Into<String>, value: NormalValue) -> Self {
+        Self {
+            doc_id: doc_id.into(),
+            values: vec![value],
+        }
+    }
+}
+
+/// Bound for range queries on an index field.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Bound {
+    /// Include values equal to or greater than (for forward) or equal to or less than (for reverse)
+    Inclusive(NormalValue),
+    /// Exclude values equal to the bound
+    Exclusive(NormalValue),
+    /// No bound (unbounded)
+    Unbounded,
+}
+
+impl Bound {
+    /// Create an inclusive bound (>=)
+    pub fn ge(value: NormalValue) -> Self {
+        Bound::Inclusive(value)
+    }
+
+    /// Create an exclusive bound (>)
+    pub fn gt(value: NormalValue) -> Self {
+        Bound::Exclusive(value)
+    }
+
+    /// Create an inclusive upper bound (<=)
+    pub fn le(value: NormalValue) -> Self {
+        Bound::Inclusive(value)
+    }
+
+    /// Create an exclusive upper bound (<)
+    pub fn lt(value: NormalValue) -> Self {
+        Bound::Exclusive(value)
+    }
+
+    /// Check if this bound is unbounded
+    pub fn is_unbounded(&self) -> bool {
+        matches!(self, Bound::Unbounded)
+    }
+
+    /// Get the value if this is a bounded value
+    pub fn value(&self) -> Option<&NormalValue> {
+        match self {
+            Bound::Inclusive(v) | Bound::Exclusive(v) => Some(v),
+            Bound::Unbounded => None,
+        }
+    }
+}
+
+/// Trait for iterating over index entries.
+///
+/// IndexIterator provides an async interface for scanning index entries.
+/// Implementations handle the specific iteration strategy (exact match, prefix, range).
+#[async_trait]
+pub trait IndexIterator: Send {
+    /// Advance to the next index entry.
+    ///
+    /// Returns:
+    /// - `Ok(Some(IndexEntry))` if there is a next entry
+    /// - `Ok(None)` if iteration is complete
+    /// - `Err(Error)` if an error occurred
+    async fn next(&mut self) -> Result<Option<IndexEntry>>;
+
+    /// Close the iterator and release resources.
+    async fn close(&mut self) -> Result<()>;
+
+    /// Reset the iterator to the beginning.
+    async fn reset(&mut self) -> Result<()>;
+
+    /// Collect all remaining entries into a Vec.
+    ///
+    /// Consumes the iterator. Use with caution for large result sets.
+    async fn collect_all(&mut self) -> Result<Vec<IndexEntry>> {
+        let mut results = Vec::new();
+        while let Some(entry) = self.next().await? {
+            results.push(entry);
+        }
+        Ok(results)
+    }
+
+    /// Count the remaining entries without collecting them.
+    async fn count(&mut self) -> Result<usize> {
+        let mut count = 0;
+        while (self.next().await?).is_some() {
+            count += 1;
+        }
+        Ok(count)
+    }
+}
+
+/// Implement IndexIterator for Box<dyn IndexIterator>
+#[async_trait]
+impl IndexIterator for Box<dyn IndexIterator> {
+    async fn next(&mut self) -> Result<Option<IndexEntry>> {
+        (**self).next().await
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        (**self).close().await
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        (**self).reset().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_entry_new() {
+        let entry = IndexEntry::new(
+            "doc1",
+            vec![
+                NormalValue::String("alice".to_string()),
+                NormalValue::Int(25),
+            ],
+        );
+        assert_eq!(entry.doc_id, "doc1");
+        assert_eq!(entry.values.len(), 2);
+    }
+
+    #[test]
+    fn test_index_entry_single() {
+        let entry = IndexEntry::single("doc1", NormalValue::String("alice".to_string()));
+        assert_eq!(entry.doc_id, "doc1");
+        assert_eq!(entry.values.len(), 1);
+    }
+
+    #[test]
+    fn test_bound_inclusive() {
+        let bound = Bound::ge(NormalValue::Int(10));
+        assert!(!bound.is_unbounded());
+        assert_eq!(bound.value(), Some(&NormalValue::Int(10)));
+    }
+
+    #[test]
+    fn test_bound_exclusive() {
+        let bound = Bound::gt(NormalValue::Int(10));
+        assert!(!bound.is_unbounded());
+        assert_eq!(bound.value(), Some(&NormalValue::Int(10)));
+    }
+
+    #[test]
+    fn test_bound_unbounded() {
+        let bound = Bound::Unbounded;
+        assert!(bound.is_unbounded());
+        assert_eq!(bound.value(), None);
+    }
+}

--- a/crates/storage/src/index/mod.rs
+++ b/crates/storage/src/index/mod.rs
@@ -28,11 +28,25 @@
 //!
 //! For SimpleIndex, the document ID is appended to the key.
 //! For UniqueIndex, the document ID is stored as the value.
+//!
+//! # Query Execution
+//!
+//! Index iterators support:
+//! - Exact match (`get`): Find entries with exact field values
+//! - Prefix scan (`scan_prefix`): Find entries matching first N fields
+//! - Range scan (`scan_range`): Find entries within a range of values
+//! - Full scan (`scan`): Iterate all index entries
 
+mod eq_iterator;
+mod iterator;
+mod range_iterator;
 mod simple;
 mod traits;
 mod unique;
 
+pub use eq_iterator::ExactMatchIterator;
+pub use iterator::{Bound, IndexEntry, IndexIterator};
+pub use range_iterator::RangeIterator;
 pub use simple::SimpleIndex;
 pub use traits::CollectionIndex;
 pub use unique::UniqueIndex;
@@ -111,6 +125,60 @@ impl IndexType {
         match self {
             IndexType::Simple(idx) => idx.remove_all(txn).await,
             IndexType::Unique(idx) => idx.remove_all(txn).await,
+        }
+    }
+
+    /// Get all entries with exact field values.
+    pub async fn get<R: Reader + Send>(
+        &self,
+        txn: &R,
+        values: &[NormalValue],
+    ) -> Result<ExactMatchIterator> {
+        match self {
+            IndexType::Simple(idx) => idx.get(txn, values).await,
+            IndexType::Unique(idx) => idx.get(txn, values).await,
+        }
+    }
+
+    /// Scan all entries in the index.
+    pub async fn scan<R: Reader + Send>(&self, txn: &R, reverse: bool) -> Result<RangeIterator> {
+        match self {
+            IndexType::Simple(idx) => idx.scan(txn, reverse).await,
+            IndexType::Unique(idx) => idx.scan(txn, reverse).await,
+        }
+    }
+
+    /// Scan entries with a prefix match on the first N fields.
+    pub async fn scan_prefix<R: Reader + Send>(
+        &self,
+        txn: &R,
+        prefix_values: &[NormalValue],
+        reverse: bool,
+    ) -> Result<RangeIterator> {
+        match self {
+            IndexType::Simple(idx) => idx.scan_prefix(txn, prefix_values, reverse).await,
+            IndexType::Unique(idx) => idx.scan_prefix(txn, prefix_values, reverse).await,
+        }
+    }
+
+    /// Scan entries within a range on a field.
+    pub async fn scan_range<R: Reader + Send>(
+        &self,
+        txn: &R,
+        prefix_values: &[NormalValue],
+        lower: Bound,
+        upper: Bound,
+        reverse: bool,
+    ) -> Result<RangeIterator> {
+        match self {
+            IndexType::Simple(idx) => {
+                idx.scan_range(txn, prefix_values, lower, upper, reverse)
+                    .await
+            }
+            IndexType::Unique(idx) => {
+                idx.scan_range(txn, prefix_values, lower, upper, reverse)
+                    .await
+            }
         }
     }
 }

--- a/crates/storage/src/index/mod.rs
+++ b/crates/storage/src/index/mod.rs
@@ -56,6 +56,21 @@ use schema::IndexDescription;
 
 use crate::corekv::{Reader, Result, Writer};
 
+/// Validate that a document ID is valid for use in index keys.
+///
+/// Checks that the doc_id is:
+/// - Not empty
+/// - Valid UTF-8 (guaranteed by &str type parameter)
+pub(crate) fn validate_doc_id(doc_id: &str, index_name: &str) -> Result<()> {
+    if doc_id.is_empty() {
+        return Err(crate::corekv::Error::Other(format!(
+            "index '{}': doc_id cannot be empty",
+            index_name
+        )));
+    }
+    Ok(())
+}
+
 /// Enum for index types (avoids dyn trait issues).
 pub enum IndexType {
     Simple(SimpleIndex),

--- a/crates/storage/src/index/range_iterator.rs
+++ b/crates/storage/src/index/range_iterator.rs
@@ -19,6 +19,7 @@
 use async_trait::async_trait;
 use document::NormalValue;
 use schema::{FieldKind, IndexDescription};
+use tracing::trace;
 
 use super::iterator::{Bound, IndexEntry, IndexIterator};
 use crate::corekv::{IterOptions, Iterator, Reader, Result};
@@ -391,17 +392,35 @@ impl IndexIterator for RangeIterator {
                         // Check if we've passed the boundary
                         if let Some(ref upper) = self.upper_bound_key {
                             if !self.reverse && kv.key.as_slice() >= upper.as_slice() {
+                                trace!(
+                                    index_id = self.desc.id,
+                                    index_name = %self.desc.name,
+                                    key_len = kv.key.len(),
+                                    "range iterator exhausted: passed upper bound"
+                                );
                                 self.exhausted = true;
                                 return Ok(None);
                             }
                         }
                         if let Some(ref lower) = self.lower_bound_key {
                             if self.reverse && kv.key.as_slice() < lower.as_slice() {
+                                trace!(
+                                    index_id = self.desc.id,
+                                    index_name = %self.desc.name,
+                                    key_len = kv.key.len(),
+                                    "range iterator exhausted: passed lower bound (reverse)"
+                                );
                                 self.exhausted = true;
                                 return Ok(None);
                             }
                         }
-                        continue; // Skip this entry
+                        trace!(
+                            index_id = self.desc.id,
+                            index_name = %self.desc.name,
+                            key_len = kv.key.len(),
+                            "skipping entry outside bounds"
+                        );
+                        continue;
                     }
 
                     let entry = self.extract_entry(&kv.key, &kv.value)?;

--- a/crates/storage/src/index/range_iterator.rs
+++ b/crates/storage/src/index/range_iterator.rs
@@ -1,0 +1,667 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//! Range iterator for index scanning with bounds
+//!
+//! Provides iteration over index entries within a range of field values.
+//! Supports:
+//! - Prefix scanning (match first N fields exactly)
+//! - Range bounds (_gt, _ge, _lt, _le)
+//! - Forward and reverse iteration
+//!
+//! Maps to Go's `indexMatchIterator`.
+
+use async_trait::async_trait;
+use document::NormalValue;
+use schema::{FieldKind, IndexDescription};
+
+use super::iterator::{Bound, IndexEntry, IndexIterator};
+use crate::corekv::{IterOptions, Iterator, Reader, Result};
+use crate::field_value::{decode_field_value, encode_field_value};
+use crate::keys::IndexDataStoreKey;
+
+/// Iterator for range queries on an index.
+///
+/// Supports:
+/// - Prefix iteration: scan all entries matching first N field values
+/// - Bounded iteration: scan entries where a field is within a range
+/// - Reverse iteration: scan in descending order
+pub struct RangeIterator {
+    /// The underlying KV iterator
+    inner: Box<dyn Iterator>,
+    /// The base key prefix (collection/index prefix, possibly with some field values)
+    key_prefix: Vec<u8>,
+    /// Index description for decoding field values
+    desc: IndexDescription,
+    /// Whether this is a unique index
+    is_unique: bool,
+    /// Encoded lower bound key (for comparison)
+    lower_bound_key: Option<Vec<u8>>,
+    /// Encoded upper bound key (for comparison)
+    upper_bound_key: Option<Vec<u8>>,
+    /// Whether lower bound is inclusive
+    lower_inclusive: bool,
+    /// Whether upper bound is inclusive
+    upper_inclusive: bool,
+    /// Number of prefix fields (reserved for future use in composite field decoding)
+    #[allow(dead_code)]
+    prefix_field_count: usize,
+    /// Whether the iterator has been exhausted
+    exhausted: bool,
+    /// Whether iterating in reverse
+    reverse: bool,
+}
+
+impl RangeIterator {
+    /// Create a new range iterator that scans all entries in an index.
+    ///
+    /// This is equivalent to a full index scan with optional ordering.
+    pub async fn new_scan<R: Reader + Send + ?Sized>(
+        txn: &R,
+        collection_short_id: u32,
+        desc: &IndexDescription,
+        is_unique: bool,
+        reverse: bool,
+    ) -> Result<Self> {
+        let key_prefix = IndexDataStoreKey::index_prefix(collection_short_id, desc.id);
+
+        let opts = IterOptions::default()
+            .with_prefix(key_prefix.clone())
+            .with_reverse(reverse);
+        let inner = txn.iterator(opts).await?;
+
+        Ok(Self {
+            inner,
+            key_prefix,
+            desc: desc.clone(),
+            is_unique,
+            lower_bound_key: None,
+            upper_bound_key: None,
+            lower_inclusive: true,
+            upper_inclusive: true,
+            prefix_field_count: 0,
+            exhausted: false,
+            reverse,
+        })
+    }
+
+    /// Create a new range iterator with prefix matching.
+    ///
+    /// Scans all entries where the first `prefix_values.len()` fields match exactly.
+    /// Useful for composite indexes where you want to filter on the first field(s).
+    pub async fn new_prefix<R: Reader + Send + ?Sized>(
+        txn: &R,
+        collection_short_id: u32,
+        desc: &IndexDescription,
+        is_unique: bool,
+        prefix_values: &[NormalValue],
+        reverse: bool,
+    ) -> Result<Self> {
+        // Build key prefix with the exact field values
+        let mut key_prefix = IndexDataStoreKey::index_prefix(collection_short_id, desc.id);
+
+        // Encode prefix field values
+        for (i, value) in prefix_values.iter().enumerate() {
+            let descending = desc.fields.get(i).map(|f| f.descending).unwrap_or(false);
+            key_prefix = encode_field_value(key_prefix, value, descending)?;
+        }
+
+        let opts = IterOptions::default()
+            .with_prefix(key_prefix.clone())
+            .with_reverse(reverse);
+        let inner = txn.iterator(opts).await?;
+
+        Ok(Self {
+            inner,
+            key_prefix,
+            desc: desc.clone(),
+            is_unique,
+            lower_bound_key: None,
+            upper_bound_key: None,
+            lower_inclusive: true,
+            upper_inclusive: true,
+            prefix_field_count: prefix_values.len(),
+            exhausted: false,
+            reverse,
+        })
+    }
+
+    /// Create a new range iterator with bounds on a field.
+    ///
+    /// Optionally match first `prefix_values.len()` fields exactly, then apply
+    /// range bounds on the next field.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_range<R: Reader + Send + ?Sized>(
+        txn: &R,
+        collection_short_id: u32,
+        desc: &IndexDescription,
+        is_unique: bool,
+        prefix_values: &[NormalValue],
+        lower: Bound,
+        upper: Bound,
+        reverse: bool,
+    ) -> Result<Self> {
+        // Build base key prefix with collection/index and prefix values
+        let mut key_prefix = IndexDataStoreKey::index_prefix(collection_short_id, desc.id);
+
+        // Encode prefix field values
+        for (i, value) in prefix_values.iter().enumerate() {
+            let descending = desc.fields.get(i).map(|f| f.descending).unwrap_or(false);
+            key_prefix = encode_field_value(key_prefix, value, descending)?;
+        }
+
+        let range_field_idx = prefix_values.len();
+        let range_descending = desc
+            .fields
+            .get(range_field_idx)
+            .map(|f| f.descending)
+            .unwrap_or(false);
+
+        // Build encoded bound keys for comparison
+        let (lower_bound_key, lower_inclusive) = match &lower {
+            Bound::Inclusive(v) => {
+                let mut key = key_prefix.clone();
+                key = encode_field_value(key, v, range_descending)?;
+                (Some(key), true)
+            }
+            Bound::Exclusive(v) => {
+                let mut key = key_prefix.clone();
+                key = encode_field_value(key, v, range_descending)?;
+                (Some(key), false)
+            }
+            Bound::Unbounded => (None, true),
+        };
+
+        let (upper_bound_key, upper_inclusive) = match &upper {
+            Bound::Inclusive(v) => {
+                let mut key = key_prefix.clone();
+                key = encode_field_value(key, v, range_descending)?;
+                (Some(key), true)
+            }
+            Bound::Exclusive(v) => {
+                let mut key = key_prefix.clone();
+                key = encode_field_value(key, v, range_descending)?;
+                (Some(key), false)
+            }
+            Bound::Unbounded => (None, true),
+        };
+
+        // Build start and end keys for the KV iterator
+        let mut opts = IterOptions::default()
+            .with_prefix(key_prefix.clone())
+            .with_reverse(reverse);
+
+        // Use the bound keys as iterator bounds (the iterator will do initial filtering)
+        if let Some(ref start) = lower_bound_key {
+            opts = opts.with_start(start.clone());
+        }
+        if let Some(ref end) = upper_bound_key {
+            // Add 0xFF for inclusive upper bound to include all keys with the prefix
+            let mut end_key = end.clone();
+            if upper_inclusive {
+                end_key.push(0xFF);
+            }
+            opts = opts.with_end(end_key);
+        }
+
+        let inner = txn.iterator(opts).await?;
+
+        Ok(Self {
+            inner,
+            key_prefix,
+            desc: desc.clone(),
+            is_unique,
+            lower_bound_key,
+            upper_bound_key,
+            lower_inclusive,
+            upper_inclusive,
+            prefix_field_count: prefix_values.len(),
+            exhausted: false,
+            reverse,
+        })
+    }
+
+    /// Extract document ID and field values from an index key.
+    fn extract_entry(&self, key: &[u8], value: &[u8]) -> Result<IndexEntry> {
+        // First, decode the field values from the key
+        let values = self.decode_field_values(key)?;
+
+        // Determine if this is a NULL entry (doc_id in key suffix)
+        let has_nil = values.iter().any(|v| v.is_nil());
+
+        let doc_id = if self.is_unique && !has_nil && !value.is_empty() {
+            // Unique index with non-NULL value: doc_id is in value
+            String::from_utf8(value.to_vec())
+                .map_err(|e| crate::corekv::Error::Other(format!("invalid doc_id: {}", e)))?
+        } else {
+            // Simple index or unique with NULL: doc_id is in key suffix
+            self.extract_doc_id_from_key(key, &values)?
+        };
+
+        Ok(IndexEntry::new(doc_id, values))
+    }
+
+    /// Decode field values from an index key.
+    fn decode_field_values(&self, key: &[u8]) -> Result<Vec<NormalValue>> {
+        // Get the index prefix to know where field values start
+        let index_prefix = IndexDataStoreKey::index_prefix(
+            extract_collection_id(&self.key_prefix),
+            extract_index_id(&self.key_prefix),
+        );
+
+        let mut buf = &key[index_prefix.len()..];
+        let mut values = Vec::with_capacity(self.desc.fields.len());
+
+        for field_desc in &self.desc.fields {
+            if buf.is_empty() {
+                break;
+            }
+            // Use blob kind as default - the encoder type marker determines actual type
+            // and blob/string decoding works for both (we'll get Bytes for blob, String for string)
+            let kind = FieldKind::blob();
+            let (rest, value) = decode_field_value(buf, field_desc.descending, &kind)?;
+            values.push(value);
+            buf = rest;
+        }
+
+        Ok(values)
+    }
+
+    /// Extract doc_id from key suffix (after encoded field values).
+    fn extract_doc_id_from_key(&self, key: &[u8], values: &[NormalValue]) -> Result<String> {
+        // Rebuild the key without doc_id to find where doc_id starts
+        let index_prefix = IndexDataStoreKey::index_prefix(
+            extract_collection_id(&self.key_prefix),
+            extract_index_id(&self.key_prefix),
+        );
+
+        let mut encoded_values = index_prefix;
+        for (i, value) in values.iter().enumerate() {
+            let descending = self
+                .desc
+                .fields
+                .get(i)
+                .map(|f| f.descending)
+                .unwrap_or(false);
+            encoded_values = encode_field_value(encoded_values, value, descending)?;
+        }
+
+        if key.len() <= encoded_values.len() {
+            // No doc_id suffix - this shouldn't happen for simple index
+            return Err(crate::corekv::Error::Other(
+                "index key missing doc_id suffix".to_string(),
+            ));
+        }
+
+        let doc_id_bytes = &key[encoded_values.len()..];
+        String::from_utf8(doc_id_bytes.to_vec())
+            .map_err(|e| crate::corekv::Error::Other(format!("invalid doc_id: {}", e)))
+    }
+
+    /// Check if a key is within the range bounds using byte comparison.
+    ///
+    /// For SimpleIndex keys, the format is: [prefix][encoded_value][doc_id]
+    /// We need to compare just the encoded_value portion, ignoring the doc_id suffix.
+    fn is_key_within_bounds(&self, key: &[u8]) -> bool {
+        // Check lower bound
+        if let Some(ref lower) = self.lower_bound_key {
+            // Compare the key prefix (up to the bound length) with the bound
+            let cmp_len = lower.len().min(key.len());
+            let key_prefix = &key[..cmp_len];
+            let lower_prefix = &lower[..cmp_len];
+
+            if self.lower_inclusive {
+                // Inclusive: key prefix must be >= lower
+                if key_prefix < lower_prefix {
+                    return false;
+                }
+            } else {
+                // Exclusive: key prefix must be > lower
+                // If key_prefix equals lower_prefix and key has more bytes (doc_id),
+                // the value itself equals the bound - should be excluded
+                if key_prefix < lower_prefix {
+                    return false;
+                }
+                if key_prefix == lower_prefix && key.len() >= lower.len() {
+                    // Key starts with or equals the lower bound - only valid if key is longer
+                    // meaning there's a suffix (doc_id) and the value prefix matches exactly
+                    // This means the encoded value equals the bound, so exclude it
+                    if &key[..lower.len()] == lower.as_slice() {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // Check upper bound
+        if let Some(ref upper) = self.upper_bound_key {
+            let cmp_len = upper.len().min(key.len());
+            let key_prefix = &key[..cmp_len];
+            let upper_prefix = &upper[..cmp_len];
+
+            if self.upper_inclusive {
+                // Inclusive: key prefix must be <= upper
+                // If key is longer, it has a doc_id suffix which is fine
+                if key_prefix > upper_prefix {
+                    return false;
+                }
+            } else {
+                // Exclusive: key prefix must be < upper
+                if key_prefix > upper_prefix {
+                    return false;
+                }
+                // If prefixes are equal and key >= upper, exclude
+                if key_prefix == upper_prefix
+                    && key.len() >= upper.len()
+                    && &key[..upper.len()] >= upper.as_slice()
+                {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+}
+
+#[async_trait]
+impl IndexIterator for RangeIterator {
+    async fn next(&mut self) -> Result<Option<IndexEntry>> {
+        if self.exhausted {
+            return Ok(None);
+        }
+
+        loop {
+            match self.inner.next().await? {
+                Some(kv) => {
+                    // Check if key is within bounds using byte comparison
+                    let has_bounds =
+                        self.lower_bound_key.is_some() || self.upper_bound_key.is_some();
+                    if has_bounds && !self.is_key_within_bounds(&kv.key) {
+                        // Check if we've passed the boundary
+                        if let Some(ref upper) = self.upper_bound_key {
+                            if !self.reverse && kv.key.as_slice() >= upper.as_slice() {
+                                self.exhausted = true;
+                                return Ok(None);
+                            }
+                        }
+                        if let Some(ref lower) = self.lower_bound_key {
+                            if self.reverse && kv.key.as_slice() < lower.as_slice() {
+                                self.exhausted = true;
+                                return Ok(None);
+                            }
+                        }
+                        continue; // Skip this entry
+                    }
+
+                    let entry = self.extract_entry(&kv.key, &kv.value)?;
+                    return Ok(Some(entry));
+                }
+                None => {
+                    self.exhausted = true;
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.inner.close().await?;
+        self.exhausted = true;
+        Ok(())
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        self.inner.reset().await?;
+        self.exhausted = false;
+        Ok(())
+    }
+}
+
+/// Extract collection_short_id from the key prefix.
+fn extract_collection_id(prefix: &[u8]) -> u32 {
+    if prefix.is_empty() {
+        return 0;
+    }
+
+    let pos = 1; // Skip initial separator
+    let (val, _) = decode_varint(&prefix[pos..]);
+    val as u32
+}
+
+/// Extract index_id from the key prefix.
+fn extract_index_id(prefix: &[u8]) -> u32 {
+    if prefix.is_empty() {
+        return 0;
+    }
+
+    let mut pos = 1; // Skip initial separator
+    let (_col_id, bytes_read) = decode_varint(&prefix[pos..]);
+    pos += bytes_read;
+    pos += 1; // Skip separator after col_id
+
+    if pos >= prefix.len() {
+        return 0;
+    }
+
+    let (idx_id, _) = decode_varint(&prefix[pos..]);
+    idx_id as u32
+}
+
+/// Decode a varint from bytes.
+fn decode_varint(buf: &[u8]) -> (u64, usize) {
+    let mut result: u64 = 0;
+    let mut shift = 0;
+    let mut bytes_read = 0;
+
+    for &byte in buf {
+        bytes_read += 1;
+        result |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+
+    (result, bytes_read)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backends::MemoryStore;
+    use crate::corekv::Store;
+    use crate::index::{CollectionIndex, SimpleIndex};
+    use schema::IndexedFieldDescription;
+
+    fn test_index_description() -> IndexDescription {
+        IndexDescription {
+            id: 1,
+            name: "test_index".to_string(),
+            unique: false,
+            fields: vec![IndexedFieldDescription {
+                name: "age".to_string(),
+                descending: false,
+            }],
+        }
+    }
+
+    fn composite_index_description() -> IndexDescription {
+        IndexDescription {
+            id: 2,
+            name: "composite_index".to_string(),
+            unique: false,
+            fields: vec![
+                IndexedFieldDescription {
+                    name: "category".to_string(),
+                    descending: false,
+                },
+                IndexedFieldDescription {
+                    name: "score".to_string(),
+                    descending: false,
+                },
+            ],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_range_scan_all() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = test_index_description();
+        let index = SimpleIndex::new(1, desc.clone());
+
+        index
+            .save(&mut txn, "doc1", &[NormalValue::Int(10)])
+            .await
+            .unwrap();
+        index
+            .save(&mut txn, "doc2", &[NormalValue::Int(20)])
+            .await
+            .unwrap();
+        index
+            .save(&mut txn, "doc3", &[NormalValue::Int(30)])
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = RangeIterator::new_scan(txn.as_ref(), 1, &desc, false, false)
+            .await
+            .unwrap();
+
+        let entries = iter.collect_all().await.unwrap();
+        assert_eq!(entries.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_range_scan_reverse() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = test_index_description();
+        let index = SimpleIndex::new(1, desc.clone());
+
+        index
+            .save(&mut txn, "doc1", &[NormalValue::Int(10)])
+            .await
+            .unwrap();
+        index
+            .save(&mut txn, "doc2", &[NormalValue::Int(20)])
+            .await
+            .unwrap();
+        index
+            .save(&mut txn, "doc3", &[NormalValue::Int(30)])
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = RangeIterator::new_scan(txn.as_ref(), 1, &desc, false, true)
+            .await
+            .unwrap();
+
+        let entries = iter.collect_all().await.unwrap();
+        assert_eq!(entries.len(), 3);
+
+        // Should be in reverse order
+        assert_eq!(entries[0].values[0], NormalValue::Int(30));
+        assert_eq!(entries[2].values[0], NormalValue::Int(10));
+    }
+
+    #[tokio::test]
+    async fn test_range_prefix_scan() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = composite_index_description();
+        let index = SimpleIndex::new(1, desc.clone());
+
+        // Save documents with different categories
+        index
+            .save(
+                &mut txn,
+                "doc1",
+                &[NormalValue::String("A".to_string()), NormalValue::Int(100)],
+            )
+            .await
+            .unwrap();
+        index
+            .save(
+                &mut txn,
+                "doc2",
+                &[NormalValue::String("A".to_string()), NormalValue::Int(200)],
+            )
+            .await
+            .unwrap();
+        index
+            .save(
+                &mut txn,
+                "doc3",
+                &[NormalValue::String("B".to_string()), NormalValue::Int(150)],
+            )
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        // Scan only category "A"
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = RangeIterator::new_prefix(
+            txn.as_ref(),
+            1,
+            &desc,
+            false,
+            &[NormalValue::String("A".to_string())],
+            false,
+        )
+        .await
+        .unwrap();
+
+        let entries = iter.collect_all().await.unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_range_bounded() {
+        let store = MemoryStore::new();
+        let mut txn = store.new_txn(false).await.unwrap();
+
+        let desc = test_index_description();
+        let index = SimpleIndex::new(1, desc.clone());
+
+        for i in 1..=10 {
+            index
+                .save(&mut txn, &format!("doc{}", i), &[NormalValue::Int(i * 10)])
+                .await
+                .unwrap();
+        }
+        txn.commit().await.unwrap();
+
+        // Range: 30 < x <= 70
+        let txn = store.new_txn(true).await.unwrap();
+        let mut iter = RangeIterator::new_range(
+            txn.as_ref(),
+            1,
+            &desc,
+            false,
+            &[],
+            Bound::gt(NormalValue::Int(30)),
+            Bound::le(NormalValue::Int(70)),
+            false,
+        )
+        .await
+        .unwrap();
+
+        let entries = iter.collect_all().await.unwrap();
+        // Should include 40, 50, 60, 70
+        assert_eq!(entries.len(), 4);
+    }
+}

--- a/crates/storage/src/index/range_iterator.rs
+++ b/crates/storage/src/index/range_iterator.rs
@@ -15,8 +15,6 @@
 //! - Prefix scanning (match first N fields exactly)
 //! - Range bounds (_gt, _ge, _lt, _le)
 //! - Forward and reverse iteration
-//!
-//! Maps to Go's `indexMatchIterator`.
 
 use async_trait::async_trait;
 use document::NormalValue;
@@ -50,9 +48,6 @@ pub struct RangeIterator {
     lower_inclusive: bool,
     /// Whether upper bound is inclusive
     upper_inclusive: bool,
-    /// Number of prefix fields (reserved for future use in composite field decoding)
-    #[allow(dead_code)]
-    prefix_field_count: usize,
     /// Whether the iterator has been exhausted
     exhausted: bool,
     /// Whether iterating in reverse
@@ -86,7 +81,6 @@ impl RangeIterator {
             upper_bound_key: None,
             lower_inclusive: true,
             upper_inclusive: true,
-            prefix_field_count: 0,
             exhausted: false,
             reverse,
         })
@@ -127,7 +121,6 @@ impl RangeIterator {
             upper_bound_key: None,
             lower_inclusive: true,
             upper_inclusive: true,
-            prefix_field_count: prefix_values.len(),
             exhausted: false,
             reverse,
         })
@@ -222,7 +215,6 @@ impl RangeIterator {
             upper_bound_key,
             lower_inclusive,
             upper_inclusive,
-            prefix_field_count: prefix_values.len(),
             exhausted: false,
             reverse,
         })
@@ -252,8 +244,8 @@ impl RangeIterator {
     fn decode_field_values(&self, key: &[u8]) -> Result<Vec<NormalValue>> {
         // Get the index prefix to know where field values start
         let index_prefix = IndexDataStoreKey::index_prefix(
-            extract_collection_id(&self.key_prefix),
-            extract_index_id(&self.key_prefix),
+            extract_collection_id(&self.key_prefix)?,
+            extract_index_id(&self.key_prefix)?,
         );
 
         let mut buf = &key[index_prefix.len()..];
@@ -263,12 +255,26 @@ impl RangeIterator {
             if buf.is_empty() {
                 break;
             }
-            // Use blob kind as default - the encoder type marker determines actual type
-            // and blob/string decoding works for both (we'll get Bytes for blob, String for string)
+            // Use blob kind as default - the encoded type marker determines the actual type.
+            // Note: String values will be decoded as Bytes since we don't have field type
+            // information at decode time. This is acceptable for index operations where
+            // we primarily need byte-level comparison semantics.
             let kind = FieldKind::blob();
             let (rest, value) = decode_field_value(buf, field_desc.descending, &kind)?;
             values.push(value);
             buf = rest;
+        }
+
+        // Validate that we decoded the expected number of fields
+        if values.len() < self.desc.fields.len() {
+            return Err(crate::corekv::Error::Other(format!(
+                "incomplete field values in index key: expected {} fields, decoded {} \
+                 (key_len={}, remaining_buf_len={})",
+                self.desc.fields.len(),
+                values.len(),
+                key.len(),
+                buf.len()
+            )));
         }
 
         Ok(values)
@@ -278,8 +284,8 @@ impl RangeIterator {
     fn extract_doc_id_from_key(&self, key: &[u8], values: &[NormalValue]) -> Result<String> {
         // Rebuild the key without doc_id to find where doc_id starts
         let index_prefix = IndexDataStoreKey::index_prefix(
-            extract_collection_id(&self.key_prefix),
-            extract_index_id(&self.key_prefix),
+            extract_collection_id(&self.key_prefix)?,
+            extract_index_id(&self.key_prefix)?,
         );
 
         let mut encoded_values = index_prefix;
@@ -307,35 +313,34 @@ impl RangeIterator {
 
     /// Check if a key is within the range bounds using byte comparison.
     ///
-    /// For SimpleIndex keys, the format is: [prefix][encoded_value][doc_id]
-    /// We need to compare just the encoded_value portion, ignoring the doc_id suffix.
+    /// Key format: `[index_prefix][encoded_value][doc_id]`
+    /// Bound format: `[index_prefix][encoded_value]` (no doc_id)
+    ///
+    /// The algorithm compares the key's prefix bytes against the bound. If the key
+    /// starts with exactly the bound bytes, then the encoded value equals the bound
+    /// value. For exclusive bounds, such keys must be excluded.
     fn is_key_within_bounds(&self, key: &[u8]) -> bool {
         // Check lower bound
         if let Some(ref lower) = self.lower_bound_key {
-            // Compare the key prefix (up to the bound length) with the bound
             let cmp_len = lower.len().min(key.len());
             let key_prefix = &key[..cmp_len];
             let lower_prefix = &lower[..cmp_len];
 
             if self.lower_inclusive {
-                // Inclusive: key prefix must be >= lower
                 if key_prefix < lower_prefix {
                     return false;
                 }
             } else {
-                // Exclusive: key prefix must be > lower
-                // If key_prefix equals lower_prefix and key has more bytes (doc_id),
-                // the value itself equals the bound - should be excluded
+                // Exclusive: encoded value must be strictly greater than bound
                 if key_prefix < lower_prefix {
                     return false;
                 }
-                if key_prefix == lower_prefix && key.len() >= lower.len() {
-                    // Key starts with or equals the lower bound - only valid if key is longer
-                    // meaning there's a suffix (doc_id) and the value prefix matches exactly
-                    // This means the encoded value equals the bound, so exclude it
-                    if &key[..lower.len()] == lower.as_slice() {
-                        return false;
-                    }
+                // If key starts with the bound exactly, the encoded value equals the bound
+                if key_prefix == lower_prefix
+                    && key.len() >= lower.len()
+                    && &key[..lower.len()] == lower.as_slice()
+                {
+                    return false;
                 }
             }
         }
@@ -347,17 +352,15 @@ impl RangeIterator {
             let upper_prefix = &upper[..cmp_len];
 
             if self.upper_inclusive {
-                // Inclusive: key prefix must be <= upper
-                // If key is longer, it has a doc_id suffix which is fine
                 if key_prefix > upper_prefix {
                     return false;
                 }
             } else {
-                // Exclusive: key prefix must be < upper
+                // Exclusive: encoded value must be strictly less than bound
                 if key_prefix > upper_prefix {
                     return false;
                 }
-                // If prefixes are equal and key >= upper, exclude
+                // If key starts with the bound exactly, the encoded value equals the bound
                 if key_prefix == upper_prefix
                     && key.len() >= upper.len()
                     && &key[..upper.len()] >= upper.as_slice()
@@ -426,20 +429,36 @@ impl IndexIterator for RangeIterator {
 }
 
 /// Extract collection_short_id from the key prefix.
-fn extract_collection_id(prefix: &[u8]) -> u32 {
+fn extract_collection_id(prefix: &[u8]) -> Result<u32> {
     if prefix.is_empty() {
-        return 0;
+        return Err(crate::corekv::Error::Other(
+            "cannot extract collection_id: prefix is empty".to_string(),
+        ));
+    }
+    if prefix.len() < 2 {
+        return Err(crate::corekv::Error::Other(format!(
+            "cannot extract collection_id: prefix too short ({} bytes)",
+            prefix.len()
+        )));
     }
 
     let pos = 1; // Skip initial separator
     let (val, _) = decode_varint(&prefix[pos..]);
-    val as u32
+    if val > u32::MAX as u64 {
+        return Err(crate::corekv::Error::Other(format!(
+            "collection_id {} exceeds maximum u32 value",
+            val
+        )));
+    }
+    Ok(val as u32)
 }
 
 /// Extract index_id from the key prefix.
-fn extract_index_id(prefix: &[u8]) -> u32 {
+fn extract_index_id(prefix: &[u8]) -> Result<u32> {
     if prefix.is_empty() {
-        return 0;
+        return Err(crate::corekv::Error::Other(
+            "cannot extract index_id: prefix is empty".to_string(),
+        ));
     }
 
     let mut pos = 1; // Skip initial separator
@@ -448,11 +467,21 @@ fn extract_index_id(prefix: &[u8]) -> u32 {
     pos += 1; // Skip separator after col_id
 
     if pos >= prefix.len() {
-        return 0;
+        return Err(crate::corekv::Error::Other(format!(
+            "cannot extract index_id: prefix too short (pos {} >= len {})",
+            pos,
+            prefix.len()
+        )));
     }
 
     let (idx_id, _) = decode_varint(&prefix[pos..]);
-    idx_id as u32
+    if idx_id > u32::MAX as u64 {
+        return Err(crate::corekv::Error::Other(format!(
+            "index_id {} exceeds maximum u32 value",
+            idx_id
+        )));
+    }
+    Ok(idx_id as u32)
 }
 
 /// Decode a varint from bytes.

--- a/crates/storage/src/index/simple.rs
+++ b/crates/storage/src/index/simple.rs
@@ -14,6 +14,9 @@ use async_trait::async_trait;
 use document::NormalValue;
 use schema::IndexDescription;
 
+use super::eq_iterator::ExactMatchIterator;
+use super::iterator::Bound;
+use super::range_iterator::RangeIterator;
 use super::CollectionIndex;
 use crate::corekv::{IterOptions, Reader, Result, Writer};
 use crate::keys::datastore::IndexedField;
@@ -103,6 +106,71 @@ impl SimpleIndex {
             .zip(self.desc.fields.iter())
             .map(|(value, field_desc)| IndexedField::new(value.clone(), field_desc.descending))
             .collect()
+    }
+
+    /// Get all entries with exact field values.
+    ///
+    /// Returns an iterator that yields all documents with the specified values.
+    /// For simple index, multiple documents can have the same indexed values.
+    pub async fn get<R: Reader + Send>(
+        &self,
+        txn: &R,
+        values: &[NormalValue],
+    ) -> Result<ExactMatchIterator> {
+        ExactMatchIterator::new_simple(txn, self.collection_short_id, &self.desc, values).await
+    }
+
+    /// Scan all entries in the index.
+    ///
+    /// Returns an iterator over all index entries in order (or reverse order).
+    pub async fn scan<R: Reader + Send>(&self, txn: &R, reverse: bool) -> Result<RangeIterator> {
+        RangeIterator::new_scan(txn, self.collection_short_id, &self.desc, false, reverse).await
+    }
+
+    /// Scan entries with a prefix match on the first N fields.
+    ///
+    /// Returns entries where the first `prefix_values.len()` fields match exactly.
+    /// Useful for composite indexes.
+    pub async fn scan_prefix<R: Reader + Send>(
+        &self,
+        txn: &R,
+        prefix_values: &[NormalValue],
+        reverse: bool,
+    ) -> Result<RangeIterator> {
+        RangeIterator::new_prefix(
+            txn,
+            self.collection_short_id,
+            &self.desc,
+            false,
+            prefix_values,
+            reverse,
+        )
+        .await
+    }
+
+    /// Scan entries within a range on a field.
+    ///
+    /// Optionally match first `prefix_values.len()` fields exactly,
+    /// then apply bounds on the next field.
+    pub async fn scan_range<R: Reader + Send>(
+        &self,
+        txn: &R,
+        prefix_values: &[NormalValue],
+        lower: Bound,
+        upper: Bound,
+        reverse: bool,
+    ) -> Result<RangeIterator> {
+        RangeIterator::new_range(
+            txn,
+            self.collection_short_id,
+            &self.desc,
+            false,
+            prefix_values,
+            lower,
+            upper,
+            reverse,
+        )
+        .await
     }
 }
 

--- a/crates/storage/src/index/simple.rs
+++ b/crates/storage/src/index/simple.rs
@@ -17,6 +17,7 @@ use schema::IndexDescription;
 use super::eq_iterator::ExactMatchIterator;
 use super::iterator::Bound;
 use super::range_iterator::RangeIterator;
+use super::validate_doc_id;
 use super::CollectionIndex;
 use crate::corekv::{IterOptions, Reader, Result, Writer};
 use crate::keys::datastore::IndexedField;
@@ -186,6 +187,7 @@ impl CollectionIndex for SimpleIndex {
         doc_id: &str,
         values: &[NormalValue],
     ) -> Result<()> {
+        validate_doc_id(doc_id, &self.desc.name)?;
         self.validate_field_count(values, doc_id)?;
         let key = self.build_key(values, doc_id)?;
         txn.set(&key, &[]).await
@@ -198,6 +200,7 @@ impl CollectionIndex for SimpleIndex {
         old_values: &[NormalValue],
         new_values: &[NormalValue],
     ) -> Result<()> {
+        validate_doc_id(doc_id, &self.desc.name)?;
         self.validate_field_count(old_values, doc_id)?;
         self.validate_field_count(new_values, doc_id)?;
 
@@ -216,6 +219,7 @@ impl CollectionIndex for SimpleIndex {
         doc_id: &str,
         values: &[NormalValue],
     ) -> Result<()> {
+        validate_doc_id(doc_id, &self.desc.name)?;
         self.validate_field_count(values, doc_id)?;
         let key = self.build_key(values, doc_id)?;
         txn.delete(&key).await

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -17,6 +17,7 @@ use schema::IndexDescription;
 use super::eq_iterator::ExactMatchIterator;
 use super::iterator::Bound;
 use super::range_iterator::RangeIterator;
+use super::validate_doc_id;
 use super::CollectionIndex;
 use crate::corekv::{IterOptions, Reader, Result, Writer};
 use crate::keys::datastore::IndexedField;
@@ -202,6 +203,7 @@ impl CollectionIndex for UniqueIndex {
         doc_id: &str,
         values: &[NormalValue],
     ) -> Result<()> {
+        validate_doc_id(doc_id, &self.desc.name)?;
         self.validate_field_count(values, doc_id)?;
 
         // Special case: if all values are nil, allow multiple entries
@@ -237,6 +239,7 @@ impl CollectionIndex for UniqueIndex {
         old_values: &[NormalValue],
         new_values: &[NormalValue],
     ) -> Result<()> {
+        validate_doc_id(doc_id, &self.desc.name)?;
         self.validate_field_count(old_values, doc_id)?;
         self.validate_field_count(new_values, doc_id)?;
 
@@ -282,6 +285,7 @@ impl CollectionIndex for UniqueIndex {
         doc_id: &str,
         values: &[NormalValue],
     ) -> Result<()> {
+        validate_doc_id(doc_id, &self.desc.name)?;
         self.validate_field_count(values, doc_id)?;
 
         if Self::has_nil_field(values) {

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -14,6 +14,9 @@ use async_trait::async_trait;
 use document::NormalValue;
 use schema::IndexDescription;
 
+use super::eq_iterator::ExactMatchIterator;
+use super::iterator::Bound;
+use super::range_iterator::RangeIterator;
 use super::CollectionIndex;
 use crate::corekv::{IterOptions, Reader, Result, Writer};
 use crate::keys::datastore::IndexedField;
@@ -119,6 +122,71 @@ impl UniqueIndex {
             .zip(self.desc.fields.iter())
             .map(|(value, field_desc)| IndexedField::new(value.clone(), field_desc.descending))
             .collect()
+    }
+
+    /// Get the entry with exact field values.
+    ///
+    /// Returns an iterator that yields at most one document (uniqueness constraint).
+    /// For NULL values, multiple documents may be returned (NULL is not unique).
+    pub async fn get<R: Reader + Send>(
+        &self,
+        txn: &R,
+        values: &[NormalValue],
+    ) -> Result<ExactMatchIterator> {
+        ExactMatchIterator::new_unique(txn, self.collection_short_id, &self.desc, values).await
+    }
+
+    /// Scan all entries in the index.
+    ///
+    /// Returns an iterator over all index entries in order (or reverse order).
+    pub async fn scan<R: Reader + Send>(&self, txn: &R, reverse: bool) -> Result<RangeIterator> {
+        RangeIterator::new_scan(txn, self.collection_short_id, &self.desc, true, reverse).await
+    }
+
+    /// Scan entries with a prefix match on the first N fields.
+    ///
+    /// Returns entries where the first `prefix_values.len()` fields match exactly.
+    /// Useful for composite indexes.
+    pub async fn scan_prefix<R: Reader + Send>(
+        &self,
+        txn: &R,
+        prefix_values: &[NormalValue],
+        reverse: bool,
+    ) -> Result<RangeIterator> {
+        RangeIterator::new_prefix(
+            txn,
+            self.collection_short_id,
+            &self.desc,
+            true,
+            prefix_values,
+            reverse,
+        )
+        .await
+    }
+
+    /// Scan entries within a range on a field.
+    ///
+    /// Optionally match first `prefix_values.len()` fields exactly,
+    /// then apply bounds on the next field.
+    pub async fn scan_range<R: Reader + Send>(
+        &self,
+        txn: &R,
+        prefix_values: &[NormalValue],
+        lower: Bound,
+        upper: Bound,
+        reverse: bool,
+    ) -> Result<RangeIterator> {
+        RangeIterator::new_range(
+            txn,
+            self.collection_short_id,
+            &self.desc,
+            true,
+            prefix_values,
+            lower,
+            upper,
+            reverse,
+        )
+        .await
     }
 }
 

--- a/crates/storage/tests/encoding_property_tests.rs
+++ b/crates/storage/tests/encoding_property_tests.rs
@@ -433,7 +433,18 @@ fn test_varint_boundary_values() {
 
 #[test]
 fn test_uvarint_boundary_values() {
-    let boundary_values = vec![0u64, 1, 127, 128, 255, 256, 65535, 65536, u64::MAX - 1, u64::MAX];
+    let boundary_values = vec![
+        0u64,
+        1,
+        127,
+        128,
+        255,
+        256,
+        65535,
+        65536,
+        u64::MAX - 1,
+        u64::MAX,
+    ];
 
     for v in boundary_values {
         let encoded = encoding::encode_uvarint_ascending(vec![], v);

--- a/crates/storage/tests/index_tests.rs
+++ b/crates/storage/tests/index_tests.rs
@@ -511,7 +511,10 @@ async fn test_composite_unique_partial_null_second_field() {
     let index = UniqueIndex::new(1, composite_index_description(true));
 
     // First field non-NULL, second field NULL
-    let values1 = vec![NormalValue::String("category".to_string()), NormalValue::Null];
+    let values1 = vec![
+        NormalValue::String("category".to_string()),
+        NormalValue::Null,
+    ];
     let values2 = vec![
         NormalValue::String("category".to_string()),
         NormalValue::Null,


### PR DESCRIPTION
## Summary

- Add `IndexIterator` trait and `IndexEntry` struct for scanning index entries
- Add `ExactMatchIterator` for direct key lookup (`_eq` filter conditions)
- Add `RangeIterator` for prefix/range scanning (`_gt`, `_ge`, `_lt`, `_le`)
- Add query methods (`get`, `scan`, `scan_prefix`, `scan_range`) to `SimpleIndex`, `UniqueIndex`, and `IndexType`

## Context

This is Phase 2a of the indexing system - the query execution layer that actually uses indexes to speed up queries. Builds on Phase 1 (PR #79) which implemented the core index types and order-preserving encoding.

## Key Design

Leverages the order-preserving encoding from Phase 1:
- `encoded(a) < encoded(b)` when `a < b`
- RocksDB prefix/range iteration gives sorted results automatically
- Iterators decode values and extract document IDs on the fly

Resolves #84

## Test plan

- [x] `cargo build -p storage` succeeds
- [x] `cargo test -p storage` passes (330 tests)
- [x] `cargo clippy -p storage -- -D warnings` clean
- [x] Exact match iteration tests
- [x] Prefix scan tests
- [x] Range scan tests (with bounds)
- [x] Reverse iteration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)