### PR TITLE
feat(cli): Add ACP, Backup, Index, and P2P commands for CLI completeness

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -73,6 +73,9 @@ reqwest = { version = "0.12", features = ["json"] }
 # URL parsing
 url = "2.5"
 
+# URL encoding for query parameters
+urlencoding = "2.1"
+
 [dev-dependencies]
 tempfile = "3.17"
 portpicker = "0.1"

--- a/crates/cli/src/commands/client/acp.rs
+++ b/crates/cli/src/commands/client/acp.rs
@@ -1,0 +1,146 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//! ACP (Access Control Policy) command implementation
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use super::http_client::HttpClient;
+use super::{get_data_from_args, ClientContext};
+use crate::error::Result;
+
+/// Interact with Access Control Policies
+#[derive(Args, Debug)]
+pub struct AcpArgs {
+    #[command(subcommand)]
+    pub command: AcpCommand,
+}
+
+/// ACP subcommands
+#[derive(Subcommand, Debug)]
+pub enum AcpCommand {
+    /// Add a new ACP policy
+    Add(AcpAddArgs),
+    /// List all ACP policies
+    List(AcpListArgs),
+    /// Show details of a specific policy
+    Describe(AcpDescribeArgs),
+}
+
+/// Arguments for acp add command
+#[derive(Args, Debug)]
+pub struct AcpAddArgs {
+    /// The policy definition (YAML or JSON format)
+    #[arg(value_name = "POLICY")]
+    pub policy: Option<String>,
+
+    /// Read policy from file
+    #[arg(long, short = 'f', value_name = "FILE")]
+    pub file: Option<PathBuf>,
+}
+
+/// Arguments for acp list command
+#[derive(Args, Debug)]
+pub struct AcpListArgs {}
+
+/// Arguments for acp describe command
+#[derive(Args, Debug)]
+pub struct AcpDescribeArgs {
+    /// The policy ID
+    #[arg(value_name = "ID")]
+    pub id: String,
+}
+
+impl AcpArgs {
+    /// Execute the ACP command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        match &self.command {
+            AcpCommand::Add(args) => args.execute(ctx).await,
+            AcpCommand::List(args) => args.execute(ctx).await,
+            AcpCommand::Describe(args) => args.execute(ctx).await,
+        }
+    }
+}
+
+impl AcpAddArgs {
+    /// Execute the acp add command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let policy = get_data_from_args(&self.policy, &self.file)?;
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let response = client.acp_add_policy(&policy).await?;
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        Ok(())
+    }
+}
+
+impl AcpListArgs {
+    /// Execute the acp list command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let policies = client.acp_list_policies().await?;
+        println!("{}", serde_json::to_string_pretty(&policies)?);
+        Ok(())
+    }
+}
+
+impl AcpDescribeArgs {
+    /// Execute the acp describe command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let policy = client.acp_get_policy(&self.id).await?;
+        println!("{}", serde_json::to_string_pretty(&policy)?);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_acp_add_args_with_data() {
+        let args = AcpAddArgs {
+            policy: Some("test policy".to_string()),
+            file: None,
+        };
+        assert!(args.policy.is_some());
+        assert!(args.file.is_none());
+    }
+
+    #[test]
+    fn test_acp_add_args_with_file() {
+        let args = AcpAddArgs {
+            policy: None,
+            file: Some(PathBuf::from("policy.yaml")),
+        };
+        assert!(args.policy.is_none());
+        assert!(args.file.is_some());
+    }
+
+    #[test]
+    fn test_acp_describe_args() {
+        let args = AcpDescribeArgs {
+            id: "policy123".to_string(),
+        };
+        assert_eq!(args.id, "policy123");
+    }
+}

--- a/crates/cli/src/commands/client/acp.rs
+++ b/crates/cli/src/commands/client/acp.rs
@@ -16,7 +16,7 @@ use clap::{Args, Subcommand};
 
 use super::http_client::HttpClient;
 use super::{get_data_from_args, ClientContext};
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 /// Interact with Access Control Policies
 #[derive(Args, Debug)]
@@ -102,6 +102,13 @@ impl AcpListArgs {
 impl AcpDescribeArgs {
     /// Execute the acp describe command
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        // Validate policy ID is not empty
+        if self.id.trim().is_empty() {
+            return Err(Error::InvalidIdentifier(
+                "policy ID cannot be empty".to_string(),
+            ));
+        }
+
         let client = HttpClient::new(&ctx.url)?
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);

--- a/crates/cli/src/commands/client/backup.rs
+++ b/crates/cli/src/commands/client/backup.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use clap::{Args, Subcommand};
 
 use super::http_client::HttpClient;
-use super::ClientContext;
+use super::{validate_identifier, ClientContext};
 use crate::error::{Error, Result};
 
 /// Manage database backups
@@ -71,6 +71,11 @@ impl BackupArgs {
 impl BackupExportArgs {
     /// Execute the backup export command
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        // Validate collection names before making the request
+        for col in &self.collections {
+            validate_identifier(col)?;
+        }
+
         let client = HttpClient::new(&ctx.url)?
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);

--- a/crates/cli/src/commands/client/backup.rs
+++ b/crates/cli/src/commands/client/backup.rs
@@ -1,0 +1,149 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//! Backup command implementation for database export/import
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use super::http_client::HttpClient;
+use super::ClientContext;
+use crate::error::{Error, Result};
+
+/// Manage database backups
+#[derive(Args, Debug)]
+pub struct BackupArgs {
+    #[command(subcommand)]
+    pub command: BackupCommand,
+}
+
+/// Backup subcommands
+#[derive(Subcommand, Debug)]
+pub enum BackupCommand {
+    /// Export database to a file
+    Export(BackupExportArgs),
+    /// Import database from a file
+    Import(BackupImportArgs),
+}
+
+/// Arguments for backup export command
+#[derive(Args, Debug)]
+pub struct BackupExportArgs {
+    /// Output file path for the backup
+    #[arg(value_name = "FILE")]
+    pub file: PathBuf,
+
+    /// Collection(s) to export (can be specified multiple times)
+    #[arg(long, short = 'c')]
+    pub collections: Vec<String>,
+
+    /// Pretty print the JSON output
+    #[arg(long)]
+    pub pretty: bool,
+}
+
+/// Arguments for backup import command
+#[derive(Args, Debug)]
+pub struct BackupImportArgs {
+    /// Input file path for the backup to restore
+    #[arg(value_name = "FILE")]
+    pub file: PathBuf,
+}
+
+impl BackupArgs {
+    /// Execute the backup command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        match &self.command {
+            BackupCommand::Export(args) => args.execute(ctx).await,
+            BackupCommand::Import(args) => args.execute(ctx).await,
+        }
+    }
+}
+
+impl BackupExportArgs {
+    /// Execute the backup export command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let collections = if self.collections.is_empty() {
+            None
+        } else {
+            Some(self.collections.as_slice())
+        };
+
+        let data = client.backup_export(collections, self.pretty).await?;
+
+        std::fs::write(&self.file, &data).map_err(|e| Error::WriteConfig {
+            path: self.file.clone(),
+            source: e,
+        })?;
+
+        println!("Backup exported to: {}", self.file.display());
+        Ok(())
+    }
+}
+
+impl BackupImportArgs {
+    /// Execute the backup import command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let data = std::fs::read_to_string(&self.file).map_err(|e| Error::ReadFile {
+            path: self.file.clone(),
+            source: e,
+        })?;
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        client.backup_import(&data).await?;
+
+        println!("Backup imported from: {}", self.file.display());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backup_export_args() {
+        let args = BackupExportArgs {
+            file: PathBuf::from("backup.json"),
+            collections: vec![],
+            pretty: false,
+        };
+        assert_eq!(args.file, PathBuf::from("backup.json"));
+        assert!(args.collections.is_empty());
+        assert!(!args.pretty);
+    }
+
+    #[test]
+    fn test_backup_export_args_with_collections() {
+        let args = BackupExportArgs {
+            file: PathBuf::from("backup.json"),
+            collections: vec!["Users".to_string(), "Posts".to_string()],
+            pretty: true,
+        };
+        assert_eq!(args.collections.len(), 2);
+        assert!(args.pretty);
+    }
+
+    #[test]
+    fn test_backup_import_args() {
+        let args = BackupImportArgs {
+            file: PathBuf::from("backup.json"),
+        };
+        assert_eq!(args.file, PathBuf::from("backup.json"));
+    }
+}

--- a/crates/cli/src/commands/client/http_client.rs
+++ b/crates/cli/src/commands/client/http_client.rs
@@ -393,3 +393,97 @@ impl GraphQLResponse {
             .join("; ")
     }
 }
+
+/// ACP policy add request
+#[derive(Debug, Serialize)]
+pub struct AcpAddPolicyRequest {
+    pub policy: String,
+}
+
+/// ACP policy add response
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AcpAddPolicyResponse {
+    #[serde(rename = "PolicyID")]
+    pub policy_id: String,
+}
+
+/// ACP policy info from list/describe
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AcpPolicy {
+    /// Policy ID
+    #[serde(rename = "id", alias = "ID")]
+    pub id: String,
+
+    /// Policy name (if available)
+    #[serde(rename = "name", alias = "Name", default)]
+    pub name: Option<String>,
+
+    /// Policy description (if available)
+    #[serde(rename = "description", alias = "Description", default)]
+    pub description: Option<String>,
+
+    /// Resources defined in the policy
+    #[serde(rename = "resources", alias = "Resources", default)]
+    pub resources: Option<JsonValue>,
+
+    /// Actor definitions
+    #[serde(rename = "actor", alias = "Actor", default)]
+    pub actor: Option<JsonValue>,
+
+    /// Creation time (if available)
+    #[serde(rename = "creationTime", alias = "CreationTime", default)]
+    pub creation_time: Option<String>,
+}
+
+impl HttpClient {
+    /// Add a new ACP policy
+    pub async fn acp_add_policy(&self, policy: &str) -> Result<AcpAddPolicyResponse> {
+        let url = format!("{}/api/v0/acp/policy", self.base_url);
+        let request = AcpAddPolicyRequest {
+            policy: policy.to_string(),
+        };
+        self.post_json(&url, &request).await
+    }
+
+    /// List all ACP policies
+    pub async fn acp_list_policies(&self) -> Result<Vec<AcpPolicy>> {
+        let url = format!("{}/api/v0/acp/policy", self.base_url);
+        let response = self.send_with_retry("GET", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        let policies: Vec<AcpPolicy> = response.json().await?;
+        Ok(policies)
+    }
+
+    /// Get a specific ACP policy by ID
+    pub async fn acp_get_policy(&self, policy_id: &str) -> Result<AcpPolicy> {
+        let url = format!("{}/api/v0/acp/policy/{}", self.base_url, policy_id);
+        let response = self.send_with_retry("GET", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        let policy: AcpPolicy = response.json().await?;
+        Ok(policy)
+    }
+}

--- a/crates/cli/src/commands/client/http_client.rs
+++ b/crates/cli/src/commands/client/http_client.rs
@@ -268,7 +268,12 @@ impl HttpClient {
         }
 
         // All retries exhausted
-        Err(last_error.unwrap_or_else(|| Error::Server("Request failed after retries".to_string())))
+        Err(last_error.unwrap_or_else(|| {
+            Error::Server(format!(
+                "{} {} failed after {} retries",
+                method, url, MAX_RETRIES
+            ))
+        }))
     }
 
     /// Extract error details from a failed response and return an error.

--- a/crates/cli/src/commands/client/http_client.rs
+++ b/crates/cli/src/commands/client/http_client.rs
@@ -486,4 +486,64 @@ impl HttpClient {
         let policy: AcpPolicy = response.json().await?;
         Ok(policy)
     }
+
+    /// Export database backup
+    pub async fn backup_export(
+        &self,
+        collections: Option<&[String]>,
+        pretty: bool,
+    ) -> Result<String> {
+        let mut url = format!("{}/api/v0/backup/export", self.base_url);
+
+        // Build query parameters
+        let mut params = Vec::new();
+        if let Some(cols) = collections {
+            for col in cols {
+                params.push(format!("collections={}", col));
+            }
+        }
+        if pretty {
+            params.push("pretty=true".to_string());
+        }
+        if !params.is_empty() {
+            url = format!("{}?{}", url, params.join("&"));
+        }
+
+        let response = self.send_with_retry("GET", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        let data = response.text().await?;
+        Ok(data)
+    }
+
+    /// Import database backup
+    pub async fn backup_import(&self, data: &str) -> Result<()> {
+        let url = format!("{}/api/v0/backup/import", self.base_url);
+        let response = self.send_with_retry("POST", &url, Some(data)).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        Ok(())
+    }
 }

--- a/crates/cli/src/commands/client/http_client.rs
+++ b/crates/cli/src/commands/client/http_client.rs
@@ -213,6 +213,7 @@ impl HttpClient {
                         req
                     }
                 }
+                "DELETE" => self.add_auth_header(self.client.delete(url)),
                 _ => {
                     return Err(Error::Server(format!(
                         "Unsupported HTTP method: {}",
@@ -546,4 +547,112 @@ impl HttpClient {
 
         Ok(())
     }
+
+    /// Create an index on a collection
+    pub async fn index_create(
+        &self,
+        collection: &str,
+        fields: &[String],
+        name: Option<&str>,
+        unique: bool,
+    ) -> Result<IndexInfo> {
+        let url = format!("{}/api/v0/index", self.base_url);
+        let request = IndexCreateRequest {
+            collection: collection.to_string(),
+            fields: fields.to_vec(),
+            name: name.map(|s| s.to_string()),
+            unique,
+        };
+        self.post_json(&url, &request).await
+    }
+
+    /// List indexes (optionally filtered by collection)
+    pub async fn index_list(&self, collection: Option<&str>) -> Result<Vec<IndexInfo>> {
+        let url = match collection {
+            Some(col) => format!("{}/api/v0/index?collection={}", self.base_url, col),
+            None => format!("{}/api/v0/index", self.base_url),
+        };
+        let response = self.send_with_retry("GET", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        let indexes: Vec<IndexInfo> = response.json().await?;
+        Ok(indexes)
+    }
+
+    /// Drop an index by name
+    pub async fn index_drop(&self, collection: &str, name: &str) -> Result<()> {
+        let url = format!(
+            "{}/api/v0/index?collection={}&name={}",
+            self.base_url, collection, name
+        );
+        let response = self.send_with_retry("DELETE", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        Ok(())
+    }
+}
+
+/// Index create request
+#[derive(Debug, Serialize)]
+pub struct IndexCreateRequest {
+    pub collection: String,
+    pub fields: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub unique: bool,
+}
+
+/// Index info from list/create
+#[derive(Debug, Deserialize, Serialize)]
+pub struct IndexInfo {
+    /// Index name
+    #[serde(rename = "name", alias = "Name")]
+    pub name: String,
+
+    /// Collection name
+    #[serde(rename = "collection", alias = "Collection")]
+    pub collection: String,
+
+    /// Fields in the index
+    #[serde(rename = "fields", alias = "Fields")]
+    pub fields: Vec<IndexFieldInfo>,
+
+    /// Whether the index is unique
+    #[serde(rename = "unique", alias = "Unique", default)]
+    pub unique: bool,
+}
+
+/// Index field info
+#[derive(Debug, Deserialize, Serialize)]
+pub struct IndexFieldInfo {
+    /// Field name
+    #[serde(rename = "name", alias = "Name")]
+    pub name: String,
+
+    /// Sort direction (ASC or DESC)
+    #[serde(rename = "direction", alias = "Direction", default)]
+    pub direction: Option<String>,
 }

--- a/crates/cli/src/commands/client/http_client.rs
+++ b/crates/cli/src/commands/client/http_client.rs
@@ -17,6 +17,7 @@ use reqwest::{Client, RequestBuilder, Response, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use url::Url;
+use urlencoding::encode;
 
 use crate::error::{Error, Result};
 
@@ -270,6 +271,18 @@ impl HttpClient {
         Err(last_error.unwrap_or_else(|| Error::Server("Request failed after retries".to_string())))
     }
 
+    /// Extract error details from a failed response and return an error.
+    ///
+    /// This helper reduces code duplication for error handling across HTTP client methods.
+    async fn extract_error(response: Response) -> Error {
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("[failed to read body: {}]", e));
+        Error::Server(format!("HTTP {}: {}", status, body.trim()))
+    }
+
     /// Execute a GraphQL query
     pub async fn graphql(
         &self,
@@ -289,15 +302,7 @@ impl HttpClient {
         let response = self.send_with_retry("POST", &url, Some(&body)).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let result: GraphQLResponse = response.json().await?;
@@ -310,15 +315,7 @@ impl HttpClient {
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let schema = response.text().await?;
@@ -357,21 +354,14 @@ impl HttpClient {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body_text = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
+            let body_text = response
+                .text()
+                .await
+                .unwrap_or_else(|e| format!("[failed to read body: {}]", e));
             if let Ok(err) = serde_json::from_str::<ErrorResponse>(&body_text) {
                 return Err(Error::Server(err.error));
             }
-            return Err(Error::Server(format!(
-                "HTTP {}: {}",
-                status,
-                body_text.trim()
-            )));
+            return Err(Error::Server(format!("HTTP {}: {}", status, body_text.trim())));
         }
 
         let result: T = response.json().await?;
@@ -452,15 +442,7 @@ impl HttpClient {
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let policies: Vec<AcpPolicy> = response.json().await?;
@@ -469,19 +451,12 @@ impl HttpClient {
 
     /// Get a specific ACP policy by ID
     pub async fn acp_get_policy(&self, policy_id: &str) -> Result<AcpPolicy> {
-        let url = format!("{}/api/v0/acp/policy/{}", self.base_url, policy_id);
+        // URL-encode the policy ID to handle special characters safely
+        let url = format!("{}/api/v0/acp/policy/{}", self.base_url, encode(policy_id));
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let policy: AcpPolicy = response.json().await?;
@@ -496,11 +471,11 @@ impl HttpClient {
     ) -> Result<String> {
         let mut url = format!("{}/api/v0/backup/export", self.base_url);
 
-        // Build query parameters
+        // Build query parameters with URL encoding
         let mut params = Vec::new();
         if let Some(cols) = collections {
             for col in cols {
-                params.push(format!("collections={}", col));
+                params.push(format!("collections={}", encode(col)));
             }
         }
         if pretty {
@@ -513,15 +488,7 @@ impl HttpClient {
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let data = response.text().await?;
@@ -534,15 +501,7 @@ impl HttpClient {
         let response = self.send_with_retry("POST", &url, Some(data)).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         Ok(())
@@ -569,21 +528,13 @@ impl HttpClient {
     /// List indexes (optionally filtered by collection)
     pub async fn index_list(&self, collection: Option<&str>) -> Result<Vec<IndexInfo>> {
         let url = match collection {
-            Some(col) => format!("{}/api/v0/index?collection={}", self.base_url, col),
+            Some(col) => format!("{}/api/v0/index?collection={}", self.base_url, encode(col)),
             None => format!("{}/api/v0/index", self.base_url),
         };
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let indexes: Vec<IndexInfo> = response.json().await?;
@@ -594,20 +545,14 @@ impl HttpClient {
     pub async fn index_drop(&self, collection: &str, name: &str) -> Result<()> {
         let url = format!(
             "{}/api/v0/index?collection={}&name={}",
-            self.base_url, collection, name
+            self.base_url,
+            encode(collection),
+            encode(name)
         );
         let response = self.send_with_retry("DELETE", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         Ok(())
@@ -724,15 +669,7 @@ impl HttpClient {
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let info: P2pInfo = response.json().await?;
@@ -745,15 +682,7 @@ impl HttpClient {
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let peers: Vec<P2pPeerInfo> = response.json().await?;
@@ -770,15 +699,7 @@ impl HttpClient {
         let response = self.send_with_retry("POST", &url, Some(&body)).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         Ok(())
@@ -790,15 +711,7 @@ impl HttpClient {
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let replicators: Vec<P2pReplicatorInfo> = response.json().await?;
@@ -820,15 +733,7 @@ impl HttpClient {
         let response = self.send_with_retry("POST", &url, Some(&body)).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         Ok(())
@@ -842,13 +747,13 @@ impl HttpClient {
     ) -> Result<()> {
         let mut url = format!("{}/api/v0/p2p/replicator", self.base_url);
 
-        // Build query parameters
+        // Build query parameters with URL encoding
         let mut params = Vec::new();
         for col in collections {
-            params.push(format!("collections={}", col));
+            params.push(format!("collections={}", encode(col)));
         }
         if let Some(addr) = address {
-            params.push(format!("address={}", addr));
+            params.push(format!("address={}", encode(addr)));
         }
         if !params.is_empty() {
             url = format!("{}?{}", url, params.join("&"));
@@ -857,15 +762,7 @@ impl HttpClient {
         let response = self.send_with_retry("DELETE", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         Ok(())
@@ -877,15 +774,7 @@ impl HttpClient {
         let response = self.send_with_retry("GET", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         let collections: Vec<String> = response.json().await?;
@@ -902,15 +791,7 @@ impl HttpClient {
         let response = self.send_with_retry("POST", &url, Some(&body)).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         Ok(())
@@ -920,10 +801,10 @@ impl HttpClient {
     pub async fn p2p_collection_remove(&self, collections: &[String]) -> Result<()> {
         let mut url = format!("{}/api/v0/p2p/collections", self.base_url);
 
-        // Build query parameters
+        // Build query parameters with URL encoding
         let params: Vec<String> = collections
             .iter()
-            .map(|c| format!("collections={}", c))
+            .map(|c| format!("collections={}", encode(c)))
             .collect();
         if !params.is_empty() {
             url = format!("{}?{}", url, params.join("&"));
@@ -932,15 +813,7 @@ impl HttpClient {
         let response = self.send_with_retry("DELETE", &url, None).await?;
 
         if !response.status().is_success() {
-            let status = response.status();
-            let body = match response.text().await {
-                Ok(text) => text,
-                Err(e) => {
-                    eprintln!("Warning: Failed to read error response body: {}", e);
-                    String::new()
-                }
-            };
-            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+            return Err(Self::extract_error(response).await);
         }
 
         Ok(())

--- a/crates/cli/src/commands/client/http_client.rs
+++ b/crates/cli/src/commands/client/http_client.rs
@@ -656,3 +656,293 @@ pub struct IndexFieldInfo {
     #[serde(rename = "direction", alias = "Direction", default)]
     pub direction: Option<String>,
 }
+
+/// P2P node info
+#[derive(Debug, Deserialize, Serialize)]
+pub struct P2pInfo {
+    /// Peer ID
+    #[serde(rename = "id", alias = "ID", alias = "peerId", alias = "PeerID")]
+    pub id: String,
+
+    /// Listen addresses
+    #[serde(rename = "addresses", alias = "Addresses", default)]
+    pub addresses: Vec<String>,
+}
+
+/// P2P peer info
+#[derive(Debug, Deserialize, Serialize)]
+pub struct P2pPeerInfo {
+    /// Peer ID
+    #[serde(rename = "id", alias = "ID")]
+    pub id: String,
+
+    /// Peer address
+    #[serde(rename = "address", alias = "Address", default)]
+    pub address: Option<String>,
+}
+
+/// P2P replicator info
+#[derive(Debug, Deserialize, Serialize)]
+pub struct P2pReplicatorInfo {
+    /// Peer ID
+    #[serde(rename = "id", alias = "ID", default)]
+    pub id: Option<String>,
+
+    /// Collections being replicated
+    #[serde(rename = "collections", alias = "Collections", default)]
+    pub collections: Vec<String>,
+
+    /// Peer address
+    #[serde(rename = "address", alias = "Address", default)]
+    pub address: Option<String>,
+}
+
+/// P2P replicator request
+#[derive(Debug, Serialize)]
+pub struct P2pReplicatorRequest {
+    pub collections: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+}
+
+/// P2P collection request
+#[derive(Debug, Serialize)]
+pub struct P2pCollectionRequest {
+    pub collections: Vec<String>,
+}
+
+/// P2P peer add request
+#[derive(Debug, Serialize)]
+pub struct P2pPeerAddRequest {
+    pub address: String,
+}
+
+impl HttpClient {
+    /// Get P2P node info
+    pub async fn p2p_info(&self) -> Result<P2pInfo> {
+        let url = format!("{}/api/v0/p2p/info", self.base_url);
+        let response = self.send_with_retry("GET", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        let info: P2pInfo = response.json().await?;
+        Ok(info)
+    }
+
+    /// List connected peers
+    pub async fn p2p_peers_list(&self) -> Result<Vec<P2pPeerInfo>> {
+        let url = format!("{}/api/v0/p2p/peers", self.base_url);
+        let response = self.send_with_retry("GET", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        let peers: Vec<P2pPeerInfo> = response.json().await?;
+        Ok(peers)
+    }
+
+    /// Connect to a peer
+    pub async fn p2p_peers_add(&self, address: &str) -> Result<()> {
+        let url = format!("{}/api/v0/p2p/peers", self.base_url);
+        let request = P2pPeerAddRequest {
+            address: address.to_string(),
+        };
+        let body = serde_json::to_string(&request)?;
+        let response = self.send_with_retry("POST", &url, Some(&body)).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        Ok(())
+    }
+
+    /// List replicators
+    pub async fn p2p_replicator_list(&self) -> Result<Vec<P2pReplicatorInfo>> {
+        let url = format!("{}/api/v0/p2p/replicator", self.base_url);
+        let response = self.send_with_retry("GET", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        let replicators: Vec<P2pReplicatorInfo> = response.json().await?;
+        Ok(replicators)
+    }
+
+    /// Add a replicator
+    pub async fn p2p_replicator_add(
+        &self,
+        collections: &[String],
+        address: Option<&str>,
+    ) -> Result<()> {
+        let url = format!("{}/api/v0/p2p/replicator", self.base_url);
+        let request = P2pReplicatorRequest {
+            collections: collections.to_vec(),
+            address: address.map(|s| s.to_string()),
+        };
+        let body = serde_json::to_string(&request)?;
+        let response = self.send_with_retry("POST", &url, Some(&body)).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        Ok(())
+    }
+
+    /// Delete a replicator
+    pub async fn p2p_replicator_delete(
+        &self,
+        collections: &[String],
+        address: Option<&str>,
+    ) -> Result<()> {
+        let mut url = format!("{}/api/v0/p2p/replicator", self.base_url);
+
+        // Build query parameters
+        let mut params = Vec::new();
+        for col in collections {
+            params.push(format!("collections={}", col));
+        }
+        if let Some(addr) = address {
+            params.push(format!("address={}", addr));
+        }
+        if !params.is_empty() {
+            url = format!("{}?{}", url, params.join("&"));
+        }
+
+        let response = self.send_with_retry("DELETE", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        Ok(())
+    }
+
+    /// List P2P collections
+    pub async fn p2p_collection_list(&self) -> Result<Vec<String>> {
+        let url = format!("{}/api/v0/p2p/collections", self.base_url);
+        let response = self.send_with_retry("GET", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        let collections: Vec<String> = response.json().await?;
+        Ok(collections)
+    }
+
+    /// Add collections to P2P
+    pub async fn p2p_collection_add(&self, collections: &[String]) -> Result<()> {
+        let url = format!("{}/api/v0/p2p/collections", self.base_url);
+        let request = P2pCollectionRequest {
+            collections: collections.to_vec(),
+        };
+        let body = serde_json::to_string(&request)?;
+        let response = self.send_with_retry("POST", &url, Some(&body)).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        Ok(())
+    }
+
+    /// Remove collections from P2P
+    pub async fn p2p_collection_remove(&self, collections: &[String]) -> Result<()> {
+        let mut url = format!("{}/api/v0/p2p/collections", self.base_url);
+
+        // Build query parameters
+        let params: Vec<String> = collections
+            .iter()
+            .map(|c| format!("collections={}", c))
+            .collect();
+        if !params.is_empty() {
+            url = format!("{}?{}", url, params.join("&"));
+        }
+
+        let response = self.send_with_retry("DELETE", &url, None).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(text) => text,
+                Err(e) => {
+                    eprintln!("Warning: Failed to read error response body: {}", e);
+                    String::new()
+                }
+            };
+            return Err(Error::Server(format!("HTTP {}: {}", status, body.trim())));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/client/index.rs
+++ b/crates/cli/src/commands/client/index.rs
@@ -1,0 +1,205 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//! Index command implementation for database index management
+
+use clap::{Args, Subcommand};
+
+use super::http_client::HttpClient;
+use super::{validate_identifier, ClientContext};
+use crate::error::Result;
+
+/// Manage database indexes
+#[derive(Args, Debug)]
+pub struct IndexArgs {
+    #[command(subcommand)]
+    pub command: IndexCommand,
+}
+
+/// Index subcommands
+#[derive(Subcommand, Debug)]
+pub enum IndexCommand {
+    /// Create a new index on a collection
+    Create(IndexCreateArgs),
+    /// List indexes (optionally filtered by collection)
+    List(IndexListArgs),
+    /// Drop an index by name
+    Drop(IndexDropArgs),
+}
+
+/// Arguments for index create command
+#[derive(Args, Debug)]
+pub struct IndexCreateArgs {
+    /// The collection to create the index on
+    #[arg(value_name = "COLLECTION")]
+    pub collection: String,
+
+    /// Field(s) to index (comma-separated or multiple --fields)
+    #[arg(long, short = 'f', required = true, value_delimiter = ',')]
+    pub fields: Vec<String>,
+
+    /// Optional name for the index (auto-generated if not provided)
+    #[arg(long, short = 'n')]
+    pub name: Option<String>,
+
+    /// Create a unique index
+    #[arg(long)]
+    pub unique: bool,
+}
+
+/// Arguments for index list command
+#[derive(Args, Debug)]
+pub struct IndexListArgs {
+    /// Optional collection to filter indexes
+    #[arg(value_name = "COLLECTION")]
+    pub collection: Option<String>,
+}
+
+/// Arguments for index drop command
+#[derive(Args, Debug)]
+pub struct IndexDropArgs {
+    /// The collection containing the index
+    #[arg(value_name = "COLLECTION")]
+    pub collection: String,
+
+    /// The name of the index to drop
+    #[arg(value_name = "NAME")]
+    pub name: String,
+}
+
+impl IndexArgs {
+    /// Execute the index command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        match &self.command {
+            IndexCommand::Create(args) => args.execute(ctx).await,
+            IndexCommand::List(args) => args.execute(ctx).await,
+            IndexCommand::Drop(args) => args.execute(ctx).await,
+        }
+    }
+}
+
+impl IndexCreateArgs {
+    /// Execute the index create command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        validate_identifier(&self.collection)?;
+        for field in &self.fields {
+            validate_identifier(field)?;
+        }
+        if let Some(ref name) = self.name {
+            validate_identifier(name)?;
+        }
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let response = client
+            .index_create(
+                &self.collection,
+                &self.fields,
+                self.name.as_deref(),
+                self.unique,
+            )
+            .await?;
+
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        Ok(())
+    }
+}
+
+impl IndexListArgs {
+    /// Execute the index list command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        if let Some(ref col) = self.collection {
+            validate_identifier(col)?;
+        }
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let indexes = client.index_list(self.collection.as_deref()).await?;
+        println!("{}", serde_json::to_string_pretty(&indexes)?);
+        Ok(())
+    }
+}
+
+impl IndexDropArgs {
+    /// Execute the index drop command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        validate_identifier(&self.collection)?;
+        validate_identifier(&self.name)?;
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        client.index_drop(&self.collection, &self.name).await?;
+        println!(
+            "Index '{}' dropped from collection '{}'",
+            self.name, self.collection
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_create_args() {
+        let args = IndexCreateArgs {
+            collection: "Users".to_string(),
+            fields: vec!["name".to_string(), "email".to_string()],
+            name: Some("idx_name_email".to_string()),
+            unique: true,
+        };
+        assert_eq!(args.collection, "Users");
+        assert_eq!(args.fields.len(), 2);
+        assert!(args.unique);
+    }
+
+    #[test]
+    fn test_index_create_args_minimal() {
+        let args = IndexCreateArgs {
+            collection: "Users".to_string(),
+            fields: vec!["name".to_string()],
+            name: None,
+            unique: false,
+        };
+        assert!(args.name.is_none());
+        assert!(!args.unique);
+    }
+
+    #[test]
+    fn test_index_list_args_all() {
+        let args = IndexListArgs { collection: None };
+        assert!(args.collection.is_none());
+    }
+
+    #[test]
+    fn test_index_list_args_filtered() {
+        let args = IndexListArgs {
+            collection: Some("Users".to_string()),
+        };
+        assert_eq!(args.collection.as_deref(), Some("Users"));
+    }
+
+    #[test]
+    fn test_index_drop_args() {
+        let args = IndexDropArgs {
+            collection: "Users".to_string(),
+            name: "idx_name".to_string(),
+        };
+        assert_eq!(args.collection, "Users");
+        assert_eq!(args.name, "idx_name");
+    }
+}

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -15,6 +15,7 @@ mod backup;
 mod collection;
 mod document;
 pub mod http_client;
+mod index;
 mod query;
 mod schema;
 mod tx;
@@ -28,6 +29,7 @@ pub use acp::AcpArgs;
 pub use backup::BackupArgs;
 pub use collection::CollectionArgs;
 pub use document::DocumentArgs;
+pub use index::IndexArgs;
 pub use query::QueryArgs;
 pub use schema::SchemaArgs;
 pub use tx::TxArgs;
@@ -98,6 +100,8 @@ pub enum ClientCommand {
     Collection(CollectionArgs),
     /// Interact with documents
     Document(DocumentArgs),
+    /// Manage database indexes
+    Index(IndexArgs),
     /// Execute a GraphQL query
     Query(QueryArgs),
     /// Interact with schema
@@ -130,6 +134,7 @@ impl ClientArgs {
             ClientCommand::Backup(args) => args.execute(&ctx).await,
             ClientCommand::Collection(args) => args.execute(&ctx).await,
             ClientCommand::Document(args) => args.execute(&ctx).await,
+            ClientCommand::Index(args) => args.execute(&ctx).await,
             ClientCommand::Query(args) => args.execute(&ctx).await,
             ClientCommand::Schema(args) => args.execute(&ctx).await,
             ClientCommand::Tx(args) => args.execute(&ctx).await,

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -10,6 +10,7 @@
 
 //! Client commands for interacting with a running DefraDB node
 
+mod acp;
 mod collection;
 mod document;
 pub mod http_client;
@@ -22,6 +23,7 @@ use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 
+pub use acp::AcpArgs;
 pub use collection::CollectionArgs;
 pub use document::DocumentArgs;
 pub use query::QueryArgs;
@@ -86,16 +88,18 @@ pub struct ClientArgs {
 /// Client subcommands
 #[derive(Subcommand, Debug)]
 pub enum ClientCommand {
+    /// Interact with Access Control Policies
+    Acp(AcpArgs),
+    /// Interact with collections
+    Collection(CollectionArgs),
+    /// Interact with documents
+    Document(DocumentArgs),
     /// Execute a GraphQL query
     Query(QueryArgs),
     /// Interact with schema
     Schema(SchemaArgs),
     /// Manage transactions
     Tx(TxArgs),
-    /// Interact with collections
-    Collection(CollectionArgs),
-    /// Interact with documents
-    Document(DocumentArgs),
 }
 
 impl ClientArgs {
@@ -118,11 +122,12 @@ impl ClientArgs {
         };
 
         match &self.command {
+            ClientCommand::Acp(args) => args.execute(&ctx).await,
+            ClientCommand::Collection(args) => args.execute(&ctx).await,
+            ClientCommand::Document(args) => args.execute(&ctx).await,
             ClientCommand::Query(args) => args.execute(&ctx).await,
             ClientCommand::Schema(args) => args.execute(&ctx).await,
             ClientCommand::Tx(args) => args.execute(&ctx).await,
-            ClientCommand::Collection(args) => args.execute(&ctx).await,
-            ClientCommand::Document(args) => args.execute(&ctx).await,
         }
     }
 }

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -16,6 +16,7 @@ mod collection;
 mod document;
 pub mod http_client;
 mod index;
+mod p2p;
 mod query;
 mod schema;
 mod tx;
@@ -30,6 +31,7 @@ pub use backup::BackupArgs;
 pub use collection::CollectionArgs;
 pub use document::DocumentArgs;
 pub use index::IndexArgs;
+pub use p2p::P2pArgs;
 pub use query::QueryArgs;
 pub use schema::SchemaArgs;
 pub use tx::TxArgs;
@@ -102,6 +104,8 @@ pub enum ClientCommand {
     Document(DocumentArgs),
     /// Manage database indexes
     Index(IndexArgs),
+    /// Manage P2P network
+    P2p(P2pArgs),
     /// Execute a GraphQL query
     Query(QueryArgs),
     /// Interact with schema
@@ -135,6 +139,7 @@ impl ClientArgs {
             ClientCommand::Collection(args) => args.execute(&ctx).await,
             ClientCommand::Document(args) => args.execute(&ctx).await,
             ClientCommand::Index(args) => args.execute(&ctx).await,
+            ClientCommand::P2p(args) => args.execute(&ctx).await,
             ClientCommand::Query(args) => args.execute(&ctx).await,
             ClientCommand::Schema(args) => args.execute(&ctx).await,
             ClientCommand::Tx(args) => args.execute(&ctx).await,

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -11,6 +11,7 @@
 //! Client commands for interacting with a running DefraDB node
 
 mod acp;
+mod backup;
 mod collection;
 mod document;
 pub mod http_client;
@@ -24,6 +25,7 @@ use std::path::PathBuf;
 use clap::{Args, Subcommand};
 
 pub use acp::AcpArgs;
+pub use backup::BackupArgs;
 pub use collection::CollectionArgs;
 pub use document::DocumentArgs;
 pub use query::QueryArgs;
@@ -90,6 +92,8 @@ pub struct ClientArgs {
 pub enum ClientCommand {
     /// Interact with Access Control Policies
     Acp(AcpArgs),
+    /// Manage database backups
+    Backup(BackupArgs),
     /// Interact with collections
     Collection(CollectionArgs),
     /// Interact with documents
@@ -123,6 +127,7 @@ impl ClientArgs {
 
         match &self.command {
             ClientCommand::Acp(args) => args.execute(&ctx).await,
+            ClientCommand::Backup(args) => args.execute(&ctx).await,
             ClientCommand::Collection(args) => args.execute(&ctx).await,
             ClientCommand::Document(args) => args.execute(&ctx).await,
             ClientCommand::Query(args) => args.execute(&ctx).await,

--- a/crates/cli/src/commands/client/p2p.rs
+++ b/crates/cli/src/commands/client/p2p.rs
@@ -1,0 +1,383 @@
+// Copyright 2025 Democratized Data Foundation
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+//! P2P command implementation for peer-to-peer network management
+
+use clap::{Args, Subcommand};
+
+use super::http_client::HttpClient;
+use super::{validate_identifier, ClientContext};
+use crate::error::Result;
+
+/// Manage P2P network
+#[derive(Args, Debug)]
+pub struct P2pArgs {
+    #[command(subcommand)]
+    pub command: P2pCommand,
+}
+
+/// P2P subcommands
+#[derive(Subcommand, Debug)]
+pub enum P2pCommand {
+    /// Show P2P node information
+    Info(P2pInfoArgs),
+    /// Manage peer connections
+    Peers(P2pPeersArgs),
+    /// Manage replicators
+    Replicator(P2pReplicatorArgs),
+    /// Manage P2P collections
+    Collection(P2pCollectionArgs),
+}
+
+/// Arguments for p2p info command
+#[derive(Args, Debug)]
+pub struct P2pInfoArgs {}
+
+/// Peer management subcommands
+#[derive(Args, Debug)]
+pub struct P2pPeersArgs {
+    #[command(subcommand)]
+    pub command: P2pPeersCommand,
+}
+
+/// Peer subcommands
+#[derive(Subcommand, Debug)]
+pub enum P2pPeersCommand {
+    /// List connected peers
+    List(P2pPeersListArgs),
+    /// Connect to a peer
+    Add(P2pPeersAddArgs),
+}
+
+/// Arguments for peers list command
+#[derive(Args, Debug)]
+pub struct P2pPeersListArgs {}
+
+/// Arguments for peers add command
+#[derive(Args, Debug)]
+pub struct P2pPeersAddArgs {
+    /// Multiaddr of the peer to connect to
+    #[arg(value_name = "ADDRESS")]
+    pub address: String,
+}
+
+/// Replicator management subcommands
+#[derive(Args, Debug)]
+pub struct P2pReplicatorArgs {
+    #[command(subcommand)]
+    pub command: P2pReplicatorCommand,
+}
+
+/// Replicator subcommands
+#[derive(Subcommand, Debug)]
+pub enum P2pReplicatorCommand {
+    /// List replicators
+    List(P2pReplicatorListArgs),
+    /// Add a replicator for a collection
+    Add(P2pReplicatorAddArgs),
+    /// Remove a replicator
+    Delete(P2pReplicatorDeleteArgs),
+}
+
+/// Arguments for replicator list command
+#[derive(Args, Debug)]
+pub struct P2pReplicatorListArgs {}
+
+/// Arguments for replicator add command
+#[derive(Args, Debug)]
+pub struct P2pReplicatorAddArgs {
+    /// Collection(s) to replicate (comma-separated or multiple --collection)
+    #[arg(long, short = 'c', required = true, value_delimiter = ',')]
+    pub collection: Vec<String>,
+
+    /// Peer address to replicate with
+    #[arg(long, short = 'a')]
+    pub address: Option<String>,
+}
+
+/// Arguments for replicator delete command
+#[derive(Args, Debug)]
+pub struct P2pReplicatorDeleteArgs {
+    /// Collection(s) to stop replicating (comma-separated or multiple --collection)
+    #[arg(long, short = 'c', required = true, value_delimiter = ',')]
+    pub collection: Vec<String>,
+
+    /// Peer address to stop replicating with
+    #[arg(long, short = 'a')]
+    pub address: Option<String>,
+}
+
+/// P2P collection management subcommands
+#[derive(Args, Debug)]
+pub struct P2pCollectionArgs {
+    #[command(subcommand)]
+    pub command: P2pCollectionCommand,
+}
+
+/// P2P collection subcommands
+#[derive(Subcommand, Debug)]
+pub enum P2pCollectionCommand {
+    /// List collections available for P2P sync
+    List(P2pCollectionListArgs),
+    /// Add a collection to P2P sync
+    Add(P2pCollectionAddArgs),
+    /// Remove a collection from P2P sync
+    Remove(P2pCollectionRemoveArgs),
+}
+
+/// Arguments for collection list command
+#[derive(Args, Debug)]
+pub struct P2pCollectionListArgs {}
+
+/// Arguments for collection add command
+#[derive(Args, Debug)]
+pub struct P2pCollectionAddArgs {
+    /// Collection(s) to add (comma-separated or multiple --collection)
+    #[arg(long, short = 'c', required = true, value_delimiter = ',')]
+    pub collection: Vec<String>,
+}
+
+/// Arguments for collection remove command
+#[derive(Args, Debug)]
+pub struct P2pCollectionRemoveArgs {
+    /// Collection(s) to remove (comma-separated or multiple --collection)
+    #[arg(long, short = 'c', required = true, value_delimiter = ',')]
+    pub collection: Vec<String>,
+}
+
+impl P2pArgs {
+    /// Execute the p2p command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        match &self.command {
+            P2pCommand::Info(args) => args.execute(ctx).await,
+            P2pCommand::Peers(args) => args.execute(ctx).await,
+            P2pCommand::Replicator(args) => args.execute(ctx).await,
+            P2pCommand::Collection(args) => args.execute(ctx).await,
+        }
+    }
+}
+
+impl P2pInfoArgs {
+    /// Execute the p2p info command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let info = client.p2p_info().await?;
+        println!("{}", serde_json::to_string_pretty(&info)?);
+        Ok(())
+    }
+}
+
+impl P2pPeersArgs {
+    /// Execute the peers subcommand
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        match &self.command {
+            P2pPeersCommand::List(args) => args.execute(ctx).await,
+            P2pPeersCommand::Add(args) => args.execute(ctx).await,
+        }
+    }
+}
+
+impl P2pPeersListArgs {
+    /// Execute the peers list command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let peers = client.p2p_peers_list().await?;
+        println!("{}", serde_json::to_string_pretty(&peers)?);
+        Ok(())
+    }
+}
+
+impl P2pPeersAddArgs {
+    /// Execute the peers add command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        client.p2p_peers_add(&self.address).await?;
+        println!("Connected to peer: {}", self.address);
+        Ok(())
+    }
+}
+
+impl P2pReplicatorArgs {
+    /// Execute the replicator subcommand
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        match &self.command {
+            P2pReplicatorCommand::List(args) => args.execute(ctx).await,
+            P2pReplicatorCommand::Add(args) => args.execute(ctx).await,
+            P2pReplicatorCommand::Delete(args) => args.execute(ctx).await,
+        }
+    }
+}
+
+impl P2pReplicatorListArgs {
+    /// Execute the replicator list command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let replicators = client.p2p_replicator_list().await?;
+        println!("{}", serde_json::to_string_pretty(&replicators)?);
+        Ok(())
+    }
+}
+
+impl P2pReplicatorAddArgs {
+    /// Execute the replicator add command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        for col in &self.collection {
+            validate_identifier(col)?;
+        }
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        client
+            .p2p_replicator_add(&self.collection, self.address.as_deref())
+            .await?;
+        println!(
+            "Added replicator for collections: {}",
+            self.collection.join(", ")
+        );
+        Ok(())
+    }
+}
+
+impl P2pReplicatorDeleteArgs {
+    /// Execute the replicator delete command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        for col in &self.collection {
+            validate_identifier(col)?;
+        }
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        client
+            .p2p_replicator_delete(&self.collection, self.address.as_deref())
+            .await?;
+        println!(
+            "Removed replicator for collections: {}",
+            self.collection.join(", ")
+        );
+        Ok(())
+    }
+}
+
+impl P2pCollectionArgs {
+    /// Execute the collection subcommand
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        match &self.command {
+            P2pCollectionCommand::List(args) => args.execute(ctx).await,
+            P2pCollectionCommand::Add(args) => args.execute(ctx).await,
+            P2pCollectionCommand::Remove(args) => args.execute(ctx).await,
+        }
+    }
+}
+
+impl P2pCollectionListArgs {
+    /// Execute the collection list command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        let collections = client.p2p_collection_list().await?;
+        println!("{}", serde_json::to_string_pretty(&collections)?);
+        Ok(())
+    }
+}
+
+impl P2pCollectionAddArgs {
+    /// Execute the collection add command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        for col in &self.collection {
+            validate_identifier(col)?;
+        }
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        client.p2p_collection_add(&self.collection).await?;
+        println!("Added collections to P2P: {}", self.collection.join(", "));
+        Ok(())
+    }
+}
+
+impl P2pCollectionRemoveArgs {
+    /// Execute the collection remove command
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        for col in &self.collection {
+            validate_identifier(col)?;
+        }
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        client.p2p_collection_remove(&self.collection).await?;
+        println!(
+            "Removed collections from P2P: {}",
+            self.collection.join(", ")
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_p2p_peers_add_args() {
+        let args = P2pPeersAddArgs {
+            address: "/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWtest".to_string(),
+        };
+        assert!(args.address.contains("12D3KooW"));
+    }
+
+    #[test]
+    fn test_p2p_replicator_add_args() {
+        let args = P2pReplicatorAddArgs {
+            collection: vec!["Users".to_string(), "Posts".to_string()],
+            address: Some("/ip4/127.0.0.1/tcp/9000".to_string()),
+        };
+        assert_eq!(args.collection.len(), 2);
+        assert!(args.address.is_some());
+    }
+
+    #[test]
+    fn test_p2p_replicator_add_args_no_address() {
+        let args = P2pReplicatorAddArgs {
+            collection: vec!["Users".to_string()],
+            address: None,
+        };
+        assert!(args.address.is_none());
+    }
+
+    #[test]
+    fn test_p2p_collection_add_args() {
+        let args = P2pCollectionAddArgs {
+            collection: vec!["Users".to_string()],
+        };
+        assert_eq!(args.collection.len(), 1);
+    }
+}

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -21,6 +21,9 @@ pub enum HttpError {
     #[error("forbidden: {0}")]
     Forbidden(String),
 
+    #[error("service unavailable: {0}")]
+    ServiceUnavailable(String),
+
     #[error("internal error: {0}")]
     Internal(String),
 
@@ -40,6 +43,7 @@ impl IntoResponse for HttpError {
             HttpError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             HttpError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
             HttpError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
+            HttpError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg.clone()),
             HttpError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
             HttpError::QueryExecution(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
         };

--- a/crates/http/src/handlers/acp.rs
+++ b/crates/http/src/handlers/acp.rs
@@ -34,10 +34,7 @@ pub async fn add_policy(
     State(state): State<AppState>,
     Json(request): Json<AddPolicyRequest>,
 ) -> Result<Json<AddPolicyResponse>, HttpError> {
-    let acp = state
-        .acp
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("ACP (Access Control Policy) is not enabled. Start the server with ACP enabled to use this feature.".into()))?;
+    let acp = state.require_acp()?;
 
     if request.policy.trim().is_empty() {
         return Err(HttpError::BadRequest("policy cannot be empty".into()));
@@ -57,10 +54,7 @@ pub async fn add_policy(
 pub async fn list_policies(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<PolicyInfo>>, HttpError> {
-    let acp = state
-        .acp
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("ACP (Access Control Policy) is not enabled. Start the server with ACP enabled to use this feature.".into()))?;
+    let acp = state.require_acp()?;
 
     let policies = acp
         .list_policies()
@@ -77,10 +71,7 @@ pub async fn get_policy(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<PolicyInfo>, HttpError> {
-    let acp = state
-        .acp
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("ACP (Access Control Policy) is not enabled. Start the server with ACP enabled to use this feature.".into()))?;
+    let acp = state.require_acp()?;
 
     let policy = acp
         .get_policy(&id)

--- a/crates/http/src/handlers/acp.rs
+++ b/crates/http/src/handlers/acp.rs
@@ -37,7 +37,7 @@ pub async fn add_policy(
     let acp = state
         .acp
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("ACP not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("ACP (Access Control Policy) is not enabled. Start the server with ACP enabled to use this feature.".into()))?;
 
     if request.policy.trim().is_empty() {
         return Err(HttpError::BadRequest("policy cannot be empty".into()));
@@ -60,7 +60,7 @@ pub async fn list_policies(
     let acp = state
         .acp
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("ACP not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("ACP (Access Control Policy) is not enabled. Start the server with ACP enabled to use this feature.".into()))?;
 
     let policies = acp
         .list_policies()
@@ -80,7 +80,7 @@ pub async fn get_policy(
     let acp = state
         .acp
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("ACP not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("ACP (Access Control Policy) is not enabled. Start the server with ACP enabled to use this feature.".into()))?;
 
     let policy = acp
         .get_policy(&id)

--- a/crates/http/src/handlers/acp.rs
+++ b/crates/http/src/handlers/acp.rs
@@ -1,0 +1,131 @@
+//! ACP (Access Control Policy) endpoint handlers.
+//!
+//! These handlers provide HTTP access to ACP policy management:
+//! - Add policy
+//! - List policies
+//! - Get policy by ID
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::HttpError;
+use crate::router::{AppState, PolicyInfo};
+
+/// Request to add a new ACP policy.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AddPolicyRequest {
+    pub policy: String,
+}
+
+/// Response for adding a policy.
+#[derive(Debug, Clone, Serialize)]
+pub struct AddPolicyResponse {
+    #[serde(rename = "PolicyID")]
+    pub policy_id: String,
+}
+
+/// Add a new ACP policy.
+///
+/// POST /api/v0/acp/policy
+pub async fn add_policy(
+    State(state): State<AppState>,
+    Json(request): Json<AddPolicyRequest>,
+) -> Result<Json<AddPolicyResponse>, HttpError> {
+    let acp = state
+        .acp
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("ACP not configured".into()))?;
+
+    if request.policy.trim().is_empty() {
+        return Err(HttpError::BadRequest("policy cannot be empty".into()));
+    }
+
+    let policy_id = acp
+        .add_policy(&request.policy)
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(AddPolicyResponse { policy_id }))
+}
+
+/// List all ACP policies.
+///
+/// GET /api/v0/acp/policy
+pub async fn list_policies(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<PolicyInfo>>, HttpError> {
+    let acp = state
+        .acp
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("ACP not configured".into()))?;
+
+    let policies = acp
+        .list_policies()
+        .await
+        .map_err(HttpError::Internal)?;
+
+    Ok(Json(policies))
+}
+
+/// Get a specific ACP policy by ID.
+///
+/// GET /api/v0/acp/policy/:id
+pub async fn get_policy(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<PolicyInfo>, HttpError> {
+    let acp = state
+        .acp
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("ACP not configured".into()))?;
+
+    let policy = acp
+        .get_policy(&id)
+        .await
+        .map_err(HttpError::Internal)?
+        .ok_or_else(|| HttpError::NotFound(format!("Policy '{}' not found", id)))?;
+
+    Ok(Json(policy))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_policy_request_deserialize() {
+        let json = r#"{"policy": "name: test\nresources:\n  users:\n    permissions:\n      read:\n        expr: owner"}"#;
+        let request: AddPolicyRequest = serde_json::from_str(json).unwrap();
+        assert!(request.policy.contains("test"));
+    }
+
+    #[test]
+    fn test_add_policy_response_serialize() {
+        let response = AddPolicyResponse {
+            policy_id: "policy-123".to_string(),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("PolicyID"));
+        assert!(json.contains("policy-123"));
+    }
+
+    #[test]
+    fn test_policy_info_serialize() {
+        let info = PolicyInfo {
+            id: "policy-123".to_string(),
+            name: Some("Test Policy".to_string()),
+            description: None,
+            resources: None,
+            actor: None,
+            creation_time: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("policy-123"));
+        assert!(json.contains("Test Policy"));
+        // Should not contain null fields
+        assert!(!json.contains("description"));
+    }
+}

--- a/crates/http/src/handlers/backup.rs
+++ b/crates/http/src/handlers/backup.rs
@@ -1,0 +1,129 @@
+//! Backup endpoint handlers.
+//!
+//! These handlers provide HTTP access to database backup operations:
+//! - Export database to JSON
+//! - Import database from JSON
+
+use axum::{
+    body::Body,
+    extract::{Query, State},
+    http::header,
+    response::Response,
+    Json,
+};
+use serde::Deserialize;
+
+use crate::error::HttpError;
+use crate::router::AppState;
+
+/// Query parameters for export.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExportQuery {
+    /// Collections to export (if empty, exports all).
+    #[serde(default)]
+    pub collections: Vec<String>,
+    /// Whether to pretty-print the JSON output.
+    #[serde(default)]
+    pub pretty: bool,
+}
+
+/// Export the database.
+///
+/// GET /api/v0/backup/export
+pub async fn export(
+    State(state): State<AppState>,
+    Query(query): Query<ExportQuery>,
+) -> Result<Response, HttpError> {
+    let backup = state
+        .backup
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("Backup operations not configured".into()))?;
+
+    let collections = if query.collections.is_empty() {
+        None
+    } else {
+        Some(query.collections)
+    };
+
+    let data = backup
+        .export(collections, query.pretty)
+        .await
+        .map_err(HttpError::Internal)?;
+
+    // Return as JSON with appropriate content type
+    let response = Response::builder()
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(data))
+        .map_err(|e| HttpError::Internal(e.to_string()))?;
+
+    Ok(response)
+}
+
+/// Import request body - just the raw JSON data.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImportRequest {
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
+
+/// Import the database.
+///
+/// POST /api/v0/backup/import
+pub async fn import(
+    State(state): State<AppState>,
+    body: String,
+) -> Result<Json<ImportResponse>, HttpError> {
+    let backup = state
+        .backup
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("Backup operations not configured".into()))?;
+
+    if body.trim().is_empty() {
+        return Err(HttpError::BadRequest("import data cannot be empty".into()));
+    }
+
+    // Validate that the body is valid JSON
+    serde_json::from_str::<serde_json::Value>(&body)
+        .map_err(|e| HttpError::BadRequest(format!("invalid JSON: {}", e)))?;
+
+    backup
+        .import(&body)
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(ImportResponse { success: true }))
+}
+
+/// Response for import operation.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ImportResponse {
+    pub success: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_export_query_empty() {
+        let query: ExportQuery = serde_json::from_str("{}").unwrap();
+        assert!(query.collections.is_empty());
+        assert!(!query.pretty);
+    }
+
+    #[test]
+    fn test_export_query_with_collections() {
+        let json = r#"{"collections": ["Users", "Posts"], "pretty": true}"#;
+        let query: ExportQuery = serde_json::from_str(json).unwrap();
+        assert_eq!(query.collections.len(), 2);
+        assert!(query.pretty);
+    }
+
+    #[test]
+    fn test_import_response_serialize() {
+        let response = ImportResponse { success: true };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("success"));
+        assert!(json.contains("true"));
+    }
+}

--- a/crates/http/src/handlers/backup.rs
+++ b/crates/http/src/handlers/backup.rs
@@ -5,7 +5,7 @@
 //! - Import database from JSON
 
 use axum::{
-    body::Body,
+    body::{Body, Bytes},
     extract::{Query, State},
     http::header,
     response::Response,
@@ -16,6 +16,12 @@ use serde::Deserialize;
 use crate::error::HttpError;
 use crate::router::{AppState, ImportResult};
 use crate::validation::validate_collection_name;
+
+/// Maximum size for backup import data (100 MB).
+const MAX_IMPORT_SIZE: usize = 100 * 1024 * 1024;
+
+/// Maximum number of collections that can be specified in export query.
+const MAX_EXPORT_COLLECTIONS: usize = 100;
 
 /// Query parameters for export.
 #[derive(Debug, Clone, Deserialize)]
@@ -35,10 +41,15 @@ pub async fn export(
     State(state): State<AppState>,
     Query(query): Query<ExportQuery>,
 ) -> Result<Response, HttpError> {
-    let backup = state
-        .backup
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("Backup operations are not enabled. Start the server with backup enabled to use this feature.".into()))?;
+    let backup = state.require_backup()?;
+
+    // Validate collection count limit
+    if query.collections.len() > MAX_EXPORT_COLLECTIONS {
+        return Err(HttpError::BadRequest(format!(
+            "too many collections specified (max: {})",
+            MAX_EXPORT_COLLECTIONS
+        )));
+    }
 
     // Validate collection names if provided
     for col in &query.collections {
@@ -70,12 +81,21 @@ pub async fn export(
 /// POST /api/v0/backup/import
 pub async fn import(
     State(state): State<AppState>,
-    body: String,
+    body: Bytes,
 ) -> Result<Json<ImportResponse>, HttpError> {
-    let backup = state
-        .backup
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("Backup operations are not enabled. Start the server with backup enabled to use this feature.".into()))?;
+    let backup = state.require_backup()?;
+
+    // Check body size limit
+    if body.len() > MAX_IMPORT_SIZE {
+        return Err(HttpError::BadRequest(format!(
+            "import data exceeds maximum size of {} bytes",
+            MAX_IMPORT_SIZE
+        )));
+    }
+
+    // Convert bytes to UTF-8 string
+    let body = String::from_utf8(body.to_vec())
+        .map_err(|_| HttpError::BadRequest("import data must be valid UTF-8".into()))?;
 
     if body.trim().is_empty() {
         return Err(HttpError::BadRequest("import data cannot be empty".into()));

--- a/crates/http/src/handlers/backup.rs
+++ b/crates/http/src/handlers/backup.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 
 use crate::error::HttpError;
 use crate::router::AppState;
+use crate::validation::validate_collection_name;
 
 /// Query parameters for export.
 #[derive(Debug, Clone, Deserialize)]
@@ -39,6 +40,11 @@ pub async fn export(
         .as_ref()
         .ok_or_else(|| HttpError::Internal("Backup operations not configured".into()))?;
 
+    // Validate collection names if provided
+    for col in &query.collections {
+        validate_collection_name(col)?;
+    }
+
     let collections = if query.collections.is_empty() {
         None
     } else {
@@ -59,13 +65,6 @@ pub async fn export(
     Ok(response)
 }
 
-/// Import request body - just the raw JSON data.
-#[derive(Debug, Clone, Deserialize)]
-pub struct ImportRequest {
-    #[serde(flatten)]
-    pub data: serde_json::Value,
-}
-
 /// Import the database.
 ///
 /// POST /api/v0/backup/import
@@ -82,9 +81,16 @@ pub async fn import(
         return Err(HttpError::BadRequest("import data cannot be empty".into()));
     }
 
-    // Validate that the body is valid JSON
-    serde_json::from_str::<serde_json::Value>(&body)
+    // Validate that the body is valid JSON with expected structure
+    let parsed: serde_json::Value = serde_json::from_str(&body)
         .map_err(|e| HttpError::BadRequest(format!("invalid JSON: {}", e)))?;
+
+    // Backup data should be an object or array, not a primitive
+    if !parsed.is_object() && !parsed.is_array() {
+        return Err(HttpError::BadRequest(
+            "backup data must be a JSON object or array".into(),
+        ));
+    }
 
     backup
         .import(&body)

--- a/crates/http/src/handlers/backup.rs
+++ b/crates/http/src/handlers/backup.rs
@@ -14,7 +14,7 @@ use axum::{
 use serde::Deserialize;
 
 use crate::error::HttpError;
-use crate::router::AppState;
+use crate::router::{AppState, ImportResult};
 use crate::validation::validate_collection_name;
 
 /// Query parameters for export.
@@ -38,7 +38,7 @@ pub async fn export(
     let backup = state
         .backup
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("Backup operations not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("Backup operations are not enabled. Start the server with backup enabled to use this feature.".into()))?;
 
     // Validate collection names if provided
     for col in &query.collections {
@@ -75,7 +75,7 @@ pub async fn import(
     let backup = state
         .backup
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("Backup operations not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("Backup operations are not enabled. Start the server with backup enabled to use this feature.".into()))?;
 
     if body.trim().is_empty() {
         return Err(HttpError::BadRequest("import data cannot be empty".into()));
@@ -92,23 +92,58 @@ pub async fn import(
         ));
     }
 
-    backup
+    // Reject empty objects or arrays
+    let is_empty = match &parsed {
+        serde_json::Value::Object(obj) => obj.is_empty(),
+        serde_json::Value::Array(arr) => arr.is_empty(),
+        _ => false,
+    };
+    if is_empty {
+        return Err(HttpError::BadRequest(
+            "backup data is empty - nothing to import".into(),
+        ));
+    }
+
+    let result = backup
         .import(&body)
         .await
         .map_err(HttpError::BadRequest)?;
 
-    Ok(Json(ImportResponse { success: true }))
+    Ok(Json(ImportResponse::from(result)))
 }
 
 /// Response for import operation.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct ImportResponse {
+    /// Whether the import completed successfully.
     pub success: bool,
+    /// Number of documents imported.
+    pub documents_imported: u64,
+    /// Number of documents skipped.
+    pub documents_skipped: u64,
+    /// Collections affected by the import.
+    pub collections_affected: Vec<String>,
+    /// Non-fatal errors encountered during import.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<String>,
+}
+
+impl From<ImportResult> for ImportResponse {
+    fn from(result: ImportResult) -> Self {
+        Self {
+            success: result.errors.is_empty(),
+            documents_imported: result.documents_imported,
+            documents_skipped: result.documents_skipped,
+            collections_affected: result.collections_affected,
+            errors: result.errors,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::router::ImportResult;
 
     #[test]
     fn test_export_query_empty() {
@@ -127,9 +162,49 @@ mod tests {
 
     #[test]
     fn test_import_response_serialize() {
-        let response = ImportResponse { success: true };
+        let response = ImportResponse {
+            success: true,
+            documents_imported: 10,
+            documents_skipped: 2,
+            collections_affected: vec!["Users".to_string(), "Posts".to_string()],
+            errors: vec![],
+        };
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("success"));
         assert!(json.contains("true"));
+        assert!(json.contains("documents_imported"));
+        assert!(json.contains("10"));
+        assert!(json.contains("collections_affected"));
+        // errors should be omitted when empty
+        assert!(!json.contains("errors"));
+    }
+
+    #[test]
+    fn test_import_response_with_errors() {
+        let response = ImportResponse {
+            success: false,
+            documents_imported: 5,
+            documents_skipped: 0,
+            collections_affected: vec!["Users".to_string()],
+            errors: vec!["Failed to import document bae-123".to_string()],
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"success\":false"));
+        assert!(json.contains("errors"));
+        assert!(json.contains("Failed to import"));
+    }
+
+    #[test]
+    fn test_import_response_from_import_result() {
+        let result = ImportResult {
+            documents_imported: 15,
+            documents_skipped: 3,
+            collections_affected: vec!["Users".to_string()],
+            errors: vec![],
+        };
+        let response = ImportResponse::from(result);
+        assert!(response.success);
+        assert_eq!(response.documents_imported, 15);
+        assert_eq!(response.documents_skipped, 3);
     }
 }

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -76,29 +76,25 @@ mod tests {
     use super::*;
     use crate::identity_extractor::ExtractIdentity;
     use crate::mock::{FailingMockRestOperations, MockQueryExecutor, MockRestOperations};
+    use crate::router::AppStateBuilder;
     use query::executor::QueryExecutor;
     use query::rest::RestOperations;
     use std::sync::Arc;
 
     fn create_state() -> AppState {
-        AppState {
-            executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-            rest: Some(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>),
-        }
+        AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+            .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
+            .build()
     }
 
     fn create_state_without_rest() -> AppState {
-        AppState {
-            executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-            rest: None,
-        }
+        AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>).build()
     }
 
     fn create_failing_state() -> AppState {
-        AppState {
-            executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-            rest: Some(Arc::new(FailingMockRestOperations::new("test error"))),
-        }
+        AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+            .with_rest(Arc::new(FailingMockRestOperations::new("test error")))
+            .build()
     }
 
     #[tokio::test]

--- a/crates/http/src/handlers/index.rs
+++ b/crates/http/src/handlers/index.rs
@@ -1,0 +1,203 @@
+//! Index endpoint handlers.
+//!
+//! These handlers provide HTTP access to index management:
+//! - Create index
+//! - List indexes
+//! - Drop index
+
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use serde::Deserialize;
+
+use crate::error::HttpError;
+use crate::router::{AppState, IndexInfo};
+
+/// Request to create a new index.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateIndexRequest {
+    pub collection: String,
+    pub fields: Vec<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub unique: bool,
+}
+
+/// Query parameters for listing indexes.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListIndexesQuery {
+    #[serde(default)]
+    pub collection: Option<String>,
+}
+
+/// Query parameters for dropping an index.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DropIndexQuery {
+    pub collection: String,
+    pub name: String,
+}
+
+/// Create a new index.
+///
+/// POST /api/v0/index
+pub async fn create_index(
+    State(state): State<AppState>,
+    Json(request): Json<CreateIndexRequest>,
+) -> Result<Json<IndexInfo>, HttpError> {
+    let index_ops = state
+        .index
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("Index operations not configured".into()))?;
+
+    if request.collection.trim().is_empty() {
+        return Err(HttpError::BadRequest("collection cannot be empty".into()));
+    }
+
+    if request.fields.is_empty() {
+        return Err(HttpError::BadRequest(
+            "at least one field is required".into(),
+        ));
+    }
+
+    // Validate field names
+    for field in &request.fields {
+        if field.trim().is_empty() {
+            return Err(HttpError::BadRequest("field name cannot be empty".into()));
+        }
+    }
+
+    let index = index_ops
+        .create_index(
+            &request.collection,
+            request.fields,
+            request.name.as_deref(),
+            request.unique,
+        )
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(index))
+}
+
+/// List indexes, optionally filtered by collection.
+///
+/// GET /api/v0/index
+pub async fn list_indexes(
+    State(state): State<AppState>,
+    Query(query): Query<ListIndexesQuery>,
+) -> Result<Json<Vec<IndexInfo>>, HttpError> {
+    let index_ops = state
+        .index
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("Index operations not configured".into()))?;
+
+    let indexes = index_ops
+        .list_indexes(query.collection.as_deref())
+        .await
+        .map_err(HttpError::Internal)?;
+
+    Ok(Json(indexes))
+}
+
+/// Drop an index.
+///
+/// DELETE /api/v0/index
+pub async fn drop_index(
+    State(state): State<AppState>,
+    Query(query): Query<DropIndexQuery>,
+) -> Result<Json<()>, HttpError> {
+    let index_ops = state
+        .index
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("Index operations not configured".into()))?;
+
+    if query.collection.trim().is_empty() {
+        return Err(HttpError::BadRequest("collection cannot be empty".into()));
+    }
+
+    if query.name.trim().is_empty() {
+        return Err(HttpError::BadRequest("name cannot be empty".into()));
+    }
+
+    index_ops
+        .drop_index(&query.collection, &query.name)
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::router::IndexFieldInfo;
+
+    #[test]
+    fn test_create_index_request_deserialize() {
+        let json =
+            r#"{"collection": "Users", "fields": ["name", "email"], "name": "idx_name_email", "unique": true}"#;
+        let request: CreateIndexRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.collection, "Users");
+        assert_eq!(request.fields.len(), 2);
+        assert_eq!(request.name, Some("idx_name_email".to_string()));
+        assert!(request.unique);
+    }
+
+    #[test]
+    fn test_create_index_request_minimal() {
+        let json = r#"{"collection": "Users", "fields": ["name"]}"#;
+        let request: CreateIndexRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.collection, "Users");
+        assert_eq!(request.fields.len(), 1);
+        assert!(request.name.is_none());
+        assert!(!request.unique);
+    }
+
+    #[test]
+    fn test_list_indexes_query_empty() {
+        let query: ListIndexesQuery = serde_json::from_str("{}").unwrap();
+        assert!(query.collection.is_none());
+    }
+
+    #[test]
+    fn test_list_indexes_query_with_collection() {
+        let json = r#"{"collection": "Users"}"#;
+        let query: ListIndexesQuery = serde_json::from_str(json).unwrap();
+        assert_eq!(query.collection, Some("Users".to_string()));
+    }
+
+    #[test]
+    fn test_drop_index_query() {
+        let json = r#"{"collection": "Users", "name": "idx_name"}"#;
+        let query: DropIndexQuery = serde_json::from_str(json).unwrap();
+        assert_eq!(query.collection, "Users");
+        assert_eq!(query.name, "idx_name");
+    }
+
+    #[test]
+    fn test_index_info_serialize() {
+        let info = IndexInfo {
+            name: "idx_name".to_string(),
+            collection: "Users".to_string(),
+            fields: vec![
+                IndexFieldInfo {
+                    name: "name".to_string(),
+                    direction: Some("ASC".to_string()),
+                },
+                IndexFieldInfo {
+                    name: "email".to_string(),
+                    direction: None,
+                },
+            ],
+            unique: true,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("idx_name"));
+        assert!(json.contains("Users"));
+        assert!(json.contains("name"));
+        assert!(json.contains("email"));
+        assert!(json.contains("unique"));
+    }
+}

--- a/crates/http/src/handlers/index.rs
+++ b/crates/http/src/handlers/index.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 
 use crate::error::HttpError;
 use crate::router::{AppState, IndexInfo};
+use crate::validation::validate_identifier;
 
 /// Request to create a new index.
 #[derive(Debug, Clone, Deserialize)]
@@ -51,9 +52,13 @@ pub async fn create_index(
         .as_ref()
         .ok_or_else(|| HttpError::Internal("Index operations not configured".into()))?;
 
-    if request.collection.trim().is_empty() {
-        return Err(HttpError::BadRequest("collection cannot be empty".into()));
-    }
+    // Validate collection name
+    validate_identifier(&request.collection).map_err(|_| {
+        HttpError::BadRequest(format!(
+            "invalid collection name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
+            request.collection
+        ))
+    })?;
 
     if request.fields.is_empty() {
         return Err(HttpError::BadRequest(
@@ -63,9 +68,22 @@ pub async fn create_index(
 
     // Validate field names
     for field in &request.fields {
-        if field.trim().is_empty() {
-            return Err(HttpError::BadRequest("field name cannot be empty".into()));
-        }
+        validate_identifier(field).map_err(|_| {
+            HttpError::BadRequest(format!(
+                "invalid field name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
+                field
+            ))
+        })?;
+    }
+
+    // Validate index name if provided
+    if let Some(ref name) = request.name {
+        validate_identifier(name).map_err(|_| {
+            HttpError::BadRequest(format!(
+                "invalid index name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
+                name
+            ))
+        })?;
     }
 
     let index = index_ops
@@ -113,13 +131,21 @@ pub async fn drop_index(
         .as_ref()
         .ok_or_else(|| HttpError::Internal("Index operations not configured".into()))?;
 
-    if query.collection.trim().is_empty() {
-        return Err(HttpError::BadRequest("collection cannot be empty".into()));
-    }
+    // Validate collection name
+    validate_identifier(&query.collection).map_err(|_| {
+        HttpError::BadRequest(format!(
+            "invalid collection name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
+            query.collection
+        ))
+    })?;
 
-    if query.name.trim().is_empty() {
-        return Err(HttpError::BadRequest("name cannot be empty".into()));
-    }
+    // Validate index name
+    validate_identifier(&query.name).map_err(|_| {
+        HttpError::BadRequest(format!(
+            "invalid index name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
+            query.name
+        ))
+    })?;
 
     index_ops
         .drop_index(&query.collection, &query.name)

--- a/crates/http/src/handlers/index.rs
+++ b/crates/http/src/handlers/index.rs
@@ -47,10 +47,7 @@ pub async fn create_index(
     State(state): State<AppState>,
     Json(request): Json<CreateIndexRequest>,
 ) -> Result<Json<IndexInfo>, HttpError> {
-    let index_ops = state
-        .index
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("Index operations are not enabled. Start the server with indexing enabled to use this feature.".into()))?;
+    let index_ops = state.require_index()?;
 
     // Validate collection name
     validate_identifier(&request.collection).map_err(|_| {
@@ -106,10 +103,7 @@ pub async fn list_indexes(
     State(state): State<AppState>,
     Query(query): Query<ListIndexesQuery>,
 ) -> Result<Json<Vec<IndexInfo>>, HttpError> {
-    let index_ops = state
-        .index
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("Index operations are not enabled. Start the server with indexing enabled to use this feature.".into()))?;
+    let index_ops = state.require_index()?;
 
     // Validate collection name if provided
     if let Some(ref col) = query.collection {
@@ -124,7 +118,7 @@ pub async fn list_indexes(
     let indexes = index_ops
         .list_indexes(query.collection.as_deref())
         .await
-        .map_err(HttpError::BadRequest)?;
+        .map_err(HttpError::Internal)?;
 
     Ok(Json(indexes))
 }
@@ -136,10 +130,7 @@ pub async fn drop_index(
     State(state): State<AppState>,
     Query(query): Query<DropIndexQuery>,
 ) -> Result<Json<()>, HttpError> {
-    let index_ops = state
-        .index
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("Index operations are not enabled. Start the server with indexing enabled to use this feature.".into()))?;
+    let index_ops = state.require_index()?;
 
     // Validate collection name
     validate_identifier(&query.collection).map_err(|_| {

--- a/crates/http/src/handlers/index.rs
+++ b/crates/http/src/handlers/index.rs
@@ -50,7 +50,7 @@ pub async fn create_index(
     let index_ops = state
         .index
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("Index operations not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("Index operations are not enabled. Start the server with indexing enabled to use this feature.".into()))?;
 
     // Validate collection name
     validate_identifier(&request.collection).map_err(|_| {
@@ -109,12 +109,22 @@ pub async fn list_indexes(
     let index_ops = state
         .index
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("Index operations not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("Index operations are not enabled. Start the server with indexing enabled to use this feature.".into()))?;
+
+    // Validate collection name if provided
+    if let Some(ref col) = query.collection {
+        validate_identifier(col).map_err(|_| {
+            HttpError::BadRequest(format!(
+                "invalid collection name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
+                col
+            ))
+        })?;
+    }
 
     let indexes = index_ops
         .list_indexes(query.collection.as_deref())
         .await
-        .map_err(HttpError::Internal)?;
+        .map_err(HttpError::BadRequest)?;
 
     Ok(Json(indexes))
 }
@@ -129,7 +139,7 @@ pub async fn drop_index(
     let index_ops = state
         .index
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("Index operations not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("Index operations are not enabled. Start the server with indexing enabled to use this feature.".into()))?;
 
     // Validate collection name
     validate_identifier(&query.collection).map_err(|_| {

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -4,10 +4,18 @@
 //! - GraphQL and transaction endpoints
 //! - REST collection endpoints
 //! - REST document endpoints
+//! - P2P endpoints
+//! - ACP (Access Control Policy) endpoints
+//! - Index management endpoints
+//! - Backup endpoints
 
+pub mod acp;
+pub mod backup;
 pub mod collections;
 pub mod documents;
 pub mod graphql;
+pub mod index;
+pub mod p2p;
 
 // Re-export GraphQL handlers for backwards compatibility
 pub use graphql::{

--- a/crates/http/src/handlers/p2p.rs
+++ b/crates/http/src/handlers/p2p.rs
@@ -81,10 +81,7 @@ pub struct CollectionsDeleteQuery {
 ///
 /// GET /api/v0/p2p/info
 pub async fn get_info(State(state): State<AppState>) -> Result<Json<P2pInfoResponse>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     let peer_id = p2p
         .local_peer_id()
@@ -106,10 +103,7 @@ pub async fn get_info(State(state): State<AppState>) -> Result<Json<P2pInfoRespo
 ///
 /// GET /api/v0/p2p/peers
 pub async fn list_peers(State(state): State<AppState>) -> Result<Json<Vec<PeerInfo>>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     let peers = p2p
         .connected_peers()
@@ -131,10 +125,7 @@ pub async fn connect_peer(
     State(state): State<AppState>,
     Json(request): Json<ConnectPeerRequest>,
 ) -> Result<Json<()>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     // Validate the multiaddr format
     validate_multiaddr(&request.address)?;
@@ -152,10 +143,7 @@ pub async fn connect_peer(
 pub async fn list_replicators(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<ReplicatorInfoResponse>>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     let replicators = p2p
         .get_replicators()
@@ -181,10 +169,7 @@ pub async fn add_replicator(
     State(state): State<AppState>,
     Json(request): Json<ReplicatorRequest>,
 ) -> Result<Json<()>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     if request.collections.is_empty() {
         return Err(HttpError::BadRequest(
@@ -216,10 +201,7 @@ pub async fn remove_replicator(
     State(state): State<AppState>,
     Query(query): Query<ReplicatorDeleteQuery>,
 ) -> Result<Json<()>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     if query.collections.is_empty() {
         return Err(HttpError::BadRequest(
@@ -250,10 +232,7 @@ pub async fn remove_replicator(
 pub async fn list_collections(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<String>>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     let collections = p2p
         .get_collections()
@@ -270,10 +249,7 @@ pub async fn add_collections(
     State(state): State<AppState>,
     Json(request): Json<CollectionsRequest>,
 ) -> Result<Json<()>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     if request.collections.is_empty() {
         return Err(HttpError::BadRequest(
@@ -300,10 +276,7 @@ pub async fn remove_collections(
     State(state): State<AppState>,
     Query(query): Query<CollectionsDeleteQuery>,
 ) -> Result<Json<()>, HttpError> {
-    let p2p = state
-        .p2p
-        .as_ref()
-        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
+    let p2p = state.require_p2p()?;
 
     if query.collections.is_empty() {
         return Err(HttpError::BadRequest(

--- a/crates/http/src/handlers/p2p.rs
+++ b/crates/http/src/handlers/p2p.rs
@@ -1,0 +1,336 @@
+//! P2P endpoint handlers.
+//!
+//! These handlers provide HTTP access to P2P networking functionality:
+//! - Node info (peer ID, addresses)
+//! - Peer management (list, connect)
+//! - Replicator management (list, add, remove)
+//! - P2P collection management (list, add, remove)
+
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::HttpError;
+use crate::router::AppState;
+
+/// Response for P2P node info.
+#[derive(Debug, Clone, Serialize)]
+pub struct P2pInfoResponse {
+    pub id: String,
+    pub addresses: Vec<String>,
+}
+
+/// Response for listing peers.
+#[derive(Debug, Clone, Serialize)]
+pub struct PeerInfo {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+}
+
+/// Request to connect to a peer.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConnectPeerRequest {
+    pub address: String,
+}
+
+/// Response for replicator info.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReplicatorInfoResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub collections: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+}
+
+/// Request to add/remove a replicator.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReplicatorRequest {
+    pub collections: Vec<String>,
+    #[serde(default)]
+    pub address: Option<String>,
+}
+
+/// Query parameters for replicator removal.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReplicatorDeleteQuery {
+    #[serde(default)]
+    pub collections: Vec<String>,
+    #[serde(default)]
+    pub address: Option<String>,
+}
+
+/// Request to add/remove P2P collections.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CollectionsRequest {
+    pub collections: Vec<String>,
+}
+
+/// Query parameters for collection removal.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CollectionsDeleteQuery {
+    #[serde(default)]
+    pub collections: Vec<String>,
+}
+
+/// Get P2P node information.
+///
+/// GET /api/v0/p2p/info
+pub async fn get_info(State(state): State<AppState>) -> Result<Json<P2pInfoResponse>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    let peer_id = p2p
+        .local_peer_id()
+        .await
+        .map_err(HttpError::Internal)?;
+
+    let addresses = p2p
+        .listen_addresses()
+        .await
+        .map_err(HttpError::Internal)?;
+
+    Ok(Json(P2pInfoResponse {
+        id: peer_id,
+        addresses,
+    }))
+}
+
+/// List connected peers.
+///
+/// GET /api/v0/p2p/peers
+pub async fn list_peers(State(state): State<AppState>) -> Result<Json<Vec<PeerInfo>>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    let peers = p2p
+        .connected_peers()
+        .await
+        .map_err(HttpError::Internal)?;
+
+    let peer_infos: Vec<PeerInfo> = peers
+        .into_iter()
+        .map(|id| PeerInfo { id, address: None })
+        .collect();
+
+    Ok(Json(peer_infos))
+}
+
+/// Connect to a peer.
+///
+/// POST /api/v0/p2p/peers
+pub async fn connect_peer(
+    State(state): State<AppState>,
+    Json(request): Json<ConnectPeerRequest>,
+) -> Result<Json<()>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    p2p.connect_peer(&request.address)
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(()))
+}
+
+/// List replicators.
+///
+/// GET /api/v0/p2p/replicator
+pub async fn list_replicators(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<ReplicatorInfoResponse>>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    let replicators = p2p
+        .get_replicators()
+        .await
+        .map_err(HttpError::Internal)?;
+
+    let response: Vec<ReplicatorInfoResponse> = replicators
+        .into_iter()
+        .map(|r| ReplicatorInfoResponse {
+            id: r.id,
+            collections: r.collections,
+            address: r.address,
+        })
+        .collect();
+
+    Ok(Json(response))
+}
+
+/// Add a replicator.
+///
+/// POST /api/v0/p2p/replicator
+pub async fn add_replicator(
+    State(state): State<AppState>,
+    Json(request): Json<ReplicatorRequest>,
+) -> Result<Json<()>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    if request.collections.is_empty() {
+        return Err(HttpError::BadRequest(
+            "at least one collection is required".into(),
+        ));
+    }
+
+    p2p.add_replicator(request.collections, request.address.as_deref())
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(()))
+}
+
+/// Remove a replicator.
+///
+/// DELETE /api/v0/p2p/replicator
+pub async fn remove_replicator(
+    State(state): State<AppState>,
+    Query(query): Query<ReplicatorDeleteQuery>,
+) -> Result<Json<()>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    if query.collections.is_empty() {
+        return Err(HttpError::BadRequest(
+            "at least one collection is required".into(),
+        ));
+    }
+
+    p2p.remove_replicator(query.collections, query.address.as_deref())
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(()))
+}
+
+/// List P2P collections.
+///
+/// GET /api/v0/p2p/collections
+pub async fn list_collections(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<String>>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    let collections = p2p
+        .get_collections()
+        .await
+        .map_err(HttpError::Internal)?;
+
+    Ok(Json(collections))
+}
+
+/// Add collections to P2P.
+///
+/// POST /api/v0/p2p/collections
+pub async fn add_collections(
+    State(state): State<AppState>,
+    Json(request): Json<CollectionsRequest>,
+) -> Result<Json<()>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    if request.collections.is_empty() {
+        return Err(HttpError::BadRequest(
+            "at least one collection is required".into(),
+        ));
+    }
+
+    p2p.add_collections(request.collections)
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(()))
+}
+
+/// Remove collections from P2P.
+///
+/// DELETE /api/v0/p2p/collections
+pub async fn remove_collections(
+    State(state): State<AppState>,
+    Query(query): Query<CollectionsDeleteQuery>,
+) -> Result<Json<()>, HttpError> {
+    let p2p = state
+        .p2p
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+
+    if query.collections.is_empty() {
+        return Err(HttpError::BadRequest(
+            "at least one collection is required".into(),
+        ));
+    }
+
+    p2p.remove_collections(query.collections)
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_connect_peer_request_deserialize() {
+        let json = r#"{"address": "/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWtest"}"#;
+        let request: ConnectPeerRequest = serde_json::from_str(json).unwrap();
+        assert!(request.address.contains("12D3KooW"));
+    }
+
+    #[test]
+    fn test_replicator_request_deserialize() {
+        let json = r#"{"collections": ["Users", "Posts"], "address": "/ip4/127.0.0.1/tcp/9000"}"#;
+        let request: ReplicatorRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.collections.len(), 2);
+        assert!(request.address.is_some());
+    }
+
+    #[test]
+    fn test_replicator_request_without_address() {
+        let json = r#"{"collections": ["Users"]}"#;
+        let request: ReplicatorRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.collections.len(), 1);
+        assert!(request.address.is_none());
+    }
+
+    #[test]
+    fn test_collections_request_deserialize() {
+        let json = r#"{"collections": ["Users", "Posts"]}"#;
+        let request: CollectionsRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.collections.len(), 2);
+    }
+
+    #[test]
+    fn test_p2p_info_response_serialize() {
+        let response = P2pInfoResponse {
+            id: "12D3KooWtest".to_string(),
+            addresses: vec!["/ip4/127.0.0.1/tcp/9000".to_string()],
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("12D3KooWtest"));
+        assert!(json.contains("/ip4/127.0.0.1/tcp/9000"));
+    }
+}

--- a/crates/http/src/handlers/p2p.rs
+++ b/crates/http/src/handlers/p2p.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::HttpError;
 use crate::router::AppState;
+use crate::validation::{validate_collection_name, validate_multiaddr};
 
 /// Response for P2P node info.
 #[derive(Debug, Clone, Serialize)]
@@ -135,6 +136,9 @@ pub async fn connect_peer(
         .as_ref()
         .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
 
+    // Validate the multiaddr format
+    validate_multiaddr(&request.address)?;
+
     p2p.connect_peer(&request.address)
         .await
         .map_err(HttpError::BadRequest)?;
@@ -188,6 +192,16 @@ pub async fn add_replicator(
         ));
     }
 
+    // Validate collection names
+    for col in &request.collections {
+        validate_collection_name(col)?;
+    }
+
+    // Validate address if provided
+    if let Some(ref addr) = request.address {
+        validate_multiaddr(addr)?;
+    }
+
     p2p.add_replicator(request.collections, request.address.as_deref())
         .await
         .map_err(HttpError::BadRequest)?;
@@ -211,6 +225,16 @@ pub async fn remove_replicator(
         return Err(HttpError::BadRequest(
             "at least one collection is required".into(),
         ));
+    }
+
+    // Validate collection names
+    for col in &query.collections {
+        validate_collection_name(col)?;
+    }
+
+    // Validate address if provided
+    if let Some(ref addr) = query.address {
+        validate_multiaddr(addr)?;
     }
 
     p2p.remove_replicator(query.collections, query.address.as_deref())
@@ -257,6 +281,11 @@ pub async fn add_collections(
         ));
     }
 
+    // Validate collection names
+    for col in &request.collections {
+        validate_collection_name(col)?;
+    }
+
     p2p.add_collections(request.collections)
         .await
         .map_err(HttpError::BadRequest)?;
@@ -280,6 +309,11 @@ pub async fn remove_collections(
         return Err(HttpError::BadRequest(
             "at least one collection is required".into(),
         ));
+    }
+
+    // Validate collection names
+    for col in &query.collections {
+        validate_collection_name(col)?;
     }
 
     p2p.remove_collections(query.collections)

--- a/crates/http/src/handlers/p2p.rs
+++ b/crates/http/src/handlers/p2p.rs
@@ -47,7 +47,7 @@ pub struct ReplicatorInfoResponse {
     pub address: Option<String>,
 }
 
-/// Request to add/remove a replicator.
+/// Request to add a replicator.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ReplicatorRequest {
     pub collections: Vec<String>,
@@ -64,7 +64,7 @@ pub struct ReplicatorDeleteQuery {
     pub address: Option<String>,
 }
 
-/// Request to add/remove P2P collections.
+/// Request to add P2P collections.
 #[derive(Debug, Clone, Deserialize)]
 pub struct CollectionsRequest {
     pub collections: Vec<String>,
@@ -84,7 +84,7 @@ pub async fn get_info(State(state): State<AppState>) -> Result<Json<P2pInfoRespo
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     let peer_id = p2p
         .local_peer_id()
@@ -109,7 +109,7 @@ pub async fn list_peers(State(state): State<AppState>) -> Result<Json<Vec<PeerIn
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     let peers = p2p
         .connected_peers()
@@ -134,7 +134,7 @@ pub async fn connect_peer(
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     // Validate the multiaddr format
     validate_multiaddr(&request.address)?;
@@ -155,7 +155,7 @@ pub async fn list_replicators(
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     let replicators = p2p
         .get_replicators()
@@ -184,7 +184,7 @@ pub async fn add_replicator(
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     if request.collections.is_empty() {
         return Err(HttpError::BadRequest(
@@ -219,7 +219,7 @@ pub async fn remove_replicator(
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     if query.collections.is_empty() {
         return Err(HttpError::BadRequest(
@@ -253,7 +253,7 @@ pub async fn list_collections(
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     let collections = p2p
         .get_collections()
@@ -273,7 +273,7 @@ pub async fn add_collections(
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     if request.collections.is_empty() {
         return Err(HttpError::BadRequest(
@@ -303,7 +303,7 @@ pub async fn remove_collections(
     let p2p = state
         .p2p
         .as_ref()
-        .ok_or_else(|| HttpError::Internal("P2P not configured".into()))?;
+        .ok_or_else(|| HttpError::ServiceUnavailable("P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()))?;
 
     if query.collections.is_empty() {
         return Err(HttpError::BadRequest(

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -26,6 +26,31 @@
 //! - `PATCH /api/v0/collections/{name}/{docID}` - Update document
 //! - `DELETE /api/v0/collections/{name}/{docID}` - Delete document
 //!
+//! ## P2P (requires P2POperations)
+//! - `GET /api/v0/p2p/info` - Get P2P node info
+//! - `GET /api/v0/p2p/peers` - List connected peers
+//! - `POST /api/v0/p2p/peers` - Connect to peer
+//! - `GET /api/v0/p2p/replicator` - List replicators
+//! - `POST /api/v0/p2p/replicator` - Add replicator
+//! - `DELETE /api/v0/p2p/replicator` - Remove replicator
+//! - `GET /api/v0/p2p/collections` - List P2P collections
+//! - `POST /api/v0/p2p/collections` - Add P2P collections
+//! - `DELETE /api/v0/p2p/collections` - Remove P2P collections
+//!
+//! ## ACP (requires AcpOperations)
+//! - `POST /api/v0/acp/policy` - Add policy
+//! - `GET /api/v0/acp/policy` - List policies
+//! - `GET /api/v0/acp/policy/{id}` - Get policy by ID
+//!
+//! ## Index (requires IndexOperations)
+//! - `POST /api/v0/index` - Create index
+//! - `GET /api/v0/index` - List indexes
+//! - `DELETE /api/v0/index` - Drop index
+//!
+//! ## Backup (requires BackupOperations)
+//! - `GET /api/v0/backup/export` - Export database
+//! - `POST /api/v0/backup/import` - Import database
+//!
 //! # Example
 //!
 //! ```ignore
@@ -51,7 +76,11 @@ pub mod mock;
 
 pub use error::{HttpError, Result};
 pub use identity_extractor::{ExtractIdentity, ExtractTokenIdentity, IdentityExtractionError};
-pub use router::{create_router, create_router_with_rest, AppState};
+pub use router::{
+    create_router, create_router_with_rest, create_router_with_state, AcpOperations, AppState,
+    AppStateBuilder, BackupOperations, IndexFieldInfo, IndexInfo, IndexOperations, P2POperations,
+    PolicyInfo, ReplicatorInfo,
+};
 pub use server::{Server, ServerConfig};
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -86,5 +86,6 @@ pub use server::{Server, ServerConfig};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use mock::{
-    FailingMockExecutor, FailingMockRestOperations, MockQueryExecutor, MockRestOperations,
+    FailingMockExecutor, FailingMockRestOperations, MockAcpOperations, MockBackupOperations,
+    MockIndexOperations, MockP2POperations, MockQueryExecutor, MockRestOperations,
 };

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -86,6 +86,8 @@ pub use server::{Server, ServerConfig};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use mock::{
-    FailingMockExecutor, FailingMockRestOperations, MockAcpOperations, MockBackupOperations,
-    MockIndexOperations, MockP2POperations, MockQueryExecutor, MockRestOperations,
+    FailingMockAcpOperations, FailingMockBackupOperations, FailingMockExecutor,
+    FailingMockIndexOperations, FailingMockP2POperations, FailingMockRestOperations,
+    MockAcpOperations, MockBackupOperations, MockIndexOperations, MockP2POperations,
+    MockQueryExecutor, MockRestOperations,
 };

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -70,6 +70,7 @@ pub mod handlers;
 pub mod identity_extractor;
 pub mod router;
 pub mod server;
+pub mod validation;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod mock;

--- a/crates/http/src/mock.rs
+++ b/crates/http/src/mock.rs
@@ -529,3 +529,424 @@ impl RestOperations for FailingMockRestOperations {
         Err(self.error.clone())
     }
 }
+
+// ============================================================================
+// Mock P2P Operations
+// ============================================================================
+
+use crate::router::{
+    AcpOperations, BackupOperations, ImportResult, IndexFieldInfo, IndexInfo, IndexOperations,
+    P2POperations, PolicyInfo, ReplicatorInfo,
+};
+
+/// Mock P2P operations for testing P2P handlers.
+#[derive(Debug)]
+pub struct MockP2POperations {
+    peer_id: String,
+    addresses: Vec<String>,
+    peers: Arc<RwLock<Vec<String>>>,
+    replicators: Arc<RwLock<Vec<ReplicatorInfo>>>,
+    collections: Arc<RwLock<Vec<String>>>,
+}
+
+impl Clone for MockP2POperations {
+    fn clone(&self) -> Self {
+        Self {
+            peer_id: self.peer_id.clone(),
+            addresses: self.addresses.clone(),
+            peers: Arc::clone(&self.peers),
+            replicators: Arc::clone(&self.replicators),
+            collections: Arc::clone(&self.collections),
+        }
+    }
+}
+
+impl Default for MockP2POperations {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockP2POperations {
+    /// Create a new mock P2P operations instance.
+    pub fn new() -> Self {
+        Self {
+            peer_id: "12D3KooWMockPeerId123456789".to_string(),
+            addresses: vec!["/ip4/127.0.0.1/tcp/9000".to_string()],
+            peers: Arc::new(RwLock::new(vec![])),
+            replicators: Arc::new(RwLock::new(vec![])),
+            collections: Arc::new(RwLock::new(vec![])),
+        }
+    }
+
+    /// Create with a connected peer.
+    pub fn with_peer(self, peer_id: &str) -> Self {
+        self.peers.write().unwrap().push(peer_id.to_string());
+        self
+    }
+
+    /// Create with a replicator.
+    pub fn with_replicator(self, collections: Vec<String>, address: Option<String>) -> Self {
+        self.replicators.write().unwrap().push(ReplicatorInfo {
+            id: Some("12D3KooWReplicator".to_string()),
+            collections,
+            address,
+        });
+        self
+    }
+
+    /// Create with P2P collections.
+    pub fn with_collections(self, collections: Vec<String>) -> Self {
+        *self.collections.write().unwrap() = collections;
+        self
+    }
+}
+
+#[async_trait]
+impl P2POperations for MockP2POperations {
+    async fn local_peer_id(&self) -> std::result::Result<String, String> {
+        Ok(self.peer_id.clone())
+    }
+
+    async fn listen_addresses(&self) -> std::result::Result<Vec<String>, String> {
+        Ok(self.addresses.clone())
+    }
+
+    async fn connected_peers(&self) -> std::result::Result<Vec<String>, String> {
+        Ok(self.peers.read().unwrap().clone())
+    }
+
+    async fn connect_peer(&self, addr: &str) -> std::result::Result<(), String> {
+        // Extract a mock peer ID from the address
+        let peer_id = if addr.contains("/p2p/") {
+            addr.split("/p2p/").last().unwrap_or("unknown").to_string()
+        } else {
+            format!("peer-{}", addr.len())
+        };
+        self.peers.write().unwrap().push(peer_id);
+        Ok(())
+    }
+
+    async fn get_replicators(&self) -> std::result::Result<Vec<ReplicatorInfo>, String> {
+        Ok(self.replicators.read().unwrap().clone())
+    }
+
+    async fn add_replicator(
+        &self,
+        collections: Vec<String>,
+        addr: Option<&str>,
+    ) -> std::result::Result<(), String> {
+        self.replicators.write().unwrap().push(ReplicatorInfo {
+            id: Some("12D3KooWNewReplicator".to_string()),
+            collections,
+            address: addr.map(|s| s.to_string()),
+        });
+        Ok(())
+    }
+
+    async fn remove_replicator(
+        &self,
+        collections: Vec<String>,
+        _addr: Option<&str>,
+    ) -> std::result::Result<(), String> {
+        let mut replicators = self.replicators.write().unwrap();
+        replicators.retain(|r| !collections.iter().all(|c| r.collections.contains(c)));
+        Ok(())
+    }
+
+    async fn get_collections(&self) -> std::result::Result<Vec<String>, String> {
+        Ok(self.collections.read().unwrap().clone())
+    }
+
+    async fn add_collections(&self, collections: Vec<String>) -> std::result::Result<(), String> {
+        let mut existing = self.collections.write().unwrap();
+        for col in collections {
+            if !existing.contains(&col) {
+                existing.push(col);
+            }
+        }
+        Ok(())
+    }
+
+    async fn remove_collections(&self, collections: Vec<String>) -> std::result::Result<(), String> {
+        let mut existing = self.collections.write().unwrap();
+        existing.retain(|c| !collections.contains(c));
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Mock ACP Operations
+// ============================================================================
+
+/// Mock ACP operations for testing ACP handlers.
+#[derive(Debug)]
+pub struct MockAcpOperations {
+    policies: Arc<RwLock<Vec<PolicyInfo>>>,
+    next_id: Arc<RwLock<u64>>,
+}
+
+impl Clone for MockAcpOperations {
+    fn clone(&self) -> Self {
+        Self {
+            policies: Arc::clone(&self.policies),
+            next_id: Arc::clone(&self.next_id),
+        }
+    }
+}
+
+impl Default for MockAcpOperations {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockAcpOperations {
+    /// Create a new mock ACP operations instance.
+    pub fn new() -> Self {
+        Self {
+            policies: Arc::new(RwLock::new(vec![])),
+            next_id: Arc::new(RwLock::new(1)),
+        }
+    }
+
+    /// Create with a pre-existing policy.
+    pub fn with_policy(self, id: &str, name: Option<&str>) -> Self {
+        self.policies.write().unwrap().push(PolicyInfo {
+            id: id.to_string(),
+            name: name.map(|s| s.to_string()),
+            description: None,
+            resources: None,
+            actor: None,
+            creation_time: Some("2024-01-01T00:00:00Z".to_string()),
+        });
+        self
+    }
+}
+
+#[async_trait]
+impl AcpOperations for MockAcpOperations {
+    async fn add_policy(&self, _policy: &str) -> std::result::Result<String, String> {
+        let mut id = self.next_id.write().unwrap();
+        let policy_id = format!("policy-{:04}", *id);
+        *id += 1;
+
+        self.policies.write().unwrap().push(PolicyInfo {
+            id: policy_id.clone(),
+            name: Some("Test Policy".to_string()),
+            description: Some("A test policy".to_string()),
+            resources: None,
+            actor: None,
+            creation_time: Some("2024-01-01T00:00:00Z".to_string()),
+        });
+
+        Ok(policy_id)
+    }
+
+    async fn list_policies(&self) -> std::result::Result<Vec<PolicyInfo>, String> {
+        Ok(self.policies.read().unwrap().clone())
+    }
+
+    async fn get_policy(&self, id: &str) -> std::result::Result<Option<PolicyInfo>, String> {
+        let policies = self.policies.read().unwrap();
+        Ok(policies.iter().find(|p| p.id == id).cloned())
+    }
+}
+
+// ============================================================================
+// Mock Index Operations
+// ============================================================================
+
+/// Mock index operations for testing index handlers.
+#[derive(Debug)]
+pub struct MockIndexOperations {
+    indexes: Arc<RwLock<Vec<IndexInfo>>>,
+    next_id: Arc<RwLock<u64>>,
+}
+
+impl Clone for MockIndexOperations {
+    fn clone(&self) -> Self {
+        Self {
+            indexes: Arc::clone(&self.indexes),
+            next_id: Arc::clone(&self.next_id),
+        }
+    }
+}
+
+impl Default for MockIndexOperations {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockIndexOperations {
+    /// Create a new mock index operations instance.
+    pub fn new() -> Self {
+        Self {
+            indexes: Arc::new(RwLock::new(vec![])),
+            next_id: Arc::new(RwLock::new(1)),
+        }
+    }
+
+    /// Create with a pre-existing index.
+    pub fn with_index(self, collection: &str, name: &str, fields: Vec<&str>, unique: bool) -> Self {
+        self.indexes.write().unwrap().push(IndexInfo {
+            name: name.to_string(),
+            collection: collection.to_string(),
+            fields: fields
+                .into_iter()
+                .map(|f| IndexFieldInfo {
+                    name: f.to_string(),
+                    direction: Some("ASC".to_string()),
+                })
+                .collect(),
+            unique,
+        });
+        self
+    }
+}
+
+#[async_trait]
+impl IndexOperations for MockIndexOperations {
+    async fn create_index(
+        &self,
+        collection: &str,
+        fields: Vec<String>,
+        name: Option<&str>,
+        unique: bool,
+    ) -> std::result::Result<IndexInfo, String> {
+        let index_name = match name {
+            Some(n) => n.to_string(),
+            None => {
+                let mut id = self.next_id.write().unwrap();
+                let name = format!("idx_{}_{}", collection.to_lowercase(), *id);
+                *id += 1;
+                name
+            }
+        };
+
+        let index = IndexInfo {
+            name: index_name,
+            collection: collection.to_string(),
+            fields: fields
+                .into_iter()
+                .map(|f| IndexFieldInfo {
+                    name: f,
+                    direction: Some("ASC".to_string()),
+                })
+                .collect(),
+            unique,
+        };
+
+        self.indexes.write().unwrap().push(index.clone());
+        Ok(index)
+    }
+
+    async fn list_indexes(&self, collection: Option<&str>) -> std::result::Result<Vec<IndexInfo>, String> {
+        let indexes = self.indexes.read().unwrap();
+        match collection {
+            Some(col) => Ok(indexes.iter().filter(|i| i.collection == col).cloned().collect()),
+            None => Ok(indexes.clone()),
+        }
+    }
+
+    async fn drop_index(&self, collection: &str, name: &str) -> std::result::Result<(), String> {
+        let mut indexes = self.indexes.write().unwrap();
+        let initial_len = indexes.len();
+        indexes.retain(|i| !(i.collection == collection && i.name == name));
+        if indexes.len() < initial_len {
+            Ok(())
+        } else {
+            Err(format!("index '{}' not found in collection '{}'", name, collection))
+        }
+    }
+}
+
+// ============================================================================
+// Mock Backup Operations
+// ============================================================================
+
+/// Mock backup operations for testing backup handlers.
+#[derive(Debug)]
+pub struct MockBackupOperations {
+    data: Arc<RwLock<String>>,
+}
+
+impl Clone for MockBackupOperations {
+    fn clone(&self) -> Self {
+        Self {
+            data: Arc::clone(&self.data),
+        }
+    }
+}
+
+impl Default for MockBackupOperations {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockBackupOperations {
+    /// Create a new mock backup operations instance.
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(r#"{"Users": [{"_docID": "bae-123", "name": "Alice"}]}"#.to_string())),
+        }
+    }
+
+    /// Create with custom backup data.
+    pub fn with_data(data: &str) -> Self {
+        Self {
+            data: Arc::new(RwLock::new(data.to_string())),
+        }
+    }
+}
+
+#[async_trait]
+impl BackupOperations for MockBackupOperations {
+    async fn export(
+        &self,
+        _collections: Option<Vec<String>>,
+        pretty: bool,
+    ) -> std::result::Result<String, String> {
+        let data = self.data.read().unwrap().clone();
+        if pretty {
+            // Format the JSON nicely
+            let parsed: serde_json::Value = serde_json::from_str(&data)
+                .map_err(|e| format!("invalid JSON: {}", e))?;
+            serde_json::to_string_pretty(&parsed)
+                .map_err(|e| format!("failed to serialize: {}", e))
+        } else {
+            Ok(data)
+        }
+    }
+
+    async fn import(&self, data: &str) -> std::result::Result<ImportResult, String> {
+        // Parse the incoming data to validate it
+        let parsed: serde_json::Value = serde_json::from_str(data)
+            .map_err(|e| format!("invalid JSON: {}", e))?;
+
+        // Count documents and collections
+        let mut documents_imported = 0u64;
+        let mut collections_affected = Vec::new();
+
+        if let Some(obj) = parsed.as_object() {
+            for (collection, docs) in obj {
+                collections_affected.push(collection.clone());
+                if let Some(arr) = docs.as_array() {
+                    documents_imported += arr.len() as u64;
+                }
+            }
+        }
+
+        // Store the new data
+        *self.data.write().unwrap() = data.to_string();
+
+        Ok(ImportResult {
+            documents_imported,
+            documents_skipped: 0,
+            collections_affected,
+            errors: vec![],
+        })
+    }
+}

--- a/crates/http/src/mock.rs
+++ b/crates/http/src/mock.rs
@@ -950,3 +950,169 @@ impl BackupOperations for MockBackupOperations {
         })
     }
 }
+
+// ============================================================================
+// Failing Mock Operations (for error path testing)
+// ============================================================================
+
+/// Mock P2P operations that always fails with a configurable error.
+#[derive(Debug, Clone)]
+pub struct FailingMockP2POperations {
+    error: String,
+}
+
+impl FailingMockP2POperations {
+    /// Create a new failing mock with the given error message.
+    pub fn new(error: impl Into<String>) -> Self {
+        Self {
+            error: error.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl P2POperations for FailingMockP2POperations {
+    async fn local_peer_id(&self) -> std::result::Result<String, String> {
+        Err(self.error.clone())
+    }
+
+    async fn listen_addresses(&self) -> std::result::Result<Vec<String>, String> {
+        Err(self.error.clone())
+    }
+
+    async fn connected_peers(&self) -> std::result::Result<Vec<String>, String> {
+        Err(self.error.clone())
+    }
+
+    async fn connect_peer(&self, _addr: &str) -> std::result::Result<(), String> {
+        Err(self.error.clone())
+    }
+
+    async fn get_replicators(&self) -> std::result::Result<Vec<ReplicatorInfo>, String> {
+        Err(self.error.clone())
+    }
+
+    async fn add_replicator(
+        &self,
+        _collections: Vec<String>,
+        _addr: Option<&str>,
+    ) -> std::result::Result<(), String> {
+        Err(self.error.clone())
+    }
+
+    async fn remove_replicator(
+        &self,
+        _collections: Vec<String>,
+        _addr: Option<&str>,
+    ) -> std::result::Result<(), String> {
+        Err(self.error.clone())
+    }
+
+    async fn get_collections(&self) -> std::result::Result<Vec<String>, String> {
+        Err(self.error.clone())
+    }
+
+    async fn add_collections(&self, _collections: Vec<String>) -> std::result::Result<(), String> {
+        Err(self.error.clone())
+    }
+
+    async fn remove_collections(&self, _collections: Vec<String>) -> std::result::Result<(), String> {
+        Err(self.error.clone())
+    }
+}
+
+/// Mock ACP operations that always fails with a configurable error.
+#[derive(Debug, Clone)]
+pub struct FailingMockAcpOperations {
+    error: String,
+}
+
+impl FailingMockAcpOperations {
+    /// Create a new failing mock with the given error message.
+    pub fn new(error: impl Into<String>) -> Self {
+        Self {
+            error: error.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl AcpOperations for FailingMockAcpOperations {
+    async fn add_policy(&self, _policy: &str) -> std::result::Result<String, String> {
+        Err(self.error.clone())
+    }
+
+    async fn list_policies(&self) -> std::result::Result<Vec<PolicyInfo>, String> {
+        Err(self.error.clone())
+    }
+
+    async fn get_policy(&self, _id: &str) -> std::result::Result<Option<PolicyInfo>, String> {
+        Err(self.error.clone())
+    }
+}
+
+/// Mock index operations that always fails with a configurable error.
+#[derive(Debug, Clone)]
+pub struct FailingMockIndexOperations {
+    error: String,
+}
+
+impl FailingMockIndexOperations {
+    /// Create a new failing mock with the given error message.
+    pub fn new(error: impl Into<String>) -> Self {
+        Self {
+            error: error.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl IndexOperations for FailingMockIndexOperations {
+    async fn create_index(
+        &self,
+        _collection: &str,
+        _fields: Vec<String>,
+        _name: Option<&str>,
+        _unique: bool,
+    ) -> std::result::Result<IndexInfo, String> {
+        Err(self.error.clone())
+    }
+
+    async fn list_indexes(&self, _collection: Option<&str>) -> std::result::Result<Vec<IndexInfo>, String> {
+        Err(self.error.clone())
+    }
+
+    async fn drop_index(&self, _collection: &str, _name: &str) -> std::result::Result<(), String> {
+        Err(self.error.clone())
+    }
+}
+
+/// Mock backup operations that always fails with a configurable error.
+#[derive(Debug, Clone)]
+pub struct FailingMockBackupOperations {
+    error: String,
+}
+
+impl FailingMockBackupOperations {
+    /// Create a new failing mock with the given error message.
+    pub fn new(error: impl Into<String>) -> Self {
+        Self {
+            error: error.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl BackupOperations for FailingMockBackupOperations {
+    async fn export(
+        &self,
+        _collections: Option<Vec<String>>,
+        _pretty: bool,
+    ) -> std::result::Result<String, String> {
+        Err(self.error.clone())
+    }
+
+    async fn import(&self, _data: &str) -> std::result::Result<ImportResult, String> {
+        Err(self.error.clone())
+    }
+}

--- a/crates/http/src/router.rs
+++ b/crates/http/src/router.rs
@@ -222,6 +222,44 @@ impl std::fmt::Debug for AppState {
     }
 }
 
+impl AppState {
+    /// Get P2P operations or return ServiceUnavailable error.
+    pub fn require_p2p(&self) -> Result<&Arc<dyn P2POperations>, crate::error::HttpError> {
+        self.p2p.as_ref().ok_or_else(|| {
+            crate::error::HttpError::ServiceUnavailable(
+                "P2P networking is not enabled. Start the server with P2P enabled to use this feature.".into()
+            )
+        })
+    }
+
+    /// Get ACP operations or return ServiceUnavailable error.
+    pub fn require_acp(&self) -> Result<&Arc<dyn AcpOperations>, crate::error::HttpError> {
+        self.acp.as_ref().ok_or_else(|| {
+            crate::error::HttpError::ServiceUnavailable(
+                "ACP (Access Control Policy) is not enabled. Start the server with ACP enabled to use this feature.".into()
+            )
+        })
+    }
+
+    /// Get index operations or return ServiceUnavailable error.
+    pub fn require_index(&self) -> Result<&Arc<dyn IndexOperations>, crate::error::HttpError> {
+        self.index.as_ref().ok_or_else(|| {
+            crate::error::HttpError::ServiceUnavailable(
+                "Index operations are not enabled. Start the server with indexing enabled to use this feature.".into()
+            )
+        })
+    }
+
+    /// Get backup operations or return ServiceUnavailable error.
+    pub fn require_backup(&self) -> Result<&Arc<dyn BackupOperations>, crate::error::HttpError> {
+        self.backup.as_ref().ok_or_else(|| {
+            crate::error::HttpError::ServiceUnavailable(
+                "Backup operations are not enabled. Start the server with backup enabled to use this feature.".into()
+            )
+        })
+    }
+}
+
 /// Builder for constructing AppState with optional components.
 pub struct AppStateBuilder {
     executor: Arc<dyn QueryExecutor>,

--- a/crates/http/src/router.rs
+++ b/crates/http/src/router.rs
@@ -12,11 +12,147 @@ use query::rest::RestOperations;
 
 use crate::handlers;
 
+/// Trait for P2P operations that can be accessed via HTTP.
+///
+/// This trait abstracts the P2P host handle for testing.
+#[async_trait::async_trait]
+pub trait P2POperations: Send + Sync {
+    /// Get the local peer ID.
+    async fn local_peer_id(&self) -> Result<String, String>;
+
+    /// Get listening addresses.
+    async fn listen_addresses(&self) -> Result<Vec<String>, String>;
+
+    /// Get connected peers.
+    async fn connected_peers(&self) -> Result<Vec<String>, String>;
+
+    /// Connect to a peer at the given address.
+    async fn connect_peer(&self, addr: &str) -> Result<(), String>;
+
+    /// Get all replicators.
+    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String>;
+
+    /// Add a replicator for collections.
+    async fn add_replicator(
+        &self,
+        collections: Vec<String>,
+        addr: Option<&str>,
+    ) -> Result<(), String>;
+
+    /// Remove a replicator for collections.
+    async fn remove_replicator(
+        &self,
+        collections: Vec<String>,
+        addr: Option<&str>,
+    ) -> Result<(), String>;
+
+    /// Get P2P collections.
+    async fn get_collections(&self) -> Result<Vec<String>, String>;
+
+    /// Add collections to P2P.
+    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String>;
+
+    /// Remove collections from P2P.
+    async fn remove_collections(&self, collections: Vec<String>) -> Result<(), String>;
+}
+
+/// Replicator information for HTTP responses.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ReplicatorInfo {
+    pub id: Option<String>,
+    pub collections: Vec<String>,
+    pub address: Option<String>,
+}
+
+/// Trait for ACP policy operations.
+#[async_trait::async_trait]
+pub trait AcpOperations: Send + Sync {
+    /// Add a new policy. Returns the policy ID.
+    async fn add_policy(&self, policy: &str) -> Result<String, String>;
+
+    /// List all policies.
+    async fn list_policies(&self) -> Result<Vec<PolicyInfo>, String>;
+
+    /// Get a policy by ID.
+    async fn get_policy(&self, id: &str) -> Result<Option<PolicyInfo>, String>;
+}
+
+/// Policy information for HTTP responses.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PolicyInfo {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creation_time: Option<String>,
+}
+
+/// Trait for index operations.
+#[async_trait::async_trait]
+pub trait IndexOperations: Send + Sync {
+    /// Create an index. Returns the created index info.
+    async fn create_index(
+        &self,
+        collection: &str,
+        fields: Vec<String>,
+        name: Option<&str>,
+        unique: bool,
+    ) -> Result<IndexInfo, String>;
+
+    /// List indexes, optionally filtered by collection.
+    async fn list_indexes(&self, collection: Option<&str>) -> Result<Vec<IndexInfo>, String>;
+
+    /// Drop an index.
+    async fn drop_index(&self, collection: &str, name: &str) -> Result<(), String>;
+}
+
+/// Index information for HTTP responses.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IndexInfo {
+    pub name: String,
+    pub collection: String,
+    pub fields: Vec<IndexFieldInfo>,
+    #[serde(default)]
+    pub unique: bool,
+}
+
+/// Index field information.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IndexFieldInfo {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<String>,
+}
+
+/// Trait for backup operations.
+#[async_trait::async_trait]
+pub trait BackupOperations: Send + Sync {
+    /// Export database to JSON.
+    async fn export(
+        &self,
+        collections: Option<Vec<String>>,
+        pretty: bool,
+    ) -> Result<String, String>;
+
+    /// Import database from JSON.
+    async fn import(&self, data: &str) -> Result<(), String>;
+}
+
 /// Application state shared across handlers.
 #[derive(Clone)]
 pub struct AppState {
     pub executor: Arc<dyn QueryExecutor>,
     pub rest: Option<Arc<dyn RestOperations>>,
+    pub p2p: Option<Arc<dyn P2POperations>>,
+    pub acp: Option<Arc<dyn AcpOperations>>,
+    pub index: Option<Arc<dyn IndexOperations>>,
+    pub backup: Option<Arc<dyn BackupOperations>>,
 }
 
 impl std::fmt::Debug for AppState {
@@ -24,7 +160,77 @@ impl std::fmt::Debug for AppState {
         f.debug_struct("AppState")
             .field("executor", &"<QueryExecutor>")
             .field("rest", &self.rest.as_ref().map(|_| "<RestOperations>"))
+            .field("p2p", &self.p2p.as_ref().map(|_| "<P2POperations>"))
+            .field("acp", &self.acp.as_ref().map(|_| "<AcpOperations>"))
+            .field("index", &self.index.as_ref().map(|_| "<IndexOperations>"))
+            .field("backup", &self.backup.as_ref().map(|_| "<BackupOperations>"))
             .finish()
+    }
+}
+
+/// Builder for constructing AppState with optional components.
+pub struct AppStateBuilder {
+    executor: Arc<dyn QueryExecutor>,
+    rest: Option<Arc<dyn RestOperations>>,
+    p2p: Option<Arc<dyn P2POperations>>,
+    acp: Option<Arc<dyn AcpOperations>>,
+    index: Option<Arc<dyn IndexOperations>>,
+    backup: Option<Arc<dyn BackupOperations>>,
+}
+
+impl AppStateBuilder {
+    /// Create a new builder with the required executor.
+    pub fn new(executor: Arc<dyn QueryExecutor>) -> Self {
+        Self {
+            executor,
+            rest: None,
+            p2p: None,
+            acp: None,
+            index: None,
+            backup: None,
+        }
+    }
+
+    /// Set REST operations.
+    pub fn with_rest(mut self, rest: Arc<dyn RestOperations>) -> Self {
+        self.rest = Some(rest);
+        self
+    }
+
+    /// Set P2P operations.
+    pub fn with_p2p(mut self, p2p: Arc<dyn P2POperations>) -> Self {
+        self.p2p = Some(p2p);
+        self
+    }
+
+    /// Set ACP operations.
+    pub fn with_acp(mut self, acp: Arc<dyn AcpOperations>) -> Self {
+        self.acp = Some(acp);
+        self
+    }
+
+    /// Set index operations.
+    pub fn with_index(mut self, index: Arc<dyn IndexOperations>) -> Self {
+        self.index = Some(index);
+        self
+    }
+
+    /// Set backup operations.
+    pub fn with_backup(mut self, backup: Arc<dyn BackupOperations>) -> Self {
+        self.backup = Some(backup);
+        self
+    }
+
+    /// Build the AppState.
+    pub fn build(self) -> AppState {
+        AppState {
+            executor: self.executor,
+            rest: self.rest,
+            p2p: self.p2p,
+            acp: self.acp,
+            index: self.index,
+            backup: self.backup,
+        }
     }
 }
 
@@ -33,7 +239,8 @@ impl std::fmt::Debug for AppState {
 /// This creates a router with GraphQL endpoints only (no REST).
 /// Use `create_router_with_rest` to include REST endpoints.
 pub fn create_router(executor: Arc<dyn QueryExecutor>) -> Router {
-    create_router_internal(executor, None)
+    let state = AppStateBuilder::new(executor).build();
+    create_router_with_state(state)
 }
 
 /// Create the main router with all routes including REST endpoints.
@@ -41,15 +248,14 @@ pub fn create_router_with_rest(
     executor: Arc<dyn QueryExecutor>,
     rest: Arc<dyn RestOperations>,
 ) -> Router {
-    create_router_internal(executor, Some(rest))
+    let state = AppStateBuilder::new(executor).with_rest(rest).build();
+    create_router_with_state(state)
 }
 
-fn create_router_internal(
-    executor: Arc<dyn QueryExecutor>,
-    rest: Option<Arc<dyn RestOperations>>,
-) -> Router {
-    let state = AppState { executor, rest };
-
+/// Create the main router with full AppState.
+///
+/// This allows configuring all optional components (REST, P2P, ACP, Index, Backup).
+pub fn create_router_with_state(state: AppState) -> Router {
     // Health check at root level (matches Go DefraDB)
     let root_routes = Router::new().route("/health-check", get(handlers::health_check));
 
@@ -68,6 +274,35 @@ fn create_router_internal(
         .route("/:name/:docID", patch(handlers::update_document))
         .route("/:name/:docID", delete(handlers::delete_document));
 
+    // P2P routes
+    let p2p_routes = Router::new()
+        .route("/info", get(handlers::p2p::get_info))
+        .route("/peers", get(handlers::p2p::list_peers))
+        .route("/peers", post(handlers::p2p::connect_peer))
+        .route("/replicator", get(handlers::p2p::list_replicators))
+        .route("/replicator", post(handlers::p2p::add_replicator))
+        .route("/replicator", delete(handlers::p2p::remove_replicator))
+        .route("/collections", get(handlers::p2p::list_collections))
+        .route("/collections", post(handlers::p2p::add_collections))
+        .route("/collections", delete(handlers::p2p::remove_collections));
+
+    // ACP routes
+    let acp_routes = Router::new()
+        .route("/policy", post(handlers::acp::add_policy))
+        .route("/policy", get(handlers::acp::list_policies))
+        .route("/policy/:id", get(handlers::acp::get_policy));
+
+    // Index routes
+    let index_routes = Router::new()
+        .route("/", post(handlers::index::create_index))
+        .route("/", get(handlers::index::list_indexes))
+        .route("/", delete(handlers::index::drop_index));
+
+    // Backup routes
+    let backup_routes = Router::new()
+        .route("/export", get(handlers::backup::export))
+        .route("/import", post(handlers::backup::import));
+
     // API v0 routes
     let api_routes = Router::new()
         // GraphQL endpoints
@@ -79,6 +314,14 @@ fn create_router_internal(
         .nest("/tx", tx_routes)
         // REST collection endpoints
         .nest("/collections", collection_routes)
+        // P2P endpoints
+        .nest("/p2p", p2p_routes)
+        // ACP endpoints
+        .nest("/acp", acp_routes)
+        // Index endpoints
+        .nest("/index", index_routes)
+        // Backup endpoints
+        .nest("/backup", backup_routes)
         .with_state(state);
 
     root_routes.nest("/api/v0", api_routes)

--- a/crates/http/src/router.rs
+++ b/crates/http/src/router.rs
@@ -14,7 +14,13 @@ use crate::handlers;
 
 /// Trait for P2P operations that can be accessed via HTTP.
 ///
-/// This trait abstracts the P2P host handle for testing.
+/// Abstracts P2P host functionality to decouple HTTP handlers from the
+/// actual P2P implementation, enabling both dependency injection and testing.
+///
+/// All methods return `Result<T, String>` where the error string should be
+/// a user-friendly message. For validation failures, use descriptive messages
+/// like "invalid address format". For internal errors, use messages like
+/// "failed to connect: <reason>".
 #[async_trait::async_trait]
 pub trait P2POperations: Send + Sync {
     /// Get the local peer ID.
@@ -64,16 +70,28 @@ pub struct ReplicatorInfo {
     pub address: Option<String>,
 }
 
-/// Trait for ACP policy operations.
+/// Trait for ACP (Access Control Policy) operations.
+///
+/// ACP policies define access permissions for collections and documents,
+/// determining which identities can read, write, or manage data.
+///
+/// Policies should be provided in YAML or JSON format following the ACP
+/// policy specification.
 #[async_trait::async_trait]
 pub trait AcpOperations: Send + Sync {
-    /// Add a new policy. Returns the policy ID.
+    /// Add a new policy. Returns the policy ID on success.
+    ///
+    /// The policy should be valid YAML or JSON. Returns an error string
+    /// if the policy is malformed or cannot be added.
     async fn add_policy(&self, policy: &str) -> Result<String, String>;
 
     /// List all policies.
     async fn list_policies(&self) -> Result<Vec<PolicyInfo>, String>;
 
     /// Get a policy by ID.
+    ///
+    /// Returns `Ok(None)` if the policy doesn't exist, `Ok(Some(info))` if found,
+    /// or `Err(message)` on internal errors.
     async fn get_policy(&self, id: &str) -> Result<Option<PolicyInfo>, String>;
 }
 
@@ -94,9 +112,15 @@ pub struct PolicyInfo {
 }
 
 /// Trait for index operations.
+///
+/// Indexes improve query performance for specific fields. Creating unique
+/// indexes also enforces uniqueness constraints on the indexed fields.
 #[async_trait::async_trait]
 pub trait IndexOperations: Send + Sync {
-    /// Create an index. Returns the created index info.
+    /// Create an index on a collection. Returns the created index info.
+    ///
+    /// If `name` is `None`, an index name will be auto-generated.
+    /// The `unique` flag enforces uniqueness constraints on the indexed fields.
     async fn create_index(
         &self,
         collection: &str,
@@ -106,9 +130,11 @@ pub trait IndexOperations: Send + Sync {
     ) -> Result<IndexInfo, String>;
 
     /// List indexes, optionally filtered by collection.
+    ///
+    /// If `collection` is `None`, returns indexes from all collections.
     async fn list_indexes(&self, collection: Option<&str>) -> Result<Vec<IndexInfo>, String>;
 
-    /// Drop an index.
+    /// Drop an index by collection and name.
     async fn drop_index(&self, collection: &str, name: &str) -> Result<(), String>;
 }
 
@@ -131,9 +157,19 @@ pub struct IndexFieldInfo {
 }
 
 /// Trait for backup operations.
+///
+/// Enables exporting and importing database state as JSON. Export produces
+/// a JSON representation of documents that can be reimported to restore state.
+///
+/// For export, the JSON includes document metadata and relationships.
+/// For import, the JSON must match the expected structure with valid document
+/// IDs and collection references.
 #[async_trait::async_trait]
 pub trait BackupOperations: Send + Sync {
     /// Export database to JSON.
+    ///
+    /// If `collections` is `None`, exports all collections.
+    /// If `pretty` is true, the JSON output is formatted with indentation.
     async fn export(
         &self,
         collections: Option<Vec<String>>,
@@ -141,6 +177,9 @@ pub trait BackupOperations: Send + Sync {
     ) -> Result<String, String>;
 
     /// Import database from JSON.
+    ///
+    /// The `data` parameter should be valid JSON matching the export format.
+    /// Returns an error if the JSON is malformed or references invalid collections.
     async fn import(&self, data: &str) -> Result<(), String>;
 }
 

--- a/crates/http/src/router.rs
+++ b/crates/http/src/router.rs
@@ -156,6 +156,20 @@ pub struct IndexFieldInfo {
     pub direction: Option<String>,
 }
 
+/// Result of a backup import operation.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ImportResult {
+    /// Number of documents successfully imported.
+    pub documents_imported: u64,
+    /// Number of documents skipped (e.g., duplicates).
+    pub documents_skipped: u64,
+    /// Collections that were affected by the import.
+    pub collections_affected: Vec<String>,
+    /// Errors encountered during import (non-fatal).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<String>,
+}
+
 /// Trait for backup operations.
 ///
 /// Enables exporting and importing database state as JSON. Export produces
@@ -179,8 +193,9 @@ pub trait BackupOperations: Send + Sync {
     /// Import database from JSON.
     ///
     /// The `data` parameter should be valid JSON matching the export format.
-    /// Returns an error if the JSON is malformed or references invalid collections.
-    async fn import(&self, data: &str) -> Result<(), String>;
+    /// Returns `ImportResult` with details about what was imported, skipped, and any errors.
+    /// A fatal error (e.g., completely malformed data) returns `Err(message)`.
+    async fn import(&self, data: &str) -> Result<ImportResult, String>;
 }
 
 /// Application state shared across handlers.

--- a/crates/http/src/validation.rs
+++ b/crates/http/src/validation.rs
@@ -1,0 +1,99 @@
+//! Input validation utilities for HTTP handlers.
+
+use crate::error::HttpError;
+
+/// Validate that a string is a valid identifier (collection name, field name, etc.)
+///
+/// Identifiers must:
+/// - Start with a letter or underscore
+/// - Contain only letters, digits, and underscores
+/// - Not be empty
+pub fn validate_identifier(name: &str) -> Result<(), HttpError> {
+    if name.is_empty() {
+        return Err(HttpError::BadRequest(
+            "identifier cannot be empty".to_string(),
+        ));
+    }
+
+    let valid = name.chars().enumerate().all(|(i, c)| {
+        if i == 0 {
+            c.is_ascii_alphabetic() || c == '_'
+        } else {
+            c.is_ascii_alphanumeric() || c == '_'
+        }
+    });
+
+    if !valid {
+        return Err(HttpError::BadRequest(format!(
+            "'{}' is not a valid identifier (must match [A-Za-z_][A-Za-z0-9_]*)",
+            name
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate a collection name.
+pub fn validate_collection_name(name: &str) -> Result<(), HttpError> {
+    validate_identifier(name).map_err(|_| {
+        HttpError::BadRequest(format!(
+            "invalid collection name '{}': must match [A-Za-z_][A-Za-z0-9_]*",
+            name
+        ))
+    })
+}
+
+/// Validate a P2P multiaddr address format.
+///
+/// Basic validation: multiaddrs must start with '/'.
+/// Full validation happens in the P2P layer.
+pub fn validate_multiaddr(address: &str) -> Result<(), HttpError> {
+    if address.trim().is_empty() {
+        return Err(HttpError::BadRequest(
+            "address cannot be empty".to_string(),
+        ));
+    }
+
+    if !address.starts_with('/') {
+        return Err(HttpError::BadRequest(format!(
+            "invalid multiaddr '{}': must start with '/' (e.g., /ip4/127.0.0.1/tcp/9000/p2p/...)",
+            address
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_identifier_valid() {
+        assert!(validate_identifier("Users").is_ok());
+        assert!(validate_identifier("_private").is_ok());
+        assert!(validate_identifier("User123").is_ok());
+        assert!(validate_identifier("_").is_ok());
+    }
+
+    #[test]
+    fn test_validate_identifier_invalid() {
+        assert!(validate_identifier("").is_err());
+        assert!(validate_identifier("123Users").is_err());
+        assert!(validate_identifier("User-Name").is_err());
+        assert!(validate_identifier("User Name").is_err());
+    }
+
+    #[test]
+    fn test_validate_multiaddr_valid() {
+        assert!(validate_multiaddr("/ip4/127.0.0.1/tcp/9000").is_ok());
+        assert!(validate_multiaddr("/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWtest").is_ok());
+    }
+
+    #[test]
+    fn test_validate_multiaddr_invalid() {
+        assert!(validate_multiaddr("").is_err());
+        assert!(validate_multiaddr("192.168.1.1").is_err());
+        assert!(validate_multiaddr("localhost:9000").is_err());
+    }
+}

--- a/crates/http/src/validation.rs
+++ b/crates/http/src/validation.rs
@@ -74,6 +74,8 @@ mod tests {
         assert!(validate_identifier("_private").is_ok());
         assert!(validate_identifier("User123").is_ok());
         assert!(validate_identifier("_").is_ok());
+        assert!(validate_identifier("A").is_ok());
+        assert!(validate_identifier("_1").is_ok());
     }
 
     #[test]
@@ -85,9 +87,51 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_identifier_unicode() {
+        // Unicode characters should be rejected
+        assert!(validate_identifier("Usuários").is_err());
+        assert!(validate_identifier("用户").is_err());
+        assert!(validate_identifier("Users日本").is_err());
+        assert!(validate_identifier("Пользователи").is_err());
+    }
+
+    #[test]
+    fn test_validate_identifier_control_chars() {
+        // Control characters should be rejected
+        assert!(validate_identifier("Users\0").is_err()); // null byte
+        assert!(validate_identifier("Users\n").is_err()); // newline
+        assert!(validate_identifier("Users\t").is_err()); // tab
+        assert!(validate_identifier("Users\r").is_err()); // carriage return
+    }
+
+    #[test]
+    fn test_validate_identifier_special_chars() {
+        // Special characters should be rejected
+        assert!(validate_identifier("Users!").is_err());
+        assert!(validate_identifier("Users@").is_err());
+        assert!(validate_identifier("Users#").is_err());
+        assert!(validate_identifier("Users$").is_err());
+        assert!(validate_identifier("Users%").is_err());
+        assert!(validate_identifier("Users.field").is_err());
+        assert!(validate_identifier("Users/path").is_err());
+        assert!(validate_identifier("Users;DROP").is_err());
+        assert!(validate_identifier("Users'--").is_err());
+        assert!(validate_identifier("Users\"quote").is_err());
+    }
+
+    #[test]
+    fn test_validate_identifier_long_name() {
+        // Very long identifier should still be valid if it meets the pattern
+        let long_name = "a".repeat(1000);
+        assert!(validate_identifier(&long_name).is_ok());
+    }
+
+    #[test]
     fn test_validate_multiaddr_valid() {
         assert!(validate_multiaddr("/ip4/127.0.0.1/tcp/9000").is_ok());
         assert!(validate_multiaddr("/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWtest").is_ok());
+        assert!(validate_multiaddr("/dns/example.com/tcp/9000").is_ok());
+        assert!(validate_multiaddr("/ip6/::1/tcp/9000").is_ok());
     }
 
     #[test]
@@ -95,5 +139,28 @@ mod tests {
         assert!(validate_multiaddr("").is_err());
         assert!(validate_multiaddr("192.168.1.1").is_err());
         assert!(validate_multiaddr("localhost:9000").is_err());
+        assert!(validate_multiaddr("http://example.com").is_err());
+    }
+
+    #[test]
+    fn test_validate_multiaddr_whitespace() {
+        // Empty and whitespace-only should be rejected
+        assert!(validate_multiaddr("   ").is_err());
+        assert!(validate_multiaddr("\t").is_err());
+        assert!(validate_multiaddr("\n").is_err());
+    }
+
+    #[test]
+    fn test_validate_collection_name_valid() {
+        assert!(validate_collection_name("Users").is_ok());
+        assert!(validate_collection_name("_private").is_ok());
+        assert!(validate_collection_name("Collection123").is_ok());
+    }
+
+    #[test]
+    fn test_validate_collection_name_invalid() {
+        assert!(validate_collection_name("").is_err());
+        assert!(validate_collection_name("123Collection").is_err());
+        assert!(validate_collection_name("User-Name").is_err());
     }
 }

--- a/crates/http/tests/documents_tests.rs
+++ b/crates/http/tests/documents_tests.rs
@@ -8,29 +8,24 @@ use serde_json::json;
 
 use defra_http::identity_extractor::ExtractIdentity;
 use defra_http::mock::{FailingMockRestOperations, MockQueryExecutor, MockRestOperations};
-use defra_http::{handlers, AppState, HttpError};
+use defra_http::{handlers, AppState, AppStateBuilder, HttpError};
 use query::executor::QueryExecutor;
 use query::rest::RestOperations;
 
 fn create_state() -> AppState {
-    AppState {
-        executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-        rest: Some(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>),
-    }
+    AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+        .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
+        .build()
 }
 
 fn create_state_without_rest() -> AppState {
-    AppState {
-        executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-        rest: None,
-    }
+    AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>).build()
 }
 
 fn create_failing_state() -> AppState {
-    AppState {
-        executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-        rest: Some(Arc::new(FailingMockRestOperations::new("test error"))),
-    }
+    AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+        .with_rest(Arc::new(FailingMockRestOperations::new("test error")))
+        .build()
 }
 
 fn anonymous() -> ExtractIdentity {
@@ -345,12 +340,11 @@ async fn test_create_empty_document_array() {
 // =========================================================================
 
 fn create_invalid_doc_id_state() -> AppState {
-    AppState {
-        executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-        rest: Some(Arc::new(FailingMockRestOperations::with_invalid_doc_id(
+    AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+        .with_rest(Arc::new(FailingMockRestOperations::with_invalid_doc_id(
             "bad-id",
-        ))),
-    }
+        )))
+        .build()
 }
 
 #[tokio::test]
@@ -407,12 +401,11 @@ async fn test_delete_document_invalid_doc_id() {
 // =========================================================================
 
 fn create_invalid_input_state() -> AppState {
-    AppState {
-        executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-        rest: Some(Arc::new(FailingMockRestOperations::with_invalid_input(
+    AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+        .with_rest(Arc::new(FailingMockRestOperations::with_invalid_input(
             "type mismatch: expected String, got Int",
-        ))),
-    }
+        )))
+        .build()
 }
 
 #[tokio::test]
@@ -454,12 +447,11 @@ async fn test_update_document_invalid_input() {
 // =========================================================================
 
 fn create_permission_denied_state() -> AppState {
-    AppState {
-        executor: Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>,
-        rest: Some(Arc::new(FailingMockRestOperations::with_permission_denied(
+    AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+        .with_rest(Arc::new(FailingMockRestOperations::with_permission_denied(
             "access denied for user",
-        ))),
-    }
+        )))
+        .build()
 }
 
 #[tokio::test]

--- a/crates/http/tests/handler_tests.rs
+++ b/crates/http/tests/handler_tests.rs
@@ -1,0 +1,729 @@
+//! Integration tests for ACP, Index, Backup, and P2P handlers.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tower::ServiceExt;
+
+use defra_http::mock::{
+    MockAcpOperations, MockBackupOperations, MockIndexOperations, MockP2POperations,
+    MockQueryExecutor,
+};
+use defra_http::{create_router_with_state, AppStateBuilder};
+
+// ============================================================================
+// P2P Handler Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_p2p_info_without_p2p_enabled() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let state = AppStateBuilder::new(executor).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/p2p/info")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should return 503 Service Unavailable when P2P not configured
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_p2p_info_with_p2p_enabled() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/p2p/info")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let info: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(info.get("id").is_some());
+    assert!(info.get("addresses").is_some());
+}
+
+#[tokio::test]
+async fn test_p2p_list_peers() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new().with_peer("12D3KooWTestPeer"));
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/p2p/peers")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let peers: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+    assert_eq!(peers.len(), 1);
+}
+
+#[tokio::test]
+async fn test_p2p_connect_peer() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/peers")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"address": "/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWTestPeer"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_p2p_connect_peer_invalid_address() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/peers")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"address": "invalid-address"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_p2p_add_replicator() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/replicator")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"collections": ["Users"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_p2p_add_replicator_empty_collections() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/replicator")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"collections": []}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_p2p_add_collections() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/collections")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"collections": ["Users", "Posts"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ============================================================================
+// ACP Handler Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_acp_without_acp_enabled() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let state = AppStateBuilder::new(executor).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/acp/policy")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should return 503 Service Unavailable when ACP not configured
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_acp_add_policy() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let acp = Arc::new(MockAcpOperations::new());
+    let state = AppStateBuilder::new(executor).with_acp(acp).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/acp/policy")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"policy": "name: test\nresources: []"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(result.get("PolicyID").is_some());
+}
+
+#[tokio::test]
+async fn test_acp_list_policies() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let acp = Arc::new(MockAcpOperations::new().with_policy("policy-1", Some("Test Policy")));
+    let state = AppStateBuilder::new(executor).with_acp(acp).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/acp/policy")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let policies: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+    assert_eq!(policies.len(), 1);
+    assert_eq!(policies[0].get("id").unwrap(), "policy-1");
+}
+
+#[tokio::test]
+async fn test_acp_get_policy() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let acp = Arc::new(MockAcpOperations::new().with_policy("policy-1", Some("Test Policy")));
+    let state = AppStateBuilder::new(executor).with_acp(acp).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/acp/policy/policy-1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let policy: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(policy.get("id").unwrap(), "policy-1");
+}
+
+#[tokio::test]
+async fn test_acp_get_policy_not_found() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let acp = Arc::new(MockAcpOperations::new());
+    let state = AppStateBuilder::new(executor).with_acp(acp).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/acp/policy/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ============================================================================
+// Index Handler Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_index_without_index_enabled() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let state = AppStateBuilder::new(executor).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/index")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should return 503 Service Unavailable when Index not configured
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_index_create() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(MockIndexOperations::new());
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/index")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"collection": "Users", "fields": ["name", "email"], "unique": true}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let index_info: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(index_info.get("name").is_some());
+    assert_eq!(index_info.get("collection").unwrap(), "Users");
+    assert_eq!(index_info.get("unique").unwrap(), true);
+}
+
+#[tokio::test]
+async fn test_index_create_empty_fields() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(MockIndexOperations::new());
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/index")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"collection": "Users", "fields": []}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_index_create_invalid_collection_name() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(MockIndexOperations::new());
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/index")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"collection": "123Invalid", "fields": ["name"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_index_list() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(
+        MockIndexOperations::new().with_index("Users", "idx_name", vec!["name"], false),
+    );
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/index")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let indexes: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+    assert_eq!(indexes.len(), 1);
+}
+
+#[tokio::test]
+async fn test_index_list_filtered_by_collection() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(
+        MockIndexOperations::new()
+            .with_index("Users", "idx_name", vec!["name"], false)
+            .with_index("Posts", "idx_title", vec!["title"], false),
+    );
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/index?collection=Users")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let indexes: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+    assert_eq!(indexes.len(), 1);
+    assert_eq!(indexes[0].get("collection").unwrap(), "Users");
+}
+
+#[tokio::test]
+async fn test_index_list_invalid_collection_name() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(MockIndexOperations::new());
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/index?collection=123Invalid")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_index_drop() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(
+        MockIndexOperations::new().with_index("Users", "idx_name", vec!["name"], false),
+    );
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/v0/index?collection=Users&name=idx_name")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ============================================================================
+// Backup Handler Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_backup_without_backup_enabled() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let state = AppStateBuilder::new(executor).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/backup/export")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should return 503 Service Unavailable when Backup not configured
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_backup_export() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/backup/export")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let data: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(data.get("Users").is_some());
+}
+
+#[tokio::test]
+async fn test_backup_export_pretty() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/backup/export?pretty=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    // Pretty printed JSON should have newlines
+    assert!(body_str.contains('\n'));
+}
+
+#[tokio::test]
+async fn test_backup_import() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/backup/import")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"Users": [{"_docID": "bae-456", "name": "Bob"}]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(result.get("success").unwrap(), true);
+    assert_eq!(result.get("documents_imported").unwrap(), 1);
+}
+
+#[tokio::test]
+async fn test_backup_import_empty_body() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/backup/import")
+                .header("content-type", "application/json")
+                .body(Body::from(""))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_backup_import_empty_json() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/backup/import")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_backup_import_invalid_json() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/backup/import")
+                .header("content-type", "application/json")
+                .body(Body::from("{invalid json}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_backup_import_primitive_json() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/backup/import")
+                .header("content-type", "application/json")
+                .body(Body::from("\"just a string\""))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/http/tests/handler_tests.rs
+++ b/crates/http/tests/handler_tests.rs
@@ -9,8 +9,9 @@ use axum::{
 use tower::ServiceExt;
 
 use defra_http::mock::{
-    MockAcpOperations, MockBackupOperations, MockIndexOperations, MockP2POperations,
-    MockQueryExecutor,
+    FailingMockAcpOperations, FailingMockBackupOperations, FailingMockIndexOperations,
+    FailingMockP2POperations, MockAcpOperations, MockBackupOperations, MockIndexOperations,
+    MockP2POperations, MockQueryExecutor,
 };
 use defra_http::{create_router_with_state, AppStateBuilder};
 
@@ -720,6 +721,469 @@ async fn test_backup_import_primitive_json() {
                 .uri("/api/v0/backup/import")
                 .header("content-type", "application/json")
                 .body(Body::from("\"just a string\""))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ============================================================================
+// Error Path Tests with Failing Mocks
+// ============================================================================
+
+#[tokio::test]
+async fn test_p2p_info_internal_error() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(FailingMockP2POperations::new("P2P service unavailable"));
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/p2p/info")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_p2p_connect_peer_internal_error() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(FailingMockP2POperations::new("Connection refused"));
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/peers")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"address": "/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWTestPeer"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_acp_add_policy_internal_error() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let acp = Arc::new(FailingMockAcpOperations::new("Policy validation failed"));
+    let state = AppStateBuilder::new(executor).with_acp(acp).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/acp/policy")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"policy": "name: test\nresources: []"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_acp_list_policies_internal_error() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let acp = Arc::new(FailingMockAcpOperations::new("Database connection failed"));
+    let state = AppStateBuilder::new(executor).with_acp(acp).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/acp/policy")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_index_create_internal_error() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(FailingMockIndexOperations::new("Collection not found"));
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/index")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"collection": "Users", "fields": ["name"], "unique": false}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_index_list_internal_error() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(FailingMockIndexOperations::new("Database unavailable"));
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/index")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_backup_export_internal_error() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(FailingMockBackupOperations::new("Export failed"));
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/backup/export")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_backup_import_internal_error() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(FailingMockBackupOperations::new("Import failed"));
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/backup/import")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"Users": [{"_docID": "bae-456", "name": "Bob"}]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ============================================================================
+// Validation Edge Case Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_index_create_unicode_collection_name() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(MockIndexOperations::new());
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/index")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"collection": "Usuários", "fields": ["name"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Unicode characters should be rejected
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_index_create_field_with_special_chars() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(MockIndexOperations::new());
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/index")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"collection": "Users", "fields": ["name-field"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Hyphens should be rejected
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_index_create_field_with_spaces() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let index = Arc::new(MockIndexOperations::new());
+    let state = AppStateBuilder::new(executor).with_index(index).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/index")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"collection": "Users", "fields": ["field name"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Spaces should be rejected
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_p2p_add_replicator_invalid_collection_name() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/replicator")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"collections": ["123Invalid"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_p2p_add_collections_invalid_collection_name() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/collections")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"collections": ["Users", "Invalid-Name"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_p2p_multiaddr_empty_string() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/peers")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"address": ""}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_p2p_multiaddr_whitespace_only() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let p2p = Arc::new(MockP2POperations::new());
+    let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/p2p/peers")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"address": "   "}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ============================================================================
+// ACP Policy Validation Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_acp_add_policy_empty_string() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let acp = Arc::new(MockAcpOperations::new());
+    let state = AppStateBuilder::new(executor).with_acp(acp).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/acp/policy")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"policy": ""}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_acp_add_policy_whitespace_only() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let acp = Arc::new(MockAcpOperations::new());
+    let state = AppStateBuilder::new(executor).with_acp(acp).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/acp/policy")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"policy": "   \n\t  "}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ============================================================================
+// Backup Edge Case Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_backup_import_empty_array() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/backup/import")
+                .header("content-type", "application/json")
+                .body(Body::from("[]"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Empty array should be rejected
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_backup_import_number_json() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v0/backup/import")
+                .header("content-type", "application/json")
+                .body(Body::from("123"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Number primitive should be rejected
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_backup_export_invalid_collection_name() {
+    let executor = Arc::new(MockQueryExecutor::new());
+    let backup = Arc::new(MockBackupOperations::new());
+    let state = AppStateBuilder::new(executor).with_backup(backup).build();
+    let router = create_router_with_state(state);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/api/v0/backup/export?collections=123Invalid")
+                .body(Body::empty())
                 .unwrap(),
         )
         .await

--- a/crates/http/tests/router_tests.rs
+++ b/crates/http/tests/router_tests.rs
@@ -63,6 +63,7 @@ async fn test_collections_route_without_rest() {
         .unwrap();
 
     // Should return 500 because REST operations are not configured
+    // (REST uses Internal error, unlike P2P/ACP/Index/Backup which use ServiceUnavailable)
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
 


### PR DESCRIPTION
## Summary
Add four new CLI command groups to achieve Go CLI parity:
- `defra client acp` - Access Control Policy management
- `defra client backup` - Database backup/restore  
- `defra client index` - Index management
- `defra client p2p` - P2P network management

## New Commands

### ACP (Access Control Policies)
```
defra client acp add <policy>        # Add policy from inline YAML/JSON
defra client acp add -f <file>       # Add policy from file
defra client acp list                # List all policies
defra client acp describe <id>       # Show policy details
```

### Backup
```
defra client backup export <file>    # Export database to file
  -c, --collections                  # Filter by collection(s)
  --pretty                           # Pretty print JSON output
defra client backup import <file>    # Import database from file
```

### Index
```
defra client index create <collection> --fields <fields>
  -n, --name                         # Optional custom index name
  --unique                           # Create unique index
defra client index list [collection] # List indexes
defra client index drop <collection> <name>
```

### P2P
```
defra client p2p info                # Show P2P node information
defra client p2p peers list          # List connected peers
defra client p2p peers add <address> # Connect to a peer
defra client p2p replicator list     # List replicators
defra client p2p replicator add -c <collection>
defra client p2p replicator delete -c <collection>
defra client p2p collection list     # List P2P collections
defra client p2p collection add -c <collection>
defra client p2p collection remove -c <collection>
```

## Test plan
- [x] All existing tests pass
- [x] Clippy clean
- [x] CLI help shows new commands correctly
- [ ] Integration testing with live server (requires #119 backend implementation)

Closes #106, #107, #108, #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)