### PR TITLE
feat(storage): Unify ACP storage into main database with namespace isolation

### DIFF
--- a/crates/acp/src/persistent.rs
+++ b/crates/acp/src/persistent.rs
@@ -1,8 +1,8 @@
-//! Persistent ACP store backed by redb.
+//! Persistent ACP store backed by any Store implementation.
 //!
-//! This implementation stores relation tuples in a separate redb instance,
-//! following Go DefraDB's architecture where ACP data is stored independently
-//! from document data at `<root>/local_document_acp/`.
+//! This implementation stores relation tuples with namespace isolation,
+//! allowing ACP data to be stored in the main database using the
+//! `Namespace::Acpstore` prefix, or in a standalone database.
 
 use async_trait::async_trait;
 use identity::Did;
@@ -10,41 +10,75 @@ use std::path::Path;
 use std::sync::Arc;
 
 use storage::corekv::{IterOptions, Reader, Store, Writer};
+use storage::namespace::{Namespace, NamespacedStore};
 use storage::RedbStore;
 
 use crate::error::{Error, Result};
 use crate::relation::RelationTuple;
 use crate::store::AcpStore;
 
-/// Persistent ACP store backed by redb.
+/// Persistent ACP store backed by any Store implementation.
 ///
-/// Stores relation tuples in a separate redb instance, providing:
+/// Stores relation tuples with namespace isolation, providing:
 /// - Persistence across node restarts
 /// - ACID transactions for tuple operations
 /// - Efficient prefix-based queries for document lookups
+/// - Namespace isolation when sharing a database with other stores
 ///
-/// # Directory Structure
+/// # Usage Modes
 ///
-/// Following Go DefraDB's convention, this store should be opened at:
-/// `<root>/local_document_acp/`
+/// ## Unified Mode (Recommended)
 ///
-/// # Example
+/// Share the main database with ACP namespace isolation:
 ///
 /// ```ignore
 /// use acp::PersistentAcpStore;
-/// use std::path::Path;
+/// use storage::RedbStore;
+/// use std::sync::Arc;
 ///
-/// let store = PersistentAcpStore::open(Path::new("/data/local_document_acp"))?;
+/// let main_store = Arc::new(RedbStore::open("/data")?);
+/// let acp_store = PersistentAcpStore::from_store(main_store);
 /// ```
-pub struct PersistentAcpStore {
-    store: Arc<RedbStore>,
+///
+/// ## Standalone Mode (Backward Compatible)
+///
+/// Use a separate database at `<root>/local_document_acp/`:
+///
+/// ```ignore
+/// use acp::PersistentAcpStore;
+///
+/// let store = PersistentAcpStore::open("/data/local_document_acp")?;
+/// ```
+pub struct PersistentAcpStore<S: Store> {
+    store: NamespacedStore<S>,
 }
 
-impl PersistentAcpStore {
+impl<S: Store> PersistentAcpStore<S> {
+    /// Create from an existing Store with ACP namespace isolation.
+    ///
+    /// This is the recommended way to create a PersistentAcpStore when
+    /// sharing a database with other stores. The ACP namespace prefix
+    /// ensures complete isolation from other data.
+    pub fn from_store(store: Arc<S>) -> Self {
+        Self {
+            store: NamespacedStore::new(store, Namespace::Acpstore),
+        }
+    }
+
+    /// Get the underlying namespaced store.
+    pub fn inner(&self) -> &NamespacedStore<S> {
+        &self.store
+    }
+}
+
+impl PersistentAcpStore<RedbStore> {
     /// Open a persistent ACP store at the given directory path.
     ///
     /// Creates the directory and database file (`acp.redb`) if they don't exist.
     /// The path should be a directory (e.g., `<root>/local_document_acp/`).
+    ///
+    /// This method provides backward compatibility for standalone ACP stores.
+    /// For new deployments, prefer `from_store()` with a shared database.
     ///
     /// # Errors
     ///
@@ -109,15 +143,8 @@ impl PersistentAcpStore {
         })?;
 
         Ok(Self {
-            store: Arc::new(store),
+            store: NamespacedStore::new(Arc::new(store), Namespace::Acpstore),
         })
-    }
-
-    /// Create from an existing RedbStore.
-    ///
-    /// Useful when the store is managed externally.
-    pub fn from_store(store: Arc<RedbStore>) -> Self {
-        Self { store }
     }
 
     /// Close the store.
@@ -130,7 +157,7 @@ impl PersistentAcpStore {
 }
 
 #[async_trait]
-impl AcpStore for PersistentAcpStore {
+impl<S: Store> AcpStore for PersistentAcpStore<S> {
     async fn put_tuple(&self, tuple: &RelationTuple) -> Result<()> {
         let mut txn = self
             .store

--- a/crates/acp/tests/persistent_tests.rs
+++ b/crates/acp/tests/persistent_tests.rs
@@ -3,7 +3,8 @@
 use acp::{AcpStore, PersistentAcpStore, RelationTuple};
 use identity::Did;
 use std::sync::Arc;
-use storage::corekv::{Reader, Store, Writer};
+use storage::corekv::{IterOptions, Reader, Store, Writer};
+use storage::namespace::{Namespace, NamespacedStore};
 use tempfile::TempDir;
 
 fn test_did() -> Did {
@@ -273,12 +274,10 @@ async fn test_unified_store_multiple_documents() {
     // Verify both documents are registered
     assert!(acp_store.is_doc_registered("users", "doc1").await.unwrap());
     assert!(acp_store.is_doc_registered("posts", "post1").await.unwrap());
-    assert!(
-        !acp_store
-            .is_doc_registered("users", "nonexistent")
-            .await
-            .unwrap()
-    );
+    assert!(!acp_store
+        .is_doc_registered("users", "nonexistent")
+        .await
+        .unwrap());
 }
 
 #[tokio::test]
@@ -310,4 +309,91 @@ async fn test_unified_store_atomic_registration() {
 
     // Document should be registered with the original owner
     assert!(acp_store.is_doc_registered("users", "doc1").await.unwrap());
+}
+
+#[tokio::test]
+async fn test_unified_store_atomic_registration_concurrent() {
+    let tmp_dir = TempDir::new().unwrap();
+    let db_path = tmp_dir.path().join("data");
+
+    let redb_store = Arc::new(storage::RedbStore::open(&db_path).unwrap());
+    let acp_store = Arc::new(PersistentAcpStore::from_store(redb_store.clone()));
+
+    let owner1 = test_did();
+    let owner2 = test_did2();
+
+    // Spawn concurrent registration attempts
+    let store1 = acp_store.clone();
+    let o1 = owner1.clone();
+    let h1 = tokio::spawn(async move { store1.register_doc_atomic(&o1, "users", "doc1").await });
+
+    let store2 = acp_store.clone();
+    let o2 = owner2.clone();
+    let h2 = tokio::spawn(async move { store2.register_doc_atomic(&o2, "users", "doc1").await });
+
+    let (r1, r2) = tokio::join!(h1, h2);
+    let success1 = r1.unwrap().unwrap();
+    let success2 = r2.unwrap().unwrap();
+
+    // Exactly one should succeed
+    assert!(
+        (success1 && !success2) || (!success1 && success2),
+        "Exactly one concurrent registration must succeed, got: r1={}, r2={}",
+        success1,
+        success2
+    );
+
+    // Document should be registered
+    assert!(acp_store.is_doc_registered("users", "doc1").await.unwrap());
+}
+
+#[tokio::test]
+async fn test_unified_store_isolation_from_namespaced_stores() {
+    let tmp_dir = TempDir::new().unwrap();
+    let db_path = tmp_dir.path().join("data");
+
+    let redb_store = Arc::new(storage::RedbStore::open(&db_path).unwrap());
+
+    // Create both ACP and Datastore using the NamespacedStore pattern
+    let acp_store = PersistentAcpStore::from_store(redb_store.clone());
+    let datastore = NamespacedStore::new(redb_store.clone(), Namespace::Datastore);
+
+    // Write ACP data
+    let tuple = RelationTuple::try_new(test_did(), "owner", "users", "doc1").expect("valid tuple");
+    acp_store.put_tuple(&tuple).await.unwrap();
+
+    // Write datastore data
+    {
+        let mut txn = datastore.new_txn(false).await.unwrap();
+        txn.set(b"collection/doc", b"document data").await.unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    // Datastore iteration should NOT see ACP data
+    {
+        let txn = datastore.new_txn(true).await.unwrap();
+        let opts = IterOptions::default();
+        let mut iter = txn.iterator(opts).await.unwrap();
+
+        while let Some(pair) = iter.next().await.unwrap() {
+            let key_str = String::from_utf8_lossy(&pair.key);
+            assert!(
+                !key_str.contains("/acp/"),
+                "Datastore should not see ACP keys via iteration, found: {}",
+                key_str
+            );
+        }
+    }
+
+    // ACP store should still work correctly
+    assert!(acp_store.has_tuple(&tuple).await.unwrap());
+    let doc_tuples = acp_store.get_doc_tuples("users", "doc1").await.unwrap();
+    assert_eq!(doc_tuples.len(), 1);
+
+    // Verify datastore can still read its own data
+    {
+        let txn = datastore.new_txn(true).await.unwrap();
+        let value = txn.get(b"collection/doc").await.unwrap();
+        assert_eq!(value, Some(b"document data".to_vec()));
+    }
 }

--- a/crates/acp/tests/persistent_tests.rs
+++ b/crates/acp/tests/persistent_tests.rs
@@ -2,6 +2,8 @@
 
 use acp::{AcpStore, PersistentAcpStore, RelationTuple};
 use identity::Did;
+use std::sync::Arc;
+use storage::corekv::{Reader, Store, Writer};
 use tempfile::TempDir;
 
 fn test_did() -> Did {
@@ -159,4 +161,153 @@ async fn test_persistent_store_unicode_identifiers() {
     // Cleanup works
     store.delete_doc_tuples("users", "文档1").await.unwrap();
     assert!(!store.is_doc_registered("users", "文档1").await.unwrap());
+}
+
+// ============================================================================
+// Unified Mode Tests (ACP sharing main database with namespace isolation)
+// ============================================================================
+
+#[tokio::test]
+async fn test_unified_store_basic_operations() {
+    let tmp_dir = TempDir::new().unwrap();
+    let db_path = tmp_dir.path().join("data");
+
+    // Create main redb store (simulating the main database)
+    let redb_store = Arc::new(storage::RedbStore::open(&db_path).unwrap());
+
+    // Create ACP store from main database using unified mode
+    let acp_store = PersistentAcpStore::from_store(redb_store.clone());
+
+    // Verify basic ACP operations work
+    let tuple = RelationTuple::try_new(test_did(), "owner", "users", "doc1").expect("valid tuple");
+
+    assert!(!acp_store.has_tuple(&tuple).await.unwrap());
+    acp_store.put_tuple(&tuple).await.unwrap();
+    assert!(acp_store.has_tuple(&tuple).await.unwrap());
+
+    // Verify document registration
+    assert!(acp_store.is_doc_registered("users", "doc1").await.unwrap());
+
+    // Cleanup
+    acp_store.delete_tuple(&tuple).await.unwrap();
+    assert!(!acp_store.has_tuple(&tuple).await.unwrap());
+}
+
+#[tokio::test]
+async fn test_unified_store_namespace_isolation() {
+    let tmp_dir = TempDir::new().unwrap();
+    let db_path = tmp_dir.path().join("data");
+
+    // Create main redb store
+    let redb_store = Arc::new(storage::RedbStore::open(&db_path).unwrap());
+
+    // Create ACP store from main database
+    let acp_store = PersistentAcpStore::from_store(redb_store.clone());
+
+    // Write an ACP tuple
+    let tuple = RelationTuple::try_new(test_did(), "owner", "users", "doc1").expect("valid tuple");
+    acp_store.put_tuple(&tuple).await.unwrap();
+
+    // Write some non-ACP data directly to the main store
+    // This simulates other stores (datastore, blockstore, etc.) writing data
+    {
+        let mut txn = redb_store.new_txn(false).await.unwrap();
+        txn.set(b"d/collection/doc", b"document data")
+            .await
+            .unwrap();
+        txn.set(b"b/block/cid", b"block data").await.unwrap();
+        txn.commit().await.unwrap();
+    }
+
+    // Verify ACP data is still accessible and correct
+    assert!(acp_store.has_tuple(&tuple).await.unwrap());
+
+    // Verify the raw store contains both ACP (with 'a' prefix) and other data
+    {
+        let txn = redb_store.new_txn(true).await.unwrap();
+
+        // Non-ACP data should be accessible directly
+        assert!(txn.has(b"d/collection/doc").await.unwrap());
+        assert!(txn.has(b"b/block/cid").await.unwrap());
+
+        // ACP data should be prefixed with 'a' namespace byte
+        let acp_key = tuple.storage_key();
+        let prefixed_key = format!("a{}", acp_key);
+        assert!(
+            txn.has(prefixed_key.as_bytes()).await.unwrap(),
+            "ACP data should be stored with 'a' namespace prefix"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_unified_store_multiple_documents() {
+    let tmp_dir = TempDir::new().unwrap();
+    let db_path = tmp_dir.path().join("data");
+
+    let redb_store = Arc::new(storage::RedbStore::open(&db_path).unwrap());
+    let acp_store = PersistentAcpStore::from_store(redb_store.clone());
+
+    let did1 = test_did();
+    let did2 = test_did2();
+
+    // Register multiple documents with different permissions
+    let tuple1 =
+        RelationTuple::try_new(did1.clone(), "owner", "users", "doc1").expect("valid tuple");
+    let tuple2 =
+        RelationTuple::try_new(did2.clone(), "reader", "users", "doc1").expect("valid tuple");
+    let tuple3 =
+        RelationTuple::try_new(did1.clone(), "owner", "posts", "post1").expect("valid tuple");
+
+    acp_store.put_tuple(&tuple1).await.unwrap();
+    acp_store.put_tuple(&tuple2).await.unwrap();
+    acp_store.put_tuple(&tuple3).await.unwrap();
+
+    // Verify document lookups work correctly
+    let doc1_tuples = acp_store.get_doc_tuples("users", "doc1").await.unwrap();
+    assert_eq!(doc1_tuples.len(), 2);
+
+    let post1_tuples = acp_store.get_doc_tuples("posts", "post1").await.unwrap();
+    assert_eq!(post1_tuples.len(), 1);
+
+    // Verify both documents are registered
+    assert!(acp_store.is_doc_registered("users", "doc1").await.unwrap());
+    assert!(acp_store.is_doc_registered("posts", "post1").await.unwrap());
+    assert!(
+        !acp_store
+            .is_doc_registered("users", "nonexistent")
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_unified_store_atomic_registration() {
+    let tmp_dir = TempDir::new().unwrap();
+    let db_path = tmp_dir.path().join("data");
+
+    let redb_store = Arc::new(storage::RedbStore::open(&db_path).unwrap());
+    let acp_store = PersistentAcpStore::from_store(redb_store.clone());
+
+    let owner = test_did();
+
+    // First registration should succeed
+    let registered = acp_store
+        .register_doc_atomic(&owner, "users", "doc1")
+        .await
+        .unwrap();
+    assert!(registered, "first registration should succeed");
+
+    // Second registration should fail (document already registered)
+    let registered_again = acp_store
+        .register_doc_atomic(&owner, "users", "doc1")
+        .await
+        .unwrap();
+    assert!(
+        !registered_again,
+        "second registration should fail - doc already registered"
+    );
+
+    // Document should be registered with the original owner
+    assert!(acp_store.is_doc_registered("users", "doc1").await.unwrap());
 }

--- a/crates/cli/src/commands/client/http_client.rs
+++ b/crates/cli/src/commands/client/http_client.rs
@@ -366,7 +366,11 @@ impl HttpClient {
             if let Ok(err) = serde_json::from_str::<ErrorResponse>(&body_text) {
                 return Err(Error::Server(err.error));
             }
-            return Err(Error::Server(format!("HTTP {}: {}", status, body_text.trim())));
+            return Err(Error::Server(format!(
+                "HTTP {}: {}",
+                status,
+                body_text.trim()
+            )));
         }
 
         let result: T = response.json().await?;

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -288,16 +288,10 @@ impl Node {
             DatastoreType::Badger => {
                 info!("Using Redb datastore at {}", config.data_path().display());
                 let store = Arc::new(storage::RedbStore::open(config.data_path())?);
-                // Use persistent ACP store at <rootdir>/local_document_acp
-                let acp_path = config.rootdir.join("local_document_acp");
-                info!("Using persistent ACP store at {}", acp_path.display());
+                // Use unified ACP store backed by main database with namespace isolation
+                info!("Using unified ACP store (namespace isolated in main database)");
                 let acp_store: Arc<dyn acp::AcpStore> =
-                    Arc::new(acp::PersistentAcpStore::open(&acp_path).map_err(|e| {
-                        Error::Storage(storage::Error::Other(format!(
-                            "failed to open ACP store: {}",
-                            e
-                        )))
-                    })?);
+                    Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
                 Self::init_store_and_server(
                     store,
                     &config,

--- a/crates/datastore/src/txn.rs
+++ b/crates/datastore/src/txn.rs
@@ -203,8 +203,7 @@ impl BasicTxn {
 
         // Execute sync callbacks with panic protection
         for (i, callback) in sync_fns.into_iter().enumerate() {
-            let callback_result =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback));
+            let callback_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback));
             if let Err(e) = callback_result {
                 tracing::error!(
                     txn_id = self.id,
@@ -278,8 +277,7 @@ impl BasicTxn {
 
         // Execute sync callbacks with panic protection
         for (i, callback) in self.discard_fns.into_iter().enumerate() {
-            let callback_result =
-                std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback));
+            let callback_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback));
             if let Err(e) = callback_result {
                 tracing::error!(
                     txn_id = self.id,

--- a/crates/db/tests/database_tests.rs
+++ b/crates/db/tests/database_tests.rs
@@ -1018,10 +1018,7 @@ async fn test_create_collection_rejects_invalid_policy_dotdot() {
     .with_policy(PolicyDescription::new("policy..secret", "users"));
 
     let result = db.create_collection(schema).await;
-    assert!(
-        result.is_err(),
-        "Should reject policy with '..' sequence"
-    );
+    assert!(result.is_err(), "Should reject policy with '..' sequence");
     let err = result.unwrap_err();
     assert!(
         err.to_string().contains("'..'"),

--- a/crates/http/src/handlers/acp.rs
+++ b/crates/http/src/handlers/acp.rs
@@ -56,10 +56,7 @@ pub async fn list_policies(
 ) -> Result<Json<Vec<PolicyInfo>>, HttpError> {
     let acp = state.require_acp()?;
 
-    let policies = acp
-        .list_policies()
-        .await
-        .map_err(HttpError::Internal)?;
+    let policies = acp.list_policies().await.map_err(HttpError::Internal)?;
 
     Ok(Json(policies))
 }

--- a/crates/http/src/handlers/backup.rs
+++ b/crates/http/src/handlers/backup.rs
@@ -124,10 +124,7 @@ pub async fn import(
         ));
     }
 
-    let result = backup
-        .import(&body)
-        .await
-        .map_err(HttpError::BadRequest)?;
+    let result = backup.import(&body).await.map_err(HttpError::BadRequest)?;
 
     Ok(Json(ImportResponse::from(result)))
 }

--- a/crates/http/src/handlers/index.rs
+++ b/crates/http/src/handlers/index.rs
@@ -163,8 +163,7 @@ mod tests {
 
     #[test]
     fn test_create_index_request_deserialize() {
-        let json =
-            r#"{"collection": "Users", "fields": ["name", "email"], "name": "idx_name_email", "unique": true}"#;
+        let json = r#"{"collection": "Users", "fields": ["name", "email"], "name": "idx_name_email", "unique": true}"#;
         let request: CreateIndexRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.collection, "Users");
         assert_eq!(request.fields.len(), 2);

--- a/crates/http/src/handlers/p2p.rs
+++ b/crates/http/src/handlers/p2p.rs
@@ -83,15 +83,9 @@ pub struct CollectionsDeleteQuery {
 pub async fn get_info(State(state): State<AppState>) -> Result<Json<P2pInfoResponse>, HttpError> {
     let p2p = state.require_p2p()?;
 
-    let peer_id = p2p
-        .local_peer_id()
-        .await
-        .map_err(HttpError::Internal)?;
+    let peer_id = p2p.local_peer_id().await.map_err(HttpError::Internal)?;
 
-    let addresses = p2p
-        .listen_addresses()
-        .await
-        .map_err(HttpError::Internal)?;
+    let addresses = p2p.listen_addresses().await.map_err(HttpError::Internal)?;
 
     Ok(Json(P2pInfoResponse {
         id: peer_id,
@@ -105,10 +99,7 @@ pub async fn get_info(State(state): State<AppState>) -> Result<Json<P2pInfoRespo
 pub async fn list_peers(State(state): State<AppState>) -> Result<Json<Vec<PeerInfo>>, HttpError> {
     let p2p = state.require_p2p()?;
 
-    let peers = p2p
-        .connected_peers()
-        .await
-        .map_err(HttpError::Internal)?;
+    let peers = p2p.connected_peers().await.map_err(HttpError::Internal)?;
 
     let peer_infos: Vec<PeerInfo> = peers
         .into_iter()
@@ -145,10 +136,7 @@ pub async fn list_replicators(
 ) -> Result<Json<Vec<ReplicatorInfoResponse>>, HttpError> {
     let p2p = state.require_p2p()?;
 
-    let replicators = p2p
-        .get_replicators()
-        .await
-        .map_err(HttpError::Internal)?;
+    let replicators = p2p.get_replicators().await.map_err(HttpError::Internal)?;
 
     let response: Vec<ReplicatorInfoResponse> = replicators
         .into_iter()
@@ -234,10 +222,7 @@ pub async fn list_collections(
 ) -> Result<Json<Vec<String>>, HttpError> {
     let p2p = state.require_p2p()?;
 
-    let collections = p2p
-        .get_collections()
-        .await
-        .map_err(HttpError::Internal)?;
+    let collections = p2p.get_collections().await.map_err(HttpError::Internal)?;
 
     Ok(Json(collections))
 }

--- a/crates/http/src/mock.rs
+++ b/crates/http/src/mock.rs
@@ -668,7 +668,10 @@ impl P2POperations for MockP2POperations {
         Ok(())
     }
 
-    async fn remove_collections(&self, collections: Vec<String>) -> std::result::Result<(), String> {
+    async fn remove_collections(
+        &self,
+        collections: Vec<String>,
+    ) -> std::result::Result<(), String> {
         let mut existing = self.collections.write().unwrap();
         existing.retain(|c| !collections.contains(c));
         Ok(())
@@ -842,10 +845,17 @@ impl IndexOperations for MockIndexOperations {
         Ok(index)
     }
 
-    async fn list_indexes(&self, collection: Option<&str>) -> std::result::Result<Vec<IndexInfo>, String> {
+    async fn list_indexes(
+        &self,
+        collection: Option<&str>,
+    ) -> std::result::Result<Vec<IndexInfo>, String> {
         let indexes = self.indexes.read().unwrap();
         match collection {
-            Some(col) => Ok(indexes.iter().filter(|i| i.collection == col).cloned().collect()),
+            Some(col) => Ok(indexes
+                .iter()
+                .filter(|i| i.collection == col)
+                .cloned()
+                .collect()),
             None => Ok(indexes.clone()),
         }
     }
@@ -857,7 +867,10 @@ impl IndexOperations for MockIndexOperations {
         if indexes.len() < initial_len {
             Ok(())
         } else {
-            Err(format!("index '{}' not found in collection '{}'", name, collection))
+            Err(format!(
+                "index '{}' not found in collection '{}'",
+                name, collection
+            ))
         }
     }
 }
@@ -890,7 +903,9 @@ impl MockBackupOperations {
     /// Create a new mock backup operations instance.
     pub fn new() -> Self {
         Self {
-            data: Arc::new(RwLock::new(r#"{"Users": [{"_docID": "bae-123", "name": "Alice"}]}"#.to_string())),
+            data: Arc::new(RwLock::new(
+                r#"{"Users": [{"_docID": "bae-123", "name": "Alice"}]}"#.to_string(),
+            )),
         }
     }
 
@@ -912,10 +927,9 @@ impl BackupOperations for MockBackupOperations {
         let data = self.data.read().unwrap().clone();
         if pretty {
             // Format the JSON nicely
-            let parsed: serde_json::Value = serde_json::from_str(&data)
-                .map_err(|e| format!("invalid JSON: {}", e))?;
-            serde_json::to_string_pretty(&parsed)
-                .map_err(|e| format!("failed to serialize: {}", e))
+            let parsed: serde_json::Value =
+                serde_json::from_str(&data).map_err(|e| format!("invalid JSON: {}", e))?;
+            serde_json::to_string_pretty(&parsed).map_err(|e| format!("failed to serialize: {}", e))
         } else {
             Ok(data)
         }
@@ -923,8 +937,8 @@ impl BackupOperations for MockBackupOperations {
 
     async fn import(&self, data: &str) -> std::result::Result<ImportResult, String> {
         // Parse the incoming data to validate it
-        let parsed: serde_json::Value = serde_json::from_str(data)
-            .map_err(|e| format!("invalid JSON: {}", e))?;
+        let parsed: serde_json::Value =
+            serde_json::from_str(data).map_err(|e| format!("invalid JSON: {}", e))?;
 
         // Count documents and collections
         let mut documents_imported = 0u64;
@@ -1016,7 +1030,10 @@ impl P2POperations for FailingMockP2POperations {
         Err(self.error.clone())
     }
 
-    async fn remove_collections(&self, _collections: Vec<String>) -> std::result::Result<(), String> {
+    async fn remove_collections(
+        &self,
+        _collections: Vec<String>,
+    ) -> std::result::Result<(), String> {
         Err(self.error.clone())
     }
 }
@@ -1078,7 +1095,10 @@ impl IndexOperations for FailingMockIndexOperations {
         Err(self.error.clone())
     }
 
-    async fn list_indexes(&self, _collection: Option<&str>) -> std::result::Result<Vec<IndexInfo>, String> {
+    async fn list_indexes(
+        &self,
+        _collection: Option<&str>,
+    ) -> std::result::Result<Vec<IndexInfo>, String> {
         Err(self.error.clone())
     }
 

--- a/crates/http/src/router.rs
+++ b/crates/http/src/router.rs
@@ -217,7 +217,10 @@ impl std::fmt::Debug for AppState {
             .field("p2p", &self.p2p.as_ref().map(|_| "<P2POperations>"))
             .field("acp", &self.acp.as_ref().map(|_| "<AcpOperations>"))
             .field("index", &self.index.as_ref().map(|_| "<IndexOperations>"))
-            .field("backup", &self.backup.as_ref().map(|_| "<BackupOperations>"))
+            .field(
+                "backup",
+                &self.backup.as_ref().map(|_| "<BackupOperations>"),
+            )
             .finish()
     }
 }

--- a/crates/http/src/validation.rs
+++ b/crates/http/src/validation.rs
@@ -49,9 +49,7 @@ pub fn validate_collection_name(name: &str) -> Result<(), HttpError> {
 /// Full validation happens in the P2P layer.
 pub fn validate_multiaddr(address: &str) -> Result<(), HttpError> {
     if address.trim().is_empty() {
-        return Err(HttpError::BadRequest(
-            "address cannot be empty".to_string(),
-        ));
+        return Err(HttpError::BadRequest("address cannot be empty".to_string()));
     }
 
     if !address.starts_with('/') {

--- a/crates/http/tests/handler_tests.rs
+++ b/crates/http/tests/handler_tests.rs
@@ -434,9 +434,8 @@ async fn test_index_create_invalid_collection_name() {
 #[tokio::test]
 async fn test_index_list() {
     let executor = Arc::new(MockQueryExecutor::new());
-    let index = Arc::new(
-        MockIndexOperations::new().with_index("Users", "idx_name", vec!["name"], false),
-    );
+    let index =
+        Arc::new(MockIndexOperations::new().with_index("Users", "idx_name", vec!["name"], false));
     let state = AppStateBuilder::new(executor).with_index(index).build();
     let router = create_router_with_state(state);
 
@@ -513,9 +512,8 @@ async fn test_index_list_invalid_collection_name() {
 #[tokio::test]
 async fn test_index_drop() {
     let executor = Arc::new(MockQueryExecutor::new());
-    let index = Arc::new(
-        MockIndexOperations::new().with_index("Users", "idx_name", vec!["name"], false),
-    );
+    let index =
+        Arc::new(MockIndexOperations::new().with_index("Users", "idx_name", vec!["name"], false));
     let state = AppStateBuilder::new(executor).with_index(index).build();
     let router = create_router_with_state(state);
 

--- a/crates/schema/src/policy.rs
+++ b/crates/schema/src/policy.rs
@@ -111,10 +111,7 @@ mod tests {
         let policy = PolicyDescription::new("", "users");
         let result = policy.validate();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("cannot be empty"));
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
     }
 
     #[test]
@@ -122,10 +119,7 @@ mod tests {
         let policy = PolicyDescription::new("policy-123", "");
         let result = policy.validate();
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("cannot be empty"));
+        assert!(result.unwrap_err().to_string().contains("cannot be empty"));
     }
 
     // === Whitespace-only tests ===

--- a/crates/storage/src/backends/redb.rs
+++ b/crates/storage/src/backends/redb.rs
@@ -1086,9 +1086,7 @@ impl Txn for RedbTxn {
                     "Failed to finalize commit - all changes rolled back"
                 );
                 // Note: redb guarantees atomicity - if commit fails, no changes are persisted
-                tracing::debug!(
-                    "Commit failed at finalization stage - database state unchanged"
-                );
+                tracing::debug!("Commit failed at finalization stage - database state unchanged");
                 let on_error = std::mem::take(&mut *self.on_error.lock());
                 let on_error_async = std::mem::take(&mut *self.on_error_async.lock());
                 Self::execute_callbacks(on_error);
@@ -1401,7 +1399,8 @@ impl From<redb::Error> for Error {
                 tracing::warn!("Database is locked by another process");
                 Error::Backend(
                     "database is locked by another process. \
-                     Check for other running processes or stale lock files".into()
+                     Check for other running processes or stale lock files"
+                        .into(),
                 )
             }
 
@@ -1420,7 +1419,8 @@ impl From<redb::Error> for Error {
                 tracing::warn!("Transaction still held by table or iterator");
                 Error::Backend(
                     "transaction still in use - ensure all tables and iterators are dropped \
-                     before committing or discarding the transaction".into(),
+                     before committing or discarding the transaction"
+                        .into(),
                 )
             }
 
@@ -1460,7 +1460,8 @@ impl From<redb::DatabaseError> for Error {
                 tracing::warn!("Database is locked by another process");
                 Error::Backend(
                     "database is locked by another process. \
-                     Check for other running processes or stale lock files".into()
+                     Check for other running processes or stale lock files"
+                        .into(),
                 )
             }
             redb::DatabaseError::UpgradeRequired(version) => {
@@ -1475,7 +1476,8 @@ impl From<redb::DatabaseError> for Error {
                 tracing::warn!("Database repair was aborted");
                 Error::Backend(
                     "database repair was aborted before completion. \
-                     Database may be in inconsistent state - restore from backup recommended".into()
+                     Database may be in inconsistent state - restore from backup recommended"
+                        .into(),
                 )
             }
             redb::DatabaseError::Storage(storage_err) => storage_err.into(),
@@ -2874,10 +2876,16 @@ mod redb_specific_tests {
 
         // Empty database should pass integrity check
         let report = store.check_integrity().unwrap();
-        assert!(report.is_valid, "Empty database should pass integrity check");
+        assert!(
+            report.is_valid,
+            "Empty database should pass integrity check"
+        );
         assert_eq!(report.total_keys, 0, "Empty database should have 0 keys");
         assert_eq!(report.error_count, 0, "Empty database should have 0 errors");
-        assert!(report.first_error.is_none(), "Empty database should have no error message");
+        assert!(
+            report.first_error.is_none(),
+            "Empty database should have no error message"
+        );
 
         // Add some data
         {
@@ -2892,10 +2900,16 @@ mod redb_specific_tests {
 
         // Database with data should pass integrity check
         let report = store.check_integrity().unwrap();
-        assert!(report.is_valid, "Database with data should pass integrity check");
+        assert!(
+            report.is_valid,
+            "Database with data should pass integrity check"
+        );
         assert_eq!(report.total_keys, 100, "Database should have 100 keys");
         assert_eq!(report.error_count, 0, "Database should have 0 errors");
-        assert!(report.first_error.is_none(), "Database should have no error message");
+        assert!(
+            report.first_error.is_none(),
+            "Database should have no error message"
+        );
     }
 
     #[tokio::test]
@@ -2961,7 +2975,10 @@ mod redb_specific_tests {
 
         // Creating a new transaction should fail because it exceeds the snapshot limit
         let result = store.new_txn(false).await;
-        assert!(result.is_err(), "Should fail when snapshot exceeds max_snapshot_keys");
+        assert!(
+            result.is_err(),
+            "Should fail when snapshot exceeds max_snapshot_keys"
+        );
 
         // Use pattern matching to extract error (Box<dyn Txn> doesn't impl Debug)
         if let Err(err) = result {
@@ -3016,13 +3033,25 @@ mod redb_specific_tests {
 
         // Register some callbacks
         txn.on_success(Box::new(|| {}));
-        assert_eq!(txn.callback_count(), 1, "Should have 1 callback after on_success");
+        assert_eq!(
+            txn.callback_count(),
+            1,
+            "Should have 1 callback after on_success"
+        );
 
         txn.on_error(Box::new(|| {}));
-        assert_eq!(txn.callback_count(), 2, "Should have 2 callbacks after on_error");
+        assert_eq!(
+            txn.callback_count(),
+            2,
+            "Should have 2 callbacks after on_error"
+        );
 
         txn.on_discard(Box::new(|| {}));
-        assert_eq!(txn.callback_count(), 3, "Should have 3 callbacks after on_discard");
+        assert_eq!(
+            txn.callback_count(),
+            3,
+            "Should have 3 callbacks after on_discard"
+        );
 
         txn.discard();
     }
@@ -3046,7 +3075,9 @@ mod redb_specific_tests {
 
         // Use a reasonable max_snapshot_keys limit for this test
         let opts = RedbStoreOptions::new().with_max_snapshot_keys(100_000);
-        let store = Arc::new(RedbStore::open_with_options(temp_dir.path().join("test.redb"), opts).unwrap());
+        let store = Arc::new(
+            RedbStore::open_with_options(temp_dir.path().join("test.redb"), opts).unwrap(),
+        );
 
         // Setup: Create 10K keys with 100-byte values (~1MB total)
         let value = vec![0xAB; 100];

--- a/crates/storage/src/namespace.rs
+++ b/crates/storage/src/namespace.rs
@@ -8,6 +8,7 @@
 /// - 's' (0x73): Systemstore
 /// - 'p' (0x70): Peerstore
 /// - 'e' (0x65): Encstore
+/// - 'a' (0x61): Acpstore
 ///
 /// The NamespacedStore wraps any Store implementation and automatically
 /// prepends the prefix to all keys, ensuring complete isolation between stores.
@@ -30,6 +31,8 @@ pub enum Namespace {
     Peerstore,
     /// Encstore - encrypted blocks
     Encstore,
+    /// Acpstore - Access Control Policy tuples
+    Acpstore,
 }
 
 impl Namespace {
@@ -42,6 +45,7 @@ impl Namespace {
             Namespace::Systemstore => b's',
             Namespace::Peerstore => b'p',
             Namespace::Encstore => b'e',
+            Namespace::Acpstore => b'a',
         }
     }
 
@@ -54,6 +58,7 @@ impl Namespace {
             Namespace::Systemstore => "systemstore",
             Namespace::Peerstore => "peerstore",
             Namespace::Encstore => "encstore",
+            Namespace::Acpstore => "acpstore",
         }
     }
 

--- a/crates/storage/tests/multistore_tests.rs
+++ b/crates/storage/tests/multistore_tests.rs
@@ -813,15 +813,18 @@ mod redb_multistore_tests {
         for i in 0..10 {
             assert!(
                 txn.has(format!("ds_key_{}", i).as_bytes()).await.unwrap(),
-                "Datastore should have ds_key_{}", i
+                "Datastore should have ds_key_{}",
+                i
             );
             assert!(
                 !txn.has(format!("bs_key_{}", i).as_bytes()).await.unwrap(),
-                "Datastore should NOT have bs_key_{}", i
+                "Datastore should NOT have bs_key_{}",
+                i
             );
             assert!(
                 !txn.has(format!("ss_key_{}", i).as_bytes()).await.unwrap(),
-                "Datastore should NOT have ss_key_{}", i
+                "Datastore should NOT have ss_key_{}",
+                i
             );
         }
         txn.discard();
@@ -830,7 +833,8 @@ mod redb_multistore_tests {
         for i in 0..10 {
             assert!(
                 txn.has(format!("bs_key_{}", i).as_bytes()).await.unwrap(),
-                "Blockstore should have bs_key_{}", i
+                "Blockstore should have bs_key_{}",
+                i
             );
         }
         txn.discard();
@@ -839,7 +843,8 @@ mod redb_multistore_tests {
         for i in 0..10 {
             assert!(
                 txn.has(format!("ss_key_{}", i).as_bytes()).await.unwrap(),
-                "Systemstore should have ss_key_{}", i
+                "Systemstore should have ss_key_{}",
+                i
             );
         }
         txn.discard();

--- a/crates/storage/tests/namespace_tests.rs
+++ b/crates/storage/tests/namespace_tests.rs
@@ -17,6 +17,7 @@ fn test_namespace_prefix() {
     assert_eq!(Namespace::Systemstore.prefix(), b's');
     assert_eq!(Namespace::Peerstore.prefix(), b'p');
     assert_eq!(Namespace::Encstore.prefix(), b'e');
+    assert_eq!(Namespace::Acpstore.prefix(), b'a');
 }
 
 #[test]
@@ -27,6 +28,7 @@ fn test_namespace_name() {
     assert_eq!(Namespace::Systemstore.name(), "systemstore");
     assert_eq!(Namespace::Peerstore.name(), "peerstore");
     assert_eq!(Namespace::Encstore.name(), "encstore");
+    assert_eq!(Namespace::Acpstore.name(), "acpstore");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Consolidates ACP storage from separate database (`local_document_acp/acp.redb`) into main redb database
- Adds `Namespace::Acpstore` variant with prefix `'a'` (0x61) for namespace isolation
- Makes `PersistentAcpStore` generic over any `Store` implementation
- Eliminates separate directory, simplifying deployment

## Changes

| File | Change |
|------|--------|
| `crates/storage/src/namespace.rs` | Add `Acpstore` variant with prefix `'a'` |
| `crates/acp/src/persistent.rs` | Make generic over `Store`, add `from_store()` constructor |
| `crates/cli/src/commands/start.rs` | Use unified ACP store instead of separate database |
| `crates/acp/tests/persistent_tests.rs` | Add unified mode and namespace isolation tests |

## Migration

**Breaking change for existing installations**: If `local_document_acp/` directory exists with data, users must re-register ACP permissions. This was chosen as the initial approach since ACP is relatively new. Automatic migration can be added later if needed.

## Test plan

- [x] `cargo test -p storage` - All namespace tests pass
- [x] `cargo test -p acp` - All ACP tests pass including new unified mode tests
- [x] Verify namespace isolation in `test_unified_store_namespace_isolation`
- [ ] Manual test: Start node, verify single database file at `<rootdir>/data/`
- [ ] Manual test: Verify ACP operations work (register doc, check permissions)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)