### PR TITLE
feat(interop): Add Go-based P2P interoperability test framework

### DIFF
--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -545,8 +545,15 @@ impl Node {
             // Create HTTP server with REST endpoints enabled
             // Cast the Arc<QueryRunner> to Arc<dyn QueryExecutor> for the server
             let executor: Arc<dyn query::executor::QueryExecutor> = runner;
-            let server = defra_http::Server::from_arc_with_config(executor, server_config)
+            let mut server = defra_http::Server::from_arc_with_config(executor, server_config)
                 .with_rest(rest_ops);
+
+            // Wire P2P to HTTP server if enabled
+            if let Some(ref p2p_handle) = p2p {
+                let p2p_adapter = crate::p2p_adapter::P2PAdapter::new_arc(p2p_handle.clone());
+                server = server.with_p2p_arc(p2p_adapter);
+                info!("P2P HTTP endpoints enabled");
+            }
 
             info!(
                 "HTTP server configured on {} with REST endpoints enabled",
@@ -572,6 +579,9 @@ impl Node {
             None => p2p::P2PHost::new(bitswap_store).map_err(Error::P2P)?,
         };
 
+        // Spawn the host event loop FIRST - it must be running to process commands
+        tokio::spawn(host.run());
+
         // Start listening on configured addresses
         for addr_str in &config.net.p2p_addresses {
             let addr: p2p::Multiaddr = addr_str
@@ -581,9 +591,6 @@ impl Node {
             handle.listen(addr.clone()).await.map_err(Error::P2P)?;
             info!("P2P listening on {}", addr);
         }
-
-        // Spawn the host event loop
-        tokio::spawn(host.run());
 
         // Spawn event handler
         tokio::spawn(async move {

--- a/crates/cli/src/commands/start.rs
+++ b/crates/cli/src/commands/start.rs
@@ -555,6 +555,11 @@ impl Node {
                 info!("P2P HTTP endpoints enabled");
             }
 
+            // Wire schema operations to HTTP server
+            let schema_adapter = crate::schema_adapter::SchemaAdapter::new_arc(database.clone());
+            server = server.with_schema_arc(schema_adapter);
+            info!("Schema HTTP endpoint enabled");
+
             info!(
                 "HTTP server configured on {} with REST endpoints enabled",
                 api_address

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -19,3 +19,4 @@ pub mod config;
 pub mod error;
 pub mod logging;
 pub mod p2p_adapter;
+pub mod schema_adapter;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -18,3 +18,4 @@ pub mod commands;
 pub mod config;
 pub mod error;
 pub mod logging;
+pub mod p2p_adapter;

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -1,0 +1,111 @@
+//! Adapter to bridge P2PHostHandle to HTTP's P2POperations trait.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use defra_http::router::{P2POperations, ReplicatorInfo};
+use p2p::P2PHostHandle;
+
+/// Adapter that implements P2POperations using P2PHostHandle.
+pub struct P2PAdapter {
+    handle: P2PHostHandle,
+}
+
+impl P2PAdapter {
+    /// Create a new adapter wrapping the given P2P handle.
+    pub fn new(handle: P2PHostHandle) -> Self {
+        Self { handle }
+    }
+
+    /// Create an Arc-wrapped adapter.
+    pub fn new_arc(handle: P2PHostHandle) -> Arc<dyn P2POperations> {
+        Arc::new(Self::new(handle))
+    }
+}
+
+#[async_trait]
+impl P2POperations for P2PAdapter {
+    async fn local_peer_id(&self) -> Result<String, String> {
+        self.handle
+            .local_peer_id()
+            .await
+            .map(|id| id.to_string())
+            .map_err(|e| e.to_string())
+    }
+
+    async fn listen_addresses(&self) -> Result<Vec<String>, String> {
+        self.handle
+            .listen_addresses()
+            .await
+            .map(|addrs| addrs.into_iter().map(|a| a.to_string()).collect())
+            .map_err(|e| e.to_string())
+    }
+
+    async fn connected_peers(&self) -> Result<Vec<String>, String> {
+        self.handle
+            .connected_peers()
+            .await
+            .map(|peers| peers.into_iter().map(|p| p.to_string()).collect())
+            .map_err(|e| e.to_string())
+    }
+
+    async fn connect_peer(&self, addr: &str) -> Result<(), String> {
+        // Parse multiaddr and extract peer ID
+        let multiaddr: libp2p::Multiaddr = addr.parse().map_err(|e| format!("invalid multiaddr: {}", e))?;
+
+        // Extract peer ID from multiaddr (should be in /p2p/<peer_id> component)
+        let peer_id = multiaddr
+            .iter()
+            .find_map(|proto| match proto {
+                libp2p::multiaddr::Protocol::P2p(peer_id) => Some(peer_id),
+                _ => None,
+            })
+            .ok_or_else(|| "multiaddr must contain /p2p/<peer_id> component".to_string())?;
+
+        // Remove the p2p component from the address for dialing
+        let dial_addr: libp2p::Multiaddr = multiaddr
+            .iter()
+            .filter(|proto| !matches!(proto, libp2p::multiaddr::Protocol::P2p(_)))
+            .collect();
+
+        self.handle
+            .dial(peer_id, vec![dial_addr])
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String> {
+        // Replicator functionality is not implemented yet
+        Ok(Vec::new())
+    }
+
+    async fn add_replicator(
+        &self,
+        _collections: Vec<String>,
+        _addr: Option<&str>,
+    ) -> Result<(), String> {
+        Err("replicator functionality not yet implemented".to_string())
+    }
+
+    async fn remove_replicator(
+        &self,
+        _collections: Vec<String>,
+        _addr: Option<&str>,
+    ) -> Result<(), String> {
+        Err("replicator functionality not yet implemented".to_string())
+    }
+
+    async fn get_collections(&self) -> Result<Vec<String>, String> {
+        // P2P collections not implemented yet
+        Ok(Vec::new())
+    }
+
+    async fn add_collections(&self, _collections: Vec<String>) -> Result<(), String> {
+        Err("p2p collections functionality not yet implemented".to_string())
+    }
+
+    async fn remove_collections(&self, _collections: Vec<String>) -> Result<(), String> {
+        Err("p2p collections functionality not yet implemented".to_string())
+    }
+}

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -1,0 +1,50 @@
+//! Adapter to bridge database schema operations to HTTP's SchemaOperations trait.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use defra_http::router::SchemaOperations;
+use schema::CollectionVersion;
+use storage::corekv::Store;
+
+/// Adapter that implements SchemaOperations using database.
+pub struct SchemaAdapter<S: Store> {
+    database: Arc<db::DB<S>>,
+}
+
+impl<S: Store + 'static> SchemaAdapter<S> {
+    /// Create a new adapter wrapping the given database.
+    pub fn new(database: Arc<db::DB<S>>) -> Self {
+        Self { database }
+    }
+
+    /// Create an Arc-wrapped adapter.
+    pub fn new_arc(database: Arc<db::DB<S>>) -> Arc<dyn SchemaOperations> {
+        Arc::new(Self::new(database))
+    }
+}
+
+#[async_trait]
+impl<S: Store + 'static> SchemaOperations for SchemaAdapter<S> {
+    async fn add_schema(&self, sdl: &str) -> Result<Vec<CollectionVersion>, String> {
+        // Parse SDL into CollectionVersions
+        let collections =
+            query::sdl_parse::parse_sdl(sdl).map_err(|e| format!("failed to parse SDL: {}", e))?;
+
+        let mut created = Vec::new();
+
+        // Create each collection in the database
+        for collection in collections {
+            // Clone before moving into create_collection
+            let col_clone = collection.clone();
+            self.database
+                .create_collection(collection)
+                .await
+                .map_err(|e| format!("failed to create collection: {}", e))?;
+            created.push(col_clone);
+        }
+
+        Ok(created)
+    }
+}

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -15,6 +15,7 @@ test-utils = []
 # Internal crates
 query = { path = "../query" }
 identity = { path = "../identity" }
+schema = { path = "../schema" }
 
 # Async runtime
 tokio.workspace = true

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -16,6 +16,7 @@ pub mod documents;
 pub mod graphql;
 pub mod index;
 pub mod p2p;
+pub mod schema;
 
 // Re-export GraphQL handlers for backwards compatibility
 pub use graphql::{

--- a/crates/http/src/handlers/p2p.rs
+++ b/crates/http/src/handlers/p2p.rs
@@ -16,12 +16,10 @@ use crate::error::HttpError;
 use crate::router::AppState;
 use crate::validation::{validate_collection_name, validate_multiaddr};
 
-/// Response for P2P node info.
-#[derive(Debug, Clone, Serialize)]
-pub struct P2pInfoResponse {
-    pub id: String,
-    pub addresses: Vec<String>,
-}
+/// Response for P2P node info (Go-compatible format).
+/// Returns array of full multiaddrs with peer ID embedded.
+/// Example: ["/ip4/127.0.0.1/tcp/9181/p2p/12D3KooWxyz..."]
+pub type P2pInfoResponse = Vec<String>;
 
 /// Response for listing peers.
 #[derive(Debug, Clone, Serialize)]
@@ -47,12 +45,15 @@ pub struct ReplicatorInfoResponse {
     pub address: Option<String>,
 }
 
-/// Request to add a replicator.
+/// Request to add a replicator (Go-compatible format).
 #[derive(Debug, Clone, Deserialize)]
 pub struct ReplicatorRequest {
+    /// List of collection names to replicate.
+    #[serde(rename = "Collections")]
     pub collections: Vec<String>,
-    #[serde(default)]
-    pub address: Option<String>,
+    /// List of peer multiaddrs to replicate to.
+    #[serde(rename = "Addresses", default)]
+    pub addresses: Vec<String>,
 }
 
 /// Query parameters for replicator removal.
@@ -77,9 +78,12 @@ pub struct CollectionsDeleteQuery {
     pub collections: Vec<String>,
 }
 
-/// Get P2P node information.
+/// Get P2P node information (Go-compatible format).
 ///
 /// GET /api/v0/p2p/info
+///
+/// Returns array of full multiaddrs with peer ID embedded.
+/// Example: ["/ip4/127.0.0.1/tcp/9181/p2p/12D3KooWxyz..."]
 pub async fn get_info(State(state): State<AppState>) -> Result<Json<P2pInfoResponse>, HttpError> {
     let p2p = state.require_p2p()?;
 
@@ -93,10 +97,13 @@ pub async fn get_info(State(state): State<AppState>) -> Result<Json<P2pInfoRespo
         .await
         .map_err(HttpError::Internal)?;
 
-    Ok(Json(P2pInfoResponse {
-        id: peer_id,
-        addresses,
-    }))
+    // Build full multiaddrs with peer ID embedded (Go-compatible format)
+    let full_addrs: Vec<String> = addresses
+        .into_iter()
+        .map(|addr| format!("{}/p2p/{}", addr, peer_id))
+        .collect();
+
+    Ok(Json(full_addrs))
 }
 
 /// List connected peers.
@@ -118,9 +125,11 @@ pub async fn list_peers(State(state): State<AppState>) -> Result<Json<Vec<PeerIn
     Ok(Json(peer_infos))
 }
 
-/// Connect to a peer.
+/// Connect to a peer (legacy format).
 ///
 /// POST /api/v0/p2p/peers
+///
+/// Body: {"address": "/ip4/..."}
 pub async fn connect_peer(
     State(state): State<AppState>,
     Json(request): Json<ConnectPeerRequest>,
@@ -135,6 +144,27 @@ pub async fn connect_peer(
         .map_err(HttpError::BadRequest)?;
 
     Ok(Json(()))
+}
+
+/// Connect to peers (Go-compatible format).
+///
+/// POST /api/v0/p2p/connect
+///
+/// Body: ["/ip4/.../p2p/...", ...]
+pub async fn connect(
+    State(state): State<AppState>,
+    Json(addresses): Json<Vec<String>>,
+) -> Result<(), HttpError> {
+    let p2p = state.require_p2p()?;
+
+    for addr in &addresses {
+        validate_multiaddr(addr)?;
+        p2p.connect_peer(addr)
+            .await
+            .map_err(HttpError::BadRequest)?;
+    }
+
+    Ok(())
 }
 
 /// List replicators.
@@ -162,9 +192,11 @@ pub async fn list_replicators(
     Ok(Json(response))
 }
 
-/// Add a replicator.
+/// Add a replicator (Go-compatible format).
 ///
-/// POST /api/v0/p2p/replicator
+/// POST /api/v0/p2p/replicators
+///
+/// Body: {"Addresses": ["..."], "Collections": ["..."]}
 pub async fn add_replicator(
     State(state): State<AppState>,
     Json(request): Json<ReplicatorRequest>,
@@ -182,12 +214,15 @@ pub async fn add_replicator(
         validate_collection_name(col)?;
     }
 
-    // Validate address if provided
-    if let Some(ref addr) = request.address {
+    // Validate and use addresses
+    for addr in &request.addresses {
         validate_multiaddr(addr)?;
     }
 
-    p2p.add_replicator(request.collections, request.address.as_deref())
+    // Use first address if provided (Go sends array, trait takes optional single)
+    let addr = request.addresses.first().map(|s| s.as_str());
+
+    p2p.add_replicator(request.collections, addr)
         .await
         .map_err(HttpError::BadRequest)?;
 
@@ -309,18 +344,19 @@ mod tests {
 
     #[test]
     fn test_replicator_request_deserialize() {
-        let json = r#"{"collections": ["Users", "Posts"], "address": "/ip4/127.0.0.1/tcp/9000"}"#;
+        // Go-compatible format with PascalCase field names
+        let json = r#"{"Collections": ["Users", "Posts"], "Addresses": ["/ip4/127.0.0.1/tcp/9000"]}"#;
         let request: ReplicatorRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.collections.len(), 2);
-        assert!(request.address.is_some());
+        assert_eq!(request.addresses.len(), 1);
     }
 
     #[test]
     fn test_replicator_request_without_address() {
-        let json = r#"{"collections": ["Users"]}"#;
+        let json = r#"{"Collections": ["Users"]}"#;
         let request: ReplicatorRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.collections.len(), 1);
-        assert!(request.address.is_none());
+        assert!(request.addresses.is_empty());
     }
 
     #[test]
@@ -332,12 +368,13 @@ mod tests {
 
     #[test]
     fn test_p2p_info_response_serialize() {
-        let response = P2pInfoResponse {
-            id: "12D3KooWtest".to_string(),
-            addresses: vec!["/ip4/127.0.0.1/tcp/9000".to_string()],
-        };
+        // Response is now array of full multiaddrs (Go-compatible format)
+        let response: P2pInfoResponse =
+            vec!["/ip4/127.0.0.1/tcp/9000/p2p/12D3KooWtest".to_string()];
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("12D3KooWtest"));
         assert!(json.contains("/ip4/127.0.0.1/tcp/9000"));
+        // Verify it's an array, not an object
+        assert!(json.starts_with('['));
     }
 }

--- a/crates/http/src/handlers/schema.rs
+++ b/crates/http/src/handlers/schema.rs
@@ -1,0 +1,38 @@
+//! Schema endpoint handlers.
+//!
+//! These handlers provide HTTP access to schema management:
+//! - Add schema (POST /schema)
+
+use axum::{extract::State, Json};
+
+use crate::error::HttpError;
+use crate::router::AppState;
+use schema::CollectionVersion;
+
+/// Add a schema (Go-compatible format).
+///
+/// POST /api/v0/schema
+///
+/// Body: SDL text (text/plain)
+/// Returns: Array of created CollectionVersions
+pub async fn add_schema(
+    State(state): State<AppState>,
+    body: String,
+) -> Result<Json<Vec<CollectionVersion>>, HttpError> {
+    let schema_ops = state.require_schema()?;
+
+    let collections = schema_ops
+        .add_schema(&body)
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(collections))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_schema_handler_exists() {
+        // Handler compiles correctly
+    }
+}

--- a/crates/http/src/router.rs
+++ b/crates/http/src/router.rs
@@ -170,6 +170,18 @@ pub struct ImportResult {
     pub errors: Vec<String>,
 }
 
+/// Trait for schema operations.
+///
+/// Enables adding and managing collection schemas via SDL.
+#[async_trait::async_trait]
+pub trait SchemaOperations: Send + Sync {
+    /// Add a schema from SDL string.
+    ///
+    /// Parses the SDL and creates collections for each type defined.
+    /// Returns the created collection versions.
+    async fn add_schema(&self, sdl: &str) -> Result<Vec<schema::CollectionVersion>, String>;
+}
+
 /// Trait for backup operations.
 ///
 /// Enables exporting and importing database state as JSON. Export produces
@@ -207,6 +219,7 @@ pub struct AppState {
     pub acp: Option<Arc<dyn AcpOperations>>,
     pub index: Option<Arc<dyn IndexOperations>>,
     pub backup: Option<Arc<dyn BackupOperations>>,
+    pub schema: Option<Arc<dyn SchemaOperations>>,
 }
 
 impl std::fmt::Debug for AppState {
@@ -218,6 +231,7 @@ impl std::fmt::Debug for AppState {
             .field("acp", &self.acp.as_ref().map(|_| "<AcpOperations>"))
             .field("index", &self.index.as_ref().map(|_| "<IndexOperations>"))
             .field("backup", &self.backup.as_ref().map(|_| "<BackupOperations>"))
+            .field("schema", &self.schema.as_ref().map(|_| "<SchemaOperations>"))
             .finish()
     }
 }
@@ -258,6 +272,15 @@ impl AppState {
             )
         })
     }
+
+    /// Get schema operations or return ServiceUnavailable error.
+    pub fn require_schema(&self) -> Result<&Arc<dyn SchemaOperations>, crate::error::HttpError> {
+        self.schema.as_ref().ok_or_else(|| {
+            crate::error::HttpError::ServiceUnavailable(
+                "Schema operations are not enabled. Start the server with schema enabled to use this feature.".into()
+            )
+        })
+    }
 }
 
 /// Builder for constructing AppState with optional components.
@@ -268,6 +291,7 @@ pub struct AppStateBuilder {
     acp: Option<Arc<dyn AcpOperations>>,
     index: Option<Arc<dyn IndexOperations>>,
     backup: Option<Arc<dyn BackupOperations>>,
+    schema: Option<Arc<dyn SchemaOperations>>,
 }
 
 impl AppStateBuilder {
@@ -280,6 +304,7 @@ impl AppStateBuilder {
             acp: None,
             index: None,
             backup: None,
+            schema: None,
         }
     }
 
@@ -313,6 +338,12 @@ impl AppStateBuilder {
         self
     }
 
+    /// Set schema operations.
+    pub fn with_schema(mut self, schema: Arc<dyn SchemaOperations>) -> Self {
+        self.schema = Some(schema);
+        self
+    }
+
     /// Build the AppState.
     pub fn build(self) -> AppState {
         AppState {
@@ -322,6 +353,7 @@ impl AppStateBuilder {
             acp: self.acp,
             index: self.index,
             backup: self.backup,
+            schema: self.schema,
         }
     }
 }
@@ -369,9 +401,13 @@ pub fn create_router_with_state(state: AppState) -> Router {
     // P2P routes
     let p2p_routes = Router::new()
         .route("/info", get(handlers::p2p::get_info))
+        .route("/connect", post(handlers::p2p::connect)) // Go-compatible
         .route("/peers", get(handlers::p2p::list_peers))
-        .route("/peers", post(handlers::p2p::connect_peer))
-        .route("/replicator", get(handlers::p2p::list_replicators))
+        .route("/peers", post(handlers::p2p::connect_peer)) // Legacy
+        .route("/replicators", get(handlers::p2p::list_replicators)) // Go uses /replicators
+        .route("/replicators", post(handlers::p2p::add_replicator))
+        .route("/replicators", delete(handlers::p2p::remove_replicator))
+        .route("/replicator", get(handlers::p2p::list_replicators)) // Legacy
         .route("/replicator", post(handlers::p2p::add_replicator))
         .route("/replicator", delete(handlers::p2p::remove_replicator))
         .route("/collections", get(handlers::p2p::list_collections))
@@ -401,6 +437,7 @@ pub fn create_router_with_state(state: AppState) -> Router {
         .route("/graphql", post(handlers::graphql_transactional))
         .route("/graphql", get(handlers::graphql_get))
         .route("/schema", get(handlers::schema))
+        .route("/schema", post(handlers::schema::add_schema))
         .route("/version", get(handlers::version))
         // Transaction endpoints
         .nest("/tx", tx_routes)

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -14,7 +14,7 @@ use query::executor::QueryExecutor;
 use query::rest::RestOperations;
 
 use crate::error::Result;
-use crate::router::{create_router, create_router_with_rest};
+use crate::router::{AppStateBuilder, P2POperations, create_router_with_state};
 
 /// Server configuration options.
 #[derive(Debug, Clone)]
@@ -40,6 +40,7 @@ pub struct Server {
     config: ServerConfig,
     executor: Arc<dyn QueryExecutor>,
     rest: Option<Arc<dyn RestOperations>>,
+    p2p: Option<Arc<dyn P2POperations>>,
 }
 
 impl Server {
@@ -49,6 +50,7 @@ impl Server {
             config: ServerConfig::default(),
             executor: Arc::new(executor),
             rest: None,
+            p2p: None,
         }
     }
 
@@ -58,6 +60,7 @@ impl Server {
             config,
             executor: Arc::new(executor),
             rest: None,
+            p2p: None,
         }
     }
 
@@ -67,6 +70,7 @@ impl Server {
             config: ServerConfig::default(),
             executor,
             rest: None,
+            p2p: None,
         }
     }
 
@@ -76,6 +80,7 @@ impl Server {
             config,
             executor,
             rest: None,
+            p2p: None,
         }
     }
 
@@ -99,6 +104,24 @@ impl Server {
         self
     }
 
+    /// Set P2P operations for peer-to-peer networking endpoints.
+    ///
+    /// When P2P operations are configured, the server enables additional endpoints:
+    /// - `GET /api/v0/p2p/info` - Get P2P node info (peer ID, addresses)
+    /// - `GET /api/v0/p2p/peers` - List connected peers
+    /// - `POST /api/v0/p2p/peers` - Connect to a peer
+    /// - And other P2P management endpoints
+    pub fn with_p2p<P: P2POperations + 'static>(mut self, p2p: P) -> Self {
+        self.p2p = Some(Arc::new(p2p));
+        self
+    }
+
+    /// Set P2P operations from an Arc.
+    pub fn with_p2p_arc(mut self, p2p: Arc<dyn P2POperations>) -> Self {
+        self.p2p = Some(p2p);
+        self
+    }
+
     /// Build the router with all routes and middleware.
     ///
     /// CORS configuration matches Go DefraDB behavior:
@@ -110,10 +133,16 @@ impl Server {
     pub fn router(&self) -> Result<Router> {
         let cors = self.build_cors_layer()?;
 
-        let router = match &self.rest {
-            Some(rest) => create_router_with_rest(Arc::clone(&self.executor), Arc::clone(rest)),
-            None => create_router(Arc::clone(&self.executor)),
-        };
+        // Build state with all configured components
+        let mut builder = AppStateBuilder::new(Arc::clone(&self.executor));
+        if let Some(ref rest) = self.rest {
+            builder = builder.with_rest(Arc::clone(rest));
+        }
+        if let Some(ref p2p) = self.p2p {
+            builder = builder.with_p2p(Arc::clone(p2p));
+        }
+        let state = builder.build();
+        let router = create_router_with_state(state);
 
         Ok(router.layer(TraceLayer::new_for_http()).layer(cors))
     }

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -14,7 +14,7 @@ use query::executor::QueryExecutor;
 use query::rest::RestOperations;
 
 use crate::error::Result;
-use crate::router::{AppStateBuilder, P2POperations, create_router_with_state};
+use crate::router::{AppStateBuilder, P2POperations, SchemaOperations, create_router_with_state};
 
 /// Server configuration options.
 #[derive(Debug, Clone)]
@@ -41,6 +41,7 @@ pub struct Server {
     executor: Arc<dyn QueryExecutor>,
     rest: Option<Arc<dyn RestOperations>>,
     p2p: Option<Arc<dyn P2POperations>>,
+    schema: Option<Arc<dyn SchemaOperations>>,
 }
 
 impl Server {
@@ -51,6 +52,7 @@ impl Server {
             executor: Arc::new(executor),
             rest: None,
             p2p: None,
+            schema: None,
         }
     }
 
@@ -61,6 +63,7 @@ impl Server {
             executor: Arc::new(executor),
             rest: None,
             p2p: None,
+            schema: None,
         }
     }
 
@@ -71,6 +74,7 @@ impl Server {
             executor,
             rest: None,
             p2p: None,
+            schema: None,
         }
     }
 
@@ -81,6 +85,7 @@ impl Server {
             executor,
             rest: None,
             p2p: None,
+            schema: None,
         }
     }
 
@@ -122,6 +127,21 @@ impl Server {
         self
     }
 
+    /// Set schema operations for schema management endpoints.
+    ///
+    /// When schema operations are configured, the server enables:
+    /// - `POST /api/v0/schema` - Add schema from SDL
+    pub fn with_schema<S: SchemaOperations + 'static>(mut self, schema: S) -> Self {
+        self.schema = Some(Arc::new(schema));
+        self
+    }
+
+    /// Set schema operations from an Arc.
+    pub fn with_schema_arc(mut self, schema: Arc<dyn SchemaOperations>) -> Self {
+        self.schema = Some(schema);
+        self
+    }
+
     /// Build the router with all routes and middleware.
     ///
     /// CORS configuration matches Go DefraDB behavior:
@@ -140,6 +160,9 @@ impl Server {
         }
         if let Some(ref p2p) = self.p2p {
             builder = builder.with_p2p(Arc::clone(p2p));
+        }
+        if let Some(ref schema) = self.schema {
+            builder = builder.with_schema(Arc::clone(schema));
         }
         let state = builder.build();
         let router = create_router_with_state(state);

--- a/crates/http/tests/handler_tests.rs
+++ b/crates/http/tests/handler_tests.rs
@@ -61,9 +61,11 @@ async fn test_p2p_info_with_p2p_enabled() {
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap();
-    let info: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert!(info.get("id").is_some());
-    assert!(info.get("addresses").is_some());
+    // Response is now an array of full multiaddrs with peer ID embedded (Go-compatible format)
+    let info: Vec<String> = serde_json::from_slice(&body).unwrap();
+    assert!(!info.is_empty());
+    // Each address should contain /p2p/ with the peer ID
+    assert!(info[0].contains("/p2p/"));
 }
 
 #[tokio::test]

--- a/tests/interop/Makefile
+++ b/tests/interop/Makefile
@@ -1,16 +1,30 @@
-.PHONY: build-rust test test-connection clean
+.PHONY: build-rust build-go build-all test test-connection test-cross clean
+
+# Path to Go DefraDB repo (sibling directory)
+DEFRA_GO_PATH ?= ../../../defradb
 
 # Build the Rust defra binary
 build-rust:
 	cd ../.. && cargo build --release -p cli
 
-# Run all tests
-test: build-rust
+# Build the Go defra binary
+build-go:
+	cd $(DEFRA_GO_PATH) && make build
+
+# Build both binaries
+build-all: build-rust build-go
+
+# Run all tests (builds both binaries first)
+test: build-all
 	go test -v -timeout 5m ./...
 
-# Run connection tests only
+# Run connection tests only (Rust-only, faster)
 test-connection: build-rust
 	go test -v -timeout 5m -run TestConnection ./...
+
+# Run cross-implementation tests (requires both binaries)
+test-cross: build-all
+	go test -v -timeout 5m -run TestCross ./...
 
 # Clean test artifacts
 clean:

--- a/tests/interop/Makefile
+++ b/tests/interop/Makefile
@@ -1,0 +1,17 @@
+.PHONY: build-rust test test-connection clean
+
+# Build the Rust defra binary
+build-rust:
+	cd ../.. && cargo build --release -p cli
+
+# Run all tests
+test: build-rust
+	go test -v -timeout 5m ./...
+
+# Run connection tests only
+test-connection: build-rust
+	go test -v -timeout 5m -run TestConnection ./...
+
+# Clean test artifacts
+clean:
+	go clean -testcache

--- a/tests/interop/connection_test.go
+++ b/tests/interop/connection_test.go
@@ -1,0 +1,194 @@
+package interop
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb.rs-interop/tests/interop/framework"
+)
+
+// dumpLogsOnFailure registers a cleanup function that dumps node logs if the test failed.
+func dumpLogsOnFailure(t *testing.T, name string, node *framework.Node) {
+	t.Cleanup(func() {
+		if t.Failed() {
+			logs, err := node.DumpLogsString()
+			if err != nil {
+				t.Logf("Failed to dump %s logs: %v", name, err)
+				return
+			}
+			t.Logf("=== %s logs ===\n%s", name, logs)
+		}
+	})
+}
+
+// TestConnectionTwoRustNodesConnect tests that two Rust nodes can discover
+// and connect to each other via P2P.
+func TestConnectionTwoRustNodesConnect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Allocate ports for both nodes
+	http1, p2p1, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for node1")
+
+	http2, p2p2, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for node2")
+
+	// Start node1
+	node1 := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     http1,
+		P2PPort:      p2p1,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting node1...")
+	require.NoError(t, node1.Start(ctx), "failed to start node1")
+	defer node1.Stop()
+	dumpLogsOnFailure(t, "node1", node1)
+
+	t.Logf("Node1 started with peer ID: %s", node1.PeerID())
+
+	// Start node2
+	node2 := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     http2,
+		P2PPort:      p2p2,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting node2...")
+	require.NoError(t, node2.Start(ctx), "failed to start node2")
+	defer node2.Stop()
+	dumpLogsOnFailure(t, "node2", node2)
+
+	t.Logf("Node2 started with peer ID: %s", node2.PeerID())
+
+	// Get node1's multiaddr for node2 to connect to
+	node1Multiaddr := node1.P2PMultiaddr()
+	t.Logf("Node1 multiaddr: %s", node1Multiaddr)
+
+	// Connect node2 to node1
+	t.Log("Connecting node2 to node1...")
+	client2 := node2.Client()
+	err = client2.ConnectPeer(ctx, node1Multiaddr)
+	require.NoError(t, err, "failed to connect node2 to node1")
+
+	// Wait for node1 to see node2 as connected
+	t.Log("Waiting for node1 to see node2...")
+	client1 := node1.Client()
+	err = framework.WaitForPeerConnected(ctx, client1, node2.PeerID(), 30*time.Second)
+	require.NoError(t, err, "node1 did not see node2 connect")
+
+	// Wait for node2 to see node1 as connected
+	t.Log("Waiting for node2 to see node1...")
+	err = framework.WaitForPeerConnected(ctx, client2, node1.PeerID(), 30*time.Second)
+	require.NoError(t, err, "node2 did not see node1 connect")
+
+	// Verify both nodes see each other
+	peers1, err := client1.ListPeers(ctx)
+	require.NoError(t, err, "failed to list peers from node1")
+	require.Len(t, peers1, 1, "node1 should see exactly 1 peer")
+	require.Equal(t, node2.PeerID(), peers1[0].ID, "node1 should see node2")
+
+	peers2, err := client2.ListPeers(ctx)
+	require.NoError(t, err, "failed to list peers from node2")
+	require.Len(t, peers2, 1, "node2 should see exactly 1 peer")
+	require.Equal(t, node1.PeerID(), peers2[0].ID, "node2 should see node1")
+
+	t.Log("Both nodes successfully connected and see each other!")
+}
+
+// setupConnectedRustNodes is a helper that starts two Rust nodes and connects them.
+func setupConnectedRustNodes(t *testing.T, ctx context.Context) (node1, node2 *framework.Node, cleanup func()) {
+	t.Helper()
+
+	// Allocate ports
+	http1, p2p1, err := framework.AllocateNodePorts()
+	require.NoError(t, err)
+	http2, p2p2, err := framework.AllocateNodePorts()
+	require.NoError(t, err)
+
+	// Create nodes
+	node1 = framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     http1,
+		P2PPort:      p2p1,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	node2 = framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     http2,
+		P2PPort:      p2p2,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	// Start nodes
+	require.NoError(t, node1.Start(ctx), "failed to start node1")
+	dumpLogsOnFailure(t, "node1", node1)
+
+	require.NoError(t, node2.Start(ctx), "failed to start node2")
+	dumpLogsOnFailure(t, "node2", node2)
+
+	// Connect node2 to node1
+	err = node2.Client().ConnectPeer(ctx, node1.P2PMultiaddr())
+	require.NoError(t, err, "failed to connect nodes")
+
+	// Wait for bidirectional connection
+	require.NoError(t, framework.WaitForPeerConnected(ctx, node1.Client(), node2.PeerID(), 30*time.Second))
+	require.NoError(t, framework.WaitForPeerConnected(ctx, node2.Client(), node1.PeerID(), 30*time.Second))
+
+	cleanup = func() {
+		node2.Stop()
+		node1.Stop()
+	}
+
+	return node1, node2, cleanup
+}
+
+// TestConnectionNodeInfo verifies the P2P info endpoint returns valid data.
+func TestConnectionNodeInfo(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	http1, p2p1, err := framework.AllocateNodePorts()
+	require.NoError(t, err)
+
+	node := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     http1,
+		P2PPort:      p2p1,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	require.NoError(t, node.Start(ctx))
+	defer node.Stop()
+	dumpLogsOnFailure(t, "node", node)
+
+	// Verify peer ID is set
+	require.NotEmpty(t, node.PeerID(), "peer ID should not be empty")
+
+	// Verify we can fetch P2P info
+	client := node.Client()
+	info, err := client.P2PInfo(ctx)
+	require.NoError(t, err)
+	require.Equal(t, node.PeerID(), info.ID)
+	require.NotEmpty(t, info.Addresses, "should have at least one listen address")
+
+	t.Logf("Node peer ID: %s", info.ID)
+	t.Logf("Node addresses: %v", info.Addresses)
+}

--- a/tests/interop/connection_test.go
+++ b/tests/interop/connection_test.go
@@ -192,3 +192,153 @@ func TestConnectionNodeInfo(t *testing.T) {
 	t.Logf("Node peer ID: %s", info.ID)
 	t.Logf("Node addresses: %v", info.Addresses)
 }
+
+// TestCrossRustToGoConnect tests that a Rust node can connect to a Go node.
+func TestCrossRustToGoConnect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Allocate ports for both nodes
+	httpRust, p2pRust, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for Rust node")
+
+	httpGo, p2pGo, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for Go node")
+
+	// Start Go node first (server)
+	goNode := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeGo,
+		HTTPPort:     httpGo,
+		P2PPort:      p2pGo,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting Go node...")
+	require.NoError(t, goNode.Start(ctx), "failed to start Go node")
+	defer goNode.Stop()
+	dumpLogsOnFailure(t, "go-node", goNode)
+
+	t.Logf("Go node started with peer ID: %s", goNode.PeerID())
+
+	// Start Rust node (client)
+	rustNode := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     httpRust,
+		P2PPort:      p2pRust,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting Rust node...")
+	require.NoError(t, rustNode.Start(ctx), "failed to start Rust node")
+	defer rustNode.Stop()
+	dumpLogsOnFailure(t, "rust-node", rustNode)
+
+	t.Logf("Rust node started with peer ID: %s", rustNode.PeerID())
+
+	// Get Go node's multiaddr for Rust node to connect to
+	goMultiaddr := goNode.P2PMultiaddr()
+	t.Logf("Go node multiaddr: %s", goMultiaddr)
+
+	// Connect Rust node to Go node
+	t.Log("Connecting Rust node to Go node...")
+	rustClient := rustNode.Client()
+	err = rustClient.ConnectPeer(ctx, goMultiaddr)
+	require.NoError(t, err, "failed to connect Rust node to Go node")
+
+	// Wait for connection to establish (Go doesn't support peer listing)
+	t.Log("Waiting for connection to establish...")
+	goClient := goNode.Client()
+	err = framework.WaitForPeerConnected(ctx, goClient, rustNode.PeerID(), 30*time.Second)
+	require.NoError(t, err, "connection wait failed on Go node")
+
+	err = framework.WaitForPeerConnected(ctx, rustClient, goNode.PeerID(), 30*time.Second)
+	require.NoError(t, err, "Rust node did not see Go node connect")
+
+	// Verify Rust node sees Go node (Go doesn't support peer listing)
+	peersRust, err := rustClient.ListPeers(ctx)
+	require.NoError(t, err, "failed to list peers from Rust node")
+	require.Len(t, peersRust, 1, "Rust node should see exactly 1 peer")
+	require.Equal(t, goNode.PeerID(), peersRust[0].ID, "Rust node should see Go node")
+
+	t.Log("Rust and Go nodes successfully connected!")
+}
+
+// TestCrossGoToRustConnect tests that a Go node can connect to a Rust node.
+func TestCrossGoToRustConnect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// Allocate ports for both nodes
+	httpRust, p2pRust, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for Rust node")
+
+	httpGo, p2pGo, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for Go node")
+
+	// Start Rust node first (server)
+	rustNode := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     httpRust,
+		P2PPort:      p2pRust,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting Rust node...")
+	require.NoError(t, rustNode.Start(ctx), "failed to start Rust node")
+	defer rustNode.Stop()
+	dumpLogsOnFailure(t, "rust-node", rustNode)
+
+	t.Logf("Rust node started with peer ID: %s", rustNode.PeerID())
+
+	// Start Go node (client)
+	goNode := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeGo,
+		HTTPPort:     httpGo,
+		P2PPort:      p2pGo,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting Go node...")
+	require.NoError(t, goNode.Start(ctx), "failed to start Go node")
+	defer goNode.Stop()
+	dumpLogsOnFailure(t, "go-node", goNode)
+
+	t.Logf("Go node started with peer ID: %s", goNode.PeerID())
+
+	// Get Rust node's multiaddr for Go node to connect to
+	rustMultiaddr := rustNode.P2PMultiaddr()
+	t.Logf("Rust node multiaddr: %s", rustMultiaddr)
+
+	// Connect Go node to Rust node
+	t.Log("Connecting Go node to Rust node...")
+	goClient := goNode.Client()
+	err = goClient.ConnectPeer(ctx, rustMultiaddr)
+	require.NoError(t, err, "failed to connect Go node to Rust node")
+
+	// Wait for Rust node to see Go node as connected
+	t.Log("Waiting for Rust node to see Go node...")
+	rustClient := rustNode.Client()
+	err = framework.WaitForPeerConnected(ctx, rustClient, goNode.PeerID(), 30*time.Second)
+	require.NoError(t, err, "Rust node did not see Go node connect")
+
+	// Wait for Go node (Go doesn't support peer listing, so this returns immediately)
+	t.Log("Waiting for Go node connection confirmation...")
+	err = framework.WaitForPeerConnected(ctx, goClient, rustNode.PeerID(), 30*time.Second)
+	require.NoError(t, err, "connection wait failed on Go node")
+
+	// Verify Rust node sees Go node (Go doesn't support peer listing)
+	peersRust, err := rustClient.ListPeers(ctx)
+	require.NoError(t, err, "failed to list peers from Rust node")
+	require.Len(t, peersRust, 1, "Rust node should see exactly 1 peer")
+	require.Equal(t, goNode.PeerID(), peersRust[0].ID, "Rust node should see Go node")
+
+	t.Log("Go and Rust nodes successfully connected!")
+}

--- a/tests/interop/framework/client.go
+++ b/tests/interop/framework/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // Client wraps HTTP communication with a DefraDB node.
@@ -24,9 +25,20 @@ func NewClient(baseURL string) *Client {
 }
 
 // P2PInfoResponse represents the response from GET /api/v0/p2p/info.
+// Both Rust and Go now return array of full multiaddrs with peer ID embedded.
 type P2PInfoResponse struct {
-	ID        string   `json:"id"`
-	Addresses []string `json:"addresses"`
+	ID        string
+	Addresses []string
+}
+
+// extractPeerIDFromMultiaddr extracts the peer ID from a multiaddr string.
+// Example: "/ip4/127.0.0.1/tcp/9182/p2p/12D3KooW..." -> "12D3KooW..."
+func extractPeerIDFromMultiaddr(addr string) string {
+	parts := strings.Split(addr, "/p2p/")
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return ""
 }
 
 // PeerInfo represents information about a connected peer.
@@ -79,6 +91,7 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 }
 
 // P2PInfo retrieves P2P node information.
+// Both Rust and Go now return array of multiaddrs with peer ID embedded.
 func (c *Client) P2PInfo(ctx context.Context) (*P2PInfoResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v0/p2p/info", nil)
 	if err != nil {
@@ -96,23 +109,39 @@ func (c *Client) P2PInfo(ctx context.Context) (*P2PInfoResponse, error) {
 		return nil, fmt.Errorf("p2p info returned status %d: %s", resp.StatusCode, string(body))
 	}
 
-	var info P2PInfoResponse
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+	// Response is array of full multiaddrs with peer ID embedded
+	var addresses []string
+	if err := json.NewDecoder(resp.Body).Decode(&addresses); err != nil {
 		return nil, fmt.Errorf("failed to decode p2p info response: %w", err)
 	}
 
-	return &info, nil
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("no addresses returned from p2p/info")
+	}
+
+	// Extract peer ID from first address containing /p2p/
+	var peerID string
+	for _, addr := range addresses {
+		if id := extractPeerIDFromMultiaddr(addr); id != "" {
+			peerID = id
+			break
+		}
+	}
+	if peerID == "" {
+		return nil, fmt.Errorf("no peer ID found in p2p/info response: %v", addresses)
+	}
+
+	return &P2PInfoResponse{
+		ID:        peerID,
+		Addresses: addresses,
+	}, nil
 }
 
 // ConnectPeer connects to a peer via multiaddr.
+// Both Rust and Go now support POST /api/v0/p2p/connect with ["..."]
 func (c *Client) ConnectPeer(ctx context.Context, multiaddr string) error {
-	reqBody := ConnectPeerRequest{Address: multiaddr}
-	body, err := json.Marshal(reqBody)
-	if err != nil {
-		return fmt.Errorf("failed to marshal connect peer request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v0/p2p/peers", bytes.NewReader(body))
+	body, _ := json.Marshal([]string{multiaddr})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v0/p2p/connect", bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to create connect peer request: %w", err)
 	}
@@ -124,15 +153,19 @@ func (c *Client) ConnectPeer(ctx context.Context, multiaddr string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("connect peer returned status %d: %s", resp.StatusCode, string(respBody))
+	if resp.StatusCode == http.StatusOK {
+		return nil
 	}
 
-	return nil
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("connect peer returned status %d: %s", resp.StatusCode, string(respBody))
 }
 
+// ErrEndpointNotSupported indicates the endpoint doesn't exist on this node type.
+var ErrEndpointNotSupported = fmt.Errorf("endpoint not supported")
+
 // ListPeers returns a list of connected peers.
+// Note: Go DefraDB doesn't have this endpoint (returns ErrEndpointNotSupported).
 func (c *Client) ListPeers(ctx context.Context) ([]PeerInfo, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v0/p2p/peers", nil)
 	if err != nil {
@@ -144,6 +177,11 @@ func (c *Client) ListPeers(ctx context.Context) ([]PeerInfo, error) {
 		return nil, fmt.Errorf("list peers request failed: %w", err)
 	}
 	defer resp.Body.Close()
+
+	// Go DefraDB doesn't have this endpoint
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrEndpointNotSupported
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
@@ -189,4 +227,139 @@ func (c *Client) GraphQL(ctx context.Context, query string, vars map[string]any)
 	}
 
 	return &gqlResp, nil
+}
+
+// SetReplicatorRequest represents a request to set up replication.
+type SetReplicatorRequest struct {
+	Addresses   []string `json:"Addresses"`
+	Collections []string `json:"Collections"`
+}
+
+// SetReplicator sets up replication for collections to peer addresses.
+func (c *Client) SetReplicator(ctx context.Context, addresses []string, collections []string) error {
+	reqBody := SetReplicatorRequest{Addresses: addresses, Collections: collections}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal set replicator request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v0/p2p/replicators", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create set replicator request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("set replicator request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("set replicator returned status %d: %s", resp.StatusCode, string(respBody))
+}
+
+// AddP2PCollections adds collections to P2P sync.
+func (c *Client) AddP2PCollections(ctx context.Context, collectionIDs []string) error {
+	body, err := json.Marshal(collectionIDs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal add p2p collections request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v0/p2p/collections", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create add p2p collections request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("add p2p collections request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("add p2p collections returned status %d: %s", resp.StatusCode, string(respBody))
+}
+
+// SyncDocumentsRequest represents a request to sync documents.
+type SyncDocumentsRequest struct {
+	CollectionName string   `json:"collectionName"`
+	DocIDs         []string `json:"docIDs"`
+	Timeout        string   `json:"timeout,omitempty"`
+}
+
+// SyncDocuments synchronizes documents from the network.
+func (c *Client) SyncDocuments(ctx context.Context, collectionName string, docIDs []string, timeout string) error {
+	reqBody := SyncDocumentsRequest{
+		CollectionName: collectionName,
+		DocIDs:         docIDs,
+		Timeout:        timeout,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sync documents request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v0/p2p/documents/sync", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create sync documents request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sync documents request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("sync documents returned status %d: %s", resp.StatusCode, string(respBody))
+}
+
+// AddSchemaResponse represents a response from POST /api/v0/schema.
+type AddSchemaResponse struct {
+	Name         string `json:"Name"`
+	VersionID    string `json:"VersionID"`
+	CollectionID string `json:"CollectionID"`
+}
+
+// AddSchema adds a schema to the database via HTTP POST /api/v0/schema.
+// The body should be GraphQL SDL defining the collection types.
+func (c *Client) AddSchema(ctx context.Context, sdl string) ([]AddSchemaResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v0/schema", strings.NewReader(sdl))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create add schema request: %w", err)
+	}
+	req.Header.Set("Content-Type", "text/plain")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("add schema request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("add schema returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var schemas []AddSchemaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&schemas); err != nil {
+		return nil, fmt.Errorf("failed to decode add schema response: %w", err)
+	}
+
+	return schemas, nil
 }

--- a/tests/interop/framework/client.go
+++ b/tests/interop/framework/client.go
@@ -1,0 +1,192 @@
+package framework
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Client wraps HTTP communication with a DefraDB node.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewClient creates a new Client for the given base URL.
+func NewClient(baseURL string) *Client {
+	return &Client{
+		httpClient: &http.Client{},
+		baseURL:    baseURL,
+	}
+}
+
+// P2PInfoResponse represents the response from GET /api/v0/p2p/info.
+type P2PInfoResponse struct {
+	ID        string   `json:"id"`
+	Addresses []string `json:"addresses"`
+}
+
+// PeerInfo represents information about a connected peer.
+type PeerInfo struct {
+	ID      string  `json:"id"`
+	Address *string `json:"address,omitempty"`
+}
+
+// ConnectPeerRequest represents a request to connect to a peer.
+type ConnectPeerRequest struct {
+	Address string `json:"address"`
+}
+
+// GraphQLRequest represents a GraphQL request body.
+type GraphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// GraphQLResponse represents a GraphQL response.
+type GraphQLResponse struct {
+	Data   json.RawMessage `json:"data,omitempty"`
+	Errors []GraphQLError  `json:"errors,omitempty"`
+}
+
+// GraphQLError represents a GraphQL error.
+type GraphQLError struct {
+	Message string `json:"message"`
+}
+
+// HealthCheck checks if the node is healthy.
+func (c *Client) HealthCheck(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health-check", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create health check request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("health check request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("health check returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+// P2PInfo retrieves P2P node information.
+func (c *Client) P2PInfo(ctx context.Context) (*P2PInfoResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v0/p2p/info", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create p2p info request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("p2p info request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("p2p info returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var info P2PInfoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("failed to decode p2p info response: %w", err)
+	}
+
+	return &info, nil
+}
+
+// ConnectPeer connects to a peer via multiaddr.
+func (c *Client) ConnectPeer(ctx context.Context, multiaddr string) error {
+	reqBody := ConnectPeerRequest{Address: multiaddr}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal connect peer request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v0/p2p/peers", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create connect peer request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect peer request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("connect peer returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
+// ListPeers returns a list of connected peers.
+func (c *Client) ListPeers(ctx context.Context) ([]PeerInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/v0/p2p/peers", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create list peers request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list peers request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list peers returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var peers []PeerInfo
+	if err := json.NewDecoder(resp.Body).Decode(&peers); err != nil {
+		return nil, fmt.Errorf("failed to decode list peers response: %w", err)
+	}
+
+	return peers, nil
+}
+
+// GraphQL executes a GraphQL query.
+func (c *Client) GraphQL(ctx context.Context, query string, vars map[string]any) (*GraphQLResponse, error) {
+	reqBody := GraphQLRequest{Query: query, Variables: vars}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal graphql request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/api/v0/graphql", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create graphql request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("graphql request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("graphql returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var gqlResp GraphQLResponse
+	if err := json.NewDecoder(resp.Body).Decode(&gqlResp); err != nil {
+		return nil, fmt.Errorf("failed to decode graphql response: %w", err)
+	}
+
+	return &gqlResp, nil
+}

--- a/tests/interop/framework/node.go
+++ b/tests/interop/framework/node.go
@@ -1,0 +1,281 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// NodeType identifies the implementation type.
+type NodeType string
+
+const (
+	NodeTypeRust NodeType = "rust"
+	NodeTypeGo   NodeType = "go"
+)
+
+// NodeConfig holds configuration for starting a node.
+type NodeConfig struct {
+	Type         NodeType
+	HTTPPort     int
+	P2PPort      int
+	Store        string // "memory", "redb", "badger"
+	NoEncryption bool
+	NoSigning    bool
+}
+
+// Node represents a running DefraDB node.
+type Node struct {
+	Config  NodeConfig
+	cmd     *exec.Cmd
+	tempDir string
+	httpURL string
+	peerID  string
+	logFile *os.File
+}
+
+// NewNode creates a new Node with the given configuration.
+func NewNode(cfg NodeConfig) *Node {
+	return &Node{
+		Config:  cfg,
+		httpURL: fmt.Sprintf("http://127.0.0.1:%d", cfg.HTTPPort),
+	}
+}
+
+// Start starts the node and waits for it to become ready.
+func (n *Node) Start(ctx context.Context) error {
+	// Create temp directory for node data
+	tempDir, err := os.MkdirTemp("", "defra-interop-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	n.tempDir = tempDir
+
+	// Build command based on node type
+	switch n.Config.Type {
+	case NodeTypeRust:
+		if err := n.startRust(ctx); err != nil {
+			n.cleanup()
+			return err
+		}
+	case NodeTypeGo:
+		return fmt.Errorf("Go node type not yet implemented")
+	default:
+		return fmt.Errorf("unknown node type: %s", n.Config.Type)
+	}
+
+	// Wait for the node to become ready
+	client := n.Client()
+	if err := WaitForReady(ctx, client, 30*time.Second); err != nil {
+		n.Stop()
+		return fmt.Errorf("node failed to become ready: %w", err)
+	}
+
+	// Fetch peer ID
+	info, err := client.P2PInfo(ctx)
+	if err != nil {
+		n.Stop()
+		return fmt.Errorf("failed to get peer info: %w", err)
+	}
+	n.peerID = info.ID
+
+	return nil
+}
+
+// startRust starts the Rust defra binary.
+func (n *Node) startRust(ctx context.Context) error {
+	binary := n.rustBinaryPath()
+
+	// Check if binary exists
+	if _, err := os.Stat(binary); os.IsNotExist(err) {
+		return fmt.Errorf("rust binary not found at %s (run 'make build-rust' first)", binary)
+	}
+
+	// Build command arguments
+	args := []string{
+		"start",
+		"--url", fmt.Sprintf("127.0.0.1:%d", n.Config.HTTPPort),
+		"--p2paddr", fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", n.Config.P2PPort),
+		"--rootdir", n.tempDir,
+		"--no-keyring", "true",
+	}
+
+	// Add store type
+	store := n.Config.Store
+	if store == "" {
+		store = "memory"
+	}
+	args = append(args, "--store", store)
+
+	// Add optional flags (boolean flags require explicit true/false values)
+	if n.Config.NoEncryption {
+		args = append(args, "--no-encryption", "true")
+	}
+	if n.Config.NoSigning {
+		args = append(args, "--no-signing", "true")
+	}
+
+	n.cmd = exec.CommandContext(ctx, binary, args...)
+
+	// Create log file in temp directory
+	logPath := filepath.Join(n.tempDir, "node.log")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf("failed to create log file: %w", err)
+	}
+	n.logFile = logFile
+
+	// Redirect stdout and stderr to log file
+	n.cmd.Stdout = logFile
+	n.cmd.Stderr = logFile
+
+	// Start the process
+	if err := n.cmd.Start(); err != nil {
+		logFile.Close()
+		return fmt.Errorf("failed to start rust binary: %w", err)
+	}
+
+	return nil
+}
+
+// rustBinaryPath returns the path to the Rust defra binary.
+func (n *Node) rustBinaryPath() string {
+	// Check environment variable first
+	if path := os.Getenv("DEFRA_RS_BINARY"); path != "" {
+		return path
+	}
+
+	// Default to relative path from tests/interop directory
+	return filepath.Join("..", "..", "target", "release", "defra")
+}
+
+// Stop stops the node and cleans up resources.
+func (n *Node) Stop() error {
+	var errs []error
+
+	if n.cmd != nil && n.cmd.Process != nil {
+		// Send SIGINT for graceful shutdown
+		if err := n.cmd.Process.Signal(syscall.SIGINT); err != nil {
+			errs = append(errs, fmt.Errorf("failed to send SIGINT: %w", err))
+		}
+
+		// Wait with timeout
+		done := make(chan error, 1)
+		go func() {
+			done <- n.cmd.Wait()
+		}()
+
+		select {
+		case <-done:
+			// Process exited cleanly
+		case <-time.After(5 * time.Second):
+			// Force kill after timeout
+			if err := n.cmd.Process.Kill(); err != nil {
+				errs = append(errs, fmt.Errorf("failed to kill process: %w", err))
+			}
+		}
+	}
+
+	// Close log file
+	if n.logFile != nil {
+		n.logFile.Close()
+		n.logFile = nil
+	}
+
+	// Clean up temp directory
+	if err := n.cleanup(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("stop errors: %v", errs)
+	}
+
+	return nil
+}
+
+// cleanup removes the temp directory.
+func (n *Node) cleanup() error {
+	if n.tempDir != "" {
+		if err := os.RemoveAll(n.tempDir); err != nil {
+			return fmt.Errorf("failed to remove temp dir: %w", err)
+		}
+		n.tempDir = ""
+	}
+	return nil
+}
+
+// Client returns an HTTP client for this node.
+func (n *Node) Client() *Client {
+	return NewClient(n.httpURL)
+}
+
+// PeerID returns the node's peer ID.
+func (n *Node) PeerID() string {
+	return n.peerID
+}
+
+// P2PMultiaddr returns the full P2P multiaddr for connecting to this node.
+func (n *Node) P2PMultiaddr() string {
+	return fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/p2p/%s", n.Config.P2PPort, n.peerID)
+}
+
+// HTTPURL returns the node's HTTP URL.
+func (n *Node) HTTPURL() string {
+	return n.httpURL
+}
+
+// LogPath returns the path to the node's log file.
+func (n *Node) LogPath() string {
+	if n.tempDir == "" {
+		return ""
+	}
+	return filepath.Join(n.tempDir, "node.log")
+}
+
+// DumpLogs writes the node's logs to the given writer.
+// Useful for debugging test failures.
+func (n *Node) DumpLogs(w io.Writer) error {
+	logPath := n.LogPath()
+	if logPath == "" {
+		return fmt.Errorf("no log file available")
+	}
+
+	// Sync log file to ensure all data is written
+	if n.logFile != nil {
+		n.logFile.Sync()
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return fmt.Errorf("failed to read log file: %w", err)
+	}
+
+	_, err = w.Write(data)
+	return err
+}
+
+// DumpLogsString returns the node's logs as a string.
+func (n *Node) DumpLogsString() (string, error) {
+	logPath := n.LogPath()
+	if logPath == "" {
+		return "", fmt.Errorf("no log file available")
+	}
+
+	// Sync log file to ensure all data is written
+	if n.logFile != nil {
+		n.logFile.Sync()
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read log file: %w", err)
+	}
+
+	return string(data), nil
+}

--- a/tests/interop/framework/node.go
+++ b/tests/interop/framework/node.go
@@ -24,7 +24,7 @@ type NodeConfig struct {
 	Type         NodeType
 	HTTPPort     int
 	P2PPort      int
-	Store        string // "memory", "redb", "badger"
+	Store        string // "memory", "redb" (rust only), "badger"
 	NoEncryption bool
 	NoSigning    bool
 }
@@ -64,7 +64,10 @@ func (n *Node) Start(ctx context.Context) error {
 			return err
 		}
 	case NodeTypeGo:
-		return fmt.Errorf("Go node type not yet implemented")
+		if err := n.startGo(ctx); err != nil {
+			n.cleanup()
+			return err
+		}
 	default:
 		return fmt.Errorf("unknown node type: %s", n.Config.Type)
 	}
@@ -97,6 +100,7 @@ func (n *Node) startRust(ctx context.Context) error {
 	}
 
 	// Build command arguments
+	// Rust CLI requires explicit true/false values for boolean flags
 	args := []string{
 		"start",
 		"--url", fmt.Sprintf("127.0.0.1:%d", n.Config.HTTPPort),
@@ -120,6 +124,53 @@ func (n *Node) startRust(ctx context.Context) error {
 		args = append(args, "--no-signing", "true")
 	}
 
+	return n.startBinary(ctx, binary, args)
+}
+
+// startGo starts the Go defra binary.
+func (n *Node) startGo(ctx context.Context) error {
+	binary := n.goBinaryPath()
+
+	// Check if binary exists
+	if _, err := os.Stat(binary); os.IsNotExist(err) {
+		return fmt.Errorf("go binary not found at %s (run 'make build-go' first)", binary)
+	}
+
+	// Build command arguments
+	// Go CLI uses simple boolean flags (no value needed)
+	args := []string{
+		"start",
+		"--url", fmt.Sprintf("127.0.0.1:%d", n.Config.HTTPPort),
+		"--p2paddr", fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", n.Config.P2PPort),
+		"--rootdir", n.tempDir,
+		"--no-keyring",
+		"--development",
+	}
+
+	// Add store type (Go supports: memory, badger)
+	store := n.Config.Store
+	if store == "" {
+		store = "memory"
+	}
+	// Map redb to badger for Go (redb is Rust-only)
+	if store == "redb" {
+		store = "badger"
+	}
+	args = append(args, "--store", store)
+
+	// Add optional flags (simple boolean flags, no values)
+	if n.Config.NoEncryption {
+		args = append(args, "--no-encryption")
+	}
+	if n.Config.NoSigning {
+		args = append(args, "--no-signing")
+	}
+
+	return n.startBinary(ctx, binary, args)
+}
+
+// startBinary starts the given binary with the given arguments.
+func (n *Node) startBinary(ctx context.Context, binary string, args []string) error {
 	n.cmd = exec.CommandContext(ctx, binary, args...)
 
 	// Create log file in temp directory
@@ -137,7 +188,7 @@ func (n *Node) startRust(ctx context.Context) error {
 	// Start the process
 	if err := n.cmd.Start(); err != nil {
 		logFile.Close()
-		return fmt.Errorf("failed to start rust binary: %w", err)
+		return fmt.Errorf("failed to start binary: %w", err)
 	}
 
 	return nil
@@ -152,6 +203,18 @@ func (n *Node) rustBinaryPath() string {
 
 	// Default to relative path from tests/interop directory
 	return filepath.Join("..", "..", "target", "release", "defra")
+}
+
+// goBinaryPath returns the path to the Go defra binary.
+func (n *Node) goBinaryPath() string {
+	// Check environment variable first
+	if path := os.Getenv("DEFRA_GO_BINARY"); path != "" {
+		return path
+	}
+
+	// Default to relative path from tests/interop directory
+	// This assumes the Go DefraDB is built to build/defradb in the Go repo
+	return filepath.Join("..", "..", "..", "defradb", "build", "defradb")
 }
 
 // Stop stops the node and cleans up resources.

--- a/tests/interop/framework/ports.go
+++ b/tests/interop/framework/ports.go
@@ -1,0 +1,33 @@
+package framework
+
+import (
+	"fmt"
+	"net"
+)
+
+// FindFreePort finds an available TCP port on localhost.
+func FindFreePort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("failed to find free port: %w", err)
+	}
+	defer listener.Close()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.Port, nil
+}
+
+// AllocateNodePorts allocates HTTP and P2P ports for a node.
+func AllocateNodePorts() (httpPort, p2pPort int, err error) {
+	httpPort, err = FindFreePort()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to allocate HTTP port: %w", err)
+	}
+
+	p2pPort, err = FindFreePort()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to allocate P2P port: %w", err)
+	}
+
+	return httpPort, p2pPort, nil
+}

--- a/tests/interop/framework/schema.go
+++ b/tests/interop/framework/schema.go
@@ -1,0 +1,26 @@
+package framework
+
+import "fmt"
+
+// UsersSchema is a simple test schema for user documents.
+const UsersSchema = `
+type Users {
+    name: String
+    age: Int
+}
+`
+
+// AddSchemaQuery generates a GraphQL mutation to add a schema.
+func AddSchemaQuery(schema string) string {
+	return fmt.Sprintf(`mutation { addSchema(schema: %q) }`, schema)
+}
+
+// CreateUserQuery generates a GraphQL mutation to create a user document.
+func CreateUserQuery(name string, age int) string {
+	return fmt.Sprintf(`mutation { create_Users(input: {name: %q, age: %d}) { _docID name age } }`, name, age)
+}
+
+// QueryUsersQuery generates a GraphQL query to fetch all users.
+func QueryUsersQuery() string {
+	return `{ Users { _docID name age } }`
+}

--- a/tests/interop/framework/wait.go
+++ b/tests/interop/framework/wait.go
@@ -30,11 +30,18 @@ func WaitForReady(ctx context.Context, client *Client, timeout time.Duration) er
 }
 
 // WaitForPeerConnected polls until the expected peer appears in the connected peers list.
+// Note: Go DefraDB doesn't support listing peers, so this returns nil immediately for Go nodes
+// (assuming the connect call succeeded).
 func WaitForPeerConnected(ctx context.Context, client *Client, expectedPeerID string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
 		peers, err := client.ListPeers(ctx)
+		if err == ErrEndpointNotSupported {
+			// Go DefraDB doesn't support listing peers
+			// If connect succeeded, we assume peer is connected
+			return nil
+		}
 		if err == nil {
 			for _, peer := range peers {
 				if peer.ID == expectedPeerID {

--- a/tests/interop/framework/wait.go
+++ b/tests/interop/framework/wait.go
@@ -1,0 +1,55 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const pollInterval = 100 * time.Millisecond
+
+// WaitForReady polls the health endpoint until ready or timeout.
+func WaitForReady(ctx context.Context, client *Client, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		err := client.HealthCheck(ctx)
+		if err == nil {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+			// Continue polling
+		}
+	}
+
+	return fmt.Errorf("node did not become ready within %v", timeout)
+}
+
+// WaitForPeerConnected polls until the expected peer appears in the connected peers list.
+func WaitForPeerConnected(ctx context.Context, client *Client, expectedPeerID string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		peers, err := client.ListPeers(ctx)
+		if err == nil {
+			for _, peer := range peers {
+				if peer.ID == expectedPeerID {
+					return nil
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+			// Continue polling
+		}
+	}
+
+	return fmt.Errorf("peer %s did not connect within %v", expectedPeerID, timeout)
+}

--- a/tests/interop/go.mod
+++ b/tests/interop/go.mod
@@ -1,0 +1,11 @@
+module github.com/sourcenetwork/defradb.rs-interop/tests/interop
+
+go 1.21
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/tests/interop/go.sum
+++ b/tests/interop/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/interop/sync_test.go
+++ b/tests/interop/sync_test.go
@@ -1,0 +1,278 @@
+package interop
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcenetwork/defradb.rs-interop/tests/interop/framework"
+)
+
+// TestSyncRustToGoWriteRead tests writing a document to a Rust node
+// and reading it from a Go node via P2P replication.
+func TestSyncRustToGoWriteRead(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// Allocate ports for both nodes
+	httpRust, p2pRust, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for Rust node")
+
+	httpGo, p2pGo, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for Go node")
+
+	// Start Rust node
+	rustNode := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     httpRust,
+		P2PPort:      p2pRust,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting Rust node...")
+	require.NoError(t, rustNode.Start(ctx), "failed to start Rust node")
+	defer rustNode.Stop()
+	dumpLogsOnFailure(t, "rust-node", rustNode)
+
+	t.Logf("Rust node started with peer ID: %s", rustNode.PeerID())
+
+	// Start Go node
+	goNode := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeGo,
+		HTTPPort:     httpGo,
+		P2PPort:      p2pGo,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting Go node...")
+	require.NoError(t, goNode.Start(ctx), "failed to start Go node")
+	defer goNode.Stop()
+	dumpLogsOnFailure(t, "go-node", goNode)
+
+	t.Logf("Go node started with peer ID: %s", goNode.PeerID())
+
+	rustClient := rustNode.Client()
+	goClient := goNode.Client()
+
+	// Connect Go node to Rust node
+	t.Log("Connecting Go node to Rust node...")
+	err = goClient.ConnectPeer(ctx, rustNode.P2PMultiaddr())
+	require.NoError(t, err, "failed to connect Go node to Rust node")
+
+	// Wait for connection to establish
+	err = framework.WaitForPeerConnected(ctx, rustClient, goNode.PeerID(), 30*time.Second)
+	require.NoError(t, err, "Rust node did not see Go node connect")
+
+	t.Log("Nodes connected successfully")
+
+	// Add schema to both nodes using HTTP endpoint
+	t.Log("Adding schema to both nodes...")
+
+	rustSchemas, err := rustClient.AddSchema(ctx, framework.UsersSchema)
+	require.NoError(t, err, "failed to add schema to Rust node")
+	require.Len(t, rustSchemas, 1, "expected 1 schema from Rust node")
+	t.Logf("Schema added to Rust node: %s", rustSchemas[0].Name)
+
+	goSchemas, err := goClient.AddSchema(ctx, framework.UsersSchema)
+	require.NoError(t, err, "failed to add schema to Go node")
+	require.Len(t, goSchemas, 1, "expected 1 schema from Go node")
+	t.Logf("Schema added to Go node: %s", goSchemas[0].Name)
+
+	// Set up replication from Rust to Go
+	// The Rust node will push data to the Go node
+	t.Log("Setting up replication...")
+	err = rustClient.SetReplicator(ctx, []string{goNode.P2PMultiaddr()}, []string{"Users"})
+	require.NoError(t, err, "failed to set replicator on Rust node")
+	t.Log("Replicator set on Rust node")
+
+	// Create a document on the Rust node
+	t.Log("Creating document on Rust node...")
+	createQuery := framework.CreateUserQuery("Alice", 30)
+	createResp, err := rustClient.GraphQL(ctx, createQuery, nil)
+	require.NoError(t, err, "failed to create document on Rust node")
+	require.Empty(t, createResp.Errors, "Create errors: %v", createResp.Errors)
+
+	// Parse the created document to get the docID
+	var createData struct {
+		CreateUsers struct {
+			DocID string `json:"_docID"`
+			Name  string `json:"name"`
+			Age   int    `json:"age"`
+		} `json:"create_Users"`
+	}
+	err = json.Unmarshal(createResp.Data, &createData)
+	require.NoError(t, err, "failed to parse create response")
+	docID := createData.CreateUsers.DocID
+	t.Logf("Created document with ID: %s", docID)
+
+	// Wait a bit for replication to happen
+	t.Log("Waiting for replication...")
+	time.Sleep(2 * time.Second)
+
+	// Query the document from the Go node
+	t.Log("Querying document from Go node...")
+	queryResp, err := goClient.GraphQL(ctx, framework.QueryUsersQuery(), nil)
+	require.NoError(t, err, "failed to query Go node")
+	require.Empty(t, queryResp.Errors, "Query errors: %v", queryResp.Errors)
+
+	// Parse the query response
+	var queryData struct {
+		Users []struct {
+			DocID string `json:"_docID"`
+			Name  string `json:"name"`
+			Age   int    `json:"age"`
+		} `json:"Users"`
+	}
+	err = json.Unmarshal(queryResp.Data, &queryData)
+	require.NoError(t, err, "failed to parse query response")
+
+	t.Logf("Query response: %+v", queryData)
+
+	// Verify the document was replicated
+	require.Len(t, queryData.Users, 1, "expected 1 user document on Go node")
+	require.Equal(t, docID, queryData.Users[0].DocID, "document ID mismatch")
+	require.Equal(t, "Alice", queryData.Users[0].Name, "name mismatch")
+	require.Equal(t, 30, queryData.Users[0].Age, "age mismatch")
+
+	t.Log("Document successfully replicated from Rust to Go!")
+}
+
+// TestSyncGoToRustWriteRead tests writing a document to a Go node
+// and reading it from a Rust node via P2P replication.
+func TestSyncGoToRustWriteRead(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// Allocate ports for both nodes
+	httpRust, p2pRust, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for Rust node")
+
+	httpGo, p2pGo, err := framework.AllocateNodePorts()
+	require.NoError(t, err, "failed to allocate ports for Go node")
+
+	// Start Rust node
+	rustNode := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeRust,
+		HTTPPort:     httpRust,
+		P2PPort:      p2pRust,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting Rust node...")
+	require.NoError(t, rustNode.Start(ctx), "failed to start Rust node")
+	defer rustNode.Stop()
+	dumpLogsOnFailure(t, "rust-node", rustNode)
+
+	t.Logf("Rust node started with peer ID: %s", rustNode.PeerID())
+
+	// Start Go node
+	goNode := framework.NewNode(framework.NodeConfig{
+		Type:         framework.NodeTypeGo,
+		HTTPPort:     httpGo,
+		P2PPort:      p2pGo,
+		Store:        "memory",
+		NoEncryption: true,
+		NoSigning:    true,
+	})
+
+	t.Log("Starting Go node...")
+	require.NoError(t, goNode.Start(ctx), "failed to start Go node")
+	defer goNode.Stop()
+	dumpLogsOnFailure(t, "go-node", goNode)
+
+	t.Logf("Go node started with peer ID: %s", goNode.PeerID())
+
+	rustClient := rustNode.Client()
+	goClient := goNode.Client()
+
+	// Connect Rust node to Go node
+	t.Log("Connecting Rust node to Go node...")
+	err = rustClient.ConnectPeer(ctx, goNode.P2PMultiaddr())
+	require.NoError(t, err, "failed to connect Rust node to Go node")
+
+	// Wait for connection to establish
+	err = framework.WaitForPeerConnected(ctx, rustClient, goNode.PeerID(), 30*time.Second)
+	require.NoError(t, err, "Rust node did not see Go node connect")
+
+	t.Log("Nodes connected successfully")
+
+	// Add schema to both nodes using HTTP endpoint
+	t.Log("Adding schema to both nodes...")
+
+	rustSchemas, err := rustClient.AddSchema(ctx, framework.UsersSchema)
+	require.NoError(t, err, "failed to add schema to Rust node")
+	require.Len(t, rustSchemas, 1, "expected 1 schema from Rust node")
+	t.Logf("Schema added to Rust node: %s", rustSchemas[0].Name)
+
+	goSchemas, err := goClient.AddSchema(ctx, framework.UsersSchema)
+	require.NoError(t, err, "failed to add schema to Go node")
+	require.Len(t, goSchemas, 1, "expected 1 schema from Go node")
+	t.Logf("Schema added to Go node: %s", goSchemas[0].Name)
+
+	// Set up replication from Go to Rust
+	// The Go node will push data to the Rust node
+	t.Log("Setting up replication...")
+	err = goClient.SetReplicator(ctx, []string{rustNode.P2PMultiaddr()}, []string{"Users"})
+	require.NoError(t, err, "failed to set replicator on Go node")
+	t.Log("Replicator set on Go node")
+
+	// Create a document on the Go node
+	t.Log("Creating document on Go node...")
+	createQuery := framework.CreateUserQuery("Bob", 25)
+	createResp, err := goClient.GraphQL(ctx, createQuery, nil)
+	require.NoError(t, err, "failed to create document on Go node")
+	require.Empty(t, createResp.Errors, "Create errors: %v", createResp.Errors)
+
+	// Parse the created document to get the docID
+	var createData struct {
+		CreateUsers struct {
+			DocID string `json:"_docID"`
+			Name  string `json:"name"`
+			Age   int    `json:"age"`
+		} `json:"create_Users"`
+	}
+	err = json.Unmarshal(createResp.Data, &createData)
+	require.NoError(t, err, "failed to parse create response")
+	docID := createData.CreateUsers.DocID
+	t.Logf("Created document with ID: %s", docID)
+
+	// Wait a bit for replication to happen
+	t.Log("Waiting for replication...")
+	time.Sleep(2 * time.Second)
+
+	// Query the document from the Rust node
+	t.Log("Querying document from Rust node...")
+	queryResp, err := rustClient.GraphQL(ctx, framework.QueryUsersQuery(), nil)
+	require.NoError(t, err, "failed to query Rust node")
+	require.Empty(t, queryResp.Errors, "Query errors: %v", queryResp.Errors)
+
+	// Parse the query response
+	var queryData struct {
+		Users []struct {
+			DocID string `json:"_docID"`
+			Name  string `json:"name"`
+			Age   int    `json:"age"`
+		} `json:"Users"`
+	}
+	err = json.Unmarshal(queryResp.Data, &queryData)
+	require.NoError(t, err, "failed to parse query response")
+
+	t.Logf("Query response: %+v", queryData)
+
+	// Verify the document was replicated
+	require.Len(t, queryData.Users, 1, "expected 1 user document on Rust node")
+	require.Equal(t, docID, queryData.Users[0].DocID, "document ID mismatch")
+	require.Equal(t, "Bob", queryData.Users[0].Name, "name mismatch")
+	require.Equal(t, 25, queryData.Users[0].Age, "age mismatch")
+
+	t.Log("Document successfully replicated from Go to Rust!")
+}


### PR DESCRIPTION
## Summary

- Add Go test framework in `tests/interop/` for P2P interoperability testing
- Fix P2P host event loop ordering bug (must spawn before listen)
- Wire P2P endpoints to HTTP server via new `P2PAdapter`
- Add `with_p2p()` support to HTTP Server struct

## Test Framework Structure

```
tests/interop/
├── go.mod                    # Go module
├── Makefile                  # Build and test targets
├── framework/
│   ├── node.go              # Node abstraction (start, stop, log capture)
│   ├── client.go            # HTTP client wrapper for DefraDB API
│   ├── ports.go             # Port allocation utilities
│   ├── wait.go              # Readiness polling utilities
│   └── schema.go            # Shared test schemas
└── connection_test.go       # P2P discovery tests
```

## Bug Fixes

1. **P2P host event loop ordering** (`crates/cli/src/commands/start.rs`): The P2P host event loop was being spawned AFTER calling `listen()`, but `listen()` requires the event loop to be running to process commands. Fixed by spawning the host first.

2. **P2P HTTP endpoint wiring**: The HTTP server wasn't exposing P2P endpoints because the P2P handle wasn't being registered. Fixed by:
   - Adding `P2PAdapter` (`crates/cli/src/p2p_adapter.rs`) to implement `P2POperations` using `P2PHostHandle`
   - Adding `with_p2p()` method to `Server` struct (`crates/http/src/server.rs`)
   - Wiring the P2P adapter to the HTTP server in the CLI

## Test plan

- [x] `TestConnectionNodeInfo` - Verifies P2P info endpoint returns valid peer ID and addresses
- [x] `TestConnectionTwoRustNodesConnect` - Two Rust nodes connect and see each other as peers
- [x] All existing Rust tests pass (`cargo test`)

## Run tests

```bash
cd tests/interop
make build-rust
make test
```

🤖 Generated with [Claude Code](https://claude.ai/code)