### PR TITLE
feat(acp): Add Identity enum and MemoryAcpStore validation

### DIFF
--- a/crates/acp/src/dac.rs
+++ b/crates/acp/src/dac.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use identity::Did;
 
 use crate::error::Result;
+use crate::identity::Identity;
 use crate::permission::DocumentPermission;
 
 /// Document ACP interface (matches Go acp/dac/dac.go)
@@ -49,19 +50,19 @@ pub trait DocumentACP: Send + Sync {
     ///
     /// # Access Rules
     /// 1. If document is unregistered (public) -> allow all
-    /// 2. If identity is None -> deny (anonymous cannot access registered docs)
+    /// 2. If identity is Anonymous -> deny (anonymous cannot access registered docs)
     /// 3. If identity is owner -> allow all
     /// 4. Check if identity has specific relation granting permission
     ///
     /// # Arguments
-    /// * `identity` - The DID of the requester (None for anonymous)
+    /// * `identity` - The identity of the requester (Anonymous or Authenticated)
     /// * `permission` - The permission being requested
     /// * `policy_id` - The policy ID from the collection
     /// * `resource_name` - The resource name from the policy
     /// * `doc_id` - The document ID being accessed
     async fn check_doc_access(
         &self,
-        identity: Option<&Did>,
+        identity: &Identity,
         permission: DocumentPermission,
         policy_id: &str,
         resource_name: &str,

--- a/crates/acp/src/identity.rs
+++ b/crates/acp/src/identity.rs
@@ -1,0 +1,181 @@
+//! Identity types for ACP.
+//!
+//! This module provides the `Identity` enum which represents the identity
+//! context for ACP operations. Using an explicit enum is clearer than
+//! `Option<Did>` and prevents confusion about semantics.
+
+use identity::Did;
+
+/// Identity context for ACP operations.
+///
+/// This enum explicitly represents the two possible identity states:
+/// - Anonymous: No identity provided (requests without authentication)
+/// - Authenticated: A verified DID identity
+///
+/// Using this enum instead of `Option<Did>` provides clearer semantics:
+/// - `Identity::Anonymous` clearly indicates no identity (not "missing" identity)
+/// - `Identity::Authenticated(did)` clearly indicates a verified identity
+///
+/// # Access Control Behavior
+///
+/// - `Anonymous`: Can access unregistered (public) documents only
+/// - `Authenticated`: Can access owned documents and documents with granted relations
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Identity {
+    /// No identity provided (anonymous/unauthenticated request).
+    Anonymous,
+
+    /// An authenticated identity with a verified DID.
+    Authenticated(Did),
+}
+
+impl Identity {
+    /// Create an anonymous identity.
+    pub fn anonymous() -> Self {
+        Self::Anonymous
+    }
+
+    /// Create an authenticated identity.
+    pub fn authenticated(did: Did) -> Self {
+        Self::Authenticated(did)
+    }
+
+    /// Check if this is an anonymous identity.
+    pub fn is_anonymous(&self) -> bool {
+        matches!(self, Self::Anonymous)
+    }
+
+    /// Check if this is an authenticated identity.
+    pub fn is_authenticated(&self) -> bool {
+        matches!(self, Self::Authenticated(_))
+    }
+
+    /// Get the DID if authenticated, None if anonymous.
+    pub fn did(&self) -> Option<&Did> {
+        match self {
+            Self::Anonymous => None,
+            Self::Authenticated(did) => Some(did),
+        }
+    }
+
+    /// Convert to Option<&Did> for compatibility with existing APIs.
+    pub fn as_option(&self) -> Option<&Did> {
+        self.did()
+    }
+}
+
+impl From<Did> for Identity {
+    fn from(did: Did) -> Self {
+        Self::Authenticated(did)
+    }
+}
+
+impl From<Option<Did>> for Identity {
+    fn from(opt: Option<Did>) -> Self {
+        match opt {
+            Some(did) => Self::Authenticated(did),
+            None => Self::Anonymous,
+        }
+    }
+}
+
+impl<'a> From<Option<&'a Did>> for Identity {
+    fn from(opt: Option<&'a Did>) -> Self {
+        match opt {
+            Some(did) => Self::Authenticated(did.clone()),
+            None => Self::Anonymous,
+        }
+    }
+}
+
+impl std::fmt::Display for Identity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Anonymous => write!(f, "anonymous"),
+            Self::Authenticated(did) => write!(f, "{}", did),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_did() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    #[test]
+    fn test_identity_anonymous() {
+        let id = Identity::anonymous();
+        assert!(id.is_anonymous());
+        assert!(!id.is_authenticated());
+        assert!(id.did().is_none());
+        assert_eq!(format!("{}", id), "anonymous");
+    }
+
+    #[test]
+    fn test_identity_authenticated() {
+        let did = test_did();
+        let id = Identity::authenticated(did.clone());
+        assert!(!id.is_anonymous());
+        assert!(id.is_authenticated());
+        assert_eq!(id.did(), Some(&did));
+        assert!(format!("{}", id).contains("did:key:"));
+    }
+
+    #[test]
+    fn test_identity_from_did() {
+        let did = test_did();
+        let id: Identity = did.clone().into();
+        assert!(id.is_authenticated());
+        assert_eq!(id.did(), Some(&did));
+    }
+
+    #[test]
+    fn test_identity_from_option_did() {
+        let did = test_did();
+
+        let id1: Identity = Some(did.clone()).into();
+        assert!(id1.is_authenticated());
+
+        let none_did: Option<Did> = None;
+        let id2: Identity = none_did.into();
+        assert!(id2.is_anonymous());
+    }
+
+    #[test]
+    fn test_identity_from_option_ref_did() {
+        let did = test_did();
+
+        let id1: Identity = Some(&did).into();
+        assert!(id1.is_authenticated());
+
+        let id2: Identity = (None as Option<&Did>).into();
+        assert!(id2.is_anonymous());
+    }
+
+    #[test]
+    fn test_identity_as_option() {
+        let did = test_did();
+
+        let anon = Identity::anonymous();
+        assert_eq!(anon.as_option(), None);
+
+        let auth = Identity::authenticated(did.clone());
+        assert_eq!(auth.as_option(), Some(&did));
+    }
+
+    #[test]
+    fn test_identity_equality() {
+        let did1 = test_did();
+        let did2 = test_did();
+
+        assert_eq!(Identity::Anonymous, Identity::Anonymous);
+        assert_eq!(
+            Identity::Authenticated(did1.clone()),
+            Identity::Authenticated(did2)
+        );
+        assert_ne!(Identity::Anonymous, Identity::Authenticated(did1));
+    }
+}

--- a/crates/acp/src/identity.rs
+++ b/crates/acp/src/identity.rs
@@ -20,7 +20,7 @@ use identity::Did;
 ///
 /// - `Anonymous`: Can access unregistered (public) documents only
 /// - `Authenticated`: Can access owned documents and documents with granted relations
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Identity {
     /// No identity provided (anonymous/unauthenticated request).
     Anonymous,
@@ -59,6 +59,7 @@ impl Identity {
     }
 
     /// Convert to Option<&Did> for compatibility with existing APIs.
+    #[deprecated(since = "0.1.0", note = "use did() instead")]
     pub fn as_option(&self) -> Option<&Did> {
         self.did()
     }
@@ -156,6 +157,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_identity_as_option() {
         let did = test_did();
 
@@ -164,6 +166,21 @@ mod tests {
 
         let auth = Identity::authenticated(did.clone());
         assert_eq!(auth.as_option(), Some(&did));
+    }
+
+    #[test]
+    fn test_identity_hash() {
+        use std::collections::HashSet;
+
+        let did = test_did();
+        let mut set = HashSet::new();
+
+        set.insert(Identity::Anonymous);
+        set.insert(Identity::Authenticated(did.clone()));
+
+        assert!(set.contains(&Identity::Anonymous));
+        assert!(set.contains(&Identity::Authenticated(did)));
+        assert_eq!(set.len(), 2);
     }
 
     #[test]

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -26,6 +26,7 @@
 
 mod dac;
 mod error;
+mod identity;
 mod local;
 mod permission;
 mod persistent;
@@ -34,6 +35,7 @@ mod store;
 
 pub use dac::DocumentACP;
 pub use error::{Error, Result};
+pub use identity::Identity;
 pub use local::{LocalDocumentACP, MemoryAcpStore};
 pub use permission::DocumentPermission;
 pub use persistent::PersistentAcpStore;

--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use crate::dac::DocumentACP;
 use crate::error::{Error, Result};
+use crate::identity::Identity;
 use crate::permission::DocumentPermission;
 use crate::relation::{
     RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION,
@@ -93,7 +94,7 @@ impl DocumentACP for LocalDocumentACP {
 
     async fn check_doc_access(
         &self,
-        identity: Option<&Did>,
+        identity: &Identity,
         permission: DocumentPermission,
         _policy_id: &str,
         resource_name: &str,
@@ -105,14 +106,14 @@ impl DocumentACP for LocalDocumentACP {
             return Ok(true);
         }
 
-        // Document is registered, need identity to access
-        let identity = match identity {
-            Some(id) => id,
-            None => return Ok(false), // Anonymous cannot access registered docs
+        // Document is registered, need authenticated identity to access
+        let did = match identity {
+            Identity::Authenticated(did) => did,
+            Identity::Anonymous => return Ok(false), // Anonymous cannot access registered docs
         };
 
         // Owner always has all permissions (DPI rule: every permission starts with owner)
-        if self.is_owner(identity, resource_name, doc_id).await? {
+        if self.is_owner(did, resource_name, doc_id).await? {
             return Ok(true);
         }
 
@@ -122,23 +123,23 @@ impl DocumentACP for LocalDocumentACP {
             DocumentPermission::Read => {
                 // reader OR updater OR deleter grants read (implied read)
                 Ok(self
-                    .has_relation(identity, resource_name, doc_id, READER_RELATION)
+                    .has_relation(did, resource_name, doc_id, READER_RELATION)
                     .await?
                     || self
-                        .has_relation(identity, resource_name, doc_id, UPDATER_RELATION)
+                        .has_relation(did, resource_name, doc_id, UPDATER_RELATION)
                         .await?
                     || self
-                        .has_relation(identity, resource_name, doc_id, DELETER_RELATION)
+                        .has_relation(did, resource_name, doc_id, DELETER_RELATION)
                         .await?)
             }
             DocumentPermission::Update => {
                 // updater grants update
-                self.has_relation(identity, resource_name, doc_id, UPDATER_RELATION)
+                self.has_relation(did, resource_name, doc_id, UPDATER_RELATION)
                     .await
             }
             DocumentPermission::Delete => {
                 // deleter grants delete
-                self.has_relation(identity, resource_name, doc_id, DELETER_RELATION)
+                self.has_relation(did, resource_name, doc_id, DELETER_RELATION)
                     .await
             }
         }
@@ -272,6 +273,9 @@ impl AcpStore for MemoryAcpStore {
         collection_id: &str,
         doc_id: &str,
     ) -> Result<Vec<RelationTuple>> {
+        // Validate inputs to prevent path traversal
+        RelationTuple::validate_prefix(collection_id, doc_id)?;
+
         let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
         let tuples = self
             .tuples
@@ -289,6 +293,9 @@ impl AcpStore for MemoryAcpStore {
         doc_id: &str,
         relation: &str,
     ) -> Result<Vec<Did>> {
+        // Validate inputs to prevent path traversal
+        RelationTuple::validate_relation_prefix(collection_id, doc_id, relation)?;
+
         let prefix = RelationTuple::relation_prefix(collection_id, doc_id, relation);
         let subjects = self
             .tuples
@@ -306,6 +313,9 @@ impl AcpStore for MemoryAcpStore {
         collection_id: &str,
         doc_id: &str,
     ) -> Result<Vec<String>> {
+        // Validate inputs to prevent path traversal
+        RelationTuple::validate_prefix(collection_id, doc_id)?;
+
         let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
         let relations = self
             .tuples
@@ -318,12 +328,18 @@ impl AcpStore for MemoryAcpStore {
     }
 
     async fn delete_doc_tuples(&self, collection_id: &str, doc_id: &str) -> Result<()> {
+        // Validate inputs to prevent path traversal
+        RelationTuple::validate_prefix(collection_id, doc_id)?;
+
         let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
         self.tuples.write().retain(|k, _| !k.starts_with(&prefix));
         Ok(())
     }
 
     async fn is_doc_registered(&self, collection_id: &str, doc_id: &str) -> Result<bool> {
+        // Validate inputs to prevent path traversal
+        RelationTuple::validate_prefix(collection_id, doc_id)?;
+
         let prefix = RelationTuple::doc_prefix(collection_id, doc_id);
         Ok(self.tuples.read().keys().any(|k| k.starts_with(&prefix)))
     }
@@ -353,7 +369,13 @@ mod tests {
 
         // Anonymous can access unregistered doc
         let access = acp
-            .check_doc_access(None, DocumentPermission::Read, "policy1", "users", "doc1")
+            .check_doc_access(
+                &Identity::Anonymous,
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1",
+            )
             .await
             .unwrap();
         assert!(access, "unregistered doc should allow anonymous read");
@@ -361,7 +383,7 @@ mod tests {
         // Any identity can access unregistered doc
         let access = acp
             .check_doc_access(
-                Some(&test_did()),
+                &Identity::Authenticated(test_did()),
                 DocumentPermission::Update,
                 "policy1",
                 "users",
@@ -413,9 +435,10 @@ mod tests {
             .await
             .unwrap();
 
+        let owner_id = Identity::Authenticated(owner);
         assert!(acp
             .check_doc_access(
-                Some(&owner),
+                &owner_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -425,7 +448,7 @@ mod tests {
             .unwrap());
         assert!(acp
             .check_doc_access(
-                Some(&owner),
+                &owner_id,
                 DocumentPermission::Update,
                 "policy1",
                 "users",
@@ -435,7 +458,7 @@ mod tests {
             .unwrap());
         assert!(acp
             .check_doc_access(
-                Some(&owner),
+                &owner_id,
                 DocumentPermission::Delete,
                 "policy1",
                 "users",
@@ -455,7 +478,13 @@ mod tests {
             .unwrap();
 
         let access = acp
-            .check_doc_access(None, DocumentPermission::Read, "policy1", "users", "doc1")
+            .check_doc_access(
+                &Identity::Anonymous,
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1",
+            )
             .await
             .unwrap();
         assert!(!access, "anonymous should not read registered doc");
@@ -471,9 +500,10 @@ mod tests {
             .await
             .unwrap();
 
+        let other_id = Identity::Authenticated(other);
         assert!(!acp
             .check_doc_access(
-                Some(&other),
+                &other_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -483,7 +513,7 @@ mod tests {
             .unwrap());
         assert!(!acp
             .check_doc_access(
-                Some(&other),
+                &other_id,
                 DocumentPermission::Update,
                 "policy1",
                 "users",
@@ -493,7 +523,7 @@ mod tests {
             .unwrap());
         assert!(!acp
             .check_doc_access(
-                Some(&other),
+                &other_id,
                 DocumentPermission::Delete,
                 "policy1",
                 "users",
@@ -521,10 +551,11 @@ mod tests {
             .unwrap();
         assert!(added, "relationship should be added");
 
+        let reader_id = Identity::Authenticated(reader);
         // Reader can read
         assert!(acp
             .check_doc_access(
-                Some(&reader),
+                &reader_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -536,7 +567,7 @@ mod tests {
         // Reader cannot update
         assert!(!acp
             .check_doc_access(
-                Some(&reader),
+                &reader_id,
                 DocumentPermission::Update,
                 "policy1",
                 "users",
@@ -548,7 +579,7 @@ mod tests {
         // Reader cannot delete
         assert!(!acp
             .check_doc_access(
-                Some(&reader),
+                &reader_id,
                 DocumentPermission::Delete,
                 "policy1",
                 "users",
@@ -572,10 +603,11 @@ mod tests {
             .await
             .unwrap();
 
+        let updater_id = Identity::Authenticated(updater);
         // Updater can read (implied)
         assert!(acp
             .check_doc_access(
-                Some(&updater),
+                &updater_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -587,7 +619,7 @@ mod tests {
         // Updater can update
         assert!(acp
             .check_doc_access(
-                Some(&updater),
+                &updater_id,
                 DocumentPermission::Update,
                 "policy1",
                 "users",
@@ -599,7 +631,7 @@ mod tests {
         // Updater cannot delete
         assert!(!acp
             .check_doc_access(
-                Some(&updater),
+                &updater_id,
                 DocumentPermission::Delete,
                 "policy1",
                 "users",
@@ -709,10 +741,11 @@ mod tests {
             .await
             .unwrap();
 
+        let reader_id = Identity::Authenticated(reader.clone());
         // Verify reader has access
         assert!(acp
             .check_doc_access(
-                Some(&reader),
+                &reader_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -731,7 +764,7 @@ mod tests {
         // Verify reader no longer has access
         assert!(!acp
             .check_doc_access(
-                Some(&reader),
+                &reader_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -774,10 +807,11 @@ mod tests {
             .await
             .unwrap();
 
+        let deleter_id = Identity::Authenticated(deleter);
         // Deleter can read (implied by deleter relation)
         assert!(
             acp.check_doc_access(
-                Some(&deleter),
+                &deleter_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -791,7 +825,7 @@ mod tests {
         // Deleter can delete
         assert!(
             acp.check_doc_access(
-                Some(&deleter),
+                &deleter_id,
                 DocumentPermission::Delete,
                 "policy1",
                 "users",
@@ -805,7 +839,7 @@ mod tests {
         // Deleter CANNOT update
         assert!(
             !acp.check_doc_access(
-                Some(&deleter),
+                &deleter_id,
                 DocumentPermission::Update,
                 "policy1",
                 "users",
@@ -831,10 +865,11 @@ mod tests {
             .await
             .unwrap();
 
+        let deleter_id = Identity::Authenticated(deleter.clone());
         // Verify deleter has access
         assert!(acp
             .check_doc_access(
-                Some(&deleter),
+                &deleter_id,
                 DocumentPermission::Delete,
                 "policy1",
                 "users",
@@ -851,7 +886,7 @@ mod tests {
         // Verify deleter no longer has delete access
         assert!(!acp
             .check_doc_access(
-                Some(&deleter),
+                &deleter_id,
                 DocumentPermission::Delete,
                 "policy1",
                 "users",
@@ -863,7 +898,7 @@ mod tests {
         // Verify deleter also lost implied read access
         assert!(!acp
             .check_doc_access(
-                Some(&deleter),
+                &deleter_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -940,10 +975,11 @@ mod tests {
             .await
             .unwrap();
 
+        let reader_id = Identity::Authenticated(reader);
         // Reader CAN access users/doc1
         assert!(
             acp.check_doc_access(
-                Some(&reader),
+                &reader_id,
                 DocumentPermission::Read,
                 "policy1",
                 "users",
@@ -957,7 +993,7 @@ mod tests {
         // Reader CANNOT access posts/doc1 (different collection, no permission)
         assert!(
             !acp.check_doc_access(
-                Some(&reader),
+                &reader_id,
                 DocumentPermission::Read,
                 "policy1",
                 "posts",
@@ -966,6 +1002,110 @@ mod tests {
             .await
             .unwrap(),
             "reader should NOT access posts/doc1 (cross-collection isolation)"
+        );
+    }
+
+    // MemoryAcpStore path traversal validation tests
+
+    #[tokio::test]
+    async fn test_memory_store_validates_get_doc_tuples() {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = LocalDocumentACP::new(store.clone());
+
+        // Register a doc first
+        acp.register_doc_object(&test_did(), "policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        // Valid inputs should work
+        assert!(store.get_doc_tuples("users", "doc1").await.is_ok());
+
+        // Path traversal attempts should be rejected
+        assert!(
+            store.get_doc_tuples("../etc", "passwd").await.is_err(),
+            "path traversal should be rejected"
+        );
+        assert!(
+            store
+                .get_doc_tuples("users", "doc/../../../etc/passwd")
+                .await
+                .is_err(),
+            "path traversal should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_validates_is_doc_registered() {
+        let store = MemoryAcpStore::new();
+
+        // Valid inputs should work
+        assert!(store.is_doc_registered("users", "doc1").await.is_ok());
+
+        // Path traversal attempts should be rejected
+        assert!(
+            store.is_doc_registered("../etc", "passwd").await.is_err(),
+            "path traversal should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_validates_delete_doc_tuples() {
+        let store = MemoryAcpStore::new();
+
+        // Valid inputs should work
+        assert!(store.delete_doc_tuples("users", "doc1").await.is_ok());
+
+        // Path traversal attempts should be rejected
+        assert!(
+            store.delete_doc_tuples("../etc", "passwd").await.is_err(),
+            "path traversal should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_validates_get_relation_subjects() {
+        let store = MemoryAcpStore::new();
+
+        // Valid inputs should work
+        assert!(store
+            .get_relation_subjects("users", "doc1", "owner")
+            .await
+            .is_ok());
+
+        // Path traversal attempts should be rejected
+        assert!(
+            store
+                .get_relation_subjects("../etc", "passwd", "owner")
+                .await
+                .is_err(),
+            "path traversal should be rejected"
+        );
+        assert!(
+            store
+                .get_relation_subjects("users", "doc1", "../admin")
+                .await
+                .is_err(),
+            "path traversal in relation should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_memory_store_validates_get_subject_relations() {
+        let store = MemoryAcpStore::new();
+
+        // Valid inputs should work
+        assert!(store
+            .get_subject_relations(&test_did(), "users", "doc1")
+            .await
+            .is_ok());
+
+        // Path traversal attempts should be rejected
+        assert!(
+            store
+                .get_subject_relations(&test_did(), "../etc", "passwd")
+                .await
+                .is_err(),
+            "path traversal should be rejected"
         );
     }
 }

--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -1108,4 +1108,85 @@ mod tests {
             "path traversal should be rejected"
         );
     }
+
+    #[tokio::test]
+    async fn test_unregister_doc_cleans_all_relations() {
+        let acp = create_acp();
+        let owner = test_did();
+        let reader = test_did2();
+
+        // Register and add multiple relations
+        acp.register_doc_object(&owner, "policy1", "users", "doc1")
+            .await
+            .unwrap();
+        acp.add_actor_relationship(&owner, &reader, "users", "doc1", READER_RELATION)
+            .await
+            .unwrap();
+        acp.add_actor_relationship(&owner, &reader, "users", "doc1", UPDATER_RELATION)
+            .await
+            .unwrap();
+
+        // Verify relations exist
+        assert!(acp
+            .is_doc_registered("policy1", "users", "doc1")
+            .await
+            .unwrap());
+
+        let reader_id = Identity::Authenticated(reader.clone());
+        assert!(
+            acp.check_doc_access(
+                &reader_id,
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap(),
+            "reader should have access before unregister"
+        );
+
+        // Unregister the document
+        acp.unregister_doc_object("policy1", "users", "doc1")
+            .await
+            .unwrap();
+
+        // Verify ALL relations are gone - document is now unregistered (public)
+        assert!(
+            !acp.is_doc_registered("policy1", "users", "doc1")
+                .await
+                .unwrap(),
+            "document should be unregistered after cleanup"
+        );
+
+        // Since document is now unregistered (public), anyone can access it
+        // This verifies the tuples were deleted, not that access is denied
+        assert!(
+            acp.check_doc_access(
+                &reader_id,
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap(),
+            "unregistered (public) doc allows all access"
+        );
+
+        // Owner relation should also be gone
+        let owner_id = Identity::Authenticated(owner);
+        assert!(
+            acp.check_doc_access(
+                &owner_id,
+                DocumentPermission::Read,
+                "policy1",
+                "users",
+                "doc1"
+            )
+            .await
+            .unwrap(),
+            "unregistered (public) doc allows all access"
+        );
+    }
 }

--- a/crates/acp/src/persistent.rs
+++ b/crates/acp/src/persistent.rs
@@ -470,4 +470,106 @@ mod tests {
         store.delete_doc_tuples("用户", "文档1").await.unwrap();
         assert!(!store.is_doc_registered("用户", "文档1").await.unwrap());
     }
+
+    #[tokio::test]
+    async fn test_persistent_store_get_relation_subjects() {
+        let tmp_dir = TempDir::new().unwrap();
+        let store = PersistentAcpStore::open(tmp_dir.path()).unwrap();
+
+        let did1 = test_did();
+        let did2 = test_did2();
+
+        // Add owner and reader relations
+        let owner_tuple = RelationTuple::owner(did1.clone(), "users", "doc1");
+        let reader_tuple = RelationTuple::new(did2.clone(), "reader", "users", "doc1");
+
+        store.put_tuple(&owner_tuple).await.unwrap();
+        store.put_tuple(&reader_tuple).await.unwrap();
+
+        // Get subjects with "owner" relation
+        let owners = store
+            .get_relation_subjects("users", "doc1", "owner")
+            .await
+            .unwrap();
+        assert_eq!(owners.len(), 1);
+        assert_eq!(owners[0], did1);
+
+        // Get subjects with "reader" relation
+        let readers = store
+            .get_relation_subjects("users", "doc1", "reader")
+            .await
+            .unwrap();
+        assert_eq!(readers.len(), 1);
+        assert_eq!(readers[0], did2);
+
+        // Non-existent relation returns empty
+        let deleters = store
+            .get_relation_subjects("users", "doc1", "deleter")
+            .await
+            .unwrap();
+        assert!(deleters.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_persistent_store_get_subject_relations() {
+        let tmp_dir = TempDir::new().unwrap();
+        let store = PersistentAcpStore::open(tmp_dir.path()).unwrap();
+
+        let did = test_did();
+
+        // Add multiple relations for the same subject on the same doc
+        let owner_tuple = RelationTuple::owner(did.clone(), "users", "doc1");
+        let reader_tuple = RelationTuple::new(did.clone(), "reader", "users", "doc1");
+
+        store.put_tuple(&owner_tuple).await.unwrap();
+        store.put_tuple(&reader_tuple).await.unwrap();
+
+        // Get relations for the subject on doc1
+        let relations = store
+            .get_subject_relations(&did, "users", "doc1")
+            .await
+            .unwrap();
+        assert_eq!(relations.len(), 2);
+        assert!(relations.contains(&"owner".to_string()));
+        assert!(relations.contains(&"reader".to_string()));
+
+        // Different doc returns no relations
+        let relations = store
+            .get_subject_relations(&did, "users", "doc2")
+            .await
+            .unwrap();
+        assert!(relations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_persistent_store_validates_relation_prefix() {
+        let tmp_dir = TempDir::new().unwrap();
+        let store = PersistentAcpStore::open(tmp_dir.path()).unwrap();
+
+        // Path traversal in relation parameter should be rejected
+        let result = store
+            .get_relation_subjects("users", "doc1", "../admin")
+            .await;
+        assert!(
+            result.is_err(),
+            "path traversal in relation should be rejected"
+        );
+
+        let result = store
+            .get_relation_subjects("users", "doc1", "reader/../../admin")
+            .await;
+        assert!(
+            result.is_err(),
+            "nested path traversal in relation should be rejected"
+        );
+
+        // Backslash in relation should also be rejected
+        let result = store
+            .get_relation_subjects("users", "doc1", "reader\\admin")
+            .await;
+        assert!(
+            result.is_err(),
+            "backslash in relation should be rejected"
+        );
+    }
 }

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -551,7 +551,12 @@ impl Node {
             Some(identity) => match identity.did() {
                 Ok(did) => Some(did),
                 Err(e) => {
-                    warn!("Failed to extract DID from user identity: {}", e);
+                    error!(
+                        error = %e,
+                        "Failed to extract DID from --identity flag. \
+                         ACP will treat all requests as anonymous. \
+                         Check that your identity key is valid and matches the --identity-key-type."
+                    );
                     None
                 }
             },

--- a/crates/db/src/collection_acp.rs
+++ b/crates/db/src/collection_acp.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use acp::{DocumentACP, DocumentPermission};
+use acp::{DocumentACP, DocumentPermission, Identity};
 use identity::Did;
 use schema::CollectionVersion;
 
@@ -17,7 +17,7 @@ use schema::CollectionVersion;
 /// 3. Identity has the required permission
 pub async fn check_doc_permission(
     acp: &dyn DocumentACP,
-    identity: Option<&Did>,
+    identity: &Identity,
     permission: DocumentPermission,
     collection: &CollectionVersion,
     doc_id: &str,
@@ -99,13 +99,21 @@ pub struct AcpContext {
     /// Document ACP for permission checks
     pub acp: Arc<dyn DocumentACP>,
     /// Identity making the request
-    pub identity: Option<Did>,
+    pub identity: Identity,
 }
 
 impl AcpContext {
     /// Create a new ACP context.
-    pub fn new(acp: Arc<dyn DocumentACP>, identity: Option<Did>) -> Self {
+    pub fn new(acp: Arc<dyn DocumentACP>, identity: Identity) -> Self {
         Self { acp, identity }
+    }
+
+    /// Create from an optional DID for backward compatibility.
+    pub fn from_optional_did(acp: Arc<dyn DocumentACP>, did: Option<Did>) -> Self {
+        Self {
+            acp,
+            identity: Identity::from(did),
+        }
     }
 
     /// Check if identity has permission for a document operation.
@@ -117,7 +125,7 @@ impl AcpContext {
     ) -> acp::Result<bool> {
         check_doc_permission(
             self.acp.as_ref(),
-            self.identity.as_ref(),
+            &self.identity,
             permission,
             collection,
             doc_id,
@@ -131,13 +139,7 @@ impl AcpContext {
         collection: &CollectionVersion,
         doc_id: &str,
     ) -> acp::Result<()> {
-        register_doc_if_needed(
-            self.acp.as_ref(),
-            self.identity.as_ref(),
-            collection,
-            doc_id,
-        )
-        .await
+        register_doc_if_needed(self.acp.as_ref(), self.identity.did(), collection, doc_id).await
     }
 }
 
@@ -189,7 +191,7 @@ mod tests {
         // Anyone should have access when there's no policy
         let allowed = check_doc_permission(
             &acp,
-            None, // Anonymous
+            &Identity::Anonymous,
             DocumentPermission::Read,
             &collection,
             "doc1",
@@ -256,7 +258,7 @@ mod tests {
         // Owner should have update permission
         let allowed = check_doc_permission(
             &acp,
-            Some(&owner),
+            &Identity::Authenticated(owner),
             DocumentPermission::Update,
             &collection,
             "doc1",
@@ -282,7 +284,7 @@ mod tests {
         // Stranger should NOT have update permission
         let allowed = check_doc_permission(
             &acp,
-            Some(&stranger),
+            &Identity::Authenticated(stranger),
             DocumentPermission::Update,
             &collection,
             "doc1",
@@ -299,7 +301,7 @@ mod tests {
         let collection = collection_with_policy();
         let owner = test_did();
 
-        let ctx = AcpContext::new(acp, Some(owner));
+        let ctx = AcpContext::new(acp, Identity::Authenticated(owner));
 
         // Register document using context
         ctx.register_doc(&collection, "doc1").await.unwrap();

--- a/crates/p2p/src/bitswap/access.rs
+++ b/crates/p2p/src/bitswap/access.rs
@@ -31,7 +31,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use acp::{DocumentACP, DocumentPermission};
+use acp::{DocumentACP, DocumentPermission, Identity};
 use cid::Cid;
 use identity::Did;
 use libp2p::PeerId;
@@ -421,12 +421,12 @@ impl BlockAccessController {
             None => return false, // Deny if no ACP and not a replicator
         };
 
-        // Look up peer's DID
-        let did = self.peer_identities.get_did(peer_id);
+        // Look up peer's DID and convert to Identity
+        let identity = Identity::from(self.peer_identities.get_did(peer_id));
 
         // Check document-level ACP permissions
         // Fail-closed: deny access on any error to prevent security bypass
-        acp.check_doc_access(did.as_ref(), permission, policy_id, resource_name, doc_id)
+        acp.check_doc_access(&identity, permission, policy_id, resource_name, doc_id)
             .await
             .unwrap_or_else(|e| {
                 tracing::error!(
@@ -1133,7 +1133,7 @@ mod tests {
 
         async fn check_doc_access(
             &self,
-            _identity: Option<&Did>,
+            _identity: &Identity,
             _permission: DocumentPermission,
             _policy_id: &str,
             _resource_name: &str,

--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use acp::{DocumentACP, DocumentPermission};
+use acp::{DocumentACP, DocumentPermission, Identity};
 use async_trait::async_trait;
 use identity::Did;
 
@@ -25,8 +25,8 @@ pub struct PermissionFilterNode {
     /// Document ACP for permission checks
     acp: Arc<dyn DocumentACP>,
 
-    /// Identity requesting access (None = anonymous)
-    identity: Option<Did>,
+    /// Identity requesting access
+    identity: Identity,
 
     /// Policy ID from the collection
     policy_id: String,
@@ -47,13 +47,13 @@ impl PermissionFilterNode {
     /// # Arguments
     /// * `source` - The source node to filter
     /// * `acp` - Document ACP for permission checks
-    /// * `identity` - The identity requesting access (None for anonymous)
+    /// * `identity` - The identity requesting access
     /// * `policy_id` - Policy ID from the collection
     /// * `resource_name` - Resource name from the policy
     pub fn new(
         source: Box<dyn PlanNode>,
         acp: Arc<dyn DocumentACP>,
-        identity: Option<Did>,
+        identity: Identity,
         policy_id: impl Into<String>,
         resource_name: impl Into<String>,
     ) -> Self {
@@ -69,6 +69,17 @@ impl PermissionFilterNode {
         }
     }
 
+    /// Create from an optional DID for backward compatibility.
+    pub fn from_optional_did(
+        source: Box<dyn PlanNode>,
+        acp: Arc<dyn DocumentACP>,
+        did: Option<Did>,
+        policy_id: impl Into<String>,
+        resource_name: impl Into<String>,
+    ) -> Self {
+        Self::new(source, acp, Identity::from(did), policy_id, resource_name)
+    }
+
     /// Check if the identity has read permission for a document.
     ///
     /// Fail-closed: returns false on any error to prevent security bypass.
@@ -76,7 +87,7 @@ impl PermissionFilterNode {
         Ok(self
             .acp
             .check_doc_access(
-                self.identity.as_ref(),
+                &self.identity,
                 DocumentPermission::Read,
                 &self.policy_id,
                 &self.resource_name,
@@ -88,7 +99,7 @@ impl PermissionFilterNode {
                     doc_id = %doc_id,
                     policy_id = %self.policy_id,
                     resource_name = %self.resource_name,
-                    identity = ?self.identity,
+                    identity = %self.identity,
                     error = %e,
                     "Permission check failed, denying access to document"
                 );
@@ -212,13 +223,8 @@ mod tests {
         let docs = make_test_docs();
         let scan = create_scan_node(docs);
 
-        let mut filter = PermissionFilterNode::new(
-            Box::new(scan),
-            acp,
-            None, // Anonymous
-            "policy1",
-            "users",
-        );
+        let mut filter =
+            PermissionFilterNode::new(Box::new(scan), acp, Identity::Anonymous, "policy1", "users");
 
         filter.init().await.unwrap();
         filter.start().await.unwrap();
@@ -250,7 +256,7 @@ mod tests {
         let mut filter = PermissionFilterNode::new(
             Box::new(scan),
             acp,
-            Some(owner), // Owner identity
+            Identity::Authenticated(owner),
             "policy1",
             "users",
         );
@@ -286,7 +292,7 @@ mod tests {
         let mut filter = PermissionFilterNode::new(
             Box::new(scan),
             acp,
-            Some(stranger), // Different identity
+            Identity::Authenticated(stranger),
             "policy1",
             "users",
         );
@@ -326,8 +332,13 @@ mod tests {
         let docs = make_test_docs();
         let scan = create_scan_node(docs);
 
-        let mut filter =
-            PermissionFilterNode::new(Box::new(scan), acp, Some(reader), "policy1", "users");
+        let mut filter = PermissionFilterNode::new(
+            Box::new(scan),
+            acp,
+            Identity::Authenticated(reader),
+            "policy1",
+            "users",
+        );
 
         filter.init().await.unwrap();
         filter.start().await.unwrap();
@@ -364,13 +375,8 @@ mod tests {
         let docs = make_test_docs();
         let scan = create_scan_node(docs);
 
-        let mut filter = PermissionFilterNode::new(
-            Box::new(scan),
-            acp,
-            None, // Anonymous
-            "policy1",
-            "users",
-        );
+        let mut filter =
+            PermissionFilterNode::new(Box::new(scan), acp, Identity::Anonymous, "policy1", "users");
 
         filter.init().await.unwrap();
         filter.start().await.unwrap();
@@ -415,7 +421,7 @@ mod tests {
 
         async fn check_doc_access(
             &self,
-            _identity: Option<&Did>,
+            _identity: &Identity,
             _permission: acp::DocumentPermission,
             _policy_id: &str,
             _resource_name: &str,
@@ -466,7 +472,7 @@ mod tests {
         let mut filter = PermissionFilterNode::new(
             Box::new(scan),
             acp,
-            Some(test_did()), // Even with identity
+            Identity::Authenticated(test_did()),
             "policy1",
             "users",
         );
@@ -494,13 +500,8 @@ mod tests {
         let docs = make_test_docs();
         let scan = create_scan_node(docs);
 
-        let mut filter = PermissionFilterNode::new(
-            Box::new(scan),
-            acp,
-            None, // Anonymous
-            "policy1",
-            "users",
-        );
+        let mut filter =
+            PermissionFilterNode::new(Box::new(scan), acp, Identity::Anonymous, "policy1", "users");
 
         filter.init().await.unwrap();
         filter.start().await.unwrap();

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -9,7 +9,7 @@
 //! a `TransactionRegistry`. The registry manages transaction lifecycle and provides
 //! transaction-scoped document fetchers for query execution.
 
-use acp::DocumentACP;
+use acp::{DocumentACP, Identity};
 use async_trait::async_trait;
 use document::Document;
 use identity::Did;
@@ -298,7 +298,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             plan = Box::new(PermissionFilterNode::new(
                 plan,
                 acp.clone(),
-                identity,
+                Identity::from(identity),
                 &policy.id,
                 &policy.resource_name,
             ));
@@ -426,10 +426,11 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 MutationType::Update | MutationType::Upsert => {
                     // For UPDATE, check updater permission on each target doc
                     if let Some(ref doc_ids) = doc_ids_for_check {
+                        let identity_for_acp = Identity::from(identity.as_ref());
                         for doc_id in doc_ids {
                             let has_permission = acp
                                 .check_doc_access(
-                                    caller_identity.as_ref(),
+                                    &identity_for_acp,
                                     DocumentPermission::Update,
                                     &policy.id,
                                     &policy.resource_name,
@@ -439,7 +440,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                                 .unwrap_or_else(|e| {
                                     tracing::warn!(
                                         doc_id = %doc_id,
-                                        caller_identity = ?caller_identity,
+                                        identity = %identity_for_acp,
                                         error = %e,
                                         "ACP permission check failed during UPDATE, denying access"
                                     );
@@ -465,10 +466,11 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 MutationType::Delete => {
                     // For DELETE, check deleter permission on each target doc
                     if let Some(ref doc_ids) = doc_ids_for_check {
+                        let identity_for_acp = Identity::from(identity.as_ref());
                         for doc_id in doc_ids {
                             let has_permission = acp
                                 .check_doc_access(
-                                    caller_identity.as_ref(),
+                                    &identity_for_acp,
                                     DocumentPermission::Delete,
                                     &policy.id,
                                     &policy.resource_name,
@@ -478,7 +480,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                                 .unwrap_or_else(|e| {
                                     tracing::warn!(
                                         doc_id = %doc_id,
-                                        caller_identity = ?caller_identity,
+                                        identity = %identity_for_acp,
                                         error = %e,
                                         "ACP permission check failed during DELETE, denying access"
                                     );
@@ -3942,7 +3944,7 @@ mod tests {
         // Verify owner has access
         let has_access = acp
             .check_doc_access(
-                Some(&owner),
+                &Identity::Authenticated(owner),
                 acp::DocumentPermission::Read,
                 "policy-acp",
                 "Users",

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -588,7 +588,14 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                         let is_registered = acp
                             .is_doc_registered(&policy.id, &policy.resource_name, doc_id)
                             .await
-                            .unwrap_or(false);
+                            .unwrap_or_else(|e| {
+                                tracing::warn!(
+                                    doc_id = %doc_id,
+                                    error = %e,
+                                    "Failed to check document registration status - assuming unregistered"
+                                );
+                                false
+                            });
 
                         // Only register if not already registered (new document)
                         if !is_registered {

--- a/crates/query/src/runner.rs
+++ b/crates/query/src/runner.rs
@@ -199,9 +199,34 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             .iter()
             .any(|f| matches!(f, Requestable::Select(_)));
 
+        // SECURITY: Block nested queries on ACP-protected collections until Planner ACP is implemented.
+        // See issue #114 for tracking the full fix.
+        if has_nested && self.acp.is_some() {
+            // Check root collection for ACP
+            if collection.policy.is_some() {
+                return Err(QueryError::execution(format!(
+                    "Nested queries on ACP-protected collections are not yet supported. \
+                     Collection '{}' has an ACP policy. Remove nested selections or use \
+                     separate queries. See issue #114 for tracking.",
+                    collection.name
+                )));
+            }
+
+            // Check nested collections by resolving relation targets from parent collection
+            if let Some(acp_coll) = self.find_acp_collection_in_nested(select, collection) {
+                return Err(QueryError::execution(format!(
+                    "Nested queries on ACP-protected collections are not yet supported. \
+                     Collection '{}' has an ACP policy. Remove nested selections or use \
+                     separate queries. See issue #114 for tracking.",
+                    acp_coll
+                )));
+            }
+        }
+
         if has_nested {
             // Use the Planner for queries with nested selections (joins)
-            // Note: ACP filtering for nested queries is not yet implemented
+            // Note: ACP filtering for nested queries is not yet implemented.
+            // Queries on ACP-protected collections are blocked above.
             self.execute_nested_select_with_planner(select, fetcher, caller_identity)
                 .await
         } else {
@@ -216,8 +241,9 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     /// The Planner builds a proper join plan with TypeJoinOne/TypeJoinMany nodes.
     /// ScanNodes fetch their own data via the attached fetcher.
     ///
-    /// Note: ACP filtering for nested queries is not yet implemented.
-    /// The identity parameter is accepted for future use.
+    /// Note: This path does NOT enforce ACP permissions. Queries involving
+    /// ACP-protected collections are blocked at the caller level (execute_select_internal).
+    /// The identity parameter is accepted for future use when Planner ACP is implemented.
     async fn execute_nested_select_with_planner(
         &self,
         select: &Select,
@@ -426,7 +452,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 MutationType::Update | MutationType::Upsert => {
                     // For UPDATE, check updater permission on each target doc
                     if let Some(ref doc_ids) = doc_ids_for_check {
-                        let identity_for_acp = Identity::from(identity.as_ref());
+                        let identity_for_acp = Identity::from(caller_identity.as_ref());
                         for doc_id in doc_ids {
                             let has_permission = acp
                                 .check_doc_access(
@@ -466,7 +492,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 MutationType::Delete => {
                     // For DELETE, check deleter permission on each target doc
                     if let Some(ref doc_ids) = doc_ids_for_check {
-                        let identity_for_acp = Identity::from(identity.as_ref());
+                        let identity_for_acp = Identity::from(caller_identity.as_ref());
                         for doc_id in doc_ids {
                             let has_permission = acp
                                 .check_doc_access(
@@ -1031,6 +1057,45 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     /// Check if a collection exists.
     pub fn has_collection(&self, name: &str) -> bool {
         self.collections.contains_key(name)
+    }
+
+    /// Find the first ACP-protected collection in nested selections.
+    ///
+    /// This resolves relation field names to actual collection names by looking up
+    /// the relation definition in the parent collection's schema.
+    ///
+    /// Returns Some(collection_name) if an ACP-protected collection is found, None otherwise.
+    fn find_acp_collection_in_nested(
+        &self,
+        select: &Select,
+        parent_collection: &CollectionVersion,
+    ) -> Option<String> {
+        for field in &select.fields {
+            if let Requestable::Select(nested) = field {
+                // The nested select's collection_name is the field name in the query
+                // We need to resolve it to the actual target collection via the relation
+                let field_name = &nested.collection_name;
+
+                // Find the relation field in the parent collection
+                if let Some(relation_field) = parent_collection.fields.iter().find(|f| &f.name == field_name) {
+                    // Get the target collection name from the relation field's kind
+                    if let Some(target_coll_name) = relation_field.kind.relation_collection_id() {
+                        // Check if target collection has ACP
+                        if let Some(target_coll) = self.collections.get(target_coll_name) {
+                            if target_coll.policy.is_some() {
+                                return Some(target_coll.name.clone());
+                            }
+
+                            // Recursively check deeper nested selections
+                            if let Some(deep_acp) = self.find_acp_collection_in_nested(nested, target_coll) {
+                                return Some(deep_acp);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
     }
 }
 
@@ -4354,5 +4419,223 @@ mod tests {
             "anyone should be able to update public (unregistered) doc: {:?}",
             result.as_ref().err()
         );
+    }
+
+    // =====================================================================
+    // Nested Query ACP Blocking Tests (Issue #114)
+    // =====================================================================
+
+    /// Helper to create a collection with a relation field (for nested query tests)
+    fn make_collection_with_relation() -> CollectionVersion {
+        CollectionVersion::new(
+            "Authors",
+            "v1",
+            "coll-authors",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+                // Relation to Books collection (is_array=true for one-to-many)
+                FieldDescription::new("3", "books", FieldKind::relation("Books", true)),
+            ],
+        )
+    }
+
+    fn make_related_collection_with_acp() -> CollectionVersion {
+        use schema::PolicyDescription;
+
+        CollectionVersion::new(
+            "Books",
+            "v1",
+            "coll-books",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "title", FieldKind::string()),
+                FieldDescription::new("3", "author_id", FieldKind::string()),
+            ],
+        )
+        .with_policy(PolicyDescription::new("policy-books", "Books"))
+    }
+
+    fn make_related_collection_no_acp() -> CollectionVersion {
+        CollectionVersion::new(
+            "Books",
+            "v1",
+            "coll-books",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "title", FieldKind::string()),
+                FieldDescription::new("3", "author_id", FieldKind::string()),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn test_nested_query_blocked_when_nested_collection_has_acp() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        // Set up collections: Authors (no ACP) with relation to Books (has ACP)
+        let runner = QueryRunner::new(
+            fetcher,
+            vec![
+                make_collection_with_relation(),
+                make_related_collection_with_acp(),
+            ],
+        )
+        .with_acp(acp);
+
+        // Attempt a nested query that touches the ACP-protected collection
+        let result = runner
+            .execute_query("{ Authors { name books { title } } }")
+            .await;
+
+        // Should be rejected due to ACP protection on nested collection
+        assert!(result.is_err(), "nested query on ACP collection should fail");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("not yet supported"),
+            "error should mention nested queries not supported: {}",
+            err
+        );
+        assert!(
+            err.to_string().contains("Books"),
+            "error should mention the ACP-protected collection: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nested_query_blocked_when_root_collection_has_acp() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+        use schema::PolicyDescription;
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        // Set up root collection with ACP
+        let acp_collection = make_collection_with_relation()
+            .with_policy(PolicyDescription::new("policy-authors", "Authors"));
+
+        let runner = QueryRunner::new(
+            fetcher,
+            vec![acp_collection, make_related_collection_no_acp()],
+        )
+        .with_acp(acp);
+
+        // Attempt a nested query where root has ACP
+        let result = runner
+            .execute_query("{ Authors { name books { title } } }")
+            .await;
+
+        // Should be rejected
+        assert!(result.is_err(), "nested query on ACP root should fail");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("not yet supported"),
+            "error should mention nested queries not supported: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_nested_query_allowed_when_no_acp_configured() {
+        // Without ACP configured on the runner, nested queries should work
+        // (even if collections have policy metadata - the runner just doesn't enforce)
+        let fetcher = MockFetcher::new();
+
+        // Note: NOT calling .with_acp() - no ACP on runner
+        let runner = QueryRunner::new(
+            fetcher,
+            vec![
+                make_collection_with_relation(),
+                make_related_collection_with_acp(),
+            ],
+        );
+
+        // This should NOT be blocked since ACP isn't configured on runner
+        // (It may still fail for other reasons like missing relation data, but not due to ACP block)
+        let result = runner
+            .execute_query("{ Authors { name books { title } } }")
+            .await;
+
+        // Should not contain our ACP blocking error
+        if let Err(ref e) = result {
+            assert!(
+                !e.to_string().contains("not yet supported"),
+                "should not block when ACP not configured: {}",
+                e
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_nested_query_allowed_when_no_collections_have_acp() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        // Both collections have no ACP policy
+        let runner = QueryRunner::new(
+            fetcher,
+            vec![
+                make_collection_with_relation(),
+                make_related_collection_no_acp(),
+            ],
+        )
+        .with_acp(acp);
+
+        // This should NOT be blocked - no ACP policies involved
+        let result = runner
+            .execute_query("{ Authors { name books { title } } }")
+            .await;
+
+        // Should not contain our ACP blocking error
+        if let Err(ref e) = result {
+            assert!(
+                !e.to_string().contains("not yet supported"),
+                "should not block when no collections have ACP: {}",
+                e
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_simple_query_still_works_with_acp() {
+        use acp::{LocalDocumentACP, MemoryAcpStore};
+
+        let fetcher = MockFetcher::new();
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = Arc::new(LocalDocumentACP::new(store));
+
+        // Add a doc
+        let mut doc = Document::new();
+        doc.set("_docID", "author1");
+        doc.set("name", "Jane Austen");
+        fetcher.add_doc("Authors", doc);
+
+        let runner = QueryRunner::new(
+            fetcher,
+            vec![
+                make_collection_with_relation(),
+                make_related_collection_with_acp(),
+            ],
+        )
+        .with_acp(acp);
+
+        // Simple query (no nested) should still work
+        let result = runner
+            .execute_query("{ Authors { name } }")
+            .await
+            .expect("simple query should work even with ACP configured");
+
+        let authors = result.get("Authors").unwrap().as_array().unwrap();
+        assert_eq!(authors.len(), 1);
+        assert_eq!(authors[0].get("name").unwrap(), "Jane Austen");
     }
 }


### PR DESCRIPTION
## Summary
- Add `validate_prefix()` enforcement to `MemoryAcpStore` to prevent path traversal attacks
- Add `Identity` enum (`Anonymous | Authenticated(Did)`) replacing `Option<Did>` for clearer semantics
- Update all ACP API usages across `acp`, `db`, `p2p`, and `query` crates

## Test plan
- [x] All existing ACP tests pass
- [x] New path traversal validation tests added for `MemoryAcpStore`
- [x] New `Identity` enum unit tests added
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` applied

## Related
Closes partial work for #43 (PR #99 review feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)