### PR TITLE
feat(acp): Implement document-level Access Control Policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/db",
     "crates/keyring",
     "crates/identity",
+    "crates/acp",
 ]
 
 [workspace.package]

--- a/crates/acp/Cargo.toml
+++ b/crates/acp/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "acp"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Access Control Policy for DefraDB"
+
+[dependencies]
+defra-core = { path = "../defra-core" }
+identity = { path = "../identity" }
+schema = { path = "../schema" }
+storage = { path = "../storage" }
+
+async-trait.workspace = true
+tokio.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+parking_lot.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }

--- a/crates/acp/src/dac.rs
+++ b/crates/acp/src/dac.rs
@@ -113,4 +113,20 @@ pub trait DocumentACP: Send + Sync {
         doc_id: &str,
         relation: &str,
     ) -> Result<bool>;
+
+    /// Unregister a document, removing all ACP tuples.
+    ///
+    /// This should be called when a document is deleted to clean up
+    /// all associated relation tuples (owner, reader, updater, etc.).
+    ///
+    /// # Arguments
+    /// * `policy_id` - The policy ID from the collection
+    /// * `resource_name` - The resource name from the policy
+    /// * `doc_id` - The document ID being unregistered
+    async fn unregister_doc_object(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<()>;
 }

--- a/crates/acp/src/dac.rs
+++ b/crates/acp/src/dac.rs
@@ -1,0 +1,116 @@
+//! Document ACP trait (matches Go acp/dac/dac.go)
+//!
+//! This trait defines the interface for document-level access control.
+
+use async_trait::async_trait;
+use identity::Did;
+
+use crate::error::Result;
+use crate::permission::DocumentPermission;
+
+/// Document ACP interface (matches Go acp/dac/dac.go)
+///
+/// This trait provides document-level access control operations:
+/// - Registration: Documents are registered with an owner when created with identity
+/// - Access checks: Verify if an identity has permission to perform an operation
+/// - Relationship management: Add/remove actor relationships for sharing
+#[async_trait]
+pub trait DocumentACP: Send + Sync {
+    /// Register a document with creator as owner.
+    ///
+    /// This is called when a document is created with an identity.
+    /// The identity becomes the owner of the document.
+    ///
+    /// # Arguments
+    /// * `identity` - The DID of the document creator (becomes owner)
+    /// * `policy_id` - The policy ID from the collection
+    /// * `resource_name` - The resource name from the policy
+    /// * `doc_id` - The document ID being registered
+    async fn register_doc_object(
+        &self,
+        identity: &Did,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<()>;
+
+    /// Check if document is registered with ACP.
+    ///
+    /// Documents created without identity are unregistered (public).
+    /// Documents created with identity are registered.
+    async fn is_doc_registered(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<bool>;
+
+    /// Check if identity has permission on document.
+    ///
+    /// # Access Rules
+    /// 1. If document is unregistered (public) -> allow all
+    /// 2. If identity is None -> deny (anonymous cannot access registered docs)
+    /// 3. If identity is owner -> allow all
+    /// 4. Check if identity has specific relation granting permission
+    ///
+    /// # Arguments
+    /// * `identity` - The DID of the requester (None for anonymous)
+    /// * `permission` - The permission being requested
+    /// * `policy_id` - The policy ID from the collection
+    /// * `resource_name` - The resource name from the policy
+    /// * `doc_id` - The document ID being accessed
+    async fn check_doc_access(
+        &self,
+        identity: Option<&Did>,
+        permission: DocumentPermission,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<bool>;
+
+    /// Add actor relationship (sharing).
+    ///
+    /// Only the document owner can add relationships.
+    ///
+    /// # Arguments
+    /// * `requestor` - The DID making the request (must be owner)
+    /// * `target` - The DID to grant the relation to
+    /// * `collection_id` - The collection ID (used as resource identifier)
+    /// * `doc_id` - The document ID
+    /// * `relation` - The relation to grant (e.g., "reader", "updater")
+    ///
+    /// # Returns
+    /// * `Ok(true)` - Relationship was added
+    /// * `Ok(false)` - Relationship already exists
+    async fn add_actor_relationship(
+        &self,
+        requestor: &Did,
+        target: &Did,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<bool>;
+
+    /// Remove actor relationship.
+    ///
+    /// Only the document owner can remove relationships.
+    ///
+    /// # Arguments
+    /// * `requestor` - The DID making the request (must be owner)
+    /// * `target` - The DID to remove the relation from
+    /// * `collection_id` - The collection ID
+    /// * `doc_id` - The document ID
+    /// * `relation` - The relation to remove
+    ///
+    /// # Returns
+    /// * `Ok(true)` - Relationship was removed
+    /// * `Ok(false)` - Relationship didn't exist
+    async fn delete_actor_relationship(
+        &self,
+        requestor: &Did,
+        target: &Did,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<bool>;
+}

--- a/crates/acp/src/error.rs
+++ b/crates/acp/src/error.rs
@@ -1,0 +1,48 @@
+//! Error types for the ACP crate
+
+use thiserror::Error;
+
+/// Result type alias for ACP operations
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// ACP-specific error types
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Permission denied for the requested operation
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+
+    /// Document is not registered with ACP
+    #[error("document not registered: {0}")]
+    DocumentNotRegistered(String),
+
+    /// Document is already registered with ACP
+    #[error("document already registered: {0}")]
+    DocumentAlreadyRegistered(String),
+
+    /// Invalid relation name
+    #[error("invalid relation: {0}")]
+    InvalidRelation(String),
+
+    /// Not the owner of the document
+    #[error("not document owner: only owner can {operation}")]
+    NotOwner { operation: String },
+
+    /// Invalid policy configuration
+    #[error("invalid policy: {0}")]
+    InvalidPolicy(String),
+
+    /// Storage operation failed
+    #[error("storage error: {0}")]
+    Storage(String),
+
+    /// Serialization/deserialization error
+    #[error("serialization error: {0}")]
+    Serialization(String),
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Error::Serialization(err.to_string())
+    }
+}

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -1,0 +1,41 @@
+//! Access Control Policy (ACP) for DefraDB
+//!
+//! This crate provides document-level access control following Go DefraDB's pattern:
+//! 1. If ACP not configured -> allow all
+//! 2. Check if peer is replicator -> allow (fast path)
+//! 3. Verify peer's identity token
+//! 4. Check document-level ACP permissions -> allow/deny
+//!
+//! # Architecture
+//!
+//! - `DocumentACP` trait: Core interface for document access control
+//! - `LocalDocumentACP`: Local implementation using in-memory storage
+//! - `DocumentPermission`: Read/Update/Delete permissions
+//! - `RelationTuple`: Subject-relation-object tuples for permission storage
+//!
+//! # Public vs Registered Documents
+//!
+//! - Document created WITHOUT identity -> public (unregistered) -> anyone can access
+//! - Document created WITH identity -> registered -> creator is owner -> ACP enforced
+//!
+//! # DPI Rules (DefraDB Policy Interface)
+//!
+//! - Every resource MUST have `owner` relation
+//! - Every permission expression MUST start with `owner`
+//! - Only union (`+`) operations allowed: `owner + reader`
+
+mod dac;
+mod error;
+mod local;
+mod permission;
+mod relation;
+mod store;
+
+pub use dac::DocumentACP;
+pub use error::{Error, Result};
+pub use local::{LocalDocumentACP, MemoryAcpStore};
+pub use permission::DocumentPermission;
+pub use relation::{
+    RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION,
+};
+pub use store::AcpStore;

--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -15,6 +15,15 @@ use crate::permission::DocumentPermission;
 use crate::relation::{RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION};
 use crate::store::AcpStore;
 
+/// Known valid relation names that can be added.
+/// Owner relation is excluded because it's immutable (set at registration time).
+const VALID_ADDABLE_RELATIONS: &[&str] = &[READER_RELATION, UPDATER_RELATION, DELETER_RELATION];
+
+/// Check if a relation name is valid for adding.
+fn is_valid_relation(relation: &str) -> bool {
+    VALID_ADDABLE_RELATIONS.contains(&relation)
+}
+
 /// Local document ACP implementation using in-memory storage.
 ///
 /// This provides ACP functionality without requiring SourceHub.
@@ -150,6 +159,14 @@ impl DocumentACP for LocalDocumentACP {
             return Err(Error::InvalidRelation(
                 "cannot add owner relation".to_string(),
             ));
+        }
+
+        // Validate relation name against known valid relations
+        if !is_valid_relation(relation) {
+            return Err(Error::InvalidRelation(format!(
+                "unknown relation '{}', valid relations are: reader, updater, deleter",
+                relation
+            )));
         }
 
         let tuple = RelationTuple::new(target.clone(), relation, collection_id, doc_id);
@@ -603,6 +620,35 @@ mod tests {
             .add_actor_relationship(&owner, &other, "users", "doc1", OWNER_RELATION)
             .await;
         assert!(matches!(result, Err(Error::InvalidRelation(_))));
+    }
+
+    #[tokio::test]
+    async fn test_cannot_add_unknown_relation() {
+        let acp = create_acp();
+        let owner = test_did();
+        let other = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        // Try to add a typo/unknown relation
+        let result = acp
+            .add_actor_relationship(&owner, &other, "users", "doc1", "reador") // typo
+            .await;
+        assert!(
+            matches!(result, Err(Error::InvalidRelation(msg)) if msg.contains("unknown relation")),
+            "should reject unknown relation names"
+        );
+
+        // Try another unknown relation
+        let result = acp
+            .add_actor_relationship(&owner, &other, "users", "doc1", "admin")
+            .await;
+        assert!(
+            matches!(result, Err(Error::InvalidRelation(msg)) if msg.contains("unknown relation")),
+            "should reject 'admin' as unknown relation"
+        );
     }
 
     #[tokio::test]

--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -259,7 +259,7 @@ impl AcpStore for MemoryAcpStore {
             .read()
             .iter()
             .filter(|(k, _)| k.starts_with(&prefix))
-            .map(|(_, v)| v.subject.clone())
+            .map(|(_, v)| v.subject().clone())
             .collect();
         Ok(subjects)
     }
@@ -275,8 +275,8 @@ impl AcpStore for MemoryAcpStore {
             .tuples
             .read()
             .iter()
-            .filter(|(k, v)| k.starts_with(&prefix) && &v.subject == subject)
-            .map(|(_, v)| v.relation.clone())
+            .filter(|(k, v)| k.starts_with(&prefix) && v.subject() == subject)
+            .map(|(_, v)| v.relation().to_string())
             .collect();
         Ok(relations)
     }
@@ -691,5 +691,216 @@ mod tests {
             .await
             .unwrap();
         assert!(!deleted);
+    }
+
+    // Deleter relation tests
+
+    #[tokio::test]
+    async fn test_add_deleter_grants_read_and_delete() {
+        let acp = create_acp();
+        let owner = test_did();
+        let deleter = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        acp.add_actor_relationship(&owner, &deleter, "users", "doc1", DELETER_RELATION)
+            .await
+            .unwrap();
+
+        // Deleter can read (implied by deleter relation)
+        assert!(
+            acp.check_doc_access(
+                Some(&deleter),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap(),
+            "deleter should have implied read permission"
+        );
+
+        // Deleter can delete
+        assert!(
+            acp.check_doc_access(
+                Some(&deleter),
+                DocumentPermission::Delete,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap(),
+            "deleter should have delete permission"
+        );
+
+        // Deleter CANNOT update
+        assert!(
+            !acp.check_doc_access(
+                Some(&deleter),
+                DocumentPermission::Update,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap(),
+            "deleter should NOT have update permission"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_deleter_relationship_revokes_access() {
+        let acp = create_acp();
+        let owner = test_did();
+        let deleter = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        acp.add_actor_relationship(&owner, &deleter, "users", "doc1", DELETER_RELATION)
+            .await
+            .unwrap();
+
+        // Verify deleter has access
+        assert!(acp
+            .check_doc_access(
+                Some(&deleter),
+                DocumentPermission::Delete,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+
+        // Delete relationship
+        acp.delete_actor_relationship(&owner, &deleter, "users", "doc1", DELETER_RELATION)
+            .await
+            .unwrap();
+
+        // Verify deleter no longer has delete access
+        assert!(!acp
+            .check_doc_access(
+                Some(&deleter),
+                DocumentPermission::Delete,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+
+        // Verify deleter also lost implied read access
+        assert!(!acp
+            .check_doc_access(
+                Some(&deleter),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+    }
+
+    // Non-owner cannot delete relationship test
+
+    #[tokio::test]
+    async fn test_non_owner_cannot_delete_relationship() {
+        let acp = create_acp();
+        let owner = test_did();
+        let reader = test_did2();
+        let attacker = Did::new("did:key:z6MkattackerAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        acp.add_actor_relationship(&owner, &reader, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+
+        // Attacker (non-owner) tries to delete reader relationship
+        let result = acp
+            .delete_actor_relationship(&attacker, &reader, "users", "doc1", READER_RELATION)
+            .await;
+        assert!(
+            matches!(result, Err(Error::NotOwner { .. })),
+            "non-owner should not be able to delete relationships"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cannot_delete_owner_relation() {
+        let acp = create_acp();
+        let owner = test_did();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        // Owner tries to delete their own owner relation
+        let result = acp
+            .delete_actor_relationship(&owner, &owner, "users", "doc1", OWNER_RELATION)
+            .await;
+        assert!(
+            matches!(result, Err(Error::InvalidRelation(_))),
+            "should not be able to delete owner relation"
+        );
+    }
+
+    // Cross-collection isolation test
+
+    #[tokio::test]
+    async fn test_cross_collection_isolation() {
+        let acp = create_acp();
+        let owner = test_did();
+        let reader = test_did2();
+
+        // Register same doc_id in two different collections
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+        acp.register_doc_object(&owner, "policy1", "posts", "doc1")
+            .await
+            .unwrap();
+
+        // Grant reader access to doc1 in "users" collection ONLY
+        acp.add_actor_relationship(&owner, &reader, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+
+        // Reader CAN access users/doc1
+        assert!(
+            acp.check_doc_access(
+                Some(&reader),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap(),
+            "reader should access users/doc1"
+        );
+
+        // Reader CANNOT access posts/doc1 (different collection, no permission)
+        assert!(
+            !acp.check_doc_access(
+                Some(&reader),
+                DocumentPermission::Read,
+                "policy1",
+                "posts",
+                "doc1"
+            )
+            .await
+            .unwrap(),
+            "reader should NOT access posts/doc1 (cross-collection isolation)"
+        );
     }
 }

--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -217,6 +217,16 @@ impl DocumentACP for LocalDocumentACP {
         self.store.delete_tuple(&tuple).await?;
         Ok(true)
     }
+
+    async fn unregister_doc_object(
+        &self,
+        _policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<()> {
+        // Delete all tuples for this document (owner, reader, updater, deleter, etc.)
+        self.store.delete_doc_tuples(resource_name, doc_id).await
+    }
 }
 
 /// In-memory ACP store for local use and testing.

--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -1,0 +1,695 @@
+//! Local DocumentACP implementation.
+//!
+//! This implementation stores relation tuples locally and evaluates
+//! permission checks against them. SourceHub integration is deferred.
+
+use async_trait::async_trait;
+use identity::Did;
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::dac::DocumentACP;
+use crate::error::{Error, Result};
+use crate::permission::DocumentPermission;
+use crate::relation::{RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION};
+use crate::store::AcpStore;
+
+/// Local document ACP implementation using in-memory storage.
+///
+/// This provides ACP functionality without requiring SourceHub.
+/// Relation tuples are stored locally and permission checks are
+/// evaluated based on the DPI rules (owner + relation unions).
+pub struct LocalDocumentACP {
+    store: Arc<dyn AcpStore>,
+}
+
+impl LocalDocumentACP {
+    /// Create a new LocalDocumentACP with the given store.
+    pub fn new(store: Arc<dyn AcpStore>) -> Self {
+        Self { store }
+    }
+
+    /// Check if the subject is the owner of the document.
+    async fn is_owner(
+        &self,
+        subject: &Did,
+        collection_id: &str,
+        doc_id: &str,
+    ) -> Result<bool> {
+        let tuple = RelationTuple::owner(subject.clone(), collection_id, doc_id);
+        self.store.has_tuple(&tuple).await
+    }
+
+    /// Check if subject has a specific relation to the document.
+    async fn has_relation(
+        &self,
+        subject: &Did,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<bool> {
+        let tuple = RelationTuple::new(subject.clone(), relation, collection_id, doc_id);
+        self.store.has_tuple(&tuple).await
+    }
+}
+
+#[async_trait]
+impl DocumentACP for LocalDocumentACP {
+    async fn register_doc_object(
+        &self,
+        identity: &Did,
+        _policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<()> {
+        // Check if document is already registered
+        if self.store.is_doc_registered(resource_name, doc_id).await? {
+            return Err(Error::DocumentAlreadyRegistered(format!(
+                "{}:{}",
+                resource_name, doc_id
+            )));
+        }
+
+        // Register owner relation
+        let tuple = RelationTuple::owner(identity.clone(), resource_name, doc_id);
+        self.store.put_tuple(&tuple).await
+    }
+
+    async fn is_doc_registered(
+        &self,
+        _policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<bool> {
+        self.store.is_doc_registered(resource_name, doc_id).await
+    }
+
+    async fn check_doc_access(
+        &self,
+        identity: Option<&Did>,
+        permission: DocumentPermission,
+        _policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<bool> {
+        // Check if document is registered
+        if !self.store.is_doc_registered(resource_name, doc_id).await? {
+            // Unregistered (public) documents allow all access
+            return Ok(true);
+        }
+
+        // Document is registered, need identity to access
+        let identity = match identity {
+            Some(id) => id,
+            None => return Ok(false), // Anonymous cannot access registered docs
+        };
+
+        // Owner always has all permissions (DPI rule: every permission starts with owner)
+        if self.is_owner(identity, resource_name, doc_id).await? {
+            return Ok(true);
+        }
+
+        // Check specific relations based on permission
+        // DPI rule: permissions are unions (owner + relation)
+        match permission {
+            DocumentPermission::Read => {
+                // reader OR updater OR deleter grants read (implied read)
+                Ok(self.has_relation(identity, resource_name, doc_id, READER_RELATION).await?
+                    || self.has_relation(identity, resource_name, doc_id, UPDATER_RELATION).await?
+                    || self.has_relation(identity, resource_name, doc_id, DELETER_RELATION).await?)
+            }
+            DocumentPermission::Update => {
+                // updater grants update
+                self.has_relation(identity, resource_name, doc_id, UPDATER_RELATION).await
+            }
+            DocumentPermission::Delete => {
+                // deleter grants delete
+                self.has_relation(identity, resource_name, doc_id, DELETER_RELATION).await
+            }
+        }
+    }
+
+    async fn add_actor_relationship(
+        &self,
+        requestor: &Did,
+        target: &Did,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<bool> {
+        // Only owner can add relationships
+        if !self.is_owner(requestor, collection_id, doc_id).await? {
+            return Err(Error::NotOwner {
+                operation: "add actor relationship".to_string(),
+            });
+        }
+
+        // Cannot add owner relation (it's immutable)
+        if relation == OWNER_RELATION {
+            return Err(Error::InvalidRelation(
+                "cannot add owner relation".to_string(),
+            ));
+        }
+
+        let tuple = RelationTuple::new(target.clone(), relation, collection_id, doc_id);
+
+        // Check if already exists
+        if self.store.has_tuple(&tuple).await? {
+            return Ok(false);
+        }
+
+        self.store.put_tuple(&tuple).await?;
+        Ok(true)
+    }
+
+    async fn delete_actor_relationship(
+        &self,
+        requestor: &Did,
+        target: &Did,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<bool> {
+        // Only owner can delete relationships
+        if !self.is_owner(requestor, collection_id, doc_id).await? {
+            return Err(Error::NotOwner {
+                operation: "delete actor relationship".to_string(),
+            });
+        }
+
+        // Cannot delete owner relation (it's immutable)
+        if relation == OWNER_RELATION {
+            return Err(Error::InvalidRelation(
+                "cannot delete owner relation".to_string(),
+            ));
+        }
+
+        let tuple = RelationTuple::new(target.clone(), relation, collection_id, doc_id);
+
+        // Check if exists
+        if !self.store.has_tuple(&tuple).await? {
+            return Ok(false);
+        }
+
+        self.store.delete_tuple(&tuple).await?;
+        Ok(true)
+    }
+}
+
+/// In-memory ACP store for local use and testing.
+pub struct MemoryAcpStore {
+    tuples: RwLock<HashMap<String, RelationTuple>>,
+}
+
+impl MemoryAcpStore {
+    /// Create a new in-memory ACP store.
+    pub fn new() -> Self {
+        Self {
+            tuples: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for MemoryAcpStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AcpStore for MemoryAcpStore {
+    async fn put_tuple(&self, tuple: &RelationTuple) -> Result<()> {
+        self.tuples
+            .write()
+            .insert(tuple.storage_key(), tuple.clone());
+        Ok(())
+    }
+
+    async fn delete_tuple(&self, tuple: &RelationTuple) -> Result<()> {
+        self.tuples.write().remove(&tuple.storage_key());
+        Ok(())
+    }
+
+    async fn has_tuple(&self, tuple: &RelationTuple) -> Result<bool> {
+        Ok(self.tuples.read().contains_key(&tuple.storage_key()))
+    }
+
+    async fn get_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<Vec<RelationTuple>> {
+        let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
+        let tuples = self
+            .tuples
+            .read()
+            .iter()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(_, v)| v.clone())
+            .collect();
+        Ok(tuples)
+    }
+
+    async fn get_relation_subjects(
+        &self,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<Vec<Did>> {
+        let prefix = RelationTuple::relation_prefix(collection_id, doc_id, relation);
+        let subjects = self
+            .tuples
+            .read()
+            .iter()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(_, v)| v.subject.clone())
+            .collect();
+        Ok(subjects)
+    }
+
+    async fn get_subject_relations(
+        &self,
+        subject: &Did,
+        collection_id: &str,
+        doc_id: &str,
+    ) -> Result<Vec<String>> {
+        let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
+        let relations = self
+            .tuples
+            .read()
+            .iter()
+            .filter(|(k, v)| k.starts_with(&prefix) && &v.subject == subject)
+            .map(|(_, v)| v.relation.clone())
+            .collect();
+        Ok(relations)
+    }
+
+    async fn delete_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<()> {
+        let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
+        self.tuples.write().retain(|k, _| !k.starts_with(&prefix));
+        Ok(())
+    }
+
+    async fn is_doc_registered(&self, collection_id: &str, doc_id: &str) -> Result<bool> {
+        let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
+        Ok(self.tuples.read().keys().any(|k| k.starts_with(&prefix)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_did() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    fn test_did2() -> Did {
+        Did::new("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR").unwrap()
+    }
+
+    fn create_acp() -> LocalDocumentACP {
+        LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()))
+    }
+
+    // Public Documents tests
+
+    #[tokio::test]
+    async fn test_unregistered_doc_allows_all_access() {
+        let acp = create_acp();
+
+        // Anonymous can access unregistered doc
+        let access = acp
+            .check_doc_access(None, DocumentPermission::Read, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+        assert!(access, "unregistered doc should allow anonymous read");
+
+        // Any identity can access unregistered doc
+        let access = acp
+            .check_doc_access(
+                Some(&test_did()),
+                DocumentPermission::Update,
+                "policy1",
+                "users",
+                "doc1",
+            )
+            .await
+            .unwrap();
+        assert!(access, "unregistered doc should allow any update");
+    }
+
+    // Registered Documents tests
+
+    #[tokio::test]
+    async fn test_register_doc_creates_owner() {
+        let acp = create_acp();
+        let owner = test_did();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        assert!(acp
+            .is_doc_registered("policy1", "users", "doc1")
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_register_doc_twice_fails() {
+        let acp = create_acp();
+        let owner = test_did();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let result = acp
+            .register_doc_object(&owner, "policy1", "users", "doc1")
+            .await;
+        assert!(matches!(result, Err(Error::DocumentAlreadyRegistered(_))));
+    }
+
+    #[tokio::test]
+    async fn test_owner_has_all_permissions() {
+        let acp = create_acp();
+        let owner = test_did();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        assert!(acp
+            .check_doc_access(
+                Some(&owner),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+        assert!(acp
+            .check_doc_access(
+                Some(&owner),
+                DocumentPermission::Update,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+        assert!(acp
+            .check_doc_access(
+                Some(&owner),
+                DocumentPermission::Delete,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_anonymous_cannot_access_registered_doc() {
+        let acp = create_acp();
+        let owner = test_did();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let access = acp
+            .check_doc_access(None, DocumentPermission::Read, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+        assert!(!access, "anonymous should not read registered doc");
+    }
+
+    #[tokio::test]
+    async fn test_non_owner_cannot_access_without_relation() {
+        let acp = create_acp();
+        let owner = test_did();
+        let other = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        assert!(!acp
+            .check_doc_access(
+                Some(&other),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+        assert!(!acp
+            .check_doc_access(
+                Some(&other),
+                DocumentPermission::Update,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+        assert!(!acp
+            .check_doc_access(
+                Some(&other),
+                DocumentPermission::Delete,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+    }
+
+    // Sharing (AddActorRelationship) tests
+
+    #[tokio::test]
+    async fn test_add_reader_grants_read_only() {
+        let acp = create_acp();
+        let owner = test_did();
+        let reader = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let added = acp
+            .add_actor_relationship(&owner, &reader, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+        assert!(added, "relationship should be added");
+
+        // Reader can read
+        assert!(acp
+            .check_doc_access(
+                Some(&reader),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+
+        // Reader cannot update
+        assert!(!acp
+            .check_doc_access(
+                Some(&reader),
+                DocumentPermission::Update,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+
+        // Reader cannot delete
+        assert!(!acp
+            .check_doc_access(
+                Some(&reader),
+                DocumentPermission::Delete,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_add_updater_grants_read_and_update() {
+        let acp = create_acp();
+        let owner = test_did();
+        let updater = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        acp.add_actor_relationship(&owner, &updater, "users", "doc1", UPDATER_RELATION)
+            .await
+            .unwrap();
+
+        // Updater can read (implied)
+        assert!(acp
+            .check_doc_access(
+                Some(&updater),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+
+        // Updater can update
+        assert!(acp
+            .check_doc_access(
+                Some(&updater),
+                DocumentPermission::Update,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+
+        // Updater cannot delete
+        assert!(!acp
+            .check_doc_access(
+                Some(&updater),
+                DocumentPermission::Delete,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_non_owner_cannot_add_relationship() {
+        let acp = create_acp();
+        let owner = test_did();
+        let other = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let result = acp
+            .add_actor_relationship(&other, &owner, "users", "doc1", READER_RELATION)
+            .await;
+        assert!(matches!(result, Err(Error::NotOwner { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_cannot_add_owner_relation() {
+        let acp = create_acp();
+        let owner = test_did();
+        let other = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let result = acp
+            .add_actor_relationship(&owner, &other, "users", "doc1", OWNER_RELATION)
+            .await;
+        assert!(matches!(result, Err(Error::InvalidRelation(_))));
+    }
+
+    #[tokio::test]
+    async fn test_add_duplicate_relationship_returns_false() {
+        let acp = create_acp();
+        let owner = test_did();
+        let reader = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let added1 = acp
+            .add_actor_relationship(&owner, &reader, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+        assert!(added1);
+
+        let added2 = acp
+            .add_actor_relationship(&owner, &reader, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+        assert!(!added2, "duplicate add should return false");
+    }
+
+    // Delete relationship tests
+
+    #[tokio::test]
+    async fn test_delete_relationship() {
+        let acp = create_acp();
+        let owner = test_did();
+        let reader = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        acp.add_actor_relationship(&owner, &reader, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+
+        // Verify reader has access
+        assert!(acp
+            .check_doc_access(
+                Some(&reader),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+
+        // Delete relationship
+        let deleted = acp
+            .delete_actor_relationship(&owner, &reader, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+        assert!(deleted);
+
+        // Verify reader no longer has access
+        assert!(!acp
+            .check_doc_access(
+                Some(&reader),
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent_relationship_returns_false() {
+        let acp = create_acp();
+        let owner = test_did();
+        let other = test_did2();
+
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let deleted = acp
+            .delete_actor_relationship(&owner, &other, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+        assert!(!deleted);
+    }
+}

--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 use crate::dac::DocumentACP;
 use crate::error::{Error, Result};
 use crate::permission::DocumentPermission;
-use crate::relation::{RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION};
+use crate::relation::{
+    RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION,
+};
 use crate::store::AcpStore;
 
 /// Known valid relation names that can be added.
@@ -40,12 +42,7 @@ impl LocalDocumentACP {
     }
 
     /// Check if the subject is the owner of the document.
-    async fn is_owner(
-        &self,
-        subject: &Did,
-        collection_id: &str,
-        doc_id: &str,
-    ) -> Result<bool> {
+    async fn is_owner(&self, subject: &Did, collection_id: &str, doc_id: &str) -> Result<bool> {
         let tuple = RelationTuple::owner(subject.clone(), collection_id, doc_id);
         self.store.has_tuple(&tuple).await
     }
@@ -124,17 +121,25 @@ impl DocumentACP for LocalDocumentACP {
         match permission {
             DocumentPermission::Read => {
                 // reader OR updater OR deleter grants read (implied read)
-                Ok(self.has_relation(identity, resource_name, doc_id, READER_RELATION).await?
-                    || self.has_relation(identity, resource_name, doc_id, UPDATER_RELATION).await?
-                    || self.has_relation(identity, resource_name, doc_id, DELETER_RELATION).await?)
+                Ok(self
+                    .has_relation(identity, resource_name, doc_id, READER_RELATION)
+                    .await?
+                    || self
+                        .has_relation(identity, resource_name, doc_id, UPDATER_RELATION)
+                        .await?
+                    || self
+                        .has_relation(identity, resource_name, doc_id, DELETER_RELATION)
+                        .await?)
             }
             DocumentPermission::Update => {
                 // updater grants update
-                self.has_relation(identity, resource_name, doc_id, UPDATER_RELATION).await
+                self.has_relation(identity, resource_name, doc_id, UPDATER_RELATION)
+                    .await
             }
             DocumentPermission::Delete => {
                 // deleter grants delete
-                self.has_relation(identity, resource_name, doc_id, DELETER_RELATION).await
+                self.has_relation(identity, resource_name, doc_id, DELETER_RELATION)
+                    .await
             }
         }
     }
@@ -252,7 +257,11 @@ impl AcpStore for MemoryAcpStore {
         Ok(self.tuples.read().contains_key(&tuple.storage_key()))
     }
 
-    async fn get_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<Vec<RelationTuple>> {
+    async fn get_doc_tuples(
+        &self,
+        collection_id: &str,
+        doc_id: &str,
+    ) -> Result<Vec<RelationTuple>> {
         let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
         let tuples = self
             .tuples

--- a/crates/acp/src/permission.rs
+++ b/crates/acp/src/permission.rs
@@ -1,0 +1,84 @@
+//! Document permission types.
+//!
+//! Matches Go's acp/types/types.go
+
+use serde::{Deserialize, Serialize};
+
+/// Document resource permissions (matches Go acp/types/types.go)
+///
+/// These are the permission types that can be checked against a document.
+/// Having Update or Delete permission implies Read access.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum DocumentPermission {
+    /// Can read document
+    Read = 0,
+    /// Can update document (implies read)
+    Update = 1,
+    /// Can delete document (implies read)
+    Delete = 2,
+}
+
+impl DocumentPermission {
+    /// Returns the string representation used in policy definitions
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DocumentPermission::Read => "read",
+            DocumentPermission::Update => "update",
+            DocumentPermission::Delete => "delete",
+        }
+    }
+
+    /// Check if this permission implies read access
+    pub fn implies_read(&self) -> bool {
+        // All permissions imply read
+        true
+    }
+}
+
+impl std::fmt::Display for DocumentPermission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_permission_repr() {
+        assert_eq!(DocumentPermission::Read as u8, 0);
+        assert_eq!(DocumentPermission::Update as u8, 1);
+        assert_eq!(DocumentPermission::Delete as u8, 2);
+    }
+
+    #[test]
+    fn test_permission_as_str() {
+        assert_eq!(DocumentPermission::Read.as_str(), "read");
+        assert_eq!(DocumentPermission::Update.as_str(), "update");
+        assert_eq!(DocumentPermission::Delete.as_str(), "delete");
+    }
+
+    #[test]
+    fn test_permission_display() {
+        assert_eq!(format!("{}", DocumentPermission::Read), "read");
+        assert_eq!(format!("{}", DocumentPermission::Update), "update");
+        assert_eq!(format!("{}", DocumentPermission::Delete), "delete");
+    }
+
+    #[test]
+    fn test_all_permissions_imply_read() {
+        assert!(DocumentPermission::Read.implies_read());
+        assert!(DocumentPermission::Update.implies_read());
+        assert!(DocumentPermission::Delete.implies_read());
+    }
+
+    #[test]
+    fn test_permission_serde() {
+        let perm = DocumentPermission::Update;
+        let json = serde_json::to_string(&perm).unwrap();
+        let parsed: DocumentPermission = serde_json::from_str(&json).unwrap();
+        assert_eq!(perm, parsed);
+    }
+}

--- a/crates/acp/src/relation.rs
+++ b/crates/acp/src/relation.rs
@@ -6,6 +6,8 @@
 use identity::Did;
 use serde::{Deserialize, Serialize};
 
+use crate::error::{Error, Result};
+
 /// The required relation that represents document ownership.
 /// Every document MUST have an owner relation as per DPI rules.
 pub const OWNER_RELATION: &str = "owner";
@@ -23,23 +25,69 @@ pub const DELETER_RELATION: &str = "deleter";
 ///
 /// The object is identified by collection_id and doc_id.
 /// Relations are policy-defined strings like "owner", "reader", etc.
+///
+/// All path components are validated to prevent path traversal attacks.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RelationTuple {
     /// The subject (identity) that has the relation
-    pub subject: Did,
+    subject: Did,
 
     /// The relation name (e.g., "owner", "reader", "updater")
-    pub relation: String,
+    relation: String,
 
     /// The collection ID (resource type)
-    pub collection_id: String,
+    collection_id: String,
 
     /// The document ID within the collection
-    pub doc_id: String,
+    doc_id: String,
+}
+
+/// Validate a path component for storage key safety.
+/// Rejects empty strings and strings containing path separators.
+fn validate_path_component(value: &str, field_name: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(Error::InvalidPolicy(format!("{} cannot be empty", field_name)));
+    }
+    if value.contains('/') || value.contains('\\') {
+        return Err(Error::InvalidPolicy(format!(
+            "{} cannot contain path separators: {}",
+            field_name, value
+        )));
+    }
+    Ok(())
 }
 
 impl RelationTuple {
-    /// Create a new relation tuple.
+    /// Create a new relation tuple with validation.
+    ///
+    /// Returns an error if any path component (relation, collection_id, doc_id)
+    /// contains path separators or is empty.
+    pub fn try_new(
+        subject: Did,
+        relation: impl Into<String>,
+        collection_id: impl Into<String>,
+        doc_id: impl Into<String>,
+    ) -> Result<Self> {
+        let relation = relation.into();
+        let collection_id = collection_id.into();
+        let doc_id = doc_id.into();
+
+        validate_path_component(&relation, "relation")?;
+        validate_path_component(&collection_id, "collection_id")?;
+        validate_path_component(&doc_id, "doc_id")?;
+
+        Ok(Self {
+            subject,
+            relation,
+            collection_id,
+            doc_id,
+        })
+    }
+
+    /// Create a new relation tuple without validation.
+    ///
+    /// Use `try_new` when working with untrusted input.
+    /// This method is for internal use where inputs are already validated.
     pub fn new(
         subject: Did,
         relation: impl Into<String>,
@@ -52,6 +100,26 @@ impl RelationTuple {
             collection_id: collection_id.into(),
             doc_id: doc_id.into(),
         }
+    }
+
+    /// Get the subject DID.
+    pub fn subject(&self) -> &Did {
+        &self.subject
+    }
+
+    /// Get the relation name.
+    pub fn relation(&self) -> &str {
+        &self.relation
+    }
+
+    /// Get the collection ID.
+    pub fn collection_id(&self) -> &str {
+        &self.collection_id
+    }
+
+    /// Get the document ID.
+    pub fn doc_id(&self) -> &str {
+        &self.doc_id
     }
 
     /// Create an owner relation tuple.
@@ -72,6 +140,25 @@ impl RelationTuple {
             "/acp/{}/{}/{}/{}",
             self.collection_id, self.doc_id, self.relation, self.subject
         )
+    }
+
+    /// Validate a storage key prefix.
+    ///
+    /// Returns an error if any component contains path separators.
+    pub fn validate_prefix(collection_id: &str, doc_id: &str) -> Result<()> {
+        validate_path_component(collection_id, "collection_id")?;
+        validate_path_component(doc_id, "doc_id")?;
+        Ok(())
+    }
+
+    /// Validate a relation prefix.
+    ///
+    /// Returns an error if any component contains path separators.
+    pub fn validate_relation_prefix(collection_id: &str, doc_id: &str, relation: &str) -> Result<()> {
+        validate_path_component(collection_id, "collection_id")?;
+        validate_path_component(doc_id, "doc_id")?;
+        validate_path_component(relation, "relation")?;
+        Ok(())
     }
 
     /// Get the prefix for scanning all relations of a document.
@@ -112,10 +199,10 @@ mod tests {
         let did = test_did();
         let tuple = RelationTuple::new(did.clone(), "reader", "users", "doc123");
 
-        assert_eq!(tuple.subject, did);
-        assert_eq!(tuple.relation, "reader");
-        assert_eq!(tuple.collection_id, "users");
-        assert_eq!(tuple.doc_id, "doc123");
+        assert_eq!(tuple.subject(), &did);
+        assert_eq!(tuple.relation(), "reader");
+        assert_eq!(tuple.collection_id(), "users");
+        assert_eq!(tuple.doc_id(), "doc123");
     }
 
     #[test]
@@ -123,8 +210,37 @@ mod tests {
         let did = test_did();
         let tuple = RelationTuple::owner(did.clone(), "users", "doc123");
 
-        assert_eq!(tuple.relation, OWNER_RELATION);
+        assert_eq!(tuple.relation(), OWNER_RELATION);
         assert!(tuple.is_owner());
+    }
+
+    #[test]
+    fn test_try_new_validates_path_components() {
+        let did = test_did();
+
+        // Valid components should work
+        assert!(RelationTuple::try_new(did.clone(), "reader", "users", "doc123").is_ok());
+
+        // Relation with slash should fail
+        assert!(RelationTuple::try_new(did.clone(), "reader/admin", "users", "doc123").is_err());
+
+        // Collection ID with slash should fail
+        assert!(RelationTuple::try_new(did.clone(), "reader", "users/internal", "doc123").is_err());
+
+        // Doc ID with slash should fail
+        assert!(RelationTuple::try_new(did.clone(), "reader", "users", "doc/123").is_err());
+
+        // Backslash should also fail
+        assert!(RelationTuple::try_new(did.clone(), "reader\\admin", "users", "doc123").is_err());
+
+        // Empty relation should fail
+        assert!(RelationTuple::try_new(did.clone(), "", "users", "doc123").is_err());
+
+        // Empty collection_id should fail
+        assert!(RelationTuple::try_new(did.clone(), "reader", "", "doc123").is_err());
+
+        // Empty doc_id should fail
+        assert!(RelationTuple::try_new(did.clone(), "reader", "users", "").is_err());
     }
 
     #[test]

--- a/crates/acp/src/relation.rs
+++ b/crates/acp/src/relation.rs
@@ -1,0 +1,173 @@
+//! Relation tuple types for ACP.
+//!
+//! A relation tuple represents a subject having a relation to an object.
+//! For example: "did:key:abc123 is owner of doc:users/doc456"
+
+use identity::Did;
+use serde::{Deserialize, Serialize};
+
+/// The required relation that represents document ownership.
+/// Every document MUST have an owner relation as per DPI rules.
+pub const OWNER_RELATION: &str = "owner";
+
+/// Common relation name for read access
+pub const READER_RELATION: &str = "reader";
+
+/// Common relation name for update access
+pub const UPDATER_RELATION: &str = "updater";
+
+/// Common relation name for delete access
+pub const DELETER_RELATION: &str = "deleter";
+
+/// A relation tuple: subject has relation to object.
+///
+/// The object is identified by collection_id and doc_id.
+/// Relations are policy-defined strings like "owner", "reader", etc.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RelationTuple {
+    /// The subject (identity) that has the relation
+    pub subject: Did,
+
+    /// The relation name (e.g., "owner", "reader", "updater")
+    pub relation: String,
+
+    /// The collection ID (resource type)
+    pub collection_id: String,
+
+    /// The document ID within the collection
+    pub doc_id: String,
+}
+
+impl RelationTuple {
+    /// Create a new relation tuple.
+    pub fn new(
+        subject: Did,
+        relation: impl Into<String>,
+        collection_id: impl Into<String>,
+        doc_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            subject,
+            relation: relation.into(),
+            collection_id: collection_id.into(),
+            doc_id: doc_id.into(),
+        }
+    }
+
+    /// Create an owner relation tuple.
+    pub fn owner(subject: Did, collection_id: impl Into<String>, doc_id: impl Into<String>) -> Self {
+        Self::new(subject, OWNER_RELATION, collection_id, doc_id)
+    }
+
+    /// Check if this is an owner relation.
+    pub fn is_owner(&self) -> bool {
+        self.relation == OWNER_RELATION
+    }
+
+    /// Get the storage key for this tuple.
+    ///
+    /// Key format: `/acp/{collection_id}/{doc_id}/{relation}/{subject_did}`
+    pub fn storage_key(&self) -> String {
+        format!(
+            "/acp/{}/{}/{}/{}",
+            self.collection_id, self.doc_id, self.relation, self.subject
+        )
+    }
+
+    /// Get the prefix for scanning all relations of a document.
+    ///
+    /// Key format: `/acp/{collection_id}/{doc_id}/`
+    pub fn doc_prefix(collection_id: &str, doc_id: &str) -> String {
+        format!("/acp/{}/{}/", collection_id, doc_id)
+    }
+
+    /// Get the prefix for scanning all tuples with a specific relation.
+    ///
+    /// Key format: `/acp/{collection_id}/{doc_id}/{relation}/`
+    pub fn relation_prefix(collection_id: &str, doc_id: &str, relation: &str) -> String {
+        format!("/acp/{}/{}/{}/", collection_id, doc_id, relation)
+    }
+}
+
+impl std::fmt::Display for RelationTuple {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}@{}:{}#{}",
+            self.subject, self.collection_id, self.doc_id, self.relation
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_did() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    #[test]
+    fn test_relation_tuple_new() {
+        let did = test_did();
+        let tuple = RelationTuple::new(did.clone(), "reader", "users", "doc123");
+
+        assert_eq!(tuple.subject, did);
+        assert_eq!(tuple.relation, "reader");
+        assert_eq!(tuple.collection_id, "users");
+        assert_eq!(tuple.doc_id, "doc123");
+    }
+
+    #[test]
+    fn test_relation_tuple_owner() {
+        let did = test_did();
+        let tuple = RelationTuple::owner(did.clone(), "users", "doc123");
+
+        assert_eq!(tuple.relation, OWNER_RELATION);
+        assert!(tuple.is_owner());
+    }
+
+    #[test]
+    fn test_relation_tuple_storage_key() {
+        let did = test_did();
+        let tuple = RelationTuple::new(did.clone(), "reader", "users", "doc123");
+
+        let key = tuple.storage_key();
+        assert!(key.starts_with("/acp/"));
+        assert!(key.contains("users"));
+        assert!(key.contains("doc123"));
+        assert!(key.contains("reader"));
+        assert!(key.contains(did.as_str()));
+    }
+
+    #[test]
+    fn test_doc_prefix() {
+        let prefix = RelationTuple::doc_prefix("users", "doc123");
+        assert_eq!(prefix, "/acp/users/doc123/");
+    }
+
+    #[test]
+    fn test_relation_prefix() {
+        let prefix = RelationTuple::relation_prefix("users", "doc123", "owner");
+        assert_eq!(prefix, "/acp/users/doc123/owner/");
+    }
+
+    #[test]
+    fn test_relation_tuple_display() {
+        let did = test_did();
+        let tuple = RelationTuple::new(did, "reader", "users", "doc123");
+        let display = format!("{}", tuple);
+        assert!(display.contains("reader"));
+        assert!(display.contains("users"));
+        assert!(display.contains("doc123"));
+    }
+
+    #[test]
+    fn test_relation_tuple_serde() {
+        let did = test_did();
+        let tuple = RelationTuple::new(did, "owner", "users", "doc123");
+        let json = serde_json::to_string(&tuple).unwrap();
+        let parsed: RelationTuple = serde_json::from_str(&json).unwrap();
+        assert_eq!(tuple, parsed);
+    }
+}

--- a/crates/acp/src/relation.rs
+++ b/crates/acp/src/relation.rs
@@ -47,7 +47,10 @@ pub struct RelationTuple {
 /// Rejects empty strings and strings containing path separators.
 fn validate_path_component(value: &str, field_name: &str) -> Result<()> {
     if value.is_empty() {
-        return Err(Error::InvalidPolicy(format!("{} cannot be empty", field_name)));
+        return Err(Error::InvalidPolicy(format!(
+            "{} cannot be empty",
+            field_name
+        )));
     }
     if value.contains('/') || value.contains('\\') {
         return Err(Error::InvalidPolicy(format!(
@@ -126,7 +129,11 @@ impl RelationTuple {
     }
 
     /// Create an owner relation tuple.
-    pub fn owner(subject: Did, collection_id: impl Into<String>, doc_id: impl Into<String>) -> Self {
+    pub fn owner(
+        subject: Did,
+        collection_id: impl Into<String>,
+        doc_id: impl Into<String>,
+    ) -> Self {
         Self::new(subject, OWNER_RELATION, collection_id, doc_id)
     }
 
@@ -157,7 +164,11 @@ impl RelationTuple {
     /// Validate a relation prefix.
     ///
     /// Returns an error if any component contains path separators.
-    pub fn validate_relation_prefix(collection_id: &str, doc_id: &str, relation: &str) -> Result<()> {
+    pub fn validate_relation_prefix(
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<()> {
         validate_path_component(collection_id, "collection_id")?;
         validate_path_component(doc_id, "doc_id")?;
         validate_path_component(relation, "relation")?;

--- a/crates/acp/src/relation.rs
+++ b/crates/acp/src/relation.rs
@@ -178,15 +178,52 @@ impl RelationTuple {
     /// Get the prefix for scanning all relations of a document.
     ///
     /// Key format: `/acp/{collection_id}/{doc_id}/`
+    ///
+    /// # Security
+    ///
+    /// This method constructs a storage key from the inputs. Callers MUST validate
+    /// inputs using [`Self::validate_prefix`] before calling this method with
+    /// untrusted input to prevent path traversal attacks.
+    ///
+    /// For trusted internal calls where inputs are known to be safe, validation
+    /// can be skipped.
     pub fn doc_prefix(collection_id: &str, doc_id: &str) -> String {
         format!("/acp/{}/{}/", collection_id, doc_id)
+    }
+
+    /// Get the prefix for scanning all relations of a document with validation.
+    ///
+    /// This is the safe version that validates inputs before constructing the prefix.
+    /// Use this when constructing prefixes from potentially untrusted input.
+    pub fn doc_prefix_validated(collection_id: &str, doc_id: &str) -> Result<String> {
+        Self::validate_prefix(collection_id, doc_id)?;
+        Ok(Self::doc_prefix(collection_id, doc_id))
     }
 
     /// Get the prefix for scanning all tuples with a specific relation.
     ///
     /// Key format: `/acp/{collection_id}/{doc_id}/{relation}/`
+    ///
+    /// # Security
+    ///
+    /// This method constructs a storage key from the inputs. Callers MUST validate
+    /// inputs using [`Self::validate_relation_prefix`] before calling this method
+    /// with untrusted input to prevent path traversal attacks.
     pub fn relation_prefix(collection_id: &str, doc_id: &str, relation: &str) -> String {
         format!("/acp/{}/{}/{}/", collection_id, doc_id, relation)
+    }
+
+    /// Get the prefix for scanning tuples with a specific relation, with validation.
+    ///
+    /// This is the safe version that validates inputs before constructing the prefix.
+    /// Use this when constructing prefixes from potentially untrusted input.
+    pub fn relation_prefix_validated(
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<String> {
+        Self::validate_relation_prefix(collection_id, doc_id, relation)?;
+        Ok(Self::relation_prefix(collection_id, doc_id, relation))
     }
 }
 

--- a/crates/acp/src/relation.rs
+++ b/crates/acp/src/relation.rs
@@ -27,7 +27,8 @@ pub const DELETER_RELATION: &str = "deleter";
 /// Relations are policy-defined strings like "owner", "reader", etc.
 ///
 /// All path components are validated to prevent path traversal attacks.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Use `try_new` to construct instances from untrusted input.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct RelationTuple {
     /// The subject (identity) that has the relation
     subject: Did,
@@ -86,9 +87,11 @@ impl RelationTuple {
 
     /// Create a new relation tuple without validation.
     ///
-    /// Use `try_new` when working with untrusted input.
-    /// This method is for internal use where inputs are already validated.
-    pub fn new(
+    /// This is crate-internal for use where inputs are already validated
+    /// (e.g., from database storage or internal code paths).
+    ///
+    /// External code should use `try_new` to ensure path traversal safety.
+    pub(crate) fn new(
         subject: Did,
         relation: impl Into<String>,
         collection_id: impl Into<String>,
@@ -183,6 +186,32 @@ impl std::fmt::Display for RelationTuple {
             "{}@{}:{}#{}",
             self.subject, self.collection_id, self.doc_id, self.relation
         )
+    }
+}
+
+/// Custom Deserialize implementation that validates path components.
+/// This prevents path traversal attacks via deserialized data.
+impl<'de> Deserialize<'de> for RelationTuple {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        // Deserialize into a helper struct first
+        #[derive(Deserialize)]
+        struct RelationTupleRaw {
+            subject: Did,
+            relation: String,
+            collection_id: String,
+            doc_id: String,
+        }
+
+        let raw = RelationTupleRaw::deserialize(deserializer)?;
+
+        // Validate path components
+        RelationTuple::try_new(raw.subject, raw.relation, raw.collection_id, raw.doc_id)
+            .map_err(|e| D::Error::custom(e.to_string()))
     }
 }
 
@@ -285,5 +314,50 @@ mod tests {
         let json = serde_json::to_string(&tuple).unwrap();
         let parsed: RelationTuple = serde_json::from_str(&json).unwrap();
         assert_eq!(tuple, parsed);
+    }
+
+    #[test]
+    fn test_deserialize_rejects_path_traversal() {
+        // Craft JSON with path separator in relation field
+        let malicious_json = r#"{
+            "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+            "relation": "reader/../admin",
+            "collection_id": "users",
+            "doc_id": "doc123"
+        }"#;
+
+        let result: std::result::Result<RelationTuple, _> = serde_json::from_str(malicious_json);
+        assert!(
+            result.is_err(),
+            "should reject path traversal in relation field"
+        );
+
+        // Craft JSON with path separator in collection_id
+        let malicious_json = r#"{
+            "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+            "relation": "reader",
+            "collection_id": "users/../secrets",
+            "doc_id": "doc123"
+        }"#;
+
+        let result: std::result::Result<RelationTuple, _> = serde_json::from_str(malicious_json);
+        assert!(
+            result.is_err(),
+            "should reject path traversal in collection_id field"
+        );
+
+        // Craft JSON with path separator in doc_id
+        let malicious_json = r#"{
+            "subject": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+            "relation": "reader",
+            "collection_id": "users",
+            "doc_id": "doc/123"
+        }"#;
+
+        let result: std::result::Result<RelationTuple, _> = serde_json::from_str(malicious_json);
+        assert!(
+            result.is_err(),
+            "should reject path traversal in doc_id field"
+        );
     }
 }

--- a/crates/acp/src/store.rs
+++ b/crates/acp/src/store.rs
@@ -1,0 +1,228 @@
+//! ACP tuple storage trait.
+//!
+//! Defines the interface for storing and retrieving relation tuples.
+
+use async_trait::async_trait;
+use identity::Did;
+
+use crate::error::Result;
+use crate::relation::RelationTuple;
+
+/// Trait for storing and querying relation tuples.
+///
+/// This abstraction allows different storage backends to be used
+/// (in-memory for testing, RocksDB for production, etc.)
+#[async_trait]
+pub trait AcpStore: Send + Sync {
+    /// Store a relation tuple.
+    async fn put_tuple(&self, tuple: &RelationTuple) -> Result<()>;
+
+    /// Delete a relation tuple.
+    async fn delete_tuple(&self, tuple: &RelationTuple) -> Result<()>;
+
+    /// Check if a tuple exists.
+    async fn has_tuple(&self, tuple: &RelationTuple) -> Result<bool>;
+
+    /// Get all tuples for a document.
+    async fn get_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<Vec<RelationTuple>>;
+
+    /// Get all subjects with a specific relation to a document.
+    async fn get_relation_subjects(
+        &self,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+    ) -> Result<Vec<Did>>;
+
+    /// Get all relations a subject has to a document.
+    async fn get_subject_relations(
+        &self,
+        subject: &Did,
+        collection_id: &str,
+        doc_id: &str,
+    ) -> Result<Vec<String>>;
+
+    /// Delete all tuples for a document.
+    async fn delete_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<()>;
+
+    /// Check if a document has any tuples (i.e., is registered with ACP).
+    async fn is_doc_registered(&self, collection_id: &str, doc_id: &str) -> Result<bool>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+
+    /// In-memory implementation for testing
+    struct MemoryAcpStore {
+        tuples: RwLock<HashMap<String, RelationTuple>>,
+    }
+
+    impl MemoryAcpStore {
+        fn new() -> Self {
+            Self {
+                tuples: RwLock::new(HashMap::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl AcpStore for MemoryAcpStore {
+        async fn put_tuple(&self, tuple: &RelationTuple) -> Result<()> {
+            self.tuples
+                .write()
+                .insert(tuple.storage_key(), tuple.clone());
+            Ok(())
+        }
+
+        async fn delete_tuple(&self, tuple: &RelationTuple) -> Result<()> {
+            self.tuples.write().remove(&tuple.storage_key());
+            Ok(())
+        }
+
+        async fn has_tuple(&self, tuple: &RelationTuple) -> Result<bool> {
+            Ok(self.tuples.read().contains_key(&tuple.storage_key()))
+        }
+
+        async fn get_doc_tuples(
+            &self,
+            collection_id: &str,
+            doc_id: &str,
+        ) -> Result<Vec<RelationTuple>> {
+            let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
+            let tuples = self
+                .tuples
+                .read()
+                .iter()
+                .filter(|(k, _)| k.starts_with(&prefix))
+                .map(|(_, v)| v.clone())
+                .collect();
+            Ok(tuples)
+        }
+
+        async fn get_relation_subjects(
+            &self,
+            collection_id: &str,
+            doc_id: &str,
+            relation: &str,
+        ) -> Result<Vec<Did>> {
+            let prefix = RelationTuple::relation_prefix(collection_id, doc_id, relation);
+            let subjects = self
+                .tuples
+                .read()
+                .iter()
+                .filter(|(k, _)| k.starts_with(&prefix))
+                .map(|(_, v)| v.subject.clone())
+                .collect();
+            Ok(subjects)
+        }
+
+        async fn get_subject_relations(
+            &self,
+            subject: &Did,
+            collection_id: &str,
+            doc_id: &str,
+        ) -> Result<Vec<String>> {
+            let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
+            let relations = self
+                .tuples
+                .read()
+                .iter()
+                .filter(|(k, v)| k.starts_with(&prefix) && &v.subject == subject)
+                .map(|(_, v)| v.relation.clone())
+                .collect();
+            Ok(relations)
+        }
+
+        async fn delete_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<()> {
+            let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
+            self.tuples.write().retain(|k, _| !k.starts_with(&prefix));
+            Ok(())
+        }
+
+        async fn is_doc_registered(&self, collection_id: &str, doc_id: &str) -> Result<bool> {
+            let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
+            Ok(self.tuples.read().keys().any(|k| k.starts_with(&prefix)))
+        }
+    }
+
+    fn test_did() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    fn test_did2() -> Did {
+        Did::new("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR").unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_put_and_has() {
+        let store = MemoryAcpStore::new();
+        let tuple = RelationTuple::owner(test_did(), "users", "doc1");
+
+        assert!(!store.has_tuple(&tuple).await.unwrap());
+        store.put_tuple(&tuple).await.unwrap();
+        assert!(store.has_tuple(&tuple).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_delete() {
+        let store = MemoryAcpStore::new();
+        let tuple = RelationTuple::owner(test_did(), "users", "doc1");
+
+        store.put_tuple(&tuple).await.unwrap();
+        assert!(store.has_tuple(&tuple).await.unwrap());
+
+        store.delete_tuple(&tuple).await.unwrap();
+        assert!(!store.has_tuple(&tuple).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_get_doc_tuples() {
+        let store = MemoryAcpStore::new();
+        let did1 = test_did();
+        let did2 = test_did2();
+
+        let tuple1 = RelationTuple::owner(did1.clone(), "users", "doc1");
+        let tuple2 = RelationTuple::new(did2.clone(), "reader", "users", "doc1");
+        let tuple3 = RelationTuple::owner(did1.clone(), "users", "doc2");
+
+        store.put_tuple(&tuple1).await.unwrap();
+        store.put_tuple(&tuple2).await.unwrap();
+        store.put_tuple(&tuple3).await.unwrap();
+
+        let doc1_tuples = store.get_doc_tuples("users", "doc1").await.unwrap();
+        assert_eq!(doc1_tuples.len(), 2);
+
+        let doc2_tuples = store.get_doc_tuples("users", "doc2").await.unwrap();
+        assert_eq!(doc2_tuples.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_is_doc_registered() {
+        let store = MemoryAcpStore::new();
+        let tuple = RelationTuple::owner(test_did(), "users", "doc1");
+
+        assert!(!store.is_doc_registered("users", "doc1").await.unwrap());
+        store.put_tuple(&tuple).await.unwrap();
+        assert!(store.is_doc_registered("users", "doc1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_delete_doc_tuples() {
+        let store = MemoryAcpStore::new();
+        let did1 = test_did();
+        let did2 = test_did2();
+
+        let tuple1 = RelationTuple::owner(did1.clone(), "users", "doc1");
+        let tuple2 = RelationTuple::new(did2.clone(), "reader", "users", "doc1");
+
+        store.put_tuple(&tuple1).await.unwrap();
+        store.put_tuple(&tuple2).await.unwrap();
+        assert!(store.is_doc_registered("users", "doc1").await.unwrap());
+
+        store.delete_doc_tuples("users", "doc1").await.unwrap();
+        assert!(!store.is_doc_registered("users", "doc1").await.unwrap());
+    }
+}

--- a/crates/acp/src/store.rs
+++ b/crates/acp/src/store.rs
@@ -24,7 +24,8 @@ pub trait AcpStore: Send + Sync {
     async fn has_tuple(&self, tuple: &RelationTuple) -> Result<bool>;
 
     /// Get all tuples for a document.
-    async fn get_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<Vec<RelationTuple>>;
+    async fn get_doc_tuples(&self, collection_id: &str, doc_id: &str)
+        -> Result<Vec<RelationTuple>>;
 
     /// Get all subjects with a specific relation to a document.
     async fn get_relation_subjects(

--- a/crates/acp/src/store.rs
+++ b/crates/acp/src/store.rs
@@ -12,22 +12,55 @@ use crate::relation::RelationTuple;
 ///
 /// This abstraction allows different storage backends to be used
 /// (in-memory for testing, RocksDB for production, etc.)
+///
+/// # Security: Input Validation
+///
+/// **CRITICAL**: Implementations MUST validate all string inputs (collection_id, doc_id,
+/// relation) to prevent path traversal attacks. Use [`RelationTuple::validate_prefix`]
+/// or [`RelationTuple::validate_relation_prefix`] before constructing storage keys.
+///
+/// Inputs containing path separators (`/` or `\`) MUST be rejected with an error.
+/// Never construct storage keys from unvalidated user input.
+///
+/// # Security: Error Handling
+///
+/// All operations that check permissions MUST follow a fail-closed pattern:
+/// - On success: return the actual result
+/// - On error: callers MUST treat the error as "access denied"
+///
+/// Never allow errors to result in unauthorized access.
 #[async_trait]
 pub trait AcpStore: Send + Sync {
     /// Store a relation tuple.
+    ///
+    /// The tuple has already been validated by construction.
     async fn put_tuple(&self, tuple: &RelationTuple) -> Result<()>;
 
     /// Delete a relation tuple.
+    ///
+    /// The tuple has already been validated by construction.
     async fn delete_tuple(&self, tuple: &RelationTuple) -> Result<()>;
 
     /// Check if a tuple exists.
+    ///
+    /// The tuple has already been validated by construction.
     async fn has_tuple(&self, tuple: &RelationTuple) -> Result<bool>;
 
     /// Get all tuples for a document.
+    ///
+    /// # Security
+    ///
+    /// Implementations MUST validate `collection_id` and `doc_id` using
+    /// [`RelationTuple::validate_prefix`] before constructing storage keys.
     async fn get_doc_tuples(&self, collection_id: &str, doc_id: &str)
         -> Result<Vec<RelationTuple>>;
 
     /// Get all subjects with a specific relation to a document.
+    ///
+    /// # Security
+    ///
+    /// Implementations MUST validate `collection_id`, `doc_id`, and `relation` using
+    /// [`RelationTuple::validate_relation_prefix`] before constructing storage keys.
     async fn get_relation_subjects(
         &self,
         collection_id: &str,
@@ -36,6 +69,11 @@ pub trait AcpStore: Send + Sync {
     ) -> Result<Vec<Did>>;
 
     /// Get all relations a subject has to a document.
+    ///
+    /// # Security
+    ///
+    /// Implementations MUST validate `collection_id` and `doc_id` using
+    /// [`RelationTuple::validate_prefix`] before constructing storage keys.
     async fn get_subject_relations(
         &self,
         subject: &Did,
@@ -44,9 +82,19 @@ pub trait AcpStore: Send + Sync {
     ) -> Result<Vec<String>>;
 
     /// Delete all tuples for a document.
+    ///
+    /// # Security
+    ///
+    /// Implementations MUST validate `collection_id` and `doc_id` using
+    /// [`RelationTuple::validate_prefix`] before constructing storage keys.
     async fn delete_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<()>;
 
     /// Check if a document has any tuples (i.e., is registered with ACP).
+    ///
+    /// # Security
+    ///
+    /// Implementations MUST validate `collection_id` and `doc_id` using
+    /// [`RelationTuple::validate_prefix`] before constructing storage keys.
     async fn is_doc_registered(&self, collection_id: &str, doc_id: &str) -> Result<bool>;
 }
 

--- a/crates/acp/src/store.rs
+++ b/crates/acp/src/store.rs
@@ -114,7 +114,7 @@ mod tests {
                 .read()
                 .iter()
                 .filter(|(k, _)| k.starts_with(&prefix))
-                .map(|(_, v)| v.subject.clone())
+                .map(|(_, v)| v.subject().clone())
                 .collect();
             Ok(subjects)
         }
@@ -130,8 +130,8 @@ mod tests {
                 .tuples
                 .read()
                 .iter()
-                .filter(|(k, v)| k.starts_with(&prefix) && &v.subject == subject)
-                .map(|(_, v)| v.relation.clone())
+                .filter(|(k, v)| k.starts_with(&prefix) && v.subject() == subject)
+                .map(|(_, v)| v.relation().to_string())
                 .collect();
             Ok(relations)
         }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -38,6 +38,7 @@ blockstore = { path = "../blockstore" }
 crypto = { path = "../crypto" }
 defra-core = { path = "../defra-core" }
 identity = { path = "../identity" }
+acp = { path = "../acp" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/db/src/collection_acp.rs
+++ b/crates/db/src/collection_acp.rs
@@ -28,8 +28,14 @@ pub async fn check_doc_permission(
         None => return Ok(true),
     };
 
-    acp.check_doc_access(identity, permission, &policy.id, &policy.resource_name, doc_id)
-        .await
+    acp.check_doc_access(
+        identity,
+        permission,
+        &policy.id,
+        &policy.resource_name,
+        doc_id,
+    )
+    .await
 }
 
 /// Register a document with ACP after creation.
@@ -126,7 +132,13 @@ impl AcpContext {
         collection: &CollectionVersion,
         doc_id: &str,
     ) -> acp::Result<()> {
-        register_doc_if_needed(self.acp.as_ref(), self.identity.as_ref(), collection, doc_id).await
+        register_doc_if_needed(
+            self.acp.as_ref(),
+            self.identity.as_ref(),
+            collection,
+            doc_id,
+        )
+        .await
     }
 }
 

--- a/crates/db/src/collection_acp.rs
+++ b/crates/db/src/collection_acp.rs
@@ -1,0 +1,303 @@
+//! Collection-level ACP helpers.
+//!
+//! These helpers provide document-level access control integration for
+//! collection mutations (create/update/delete).
+
+use std::sync::Arc;
+
+use acp::{DocumentACP, DocumentPermission};
+use identity::Did;
+use schema::CollectionVersion;
+
+/// Check if identity has permission for a document operation.
+///
+/// Returns true if:
+/// 1. Collection has no policy (ACP not enforced)
+/// 2. Document is unregistered (public)
+/// 3. Identity has the required permission
+pub async fn check_doc_permission(
+    acp: &dyn DocumentACP,
+    identity: Option<&Did>,
+    permission: DocumentPermission,
+    collection: &CollectionVersion,
+    doc_id: &str,
+) -> acp::Result<bool> {
+    // If collection has no policy, ACP is not enforced
+    let policy = match &collection.policy {
+        Some(p) => p,
+        None => return Ok(true),
+    };
+
+    acp.check_doc_access(identity, permission, &policy.id, &policy.resource_name, doc_id)
+        .await
+}
+
+/// Register a document with ACP after creation.
+///
+/// Only registers if:
+/// 1. Collection has a policy
+/// 2. Identity is provided
+///
+/// If collection has no policy or no identity is provided, the document
+/// remains unregistered (public).
+pub async fn register_doc_if_needed(
+    acp: &dyn DocumentACP,
+    identity: Option<&Did>,
+    collection: &CollectionVersion,
+    doc_id: &str,
+) -> acp::Result<()> {
+    // Only register if collection has policy AND identity is provided
+    let (policy, did) = match (&collection.policy, identity) {
+        (Some(p), Some(id)) => (p, id),
+        _ => return Ok(()), // No policy or no identity = public document
+    };
+
+    acp.register_doc_object(did, &policy.id, &policy.resource_name, doc_id)
+        .await
+}
+
+/// Clean up ACP relations when deleting a document.
+///
+/// This should be called when deleting a document to remove all
+/// associated relation tuples from the ACP store.
+pub async fn unregister_doc_if_needed(
+    acp: &dyn DocumentACP,
+    collection: &CollectionVersion,
+    doc_id: &str,
+) -> acp::Result<()> {
+    // Only need to check if document is registered if collection has policy
+    let policy = match &collection.policy {
+        Some(p) => p,
+        None => return Ok(()), // No policy = no ACP tuples to clean up
+    };
+
+    // Check if document is registered
+    if !acp
+        .is_doc_registered(&policy.id, &policy.resource_name, doc_id)
+        .await?
+    {
+        return Ok(()); // Not registered, nothing to clean up
+    }
+
+    // The AcpStore's delete_doc_tuples will be called by the LocalDocumentACP
+    // For now, we just need to verify the document can be deleted
+    // The actual tuple cleanup is handled by the delete mutation
+    Ok(())
+}
+
+/// ACP context for mutation operations.
+///
+/// This wraps the DocumentACP and identity for convenient access
+/// during collection mutations.
+#[derive(Clone)]
+pub struct AcpContext {
+    /// Document ACP for permission checks
+    pub acp: Arc<dyn DocumentACP>,
+    /// Identity making the request
+    pub identity: Option<Did>,
+}
+
+impl AcpContext {
+    /// Create a new ACP context.
+    pub fn new(acp: Arc<dyn DocumentACP>, identity: Option<Did>) -> Self {
+        Self { acp, identity }
+    }
+
+    /// Check if identity has permission for a document operation.
+    pub async fn check_permission(
+        &self,
+        permission: DocumentPermission,
+        collection: &CollectionVersion,
+        doc_id: &str,
+    ) -> acp::Result<bool> {
+        check_doc_permission(
+            self.acp.as_ref(),
+            self.identity.as_ref(),
+            permission,
+            collection,
+            doc_id,
+        )
+        .await
+    }
+
+    /// Register a document after creation.
+    pub async fn register_doc(
+        &self,
+        collection: &CollectionVersion,
+        doc_id: &str,
+    ) -> acp::Result<()> {
+        register_doc_if_needed(self.acp.as_ref(), self.identity.as_ref(), collection, doc_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acp::{LocalDocumentACP, MemoryAcpStore};
+    use schema::{FieldDescription, FieldKind, PolicyDescription};
+
+    fn test_did() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    fn test_did2() -> Did {
+        Did::new("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR").unwrap()
+    }
+
+    fn collection_without_policy() -> CollectionVersion {
+        CollectionVersion::new(
+            "users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+            ],
+        )
+    }
+
+    fn collection_with_policy() -> CollectionVersion {
+        let mut col = CollectionVersion::new(
+            "users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+            ],
+        );
+        col.policy = Some(PolicyDescription::new("policy1", "users"));
+        col
+    }
+
+    #[tokio::test]
+    async fn test_no_policy_allows_all() {
+        let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+        let collection = collection_without_policy();
+
+        // Anyone should have access when there's no policy
+        let allowed = check_doc_permission(
+            &acp,
+            None, // Anonymous
+            DocumentPermission::Read,
+            &collection,
+            "doc1",
+        )
+        .await
+        .unwrap();
+
+        assert!(allowed);
+    }
+
+    #[tokio::test]
+    async fn test_register_with_policy_and_identity() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = LocalDocumentACP::new(store);
+        let collection = collection_with_policy();
+        let owner = test_did();
+
+        // Register document
+        register_doc_if_needed(&acp, Some(&owner), &collection, "doc1")
+            .await
+            .unwrap();
+
+        // Verify owner has access
+        let policy = collection.policy.as_ref().unwrap();
+        let is_registered = acp
+            .is_doc_registered(&policy.id, &policy.resource_name, "doc1")
+            .await
+            .unwrap();
+        assert!(is_registered);
+    }
+
+    #[tokio::test]
+    async fn test_no_register_without_identity() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = LocalDocumentACP::new(store);
+        let collection = collection_with_policy();
+
+        // Register without identity (public document)
+        register_doc_if_needed(&acp, None, &collection, "doc1")
+            .await
+            .unwrap();
+
+        // Document should NOT be registered
+        let policy = collection.policy.as_ref().unwrap();
+        let is_registered = acp
+            .is_doc_registered(&policy.id, &policy.resource_name, "doc1")
+            .await
+            .unwrap();
+        assert!(!is_registered);
+    }
+
+    #[tokio::test]
+    async fn test_owner_has_update_permission() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = LocalDocumentACP::new(store);
+        let collection = collection_with_policy();
+        let owner = test_did();
+
+        // Register document
+        register_doc_if_needed(&acp, Some(&owner), &collection, "doc1")
+            .await
+            .unwrap();
+
+        // Owner should have update permission
+        let allowed = check_doc_permission(
+            &acp,
+            Some(&owner),
+            DocumentPermission::Update,
+            &collection,
+            "doc1",
+        )
+        .await
+        .unwrap();
+        assert!(allowed);
+    }
+
+    #[tokio::test]
+    async fn test_non_owner_denied_update_permission() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = LocalDocumentACP::new(store);
+        let collection = collection_with_policy();
+        let owner = test_did();
+        let stranger = test_did2();
+
+        // Register document with owner
+        register_doc_if_needed(&acp, Some(&owner), &collection, "doc1")
+            .await
+            .unwrap();
+
+        // Stranger should NOT have update permission
+        let allowed = check_doc_permission(
+            &acp,
+            Some(&stranger),
+            DocumentPermission::Update,
+            &collection,
+            "doc1",
+        )
+        .await
+        .unwrap();
+        assert!(!allowed);
+    }
+
+    #[tokio::test]
+    async fn test_acp_context() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let collection = collection_with_policy();
+        let owner = test_did();
+
+        let ctx = AcpContext::new(acp, Some(owner));
+
+        // Register document using context
+        ctx.register_doc(&collection, "doc1").await.unwrap();
+
+        // Check permission using context
+        let allowed = ctx
+            .check_permission(DocumentPermission::Delete, &collection, "doc1")
+            .await
+            .unwrap();
+        assert!(allowed);
+    }
+}

--- a/crates/db/src/collection_acp.rs
+++ b/crates/db/src/collection_acp.rs
@@ -65,13 +65,13 @@ pub async fn register_doc_if_needed(
 /// Clean up ACP relations when deleting a document.
 ///
 /// This should be called when deleting a document to remove all
-/// associated relation tuples from the ACP store.
+/// associated relation tuples from the ACP store (owner, reader, updater, deleter).
 pub async fn unregister_doc_if_needed(
     acp: &dyn DocumentACP,
     collection: &CollectionVersion,
     doc_id: &str,
 ) -> acp::Result<()> {
-    // Only need to check if document is registered if collection has policy
+    // Only need to clean up if collection has policy
     let policy = match &collection.policy {
         Some(p) => p,
         None => return Ok(()), // No policy = no ACP tuples to clean up
@@ -85,10 +85,9 @@ pub async fn unregister_doc_if_needed(
         return Ok(()); // Not registered, nothing to clean up
     }
 
-    // The AcpStore's delete_doc_tuples will be called by the LocalDocumentACP
-    // For now, we just need to verify the document can be deleted
-    // The actual tuple cleanup is handled by the delete mutation
-    Ok(())
+    // Delete all ACP tuples for this document
+    acp.unregister_doc_object(&policy.id, &policy.resource_name, doc_id)
+        .await
 }
 
 /// ACP context for mutation operations.

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -45,6 +45,7 @@
 pub mod auto_commit_fetcher;
 pub mod auto_commit_mutator;
 pub mod collection;
+pub mod collection_acp;
 pub mod collection_cache;
 pub(crate) mod collection_loader;
 pub mod collection_name;
@@ -63,6 +64,9 @@ pub mod txn_registry;
 pub use auto_commit_fetcher::AutoCommitFetcher;
 pub use auto_commit_mutator::AutoCommitMutator;
 pub use collection::Collection;
+pub use collection_acp::{
+    check_doc_permission, register_doc_if_needed, unregister_doc_if_needed, AcpContext,
+};
 pub use collection_cache::CollectionCache;
 pub use collection_name::CollectionName;
 pub use collection_snapshot::CollectionSnapshot;

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -14,6 +14,7 @@ test-utils = []
 [dependencies]
 # Internal crates
 query = { path = "../query" }
+identity = { path = "../identity" }
 
 # Async runtime
 tokio.workspace = true
@@ -40,3 +41,4 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tower = { workspace = true, features = ["util"] }
 urlencoding = "2.1"
+crypto = { path = "../crypto" }

--- a/crates/http/src/handlers.rs
+++ b/crates/http/src/handlers.rs
@@ -405,7 +405,7 @@ mod tests {
         };
         let request = QueryRequest::new("{ users { name } }");
 
-        let response = graphql(State(state), ExtractIdentity(None), Json(request)).await;
+        let response = graphql(State(state), ExtractIdentity::anonymous(), Json(request)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -421,7 +421,7 @@ mod tests {
             variables: None,
         };
 
-        let response = graphql_get(State(state), ExtractIdentity(None), Query(params)).await;
+        let response = graphql_get(State(state), ExtractIdentity::anonymous(), Query(params)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -437,7 +437,7 @@ mod tests {
             variables: Some(json!({"limit": 10}).to_string()),
         };
 
-        let response = graphql_get(State(state), ExtractIdentity(None), Query(params)).await;
+        let response = graphql_get(State(state), ExtractIdentity::anonymous(), Query(params)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -453,7 +453,7 @@ mod tests {
             variables: Some("{invalid json".to_string()),
         };
 
-        let response = graphql_get(State(state), ExtractIdentity(None), Query(params)).await;
+        let response = graphql_get(State(state), ExtractIdentity::anonymous(), Query(params)).await;
         assert!(response.has_errors());
         assert!(response.data.is_none());
         assert!(response.errors[0].message.contains("invalid JSON"));
@@ -577,7 +577,7 @@ mod tests {
         };
 
         let response =
-            graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
+            graphql_transactional(State(state), ExtractIdentity::anonymous(), Json(request)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -595,7 +595,7 @@ mod tests {
         };
 
         let response =
-            graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
+            graphql_transactional(State(state), ExtractIdentity::anonymous(), Json(request)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -613,7 +613,7 @@ mod tests {
         };
 
         let response =
-            graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
+            graphql_transactional(State(state), ExtractIdentity::anonymous(), Json(request)).await;
         assert!(response.has_errors());
         assert!(response.errors[0]
             .message

--- a/crates/http/src/handlers.rs
+++ b/crates/http/src/handlers.rs
@@ -50,6 +50,8 @@ pub async fn graphql(
         tracing::debug!(did = %did, "GraphQL POST request with identity");
     }
 
+    // Pass identity through to executor for ACP permission checks
+    let request = request.with_identity(identity.into_did());
     let response = state.executor.execute(request).await;
     if response.has_errors() {
         tracing::warn!(errors = ?response.errors, "GraphQL POST query returned errors");
@@ -96,10 +98,18 @@ pub async fn graphql_get(
         None => None,
     };
 
-    let request = QueryRequest {
-        query: params.query,
-        operation_name: params.operation_name,
-        variables,
+    // Pass identity through to executor for ACP permission checks
+    let request = QueryRequest::new(params.query)
+        .with_identity(identity.into_did());
+    let request = if let Some(op_name) = params.operation_name {
+        request.with_operation_name(op_name)
+    } else {
+        request
+    };
+    let request = if let Some(vars) = variables {
+        request.with_variables(vars)
+    } else {
+        request
     };
 
     let response = state.executor.execute(request).await;
@@ -332,10 +342,18 @@ pub async fn graphql_transactional(
         tracing::debug!(did = %did, "GraphQL transactional request with identity");
     }
 
-    let query_request = QueryRequest {
-        query: request.query,
-        operation_name: request.operation_name,
-        variables: request.variables,
+    // Pass identity through to executor for ACP permission checks
+    let query_request = QueryRequest::new(request.query)
+        .with_identity(identity.into_did());
+    let query_request = if let Some(op_name) = request.operation_name {
+        query_request.with_operation_name(op_name)
+    } else {
+        query_request
+    };
+    let query_request = if let Some(vars) = request.variables {
+        query_request.with_variables(vars)
+    } else {
+        query_request
     };
 
     let response = match request.txn_id {

--- a/crates/http/src/handlers.rs
+++ b/crates/http/src/handlers.rs
@@ -99,8 +99,7 @@ pub async fn graphql_get(
     };
 
     // Pass identity through to executor for ACP permission checks
-    let request = QueryRequest::new(params.query)
-        .with_identity(identity.into_did());
+    let request = QueryRequest::new(params.query).with_identity(identity.into_did());
     let request = if let Some(op_name) = params.operation_name {
         request.with_operation_name(op_name)
     } else {
@@ -343,8 +342,7 @@ pub async fn graphql_transactional(
     }
 
     // Pass identity through to executor for ACP permission checks
-    let query_request = QueryRequest::new(request.query)
-        .with_identity(identity.into_did());
+    let query_request = QueryRequest::new(request.query).with_identity(identity.into_did());
     let query_request = if let Some(op_name) = request.operation_name {
         query_request.with_operation_name(op_name)
     } else {
@@ -578,7 +576,8 @@ mod tests {
             txn_id: None,
         };
 
-        let response = graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
+        let response =
+            graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -595,7 +594,8 @@ mod tests {
             txn_id: Some("mock-txn-001".to_string()),
         };
 
-        let response = graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
+        let response =
+            graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -612,7 +612,8 @@ mod tests {
             txn_id: Some("".to_string()), // Empty string is invalid
         };
 
-        let response = graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
+        let response =
+            graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
         assert!(response.has_errors());
         assert!(response.errors[0]
             .message

--- a/crates/http/src/handlers.rs
+++ b/crates/http/src/handlers.rs
@@ -11,6 +11,7 @@ use serde_json::Value as JsonValue;
 
 use query::executor::{QueryRequest, QueryResponse};
 
+use crate::identity_extractor::ExtractIdentity;
 use crate::router::AppState;
 
 /// Health check response.
@@ -36,10 +37,19 @@ pub async fn version() -> Json<VersionResponse> {
 /// GraphQL POST request handler.
 ///
 /// Accepts JSON body: { query, operationName?, variables? }
+///
+/// If an `Authorization: Bearer <JWT>` header is present, the identity
+/// is extracted and passed to the query executor for ACP permission checks.
 pub async fn graphql(
     State(state): State<AppState>,
+    identity: ExtractIdentity,
     Json(request): Json<QueryRequest>,
 ) -> Json<QueryResponse> {
+    // Log identity if present for debugging
+    if let Some(did) = identity.did() {
+        tracing::debug!(did = %did, "GraphQL POST request with identity");
+    }
+
     let response = state.executor.execute(request).await;
     if response.has_errors() {
         tracing::warn!(errors = ?response.errors, "GraphQL POST query returned errors");
@@ -59,10 +69,19 @@ pub struct GraphqlQueryParams {
 /// GraphQL GET request handler.
 ///
 /// Accepts query parameters: ?query=...&operationName=...&variables=...
+///
+/// If an `Authorization: Bearer <JWT>` header is present, the identity
+/// is extracted and passed to the query executor for ACP permission checks.
 pub async fn graphql_get(
     State(state): State<AppState>,
+    identity: ExtractIdentity,
     Query(params): Query<GraphqlQueryParams>,
 ) -> Json<QueryResponse> {
+    // Log identity if present for debugging
+    if let Some(did) = identity.did() {
+        tracing::debug!(did = %did, "GraphQL GET request with identity");
+    }
+
     let variables: Option<JsonValue> = match params.variables {
         Some(v) => match serde_json::from_str(&v) {
             Ok(parsed) => Some(parsed),
@@ -300,10 +319,19 @@ pub struct TransactionalQueryRequest {
 ///
 /// If txn_id is provided, executes within the specified transaction.
 /// Otherwise, executes with auto-commit semantics.
+///
+/// If an `Authorization: Bearer <JWT>` header is present, the identity
+/// is extracted and passed to the query executor for ACP permission checks.
 pub async fn graphql_transactional(
     State(state): State<AppState>,
+    identity: ExtractIdentity,
     Json(request): Json<TransactionalQueryRequest>,
 ) -> Json<QueryResponse> {
+    // Log identity if present for debugging
+    if let Some(did) = identity.did() {
+        tracing::debug!(did = %did, "GraphQL transactional request with identity");
+    }
+
     let query_request = QueryRequest {
         query: request.query,
         operation_name: request.operation_name,
@@ -361,7 +389,7 @@ mod tests {
         };
         let request = QueryRequest::new("{ users { name } }");
 
-        let response = graphql(State(state), Json(request)).await;
+        let response = graphql(State(state), ExtractIdentity(None), Json(request)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -377,7 +405,7 @@ mod tests {
             variables: None,
         };
 
-        let response = graphql_get(State(state), Query(params)).await;
+        let response = graphql_get(State(state), ExtractIdentity(None), Query(params)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -393,7 +421,7 @@ mod tests {
             variables: Some(json!({"limit": 10}).to_string()),
         };
 
-        let response = graphql_get(State(state), Query(params)).await;
+        let response = graphql_get(State(state), ExtractIdentity(None), Query(params)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -409,7 +437,7 @@ mod tests {
             variables: Some("{invalid json".to_string()),
         };
 
-        let response = graphql_get(State(state), Query(params)).await;
+        let response = graphql_get(State(state), ExtractIdentity(None), Query(params)).await;
         assert!(response.has_errors());
         assert!(response.data.is_none());
         assert!(response.errors[0].message.contains("invalid JSON"));
@@ -532,7 +560,7 @@ mod tests {
             txn_id: None,
         };
 
-        let response = graphql_transactional(State(state), Json(request)).await;
+        let response = graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -549,7 +577,7 @@ mod tests {
             txn_id: Some("mock-txn-001".to_string()),
         };
 
-        let response = graphql_transactional(State(state), Json(request)).await;
+        let response = graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
         assert!(response.data.is_some());
         assert!(!response.has_errors());
     }
@@ -566,7 +594,7 @@ mod tests {
             txn_id: Some("".to_string()), // Empty string is invalid
         };
 
-        let response = graphql_transactional(State(state), Json(request)).await;
+        let response = graphql_transactional(State(state), ExtractIdentity(None), Json(request)).await;
         assert!(response.has_errors());
         assert!(response.errors[0]
             .message

--- a/crates/http/src/identity_extractor.rs
+++ b/crates/http/src/identity_extractor.rs
@@ -112,13 +112,7 @@ where
     fn from_request_parts<'life0, 'life1, 'async_trait>(
         parts: &'life0 mut Parts,
         _state: &'life1 S,
-    ) -> std::pin::Pin<
-        Box<
-            dyn Future<Output = Result<Self, Self::Rejection>>
-                + Send
-                + 'async_trait,
-        >,
-    >
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Self, Self::Rejection>> + Send + 'async_trait>>
     where
         'life0: 'async_trait,
         'life1: 'async_trait,
@@ -200,13 +194,7 @@ where
     fn from_request_parts<'life0, 'life1, 'async_trait>(
         parts: &'life0 mut Parts,
         _state: &'life1 S,
-    ) -> std::pin::Pin<
-        Box<
-            dyn Future<Output = Result<Self, Self::Rejection>>
-                + Send
-                + 'async_trait,
-        >,
-    >
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Self, Self::Rejection>> + Send + 'async_trait>>
     where
         'life0: 'async_trait,
         'life1: 'async_trait,

--- a/crates/http/src/identity_extractor.rs
+++ b/crates/http/src/identity_extractor.rs
@@ -1,0 +1,308 @@
+//! Identity extraction from HTTP Authorization headers.
+//!
+//! This module provides an Axum extractor for parsing JWT bearer tokens
+//! from the Authorization header and extracting the identity.
+
+use axum::{
+    extract::FromRequestParts,
+    http::{header::AUTHORIZATION, request::Parts, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use std::future::Future;
+
+use identity::{from_token, Did, Identity, TokenIdentity};
+
+use crate::error::ErrorResponse;
+
+/// Extractor for identity from Authorization header.
+///
+/// Parses `Authorization: Bearer <JWT>` header and extracts the identity.
+/// If no Authorization header is present, the identity is None (anonymous).
+/// If the token is invalid, returns a 401 Unauthorized error.
+#[derive(Debug, Clone)]
+pub struct ExtractIdentity(pub Option<Did>);
+
+impl ExtractIdentity {
+    /// Returns the extracted DID if present.
+    pub fn did(&self) -> Option<&Did> {
+        self.0.as_ref()
+    }
+}
+
+/// Error type for identity extraction failures.
+#[derive(Debug)]
+pub enum IdentityExtractionError {
+    /// Invalid token format or signature.
+    InvalidToken(String),
+}
+
+impl IntoResponse for IdentityExtractionError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            IdentityExtractionError::InvalidToken(msg) => {
+                (StatusCode::UNAUTHORIZED, format!("Invalid token: {}", msg))
+            }
+        };
+
+        (status, Json(ErrorResponse { error: message })).into_response()
+    }
+}
+
+/// Extract identity from Authorization header value.
+fn extract_identity_from_auth_header(
+    auth_value: Option<&str>,
+) -> Result<Option<Did>, IdentityExtractionError> {
+    let Some(auth_value) = auth_value else {
+        // No Authorization header = anonymous request
+        return Ok(None);
+    };
+
+    // Check for Bearer prefix
+    let token = if let Some(token) = auth_value.strip_prefix("Bearer ") {
+        token.trim()
+    } else if let Some(token) = auth_value.strip_prefix("bearer ") {
+        token.trim()
+    } else {
+        // Authorization header without Bearer prefix = anonymous
+        // This allows other auth schemes to pass through
+        return Ok(None);
+    };
+
+    // Empty token after stripping prefix = anonymous
+    if token.is_empty() {
+        return Ok(None);
+    }
+
+    // Parse the token
+    let token_identity = from_token(token.as_bytes())
+        .map_err(|e| IdentityExtractionError::InvalidToken(e.to_string()))?;
+
+    // Extract DID
+    let did = token_identity
+        .did()
+        .map_err(|e| IdentityExtractionError::InvalidToken(e.to_string()))?;
+
+    Ok(Some(did))
+}
+
+impl<S> FromRequestParts<S> for ExtractIdentity
+where
+    S: Send + Sync,
+{
+    type Rejection = IdentityExtractionError;
+
+    fn from_request_parts<'life0, 'life1, 'async_trait>(
+        parts: &'life0 mut Parts,
+        _state: &'life1 S,
+    ) -> std::pin::Pin<
+        Box<
+            dyn Future<Output = Result<Self, Self::Rejection>>
+                + Send
+                + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        // Get the auth header value before entering the async block
+        let auth_value = parts
+            .headers
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        Box::pin(async move {
+            let result = extract_identity_from_auth_header(auth_value.as_deref())?;
+            Ok(ExtractIdentity(result))
+        })
+    }
+}
+
+/// Full token identity extractor.
+///
+/// Similar to `ExtractIdentity` but keeps the full `TokenIdentity`
+/// for cases where more than just the DID is needed (e.g., audience verification).
+#[derive(Debug)]
+pub struct ExtractTokenIdentity(pub Option<TokenIdentity>);
+
+impl ExtractTokenIdentity {
+    /// Returns the extracted token identity if present.
+    pub fn identity(&self) -> Option<&TokenIdentity> {
+        self.0.as_ref()
+    }
+
+    /// Returns the DID if identity is present.
+    pub fn did(&self) -> Option<Did> {
+        self.0.as_ref().and_then(|id| id.did().ok())
+    }
+}
+
+/// Extract full token identity from Authorization header value.
+fn extract_token_identity_from_auth_header(
+    auth_value: Option<&str>,
+) -> Result<Option<TokenIdentity>, IdentityExtractionError> {
+    let Some(auth_value) = auth_value else {
+        return Ok(None);
+    };
+
+    // Check for Bearer prefix
+    let token = if let Some(token) = auth_value.strip_prefix("Bearer ") {
+        token.trim()
+    } else if let Some(token) = auth_value.strip_prefix("bearer ") {
+        token.trim()
+    } else {
+        return Ok(None);
+    };
+
+    if token.is_empty() {
+        return Ok(None);
+    }
+
+    // Parse the token
+    let token_identity = from_token(token.as_bytes())
+        .map_err(|e| IdentityExtractionError::InvalidToken(e.to_string()))?;
+
+    Ok(Some(token_identity))
+}
+
+impl<S> FromRequestParts<S> for ExtractTokenIdentity
+where
+    S: Send + Sync,
+{
+    type Rejection = IdentityExtractionError;
+
+    fn from_request_parts<'life0, 'life1, 'async_trait>(
+        parts: &'life0 mut Parts,
+        _state: &'life1 S,
+    ) -> std::pin::Pin<
+        Box<
+            dyn Future<Output = Result<Self, Self::Rejection>>
+                + Send
+                + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        // Get the auth header value before entering the async block
+        let auth_value = parts
+            .headers
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        Box::pin(async move {
+            let result = extract_token_identity_from_auth_header(auth_value.as_deref())?;
+            Ok(ExtractTokenIdentity(result))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use identity::{new_token, RawIdentity};
+    use std::time::Duration;
+
+    fn create_test_token() -> (String, Did) {
+        let private_key = crypto::generate_ed25519().unwrap();
+        let identity = RawIdentity::from_private_key(private_key).unwrap();
+        let did = identity.did().unwrap();
+
+        let token = new_token(&identity, Duration::from_secs(3600), None, None).unwrap();
+        let token_str = String::from_utf8(token).unwrap();
+
+        (token_str, did)
+    }
+
+    async fn extract_from_request(
+        auth_header: Option<&str>,
+    ) -> Result<ExtractIdentity, IdentityExtractionError> {
+        let mut builder = Request::builder().uri("/test");
+        if let Some(header) = auth_header {
+            builder = builder.header(AUTHORIZATION, header);
+        }
+        let request = builder.body(()).unwrap();
+        let (mut parts, _body) = request.into_parts();
+        ExtractIdentity::from_request_parts(&mut parts, &()).await
+    }
+
+    #[tokio::test]
+    async fn test_no_auth_header_returns_anonymous() {
+        let result = extract_from_request(None).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().0.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_empty_bearer_returns_anonymous() {
+        let result = extract_from_request(Some("Bearer ")).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().0.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_non_bearer_auth_returns_anonymous() {
+        let result = extract_from_request(Some("Basic dXNlcjpwYXNz")).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().0.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_valid_bearer_token_extracts_did() {
+        let (token, expected_did) = create_test_token();
+        let auth_header = format!("Bearer {}", token);
+
+        let result = extract_from_request(Some(&auth_header)).await;
+        assert!(result.is_ok());
+        let extracted = result.unwrap();
+        assert!(extracted.0.is_some());
+        assert_eq!(extracted.0.unwrap(), expected_did);
+    }
+
+    #[tokio::test]
+    async fn test_lowercase_bearer_works() {
+        let (token, expected_did) = create_test_token();
+        let auth_header = format!("bearer {}", token);
+
+        let result = extract_from_request(Some(&auth_header)).await;
+        assert!(result.is_ok());
+        let extracted = result.unwrap();
+        assert!(extracted.0.is_some());
+        assert_eq!(extracted.0.unwrap(), expected_did);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_token_returns_error() {
+        let result = extract_from_request(Some("Bearer invalid-token")).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            IdentityExtractionError::InvalidToken(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_extract_token_identity_full() {
+        let (token, expected_did) = create_test_token();
+        let auth_header = format!("Bearer {}", token);
+
+        let builder = Request::builder()
+            .uri("/test")
+            .header(AUTHORIZATION, auth_header);
+        let request = builder.body(()).unwrap();
+        let (mut parts, _body) = request.into_parts();
+
+        let result = ExtractTokenIdentity::from_request_parts(&mut parts, &()).await;
+        assert!(result.is_ok());
+        let extracted = result.unwrap();
+        assert!(extracted.0.is_some());
+        assert_eq!(extracted.did().unwrap(), expected_did);
+    }
+}

--- a/crates/http/src/identity_extractor.rs
+++ b/crates/http/src/identity_extractor.rs
@@ -21,10 +21,26 @@ use crate::error::ErrorResponse;
 /// If no Authorization header is present, the identity is None (anonymous).
 /// If the token is invalid or malformed, returns a 403 Forbidden error
 /// (matching Go DefraDB behavior).
+///
+/// The inner field is private to prevent construction without proper validation.
+/// Use the extractor mechanism or `ExtractIdentity::anonymous()` for testing.
 #[derive(Debug, Clone)]
-pub struct ExtractIdentity(pub Option<Did>);
+pub struct ExtractIdentity(Option<Did>);
 
 impl ExtractIdentity {
+    /// Create an anonymous identity (no authentication).
+    /// Use this for testing or internal code that needs to represent anonymous access.
+    pub fn anonymous() -> Self {
+        Self(None)
+    }
+
+    /// Create an identity from a validated DID.
+    /// Use this for testing or internal code that has already validated the identity.
+    #[cfg(test)]
+    pub(crate) fn from_did(did: Did) -> Self {
+        Self(Some(did))
+    }
+
     /// Returns a reference to the extracted DID if present.
     pub fn did(&self) -> Option<&Did> {
         self.0.as_ref()
@@ -33,6 +49,11 @@ impl ExtractIdentity {
     /// Consumes self and returns the extracted DID if present.
     pub fn into_did(self) -> Option<Did> {
         self.0
+    }
+
+    /// Check if this is an anonymous (unauthenticated) request.
+    pub fn is_anonymous(&self) -> bool {
+        self.0.is_none()
     }
 }
 
@@ -248,14 +269,14 @@ mod tests {
     async fn test_no_auth_header_returns_anonymous() {
         let result = extract_from_request(None).await;
         assert!(result.is_ok());
-        assert!(result.unwrap().0.is_none());
+        assert!(result.unwrap().is_anonymous());
     }
 
     #[tokio::test]
     async fn test_empty_bearer_returns_anonymous() {
         let result = extract_from_request(Some("Bearer ")).await;
         assert!(result.is_ok());
-        assert!(result.unwrap().0.is_none());
+        assert!(result.unwrap().is_anonymous());
     }
 
     #[tokio::test]
@@ -277,8 +298,8 @@ mod tests {
         let result = extract_from_request(Some(&auth_header)).await;
         assert!(result.is_ok());
         let extracted = result.unwrap();
-        assert!(extracted.0.is_some());
-        assert_eq!(extracted.0.unwrap(), expected_did);
+        assert!(!extracted.is_anonymous());
+        assert_eq!(extracted.into_did().unwrap(), expected_did);
     }
 
     #[tokio::test]
@@ -289,8 +310,8 @@ mod tests {
         let result = extract_from_request(Some(&auth_header)).await;
         assert!(result.is_ok());
         let extracted = result.unwrap();
-        assert!(extracted.0.is_some());
-        assert_eq!(extracted.0.unwrap(), expected_did);
+        assert!(!extracted.is_anonymous());
+        assert_eq!(extracted.into_did().unwrap(), expected_did);
     }
 
     #[tokio::test]
@@ -317,7 +338,7 @@ mod tests {
         let result = ExtractTokenIdentity::from_request_parts(&mut parts, &()).await;
         assert!(result.is_ok());
         let extracted = result.unwrap();
-        assert!(extracted.0.is_some());
+        assert!(extracted.identity().is_some());
         assert_eq!(extracted.did().unwrap(), expected_did);
     }
 }

--- a/crates/http/src/identity_extractor.rs
+++ b/crates/http/src/identity_extractor.rs
@@ -25,9 +25,14 @@ use crate::error::ErrorResponse;
 pub struct ExtractIdentity(pub Option<Did>);
 
 impl ExtractIdentity {
-    /// Returns the extracted DID if present.
+    /// Returns a reference to the extracted DID if present.
     pub fn did(&self) -> Option<&Did> {
         self.0.as_ref()
+    }
+
+    /// Consumes self and returns the extracted DID if present.
+    pub fn into_did(self) -> Option<Did> {
+        self.0
     }
 }
 

--- a/crates/http/src/identity_extractor.rs
+++ b/crates/http/src/identity_extractor.rs
@@ -19,7 +19,8 @@ use crate::error::ErrorResponse;
 ///
 /// Parses `Authorization: Bearer <JWT>` header and extracts the identity.
 /// If no Authorization header is present, the identity is None (anonymous).
-/// If the token is invalid, returns a 401 Unauthorized error.
+/// If the token is invalid or malformed, returns a 403 Forbidden error
+/// (matching Go DefraDB behavior).
 #[derive(Debug, Clone)]
 pub struct ExtractIdentity(pub Option<Did>);
 
@@ -34,14 +35,16 @@ impl ExtractIdentity {
 #[derive(Debug)]
 pub enum IdentityExtractionError {
     /// Invalid token format or signature.
+    /// Returns 403 Forbidden to match Go DefraDB behavior.
     InvalidToken(String),
 }
 
 impl IntoResponse for IdentityExtractionError {
     fn into_response(self) -> Response {
         let (status, message) = match self {
+            // Go DefraDB returns 403 Forbidden for invalid tokens, not 401 Unauthorized
             IdentityExtractionError::InvalidToken(msg) => {
-                (StatusCode::UNAUTHORIZED, format!("Invalid token: {}", msg))
+                (StatusCode::FORBIDDEN, format!("Invalid token: {}", msg))
             }
         };
 
@@ -50,6 +53,12 @@ impl IntoResponse for IdentityExtractionError {
 }
 
 /// Extract identity from Authorization header value.
+///
+/// Behavior matches Go DefraDB:
+/// - No Authorization header → anonymous
+/// - "Bearer " with empty token → anonymous
+/// - "Bearer <token>" → parse token, 403 on failure
+/// - Non-Bearer auth → 403 Forbidden (treated as invalid token)
 fn extract_identity_from_auth_header(
     auth_value: Option<&str>,
 ) -> Result<Option<Did>, IdentityExtractionError> {
@@ -58,15 +67,18 @@ fn extract_identity_from_auth_header(
         return Ok(None);
     };
 
-    // Check for Bearer prefix
+    // Check for Bearer prefix (case-insensitive for "Bearer" only)
     let token = if let Some(token) = auth_value.strip_prefix("Bearer ") {
         token.trim()
     } else if let Some(token) = auth_value.strip_prefix("bearer ") {
         token.trim()
     } else {
-        // Authorization header without Bearer prefix = anonymous
-        // This allows other auth schemes to pass through
-        return Ok(None);
+        // Go DefraDB behavior: Non-Bearer auth is treated as an invalid token.
+        // strings.TrimPrefix doesn't strip if prefix doesn't match, so the
+        // whole header becomes the "token" and fails to parse → 403 Forbidden.
+        return Err(IdentityExtractionError::InvalidToken(
+            "unsupported authorization scheme (expected Bearer)".to_string(),
+        ));
     };
 
     // Empty token after stripping prefix = anonymous
@@ -141,6 +153,9 @@ impl ExtractTokenIdentity {
 }
 
 /// Extract full token identity from Authorization header value.
+///
+/// Same behavior as `extract_identity_from_auth_header` but returns
+/// the full `TokenIdentity` instead of just the DID.
 fn extract_token_identity_from_auth_header(
     auth_value: Option<&str>,
 ) -> Result<Option<TokenIdentity>, IdentityExtractionError> {
@@ -148,13 +163,16 @@ fn extract_token_identity_from_auth_header(
         return Ok(None);
     };
 
-    // Check for Bearer prefix
+    // Check for Bearer prefix (case-insensitive for "Bearer" only)
     let token = if let Some(token) = auth_value.strip_prefix("Bearer ") {
         token.trim()
     } else if let Some(token) = auth_value.strip_prefix("bearer ") {
         token.trim()
     } else {
-        return Ok(None);
+        // Go DefraDB behavior: Non-Bearer auth is treated as an invalid token → 403
+        return Err(IdentityExtractionError::InvalidToken(
+            "unsupported authorization scheme (expected Bearer)".to_string(),
+        ));
     };
 
     if token.is_empty() {
@@ -248,10 +266,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_non_bearer_auth_returns_anonymous() {
+    async fn test_non_bearer_auth_returns_error() {
+        // Go DefraDB behavior: non-Bearer auth returns 403 Forbidden
         let result = extract_from_request(Some("Basic dXNlcjpwYXNz")).await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().0.is_none());
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            IdentityExtractionError::InvalidToken(_)
+        ));
     }
 
     #[tokio::test]

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -26,6 +26,7 @@
 
 pub mod error;
 pub mod handlers;
+pub mod identity_extractor;
 pub mod router;
 pub mod server;
 
@@ -33,6 +34,7 @@ pub mod server;
 pub mod mock;
 
 pub use error::{HttpError, Result};
+pub use identity_extractor::{ExtractIdentity, ExtractTokenIdentity, IdentityExtractionError};
 pub use router::{create_router, AppState};
 pub use server::{Server, ServerConfig};
 

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -15,6 +15,8 @@ crypto = { path = "../crypto" }
 blockstore = { path = "../blockstore" }
 crdt = { path = "../crdt" }
 storage = { path = "../storage" }
+identity = { path = "../identity" }
+acp = { path = "../acp" }
 
 # P2P
 libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "mdns", "request-response", "macros", "tokio", "gossipsub", "kad"] }

--- a/crates/p2p/src/bitswap/access.rs
+++ b/crates/p2p/src/bitswap/access.rs
@@ -1163,6 +1163,15 @@ mod tests {
         ) -> acp::Result<bool> {
             Err(acp::Error::Storage("simulated storage failure".to_string()))
         }
+
+        async fn unregister_doc_object(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<()> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
     }
 
     #[tokio::test]

--- a/crates/p2p/src/bitswap/access.rs
+++ b/crates/p2p/src/bitswap/access.rs
@@ -425,13 +425,20 @@ impl BlockAccessController {
         let did = self.peer_identities.get_did(peer_id);
 
         // Check document-level ACP permissions
-        match acp
-            .check_doc_access(did.as_ref(), permission, policy_id, resource_name, doc_id)
+        // Fail-closed: deny access on any error to prevent security bypass
+        acp.check_doc_access(did.as_ref(), permission, policy_id, resource_name, doc_id)
             .await
-        {
-            Ok(allowed) => allowed,
-            Err(_) => false, // Deny on error
-        }
+            .unwrap_or_else(|e| {
+                tracing::error!(
+                    peer_id = %peer_id,
+                    doc_id = %doc_id,
+                    resource_name = %resource_name,
+                    permission = %permission,
+                    error = %e,
+                    "ACP check failed, denying access"
+                );
+                false
+            })
     }
 
     /// Create a closure that can be used as a BlockAccessFn.
@@ -1117,6 +1124,98 @@ mod tests {
                     "unregistered_doc"
                 )
                 .await
+        );
+    }
+
+    // Fail-closed behavior tests
+
+    /// Mock ACP that always returns an error for check_doc_access
+    struct FailingAcp;
+
+    #[async_trait::async_trait]
+    impl acp::DocumentACP for FailingAcp {
+        async fn register_doc_object(
+            &self,
+            _identity: &Did,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<()> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn is_doc_registered(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn check_doc_access(
+            &self,
+            _identity: Option<&Did>,
+            _permission: DocumentPermission,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn add_actor_relationship(
+            &self,
+            _requestor: &Did,
+            _target_actor: &Did,
+            _collection_id: &str,
+            _doc_id: &str,
+            _relation: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn delete_actor_relationship(
+            &self,
+            _requestor: &Did,
+            _target_actor: &Did,
+            _collection_id: &str,
+            _doc_id: &str,
+            _relation: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_access_controller_acp_denies_on_error() {
+        let replicators = Arc::new(ReplicatorRegistry::new());
+        let peer_identities = Arc::new(PeerIdentityRegistry::new());
+        let failing_acp = Arc::new(FailingAcp);
+
+        let peer = PeerId::random();
+        let did = test_did();
+        peer_identities.register(peer, did);
+
+        let controller = BlockAccessController::with_acp(
+            replicators,
+            peer_identities,
+            failing_acp,
+            AccessMode::Controlled,
+        );
+
+        // When ACP check fails with an error, access should be DENIED (fail-closed)
+        assert!(
+            !controller
+                .has_access_acp(
+                    &peer,
+                    DocumentPermission::Read,
+                    "policy1",
+                    "users",
+                    "doc1"
+                )
+                .await,
+            "fail-closed: ACP error should result in access denied"
         );
     }
 }

--- a/crates/p2p/src/bitswap/access.rs
+++ b/crates/p2p/src/bitswap/access.rs
@@ -927,23 +927,13 @@ mod tests {
             acp::MemoryAcpStore::new(),
         )));
 
-        let controller = BlockAccessController::with_acp(
-            replicators,
-            peer_identities,
-            acp,
-            AccessMode::Open,
-        );
+        let controller =
+            BlockAccessController::with_acp(replicators, peer_identities, acp, AccessMode::Open);
 
         let peer = PeerId::random();
         assert!(
             controller
-                .has_access_acp(
-                    &peer,
-                    DocumentPermission::Read,
-                    "policy1",
-                    "users",
-                    "doc1"
-                )
+                .has_access_acp(&peer, DocumentPermission::Read, "policy1", "users", "doc1")
                 .await
         );
     }
@@ -969,13 +959,7 @@ mod tests {
         // Replicator should have access without ACP check
         assert!(
             controller
-                .has_access_acp(
-                    &peer,
-                    DocumentPermission::Read,
-                    "policy1",
-                    "users",
-                    "doc1"
-                )
+                .has_access_acp(&peer, DocumentPermission::Read, "policy1", "users", "doc1")
                 .await
         );
     }
@@ -1008,13 +992,7 @@ mod tests {
         // Owner should have access
         assert!(
             controller
-                .has_access_acp(
-                    &peer,
-                    DocumentPermission::Read,
-                    "policy1",
-                    "users",
-                    "doc1"
-                )
+                .has_access_acp(&peer, DocumentPermission::Read, "policy1", "users", "doc1")
                 .await
         );
     }
@@ -1207,13 +1185,7 @@ mod tests {
         // When ACP check fails with an error, access should be DENIED (fail-closed)
         assert!(
             !controller
-                .has_access_acp(
-                    &peer,
-                    DocumentPermission::Read,
-                    "policy1",
-                    "users",
-                    "doc1"
-                )
+                .has_access_acp(&peer, DocumentPermission::Read, "policy1", "users", "doc1")
                 .await,
             "fail-closed: ACP error should result in access denied"
         );

--- a/crates/p2p/src/bitswap/access.rs
+++ b/crates/p2p/src/bitswap/access.rs
@@ -14,30 +14,26 @@
 //! `hasAccess` callback pattern. In Go, the callback is registered with
 //! `host.SetBlockAccessFunc(p.hasAccess)` and receives (ctx, peerID, cid).
 //!
-//! # Current Limitations
-//!
-//! The Rust libp2p-bitswap-next crate doesn't support per-request access control
-//! callbacks. The `BitswapStore::get` method doesn't receive peer information.
-//!
-//! For now, access control is implemented at the **sync coordinator level**,
-//! where we have peer context. This provides:
-//! - Replicator-based access (fast path)
-//! - Collection subscription validation
-//!
-//! Full ACP integration will require modifications to the bitswap layer.
-//!
-//! # Go DefraDB Pattern
+//! # Access Control Flow
 //!
 //! Go's access control logic (from `internal/db/p2p/p2p.go:hasAccess`):
-//! 1. If ACP not configured → allow all
-//! 2. Check if peer is a replicator for the collection → allow
-//! 3. Get peer's identity token and verify it
-//! 4. Check document-level ACP permissions → allow/deny
+//! 1. If ACP not configured (Open mode) → allow all
+//! 2. Check if peer is a replicator for the collection → allow (fast path)
+//! 3. Look up peer's DID from PeerIdentityRegistry
+//! 4. Check document-level ACP permissions via DocumentACP → allow/deny
+//!
+//! # Components
+//!
+//! - `ReplicatorRegistry`: Tracks which peers are authorized replicators
+//! - `PeerIdentityRegistry`: Maps PeerId to DID for ACP lookups
+//! - `BlockAccessController`: Main entry point for access decisions
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use acp::{DocumentACP, DocumentPermission};
 use cid::Cid;
+use identity::Did;
 use libp2p::PeerId;
 use parking_lot::RwLock;
 
@@ -242,12 +238,62 @@ impl AccessMode {
     }
 }
 
+/// Registry that maps peer IDs to their decentralized identifiers (DIDs).
+///
+/// When a peer connects and provides an identity token, their DID is registered
+/// here. This allows the BlockAccessController to look up a peer's identity
+/// for document-level ACP checks.
+#[derive(Debug, Default)]
+pub struct PeerIdentityRegistry {
+    /// Map of peer ID to their DID
+    identities: RwLock<HashMap<PeerId, Did>>,
+}
+
+impl PeerIdentityRegistry {
+    /// Create a new empty registry.
+    pub fn new() -> Self {
+        Self {
+            identities: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register a peer's DID.
+    ///
+    /// Called when a peer provides a valid identity token.
+    pub fn register(&self, peer_id: PeerId, did: Did) {
+        self.identities.write().insert(peer_id, did);
+    }
+
+    /// Unregister a peer's DID.
+    ///
+    /// Called when a peer disconnects or their token expires.
+    pub fn unregister(&self, peer_id: &PeerId) {
+        self.identities.write().remove(peer_id);
+    }
+
+    /// Get the DID for a peer, if registered.
+    pub fn get_did(&self, peer_id: &PeerId) -> Option<Did> {
+        self.identities.read().get(peer_id).cloned()
+    }
+
+    /// Check if a peer has a registered identity.
+    pub fn has_identity(&self, peer_id: &PeerId) -> bool {
+        self.identities.read().contains_key(peer_id)
+    }
+}
+
 /// Block access controller that combines replicator checks with ACP.
 ///
 /// This is the main entry point for access control decisions.
 pub struct BlockAccessController {
     /// Replicator registry for fast-path checks
     replicators: Arc<ReplicatorRegistry>,
+
+    /// Peer identity registry for DID lookups
+    peer_identities: Arc<PeerIdentityRegistry>,
+
+    /// Optional document ACP for permission checks
+    document_acp: Option<Arc<dyn DocumentACP>>,
 
     /// Access control mode
     mode: AccessMode,
@@ -256,7 +302,27 @@ pub struct BlockAccessController {
 impl BlockAccessController {
     /// Create a new access controller with the specified mode.
     pub fn new(replicators: Arc<ReplicatorRegistry>, mode: AccessMode) -> Self {
-        Self { replicators, mode }
+        Self {
+            replicators,
+            peer_identities: Arc::new(PeerIdentityRegistry::new()),
+            document_acp: None,
+            mode,
+        }
+    }
+
+    /// Create a new access controller with full configuration.
+    pub fn with_acp(
+        replicators: Arc<ReplicatorRegistry>,
+        peer_identities: Arc<PeerIdentityRegistry>,
+        document_acp: Arc<dyn DocumentACP>,
+        mode: AccessMode,
+    ) -> Self {
+        Self {
+            replicators,
+            peer_identities,
+            document_acp: Some(document_acp),
+            mode,
+        }
     }
 
     /// Create a new access controller with open access (no ACP).
@@ -274,12 +340,20 @@ impl BlockAccessController {
         self.mode
     }
 
-    /// Check if a peer has access to a block.
+    /// Get the peer identity registry.
+    pub fn peer_identities(&self) -> &Arc<PeerIdentityRegistry> {
+        &self.peer_identities
+    }
+
+    /// Check if a peer has access to a block (synchronous, fast path only).
     ///
     /// This mirrors Go's `hasAccess` function logic:
     /// 1. If mode is Open → allow
     /// 2. If peer is replicator for block's collection → allow
     /// 3. If no replicator match, deny access
+    ///
+    /// Note: This method does NOT perform ACP checks. Use `has_access_acp`
+    /// for full access control including document-level permissions.
     ///
     /// # Arguments
     /// * `peer_id` - The peer requesting access
@@ -306,6 +380,58 @@ impl BlockAccessController {
 
         // Default: deny in Controlled mode when no replicator match
         false
+    }
+
+    /// Check if a peer has access to a document with full ACP checks.
+    ///
+    /// This is the full access control path that includes document-level
+    /// permission checks:
+    /// 1. If mode is Open → allow
+    /// 2. If peer is replicator for the collection → allow (fast path)
+    /// 3. Look up peer's DID from identity registry
+    /// 4. Check document-level ACP permissions → allow/deny
+    ///
+    /// # Arguments
+    /// * `peer_id` - The peer requesting access
+    /// * `permission` - The permission being requested (Read/Update/Delete)
+    /// * `policy_id` - The policy ID from the collection
+    /// * `resource_name` - The resource name from the policy
+    /// * `doc_id` - The document being accessed
+    pub async fn has_access_acp(
+        &self,
+        peer_id: &PeerId,
+        permission: DocumentPermission,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> bool {
+        // Fast path: Open mode allows all access
+        if self.mode.is_open() {
+            return true;
+        }
+
+        // Fast path: peer is a replicator for this collection
+        if self.replicators.is_replicator(resource_name, peer_id) {
+            return true;
+        }
+
+        // No ACP configured - fall back to replicator-only mode
+        let acp = match &self.document_acp {
+            Some(acp) => acp,
+            None => return false, // Deny if no ACP and not a replicator
+        };
+
+        // Look up peer's DID
+        let did = self.peer_identities.get_did(peer_id);
+
+        // Check document-level ACP permissions
+        match acp
+            .check_doc_access(did.as_ref(), permission, policy_id, resource_name, doc_id)
+            .await
+        {
+            Ok(allowed) => allowed,
+            Err(_) => false, // Deny on error
+        }
     }
 
     /// Create a closure that can be used as a BlockAccessFn.
@@ -713,6 +839,284 @@ mod tests {
         assert_eq!(
             registry1.is_replicator("comments", &peer2),
             registry2.is_replicator("comments", &peer2)
+        );
+    }
+
+    // PeerIdentityRegistry tests
+
+    fn test_did() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    fn test_did2() -> Did {
+        Did::new("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR").unwrap()
+    }
+
+    #[test]
+    fn test_peer_identity_registry_register_get() {
+        let registry = PeerIdentityRegistry::new();
+        let peer = PeerId::random();
+        let did = test_did();
+
+        assert!(!registry.has_identity(&peer));
+        assert!(registry.get_did(&peer).is_none());
+
+        registry.register(peer, did.clone());
+
+        assert!(registry.has_identity(&peer));
+        assert_eq!(registry.get_did(&peer), Some(did));
+    }
+
+    #[test]
+    fn test_peer_identity_registry_unregister() {
+        let registry = PeerIdentityRegistry::new();
+        let peer = PeerId::random();
+        let did = test_did();
+
+        registry.register(peer, did);
+        assert!(registry.has_identity(&peer));
+
+        registry.unregister(&peer);
+        assert!(!registry.has_identity(&peer));
+        assert!(registry.get_did(&peer).is_none());
+    }
+
+    #[test]
+    fn test_peer_identity_registry_multiple_peers() {
+        let registry = PeerIdentityRegistry::new();
+        let peer1 = PeerId::random();
+        let peer2 = PeerId::random();
+        let did1 = test_did();
+        let did2 = test_did2();
+
+        registry.register(peer1, did1.clone());
+        registry.register(peer2, did2.clone());
+
+        assert_eq!(registry.get_did(&peer1), Some(did1));
+        assert_eq!(registry.get_did(&peer2), Some(did2));
+    }
+
+    #[test]
+    fn test_peer_identity_registry_overwrite() {
+        let registry = PeerIdentityRegistry::new();
+        let peer = PeerId::random();
+        let did1 = test_did();
+        let did2 = test_did2();
+
+        registry.register(peer, did1);
+        registry.register(peer, did2.clone());
+
+        // Second registration should overwrite
+        assert_eq!(registry.get_did(&peer), Some(did2));
+    }
+
+    // ACP-aware access tests
+
+    #[tokio::test]
+    async fn test_access_controller_acp_open_mode_allows_all() {
+        let replicators = Arc::new(ReplicatorRegistry::new());
+        let peer_identities = Arc::new(PeerIdentityRegistry::new());
+        let acp = Arc::new(acp::LocalDocumentACP::new(Arc::new(
+            acp::MemoryAcpStore::new(),
+        )));
+
+        let controller = BlockAccessController::with_acp(
+            replicators,
+            peer_identities,
+            acp,
+            AccessMode::Open,
+        );
+
+        let peer = PeerId::random();
+        assert!(
+            controller
+                .has_access_acp(
+                    &peer,
+                    DocumentPermission::Read,
+                    "policy1",
+                    "users",
+                    "doc1"
+                )
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_access_controller_acp_replicator_fast_path() {
+        let replicators = Arc::new(ReplicatorRegistry::new());
+        let peer = PeerId::random();
+        replicators.add_replicator("users", peer);
+
+        let peer_identities = Arc::new(PeerIdentityRegistry::new());
+        let acp = Arc::new(acp::LocalDocumentACP::new(Arc::new(
+            acp::MemoryAcpStore::new(),
+        )));
+
+        let controller = BlockAccessController::with_acp(
+            replicators,
+            peer_identities,
+            acp,
+            AccessMode::Controlled,
+        );
+
+        // Replicator should have access without ACP check
+        assert!(
+            controller
+                .has_access_acp(
+                    &peer,
+                    DocumentPermission::Read,
+                    "policy1",
+                    "users",
+                    "doc1"
+                )
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_access_controller_acp_registered_doc_owner_allowed() {
+        let replicators = Arc::new(ReplicatorRegistry::new());
+        let peer_identities = Arc::new(PeerIdentityRegistry::new());
+        let store = Arc::new(acp::MemoryAcpStore::new());
+        let acp = Arc::new(acp::LocalDocumentACP::new(store));
+
+        let peer = PeerId::random();
+        let did = test_did();
+
+        // Register peer's identity
+        peer_identities.register(peer, did.clone());
+
+        // Register document with owner
+        acp.register_doc_object(&did, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let controller = BlockAccessController::with_acp(
+            replicators,
+            peer_identities,
+            acp,
+            AccessMode::Controlled,
+        );
+
+        // Owner should have access
+        assert!(
+            controller
+                .has_access_acp(
+                    &peer,
+                    DocumentPermission::Read,
+                    "policy1",
+                    "users",
+                    "doc1"
+                )
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_access_controller_acp_non_owner_denied() {
+        let replicators = Arc::new(ReplicatorRegistry::new());
+        let peer_identities = Arc::new(PeerIdentityRegistry::new());
+        let store = Arc::new(acp::MemoryAcpStore::new());
+        let acp = Arc::new(acp::LocalDocumentACP::new(store));
+
+        let owner_peer = PeerId::random();
+        let stranger_peer = PeerId::random();
+        let owner_did = test_did();
+        let stranger_did = test_did2();
+
+        // Register both peers' identities
+        peer_identities.register(owner_peer, owner_did.clone());
+        peer_identities.register(stranger_peer, stranger_did);
+
+        // Register document with owner
+        acp.register_doc_object(&owner_did, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let controller = BlockAccessController::with_acp(
+            replicators,
+            peer_identities,
+            acp,
+            AccessMode::Controlled,
+        );
+
+        // Stranger should be denied
+        assert!(
+            !controller
+                .has_access_acp(
+                    &stranger_peer,
+                    DocumentPermission::Read,
+                    "policy1",
+                    "users",
+                    "doc1"
+                )
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_access_controller_acp_anonymous_peer_denied() {
+        let replicators = Arc::new(ReplicatorRegistry::new());
+        let peer_identities = Arc::new(PeerIdentityRegistry::new());
+        let store = Arc::new(acp::MemoryAcpStore::new());
+        let acp = Arc::new(acp::LocalDocumentACP::new(store));
+
+        let owner_did = test_did();
+
+        // Register document with owner
+        acp.register_doc_object(&owner_did, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        let controller = BlockAccessController::with_acp(
+            replicators,
+            peer_identities,
+            acp,
+            AccessMode::Controlled,
+        );
+
+        // Peer without registered identity should be denied
+        let anonymous_peer = PeerId::random();
+        assert!(
+            !controller
+                .has_access_acp(
+                    &anonymous_peer,
+                    DocumentPermission::Read,
+                    "policy1",
+                    "users",
+                    "doc1"
+                )
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_access_controller_acp_unregistered_doc_allows_all() {
+        let replicators = Arc::new(ReplicatorRegistry::new());
+        let peer_identities = Arc::new(PeerIdentityRegistry::new());
+        let acp = Arc::new(acp::LocalDocumentACP::new(Arc::new(
+            acp::MemoryAcpStore::new(),
+        )));
+
+        let controller = BlockAccessController::with_acp(
+            replicators,
+            peer_identities,
+            acp,
+            AccessMode::Controlled,
+        );
+
+        // Anonymous peer can access unregistered (public) document
+        let peer = PeerId::random();
+        assert!(
+            controller
+                .has_access_acp(
+                    &peer,
+                    DocumentPermission::Read,
+                    "policy1",
+                    "users",
+                    "unregistered_doc"
+                )
+                .await
         );
     }
 }

--- a/crates/p2p/src/bitswap/mod.rs
+++ b/crates/p2p/src/bitswap/mod.rs
@@ -36,5 +36,7 @@
 mod access;
 mod store;
 
-pub use access::{AccessMode, BlockAccessController, BlockAccessFn, ReplicatorRegistry};
+pub use access::{
+    AccessMode, BlockAccessController, BlockAccessFn, PeerIdentityRegistry, ReplicatorRegistry,
+};
 pub use store::BitswapStoreAdapter;

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -103,7 +103,8 @@ pub use sync::{
 
 // Re-export bitswap types
 pub use bitswap::{
-    AccessMode, BitswapStoreAdapter, BlockAccessController, BlockAccessFn, ReplicatorRegistry,
+    AccessMode, BitswapStoreAdapter, BlockAccessController, BlockAccessFn, PeerIdentityRegistry,
+    ReplicatorRegistry,
 };
 pub use libp2p_bitswap_next::{BitswapStore, QueryId};
 

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -15,6 +15,8 @@ storage = { path = "../storage" }
 schema = { path = "../schema" }
 crdt = { path = "../crdt" }
 blockstore = { path = "../blockstore" }
+identity = { path = "../identity" }
+acp = { path = "../acp" }
 
 # Async runtime
 tokio.workspace = true

--- a/crates/query/src/error.rs
+++ b/crates/query/src/error.rs
@@ -147,6 +147,10 @@ pub enum QueryError {
     /// Internal error (should not happen)
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// Permission denied (ACP check failed)
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
 }
 
 impl QueryError {
@@ -189,6 +193,11 @@ impl QueryError {
     /// Create an internal error
     pub fn internal(msg: impl Into<String>) -> Self {
         Self::Internal(msg.into())
+    }
+
+    /// Create a permission denied error
+    pub fn permission_denied(msg: impl Into<String>) -> Self {
+        Self::PermissionDenied(msg.into())
     }
 }
 

--- a/crates/query/src/error.rs
+++ b/crates/query/src/error.rs
@@ -151,6 +151,10 @@ pub enum QueryError {
     /// Permission denied (ACP check failed)
     #[error("permission denied: {0}")]
     PermissionDenied(String),
+
+    /// ACP registration failed during document creation
+    #[error("ACP registration failed for document '{doc_id}': {message}")]
+    AcpRegistrationFailed { doc_id: String, message: String },
 }
 
 impl QueryError {
@@ -198,6 +202,17 @@ impl QueryError {
     /// Create a permission denied error
     pub fn permission_denied(msg: impl Into<String>) -> Self {
         Self::PermissionDenied(msg.into())
+    }
+
+    /// Create an ACP registration failed error
+    pub fn acp_registration_failed(
+        doc_id: impl Into<String>,
+        error: impl std::fmt::Display,
+    ) -> Self {
+        Self::AcpRegistrationFailed {
+            doc_id: doc_id.into(),
+            message: error.to_string(),
+        }
     }
 }
 

--- a/crates/query/src/executor.rs
+++ b/crates/query/src/executor.rs
@@ -4,6 +4,7 @@
 //! The HTTP crate depends on this trait, allowing parallel development of HTTP and query execution.
 
 use async_trait::async_trait;
+use identity::Did;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -23,6 +24,11 @@ pub struct QueryRequest {
     /// Optional variables for the query.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub variables: Option<JsonValue>,
+
+    /// Identity for ACP permission checks (None = anonymous).
+    /// This is set by the HTTP layer from the Authorization header.
+    #[serde(skip)]
+    pub identity: Option<Did>,
 }
 
 impl QueryRequest {
@@ -32,6 +38,7 @@ impl QueryRequest {
             query: query.into(),
             operation_name: None,
             variables: None,
+            identity: None,
         }
     }
 
@@ -44,6 +51,12 @@ impl QueryRequest {
     /// Set variables.
     pub fn with_variables(mut self, vars: JsonValue) -> Self {
         self.variables = Some(vars);
+        self
+    }
+
+    /// Set the identity for ACP permission checks.
+    pub fn with_identity(mut self, identity: Option<Did>) -> Self {
+        self.identity = identity;
         self
     }
 }

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -10,6 +10,7 @@ mod max;
 mod min;
 pub mod mutation;
 mod orderby;
+mod permission_filter;
 mod scan;
 mod select;
 mod sum;
@@ -28,6 +29,7 @@ pub use mutation::{
     UpsertNode,
 };
 pub use orderby::OrderByNode;
+pub use permission_filter::PermissionFilterNode;
 pub use scan::ScanNode;
 pub use select::SelectNode;
 pub use sum::SumNode;

--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -326,13 +326,8 @@ mod tests {
         let docs = make_test_docs();
         let scan = create_scan_node(docs);
 
-        let mut filter = PermissionFilterNode::new(
-            Box::new(scan),
-            acp,
-            Some(reader),
-            "policy1",
-            "users",
-        );
+        let mut filter =
+            PermissionFilterNode::new(Box::new(scan), acp, Some(reader), "policy1", "users");
 
         filter.init().await.unwrap();
         filter.start().await.unwrap();

--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -1,0 +1,385 @@
+//! PermissionFilterNode for ACP-based document filtering
+//!
+//! This node wraps a source node and filters out documents that the
+//! identity context doesn't have permission to read.
+
+use std::sync::Arc;
+
+use acp::{DocumentACP, DocumentPermission};
+use async_trait::async_trait;
+use identity::Did;
+
+use crate::document::DocumentMapping;
+use crate::error::Result;
+use crate::planner::{Doc, PlanNode};
+
+/// PermissionFilterNode filters documents based on ACP permissions.
+///
+/// This node wraps a source node and only yields documents that the
+/// identity has read permission for. Documents created without ACP
+/// (public/unregistered) pass through.
+pub struct PermissionFilterNode {
+    /// Source node to filter
+    source: Box<dyn PlanNode>,
+
+    /// Document ACP for permission checks
+    acp: Arc<dyn DocumentACP>,
+
+    /// Identity requesting access (None = anonymous)
+    identity: Option<Did>,
+
+    /// Policy ID from the collection
+    policy_id: String,
+
+    /// Resource name from the policy
+    resource_name: String,
+
+    /// Current document
+    current_doc: Doc,
+
+    /// Document mapping from source
+    document_mapping: DocumentMapping,
+}
+
+impl PermissionFilterNode {
+    /// Create a new permission filter node.
+    ///
+    /// # Arguments
+    /// * `source` - The source node to filter
+    /// * `acp` - Document ACP for permission checks
+    /// * `identity` - The identity requesting access (None for anonymous)
+    /// * `policy_id` - Policy ID from the collection
+    /// * `resource_name` - Resource name from the policy
+    pub fn new(
+        source: Box<dyn PlanNode>,
+        acp: Arc<dyn DocumentACP>,
+        identity: Option<Did>,
+        policy_id: impl Into<String>,
+        resource_name: impl Into<String>,
+    ) -> Self {
+        let document_mapping = source.document_map().clone();
+        Self {
+            source,
+            acp,
+            identity,
+            policy_id: policy_id.into(),
+            resource_name: resource_name.into(),
+            current_doc: Doc::default(),
+            document_mapping,
+        }
+    }
+
+    /// Check if the identity has read permission for a document.
+    async fn has_read_permission(&self, doc_id: &str) -> Result<bool> {
+        match self
+            .acp
+            .check_doc_access(
+                self.identity.as_ref(),
+                DocumentPermission::Read,
+                &self.policy_id,
+                &self.resource_name,
+                doc_id,
+            )
+            .await
+        {
+            Ok(allowed) => Ok(allowed),
+            Err(_) => Ok(false), // Deny on error
+        }
+    }
+}
+
+#[async_trait]
+impl PlanNode for PermissionFilterNode {
+    async fn init(&mut self) -> Result<()> {
+        self.source.init().await
+    }
+
+    async fn start(&mut self) -> Result<()> {
+        self.source.start().await
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        loop {
+            // Get next document from source
+            if !self.source.next().await? {
+                return Ok(false);
+            }
+
+            let doc = self.source.value();
+
+            // Get doc ID for permission check
+            let doc_id = match doc.doc_id() {
+                Some(id) => id.to_string(),
+                None => {
+                    // No doc ID, skip this document
+                    continue;
+                }
+            };
+
+            // Check read permission
+            if self.has_read_permission(&doc_id).await? {
+                self.current_doc = doc.deep_clone();
+                return Ok(true);
+            }
+
+            // No permission, continue to next document
+        }
+    }
+
+    fn value(&self) -> &Doc {
+        &self.current_doc
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.source.close().await
+    }
+
+    fn source(&self) -> Option<&dyn PlanNode> {
+        Some(self.source.as_ref())
+    }
+
+    fn document_map(&self) -> &DocumentMapping {
+        &self.document_mapping
+    }
+
+    fn kind(&self) -> &'static str {
+        "permissionFilterNode"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acp::{LocalDocumentACP, MemoryAcpStore};
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    use crate::plan::ScanNode;
+
+    fn test_did() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    fn test_did2() -> Did {
+        Did::new("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR").unwrap()
+    }
+
+    fn make_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "users",
+            "v1",
+            "coll-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+            ],
+        )
+    }
+
+    fn make_test_mapping() -> DocumentMapping {
+        let mut m = DocumentMapping::new();
+        m.add(0, "_docID");
+        m.add(1, "name");
+        m
+    }
+
+    fn make_test_docs() -> Vec<Doc> {
+        vec![
+            Doc::with_fields(vec![Some(json!("doc1")), Some(json!("Alice"))]),
+            Doc::with_fields(vec![Some(json!("doc2")), Some(json!("Bob"))]),
+            Doc::with_fields(vec![Some(json!("doc3")), Some(json!("Charlie"))]),
+        ]
+    }
+
+    fn create_scan_node(docs: Vec<Doc>) -> ScanNode {
+        let collection = make_test_collection();
+        let mapping = make_test_mapping();
+        ScanNode::new(collection, mapping).with_docs(docs)
+    }
+
+    #[tokio::test]
+    async fn test_permission_filter_public_docs_pass_through() {
+        let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+        let docs = make_test_docs();
+        let scan = create_scan_node(docs);
+
+        let mut filter = PermissionFilterNode::new(
+            Box::new(scan),
+            acp,
+            None, // Anonymous
+            "policy1",
+            "users",
+        );
+
+        filter.init().await.unwrap();
+        filter.start().await.unwrap();
+
+        // All docs should pass through (unregistered = public)
+        let mut count = 0;
+        while filter.next().await.unwrap() {
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn test_permission_filter_owner_sees_all() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let owner = test_did();
+
+        // Register all docs with the same owner
+        for doc_id in ["doc1", "doc2", "doc3"] {
+            acp.register_doc_object(&owner, "policy1", "users", doc_id)
+                .await
+                .unwrap();
+        }
+
+        let docs = make_test_docs();
+        let scan = create_scan_node(docs);
+
+        let mut filter = PermissionFilterNode::new(
+            Box::new(scan),
+            acp,
+            Some(owner), // Owner identity
+            "policy1",
+            "users",
+        );
+
+        filter.init().await.unwrap();
+        filter.start().await.unwrap();
+
+        // Owner should see all docs
+        let mut count = 0;
+        while filter.next().await.unwrap() {
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn test_permission_filter_non_owner_sees_nothing() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let owner = test_did();
+        let stranger = test_did2();
+
+        // Register all docs with owner
+        for doc_id in ["doc1", "doc2", "doc3"] {
+            acp.register_doc_object(&owner, "policy1", "users", doc_id)
+                .await
+                .unwrap();
+        }
+
+        let docs = make_test_docs();
+        let scan = create_scan_node(docs);
+
+        let mut filter = PermissionFilterNode::new(
+            Box::new(scan),
+            acp,
+            Some(stranger), // Different identity
+            "policy1",
+            "users",
+        );
+
+        filter.init().await.unwrap();
+        filter.start().await.unwrap();
+
+        // Stranger should see nothing
+        let mut count = 0;
+        while filter.next().await.unwrap() {
+            count += 1;
+        }
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_permission_filter_partial_access() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let owner = test_did();
+        let reader = test_did2();
+
+        // Register doc1 and doc2 with owner
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+        acp.register_doc_object(&owner, "policy1", "users", "doc2")
+            .await
+            .unwrap();
+        // doc3 is unregistered (public)
+
+        // Grant reader access to doc1 only
+        acp.add_actor_relationship(&owner, &reader, "users", "doc1", "reader")
+            .await
+            .unwrap();
+
+        let docs = make_test_docs();
+        let scan = create_scan_node(docs);
+
+        let mut filter = PermissionFilterNode::new(
+            Box::new(scan),
+            acp,
+            Some(reader),
+            "policy1",
+            "users",
+        );
+
+        filter.init().await.unwrap();
+        filter.start().await.unwrap();
+
+        // Reader should see doc1 (granted) and doc3 (public), but not doc2
+        let mut seen_docs = Vec::new();
+        while filter.next().await.unwrap() {
+            if let Some(doc_id) = filter.value().doc_id() {
+                seen_docs.push(doc_id.to_string());
+            }
+        }
+
+        assert_eq!(seen_docs.len(), 2);
+        assert!(seen_docs.contains(&"doc1".to_string()));
+        assert!(seen_docs.contains(&"doc3".to_string()));
+        assert!(!seen_docs.contains(&"doc2".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_permission_filter_anonymous_only_sees_public() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let owner = test_did();
+
+        // Register doc1 and doc2 with owner
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+        acp.register_doc_object(&owner, "policy1", "users", "doc2")
+            .await
+            .unwrap();
+        // doc3 is unregistered (public)
+
+        let docs = make_test_docs();
+        let scan = create_scan_node(docs);
+
+        let mut filter = PermissionFilterNode::new(
+            Box::new(scan),
+            acp,
+            None, // Anonymous
+            "policy1",
+            "users",
+        );
+
+        filter.init().await.unwrap();
+        filter.start().await.unwrap();
+
+        // Anonymous should only see doc3 (public)
+        let mut seen_docs = Vec::new();
+        while filter.next().await.unwrap() {
+            if let Some(doc_id) = filter.value().doc_id() {
+                seen_docs.push(doc_id.to_string());
+            }
+        }
+
+        assert_eq!(seen_docs.len(), 1);
+        assert!(seen_docs.contains(&"doc3".to_string()));
+    }
+}

--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -70,8 +70,10 @@ impl PermissionFilterNode {
     }
 
     /// Check if the identity has read permission for a document.
+    ///
+    /// Fail-closed: returns false on any error to prevent security bypass.
     async fn has_read_permission(&self, doc_id: &str) -> Result<bool> {
-        match self
+        Ok(self
             .acp
             .check_doc_access(
                 self.identity.as_ref(),
@@ -81,10 +83,17 @@ impl PermissionFilterNode {
                 doc_id,
             )
             .await
-        {
-            Ok(allowed) => Ok(allowed),
-            Err(_) => Ok(false), // Deny on error
-        }
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    doc_id = %doc_id,
+                    policy_id = %self.policy_id,
+                    resource_name = %self.resource_name,
+                    identity = ?self.identity,
+                    error = %e,
+                    "Permission check failed, denying access to document"
+                );
+                false
+            }))
     }
 }
 

--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -386,4 +386,135 @@ mod tests {
         assert_eq!(seen_docs.len(), 1);
         assert!(seen_docs.contains(&"doc3".to_string()));
     }
+
+    // Test fail-closed behavior: when ACP errors occur, documents should be denied
+
+    /// A DocumentACP implementation that always fails
+    struct FailingAcp;
+
+    #[async_trait::async_trait]
+    impl acp::DocumentACP for FailingAcp {
+        async fn register_doc_object(
+            &self,
+            _identity: &Did,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<()> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn is_doc_registered(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn check_doc_access(
+            &self,
+            _identity: Option<&Did>,
+            _permission: acp::DocumentPermission,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn add_actor_relationship(
+            &self,
+            _requestor: &Did,
+            _target: &Did,
+            _collection_id: &str,
+            _doc_id: &str,
+            _relation: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn delete_actor_relationship(
+            &self,
+            _requestor: &Did,
+            _target: &Did,
+            _collection_id: &str,
+            _doc_id: &str,
+            _relation: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+
+        async fn unregister_doc_object(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<()> {
+            Err(acp::Error::Storage("simulated storage failure".to_string()))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_permission_filter_fail_closed_on_acp_error() {
+        // Create a FailingAcp that always returns errors
+        let acp = Arc::new(FailingAcp);
+        let docs = make_test_docs();
+        let scan = create_scan_node(docs);
+
+        let mut filter = PermissionFilterNode::new(
+            Box::new(scan),
+            acp,
+            Some(test_did()), // Even with identity
+            "policy1",
+            "users",
+        );
+
+        filter.init().await.unwrap();
+        filter.start().await.unwrap();
+
+        // All docs should be DENIED because the ACP check fails (fail-closed behavior)
+        let mut count = 0;
+        while filter.next().await.unwrap() {
+            count += 1;
+        }
+
+        // CRITICAL: No documents should pass through when ACP errors occur
+        assert_eq!(
+            count, 0,
+            "fail-closed: ACP errors should result in all documents being denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_permission_filter_fail_closed_anonymous_with_error() {
+        // Create a FailingAcp that always returns errors
+        let acp = Arc::new(FailingAcp);
+        let docs = make_test_docs();
+        let scan = create_scan_node(docs);
+
+        let mut filter = PermissionFilterNode::new(
+            Box::new(scan),
+            acp,
+            None, // Anonymous
+            "policy1",
+            "users",
+        );
+
+        filter.init().await.unwrap();
+        filter.start().await.unwrap();
+
+        // All docs should be DENIED because the ACP check fails
+        let mut count = 0;
+        while filter.next().await.unwrap() {
+            count += 1;
+        }
+
+        // CRITICAL: No documents should pass through when ACP errors occur
+        assert_eq!(
+            count, 0,
+            "fail-closed: ACP errors should deny access even for anonymous"
+        );
+    }
 }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -308,19 +308,34 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     /// "#).await?;
     /// ```
     pub async fn execute_mutation(&self, mutation_str: &str) -> Result<JsonValue> {
+        self.execute_mutation_with_identity(mutation_str, None).await
+    }
+
+    /// Execute a GraphQL mutation with identity for ACP permission checks.
+    ///
+    /// For collections with ACP policies:
+    /// - CREATE: Registers created documents with identity as owner (if identity provided)
+    /// - UPDATE: Checks identity has updater permission on each document
+    /// - DELETE: Checks identity has deleter permission on each document
+    pub async fn execute_mutation_with_identity(
+        &self,
+        mutation_str: &str,
+        identity: Option<Did>,
+    ) -> Result<JsonValue> {
         let mutator = self.mutator.as_ref().ok_or_else(|| {
             QueryError::execution("mutations require a mutator; call with_mutator() first")
         })?;
 
-        self.execute_mutation_with_mutator(mutation_str, mutator.clone())
+        self.execute_mutation_internal(mutation_str, mutator.clone(), identity)
             .await
     }
 
-    /// Execute a GraphQL mutation with a specific mutator.
-    async fn execute_mutation_with_mutator(
+    /// Execute a GraphQL mutation with a specific mutator and identity.
+    async fn execute_mutation_internal(
         &self,
         mutation_str: &str,
         mutator: Arc<dyn DocMutator>,
+        identity: Option<Did>,
     ) -> Result<JsonValue> {
         let mutations = parse_mutations(mutation_str)?;
 
@@ -328,7 +343,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 
         for mutation in mutations {
             let result = self
-                .execute_single_mutation(&mutation, mutator.clone())
+                .execute_single_mutation(&mutation, mutator.clone(), identity.clone())
                 .await?;
             // Use collection name as key (Go behavior)
             results.insert(mutation.collection_name.clone(), result);
@@ -337,14 +352,17 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         Ok(JsonValue::Object(results))
     }
 
-    /// Execute a single mutation operation.
+    /// Execute a single mutation operation with ACP enforcement.
     async fn execute_single_mutation(
         &self,
         mutation: &Mutation,
         mutator: Arc<dyn DocMutator>,
+        identity: Option<Did>,
     ) -> Result<JsonValue> {
+        use acp::DocumentPermission;
+
         // Validate collection exists
-        let _collection = self
+        let collection = self
             .collections
             .get(&mutation.collection_name)
             .ok_or_else(|| QueryError::collection_not_found(&mutation.collection_name))?;
@@ -354,6 +372,70 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 
         // Resolve filter to doc_ids if filter is provided without doc_ids
         let resolved_doc_ids = self.resolve_filter_to_doc_ids(mutation).await?;
+
+        // Get doc_ids for permission checking (UPDATE/DELETE need this)
+        let doc_ids_for_check = resolved_doc_ids
+            .as_ref()
+            .or(mutation.doc_ids.as_ref())
+            .cloned();
+
+        // Check ACP permissions for UPDATE/DELETE operations
+        if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+            match mutation.mutation_type {
+                MutationType::Update | MutationType::Upsert => {
+                    // For UPDATE, check updater permission on each target doc
+                    if let Some(ref doc_ids) = doc_ids_for_check {
+                        for doc_id in doc_ids {
+                            let has_permission = acp
+                                .check_doc_access(
+                                    identity.as_ref(),
+                                    DocumentPermission::Update,
+                                    &policy.id,
+                                    &policy.resource_name,
+                                    doc_id,
+                                )
+                                .await
+                                .unwrap_or(false); // Fail-closed on errors
+
+                            if !has_permission {
+                                return Err(QueryError::permission_denied(format!(
+                                    "identity does not have update permission on document '{}'",
+                                    doc_id
+                                )));
+                            }
+                        }
+                    }
+                }
+                MutationType::Delete => {
+                    // For DELETE, check deleter permission on each target doc
+                    if let Some(ref doc_ids) = doc_ids_for_check {
+                        for doc_id in doc_ids {
+                            let has_permission = acp
+                                .check_doc_access(
+                                    identity.as_ref(),
+                                    DocumentPermission::Delete,
+                                    &policy.id,
+                                    &policy.resource_name,
+                                    doc_id,
+                                )
+                                .await
+                                .unwrap_or(false); // Fail-closed on errors
+
+                            if !has_permission {
+                                return Err(QueryError::permission_denied(format!(
+                                    "identity does not have delete permission on document '{}'",
+                                    doc_id
+                                )));
+                            }
+                        }
+                    }
+                }
+                MutationType::Create => {
+                    // CREATE permission is checked implicitly - anyone can create
+                    // but ownership is established via registration
+                }
+            }
+        }
 
         // Build and execute the appropriate mutation plan
         let mut plan: Box<dyn PlanNode> = match mutation.mutation_type {
@@ -419,6 +501,29 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         plan.close().await?;
+
+        // For CREATE operations with identity: register created docs with ACP
+        if mutation.mutation_type == MutationType::Create {
+            if let (Some(ref acp), Some(ref policy), Some(ref identity)) =
+                (&self.acp, &collection.policy, &identity)
+            {
+                for result in &results {
+                    if let Some(doc_id) = result.get("_docID").and_then(|v| v.as_str()) {
+                        // Register the document with the creator as owner
+                        if let Err(e) = acp
+                            .register_doc_object(identity, &policy.id, &policy.resource_name, doc_id)
+                            .await
+                        {
+                            tracing::warn!(
+                                doc_id = %doc_id,
+                                error = %e,
+                                "Failed to register document with ACP - document will be public"
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
         Ok(JsonValue::Array(results))
     }
@@ -842,7 +947,10 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryExecutor for QueryRunner<F, R> 
                 self.execute_query_with_identity(&request.query, request.identity)
                     .await
             }
-            ParsedOperation::Mutation(_) => self.execute_mutation(&request.query).await,
+            ParsedOperation::Mutation(_) => {
+                self.execute_mutation_with_identity(&request.query, request.identity)
+                    .await
+            }
         };
 
         match result {
@@ -3681,6 +3789,456 @@ mod tests {
             users.len(),
             1,
             "owner should see registered doc via execute()"
+        );
+    }
+
+    // ========================================================================
+    // Mutation ACP Integration Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_acp_create_with_identity_registers_doc() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store.clone()));
+        let mutator = Arc::new(MockMutator::new());
+
+        let owner = test_acp_did();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp.clone())
+            .with_mutator(mutator);
+
+        // Create a document with identity
+        let result = runner
+            .execute_mutation_with_identity(
+                r#"mutation { create_Users(input: [{name: "Alice"}]) { _docID name } }"#,
+                Some(owner.clone()),
+            )
+            .await
+            .unwrap();
+
+        // Get the created doc ID
+        let created = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(created.len(), 1);
+        let doc_id = created[0].get("_docID").unwrap().as_str().unwrap();
+
+        // Verify the document is registered with ACP
+        let is_registered = acp
+            .is_doc_registered("policy-acp", "Users", doc_id)
+            .await
+            .unwrap();
+        assert!(is_registered, "created doc should be registered with ACP");
+
+        // Verify owner has access
+        let has_access = acp
+            .check_doc_access(
+                Some(&owner),
+                acp::DocumentPermission::Read,
+                "policy-acp",
+                "Users",
+                doc_id,
+            )
+            .await
+            .unwrap();
+        assert!(has_access, "owner should have access to created doc");
+    }
+
+    #[tokio::test]
+    async fn test_acp_create_without_identity_doc_is_public() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store.clone()));
+        let mutator = Arc::new(MockMutator::new());
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp.clone())
+            .with_mutator(mutator);
+
+        // Create a document without identity (anonymous)
+        let result = runner
+            .execute_mutation_with_identity(
+                r#"mutation { create_Users(input: [{name: "Bob"}]) { _docID name } }"#,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let created = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(created.len(), 1);
+        let doc_id = created[0].get("_docID").unwrap().as_str().unwrap();
+
+        // Document should NOT be registered (public)
+        let is_registered = acp
+            .is_doc_registered("policy-acp", "Users", doc_id)
+            .await
+            .unwrap();
+        assert!(
+            !is_registered,
+            "anonymous create should not register doc with ACP"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_update_by_owner_succeeds() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let mutator = Arc::new(MockMutator::new());
+
+        let owner = test_acp_did();
+
+        // Create a document with proper DocID
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.set("age", 30i64);
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Register doc with ACP
+        acp.register_doc_object(&owner, "policy-acp", "Users", &doc_id)
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp)
+            .with_mutator(mutator);
+
+        // Owner should be able to update
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}"], input: {{name: "Alice Updated"}}) {{ _docID name }} }}"#,
+            doc_id
+        );
+        let result = runner
+            .execute_mutation_with_identity(&mutation, Some(owner))
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "owner should be able to update their doc: {:?}",
+            result.as_ref().err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_update_without_permission_fails() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let mutator = Arc::new(MockMutator::new());
+
+        let owner = test_acp_did();
+        let other = test_acp_did2();
+
+        // Create a document with proper DocID
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.set("age", 30i64);
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Register doc with owner
+        acp.register_doc_object(&owner, "policy-acp", "Users", &doc_id)
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp)
+            .with_mutator(mutator);
+
+        // Non-owner without updater permission should fail
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}"], input: {{name: "Hacked"}}) {{ _docID }} }}"#,
+            doc_id
+        );
+        let result = runner
+            .execute_mutation_with_identity(&mutation, Some(other))
+            .await;
+
+        assert!(
+            result.is_err(),
+            "non-owner without updater permission should not be able to update"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("permission denied"),
+            "error should indicate permission denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_update_with_updater_relation_succeeds() {
+        use acp::{LocalDocumentACP, MemoryAcpStore, UPDATER_RELATION};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let mutator = Arc::new(MockMutator::new());
+
+        let owner = test_acp_did();
+        let updater = test_acp_did2();
+
+        // Create a document with proper DocID
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.set("age", 30i64);
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Register doc and grant updater permission
+        acp.register_doc_object(&owner, "policy-acp", "Users", &doc_id)
+            .await
+            .unwrap();
+        acp.add_actor_relationship(&owner, &updater, "Users", &doc_id, UPDATER_RELATION)
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp)
+            .with_mutator(mutator);
+
+        // Updater should be able to update
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}"], input: {{name: "Updated by updater"}}) {{ _docID }} }}"#,
+            doc_id
+        );
+        let result = runner
+            .execute_mutation_with_identity(&mutation, Some(updater))
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "identity with updater relation should be able to update: {:?}",
+            result.as_ref().err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_delete_by_owner_succeeds() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let mutator = Arc::new(MockMutator::new());
+
+        let owner = test_acp_did();
+
+        // Create a document with proper DocID
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Register doc with ACP
+        acp.register_doc_object(&owner, "policy-acp", "Users", &doc_id)
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp)
+            .with_mutator(mutator);
+
+        // Owner should be able to delete
+        let mutation = format!(
+            r#"mutation {{ delete_Users(docIDs: ["{}"]) {{ _docID }} }}"#,
+            doc_id
+        );
+        let result = runner
+            .execute_mutation_with_identity(&mutation, Some(owner))
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "owner should be able to delete their doc: {:?}",
+            result.as_ref().err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_delete_without_permission_fails() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let mutator = Arc::new(MockMutator::new());
+
+        let owner = test_acp_did();
+        let other = test_acp_did2();
+
+        // Create a document with proper DocID
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Register doc with owner
+        acp.register_doc_object(&owner, "policy-acp", "Users", &doc_id)
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp)
+            .with_mutator(mutator);
+
+        // Non-owner without deleter permission should fail
+        let mutation = format!(
+            r#"mutation {{ delete_Users(docIDs: ["{}"]) {{ _docID }} }}"#,
+            doc_id
+        );
+        let result = runner
+            .execute_mutation_with_identity(&mutation, Some(other))
+            .await;
+
+        assert!(
+            result.is_err(),
+            "non-owner without deleter permission should not be able to delete"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("permission denied"),
+            "error should indicate permission denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_delete_with_deleter_relation_succeeds() {
+        use acp::{LocalDocumentACP, MemoryAcpStore, DELETER_RELATION};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let mutator = Arc::new(MockMutator::new());
+
+        let owner = test_acp_did();
+        let deleter = test_acp_did2();
+
+        // Create a document with proper DocID
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Register doc and grant deleter permission
+        acp.register_doc_object(&owner, "policy-acp", "Users", &doc_id)
+            .await
+            .unwrap();
+        acp.add_actor_relationship(&owner, &deleter, "Users", &doc_id, DELETER_RELATION)
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp)
+            .with_mutator(mutator);
+
+        // Deleter should be able to delete
+        let mutation = format!(
+            r#"mutation {{ delete_Users(docIDs: ["{}"]) {{ _docID }} }}"#,
+            doc_id
+        );
+        let result = runner
+            .execute_mutation_with_identity(&mutation, Some(deleter))
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "identity with deleter relation should be able to delete: {:?}",
+            result.as_ref().err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_anonymous_update_on_registered_doc_fails() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let mutator = Arc::new(MockMutator::new());
+
+        let owner = test_acp_did();
+
+        // Create a document with proper DocID
+        let mut doc = Document::new();
+        doc.set("name", "Alice");
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        // Register doc with owner
+        acp.register_doc_object(&owner, "policy-acp", "Users", &doc_id)
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp)
+            .with_mutator(mutator);
+
+        // Anonymous (None identity) should fail to update registered doc
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}"], input: {{name: "Hacked"}}) {{ _docID }} }}"#,
+            doc_id
+        );
+        let result = runner
+            .execute_mutation_with_identity(&mutation, None)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "anonymous should not be able to update registered doc"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_mutation_on_public_doc_succeeds() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+        let mutator = Arc::new(MockMutator::new());
+
+        let other = test_acp_did2();
+
+        // Create a document with proper DocID but DON'T register it (public)
+        let mut doc = Document::new();
+        doc.set("name", "PublicDoc");
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().to_string();
+        mutator.add_doc("Users", doc);
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()])
+            .with_acp(acp)
+            .with_mutator(mutator);
+
+        // Anyone can update public (unregistered) documents
+        let mutation = format!(
+            r#"mutation {{ update_Users(docIDs: ["{}"], input: {{name: "Updated"}}) {{ _docID }} }}"#,
+            doc_id
+        );
+        let result = runner
+            .execute_mutation_with_identity(&mutation, Some(other))
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "anyone should be able to update public (unregistered) doc: {:?}",
+            result.as_ref().err()
         );
     }
 }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -9,8 +9,10 @@
 //! a `TransactionRegistry`. The registry manages transaction lifecycle and provides
 //! transaction-scoped document fetchers for query execution.
 
+use acp::DocumentACP;
 use async_trait::async_trait;
 use document::Document;
+use identity::Did;
 use schema::CollectionVersion;
 use serde_json::{Map, Value as JsonValue};
 use std::collections::HashMap;
@@ -25,8 +27,8 @@ use crate::mapper::{AggregateType, Mutation, MutationType, Requestable, Select};
 use crate::mutator::DocMutator;
 use crate::plan::{
     AllDocsNode, AverageNode, CountNode, CreateInput, CreateNode, DeleteNode, GroupByNode,
-    LimitNode, MaxNode, MinNode, OrderByNode, ScanNode, SelectNode, SumNode, UpdateInput,
-    UpdateNode, UpsertInput, UpsertNode,
+    LimitNode, MaxNode, MinNode, OrderByNode, PermissionFilterNode, ScanNode, SelectNode, SumNode,
+    UpdateInput, UpdateNode, UpsertInput, UpsertNode,
 };
 use crate::planner::{Doc, PlanNode, Planner};
 use crate::query_parse::{parse_mutations, parse_query, parse_request, ParsedOperation};
@@ -47,6 +49,8 @@ pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRe
     registry: Arc<R>,
     /// Document mutator for mutation operations (optional)
     mutator: Option<Arc<dyn DocMutator>>,
+    /// Document ACP for permission checks (optional)
+    acp: Option<Arc<dyn DocumentACP>>,
 }
 
 impl<F: DocFetcher> QueryRunner<F, NoOpTransactionRegistry> {
@@ -64,6 +68,7 @@ impl<F: DocFetcher> QueryRunner<F, NoOpTransactionRegistry> {
             collections: collections_map,
             registry: Arc::new(NoOpTransactionRegistry),
             mutator: None,
+            acp: None,
         }
     }
 }
@@ -80,6 +85,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             collections: collections_map,
             registry: Arc::new(registry),
             mutator: None,
+            acp: None,
         }
     }
 
@@ -91,27 +97,49 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         self
     }
 
+    /// Set the document ACP for permission checks.
+    ///
+    /// When set, queries will filter results based on the identity's permissions.
+    /// Collections with a policy will have ACP enforced; others are unaffected.
+    pub fn with_acp(mut self, acp: Arc<dyn DocumentACP>) -> Self {
+        self.acp = Some(acp);
+        self
+    }
+
     /// Execute a GraphQL query and return JSON results.
     pub async fn execute_query(&self, query: &str) -> Result<JsonValue> {
-        self.execute_query_with_fetcher(query, self.fetcher.as_ref())
+        self.execute_query_internal(query, self.fetcher.as_ref(), None)
             .await
     }
 
-    /// Execute a GraphQL query with a specific fetcher.
+    /// Execute a GraphQL query with identity for ACP permission checks.
+    pub async fn execute_query_with_identity(
+        &self,
+        query: &str,
+        identity: Option<Did>,
+    ) -> Result<JsonValue> {
+        self.execute_query_internal(query, self.fetcher.as_ref(), identity)
+            .await
+    }
+
+    /// Execute a GraphQL query with a specific fetcher and identity.
     ///
     /// This is used internally for both regular queries (using the default fetcher)
     /// and transactional queries (using a transaction-scoped fetcher).
-    async fn execute_query_with_fetcher(
+    async fn execute_query_internal(
         &self,
         query: &str,
         fetcher: &dyn DocFetcher,
+        identity: Option<Did>,
     ) -> Result<JsonValue> {
         let selects = parse_query(query)?;
 
         let mut results = Map::new();
 
         for select in selects {
-            let result = self.execute_select_with_fetcher(&select, fetcher).await?;
+            let result = self
+                .execute_select_internal(&select, fetcher, identity.clone())
+                .await?;
             let key = select.field.output_name();
             results.insert(key.to_string(), result);
         }
@@ -119,11 +147,12 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         Ok(JsonValue::Object(results))
     }
 
-    /// Execute a single Select operation with a specific fetcher.
-    async fn execute_select_with_fetcher(
+    /// Execute a single Select operation with a specific fetcher and identity.
+    async fn execute_select_internal(
         &self,
         select: &Select,
         fetcher: &dyn DocFetcher,
+        identity: Option<Did>,
     ) -> Result<JsonValue> {
         // Get collection schema
         let collection = self
@@ -230,6 +259,17 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 
         // Build and execute the plan
         let mut plan = self.build_plan(select, plan_docs, mapping.clone())?;
+
+        // Wrap with permission filter if collection has ACP policy and ACP is configured
+        if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+            plan = Box::new(PermissionFilterNode::new(
+                plan,
+                acp.clone(),
+                identity,
+                &policy.id,
+                &policy.resource_name,
+            ));
+        }
 
         // Execute the plan and collect results
         plan.init().await?;
@@ -796,8 +836,12 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryExecutor for QueryRunner<F, R> 
         };
 
         // Route to appropriate handler based on operation type
+        // Pass identity through for ACP permission checks
         let result = match parsed {
-            ParsedOperation::Query(_) => self.execute_query(&request.query).await,
+            ParsedOperation::Query(_) => {
+                self.execute_query_with_identity(&request.query, request.identity)
+                    .await
+            }
             ParsedOperation::Mutation(_) => self.execute_mutation(&request.query).await,
         };
 
@@ -846,10 +890,10 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryExecutor for QueryRunner<F, R> 
             }
         };
 
-        // Get the transaction-scoped fetcher and execute
+        // Get the transaction-scoped fetcher and execute with identity for ACP
         let fetcher = txn_ctx.doc_fetcher();
         match self
-            .execute_query_with_fetcher(&request.query, fetcher.as_ref())
+            .execute_query_internal(&request.query, fetcher.as_ref(), request.identity)
             .await
         {
             Ok(data) => QueryResponse {
@@ -1146,11 +1190,7 @@ mod tests {
 
         let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
 
-        let request = QueryRequest {
-            query: "{ Users { name } }".to_string(),
-            operation_name: None,
-            variables: None,
-        };
+        let request = QueryRequest::new("{ Users { name } }");
 
         let response = runner.execute(request).await;
 
@@ -1200,11 +1240,7 @@ mod tests {
         let fetcher = MockFetcher::new();
         let runner = QueryRunner::new(fetcher, vec![make_test_collection()]);
 
-        let request = QueryRequest {
-            query: "{ InvalidCollection { name } }".to_string(),
-            operation_name: None,
-            variables: None,
-        };
+        let request = QueryRequest::new("{ InvalidCollection { name } }");
 
         let response = runner.execute(request).await;
 
@@ -3382,5 +3418,269 @@ mod tests {
         assert_eq!(alice.get("_sum").unwrap(), 0);
         // AVG of no values is null (SQL semantics)
         assert!(alice.get("_avg").unwrap().is_null());
+    }
+
+    // ========================================================================
+    // ACP Integration Tests
+    // ========================================================================
+
+    fn make_acp_collection() -> CollectionVersion {
+        use schema::PolicyDescription;
+
+        CollectionVersion::new(
+            "Users",
+            "v1",
+            "coll-acp",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                FieldDescription::new("3", "age", FieldKind::int()),
+            ],
+        )
+        .with_policy(PolicyDescription::new("policy-acp", "Users"))
+    }
+
+    fn test_acp_did() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    fn test_acp_did2() -> Did {
+        Did::new("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR").unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_acp_owner_sees_registered_docs() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        let owner = test_acp_did();
+
+        // Create docs with known IDs
+        let mut doc1 = Document::new();
+        doc1.set("_docID", "doc1");
+        doc1.set("name", "Alice");
+        doc1.set("age", 30i64);
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("_docID", "doc2");
+        doc2.set("name", "Bob");
+        doc2.set("age", 25i64);
+        fetcher.add_doc("Users", doc2);
+
+        // Register both docs with owner
+        acp.register_doc_object(&owner, "policy-acp", "Users", "doc1")
+            .await
+            .unwrap();
+        acp.register_doc_object(&owner, "policy-acp", "Users", "doc2")
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()]).with_acp(acp);
+
+        // Owner should see both docs (include _docID for ACP to work with projection)
+        let result = runner
+            .execute_query_with_identity("{ Users { _docID name } }", Some(owner))
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 2, "owner should see all registered docs");
+    }
+
+    #[tokio::test]
+    async fn test_acp_non_owner_sees_nothing() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        let owner = test_acp_did();
+        let other = test_acp_did2();
+
+        // Create doc with known ID
+        let mut doc1 = Document::new();
+        doc1.set("_docID", "doc1");
+        doc1.set("name", "Alice");
+        fetcher.add_doc("Users", doc1);
+
+        // Register doc with owner
+        acp.register_doc_object(&owner, "policy-acp", "Users", "doc1")
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()]).with_acp(acp);
+
+        // Non-owner without permissions should see nothing
+        let result = runner
+            .execute_query_with_identity("{ Users { _docID name } }", Some(other))
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(
+            users.len(),
+            0,
+            "non-owner without permissions should see no docs"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_reader_sees_shared_doc() {
+        use acp::{LocalDocumentACP, MemoryAcpStore, READER_RELATION};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        let owner = test_acp_did();
+        let reader = test_acp_did2();
+
+        // Create doc
+        let mut doc1 = Document::new();
+        doc1.set("_docID", "doc1");
+        doc1.set("name", "Alice");
+        fetcher.add_doc("Users", doc1);
+
+        // Register and share with reader
+        acp.register_doc_object(&owner, "policy-acp", "Users", "doc1")
+            .await
+            .unwrap();
+        acp.add_actor_relationship(&owner, &reader, "Users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()]).with_acp(acp);
+
+        // Reader should see the shared doc
+        let result = runner
+            .execute_query_with_identity("{ Users { _docID name } }", Some(reader))
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1, "reader should see shared doc");
+        assert_eq!(users[0].get("name").unwrap(), "Alice");
+    }
+
+    #[tokio::test]
+    async fn test_acp_anonymous_cannot_see_registered_doc() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        let owner = test_acp_did();
+
+        // Create doc
+        let mut doc1 = Document::new();
+        doc1.set("_docID", "doc1");
+        doc1.set("name", "Alice");
+        fetcher.add_doc("Users", doc1);
+
+        // Register with owner
+        acp.register_doc_object(&owner, "policy-acp", "Users", "doc1")
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()]).with_acp(acp);
+
+        // Anonymous (None identity) should see nothing
+        let result = runner
+            .execute_query_with_identity("{ Users { _docID name } }", None)
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 0, "anonymous should not see registered docs");
+    }
+
+    #[tokio::test]
+    async fn test_acp_public_docs_visible_to_all() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        let owner = test_acp_did();
+        let other = test_acp_did2();
+
+        // Create two docs - one registered, one public
+        let mut doc1 = Document::new();
+        doc1.set("_docID", "doc1");
+        doc1.set("name", "Alice");
+        fetcher.add_doc("Users", doc1);
+
+        let mut doc2 = Document::new();
+        doc2.set("_docID", "doc2");
+        doc2.set("name", "Bob");
+        fetcher.add_doc("Users", doc2);
+
+        // Only register doc1 with owner
+        acp.register_doc_object(&owner, "policy-acp", "Users", "doc1")
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()]).with_acp(acp);
+
+        // Non-owner should see only the unregistered (public) doc
+        let result = runner
+            .execute_query_with_identity("{ Users { _docID name } }", Some(other))
+            .await
+            .unwrap();
+
+        let users = result.get("Users").unwrap().as_array().unwrap();
+        assert_eq!(users.len(), 1, "non-owner should see only public doc");
+        assert_eq!(users[0].get("name").unwrap(), "Bob");
+    }
+
+    #[tokio::test]
+    async fn test_identity_passed_through_execute_request() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        let owner = test_acp_did();
+
+        // Create doc
+        let mut doc1 = Document::new();
+        doc1.set("_docID", "doc1");
+        doc1.set("name", "Alice");
+        fetcher.add_doc("Users", doc1);
+
+        // Register with owner
+        acp.register_doc_object(&owner, "policy-acp", "Users", "doc1")
+            .await
+            .unwrap();
+
+        let runner = QueryRunner::new(fetcher, vec![make_acp_collection()]).with_acp(acp);
+
+        // Use the QueryRequest with identity (simulating HTTP flow)
+        let request =
+            QueryRequest::new("{ Users { _docID name } }").with_identity(Some(owner));
+        let response = runner.execute(request).await;
+
+        assert!(response.errors.is_empty());
+        let users = response
+            .data
+            .unwrap()
+            .get("Users")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .to_vec();
+        assert_eq!(
+            users.len(),
+            1,
+            "owner should see registered doc via execute()"
+        );
     }
 }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -269,6 +269,13 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 &policy.id,
                 &policy.resource_name,
             ));
+        } else if collection.policy.is_some() && self.acp.is_none() {
+            // Collection has an ACP policy but ACP is not configured on this runner
+            // This means ACP enforcement is disabled - all documents will be accessible
+            tracing::warn!(
+                collection = %collection.name,
+                "Collection has ACP policy but QueryRunner has no ACP configured - ACP enforcement is DISABLED"
+            );
         }
 
         // Execute the plan and collect results
@@ -396,7 +403,15 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                                     doc_id,
                                 )
                                 .await
-                                .unwrap_or(false); // Fail-closed on errors
+                                .unwrap_or_else(|e| {
+                                    tracing::warn!(
+                                        doc_id = %doc_id,
+                                        identity = ?identity,
+                                        error = %e,
+                                        "ACP permission check failed during UPDATE, denying access"
+                                    );
+                                    false // Fail-closed on errors
+                                });
 
                             if !has_permission {
                                 return Err(QueryError::permission_denied(format!(
@@ -405,6 +420,13 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                                 )));
                             }
                         }
+                    } else {
+                        // No doc_ids to check - this means the mutation has no targets
+                        // Log this as it may indicate a logic issue
+                        tracing::debug!(
+                            collection = %mutation.collection_name,
+                            "UPDATE mutation has no doc_ids for ACP permission check - no documents will be affected"
+                        );
                     }
                 }
                 MutationType::Delete => {
@@ -420,7 +442,15 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                                     doc_id,
                                 )
                                 .await
-                                .unwrap_or(false); // Fail-closed on errors
+                                .unwrap_or_else(|e| {
+                                    tracing::warn!(
+                                        doc_id = %doc_id,
+                                        identity = ?identity,
+                                        error = %e,
+                                        "ACP permission check failed during DELETE, denying access"
+                                    );
+                                    false // Fail-closed on errors
+                                });
 
                             if !has_permission {
                                 return Err(QueryError::permission_denied(format!(
@@ -429,6 +459,12 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                                 )));
                             }
                         }
+                    } else {
+                        // No doc_ids to check - this means the mutation has no targets
+                        tracing::debug!(
+                            collection = %mutation.collection_name,
+                            "DELETE mutation has no doc_ids for ACP permission check - no documents will be affected"
+                        );
                     }
                 }
                 MutationType::Create => {
@@ -503,28 +539,42 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 
         plan.close().await?;
 
-        // For CREATE operations with identity: register created docs with ACP
-        if mutation.mutation_type == MutationType::Create {
+        // For CREATE/UPSERT operations with identity: register created docs with ACP
+        if matches!(
+            mutation.mutation_type,
+            MutationType::Create | MutationType::Upsert
+        ) {
             if let (Some(ref acp), Some(ref policy), Some(ref identity)) =
                 (&self.acp, &collection.policy, &identity)
             {
                 for result in &results {
                     if let Some(doc_id) = result.get("_docID").and_then(|v| v.as_str()) {
-                        // Register the document with the creator as owner
-                        if let Err(e) = acp
-                            .register_doc_object(
+                        // Check if document is already registered (for upsert of existing doc)
+                        let is_registered = acp
+                            .is_doc_registered(&policy.id, &policy.resource_name, doc_id)
+                            .await
+                            .unwrap_or(false);
+
+                        // Only register if not already registered (new document)
+                        if !is_registered {
+                            // Register the document with the creator as owner
+                            // CRITICAL: Registration failure must fail the mutation to prevent
+                            // documents from being created without proper access control
+                            acp.register_doc_object(
                                 identity,
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
                             )
                             .await
-                        {
-                            tracing::warn!(
-                                doc_id = %doc_id,
-                                error = %e,
-                                "Failed to register document with ACP - document will be public"
-                            );
+                            .map_err(|e| {
+                                tracing::error!(
+                                    doc_id = %doc_id,
+                                    error = %e,
+                                    "Failed to register document with ACP - aborting mutation"
+                                );
+                                QueryError::acp_registration_failed(doc_id, e)
+                            })?;
                         }
                     }
                 }

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -308,7 +308,8 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     /// "#).await?;
     /// ```
     pub async fn execute_mutation(&self, mutation_str: &str) -> Result<JsonValue> {
-        self.execute_mutation_with_identity(mutation_str, None).await
+        self.execute_mutation_with_identity(mutation_str, None)
+            .await
     }
 
     /// Execute a GraphQL mutation with identity for ACP permission checks.
@@ -511,7 +512,12 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                     if let Some(doc_id) = result.get("_docID").and_then(|v| v.as_str()) {
                         // Register the document with the creator as owner
                         if let Err(e) = acp
-                            .register_doc_object(identity, &policy.id, &policy.resource_name, doc_id)
+                            .register_doc_object(
+                                identity,
+                                &policy.id,
+                                &policy.resource_name,
+                                doc_id,
+                            )
                             .await
                         {
                             tracing::warn!(
@@ -3772,8 +3778,7 @@ mod tests {
         let runner = QueryRunner::new(fetcher, vec![make_acp_collection()]).with_acp(acp);
 
         // Use the QueryRequest with identity (simulating HTTP flow)
-        let request =
-            QueryRequest::new("{ Users { _docID name } }").with_identity(Some(owner));
+        let request = QueryRequest::new("{ Users { _docID name } }").with_identity(Some(owner));
         let response = runner.execute(request).await;
 
         assert!(response.errors.is_empty());
@@ -4194,9 +4199,7 @@ mod tests {
             r#"mutation {{ update_Users(docIDs: ["{}"], input: {{name: "Hacked"}}) {{ _docID }} }}"#,
             doc_id
         );
-        let result = runner
-            .execute_mutation_with_identity(&mutation, None)
-            .await;
+        let result = runner.execute_mutation_with_identity(&mutation, None).await;
 
         assert!(
             result.is_err(),


### PR DESCRIPTION
## Summary

This PR implements document-level Access Control Policy (ACP) integration following Go DefraDB's pattern. The implementation enables fine-grained permission control where:

- Documents created **without** identity are public (unregistered) - anyone can access
- Documents created **with** identity are registered - creator becomes owner, ACP enforced

### Key Components

| Crate | Changes |
|-------|---------|
| `acp` | New crate with core ACP types, traits, and local implementation |
| `p2p` | BlockAccessController extended with ACP checks |
| `query` | PermissionFilterNode for query-time filtering |
| `db` | Collection-level ACP helpers for mutations |
| `http` | Identity extraction from Authorization headers |

## Test plan

- [x] All 30 tests pass in `acp` crate
- [x] All 22 tests pass in `p2p` crate
- [x] All 5 tests pass for query permission filtering
- [x] All 6 tests pass for db collection_acp
- [x] All 47 tests pass in `http` crate
- [x] Full workspace builds successfully

## Review Guide

### Priority Areas to Review

1. **`crates/acp/src/dac.rs`** - Core `DocumentACP` trait interface
   - Does this match Go DefraDB's interface semantics?
   - Are the async signatures appropriate?

2. **`crates/acp/src/local.rs`** - LocalDocumentACP implementation
   - Permission checking logic (owner, relations, implied permissions)
   - Is the relation-based permission model correct?

3. **`crates/p2p/src/bitswap/access.rs`** - BlockAccessController integration
   - `has_access_acp()` async method
   - PeerIdentityRegistry design

4. **`crates/query/src/plan/permission_filter.rs`** - Query filtering
   - Follows Volcano Iterator Model pattern
   - Filters documents the identity can't read

5. **`crates/http/src/identity_extractor.rs`** - HTTP identity extraction
   - Bearer token parsing
   - Error handling for invalid tokens

### Architecture Decisions

- **Storage format**: `/acp/{collection_id}/{doc_id}/{relation}/{subject_did}`
- **Implied read**: Update/Delete permissions imply Read access
- **Anonymous access**: No Authorization header = anonymous (public docs only)
- **DPI rules**: Every resource must have `owner` relation

### What's NOT in this PR (deferred)

- SourceHub integration (designed for extensibility)
- Policy parsing/validation
- Custom relation types beyond owner/reader/updater/deleter

🤖 Generated with [Claude Code](https://claude.com/claude-code)