### PR TITLE
feat(identity): Add context propagation and node identity integration

### DIFF
--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -20,6 +20,7 @@ use tracing::{error, info, warn};
 
 use crate::config::{Config, DatastoreType};
 use crate::error::{Error, Result};
+use identity::Identity;
 
 const DEV_MODE_BANNER: &str = r#"
 ******************************************
@@ -94,9 +95,19 @@ pub struct StartArgs {
     #[arg(long)]
     pub no_searchable_encryption: Option<bool>,
 
-    /// Hex formatted private key used to authenticate with ACP
+    /// Hex formatted private key used to authenticate with ACP.
+    ///
+    /// The key should be a 64-byte hex string (128 hex characters) for Ed25519,
+    /// or a 32-byte hex string (64 hex characters) for secp256k1.
+    ///
+    /// Example: defra start --identity 0x<hex-encoded-private-key>
     #[arg(short = 'i', long)]
     pub identity: Option<String>,
+
+    /// Key type for the identity (ed25519 or secp256k1).
+    /// Only used if --identity is provided.
+    #[arg(long, default_value = "ed25519")]
+    pub identity_key_type: Option<String>,
 
     /// Retry intervals for the replicator (comma-separated seconds)
     #[arg(long, value_delimiter = ',')]
@@ -117,9 +128,50 @@ impl StartArgs {
             eprintln!("{}", DEV_MODE_BANNER);
         }
 
+        // Parse user identity from --identity flag if provided
+        let user_identity = self.parse_user_identity()?;
+
         // Start the node
-        let node = Node::new(config).await?;
+        let node = Node::new(config, user_identity).await?;
         node.run().await
+    }
+
+    /// Parse the user identity from the --identity flag.
+    ///
+    /// The identity flag should contain a hex-encoded private key.
+    /// Supported formats:
+    /// - Ed25519: 64-byte key (128 hex chars) or 32-byte seed (64 hex chars)
+    /// - secp256k1: 32-byte key (64 hex chars)
+    fn parse_user_identity(&self) -> Result<Option<std::sync::Arc<identity::RawIdentity>>> {
+        let hex_key = match &self.identity {
+            Some(key) => key,
+            None => return Ok(None),
+        };
+
+        // Remove 0x prefix if present
+        let hex_str = hex_key.strip_prefix("0x").unwrap_or(hex_key);
+
+        // Decode hex to bytes
+        let key_bytes = hex::decode(hex_str).map_err(|e| {
+            Error::InvalidIdentity(format!("invalid hex in --identity flag: {}", e))
+        })?;
+
+        // Determine key type
+        let key_type_str = self.identity_key_type.as_deref().unwrap_or("ed25519");
+        let key_type: identity::IdentityKeyType = key_type_str.parse().map_err(|_| {
+            Error::InvalidIdentity(format!(
+                "invalid --identity-key-type '{}': expected 'ed25519' or 'secp256k1'",
+                key_type_str
+            ))
+        })?;
+
+        // Create identity from bytes
+        let raw_identity = identity::RawIdentity::from_identity_key_type(key_type, &key_bytes)?;
+
+        let did = raw_identity.did()?;
+        info!("User identity DID: {}", did);
+
+        Ok(Some(std::sync::Arc::new(raw_identity)))
     }
 
     /// Apply start command flags to config
@@ -201,6 +253,7 @@ mod tests {
             default_key_type: None,
             no_searchable_encryption: None,
             identity: None,
+            identity_key_type: None,
             replicator_retry_intervals: None,
         }
     }
@@ -269,7 +322,8 @@ mod tests {
             no_signing: Some(true),
             default_key_type: Some("ed25519".to_string()),
             no_searchable_encryption: Some(true),
-            identity: None, // not yet implemented, see issue #23
+            identity: None, // identity is handled in Node::new, not apply_to_config
+            identity_key_type: None,
             replicator_retry_intervals: Some(vec![10, 20, 30]),
         };
 
@@ -302,11 +356,18 @@ struct Node {
     http_server: Option<defra_http::Server>,
     shutdown_tx: mpsc::Sender<()>,
     shutdown_rx: mpsc::Receiver<()>,
+    /// User identity from --identity flag (for ACP authentication).
+    /// Stored for future use in request context injection.
+    #[allow(dead_code)]
+    user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
 }
 
 impl Node {
     /// Create a new node
-    async fn new(config: Config) -> Result<Self> {
+    async fn new(
+        config: Config,
+        user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
+    ) -> Result<Self> {
         info!("Initializing DefraDB node");
         info!("Root directory: {}", config.rootdir.display());
         info!("Data directory: {}", config.data_path().display());
@@ -326,7 +387,8 @@ impl Node {
             DatastoreType::Memory => {
                 info!("Using in-memory datastore");
                 let store = Arc::new(storage::MemoryStore::new());
-                Self::init_store_and_server(store, &config, peer_keypair).await?
+                Self::init_store_and_server(store, &config, peer_keypair, user_identity.clone())
+                    .await?
             }
             DatastoreType::Badger => {
                 info!(
@@ -334,7 +396,8 @@ impl Node {
                     config.data_path().display()
                 );
                 let store = Arc::new(storage::RocksDBStore::open(config.data_path())?);
-                Self::init_store_and_server(store, &config, peer_keypair).await?
+                Self::init_store_and_server(store, &config, peer_keypair, user_identity.clone())
+                    .await?
             }
         };
 
@@ -346,6 +409,7 @@ impl Node {
             http_server: Some(http_server),
             shutdown_tx,
             shutdown_rx,
+            user_identity,
         })
     }
 
@@ -451,13 +515,21 @@ impl Node {
         store: Arc<S>,
         config: &Config,
         peer_keypair: Option<p2p::Keypair>,
+        user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
     ) -> Result<(Option<p2p::P2PHostHandle>, defra_http::Server)>
     where
         S: storage::corekv::Store + 'static,
     {
+        // Build database options with optional user identity
+        let mut db_options = db::DbOptions::new();
+        if let Some(identity) = user_identity {
+            db_options = db_options.with_node_identity_arc(identity);
+            info!("Database configured with user identity");
+        }
+
         // Open database and load collections from storage
         let database = Arc::new(
-            db::DB::open_from_arc(store.clone())
+            db::DB::open_from_arc_with_options(store.clone(), db_options)
                 .await
                 .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?,
         );
@@ -811,7 +883,7 @@ mod http_integration_tests {
         let api_url = format!("http://127.0.0.1:{}", port);
 
         // Create node
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
 
         // Get shutdown sender before moving node
         let shutdown_tx = node.shutdown_tx.clone();
@@ -851,7 +923,7 @@ mod http_integration_tests {
         let config = test_config(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
 
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -890,7 +962,7 @@ mod http_integration_tests {
         let config = test_config(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
 
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -929,7 +1001,7 @@ mod http_integration_tests {
         let config = test_config(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
 
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -996,7 +1068,7 @@ mod http_integration_tests {
         let api_url = format!("http://127.0.0.1:{}", port);
 
         // Create node with RocksDB backend
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -1114,7 +1186,7 @@ mod http_integration_tests {
         };
 
         let api_url = format!("http://127.0.0.1:{}", port);
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -1191,7 +1263,7 @@ mod http_integration_tests {
         // Phase 2: Start server and create document via mutation
         let config = test_config_rocksdb(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -1302,7 +1374,7 @@ mod http_integration_tests {
         // Phase 2: Start server and update the document
         let config = test_config_rocksdb(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -1414,7 +1486,7 @@ mod http_integration_tests {
         // Phase 2: Start server and delete one document
         let config = test_config_rocksdb(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -1490,7 +1562,7 @@ mod http_integration_tests {
 
         let config = test_config_rocksdb(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -1577,7 +1649,7 @@ mod http_integration_tests {
 
         let config = test_config_rocksdb(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -1665,7 +1737,7 @@ mod http_integration_tests {
 
         let config = test_config_rocksdb(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });
@@ -1725,7 +1797,7 @@ mod http_integration_tests {
 
         let config = test_config(port, temp_dir.path());
         let api_url = format!("http://127.0.0.1:{}", port);
-        let node = Node::new(config).await.unwrap();
+        let node = Node::new(config, None).await.unwrap();
         let shutdown_tx = node.shutdown_tx.clone();
 
         let node_handle = tokio::spawn(async move { node.run().await });

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -102,4 +102,7 @@ pub enum Error {
 
     #[error("identity error: {0}")]
     Identity(#[from] identity::Error),
+
+    #[error("invalid identity: {0}")]
+    InvalidIdentity(String),
 }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -37,6 +37,7 @@ query = { path = "../query" }
 blockstore = { path = "../blockstore" }
 crypto = { path = "../crypto" }
 defra-core = { path = "../defra-core" }
+identity = { path = "../identity" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -9,6 +9,7 @@ use crate::collection_snapshot::CollectionSnapshot;
 use crate::error::{Error, Result};
 use crate::txn::DbTxn;
 use datastore::BasicTxn;
+use identity::{Identity, RawIdentity};
 use schema::CollectionVersion;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -17,12 +18,67 @@ use storage::corekv::{IterOptions, Key, Store};
 use storage::keys::systemstore::CollectionNameKey;
 
 /// Database options.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct DbOptions {
     /// Maximum number of transaction retries.
     pub max_txn_retries: Option<u32>,
     /// Chunk size for large values in the blockstore.
     pub chunk_size: Option<usize>,
+    /// Node identity for this database instance.
+    ///
+    /// The node identity is used for:
+    /// - Signing documents and blocks
+    /// - Authenticating with the ACP (Access Control Policy) system
+    /// - Identifying this node in P2P interactions
+    pub node_identity: Option<Arc<RawIdentity>>,
+}
+
+impl std::fmt::Debug for DbOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DbOptions")
+            .field("max_txn_retries", &self.max_txn_retries)
+            .field("chunk_size", &self.chunk_size)
+            .field(
+                "node_identity",
+                &self.node_identity.as_ref().map(|id| {
+                    id.did()
+                        .map(|d| d.to_string())
+                        .unwrap_or_else(|_| "<invalid>".to_string())
+                }),
+            )
+            .finish()
+    }
+}
+
+impl DbOptions {
+    /// Creates new database options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the node identity for this database.
+    pub fn with_node_identity(mut self, identity: RawIdentity) -> Self {
+        self.node_identity = Some(Arc::new(identity));
+        self
+    }
+
+    /// Sets the node identity from an Arc for this database.
+    pub fn with_node_identity_arc(mut self, identity: Arc<RawIdentity>) -> Self {
+        self.node_identity = Some(identity);
+        self
+    }
+
+    /// Sets the maximum number of transaction retries.
+    pub fn with_max_txn_retries(mut self, retries: u32) -> Self {
+        self.max_txn_retries = Some(retries);
+        self
+    }
+
+    /// Sets the chunk size for large values.
+    pub fn with_chunk_size(mut self, size: usize) -> Self {
+        self.chunk_size = Some(size);
+        self
+    }
 }
 
 /// The main DefraDB database struct.
@@ -201,6 +257,21 @@ impl<S: Store> DB<S> {
     /// Get the database options.
     pub fn options(&self) -> &DbOptions {
         &self.options
+    }
+
+    /// Returns the node identity, if one was configured.
+    ///
+    /// The node identity is used for:
+    /// - Signing documents and blocks
+    /// - Authenticating with the ACP (Access Control Policy) system
+    /// - Identifying this node in P2P interactions
+    pub fn node_identity(&self) -> Option<Arc<RawIdentity>> {
+        self.options.node_identity.clone()
+    }
+
+    /// Returns true if this database has a configured node identity.
+    pub fn has_node_identity(&self) -> bool {
+        self.options.node_identity.is_some()
     }
 
     /// Get the current transaction ID counter value.
@@ -782,11 +853,10 @@ mod tests {
     #[tokio::test]
     async fn test_db_options() {
         let store = MemoryStore::new();
-        let options = DbOptions {
-            max_txn_retries: Some(5),
-            chunk_size: Some(1024 * 1024),
-        };
-        let db = DB::with_options(store, options.clone());
+        let options = DbOptions::new()
+            .with_max_txn_retries(5)
+            .with_chunk_size(1024 * 1024);
+        let db = DB::with_options(store, options);
 
         assert_eq!(db.options().max_txn_retries, Some(5));
         assert_eq!(db.options().chunk_size, Some(1024 * 1024));
@@ -1017,10 +1087,9 @@ mod tests {
         }
 
         // Use open_with_options with custom options
-        let opts = DbOptions {
-            max_txn_retries: Some(10),
-            chunk_size: Some(1024),
-        };
+        let opts = DbOptions::new()
+            .with_max_txn_retries(10)
+            .with_chunk_size(1024);
         let db = DB::open_with_options(store, opts).await.unwrap();
 
         // Verify collections loaded correctly
@@ -1508,10 +1577,9 @@ mod tests {
     #[tokio::test]
     async fn test_db_from_arc_with_options() {
         let store = Arc::new(MemoryStore::new());
-        let options = DbOptions {
-            max_txn_retries: Some(10),
-            chunk_size: Some(2048),
-        };
+        let options = DbOptions::new()
+            .with_max_txn_retries(10)
+            .with_chunk_size(2048);
         let db = DB::from_arc_with_options(store, options);
 
         assert_eq!(db.options().max_txn_retries, Some(10));
@@ -1696,5 +1764,134 @@ mod tests {
         // Try to extract proof between unrelated blocks
         let result = db.extract_proof(&cid1, &cid2).await.unwrap();
         assert!(result.is_none(), "Should return None for unrelated blocks");
+    }
+
+    // =========================================================================
+    // Node Identity Tests
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_db_without_node_identity() {
+        let store = MemoryStore::new();
+        let db = DB::new(store);
+
+        assert!(!db.has_node_identity());
+        assert!(db.node_identity().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_db_with_node_identity() {
+        use identity::{Identity, RawIdentity};
+
+        let store = MemoryStore::new();
+        let private_key = crypto::generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(private_key).unwrap();
+        let expected_did = identity.did().unwrap();
+
+        let options = DbOptions::new().with_node_identity(identity);
+        let db = DB::with_options(store, options);
+
+        assert!(db.has_node_identity());
+        let node_id = db.node_identity().expect("should have identity");
+        assert_eq!(node_id.did().unwrap(), expected_did);
+    }
+
+    #[tokio::test]
+    async fn test_db_options_builder_pattern() {
+        use identity::RawIdentity;
+
+        let private_key = crypto::generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(private_key).unwrap();
+
+        let options = DbOptions::new()
+            .with_max_txn_retries(10)
+            .with_chunk_size(1024)
+            .with_node_identity(identity);
+
+        assert_eq!(options.max_txn_retries, Some(10));
+        assert_eq!(options.chunk_size, Some(1024));
+        assert!(options.node_identity.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_db_options_with_arc_identity() {
+        use identity::RawIdentity;
+
+        let private_key = crypto::generate_ed25519().unwrap();
+        let identity = Arc::new(RawIdentity::from_private_key(private_key).unwrap());
+        let arc_clone = identity.clone();
+
+        let options = DbOptions::new().with_node_identity_arc(identity);
+
+        // Verify the Arc is shared
+        let stored_arc = options.node_identity.unwrap();
+        assert!(Arc::ptr_eq(&stored_arc, &arc_clone));
+    }
+
+    #[tokio::test]
+    async fn test_db_open_with_node_identity() {
+        use identity::{Identity, RawIdentity};
+
+        let store = MemoryStore::new();
+        let private_key = crypto::generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(private_key).unwrap();
+        let expected_did = identity.did().unwrap();
+
+        let options = DbOptions::new().with_node_identity(identity);
+        let db = DB::open_with_options(store, options).await.unwrap();
+
+        assert!(db.has_node_identity());
+        let node_id = db.node_identity().expect("should have identity");
+        assert_eq!(node_id.did().unwrap(), expected_did);
+    }
+
+    #[tokio::test]
+    async fn test_db_from_arc_with_node_identity() {
+        use identity::{Identity, RawIdentity};
+
+        let store = Arc::new(MemoryStore::new());
+        let private_key = crypto::generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(private_key).unwrap();
+        let expected_did = identity.did().unwrap();
+
+        let options = DbOptions::new().with_node_identity(identity);
+        let db = DB::from_arc_with_options(store, options);
+
+        assert!(db.has_node_identity());
+        let node_id = db.node_identity().expect("should have identity");
+        assert_eq!(node_id.did().unwrap(), expected_did);
+    }
+
+    #[tokio::test]
+    async fn test_db_node_identity_can_sign() {
+        use identity::{FullIdentity, Identity, RawIdentity};
+
+        let store = MemoryStore::new();
+        let private_key = crypto::generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(private_key).unwrap();
+
+        let options = DbOptions::new().with_node_identity(identity);
+        let db = DB::with_options(store, options);
+
+        let node_id = db.node_identity().expect("should have identity");
+        let message = b"test message";
+        let signature = node_id.sign(message).unwrap();
+
+        // Verify signature using the public key
+        let verified = node_id.pub_key().verify(message, &signature).unwrap();
+        assert!(verified, "Signature should verify");
+    }
+
+    #[tokio::test]
+    async fn test_db_options_debug_shows_did() {
+        use identity::RawIdentity;
+
+        let private_key = crypto::generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(private_key).unwrap();
+
+        let options = DbOptions::new().with_node_identity(identity);
+        let debug_str = format!("{:?}", options);
+
+        assert!(debug_str.contains("did:key:"), "Debug should show DID");
     }
 }

--- a/crates/identity/src/context.rs
+++ b/crates/identity/src/context.rs
@@ -1,0 +1,254 @@
+//! Identity context for propagating identity through request handling.
+//!
+//! This module provides types and functions for carrying identity information
+//! through the request handling pipeline, similar to Go's context-based approach.
+
+use std::sync::Arc;
+
+use crate::{FullIdentity, Identity, RawIdentity};
+
+/// A container for identity that can be passed through request contexts.
+///
+/// `IdentityContext` holds an optional identity that can be:
+/// - A full identity (with signing capability) for authenticated operations
+/// - A public identity (read-only) for verification
+/// - Empty for unauthenticated requests
+///
+/// # Example
+///
+/// ```rust
+/// use identity::{Identity, IdentityContext, RawIdentity};
+///
+/// // Generate a new Ed25519 key for the example
+/// let private_key = crypto::generate_ed25519().unwrap();
+/// let identity = RawIdentity::from_private_key(private_key).unwrap();
+///
+/// // Create a context with the identity
+/// let ctx = IdentityContext::with_full_identity(identity);
+///
+/// // Access the identity
+/// if let Some(id) = ctx.identity() {
+///     println!("Request from: {:?}", id.did());
+/// }
+/// ```
+#[derive(Clone)]
+pub struct IdentityContext {
+    inner: Option<IdentityHolder>,
+}
+
+/// Internal holder for different identity types.
+#[derive(Clone)]
+enum IdentityHolder {
+    /// Full identity with signing capability.
+    Full(Arc<RawIdentity>),
+}
+
+impl IdentityContext {
+    /// Creates an empty identity context (unauthenticated).
+    pub fn empty() -> Self {
+        Self { inner: None }
+    }
+
+    /// Creates a context with a full identity (has signing capability).
+    pub fn with_full_identity(identity: RawIdentity) -> Self {
+        Self {
+            inner: Some(IdentityHolder::Full(Arc::new(identity))),
+        }
+    }
+
+    /// Creates a context with a full identity from an Arc.
+    pub fn with_full_identity_arc(identity: Arc<RawIdentity>) -> Self {
+        Self {
+            inner: Some(IdentityHolder::Full(identity)),
+        }
+    }
+
+    /// Returns true if this context has an identity.
+    pub fn has_identity(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Returns true if this context has a full identity (with signing capability).
+    pub fn has_full_identity(&self) -> bool {
+        matches!(&self.inner, Some(IdentityHolder::Full(_)))
+    }
+
+    /// Returns the identity as a trait object, if present.
+    pub fn identity(&self) -> Option<&dyn Identity> {
+        match &self.inner {
+            Some(IdentityHolder::Full(id)) => Some(id.as_ref()),
+            None => None,
+        }
+    }
+
+    /// Returns the full identity if present.
+    ///
+    /// Returns `None` if there is no identity or if the identity
+    /// does not have signing capability.
+    pub fn full_identity(&self) -> Option<&dyn FullIdentity> {
+        match &self.inner {
+            Some(IdentityHolder::Full(id)) => Some(id.as_ref()),
+            None => None,
+        }
+    }
+
+    /// Returns the raw identity if present.
+    pub fn raw_identity(&self) -> Option<&RawIdentity> {
+        match &self.inner {
+            Some(IdentityHolder::Full(id)) => Some(id.as_ref()),
+            None => None,
+        }
+    }
+
+    /// Returns a shared reference to the raw identity if present.
+    pub fn raw_identity_arc(&self) -> Option<Arc<RawIdentity>> {
+        self.inner
+            .as_ref()
+            .map(|IdentityHolder::Full(id)| id.clone())
+    }
+}
+
+impl Default for IdentityContext {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl std::fmt::Debug for IdentityContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.inner {
+            Some(IdentityHolder::Full(id)) => {
+                let did_str = id
+                    .did()
+                    .map(|d| d.to_string())
+                    .unwrap_or_else(|e| format!("<DID error: {}>", e));
+                f.debug_struct("IdentityContext")
+                    .field("type", &"full")
+                    .field("did", &did_str)
+                    .finish()
+            }
+            None => f
+                .debug_struct("IdentityContext")
+                .field("type", &"empty")
+                .finish(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Identity;
+    use crypto::generate_ed25519;
+
+    #[test]
+    fn test_empty_context() {
+        let ctx = IdentityContext::empty();
+        assert!(!ctx.has_identity());
+        assert!(!ctx.has_full_identity());
+        assert!(ctx.identity().is_none());
+        assert!(ctx.full_identity().is_none());
+    }
+
+    #[test]
+    fn test_default_is_empty() {
+        let ctx = IdentityContext::default();
+        assert!(!ctx.has_identity());
+    }
+
+    #[test]
+    fn test_with_full_identity() {
+        let key = generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(key).unwrap();
+        let expected_did = identity.did().unwrap();
+
+        let ctx = IdentityContext::with_full_identity(identity);
+
+        assert!(ctx.has_identity());
+        assert!(ctx.has_full_identity());
+
+        let id = ctx.identity().unwrap();
+        assert_eq!(id.did().unwrap(), expected_did);
+
+        assert!(ctx.full_identity().is_some());
+    }
+
+    #[test]
+    fn test_with_full_identity_arc() {
+        let key = generate_ed25519().unwrap();
+        let identity = Arc::new(RawIdentity::from_private_key(key).unwrap());
+        let expected_did = identity.did().unwrap();
+
+        let ctx = IdentityContext::with_full_identity_arc(identity.clone());
+
+        assert!(ctx.has_identity());
+
+        let id = ctx.identity().unwrap();
+        assert_eq!(id.did().unwrap(), expected_did);
+
+        // Verify Arc is shared
+        let arc = ctx.raw_identity_arc().unwrap();
+        assert!(Arc::ptr_eq(&arc, &identity));
+    }
+
+    #[test]
+    fn test_raw_identity_access() {
+        let key = generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(key).unwrap();
+        let expected_did = identity.did().unwrap();
+
+        let ctx = IdentityContext::with_full_identity(identity);
+
+        let raw = ctx.raw_identity().unwrap();
+        assert_eq!(raw.did().unwrap(), expected_did);
+    }
+
+    #[test]
+    fn test_full_identity_can_sign() {
+        let key = generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(key).unwrap();
+
+        let ctx = IdentityContext::with_full_identity(identity);
+
+        let full = ctx.full_identity().unwrap();
+        let message = b"test message";
+        let signature = full.sign(message).unwrap();
+
+        // Verify signature
+        let verified = ctx
+            .identity()
+            .unwrap()
+            .pub_key()
+            .verify(message, &signature)
+            .unwrap();
+        assert!(verified);
+    }
+
+    #[test]
+    fn test_context_is_clone() {
+        let key = generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(key).unwrap();
+        let expected_did = identity.did().unwrap();
+
+        let ctx1 = IdentityContext::with_full_identity(identity);
+        let ctx2 = ctx1.clone();
+
+        // Both should have the same identity
+        assert_eq!(ctx1.identity().unwrap().did().unwrap(), expected_did);
+        assert_eq!(ctx2.identity().unwrap().did().unwrap(), expected_did);
+    }
+
+    #[test]
+    fn test_debug_output() {
+        let empty_ctx = IdentityContext::empty();
+        let debug_str = format!("{:?}", empty_ctx);
+        assert!(debug_str.contains("empty"));
+
+        let key = generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(key).unwrap();
+        let full_ctx = IdentityContext::with_full_identity(identity);
+        let debug_str = format!("{:?}", full_ctx);
+        assert!(debug_str.contains("full"));
+        assert!(debug_str.contains("did:key:"));
+    }
+}

--- a/crates/identity/src/lib.rs
+++ b/crates/identity/src/lib.rs
@@ -6,6 +6,7 @@
 //! - `RawIdentity` concrete implementation supporting secp256k1 and ed25519
 //! - `IdentityKeyType` enum for compile-time key type safety
 //! - `Did` newtype for validated DID strings
+//! - `IdentityContext` for propagating identity through request handling
 //!
 //! # Supported Key Types
 //!
@@ -16,11 +17,13 @@
 //! Use `IdentityKeyType` instead of `crypto::KeyType` to ensure compile-time
 //! safety when working with identity operations.
 
+mod context;
 mod did;
 mod error;
 mod key_type;
 mod raw;
 
+pub use context::IdentityContext;
 pub use crypto::KeyType;
 pub use did::{Did, DID_KEY_PREFIX};
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary

Implements Phase 2 and Phase 3 of the Node Identity System (Issue #23):

- **IdentityContext** - New type for propagating identity through request handling pipelines
- **`--identity` CLI flag** - Parses hex-encoded private key and creates `RawIdentity`
- **`--identity-key-type` flag** - Selects key type (ed25519 or secp256k1, defaults to ed25519)
- **`DbOptions.with_node_identity()`** - Builder method to configure database with node identity
- **`db.node_identity()`** - Returns the configured node identity
- Logs user identity DID on startup

## Changes

| File | Description |
|------|-------------|
| `crates/identity/src/context.rs` | New `IdentityContext` type with full/empty variants |
| `crates/identity/src/lib.rs` | Export `IdentityContext` |
| `crates/db/Cargo.toml` | Add `identity` dependency |
| `crates/db/src/database.rs` | Add `node_identity` to `DbOptions`, add builder methods and getters |
| `crates/cli/src/commands/start.rs` | Wire `--identity` flag, parse hex key, inject into DB |
| `crates/cli/src/error.rs` | Add `InvalidIdentity` error variant |

## Test plan

- [x] `cargo test -p identity` - All 102+ identity tests pass including new context tests
- [x] `cargo test -p db test_db_with_node` - Node identity tests pass
- [x] `cargo test -p cli` - All CLI tests pass
- [x] `cargo clippy --all -- -D warnings` - No warnings
- [x] `cargo fmt --all -- --check` - Properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)