### PR TITLE
feat(query): Query parity features: _ilike, variables, array ops, EXPLAIN, fragments

### DIFF
--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -46,7 +46,7 @@ pub use plan::{
     TypeJoinMany, TypeJoinOne, UpdateInput, UpdateNode, UpsertAction, UpsertInput, UpsertNode,
 };
 pub use planner::{Doc, DocStatus, ExecInfo, PlanNode, Planner};
-pub use query_parse::{parse_mutations, parse_query, parse_request, ParsedOperation};
+pub use query_parse::{parse_mutations, parse_query, parse_request, ExplainType, ParsedOperation};
 pub use rest::{RestError, RestOperations, RestOperationsImpl, RestResult};
 pub use runner::{DocFetcher, FetchByIdsResult, QueryRunner};
 pub use sdl_parse::parse_sdl;

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -405,6 +405,11 @@ impl Filter {
         negate: bool,
         case_insensitive: bool,
     ) -> Result<bool> {
+        // Null fields never match (standard database behavior, matches Go DefraDB)
+        if actual.is_null() {
+            return Ok(if negate { true } else { false });
+        }
+
         let op_name = if case_insensitive { "_ilike" } else { "_like" };
 
         let actual_str = actual.as_str().ok_or_else(|| {
@@ -413,28 +418,6 @@ impl Filter {
         let pattern_str = pattern.as_str().ok_or_else(|| {
             QueryError::invalid_filter(format!("{} requires string pattern", op_name))
         })?;
-
-        // Validate pattern - only simple patterns are supported:
-        // - 'prefix%' (starts with)
-        // - '%suffix' (ends with)
-        // - '%contains%' (contains)
-        // - 'exact' (exact match)
-        if pattern_str.contains('_') {
-            return Err(QueryError::invalid_filter(format!(
-                "{} with '_' wildcard is not yet supported",
-                op_name
-            )));
-        }
-
-        let percent_count = pattern_str.matches('%').count();
-        if percent_count > 2
-            || (percent_count == 2 && !(pattern_str.starts_with('%') && pattern_str.ends_with('%')))
-        {
-            return Err(QueryError::invalid_filter(format!(
-                "{} only supports: 'prefix%', '%suffix', '%contains%', or exact match",
-                op_name
-            )));
-        }
 
         // Apply case transformation if case-insensitive
         let (actual_cmp, pattern_cmp): (std::borrow::Cow<str>, std::borrow::Cow<str>) =
@@ -447,17 +430,58 @@ impl Filter {
                 (actual_str.into(), pattern_str.into())
             };
 
-        // Simple pattern matching
+        // Pattern matching following Go DefraDB behavior:
+        // - 'prefix%' (starts with)
+        // - '%suffix' (ends with)
+        // - '%contains%' (contains)
+        // - 'prefix%suffix' (starts with AND ends with)
+        // - 'exact' (exact match)
+        // Note: '_' wildcard is treated as literal character (matches Go behavior)
         let matches = if let Some(inner) = pattern_cmp
             .strip_prefix('%')
             .and_then(|s| s.strip_suffix('%'))
         {
+            // %contains%
             actual_cmp.contains(inner)
         } else if let Some(suffix) = pattern_cmp.strip_prefix('%') {
+            // %suffix (and suffix has no %)
+            if suffix.contains('%') {
+                // Invalid: multiple % not at edges
+                return Err(QueryError::invalid_filter(format!(
+                    "{} does not support multiple wildcards except '%contains%'",
+                    op_name
+                )));
+            }
             actual_cmp.ends_with(suffix)
         } else if let Some(prefix) = pattern_cmp.strip_suffix('%') {
+            // prefix% (and prefix has no %)
+            if prefix.contains('%') {
+                // Invalid: multiple % not at edges
+                return Err(QueryError::invalid_filter(format!(
+                    "{} does not support multiple wildcards except '%contains%'",
+                    op_name
+                )));
+            }
             actual_cmp.starts_with(prefix)
+        } else if pattern_cmp.contains('%') {
+            // prefix%suffix pattern (single % in the middle)
+            let parts: Vec<&str> = pattern_cmp.splitn(2, '%').collect();
+            if parts.len() == 2 {
+                let prefix = parts[0];
+                let suffix = parts[1];
+                // Suffix should not contain more %
+                if suffix.contains('%') {
+                    return Err(QueryError::invalid_filter(format!(
+                        "{} does not support multiple wildcards except '%contains%'",
+                        op_name
+                    )));
+                }
+                actual_cmp.starts_with(prefix) && actual_cmp.ends_with(suffix)
+            } else {
+                false
+            }
         } else {
+            // Exact match
             actual_cmp == pattern_cmp
         };
 
@@ -704,15 +728,90 @@ mod tests {
     }
 
     #[test]
-    fn test_ilike_unsupported_underscore() {
+    fn test_ilike_underscore_as_literal() {
+        // Underscore is treated as literal character (matches Go behavior)
         let filter = Filter::from_conditions(HashMap::from([(
             "name".to_string(),
             json!({"_ilike": "Al_ce"}),
         )]));
         let mapping = make_mapping();
+        let fields = make_fields(); // name = "Alice"
+        // "Al_ce" should NOT match "Alice" because _ is literal, not wildcard
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+
+        // But "Al_ce" should match "Al_ce" exactly
+        let mut fields_with_underscore = make_fields();
+        fields_with_underscore[1] = Some(json!("Al_ce"));
+        assert!(filter.matches(&fields_with_underscore, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_ilike_prefix_suffix_pattern() {
+        // Pattern "Ali%ce" should match "Alice" (starts with "ali" AND ends with "ce")
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "ALI%CE"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields(); // name = "Alice"
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_like_prefix_suffix_pattern() {
+        // Pattern "Ali%ce" should match "Alice" (case-sensitive)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_like": "Ali%ce"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields(); // name = "Alice"
+        assert!(filter.matches(&fields, &mapping).unwrap());
+
+        // Wrong case should NOT match
+        let filter_wrong_case = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_like": "ALI%CE"}),
+        )]));
+        assert!(!filter_wrong_case.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_ilike_prefix_suffix_no_match() {
+        // Pattern "Bob%son" should NOT match "Alice"
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "Bob%son"}),
+        )]));
+        let mapping = make_mapping();
         let fields = make_fields();
-        let result = filter.matches(&fields, &mapping);
-        assert!(result.is_err());
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_ilike_null_field_returns_false() {
+        // Null field should return false for _ilike (not error), matching Go behavior
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "Ali%"}),
+        )]));
+        let mapping = make_mapping();
+        let mut fields = make_fields();
+        fields[1] = Some(json!(null)); // name is null
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_nilike_null_field_returns_true() {
+        // Negated: null field with _nilike should return true (null doesn't match pattern)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_nilike": "Ali%"}),
+        )]));
+        let mapping = make_mapping();
+        let mut fields = make_fields();
+        fields[1] = Some(json!(null)); // name is null
+        assert!(filter.matches(&fields, &mapping).unwrap());
     }
 
     // Helper to create mapping with array and object fields for testing
@@ -960,19 +1059,21 @@ mod tests {
     }
 
     #[test]
-    fn test_like_unsupported_underscore() {
+    fn test_like_underscore_as_literal() {
+        // Underscore is treated as literal character (matches Go behavior)
         let filter = Filter::from_conditions(HashMap::from([(
             "name".to_string(),
             json!({"_like": "Al_ce"}),
         )]));
         let mapping = make_mapping();
         let fields = make_fields();
-        let result = filter.matches(&fields, &mapping);
-        assert!(result.is_err());
+        // "Al_ce" should NOT match "Alice" because _ is literal
+        assert!(!filter.matches(&fields, &mapping).unwrap());
     }
 
     #[test]
     fn test_like_unsupported_complex_pattern() {
+        // Multiple % not at edges should error (except %contains%)
         let filter = Filter::from_conditions(HashMap::from([(
             "name".to_string(),
             json!({"_like": "%li%ce"}),

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -47,6 +47,15 @@ pub enum FilterOp {
     /// Negated case-insensitive pattern match (_nilike)
     #[serde(rename = "_nilike")]
     Nilike,
+    /// Array contains value (_contains)
+    #[serde(rename = "_contains")]
+    Contains,
+    /// Array is contained in given array (_contained_in)
+    #[serde(rename = "_contained_in")]
+    ContainedIn,
+    /// Object/map has key (_has_key)
+    #[serde(rename = "_has_key")]
+    HasKey,
     /// Logical AND (_and)
     #[serde(rename = "_and")]
     And,
@@ -74,6 +83,9 @@ impl FilterOp {
             "_nlike" => Some(Self::Nlike),
             "_ilike" => Some(Self::Ilike),
             "_nilike" => Some(Self::Nilike),
+            "_contains" => Some(Self::Contains),
+            "_contained_in" => Some(Self::ContainedIn),
+            "_has_key" => Some(Self::HasKey),
             "_and" => Some(Self::And),
             "_or" => Some(Self::Or),
             "_not" => Some(Self::Not),
@@ -96,6 +108,9 @@ impl FilterOp {
             Self::Nlike => "_nlike",
             Self::Ilike => "_ilike",
             Self::Nilike => "_nilike",
+            Self::Contains => "_contains",
+            Self::ContainedIn => "_contained_in",
+            Self::HasKey => "_has_key",
             Self::And => "_and",
             Self::Or => "_or",
             Self::Not => "_not",
@@ -293,6 +308,35 @@ impl Filter {
             FilterOp::Nlike => self.like_match(actual, expected, true, false),
             FilterOp::Ilike => self.like_match(actual, expected, false, true),
             FilterOp::Nilike => self.like_match(actual, expected, true, true),
+            FilterOp::Contains => {
+                // Array field contains the expected value
+                let arr = actual
+                    .as_array()
+                    .ok_or_else(|| QueryError::invalid_filter("_contains requires array field"))?;
+                Ok(arr.iter().any(|v| Self::values_equal(v, expected)))
+            }
+            FilterOp::ContainedIn => {
+                // All elements of actual array are in expected array (actual is subset of expected)
+                let actual_arr = actual.as_array().ok_or_else(|| {
+                    QueryError::invalid_filter("_contained_in requires array field")
+                })?;
+                let expected_arr = expected.as_array().ok_or_else(|| {
+                    QueryError::invalid_filter("_contained_in requires array value")
+                })?;
+                Ok(actual_arr
+                    .iter()
+                    .all(|v| expected_arr.iter().any(|e| Self::values_equal(v, e))))
+            }
+            FilterOp::HasKey => {
+                // Object/map has the specified key
+                let key = expected
+                    .as_str()
+                    .ok_or_else(|| QueryError::invalid_filter("_has_key requires string key"))?;
+                let obj = actual
+                    .as_object()
+                    .ok_or_else(|| QueryError::invalid_filter("_has_key requires object field"))?;
+                Ok(obj.contains_key(key))
+            }
             FilterOp::And | FilterOp::Or | FilterOp::Not => Err(QueryError::internal(
                 "logical ops should be handled at top level",
             )),
@@ -659,12 +703,154 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // Helper to create mapping with array and object fields for testing
+    fn make_extended_mapping() -> DocumentMapping {
+        let mut m = DocumentMapping::new();
+        m.add(0, "_docID");
+        m.add(1, "name");
+        m.add(2, "age");
+        m.add(3, "active");
+        m.add(4, "tags"); // Array field
+        m.add(5, "metadata"); // Object field
+        m
+    }
+
+    fn make_extended_fields() -> Vec<Option<JsonValue>> {
+        vec![
+            Some(json!("doc1")),
+            Some(json!("Alice")),
+            Some(json!(30)),
+            Some(json!(true)),
+            Some(json!(["rust", "database", "graphql"])), // tags array
+            Some(json!({"version": "1.0", "author": "Alice"})), // metadata object
+        ]
+    }
+
+    #[test]
+    fn test_contains_filter_match() {
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contains": "rust"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields();
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_contains_filter_no_match() {
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contains": "python"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields();
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_contains_filter_non_array_error() {
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_contains": "rust"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields();
+        let result = filter.matches(&fields, &mapping);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires array field"));
+    }
+
+    #[test]
+    fn test_contained_in_filter_match() {
+        // All elements of tags are in the given array
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contained_in": ["rust", "database", "graphql", "sql", "nosql"]}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields();
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_contained_in_filter_no_match() {
+        // Not all elements of tags are in the given array (missing "graphql")
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contained_in": ["rust", "database"]}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields();
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_contained_in_filter_empty_field_array() {
+        // Empty array is contained in any array
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contained_in": ["anything"]}),
+        )]));
+        let mapping = make_extended_mapping();
+        let mut fields = make_extended_fields();
+        fields[4] = Some(json!([])); // Empty tags array
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_has_key_filter_match() {
+        let filter = Filter::from_conditions(HashMap::from([(
+            "metadata".to_string(),
+            json!({"_has_key": "version"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields();
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_has_key_filter_no_match() {
+        let filter = Filter::from_conditions(HashMap::from([(
+            "metadata".to_string(),
+            json!({"_has_key": "nonexistent"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields();
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_has_key_filter_non_object_error() {
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_has_key": "version"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields();
+        let result = filter.matches(&fields, &mapping);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("requires object field"));
+    }
+
     #[test]
     fn test_filter_op_parse() {
         assert_eq!(FilterOp::parse("_eq"), Some(FilterOp::Eq));
         assert_eq!(FilterOp::parse("_and"), Some(FilterOp::And));
         assert_eq!(FilterOp::parse("_ilike"), Some(FilterOp::Ilike));
         assert_eq!(FilterOp::parse("_nilike"), Some(FilterOp::Nilike));
+        assert_eq!(FilterOp::parse("_contains"), Some(FilterOp::Contains));
+        assert_eq!(
+            FilterOp::parse("_contained_in"),
+            Some(FilterOp::ContainedIn)
+        );
+        assert_eq!(FilterOp::parse("_has_key"), Some(FilterOp::HasKey));
         assert_eq!(FilterOp::parse("invalid"), None);
     }
 

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -41,6 +41,12 @@ pub enum FilterOp {
     /// Negated pattern match (_nlike)
     #[serde(rename = "_nlike")]
     Nlike,
+    /// Case-insensitive pattern match (_ilike)
+    #[serde(rename = "_ilike")]
+    Ilike,
+    /// Negated case-insensitive pattern match (_nilike)
+    #[serde(rename = "_nilike")]
+    Nilike,
     /// Logical AND (_and)
     #[serde(rename = "_and")]
     And,
@@ -66,6 +72,8 @@ impl FilterOp {
             "_nin" => Some(Self::Nin),
             "_like" => Some(Self::Like),
             "_nlike" => Some(Self::Nlike),
+            "_ilike" => Some(Self::Ilike),
+            "_nilike" => Some(Self::Nilike),
             "_and" => Some(Self::And),
             "_or" => Some(Self::Or),
             "_not" => Some(Self::Not),
@@ -86,6 +94,8 @@ impl FilterOp {
             Self::Nin => "_nin",
             Self::Like => "_like",
             Self::Nlike => "_nlike",
+            Self::Ilike => "_ilike",
+            Self::Nilike => "_nilike",
             Self::And => "_and",
             Self::Or => "_or",
             Self::Not => "_not",
@@ -279,8 +289,10 @@ impl Filter {
                     .ok_or_else(|| QueryError::invalid_filter("_nin requires array"))?;
                 Ok(!arr.iter().any(|v| Self::values_equal(actual, v)))
             }
-            FilterOp::Like => self.like_match(actual, expected, false),
-            FilterOp::Nlike => self.like_match(actual, expected, true),
+            FilterOp::Like => self.like_match(actual, expected, false, false),
+            FilterOp::Nlike => self.like_match(actual, expected, true, false),
+            FilterOp::Ilike => self.like_match(actual, expected, false, true),
+            FilterOp::Nilike => self.like_match(actual, expected, true, true),
             FilterOp::And | FilterOp::Or | FilterOp::Not => Err(QueryError::internal(
                 "logical ops should be handled at top level",
             )),
@@ -330,13 +342,21 @@ impl Filter {
         }
     }
 
-    fn like_match(&self, actual: &JsonValue, pattern: &JsonValue, negate: bool) -> Result<bool> {
-        let actual_str = actual
-            .as_str()
-            .ok_or_else(|| QueryError::invalid_filter("_like requires string field"))?;
-        let pattern_str = pattern
-            .as_str()
-            .ok_or_else(|| QueryError::invalid_filter("_like requires string pattern"))?;
+    fn like_match(
+        &self,
+        actual: &JsonValue,
+        pattern: &JsonValue,
+        negate: bool,
+        case_insensitive: bool,
+    ) -> Result<bool> {
+        let op_name = if case_insensitive { "_ilike" } else { "_like" };
+
+        let actual_str = actual.as_str().ok_or_else(|| {
+            QueryError::invalid_filter(format!("{} requires string field", op_name))
+        })?;
+        let pattern_str = pattern.as_str().ok_or_else(|| {
+            QueryError::invalid_filter(format!("{} requires string pattern", op_name))
+        })?;
 
         // Validate pattern - only simple patterns are supported:
         // - 'prefix%' (starts with)
@@ -344,32 +364,45 @@ impl Filter {
         // - '%contains%' (contains)
         // - 'exact' (exact match)
         if pattern_str.contains('_') {
-            return Err(QueryError::invalid_filter(
-                "_like with '_' wildcard is not yet supported",
-            ));
+            return Err(QueryError::invalid_filter(format!(
+                "{} with '_' wildcard is not yet supported",
+                op_name
+            )));
         }
 
         let percent_count = pattern_str.matches('%').count();
         if percent_count > 2
             || (percent_count == 2 && !(pattern_str.starts_with('%') && pattern_str.ends_with('%')))
         {
-            return Err(QueryError::invalid_filter(
-                "_like only supports: 'prefix%', '%suffix', '%contains%', or exact match",
-            ));
+            return Err(QueryError::invalid_filter(format!(
+                "{} only supports: 'prefix%', '%suffix', '%contains%', or exact match",
+                op_name
+            )));
         }
 
+        // Apply case transformation if case-insensitive
+        let (actual_cmp, pattern_cmp): (std::borrow::Cow<str>, std::borrow::Cow<str>) =
+            if case_insensitive {
+                (
+                    actual_str.to_lowercase().into(),
+                    pattern_str.to_lowercase().into(),
+                )
+            } else {
+                (actual_str.into(), pattern_str.into())
+            };
+
         // Simple pattern matching
-        let matches = if let Some(inner) = pattern_str
+        let matches = if let Some(inner) = pattern_cmp
             .strip_prefix('%')
             .and_then(|s| s.strip_suffix('%'))
         {
-            actual_str.contains(inner)
-        } else if let Some(suffix) = pattern_str.strip_prefix('%') {
-            actual_str.ends_with(suffix)
-        } else if let Some(prefix) = pattern_str.strip_suffix('%') {
-            actual_str.starts_with(prefix)
+            actual_cmp.contains(inner)
+        } else if let Some(suffix) = pattern_cmp.strip_prefix('%') {
+            actual_cmp.ends_with(suffix)
+        } else if let Some(prefix) = pattern_cmp.strip_suffix('%') {
+            actual_cmp.starts_with(prefix)
         } else {
-            actual_str == pattern_str
+            actual_cmp == pattern_cmp
         };
 
         Ok(if negate { !matches } else { matches })
@@ -536,9 +569,102 @@ mod tests {
     }
 
     #[test]
+    fn test_ilike_filter_case_insensitive_prefix() {
+        // Pattern "ALI%" should match "Alice" (case-insensitive)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "ALI%"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields(); // name = "Alice"
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_ilike_filter_case_insensitive_suffix() {
+        // Pattern "%ICE" should match "Alice" (case-insensitive)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "%ICE"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields();
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_ilike_filter_case_insensitive_contains() {
+        // Pattern "%LIC%" should match "Alice" (case-insensitive)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "%LIC%"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields();
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_ilike_filter_case_insensitive_exact() {
+        // Pattern "ALICE" should match "Alice" (case-insensitive exact)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "ALICE"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields();
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_ilike_filter_no_match() {
+        // Pattern "BOB%" should NOT match "Alice"
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "BOB%"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields();
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_nilike_filter() {
+        // Negated: pattern "BOB%" should NOT match "Alice", so nilike returns true
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_nilike": "BOB%"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields();
+        assert!(filter.matches(&fields, &mapping).unwrap());
+
+        // Negated: pattern "ALI%" WOULD match "Alice", so nilike returns false
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_nilike": "ALI%"}),
+        )]));
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_ilike_unsupported_underscore() {
+        let filter = Filter::from_conditions(HashMap::from([(
+            "name".to_string(),
+            json!({"_ilike": "Al_ce"}),
+        )]));
+        let mapping = make_mapping();
+        let fields = make_fields();
+        let result = filter.matches(&fields, &mapping);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_filter_op_parse() {
         assert_eq!(FilterOp::parse("_eq"), Some(FilterOp::Eq));
         assert_eq!(FilterOp::parse("_and"), Some(FilterOp::And));
+        assert_eq!(FilterOp::parse("_ilike"), Some(FilterOp::Ilike));
+        assert_eq!(FilterOp::parse("_nilike"), Some(FilterOp::Nilike));
         assert_eq!(FilterOp::parse("invalid"), None);
     }
 

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -290,10 +290,11 @@ impl Filter {
         match op {
             FilterOp::Eq => Ok(Self::values_equal(actual, expected)),
             FilterOp::Ne => Ok(!Self::values_equal(actual, expected)),
-            FilterOp::Gt => self.compare(actual, expected).map(|ord| ord.is_gt()),
-            FilterOp::Gte => self.compare(actual, expected).map(|ord| ord.is_ge()),
-            FilterOp::Lt => self.compare(actual, expected).map(|ord| ord.is_lt()),
-            FilterOp::Lte => self.compare(actual, expected).map(|ord| ord.is_le()),
+            // Comparison operators: None (from null or NaN) returns false (Go DefraDB behavior)
+            FilterOp::Gt => self.compare(actual, expected).map(|opt| opt.is_some_and(|ord| ord.is_gt())),
+            FilterOp::Gte => self.compare(actual, expected).map(|opt| opt.is_some_and(|ord| ord.is_ge())),
+            FilterOp::Lt => self.compare(actual, expected).map(|opt| opt.is_some_and(|ord| ord.is_lt())),
+            FilterOp::Lte => self.compare(actual, expected).map(|opt| opt.is_some_and(|ord| ord.is_le())),
             FilterOp::In => {
                 let arr = expected
                     .as_array()
@@ -379,8 +380,15 @@ impl Filter {
         }
     }
 
-    fn compare(&self, a: &JsonValue, b: &JsonValue) -> Result<std::cmp::Ordering> {
+    /// Compare two values for ordering.
+    /// Returns None for null comparisons (Go DefraDB behavior: null comparisons return false).
+    /// Supports int/float coercion (Go DefraDB uses numbers.TryUpcast).
+    fn compare(&self, a: &JsonValue, b: &JsonValue) -> Result<Option<std::cmp::Ordering>> {
         match (a, b) {
+            // Null comparisons: Go DefraDB returns false for null vs anything in ordering comparisons
+            (JsonValue::Null, _) | (_, JsonValue::Null) => Ok(None),
+
+            // Number comparisons: support int/float coercion (Go's numbers.TryUpcast behavior)
             (JsonValue::Number(a), JsonValue::Number(b)) => {
                 let a_val = a.as_f64().ok_or_else(|| {
                     QueryError::invalid_filter(format!("number {} cannot be compared", a))
@@ -388,11 +396,13 @@ impl Filter {
                 let b_val = b.as_f64().ok_or_else(|| {
                     QueryError::invalid_filter(format!("number {} cannot be compared", b))
                 })?;
-                a_val
-                    .partial_cmp(&b_val)
-                    .ok_or_else(|| QueryError::invalid_filter("cannot compare NaN values"))
+                Ok(a_val.partial_cmp(&b_val)) // Returns None for NaN, which becomes false
             }
-            (JsonValue::String(a), JsonValue::String(b)) => Ok(a.cmp(b)),
+
+            // String comparisons
+            (JsonValue::String(a), JsonValue::String(b)) => Ok(Some(a.cmp(b))),
+
+            // Type mismatch
             _ => Err(QueryError::TypeMismatch {
                 expected: "comparable types".to_string(),
                 actual: format!("{:?} vs {:?}", a, b),
@@ -409,7 +419,7 @@ impl Filter {
     ) -> Result<bool> {
         // Null fields never match (standard database behavior, matches Go DefraDB)
         if actual.is_null() {
-            return Ok(if negate { true } else { false });
+            return Ok(negate);
         }
 
         let op_name = if case_insensitive { "_ilike" } else { "_like" };
@@ -985,8 +995,8 @@ mod tests {
     }
 
     #[test]
-    fn test_null_field_gt_comparison_error() {
-        // Comparing null with _gt should fail with type mismatch
+    fn test_null_field_gt_comparison_returns_false() {
+        // Go DefraDB behavior: null _gt 25 returns false (not error)
         let filter =
             Filter::from_conditions(HashMap::from([("age".to_string(), json!({"_gt": 25}))]));
         let mapping = make_mapping();
@@ -997,7 +1007,8 @@ mod tests {
             Some(json!(true)),
         ];
         let result = filter.matches(&fields, &mapping);
-        assert!(result.is_err());
+        assert!(result.is_ok(), "null _gt comparison should not error");
+        assert!(!result.unwrap(), "null _gt 25 should return false");
     }
 
     #[test]

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -9,25 +9,26 @@ use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
 
 /// Filter operators for condition matching
+/// Uses Go DefraDB naming conventions for compatibility
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum FilterOp {
     /// Equal (_eq)
     #[serde(rename = "_eq")]
     Eq,
-    /// Not equal (_ne)
-    #[serde(rename = "_ne")]
+    /// Not equal (_neq) - Go DefraDB naming
+    #[serde(rename = "_neq", alias = "_ne")]
     Ne,
     /// Greater than (_gt)
     #[serde(rename = "_gt")]
     Gt,
-    /// Greater than or equal (_gte)
-    #[serde(rename = "_gte")]
+    /// Greater than or equal (_geq) - Go DefraDB naming
+    #[serde(rename = "_geq", alias = "_gte")]
     Gte,
     /// Less than (_lt)
     #[serde(rename = "_lt")]
     Lt,
-    /// Less than or equal (_lte)
-    #[serde(rename = "_lte")]
+    /// Less than or equal (_leq) - Go DefraDB naming
+    #[serde(rename = "_leq", alias = "_lte")]
     Lte,
     /// In array (_in)
     #[serde(rename = "_in")]
@@ -68,15 +69,16 @@ pub enum FilterOp {
 }
 
 impl FilterOp {
-    /// Parse a filter operator from string
+    /// Parse a filter operator from string.
+    /// Accepts both Go DefraDB naming (_neq, _geq, _leq) and alternative naming (_ne, _gte, _lte).
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "_eq" => Some(Self::Eq),
-            "_ne" => Some(Self::Ne),
+            "_neq" | "_ne" => Some(Self::Ne),
             "_gt" => Some(Self::Gt),
-            "_gte" => Some(Self::Gte),
+            "_geq" | "_gte" => Some(Self::Gte),
             "_lt" => Some(Self::Lt),
-            "_lte" => Some(Self::Lte),
+            "_leq" | "_lte" => Some(Self::Lte),
             "_in" => Some(Self::In),
             "_nin" => Some(Self::Nin),
             "_like" => Some(Self::Like),
@@ -93,15 +95,15 @@ impl FilterOp {
         }
     }
 
-    /// Get the string representation
+    /// Get the string representation (uses Go DefraDB naming)
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Eq => "_eq",
-            Self::Ne => "_ne",
+            Self::Ne => "_neq",
             Self::Gt => "_gt",
-            Self::Gte => "_gte",
+            Self::Gte => "_geq",
             Self::Lt => "_lt",
-            Self::Lte => "_lte",
+            Self::Lte => "_leq",
             Self::In => "_in",
             Self::Nin => "_nin",
             Self::Like => "_like",

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -310,6 +310,10 @@ impl Filter {
             FilterOp::Nilike => self.like_match(actual, expected, true, true),
             FilterOp::Contains => {
                 // Array field contains the expected value
+                // Null fields never match (standard database behavior)
+                if actual.is_null() {
+                    return Ok(false);
+                }
                 let arr = actual
                     .as_array()
                     .ok_or_else(|| QueryError::invalid_filter("_contains requires array field"))?;
@@ -317,6 +321,10 @@ impl Filter {
             }
             FilterOp::ContainedIn => {
                 // All elements of actual array are in expected array (actual is subset of expected)
+                // Null fields never match (standard database behavior)
+                if actual.is_null() {
+                    return Ok(false);
+                }
                 let actual_arr = actual.as_array().ok_or_else(|| {
                     QueryError::invalid_filter("_contained_in requires array field")
                 })?;
@@ -329,6 +337,10 @@ impl Filter {
             }
             FilterOp::HasKey => {
                 // Object/map has the specified key
+                // Null fields never match (standard database behavior)
+                if actual.is_null() {
+                    return Ok(false);
+                }
                 let key = expected
                     .as_str()
                     .ok_or_else(|| QueryError::invalid_filter("_has_key requires string key"))?;
@@ -969,5 +981,151 @@ mod tests {
         let fields = make_fields();
         let result = filter.matches(&fields, &mapping);
         assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // Null field handling tests for array/object operators
+    // =========================================================================
+
+    #[test]
+    fn test_contains_null_field_returns_false() {
+        // When field is null, _contains should return false (not error)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contains": "rust"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let mut fields = make_extended_fields();
+        fields[4] = Some(json!(null)); // tags is null
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_contained_in_null_field_returns_false() {
+        // When field is null, _contained_in should return false (not error)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contained_in": ["rust", "go"]}),
+        )]));
+        let mapping = make_extended_mapping();
+        let mut fields = make_extended_fields();
+        fields[4] = Some(json!(null)); // tags is null
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_has_key_null_field_returns_false() {
+        // When field is null, _has_key should return false (not error)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "metadata".to_string(),
+            json!({"_has_key": "version"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let mut fields = make_extended_fields();
+        fields[5] = Some(json!(null)); // metadata is null
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_contains_with_null_in_array() {
+        // Array contains null, searching for null should find it
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contains": null}),
+        )]));
+        let mapping = make_extended_mapping();
+        let mut fields = make_extended_fields();
+        fields[4] = Some(json!(["rust", null, "graphql"])); // Array with null
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_contains_null_not_in_array() {
+        // Array doesn't contain null, searching for null should not find it
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contains": null}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields(); // No null in tags
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    // =========================================================================
+    // Empty array edge cases
+    // =========================================================================
+
+    #[test]
+    fn test_contains_empty_array() {
+        // Empty array should never contain anything
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contains": "rust"}),
+        )]));
+        let mapping = make_extended_mapping();
+        let mut fields = make_extended_fields();
+        fields[4] = Some(json!([])); // Empty array
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_contained_in_empty_expected_array() {
+        // Non-empty field array vs empty expected array
+        // [a,b,c] is NOT contained in [] (no elements of expected contain the actuals)
+        let filter = Filter::from_conditions(HashMap::from([(
+            "tags".to_string(),
+            json!({"_contained_in": []}),
+        )]));
+        let mapping = make_extended_mapping();
+        let fields = make_extended_fields(); // tags = ["rust", "database", "graphql"]
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_has_key_empty_string_key() {
+        // Empty string keys are valid in JSON objects
+        let filter = Filter::from_conditions(HashMap::from([(
+            "metadata".to_string(),
+            json!({"_has_key": ""}),
+        )]));
+        let mapping = make_extended_mapping();
+        let mut fields = make_extended_fields();
+        fields[5] = Some(json!({"": "empty key value", "version": "1.0"}));
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    // =========================================================================
+    // Pattern matching edge cases
+    // =========================================================================
+
+    #[test]
+    fn test_like_pattern_only_percent() {
+        // Pattern "%" should match any non-empty string (suffix after empty prefix)
+        let filter =
+            Filter::from_conditions(HashMap::from([("name".to_string(), json!({"_like": "%"}))]));
+        let mapping = make_mapping();
+        let fields = make_fields();
+        assert!(filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_like_empty_pattern() {
+        // Empty pattern should only match empty string
+        let filter =
+            Filter::from_conditions(HashMap::from([("name".to_string(), json!({"_like": ""}))]));
+        let mapping = make_mapping();
+        let fields = make_fields(); // name = "Alice"
+        assert!(!filter.matches(&fields, &mapping).unwrap());
+    }
+
+    #[test]
+    fn test_like_empty_pattern_matches_empty_string() {
+        // Empty pattern should match empty string
+        let filter =
+            Filter::from_conditions(HashMap::from([("name".to_string(), json!({"_like": ""}))]));
+        let mapping = make_mapping();
+        let mut fields = make_fields();
+        fields[1] = Some(json!("")); // empty name
+        assert!(filter.matches(&fields, &mapping).unwrap());
     }
 }

--- a/crates/query/src/plan/average.rs
+++ b/crates/query/src/plan/average.rs
@@ -13,7 +13,7 @@ use crate::planner::{Doc, PlanNode};
 /// - Without GROUP BY: Computes average of all documents and yields a single result
 /// - With GROUP BY: For each group, adds the average to the document
 ///
-/// Null values are skipped. Returns null if no values to average (SQL semantics).
+/// Null values are skipped. Returns 0 if no values to average (Go DefraDB semantics).
 /// Always returns f64 for precision.
 pub struct AverageNode {
     source: Box<dyn PlanNode>,
@@ -67,8 +67,8 @@ impl AverageNode {
     }
 
     /// Compute average of a slice of documents
-    /// Returns None if no values (SQL semantics: AVG of empty set is NULL)
-    fn compute_average(&self, docs: &[Doc]) -> Option<f64> {
+    /// Returns 0.0 if no values (Go DefraDB semantics: AVG of empty set is 0)
+    fn compute_average(&self, docs: &[Doc]) -> f64 {
         let mut sum = 0.0;
         let mut count = 0usize;
 
@@ -83,25 +83,20 @@ impl AverageNode {
         }
 
         if count == 0 {
-            None
+            0.0 // Go DefraDB returns 0 for empty set, not null
         } else {
-            Some(sum / count as f64)
+            sum / count as f64
         }
     }
 
-    /// Convert average to JSON value (null for empty, f64 otherwise)
+    /// Convert average to JSON value
     /// Returns Null for NaN/Infinity to prevent silent data corruption
-    fn avg_to_json(avg: Option<f64>) -> JsonValue {
-        match avg {
-            None => JsonValue::Null,
-            Some(val) => {
-                // NaN and Infinity cannot be represented in JSON - return null
-                // This is safer than silently returning 0
-                serde_json::Number::from_f64(val)
-                    .map(JsonValue::Number)
-                    .unwrap_or(JsonValue::Null)
-            }
-        }
+    fn avg_to_json(avg: f64) -> JsonValue {
+        // NaN and Infinity cannot be represented in JSON - return 0
+        // This matches Go DefraDB behavior
+        serde_json::Number::from_f64(avg)
+            .map(JsonValue::Number)
+            .unwrap_or_else(|| JsonValue::Number(serde_json::Number::from(0)))
     }
 }
 
@@ -134,10 +129,11 @@ impl PlanNode for AverageNode {
                 if !self.grouped_mode && !self.done {
                     // Non-grouped mode: Return the single result
                     self.done = true;
+                    // Go DefraDB returns 0 for empty set, not null
                     let avg = if self.count == 0 {
-                        None
+                        0.0
                     } else {
-                        Some(self.sum / self.count as f64)
+                        self.sum / self.count as f64
                     };
                     let num_fields = self
                         .document_mapping
@@ -159,9 +155,6 @@ impl PlanNode for AverageNode {
 
                 // Clone the current doc from source and add the average
                 let mut doc = self.source.value().deep_clone();
-                if doc.num_fields() <= self.aggregate_index {
-                    doc.set(self.aggregate_index, JsonValue::Null);
-                }
                 doc.set(self.aggregate_index, Self::avg_to_json(group_avg));
                 self.current_doc = doc;
                 return Ok(true);
@@ -289,8 +282,10 @@ mod tests {
 
         assert!(avg_node.next().await.unwrap());
         let result = avg_node.value();
-        // Should return null for empty set (SQL semantics)
-        assert_eq!(result.get(3), Some(&JsonValue::Null));
+        // Go DefraDB returns 0 for empty set, not null
+        let avg_val = result.get(3).unwrap();
+        assert!(avg_val.is_number(), "AVG of empty set should return 0, not null");
+        assert_eq!(avg_val.as_f64().unwrap(), 0.0);
 
         avg_node.close().await.unwrap();
     }

--- a/crates/query/src/plan/limit.rs
+++ b/crates/query/src/plan/limit.rs
@@ -109,6 +109,30 @@ impl PlanNode for LimitNode {
     fn kind(&self) -> &'static str {
         "limitNode"
     }
+
+    fn explain(&self) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "node".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+
+        if let Some(limit) = self.limit {
+            obj.insert("limit".to_string(), serde_json::Value::Number(limit.into()));
+        }
+
+        if self.offset > 0 {
+            obj.insert(
+                "offset".to_string(),
+                serde_json::Value::Number(self.offset.into()),
+            );
+        }
+
+        // Recursively explain child node
+        obj.insert("source".to_string(), self.source.explain());
+
+        serde_json::Value::Object(obj)
+    }
 }
 
 #[cfg(test)]

--- a/crates/query/src/plan/limit.rs
+++ b/crates/query/src/plan/limit.rs
@@ -110,12 +110,8 @@ impl PlanNode for LimitNode {
         "limitNode"
     }
 
-    fn explain(&self) -> serde_json::Value {
+    fn explain_inner(&self) -> serde_json::Value {
         let mut obj = serde_json::Map::new();
-        obj.insert(
-            "node".to_string(),
-            serde_json::Value::String(self.kind().to_string()),
-        );
 
         if let Some(limit) = self.limit {
             obj.insert("limit".to_string(), serde_json::Value::Number(limit.into()));
@@ -128,8 +124,13 @@ impl PlanNode for LimitNode {
             );
         }
 
-        // Recursively explain child node
-        obj.insert("source".to_string(), self.source.explain());
+        // Recursively explain child node - merge their wrapped structure
+        let child_explain = self.source.explain();
+        if let Some(child_obj) = child_explain.as_object() {
+            for (key, value) in child_obj {
+                obj.insert(key.clone(), value.clone());
+            }
+        }
 
         serde_json::Value::Object(obj)
     }

--- a/crates/query/src/plan/mutation/delete.rs
+++ b/crates/query/src/plan/mutation/delete.rs
@@ -148,16 +148,13 @@ impl PlanNode for DeleteNode {
         // On first call, perform all deletions
         if !self.did_delete {
             // Get document IDs to delete
+            // Note: Filter-based deletion is handled by the mutation runner which resolves
+            // filters to doc_ids before passing to DeleteNode. See resolve_filter_to_doc_ids().
             let doc_ids_to_delete = if let Some(ref ids) = self.doc_ids {
                 ids.clone()
-            } else if self.filter.is_some() {
-                // Filter-based deletes would require fetching all docs and filtering
-                return Err(QueryError::execution(
-                    "Filter-based deletes not yet implemented - use doc_ids",
-                ));
             } else {
                 return Err(QueryError::execution(
-                    "DeleteNode requires either doc_ids or filter",
+                    "DeleteNode requires doc_ids (filter resolution should be done by runner)",
                 ));
             };
 

--- a/crates/query/src/plan/orderby.rs
+++ b/crates/query/src/plan/orderby.rs
@@ -244,18 +244,14 @@ impl PlanNode for OrderByNode {
     }
 
     fn kind(&self) -> &'static str {
-        "orderByNode"
+        "orderNode"
     }
 
-    fn explain(&self) -> JsonValue {
+    fn explain_inner(&self) -> JsonValue {
         let mut obj = serde_json::Map::new();
-        obj.insert(
-            "node".to_string(),
-            JsonValue::String(self.kind().to_string()),
-        );
 
-        // Format order conditions
-        let order_fields: Vec<JsonValue> = self
+        // Go DefraDB format: "orderings" array with { "fields": [...], "direction": "ASC/DESC" }
+        let orderings: Vec<JsonValue> = self
             .order_by
             .conditions
             .iter()
@@ -264,13 +260,21 @@ impl PlanNode for OrderByNode {
                     OrderDirection::Asc => "ASC",
                     OrderDirection::Desc => "DESC",
                 };
-                JsonValue::String(format!("{} {}", c.fields.join("."), dir))
+                serde_json::json!({
+                    "fields": c.fields,
+                    "direction": dir
+                })
             })
             .collect();
-        obj.insert("orderBy".to_string(), JsonValue::Array(order_fields));
+        obj.insert("orderings".to_string(), JsonValue::Array(orderings));
 
-        // Recursively explain child node
-        obj.insert("source".to_string(), self.source.explain());
+        // Recursively explain child node - merge their wrapped structure
+        let child_explain = self.source.explain();
+        if let Some(child_obj) = child_explain.as_object() {
+            for (key, value) in child_obj {
+                obj.insert(key.clone(), value.clone());
+            }
+        }
 
         JsonValue::Object(obj)
     }
@@ -697,7 +701,7 @@ mod tests {
         let order_by = OrderBy::new();
         let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
         let orderby = OrderByNode::new(Box::new(scan), order_by, mapping);
-        assert_eq!(orderby.kind(), "orderByNode");
+        assert_eq!(orderby.kind(), "orderNode"); // Go DefraDB compatible name
     }
 
     #[tokio::test]

--- a/crates/query/src/plan/orderby.rs
+++ b/crates/query/src/plan/orderby.rs
@@ -246,6 +246,34 @@ impl PlanNode for OrderByNode {
     fn kind(&self) -> &'static str {
         "orderByNode"
     }
+
+    fn explain(&self) -> JsonValue {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "node".to_string(),
+            JsonValue::String(self.kind().to_string()),
+        );
+
+        // Format order conditions
+        let order_fields: Vec<JsonValue> = self
+            .order_by
+            .conditions
+            .iter()
+            .map(|c| {
+                let dir = match c.direction {
+                    OrderDirection::Asc => "ASC",
+                    OrderDirection::Desc => "DESC",
+                };
+                JsonValue::String(format!("{} {}", c.fields.join("."), dir))
+            })
+            .collect();
+        obj.insert("orderBy".to_string(), JsonValue::Array(order_fields));
+
+        // Recursively explain child node
+        obj.insert("source".to_string(), self.source.explain());
+
+        JsonValue::Object(obj)
+    }
 }
 
 #[cfg(test)]

--- a/crates/query/src/plan/scan.rs
+++ b/crates/query/src/plan/scan.rs
@@ -188,15 +188,17 @@ impl PlanNode for ScanNode {
         "scanNode"
     }
 
-    fn explain(&self) -> serde_json::Value {
+    fn explain_inner(&self) -> serde_json::Value {
         let mut obj = serde_json::Map::new();
+
+        // Go DefraDB uses "collectionName" and "collectionID"
         obj.insert(
-            "node".to_string(),
-            serde_json::Value::String(self.kind().to_string()),
+            "collectionName".to_string(),
+            serde_json::Value::String(self.collection.name.clone()),
         );
         obj.insert(
-            "collection".to_string(),
-            serde_json::Value::String(self.collection.name.clone()),
+            "collectionID".to_string(),
+            serde_json::Value::String(self.collection.collection_id.clone()),
         );
 
         if let Some(ref filter) = self.filter {

--- a/crates/query/src/plan/scan.rs
+++ b/crates/query/src/plan/scan.rs
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_scan_filter_error_propagation() {
+    async fn test_scan_filter_null_comparison_returns_no_match() {
         use std::collections::HashMap;
 
         let collection = make_test_collection();
@@ -381,7 +381,7 @@ mod tests {
             None, // age is null
         ])];
 
-        // Filter with _gt on null will error
+        // Filter with _gt on null returns false (Go DefraDB behavior), not error
         let filter =
             Filter::from_conditions(HashMap::from([("age".to_string(), json!({"_gt": 25}))]));
 
@@ -392,10 +392,10 @@ mod tests {
         scan.init().await.unwrap();
         scan.start().await.unwrap();
 
+        // With Go DefraDB compatibility, null _gt 25 returns false (no match),
+        // so next() should return Ok(false) - no documents found
         let result = scan.next().await;
-        assert!(
-            result.is_err(),
-            "Filter error should propagate through scan"
-        );
+        assert!(result.is_ok(), "null comparison should not error");
+        assert!(!result.unwrap(), "null _gt 25 should not match");
     }
 }

--- a/crates/query/src/plan/scan.rs
+++ b/crates/query/src/plan/scan.rs
@@ -187,6 +187,28 @@ impl PlanNode for ScanNode {
     fn kind(&self) -> &'static str {
         "scanNode"
     }
+
+    fn explain(&self) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "node".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        obj.insert(
+            "collection".to_string(),
+            serde_json::Value::String(self.collection.name.clone()),
+        );
+
+        if let Some(ref filter) = self.filter {
+            obj.insert("filter".to_string(), serde_json::json!(filter.conditions()));
+        }
+
+        if self.show_deleted {
+            obj.insert("showDeleted".to_string(), serde_json::Value::Bool(true));
+        }
+
+        serde_json::Value::Object(obj)
+    }
 }
 
 #[cfg(test)]

--- a/crates/query/src/plan/select.rs
+++ b/crates/query/src/plan/select.rs
@@ -90,6 +90,23 @@ impl PlanNode for SelectNode {
     fn kind(&self) -> &'static str {
         "selectNode"
     }
+
+    fn explain(&self) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "node".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+
+        if let Some(ref filter) = self.filter {
+            obj.insert("filter".to_string(), serde_json::json!(filter.conditions()));
+        }
+
+        // Recursively explain child node
+        obj.insert("source".to_string(), self.source.explain());
+
+        serde_json::Value::Object(obj)
+    }
 }
 
 #[cfg(test)]

--- a/crates/query/src/plan/select.rs
+++ b/crates/query/src/plan/select.rs
@@ -91,19 +91,20 @@ impl PlanNode for SelectNode {
         "selectNode"
     }
 
-    fn explain(&self) -> serde_json::Value {
+    fn explain_inner(&self) -> serde_json::Value {
         let mut obj = serde_json::Map::new();
-        obj.insert(
-            "node".to_string(),
-            serde_json::Value::String(self.kind().to_string()),
-        );
 
         if let Some(ref filter) = self.filter {
             obj.insert("filter".to_string(), serde_json::json!(filter.conditions()));
         }
 
-        // Recursively explain child node
-        obj.insert("source".to_string(), self.source.explain());
+        // Recursively explain child node - merge their wrapped structure
+        let child_explain = self.source.explain();
+        if let Some(child_obj) = child_explain.as_object() {
+            for (key, value) in child_obj {
+                obj.insert(key.clone(), value.clone());
+            }
+        }
 
         serde_json::Value::Object(obj)
     }

--- a/crates/query/src/plan/select.rs
+++ b/crates/query/src/plan/select.rs
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_select_source_error_propagation() {
+    async fn test_select_source_null_filter_returns_no_match() {
         let collection = make_test_collection();
         let mapping = make_test_mapping();
 
@@ -217,7 +217,7 @@ mod tests {
             None, // age is null
         ])];
 
-        // Add filter on scan that will error
+        // Filter with _gt on null returns false (Go DefraDB behavior), not error
         let filter =
             Filter::from_conditions(HashMap::from([("age".to_string(), json!({"_gt": 25}))]));
 
@@ -230,10 +230,9 @@ mod tests {
         select.init().await.unwrap();
         select.start().await.unwrap();
 
+        // With Go DefraDB compatibility, null comparison returns false (no match)
         let result = select.next().await;
-        assert!(
-            result.is_err(),
-            "Source error should propagate through select"
-        );
+        assert!(result.is_ok(), "null comparison should not error");
+        assert!(!result.unwrap(), "null _gt 25 should not match");
     }
 }

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -81,7 +81,7 @@ impl FieldCondition {
                             continue;
                         }
                     }
-                    FilterOp::Like | FilterOp::Nlike => {
+                    FilterOp::Like | FilterOp::Nlike | FilterOp::Ilike | FilterOp::Nilike => {
                         if let Some(s) = value.as_str() {
                             ConditionValue::Pattern(s.to_string())
                         } else {

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -88,6 +88,25 @@ impl FieldCondition {
                             continue;
                         }
                     }
+                    FilterOp::ContainedIn => {
+                        // _contained_in expects an array value
+                        if let Some(arr) = value.as_array() {
+                            ConditionValue::Multiple(
+                                arr.iter().filter_map(json_to_normal_value).collect(),
+                            )
+                        } else {
+                            continue;
+                        }
+                    }
+                    FilterOp::HasKey => {
+                        // _has_key expects a string key
+                        if let Some(s) = value.as_str() {
+                            ConditionValue::Pattern(s.to_string())
+                        } else {
+                            continue;
+                        }
+                    }
+                    // _contains and other operators expect single values
                     _ => {
                         if let Some(nv) = json_to_normal_value(value) {
                             ConditionValue::Single(nv)

--- a/crates/query/src/planner/traits.rs
+++ b/crates/query/src/planner/traits.rs
@@ -164,19 +164,36 @@ pub trait PlanNode: Send + Sync {
 
     /// Generate an explanation of this node for EXPLAIN queries.
     ///
-    /// Returns a JSON object describing the node's role in the query plan.
-    /// The default implementation returns basic node type info.
-    /// Nodes can override this to provide more details (e.g., filter conditions, limits).
+    /// Returns a JSON object in Go DefraDB format where the node kind is the key:
+    /// `{ "scanNode": { "collectionName": "..." } }`
+    ///
+    /// Child nodes are nested under their kind name, creating a tree structure:
+    /// `{ "selectNode": { "filter": ..., "scanNode": { ... } } }`
     fn explain(&self) -> JsonValue {
-        let mut obj = serde_json::Map::new();
-        obj.insert(
-            "node".to_string(),
-            JsonValue::String(self.kind().to_string()),
-        );
+        let node_kind = self.kind().to_string();
+        let inner = self.explain_inner();
 
-        // Recursively explain child nodes
+        let mut wrapper = serde_json::Map::new();
+        wrapper.insert(node_kind, inner);
+        JsonValue::Object(wrapper)
+    }
+
+    /// Generate the inner explanation content for this node.
+    ///
+    /// Override this in specific nodes to add node-specific attributes.
+    /// Child nodes are automatically added by the default implementation.
+    fn explain_inner(&self) -> JsonValue {
+        let mut obj = serde_json::Map::new();
+
+        // Recursively explain child nodes - merge their wrapped structure
         if let Some(source) = self.source() {
-            obj.insert("source".to_string(), source.explain());
+            let child_explain = source.explain();
+            // Child explain is { "childKind": { ... } }, merge it into our object
+            if let Some(child_obj) = child_explain.as_object() {
+                for (key, value) in child_obj {
+                    obj.insert(key.clone(), value.clone());
+                }
+            }
         }
 
         JsonValue::Object(obj)
@@ -184,18 +201,28 @@ pub trait PlanNode: Send + Sync {
 
     /// Generate a debug explanation showing all nodes including internal ones.
     ///
-    /// This is more verbose than explain() and includes all plan nodes,
-    /// not just the "explainable" ones.
+    /// Uses Go DefraDB format with node kind as key.
     fn explain_debug(&self) -> JsonValue {
+        let node_kind = self.kind().to_string();
+        let inner = self.explain_debug_inner();
+
+        let mut wrapper = serde_json::Map::new();
+        wrapper.insert(node_kind, inner);
+        JsonValue::Object(wrapper)
+    }
+
+    /// Generate the inner debug explanation content for this node.
+    fn explain_debug_inner(&self) -> JsonValue {
         let mut obj = serde_json::Map::new();
-        obj.insert(
-            "node".to_string(),
-            JsonValue::String(self.kind().to_string()),
-        );
 
         // Recursively explain all child nodes
         if let Some(source) = self.source() {
-            obj.insert("source".to_string(), source.explain_debug());
+            let child_explain = source.explain_debug();
+            if let Some(child_obj) = child_explain.as_object() {
+                for (key, value) in child_obj {
+                    obj.insert(key.clone(), value.clone());
+                }
+            }
         }
 
         JsonValue::Object(obj)

--- a/crates/query/src/planner/traits.rs
+++ b/crates/query/src/planner/traits.rs
@@ -161,6 +161,26 @@ pub trait PlanNode: Send + Sync {
     fn current_group_docs(&self) -> Option<&[Doc]> {
         None
     }
+
+    /// Generate an explanation of this node for EXPLAIN queries.
+    ///
+    /// Returns a JSON object describing the node's role in the query plan.
+    /// The default implementation returns basic node type info.
+    /// Nodes can override this to provide more details (e.g., filter conditions, limits).
+    fn explain(&self) -> JsonValue {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "node".to_string(),
+            JsonValue::String(self.kind().to_string()),
+        );
+
+        // Recursively explain child nodes
+        if let Some(source) = self.source() {
+            obj.insert("source".to_string(), source.explain());
+        }
+
+        JsonValue::Object(obj)
+    }
 }
 
 /// Execution statistics for plan nodes

--- a/crates/query/src/planner/traits.rs
+++ b/crates/query/src/planner/traits.rs
@@ -181,6 +181,25 @@ pub trait PlanNode: Send + Sync {
 
         JsonValue::Object(obj)
     }
+
+    /// Generate a debug explanation showing all nodes including internal ones.
+    ///
+    /// This is more verbose than explain() and includes all plan nodes,
+    /// not just the "explainable" ones.
+    fn explain_debug(&self) -> JsonValue {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "node".to_string(),
+            JsonValue::String(self.kind().to_string()),
+        );
+
+        // Recursively explain all child nodes
+        if let Some(source) = self.source() {
+            obj.insert("source".to_string(), source.explain_debug());
+        }
+
+        JsonValue::Object(obj)
+    }
 }
 
 /// Execution statistics for plan nodes

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -7,7 +7,7 @@ use graphql_parser::query::{
     SelectionSet, Value,
 };
 use serde_json::Value as JsonValue;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
@@ -44,29 +44,56 @@ fn parse_selection_to_selects<'a>(
     variables: Option<&HashMap<String, JsonValue>>,
     fragments: &FragmentMap<'a>,
     selects: &mut Vec<Select>,
+    visiting: &mut HashSet<String>,
 ) -> Result<()> {
     match selection {
         Selection::Field(field) => {
-            let select = parse_field_to_select(field, variables, fragments)?;
+            let select = parse_field_to_select(field, variables, fragments, visiting)?;
             selects.push(select);
         }
         Selection::FragmentSpread(spread) => {
+            // Check for circular fragment reference
+            if visiting.contains(&spread.fragment_name) {
+                return Err(QueryError::parse(format!(
+                    "circular fragment reference detected: '{}'",
+                    spread.fragment_name
+                )));
+            }
+
             // Look up the fragment by name
             let frag = fragments.get(&spread.fragment_name).ok_or_else(|| {
                 QueryError::parse(format!("undefined fragment '{}'", spread.fragment_name))
             })?;
 
+            // Mark this fragment as being visited
+            visiting.insert(spread.fragment_name.clone());
+
             // Process each selection in the fragment's selection set
             for frag_selection in &frag.selection_set.items {
-                parse_selection_to_selects(frag_selection, variables, fragments, selects)?;
+                parse_selection_to_selects(
+                    frag_selection,
+                    variables,
+                    fragments,
+                    selects,
+                    visiting,
+                )?;
             }
+
+            // Unmark after processing
+            visiting.remove(&spread.fragment_name);
         }
         Selection::InlineFragment(inline) => {
             // Inline fragments: ... on Type { fields }
             // For now, we ignore the type condition and just expand the fields
             // (DefraDB doesn't have interface/union types yet)
             for inline_selection in &inline.selection_set.items {
-                parse_selection_to_selects(inline_selection, variables, fragments, selects)?;
+                parse_selection_to_selects(
+                    inline_selection,
+                    variables,
+                    fragments,
+                    selects,
+                    visiting,
+                )?;
             }
         }
     }
@@ -151,24 +178,28 @@ pub fn parse_request_with_variables(
                         if has_explain_directive(&q.directives) {
                             explain = true;
                         }
+                        let mut visiting = HashSet::new();
                         for selection in &q.selection_set.items {
                             parse_selection_to_selects(
                                 selection,
                                 variables,
                                 &fragments,
                                 &mut selects,
+                                &mut visiting,
                             )?;
                         }
                     }
                     OperationDefinition::SelectionSet(ss) => {
                         // Bare selection set is treated as query
                         has_query = true;
+                        let mut visiting = HashSet::new();
                         for selection in &ss.items {
                             parse_selection_to_selects(
                                 selection,
                                 variables,
                                 &fragments,
                                 &mut selects,
+                                &mut visiting,
                             )?;
                         }
                     }
@@ -211,6 +242,7 @@ fn parse_field_to_select(
     field: &Field<'_, String>,
     variables: Option<&HashMap<String, JsonValue>>,
     fragments: &FragmentMap<'_>,
+    visiting: &mut HashSet<String>,
 ) -> Result<Select> {
     let collection_name = field.name.clone();
     let alias = field.alias.clone();
@@ -277,8 +309,13 @@ fn parse_field_to_select(
     }
 
     // Parse selection set (child fields)
-    let (fields, mapping) =
-        parse_selection_set(&field.selection_set, &collection_name, variables, fragments)?;
+    let (fields, mapping) = parse_selection_set(
+        &field.selection_set,
+        &collection_name,
+        variables,
+        fragments,
+        visiting,
+    )?;
     select.fields = fields;
     select.document_mapping = mapping;
 
@@ -291,6 +328,7 @@ fn parse_selection_set(
     _collection_name: &str,
     variables: Option<&HashMap<String, JsonValue>>,
     fragments: &FragmentMap<'_>,
+    visiting: &mut HashSet<String>,
 ) -> Result<(Vec<Requestable>, DocumentMapping)> {
     let mut fields = Vec::new();
     let mut mapping = DocumentMapping::new();
@@ -318,7 +356,7 @@ fn parse_selection_set(
                     fields.push(Requestable::Aggregate(aggregate));
                 } else if !field.selection_set.items.is_empty() {
                     // This is a nested select (relation)
-                    let nested = parse_field_to_select(field, variables, fragments)?;
+                    let nested = parse_field_to_select(field, variables, fragments, visiting)?;
 
                     // Add nested select to document mapping
                     // Use field name for internal indexing, output_name (alias) for rendering
@@ -344,10 +382,21 @@ fn parse_selection_set(
                 }
             }
             Selection::FragmentSpread(spread) => {
+                // Check for circular fragment reference
+                if visiting.contains(&spread.fragment_name) {
+                    return Err(QueryError::parse(format!(
+                        "circular fragment reference detected: '{}'",
+                        spread.fragment_name
+                    )));
+                }
+
                 // Look up the fragment by name
                 let frag = fragments.get(&spread.fragment_name).ok_or_else(|| {
                     QueryError::parse(format!("undefined fragment '{}'", spread.fragment_name))
                 })?;
+
+                // Mark this fragment as being visited
+                visiting.insert(spread.fragment_name.clone());
 
                 // Recursively parse the fragment's selection set
                 let (frag_fields, _frag_mapping) = parse_selection_set(
@@ -355,7 +404,11 @@ fn parse_selection_set(
                     _collection_name,
                     variables,
                     fragments,
+                    visiting,
                 )?;
+
+                // Unmark after processing
+                visiting.remove(&spread.fragment_name);
 
                 // Merge fragment fields and mapping into our current sets
                 for frag_field in frag_fields {
@@ -387,6 +440,7 @@ fn parse_selection_set(
                     _collection_name,
                     variables,
                     fragments,
+                    visiting,
                 )?;
 
                 // Merge inline fragment fields into our current sets
@@ -943,12 +997,15 @@ fn parse_field_to_mutation(
 
     // Parse selection set (fields to return after mutation)
     // For mutations, we don't support fragments in return fields
+    // For mutations, we don't support fragments in return fields
     let empty_fragments: FragmentMap<'_> = HashMap::new();
+    let mut empty_visiting = HashSet::new();
     let (fields, mapping) = parse_selection_set(
         &field.selection_set,
         &collection_name,
         variables,
         &empty_fragments,
+        &mut empty_visiting,
     )?;
     mutation.fields = fields;
     mutation.document_mapping = mapping;

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -3,7 +3,8 @@
 //! Parses GraphQL query strings into Select and Mutation operations for execution.
 
 use graphql_parser::query::{
-    Definition, Document, Field, OperationDefinition, Selection, SelectionSet, Value,
+    Definition, Directive, Document, Field, FragmentDefinition, OperationDefinition, Selection,
+    SelectionSet, Value,
 };
 use serde_json::Value as JsonValue;
 use std::collections::{BTreeMap, HashMap};
@@ -20,9 +21,56 @@ use crate::mapper::{
 #[derive(Debug)]
 pub enum ParsedOperation {
     /// Query operations (SELECT)
-    Query(Vec<Select>),
+    Query {
+        selects: Vec<Select>,
+        /// Whether @explain directive was used
+        explain: bool,
+    },
     /// Mutation operations (CREATE, UPDATE, DELETE)
     Mutation(Vec<Mutation>),
+}
+
+/// Check if a directive list contains @explain
+fn has_explain_directive(directives: &[Directive<'_, String>]) -> bool {
+    directives.iter().any(|d| d.name == "explain")
+}
+
+/// Type alias for fragment definitions map
+type FragmentMap<'a> = HashMap<String, &'a FragmentDefinition<'a, String>>;
+
+/// Parse a selection into Select operations, handling fragments.
+fn parse_selection_to_selects<'a>(
+    selection: &'a Selection<'a, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+    fragments: &FragmentMap<'a>,
+    selects: &mut Vec<Select>,
+) -> Result<()> {
+    match selection {
+        Selection::Field(field) => {
+            let select = parse_field_to_select(field, variables, fragments)?;
+            selects.push(select);
+        }
+        Selection::FragmentSpread(spread) => {
+            // Look up the fragment by name
+            let frag = fragments.get(&spread.fragment_name).ok_or_else(|| {
+                QueryError::parse(format!("undefined fragment '{}'", spread.fragment_name))
+            })?;
+
+            // Process each selection in the fragment's selection set
+            for frag_selection in &frag.selection_set.items {
+                parse_selection_to_selects(frag_selection, variables, fragments, selects)?;
+            }
+        }
+        Selection::InlineFragment(inline) => {
+            // Inline fragments: ... on Type { fields }
+            // For now, we ignore the type condition and just expand the fields
+            // (DefraDB doesn't have interface/union types yet)
+            for inline_selection in &inline.selection_set.items {
+                parse_selection_to_selects(inline_selection, variables, fragments, selects)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Parse a GraphQL query string into Select operations.
@@ -31,7 +79,7 @@ pub enum ParsedOperation {
 /// For mutations, use `parse_request` instead.
 pub fn parse_query(query: &str) -> Result<Vec<Select>> {
     match parse_request(query)? {
-        ParsedOperation::Query(selects) => Ok(selects),
+        ParsedOperation::Query { selects, .. } => Ok(selects),
         ParsedOperation::Mutation(_) => Err(QueryError::parse(
             "Expected query but got mutation. Use parse_request() for mutations.",
         )),
@@ -44,7 +92,7 @@ pub fn parse_query(query: &str) -> Result<Vec<Select>> {
 pub fn parse_mutations(query: &str) -> Result<Vec<Mutation>> {
     match parse_request(query)? {
         ParsedOperation::Mutation(mutations) => Ok(mutations),
-        ParsedOperation::Query(_) => Err(QueryError::parse("Expected mutation but got query")),
+        ParsedOperation::Query { .. } => Err(QueryError::parse("Expected mutation but got query")),
     }
 }
 
@@ -78,39 +126,57 @@ pub fn parse_request_with_variables(
     let doc: Document<'_, String> =
         graphql_parser::parse_query(query).map_err(|e| QueryError::parse(e.to_string()))?;
 
+    // First pass: collect all fragment definitions
+    let mut fragments: HashMap<String, &FragmentDefinition<'_, String>> = HashMap::new();
+    for def in &doc.definitions {
+        if let Definition::Fragment(frag) = def {
+            fragments.insert(frag.name.clone(), frag);
+        }
+    }
+
     let mut selects = Vec::new();
     let mut mutations = Vec::new();
     let mut has_query = false;
     let mut has_mutation = false;
+    let mut explain = false;
 
-    for def in doc.definitions {
+    // Second pass: parse operations with fragments available
+    for def in &doc.definitions {
         match def {
             Definition::Operation(op) => {
                 match op {
                     OperationDefinition::Query(q) => {
                         has_query = true;
-                        for selection in q.selection_set.items {
-                            if let Selection::Field(field) = selection {
-                                let select = parse_field_to_select(&field, variables)?;
-                                selects.push(select);
-                            }
+                        // Check for @explain directive
+                        if has_explain_directive(&q.directives) {
+                            explain = true;
+                        }
+                        for selection in &q.selection_set.items {
+                            parse_selection_to_selects(
+                                selection,
+                                variables,
+                                &fragments,
+                                &mut selects,
+                            )?;
                         }
                     }
                     OperationDefinition::SelectionSet(ss) => {
                         // Bare selection set is treated as query
                         has_query = true;
-                        for selection in ss.items {
-                            if let Selection::Field(field) = selection {
-                                let select = parse_field_to_select(&field, variables)?;
-                                selects.push(select);
-                            }
+                        for selection in &ss.items {
+                            parse_selection_to_selects(
+                                selection,
+                                variables,
+                                &fragments,
+                                &mut selects,
+                            )?;
                         }
                     }
                     OperationDefinition::Mutation(m) => {
                         has_mutation = true;
-                        for selection in m.selection_set.items {
+                        for selection in &m.selection_set.items {
                             if let Selection::Field(field) = selection {
-                                let mutation = parse_field_to_mutation(&field, variables)?;
+                                let mutation = parse_field_to_mutation(field, variables)?;
                                 mutations.push(mutation);
                             }
                         }
@@ -121,7 +187,7 @@ pub fn parse_request_with_variables(
                 };
             }
             Definition::Fragment(_) => {
-                return Err(QueryError::parse("fragments not yet supported"))
+                // Already processed in first pass
             }
         }
     }
@@ -136,7 +202,7 @@ pub fn parse_request_with_variables(
     if has_mutation {
         Ok(ParsedOperation::Mutation(mutations))
     } else {
-        Ok(ParsedOperation::Query(selects))
+        Ok(ParsedOperation::Query { selects, explain })
     }
 }
 
@@ -144,6 +210,7 @@ pub fn parse_request_with_variables(
 fn parse_field_to_select(
     field: &Field<'_, String>,
     variables: Option<&HashMap<String, JsonValue>>,
+    fragments: &FragmentMap<'_>,
 ) -> Result<Select> {
     let collection_name = field.name.clone();
     let alias = field.alias.clone();
@@ -210,7 +277,8 @@ fn parse_field_to_select(
     }
 
     // Parse selection set (child fields)
-    let (fields, mapping) = parse_selection_set(&field.selection_set, &collection_name, variables)?;
+    let (fields, mapping) =
+        parse_selection_set(&field.selection_set, &collection_name, variables, fragments)?;
     select.fields = fields;
     select.document_mapping = mapping;
 
@@ -222,6 +290,7 @@ fn parse_selection_set(
     selection_set: &SelectionSet<'_, String>,
     _collection_name: &str,
     variables: Option<&HashMap<String, JsonValue>>,
+    fragments: &FragmentMap<'_>,
 ) -> Result<(Vec<Requestable>, DocumentMapping)> {
     let mut fields = Vec::new();
     let mut mapping = DocumentMapping::new();
@@ -249,7 +318,7 @@ fn parse_selection_set(
                     fields.push(Requestable::Aggregate(aggregate));
                 } else if !field.selection_set.items.is_empty() {
                     // This is a nested select (relation)
-                    let nested = parse_field_to_select(field, variables)?;
+                    let nested = parse_field_to_select(field, variables, fragments)?;
 
                     // Add nested select to document mapping
                     // Use field name for internal indexing, output_name (alias) for rendering
@@ -274,11 +343,71 @@ fn parse_selection_set(
                     fields.push(Requestable::Field(select_field));
                 }
             }
-            Selection::FragmentSpread(_) => {
-                return Err(QueryError::parse("fragment spreads not yet supported"))
+            Selection::FragmentSpread(spread) => {
+                // Look up the fragment by name
+                let frag = fragments.get(&spread.fragment_name).ok_or_else(|| {
+                    QueryError::parse(format!("undefined fragment '{}'", spread.fragment_name))
+                })?;
+
+                // Recursively parse the fragment's selection set
+                let (frag_fields, _frag_mapping) = parse_selection_set(
+                    &frag.selection_set,
+                    _collection_name,
+                    variables,
+                    fragments,
+                )?;
+
+                // Merge fragment fields and mapping into our current sets
+                for frag_field in frag_fields {
+                    // Update mapping indices for the merged fields
+                    let index = mapping.next_index();
+                    match &frag_field {
+                        Requestable::Field(f) => {
+                            mapping.add(index, &f.name);
+                            mapping.add_render_key(index, f.output_name());
+                        }
+                        Requestable::Aggregate(a) => {
+                            mapping.add(index, a.aggregate_type.as_str());
+                            mapping.add_render_key(index, a.output_name());
+                        }
+                        Requestable::Select(s) => {
+                            mapping.add(index, &s.field.name);
+                            mapping.add_render_key(index, s.field.output_name());
+                        }
+                    }
+                    fields.push(frag_field);
+                }
             }
-            Selection::InlineFragment(_) => {
-                return Err(QueryError::parse("inline fragments not yet supported"))
+            Selection::InlineFragment(inline) => {
+                // Inline fragments: ... on Type { fields }
+                // For now, we ignore the type condition and just expand the fields
+                // (DefraDB doesn't have interface/union types yet)
+                let (inline_fields, _inline_mapping) = parse_selection_set(
+                    &inline.selection_set,
+                    _collection_name,
+                    variables,
+                    fragments,
+                )?;
+
+                // Merge inline fragment fields into our current sets
+                for inline_field in inline_fields {
+                    let index = mapping.next_index();
+                    match &inline_field {
+                        Requestable::Field(f) => {
+                            mapping.add(index, &f.name);
+                            mapping.add_render_key(index, f.output_name());
+                        }
+                        Requestable::Aggregate(a) => {
+                            mapping.add(index, a.aggregate_type.as_str());
+                            mapping.add_render_key(index, a.output_name());
+                        }
+                        Requestable::Select(s) => {
+                            mapping.add(index, &s.field.name);
+                            mapping.add_render_key(index, s.field.output_name());
+                        }
+                    }
+                    fields.push(inline_field);
+                }
             }
         }
     }
@@ -813,7 +942,14 @@ fn parse_field_to_mutation(
     }
 
     // Parse selection set (fields to return after mutation)
-    let (fields, mapping) = parse_selection_set(&field.selection_set, &collection_name, variables)?;
+    // For mutations, we don't support fragments in return fields
+    let empty_fragments: FragmentMap<'_> = HashMap::new();
+    let (fields, mapping) = parse_selection_set(
+        &field.selection_set,
+        &collection_name,
+        variables,
+        &empty_fragments,
+    )?;
     mutation.fields = fields;
     mutation.document_mapping = mapping;
 
@@ -1215,7 +1351,7 @@ mod variable_tests {
 
         let result = parse_request_with_variables(query, Some(&variables)).unwrap();
         match result {
-            ParsedOperation::Query(selects) => {
+            ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects.len(), 1);
                 let filter = selects[0].filter.as_ref().unwrap();
                 let conditions = filter.conditions();
@@ -1240,7 +1376,7 @@ mod variable_tests {
 
         let result = parse_request_with_variables(query, Some(&variables)).unwrap();
         match result {
-            ParsedOperation::Query(selects) => {
+            ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(10));
             }
             _ => panic!("Expected query"),
@@ -1262,7 +1398,7 @@ mod variable_tests {
 
         let result = parse_request_with_variables(query, Some(&variables)).unwrap();
         match result {
-            ParsedOperation::Query(selects) => {
+            ParsedOperation::Query { selects, .. } => {
                 assert_eq!(
                     selects[0].doc_ids,
                     Some(vec!["bae-123".to_string(), "bae-456".to_string()])
@@ -1371,7 +1507,7 @@ mod variable_tests {
         // No variables provided
         let result = parse_request_with_variables(query, None).unwrap();
         match result {
-            ParsedOperation::Query(selects) => {
+            ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects.len(), 1);
                 let filter = selects[0].filter.as_ref().unwrap();
                 let conditions = filter.conditions();
@@ -1422,7 +1558,7 @@ mod variable_tests {
 
         let result = parse_request_with_variables(query, Some(&variables)).unwrap();
         match result {
-            ParsedOperation::Query(selects) => {
+            ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(5));
                 let filter = selects[0].filter.as_ref().unwrap();
                 let conditions = filter.conditions();

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -1628,4 +1628,89 @@ mod variable_tests {
             _ => panic!("Expected query"),
         }
     }
+
+    // =========================================================================
+    // Variable type mismatch tests
+    // =========================================================================
+
+    #[test]
+    fn test_variable_type_mismatch_bool() {
+        let query = r#"
+            query($deleted: Boolean!) {
+                Users(showDeleted: $deleted) {
+                    _docID
+                }
+            }
+        "#;
+
+        // Provide string instead of bool
+        let variables = HashMap::from([("deleted".to_string(), json!("true"))]);
+        let result = parse_request_with_variables(query, Some(&variables));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be a boolean"));
+    }
+
+    #[test]
+    fn test_variable_type_mismatch_string() {
+        let query = r#"
+            query($c: String!) {
+                Users(cid: $c) {
+                    _docID
+                }
+            }
+        "#;
+
+        // Provide integer instead of string
+        let variables = HashMap::from([("c".to_string(), json!(12345))]);
+        let result = parse_request_with_variables(query, Some(&variables));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("must be a string"));
+    }
+
+    #[test]
+    fn test_variable_in_order_direction() {
+        let query = r#"
+            query($dir: String!) {
+                Users(order: {name: $dir}) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        let variables = HashMap::from([("dir".to_string(), json!("DESC"))]);
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Query { selects, .. } => {
+                let order = selects[0].order_by.as_ref().unwrap();
+                assert_eq!(
+                    order.conditions[0].direction,
+                    crate::mapper::OrderDirection::Desc
+                );
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_invalid_order_direction() {
+        let query = r#"
+            query($dir: String!) {
+                Users(order: {name: $dir}) {
+                    _docID
+                }
+            }
+        "#;
+
+        let variables = HashMap::from([("dir".to_string(), json!("INVALID"))]);
+        let result = parse_request_with_variables(query, Some(&variables));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid order direction"));
+    }
 }

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -51,7 +51,30 @@ pub fn parse_mutations(query: &str) -> Result<Vec<Mutation>> {
 /// Parse a GraphQL request (query or mutation) into operations.
 ///
 /// This is the main entry point for parsing GraphQL requests.
+/// For queries with variables, use `parse_request_with_variables` instead.
 pub fn parse_request(query: &str) -> Result<ParsedOperation> {
+    parse_request_with_variables(query, None)
+}
+
+/// Parse a GraphQL request with variable substitution.
+///
+/// Variables in the query (e.g., `$userId`) will be substituted with values
+/// from the provided variables map during parsing.
+///
+/// # Example
+/// ```ignore
+/// let variables = HashMap::from([
+///     ("userId".to_string(), json!("bae-123")),
+/// ]);
+/// let result = parse_request_with_variables(
+///     "query($userId: ID!) { User(docID: $userId) { name } }",
+///     Some(&variables)
+/// )?;
+/// ```
+pub fn parse_request_with_variables(
+    query: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<ParsedOperation> {
     let doc: Document<'_, String> =
         graphql_parser::parse_query(query).map_err(|e| QueryError::parse(e.to_string()))?;
 
@@ -68,7 +91,7 @@ pub fn parse_request(query: &str) -> Result<ParsedOperation> {
                         has_query = true;
                         for selection in q.selection_set.items {
                             if let Selection::Field(field) = selection {
-                                let select = parse_field_to_select(&field)?;
+                                let select = parse_field_to_select(&field, variables)?;
                                 selects.push(select);
                             }
                         }
@@ -78,7 +101,7 @@ pub fn parse_request(query: &str) -> Result<ParsedOperation> {
                         has_query = true;
                         for selection in ss.items {
                             if let Selection::Field(field) = selection {
-                                let select = parse_field_to_select(&field)?;
+                                let select = parse_field_to_select(&field, variables)?;
                                 selects.push(select);
                             }
                         }
@@ -87,7 +110,7 @@ pub fn parse_request(query: &str) -> Result<ParsedOperation> {
                         has_mutation = true;
                         for selection in m.selection_set.items {
                             if let Selection::Field(field) = selection {
-                                let mutation = parse_field_to_mutation(&field)?;
+                                let mutation = parse_field_to_mutation(&field, variables)?;
                                 mutations.push(mutation);
                             }
                         }
@@ -118,7 +141,10 @@ pub fn parse_request(query: &str) -> Result<ParsedOperation> {
 }
 
 /// Parse a single GraphQL field into a Select operation.
-fn parse_field_to_select(field: &Field<'_, String>) -> Result<Select> {
+fn parse_field_to_select(
+    field: &Field<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Select> {
     let collection_name = field.name.clone();
     let alias = field.alias.clone();
 
@@ -131,11 +157,11 @@ fn parse_field_to_select(field: &Field<'_, String>) -> Result<Select> {
     for (arg_name, arg_value) in &field.arguments {
         match arg_name.as_str() {
             "filter" => {
-                let filter = parse_filter_value(arg_value)?;
+                let filter = parse_filter_value(arg_value, variables)?;
                 select.filter = Some(filter);
             }
             "limit" => {
-                let limit_val = parse_int_value(arg_value)?;
+                let limit_val = parse_int_value(arg_value, variables)?;
                 if limit_val < 0 {
                     return Err(QueryError::parse("limit must be non-negative"));
                 }
@@ -145,7 +171,7 @@ fn parse_field_to_select(field: &Field<'_, String>) -> Result<Select> {
                 ));
             }
             "offset" => {
-                let offset_val = parse_int_value(arg_value)?;
+                let offset_val = parse_int_value(arg_value, variables)?;
                 if offset_val < 0 {
                     return Err(QueryError::parse("offset must be non-negative"));
                 }
@@ -155,25 +181,25 @@ fn parse_field_to_select(field: &Field<'_, String>) -> Result<Select> {
                 ));
             }
             "order" => {
-                let order_by = parse_order_value(arg_value)?;
+                let order_by = parse_order_value(arg_value, variables)?;
                 select.order_by = Some(order_by);
             }
             "groupBy" => {
-                let group_by = parse_group_by_value(arg_value)?;
+                let group_by = parse_group_by_value(arg_value, variables)?;
                 select.group_by = Some(group_by);
             }
             "docIDs" | "docID" => {
-                let doc_ids = parse_doc_ids_value(arg_value)?;
+                let doc_ids = parse_doc_ids_value(arg_value, variables)?;
                 select.doc_ids = Some(doc_ids);
             }
-            "cid" => match arg_value {
-                Value::String(s) => select.cid = Some(s.clone()),
-                _ => return Err(QueryError::parse("cid argument must be a string")),
-            },
-            "showDeleted" => match arg_value {
-                Value::Boolean(b) => select.show_deleted = *b,
-                _ => return Err(QueryError::parse("showDeleted argument must be a boolean")),
-            },
+            "cid" => {
+                let cid_val = resolve_string_value(arg_value, variables, "cid")?;
+                select.cid = Some(cid_val);
+            }
+            "showDeleted" => {
+                let show_deleted = resolve_bool_value(arg_value, variables, "showDeleted")?;
+                select.show_deleted = show_deleted;
+            }
             _ => {
                 return Err(QueryError::parse(format!(
                     "unknown argument '{}' on collection '{}'. Valid arguments are: filter, limit, offset, order, groupBy, docIDs, docID, cid, showDeleted",
@@ -184,7 +210,7 @@ fn parse_field_to_select(field: &Field<'_, String>) -> Result<Select> {
     }
 
     // Parse selection set (child fields)
-    let (fields, mapping) = parse_selection_set(&field.selection_set, &collection_name)?;
+    let (fields, mapping) = parse_selection_set(&field.selection_set, &collection_name, variables)?;
     select.fields = fields;
     select.document_mapping = mapping;
 
@@ -195,6 +221,7 @@ fn parse_field_to_select(field: &Field<'_, String>) -> Result<Select> {
 fn parse_selection_set(
     selection_set: &SelectionSet<'_, String>,
     _collection_name: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
 ) -> Result<(Vec<Requestable>, DocumentMapping)> {
     let mut fields = Vec::new();
     let mut mapping = DocumentMapping::new();
@@ -207,7 +234,7 @@ fn parse_selection_set(
 
                 // Check if this is an aggregate field (_count, _sum, _avg, _min, _max)
                 if let Some(agg_type) = AggregateType::parse(&field_name) {
-                    let mut aggregate = parse_aggregate_field(field, agg_type)?;
+                    let mut aggregate = parse_aggregate_field(field, agg_type, variables)?;
 
                     // Set alias if provided
                     if let Some(ref a) = alias {
@@ -222,7 +249,7 @@ fn parse_selection_set(
                     fields.push(Requestable::Aggregate(aggregate));
                 } else if !field.selection_set.items.is_empty() {
                     // This is a nested select (relation)
-                    let nested = parse_field_to_select(field)?;
+                    let nested = parse_field_to_select(field, variables)?;
 
                     // Add nested select to document mapping
                     // Use field name for internal indexing, output_name (alias) for rendering
@@ -260,10 +287,13 @@ fn parse_selection_set(
 }
 
 /// Parse a filter argument value into a Filter.
-fn parse_filter_value(value: &Value<'_, String>) -> Result<Filter> {
+fn parse_filter_value(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Filter> {
     match value {
         Value::Object(obj) => {
-            let conditions = parse_filter_object(obj)?;
+            let conditions = parse_filter_object(obj, variables)?;
             Ok(Filter::from_conditions(conditions))
         }
         _ => Err(QueryError::parse("filter must be an object")),
@@ -273,19 +303,23 @@ fn parse_filter_value(value: &Value<'_, String>) -> Result<Filter> {
 /// Parse a filter object into conditions map.
 fn parse_filter_object(
     obj: &BTreeMap<String, Value<'_, String>>,
+    variables: Option<&HashMap<String, JsonValue>>,
 ) -> Result<HashMap<String, JsonValue>> {
     let mut conditions = HashMap::new();
 
     for (key, val) in obj {
-        let json_val = graphql_value_to_json(val)?;
+        let json_val = graphql_value_to_json(val, variables)?;
         conditions.insert(key.clone(), json_val);
     }
 
     Ok(conditions)
 }
 
-/// Convert GraphQL Value to JSON Value.
-fn graphql_value_to_json(value: &Value<'_, String>) -> Result<JsonValue> {
+/// Convert GraphQL Value to JSON Value, resolving variables if present.
+fn graphql_value_to_json(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<JsonValue> {
     match value {
         Value::Null => Ok(JsonValue::Null),
         Value::Int(n) => n
@@ -299,32 +333,65 @@ fn graphql_value_to_json(value: &Value<'_, String>) -> Result<JsonValue> {
         Value::Boolean(b) => Ok(JsonValue::Bool(*b)),
         Value::Enum(e) => Ok(JsonValue::String(e.clone())),
         Value::List(items) => {
-            let arr: Result<Vec<JsonValue>> = items.iter().map(graphql_value_to_json).collect();
+            let arr: Result<Vec<JsonValue>> = items
+                .iter()
+                .map(|v| graphql_value_to_json(v, variables))
+                .collect();
             Ok(JsonValue::Array(arr?))
         }
         Value::Object(obj) => {
             let mut map = serde_json::Map::new();
             for (k, v) in obj {
-                map.insert(k.clone(), graphql_value_to_json(v)?);
+                map.insert(k.clone(), graphql_value_to_json(v, variables)?);
             }
             Ok(JsonValue::Object(map))
         }
-        Value::Variable(_) => Err(QueryError::parse("variables not yet supported")),
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            vars.get(name)
+                .cloned()
+                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))
+        }
     }
 }
 
-/// Parse an integer value from GraphQL Value.
-fn parse_int_value(value: &Value<'_, String>) -> Result<i64> {
+/// Parse an integer value from GraphQL Value, resolving variables if present.
+fn parse_int_value(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<i64> {
     match value {
         Value::Int(n) => n
             .as_i64()
             .ok_or_else(|| QueryError::parse("integer out of range")),
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            let json_val = vars
+                .get(name)
+                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+            json_val
+                .as_i64()
+                .ok_or_else(|| QueryError::parse(format!("variable '{}' must be an integer", name)))
+        }
         _ => Err(QueryError::parse("expected integer value")),
     }
 }
 
 /// Parse order argument into OrderBy.
-fn parse_order_value(value: &Value<'_, String>) -> Result<OrderBy> {
+fn parse_order_value(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<OrderBy> {
     let mut order_by = OrderBy::new();
 
     match value {
@@ -332,6 +399,29 @@ fn parse_order_value(value: &Value<'_, String>) -> Result<OrderBy> {
             for (field_name, direction_val) in obj {
                 let direction = match direction_val {
                     Value::Enum(s) | Value::String(s) => {
+                        OrderDirection::parse(s).ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "invalid order direction '{}', expected ASC or DESC",
+                                s
+                            ))
+                        })?
+                    }
+                    Value::Variable(name) => {
+                        let vars = variables.ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "variable '{}' used but no variables provided",
+                                name
+                            ))
+                        })?;
+                        let json_val = vars.get(name).ok_or_else(|| {
+                            QueryError::parse(format!("undefined variable '${}'", name))
+                        })?;
+                        let s = json_val.as_str().ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "variable '{}' must be a string (ASC or DESC)",
+                                name
+                            ))
+                        })?;
                         OrderDirection::parse(s).ok_or_else(|| {
                             QueryError::parse(format!(
                                 "invalid order direction '{}', expected ASC or DESC",
@@ -351,14 +441,54 @@ fn parse_order_value(value: &Value<'_, String>) -> Result<OrderBy> {
 }
 
 /// Parse groupBy argument into GroupBy.
-fn parse_group_by_value(value: &Value<'_, String>) -> Result<GroupBy> {
+fn parse_group_by_value(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<GroupBy> {
     match value {
         Value::List(items) => {
             let fields: Result<Vec<String>> = items
                 .iter()
                 .map(|v| match v {
                     Value::String(s) | Value::Enum(s) => Ok(s.clone()),
+                    Value::Variable(name) => {
+                        let vars = variables.ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "variable '{}' used but no variables provided",
+                                name
+                            ))
+                        })?;
+                        let json_val = vars.get(name).ok_or_else(|| {
+                            QueryError::parse(format!("undefined variable '${}'", name))
+                        })?;
+                        json_val.as_str().map(|s| s.to_string()).ok_or_else(|| {
+                            QueryError::parse(format!("variable '{}' must be a string", name))
+                        })
+                    }
                     _ => Err(QueryError::parse("groupBy items must be strings")),
+                })
+                .collect();
+            Ok(GroupBy::new(fields?))
+        }
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            let json_val = vars
+                .get(name)
+                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+            let arr = json_val.as_array().ok_or_else(|| {
+                QueryError::parse(format!("variable '{}' must be an array of strings", name))
+            })?;
+            let fields: Result<Vec<String>> = arr
+                .iter()
+                .map(|v| {
+                    v.as_str()
+                        .map(|s| s.to_string())
+                        .ok_or_else(|| QueryError::parse("groupBy items must be strings"))
                 })
                 .collect();
             Ok(GroupBy::new(fields?))
@@ -370,7 +500,11 @@ fn parse_group_by_value(value: &Value<'_, String>) -> Result<GroupBy> {
 /// Parse an aggregate field into an Aggregate.
 ///
 /// Handles aggregate functions like `_count`, `_sum(field: "age")`, etc.
-fn parse_aggregate_field(field: &Field<'_, String>, agg_type: AggregateType) -> Result<Aggregate> {
+fn parse_aggregate_field(
+    field: &Field<'_, String>,
+    agg_type: AggregateType,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Aggregate> {
     let mut target_field: Option<String> = None;
 
     // Parse arguments (e.g., `field: "age"` for _sum)
@@ -380,6 +514,23 @@ fn parse_aggregate_field(field: &Field<'_, String>, agg_type: AggregateType) -> 
                 target_field = Some(match arg_value {
                     Value::String(s) => s.clone(),
                     Value::Enum(s) => s.clone(),
+                    Value::Variable(name) => {
+                        let vars = variables.ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "variable '{}' used but no variables provided",
+                                name
+                            ))
+                        })?;
+                        let json_val = vars.get(name).ok_or_else(|| {
+                            QueryError::parse(format!("undefined variable '${}'", name))
+                        })?;
+                        json_val
+                            .as_str()
+                            .ok_or_else(|| {
+                                QueryError::parse(format!("variable '{}' must be a string", name))
+                            })?
+                            .to_string()
+                    }
                     _ => return Err(QueryError::parse("field argument must be a string")),
                 });
             }
@@ -429,20 +580,124 @@ fn parse_aggregate_field(field: &Field<'_, String>, agg_type: AggregateType) -> 
 }
 
 /// Parse docIDs argument into vector of strings.
-fn parse_doc_ids_value(value: &Value<'_, String>) -> Result<Vec<String>> {
+fn parse_doc_ids_value(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Vec<String>> {
     match value {
         Value::List(items) => {
             let ids: Result<Vec<String>> = items
                 .iter()
                 .map(|v| match v {
                     Value::String(s) => Ok(s.clone()),
+                    Value::Variable(name) => {
+                        let vars = variables.ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "variable '{}' used but no variables provided",
+                                name
+                            ))
+                        })?;
+                        let json_val = vars.get(name).ok_or_else(|| {
+                            QueryError::parse(format!("undefined variable '${}'", name))
+                        })?;
+                        json_val.as_str().map(|s| s.to_string()).ok_or_else(|| {
+                            QueryError::parse(format!("variable '{}' must be a string", name))
+                        })
+                    }
                     _ => Err(QueryError::parse("docIDs items must be strings")),
                 })
                 .collect();
             ids
         }
         Value::String(s) => Ok(vec![s.clone()]),
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            let json_val = vars
+                .get(name)
+                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+            // Variable can be a string (single ID) or array of strings
+            if let Some(s) = json_val.as_str() {
+                Ok(vec![s.to_string()])
+            } else if let Some(arr) = json_val.as_array() {
+                arr.iter()
+                    .map(|v| {
+                        v.as_str()
+                            .map(|s| s.to_string())
+                            .ok_or_else(|| QueryError::parse("docIDs items must be strings"))
+                    })
+                    .collect()
+            } else {
+                Err(QueryError::parse(format!(
+                    "variable '{}' must be a string or array of strings",
+                    name
+                )))
+            }
+        }
         _ => Err(QueryError::parse("docIDs must be a string or list")),
+    }
+}
+
+/// Resolve a string value, handling variables.
+fn resolve_string_value(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+    arg_name: &str,
+) -> Result<String> {
+    match value {
+        Value::String(s) => Ok(s.clone()),
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            let json_val = vars
+                .get(name)
+                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+            json_val
+                .as_str()
+                .map(|s| s.to_string())
+                .ok_or_else(|| QueryError::parse(format!("variable '{}' must be a string", name)))
+        }
+        _ => Err(QueryError::parse(format!(
+            "{} argument must be a string",
+            arg_name
+        ))),
+    }
+}
+
+/// Resolve a boolean value, handling variables.
+fn resolve_bool_value(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+    arg_name: &str,
+) -> Result<bool> {
+    match value {
+        Value::Boolean(b) => Ok(*b),
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            let json_val = vars
+                .get(name)
+                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+            json_val
+                .as_bool()
+                .ok_or_else(|| QueryError::parse(format!("variable '{}' must be a boolean", name)))
+        }
+        _ => Err(QueryError::parse(format!(
+            "{} argument must be a boolean",
+            arg_name
+        ))),
     }
 }
 
@@ -454,7 +709,10 @@ fn parse_doc_ids_value(value: &Value<'_, String>) -> Result<Vec<String>> {
 ///
 /// Mutation field names follow the format: `operation_collection`
 /// Examples: `create_Users`, `update_Posts`, `delete_Comments`
-fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
+fn parse_field_to_mutation(
+    field: &Field<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Mutation> {
     let field_name = &field.name;
 
     // Parse mutation name to get operation type and collection
@@ -474,13 +732,13 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
         match (mutation_type, arg_name.as_str()) {
             // CREATE: input is array of documents
             (MutationType::Create, "input") => {
-                let input = parse_create_input(arg_value)?;
+                let input = parse_create_input(arg_value, variables)?;
                 mutation.create_input = input;
             }
 
             // UPDATE/UPSERT: input is patch object
             (MutationType::Update | MutationType::Upsert, "input") => {
-                let input = parse_update_input(arg_value)?;
+                let input = parse_update_input(arg_value, variables)?;
                 mutation.update_input = input;
             }
 
@@ -489,13 +747,13 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
                 MutationType::Update | MutationType::Delete | MutationType::Upsert,
                 "docIDs" | "_docIDs",
             ) => {
-                let doc_ids = parse_doc_ids_value(arg_value)?;
+                let doc_ids = parse_doc_ids_value(arg_value, variables)?;
                 mutation.doc_ids = Some(doc_ids);
             }
 
             // UPDATE/DELETE/UPSERT: filter to find documents
             (MutationType::Update | MutationType::Delete | MutationType::Upsert, "filter") => {
-                let filter = parse_filter_value(arg_value)?;
+                let filter = parse_filter_value(arg_value, variables)?;
                 mutation.filter = Some(filter);
             }
 
@@ -555,7 +813,7 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
     }
 
     // Parse selection set (fields to return after mutation)
-    let (fields, mapping) = parse_selection_set(&field.selection_set, &collection_name)?;
+    let (fields, mapping) = parse_selection_set(&field.selection_set, &collection_name, variables)?;
     mutation.fields = fields;
     mutation.document_mapping = mapping;
 
@@ -563,14 +821,17 @@ fn parse_field_to_mutation(field: &Field<'_, String>) -> Result<Mutation> {
 }
 
 /// Parse CREATE mutation input (array of documents).
-fn parse_create_input(value: &Value<'_, String>) -> Result<Vec<HashMap<String, JsonValue>>> {
+fn parse_create_input(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Vec<HashMap<String, JsonValue>>> {
     match value {
         Value::List(items) => {
             let mut docs = Vec::new();
             for item in items {
                 match item {
                     Value::Object(obj) => {
-                        let doc = parse_document_input(obj)?;
+                        let doc = parse_document_input(obj, variables)?;
                         docs.push(doc);
                     }
                     _ => return Err(QueryError::parse("CREATE input items must be objects")),
@@ -580,7 +841,7 @@ fn parse_create_input(value: &Value<'_, String>) -> Result<Vec<HashMap<String, J
         }
         Value::Object(obj) => {
             // Single document (wrap in array)
-            let doc = parse_document_input(obj)?;
+            let doc = parse_document_input(obj, variables)?;
             Ok(vec![doc])
         }
         _ => Err(QueryError::parse(
@@ -590,9 +851,12 @@ fn parse_create_input(value: &Value<'_, String>) -> Result<Vec<HashMap<String, J
 }
 
 /// Parse UPDATE mutation input (patch object).
-fn parse_update_input(value: &Value<'_, String>) -> Result<HashMap<String, JsonValue>> {
+fn parse_update_input(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<HashMap<String, JsonValue>> {
     match value {
-        Value::Object(obj) => parse_document_input(obj),
+        Value::Object(obj) => parse_document_input(obj, variables),
         _ => Err(QueryError::parse("UPDATE input must be an object")),
     }
 }
@@ -600,10 +864,11 @@ fn parse_update_input(value: &Value<'_, String>) -> Result<HashMap<String, JsonV
 /// Parse a document input object into field-value map.
 fn parse_document_input(
     obj: &BTreeMap<String, Value<'_, String>>,
+    variables: Option<&HashMap<String, JsonValue>>,
 ) -> Result<HashMap<String, JsonValue>> {
     let mut fields = HashMap::new();
     for (key, value) in obj {
-        let json_value = graphql_value_to_json(value)?;
+        let json_value = graphql_value_to_json(value, variables)?;
         fields.insert(key.clone(), json_value);
     }
     Ok(fields)
@@ -927,5 +1192,247 @@ mod mutation_tests {
         let result = parse_mutations(query);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("requires 'input'"));
+    }
+}
+
+#[cfg(test)]
+mod variable_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_variable_in_filter() {
+        let query = r#"
+            query($name: String!) {
+                Users(filter: {name: {_eq: $name}}) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        let variables = HashMap::from([("name".to_string(), json!("Alice"))]);
+
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Query(selects) => {
+                assert_eq!(selects.len(), 1);
+                let filter = selects[0].filter.as_ref().unwrap();
+                let conditions = filter.conditions();
+                let name_cond = conditions.get("name").unwrap();
+                assert_eq!(name_cond.get("_eq"), Some(&json!("Alice")));
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_in_limit() {
+        let query = r#"
+            query($lim: Int!) {
+                Users(limit: $lim) {
+                    _docID
+                }
+            }
+        "#;
+
+        let variables = HashMap::from([("lim".to_string(), json!(10))]);
+
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Query(selects) => {
+                assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(10));
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_in_doc_ids() {
+        let query = r#"
+            query($ids: [String!]!) {
+                Users(docIDs: $ids) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        let variables = HashMap::from([("ids".to_string(), json!(["bae-123", "bae-456"]))]);
+
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Query(selects) => {
+                assert_eq!(
+                    selects[0].doc_ids,
+                    Some(vec!["bae-123".to_string(), "bae-456".to_string()])
+                );
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_in_mutation_input() {
+        let query = r#"
+            mutation($userName: String!, $userAge: Int!) {
+                create_Users(input: [{name: $userName, age: $userAge}]) {
+                    _docID
+                }
+            }
+        "#;
+
+        let variables = HashMap::from([
+            ("userName".to_string(), json!("Bob")),
+            ("userAge".to_string(), json!(25)),
+        ]);
+
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Mutation(mutations) => {
+                assert_eq!(mutations.len(), 1);
+                let input = &mutations[0].create_input[0];
+                assert_eq!(input.get("name"), Some(&json!("Bob")));
+                assert_eq!(input.get("age"), Some(&json!(25)));
+            }
+            _ => panic!("Expected mutation"),
+        }
+    }
+
+    #[test]
+    fn test_variable_in_mutation_doc_ids() {
+        let query = r#"
+            mutation($id: String!) {
+                delete_Users(docIDs: [$id]) {
+                    _docID
+                }
+            }
+        "#;
+
+        let variables = HashMap::from([("id".to_string(), json!("bae-999"))]);
+
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Mutation(mutations) => {
+                assert_eq!(mutations[0].doc_ids, Some(vec!["bae-999".to_string()]));
+            }
+            _ => panic!("Expected mutation"),
+        }
+    }
+
+    #[test]
+    fn test_undefined_variable_error() {
+        let query = r#"
+            query {
+                Users(filter: {name: {_eq: $undefined}}) {
+                    _docID
+                }
+            }
+        "#;
+
+        let variables = HashMap::new();
+        let result = parse_request_with_variables(query, Some(&variables));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("undefined variable"));
+    }
+
+    #[test]
+    fn test_no_variables_provided_error() {
+        let query = r#"
+            query {
+                Users(filter: {name: {_eq: $name}}) {
+                    _docID
+                }
+            }
+        "#;
+
+        let result = parse_request_with_variables(query, None);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("no variables provided"));
+    }
+
+    #[test]
+    fn test_query_without_variables_still_works() {
+        let query = r#"
+            {
+                Users(filter: {name: {_eq: "Alice"}}) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        // No variables provided
+        let result = parse_request_with_variables(query, None).unwrap();
+        match result {
+            ParsedOperation::Query(selects) => {
+                assert_eq!(selects.len(), 1);
+                let filter = selects[0].filter.as_ref().unwrap();
+                let conditions = filter.conditions();
+                let name_cond = conditions.get("name").unwrap();
+                assert_eq!(name_cond.get("_eq"), Some(&json!("Alice")));
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_type_mismatch_int() {
+        let query = r#"
+            query($lim: Int!) {
+                Users(limit: $lim) {
+                    _docID
+                }
+            }
+        "#;
+
+        // Provide string instead of int
+        let variables = HashMap::from([("lim".to_string(), json!("not an int"))]);
+        let result = parse_request_with_variables(query, Some(&variables));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be an integer"));
+    }
+
+    #[test]
+    fn test_multiple_variables() {
+        let query = r#"
+            query($name: String!, $minAge: Int!, $lim: Int!) {
+                Users(filter: {name: {_eq: $name}, age: {_gte: $minAge}}, limit: $lim) {
+                    _docID
+                    name
+                    age
+                }
+            }
+        "#;
+
+        let variables = HashMap::from([
+            ("name".to_string(), json!("Alice")),
+            ("minAge".to_string(), json!(18)),
+            ("lim".to_string(), json!(5)),
+        ]);
+
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Query(selects) => {
+                assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(5));
+                let filter = selects[0].filter.as_ref().unwrap();
+                let conditions = filter.conditions();
+                assert_eq!(
+                    conditions.get("name").unwrap().get("_eq"),
+                    Some(&json!("Alice"))
+                );
+                assert_eq!(conditions.get("age").unwrap().get("_gte"), Some(&json!(18)));
+            }
+            _ => panic!("Expected query"),
+        }
     }
 }

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -4,7 +4,7 @@
 
 use graphql_parser::query::{
     Definition, Directive, Document, Field, FragmentDefinition, OperationDefinition, Selection,
-    SelectionSet, Value,
+    SelectionSet, Value, VariableDefinition,
 };
 use serde_json::Value as JsonValue;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -17,22 +17,67 @@ use crate::mapper::{
     Select,
 };
 
+/// Type of explain output requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExplainType {
+    /// Simple explanation showing query plan structure without execution.
+    #[default]
+    Simple,
+    /// Execute the query and return both the plan structure and execution metrics.
+    Execute,
+    /// Debug mode showing all plan nodes including internal ones.
+    Debug,
+}
+
+impl ExplainType {
+    /// Parse explain type from string.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "simple" => Some(Self::Simple),
+            "execute" => Some(Self::Execute),
+            "debug" => Some(Self::Debug),
+            _ => None,
+        }
+    }
+}
+
 /// Result of parsing a GraphQL request.
 #[derive(Debug)]
 pub enum ParsedOperation {
     /// Query operations (SELECT)
     Query {
         selects: Vec<Select>,
-        /// Whether @explain directive was used
-        explain: bool,
+        /// Whether @explain directive was used and which type
+        explain: Option<ExplainType>,
     },
     /// Mutation operations (CREATE, UPDATE, DELETE)
     Mutation(Vec<Mutation>),
 }
 
-/// Check if a directive list contains @explain
-fn has_explain_directive(directives: &[Directive<'_, String>]) -> bool {
-    directives.iter().any(|d| d.name == "explain")
+/// Check if a directive list contains @explain and parse its type.
+/// Returns Some(ExplainType) if @explain is present, None otherwise.
+fn parse_explain_directive(directives: &[Directive<'_, String>]) -> Option<ExplainType> {
+    for directive in directives {
+        if directive.name == "explain" {
+            // Check for type argument: @explain(type: simple|execute|debug)
+            for (name, value) in &directive.arguments {
+                if name == "type" {
+                    if let Value::Enum(type_str) = value {
+                        if let Some(explain_type) = ExplainType::from_str(type_str) {
+                            return Some(explain_type);
+                        }
+                    } else if let Value::String(type_str) = value {
+                        if let Some(explain_type) = ExplainType::from_str(type_str) {
+                            return Some(explain_type);
+                        }
+                    }
+                }
+            }
+            // No type argument or unknown type - default to Simple
+            return Some(ExplainType::Simple);
+        }
+    }
+    None
 }
 
 /// Type alias for fragment definitions map
@@ -165,7 +210,7 @@ pub fn parse_request_with_variables(
     let mut mutations = Vec::new();
     let mut has_query = false;
     let mut has_mutation = false;
-    let mut explain = false;
+    let mut explain: Option<ExplainType> = None;
 
     // Second pass: parse operations with fragments available
     for def in &doc.definitions {
@@ -174,15 +219,27 @@ pub fn parse_request_with_variables(
                 match op {
                     OperationDefinition::Query(q) => {
                         has_query = true;
-                        // Check for @explain directive
-                        if has_explain_directive(&q.directives) {
-                            explain = true;
+                        // Check for @explain directive and parse type
+                        if let Some(explain_type) = parse_explain_directive(&q.directives) {
+                            explain = Some(explain_type);
                         }
+
+                        // Extract default values from variable definitions and merge with provided variables
+                        let defaults = extract_variable_defaults(&q.variable_definitions)?;
+                        let effective_variables = merge_variables(variables, &defaults);
+                        // If variables was provided (even empty) or we have defaults, use the merged map
+                        // Otherwise preserve None to get appropriate "no variables provided" error
+                        let effective_vars_ref = if variables.is_some() || !defaults.is_empty() {
+                            Some(&effective_variables)
+                        } else {
+                            None
+                        };
+
                         let mut visiting = HashSet::new();
                         for selection in &q.selection_set.items {
                             parse_selection_to_selects(
                                 selection,
-                                variables,
+                                effective_vars_ref,
                                 &fragments,
                                 &mut selects,
                                 &mut visiting,
@@ -205,9 +262,21 @@ pub fn parse_request_with_variables(
                     }
                     OperationDefinition::Mutation(m) => {
                         has_mutation = true;
+
+                        // Extract default values from variable definitions and merge with provided variables
+                        let defaults = extract_variable_defaults(&m.variable_definitions)?;
+                        let effective_variables = merge_variables(variables, &defaults);
+                        // If variables was provided (even empty) or we have defaults, use the merged map
+                        // Otherwise preserve None to get appropriate "no variables provided" error
+                        let effective_vars_ref = if variables.is_some() || !defaults.is_empty() {
+                            Some(&effective_variables)
+                        } else {
+                            None
+                        };
+
                         for selection in &m.selection_set.items {
                             if let Selection::Field(field) = selection {
-                                let mutation = parse_field_to_mutation(field, variables)?;
+                                let mutation = parse_field_to_mutation(field, effective_vars_ref)?;
                                 mutations.push(mutation);
                             }
                         }
@@ -498,6 +567,79 @@ fn parse_filter_object(
     Ok(conditions)
 }
 
+/// Merge provided variables with default values.
+///
+/// Provided variables take precedence over defaults.
+fn merge_variables(
+    provided: Option<&HashMap<String, JsonValue>>,
+    defaults: &HashMap<String, JsonValue>,
+) -> HashMap<String, JsonValue> {
+    let mut merged = defaults.clone();
+    if let Some(vars) = provided {
+        for (k, v) in vars {
+            merged.insert(k.clone(), v.clone());
+        }
+    }
+    merged
+}
+
+/// Extract default values from variable definitions.
+///
+/// Returns a HashMap of variable name -> default value for all variables
+/// that have a default value defined.
+fn extract_variable_defaults(
+    var_defs: &[VariableDefinition<'_, String>],
+) -> Result<HashMap<String, JsonValue>> {
+    let mut defaults = HashMap::new();
+    for var_def in var_defs {
+        if let Some(default_value) = &var_def.default_value {
+            // Convert the default value without variable resolution (defaults can't reference other variables)
+            let json_val = graphql_value_to_json_no_vars(default_value)?;
+            defaults.insert(var_def.name.clone(), json_val);
+        }
+    }
+    Ok(defaults)
+}
+
+/// Convert GraphQL Value to JSON Value without variable resolution.
+///
+/// Used for converting default values where variable references are not allowed.
+fn graphql_value_to_json_no_vars(value: &Value<'_, String>) -> Result<JsonValue> {
+    match value {
+        Value::Null => Ok(JsonValue::Null),
+        Value::Int(n) => n
+            .as_i64()
+            .map(|i| JsonValue::Number(i.into()))
+            .ok_or_else(|| QueryError::parse("integer out of range")),
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(JsonValue::Number)
+            .ok_or_else(|| QueryError::parse("invalid float value")),
+        Value::String(s) => Ok(JsonValue::String(s.clone())),
+        Value::Boolean(b) => Ok(JsonValue::Bool(*b)),
+        Value::Enum(e) => Ok(JsonValue::String(e.clone())),
+        Value::List(items) => {
+            let arr: Result<Vec<JsonValue>> = items
+                .iter()
+                .map(graphql_value_to_json_no_vars)
+                .collect();
+            Ok(JsonValue::Array(arr?))
+        }
+        Value::Object(obj) => {
+            let mut map = serde_json::Map::new();
+            for (k, v) in obj {
+                map.insert(k.clone(), graphql_value_to_json_no_vars(v)?);
+            }
+            Ok(JsonValue::Object(map))
+        }
+        Value::Variable(name) => {
+            Err(QueryError::parse(format!(
+                "variable '{}' cannot be used in default value",
+                name
+            )))
+        }
+    }
+}
+
 /// Convert GraphQL Value to JSON Value, resolving variables if present.
 fn graphql_value_to_json(
     value: &Value<'_, String>,
@@ -538,7 +680,7 @@ fn graphql_value_to_json(
             })?;
             vars.get(name)
                 .cloned()
-                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" was not provided", name)))
         }
     }
 }
@@ -561,10 +703,10 @@ fn parse_int_value(
             })?;
             let json_val = vars
                 .get(name)
-                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" was not provided", name)))?;
             json_val
                 .as_i64()
-                .ok_or_else(|| QueryError::parse(format!("variable '{}' must be an integer", name)))
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" must be of type Int", name)))
         }
         _ => Err(QueryError::parse("expected integer value")),
     }
@@ -597,11 +739,11 @@ fn parse_order_value(
                             ))
                         })?;
                         let json_val = vars.get(name).ok_or_else(|| {
-                            QueryError::parse(format!("undefined variable '${}'", name))
+                            QueryError::parse(format!("Variable \"${}\" was not provided", name))
                         })?;
                         let s = json_val.as_str().ok_or_else(|| {
                             QueryError::parse(format!(
-                                "variable '{}' must be a string (ASC or DESC)",
+                                "Variable \"${}\" must be of type Ordering (ASC or DESC)",
                                 name
                             ))
                         })?;
@@ -642,10 +784,10 @@ fn parse_group_by_value(
                             ))
                         })?;
                         let json_val = vars.get(name).ok_or_else(|| {
-                            QueryError::parse(format!("undefined variable '${}'", name))
+                            QueryError::parse(format!("Variable \"${}\" was not provided", name))
                         })?;
                         json_val.as_str().map(|s| s.to_string()).ok_or_else(|| {
-                            QueryError::parse(format!("variable '{}' must be a string", name))
+                            QueryError::parse(format!("Variable \"${}\" must be of type String", name))
                         })
                     }
                     _ => Err(QueryError::parse("groupBy items must be strings")),
@@ -662,9 +804,9 @@ fn parse_group_by_value(
             })?;
             let json_val = vars
                 .get(name)
-                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" was not provided", name)))?;
             let arr = json_val.as_array().ok_or_else(|| {
-                QueryError::parse(format!("variable '{}' must be an array of strings", name))
+                QueryError::parse(format!("Variable \"${}\" must be of type [String]", name))
             })?;
             let fields: Result<Vec<String>> = arr
                 .iter()
@@ -705,12 +847,12 @@ fn parse_aggregate_field(
                             ))
                         })?;
                         let json_val = vars.get(name).ok_or_else(|| {
-                            QueryError::parse(format!("undefined variable '${}'", name))
+                            QueryError::parse(format!("Variable \"${}\" was not provided", name))
                         })?;
                         json_val
                             .as_str()
                             .ok_or_else(|| {
-                                QueryError::parse(format!("variable '{}' must be a string", name))
+                                QueryError::parse(format!("Variable \"${}\" must be of type String", name))
                             })?
                             .to_string()
                     }
@@ -781,10 +923,10 @@ fn parse_doc_ids_value(
                             ))
                         })?;
                         let json_val = vars.get(name).ok_or_else(|| {
-                            QueryError::parse(format!("undefined variable '${}'", name))
+                            QueryError::parse(format!("Variable \"${}\" was not provided", name))
                         })?;
                         json_val.as_str().map(|s| s.to_string()).ok_or_else(|| {
-                            QueryError::parse(format!("variable '{}' must be a string", name))
+                            QueryError::parse(format!("Variable \"${}\" must be of type String", name))
                         })
                     }
                     _ => Err(QueryError::parse("docIDs items must be strings")),
@@ -802,7 +944,7 @@ fn parse_doc_ids_value(
             })?;
             let json_val = vars
                 .get(name)
-                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" was not provided", name)))?;
             // Variable can be a string (single ID) or array of strings
             if let Some(s) = json_val.as_str() {
                 Ok(vec![s.to_string()])
@@ -816,7 +958,7 @@ fn parse_doc_ids_value(
                     .collect()
             } else {
                 Err(QueryError::parse(format!(
-                    "variable '{}' must be a string or array of strings",
+                    "Variable \"${}\" must be of type String or [String]",
                     name
                 )))
             }
@@ -842,11 +984,11 @@ fn resolve_string_value(
             })?;
             let json_val = vars
                 .get(name)
-                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" was not provided", name)))?;
             json_val
                 .as_str()
                 .map(|s| s.to_string())
-                .ok_or_else(|| QueryError::parse(format!("variable '{}' must be a string", name)))
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" must be of type String", name)))
         }
         _ => Err(QueryError::parse(format!(
             "{} argument must be a string",
@@ -872,10 +1014,10 @@ fn resolve_bool_value(
             })?;
             let json_val = vars
                 .get(name)
-                .ok_or_else(|| QueryError::parse(format!("undefined variable '${}'", name)))?;
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" was not provided", name)))?;
             json_val
                 .as_bool()
-                .ok_or_else(|| QueryError::parse(format!("variable '{}' must be a boolean", name)))
+                .ok_or_else(|| QueryError::parse(format!("Variable \"${}\" must be of type Boolean", name)))
         }
         _ => Err(QueryError::parse(format!(
             "{} argument must be a boolean",
@@ -1529,7 +1671,7 @@ mod variable_tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("undefined variable"));
+            .contains("was not provided"));
     }
 
     #[test]
@@ -1592,7 +1734,7 @@ mod variable_tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("must be an integer"));
+            .contains("must be of type Int"));
     }
 
     #[test]
@@ -1650,7 +1792,7 @@ mod variable_tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("must be a boolean"));
+            .contains("must be of type Boolean"));
     }
 
     #[test]
@@ -1667,7 +1809,10 @@ mod variable_tests {
         let variables = HashMap::from([("c".to_string(), json!(12345))]);
         let result = parse_request_with_variables(query, Some(&variables));
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("must be a string"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must be of type String"));
     }
 
     #[test]
@@ -1712,5 +1857,222 @@ mod variable_tests {
             .unwrap_err()
             .to_string()
             .contains("invalid order direction"));
+    }
+
+    // =========================================================================
+    // Variable default value tests
+    // =========================================================================
+
+    #[test]
+    fn test_variable_default_value_used_when_not_provided() {
+        let query = r#"
+            query($name: String = "DefaultName") {
+                Users(filter: {name: {_eq: $name}}) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        // Don't provide the variable - should use default
+        let result = parse_request_with_variables(query, None).unwrap();
+        match result {
+            ParsedOperation::Query { selects, .. } => {
+                let filter = selects[0].filter.as_ref().unwrap();
+                let conditions = filter.conditions();
+                assert_eq!(
+                    conditions.get("name").unwrap().get("_eq"),
+                    Some(&json!("DefaultName"))
+                );
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_provided_value_overrides_default() {
+        let query = r#"
+            query($name: String = "DefaultName") {
+                Users(filter: {name: {_eq: $name}}) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        // Provide a value - should override default
+        let variables = HashMap::from([("name".to_string(), json!("ProvidedName"))]);
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Query { selects, .. } => {
+                let filter = selects[0].filter.as_ref().unwrap();
+                let conditions = filter.conditions();
+                assert_eq!(
+                    conditions.get("name").unwrap().get("_eq"),
+                    Some(&json!("ProvidedName"))
+                );
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_default_int_value() {
+        let query = r#"
+            query($lim: Int = 50) {
+                Users(limit: $lim) {
+                    _docID
+                }
+            }
+        "#;
+
+        // Don't provide the variable - should use default 50
+        let result = parse_request_with_variables(query, None).unwrap();
+        match result {
+            ParsedOperation::Query { selects, .. } => {
+                assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(50));
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_default_boolean_value() {
+        let query = r#"
+            query($deleted: Boolean = true) {
+                Users(showDeleted: $deleted) {
+                    _docID
+                }
+            }
+        "#;
+
+        // Don't provide the variable - should use default true
+        let result = parse_request_with_variables(query, None).unwrap();
+        match result {
+            ParsedOperation::Query { selects, .. } => {
+                assert!(selects[0].show_deleted);
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_multiple_variables_with_some_defaults() {
+        let query = r#"
+            query($name: String!, $minAge: Int = 18, $lim: Int = 10) {
+                Users(filter: {name: {_eq: $name}, age: {_gte: $minAge}}, limit: $lim) {
+                    _docID
+                    name
+                }
+            }
+        "#;
+
+        // Only provide $name, use defaults for $minAge and $lim
+        let variables = HashMap::from([("name".to_string(), json!("Alice"))]);
+        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        match result {
+            ParsedOperation::Query { selects, .. } => {
+                assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(10));
+                let filter = selects[0].filter.as_ref().unwrap();
+                let conditions = filter.conditions();
+                assert_eq!(
+                    conditions.get("name").unwrap().get("_eq"),
+                    Some(&json!("Alice"))
+                );
+                assert_eq!(conditions.get("age").unwrap().get("_gte"), Some(&json!(18)));
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_mutation_variable_default_value() {
+        let query = r#"
+            mutation($name: String = "DefaultUser") {
+                create_Users(input: [{name: $name}]) {
+                    _docID
+                }
+            }
+        "#;
+
+        // Don't provide the variable - should use default
+        let result = parse_request_with_variables(query, None).unwrap();
+        match result {
+            ParsedOperation::Mutation(mutations) => {
+                let input = &mutations[0].create_input;
+                assert_eq!(input[0].get("name"), Some(&json!("DefaultUser")));
+            }
+            _ => panic!("Expected mutation"),
+        }
+    }
+
+    #[test]
+    fn test_variable_default_array_value() {
+        let query = r#"
+            query($ids: [String!] = ["id1", "id2"]) {
+                Users(docIDs: $ids) {
+                    _docID
+                }
+            }
+        "#;
+
+        // Don't provide the variable - should use default array
+        let result = parse_request_with_variables(query, None).unwrap();
+        match result {
+            ParsedOperation::Query { selects, .. } => {
+                let doc_ids = selects[0].doc_ids.as_ref().unwrap();
+                assert_eq!(doc_ids.len(), 2);
+                assert_eq!(doc_ids[0], "id1");
+                assert_eq!(doc_ids[1], "id2");
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_default_null_value() {
+        let query = r#"
+            query($name: String = null) {
+                Users(filter: {name: {_eq: $name}}) {
+                    _docID
+                }
+            }
+        "#;
+
+        // Don't provide the variable - should use default null
+        let result = parse_request_with_variables(query, None).unwrap();
+        match result {
+            ParsedOperation::Query { selects, .. } => {
+                let filter = selects[0].filter.as_ref().unwrap();
+                let conditions = filter.conditions();
+                assert_eq!(
+                    conditions.get("name").unwrap().get("_eq"),
+                    Some(&JsonValue::Null)
+                );
+            }
+            _ => panic!("Expected query"),
+        }
+    }
+
+    #[test]
+    fn test_variable_default_cannot_reference_other_variable() {
+        // Note: GraphQL spec doesn't allow variable references in default values
+        // graphql-parser rejects this at parse time with a parse error
+        let query = r#"
+            query($a: String = $b, $b: String = "test") {
+                Users(filter: {name: {_eq: $a}}) {
+                    _docID
+                }
+            }
+        "#;
+
+        let result = parse_request_with_variables(query, None);
+        // graphql-parser rejects this at the parse level since variable references
+        // aren't allowed in default value position per the GraphQL spec
+        assert!(
+            result.is_err(),
+            "Expected error for variable reference in default value, but got: {:?}",
+            result
+        );
     }
 }

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -34,9 +34,9 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryExecutor for QueryRunner<F, R> 
         // Pass identity through for ACP permission checks
         let result = match parsed {
             ParsedOperation::Query { explain, .. } => {
-                if explain {
+                if let Some(explain_type) = explain {
                     // Return query plan instead of executing
-                    self.explain_query_with_identity(&request.query, identity)
+                    self.explain_query_with_identity(&request.query, identity, explain_type)
                         .await
                 } else {
                     self.execute_query_with_identity(&request.query, identity)

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -33,9 +33,15 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryExecutor for QueryRunner<F, R> 
         // Route to appropriate handler based on operation type
         // Pass identity through for ACP permission checks
         let result = match parsed {
-            ParsedOperation::Query(_) => {
-                self.execute_query_with_identity(&request.query, identity)
-                    .await
+            ParsedOperation::Query { explain, .. } => {
+                if explain {
+                    // Return query plan instead of executing
+                    self.explain_query_with_identity(&request.query, identity)
+                        .await
+                } else {
+                    self.execute_query_with_identity(&request.query, identity)
+                        .await
+                }
             }
             ParsedOperation::Mutation(_) => {
                 self.execute_mutation_with_identity(&request.query, identity)

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -36,6 +36,80 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             .await
     }
 
+    /// Generate an explanation of the query plan without executing.
+    ///
+    /// Used when queries include the @explain directive.
+    pub async fn explain_query_with_identity(
+        &self,
+        query: &str,
+        _caller_identity: Option<Did>,
+    ) -> Result<JsonValue> {
+        let selects = parse_query(query)?;
+
+        let mut results = Map::new();
+
+        for select in selects {
+            let explanation = self.explain_select(&select)?;
+            let key = select.field.output_name();
+            results.insert(key.to_string(), explanation);
+        }
+
+        Ok(serde_json::json!({ "explain": results }))
+    }
+
+    /// Generate an explanation of a single Select operation.
+    fn explain_select(&self, select: &Select) -> Result<JsonValue> {
+        // Get collection schema
+        let collection = self
+            .collections
+            .get(&select.collection_name)
+            .ok_or_else(|| QueryError::collection_not_found(&select.collection_name))?;
+
+        // Check if this query has nested selections (relations)
+        let has_nested = select
+            .fields
+            .iter()
+            .any(|f| matches!(f, Requestable::Select(_)));
+
+        if has_nested {
+            // Use the Planner for queries with nested selections
+            self.explain_nested_select(select)
+        } else {
+            // Explain simple query plan
+            self.explain_simple_select(select, collection)
+        }
+    }
+
+    /// Generate an explanation for a query with nested selections.
+    fn explain_nested_select(&self, select: &Select) -> Result<JsonValue> {
+        // Build the plan using the Planner
+        let collections: Vec<CollectionVersion> =
+            self.collections.values().map(|c| (**c).clone()).collect();
+
+        let planner = Planner::new(collections);
+        let plan_result = planner.plan_with_index_info(select)?;
+        let plan = plan_result.plan;
+
+        // Return the plan explanation
+        Ok(plan.explain())
+    }
+
+    /// Generate an explanation for a simple query without nested selections.
+    fn explain_simple_select(
+        &self,
+        select: &Select,
+        collection: &Arc<CollectionVersion>,
+    ) -> Result<JsonValue> {
+        // Build document mapping and plan
+        let mapping = plan::build_mapping(select, collection, &self.collections)?;
+
+        // Create an empty plan with no documents for explanation purposes
+        let plan = plan::build_plan(select, vec![], mapping, &self.collections)?;
+
+        // Return the plan explanation
+        Ok(plan.explain())
+    }
+
     /// Execute a GraphQL query with a specific fetcher and identity.
     ///
     /// This is used internally for both regular queries (using the default fetcher)

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -12,7 +12,7 @@ use crate::error::{QueryError, Result};
 use crate::mapper::{Requestable, Select};
 use crate::plan::PermissionFilterNode;
 use crate::planner::Planner;
-use crate::query_parse::parse_query;
+use crate::query_parse::{parse_query, ExplainType};
 use crate::txn::TransactionRegistry;
 
 use super::fetcher::FetcherWrapper;
@@ -36,29 +36,166 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
             .await
     }
 
-    /// Generate an explanation of the query plan without executing.
+    /// Generate an explanation of the query plan.
     ///
     /// Used when queries include the @explain directive.
+    /// Supports three modes:
+    /// - Simple: Query plan structure without execution
+    /// - Execute: Run the query and return plan structure with execution metrics
+    /// - Debug: All plan nodes including internal ones
     pub async fn explain_query_with_identity(
         &self,
         query: &str,
-        _caller_identity: Option<Did>,
+        caller_identity: Option<Did>,
+        explain_type: ExplainType,
+    ) -> Result<JsonValue> {
+        match explain_type {
+            ExplainType::Simple | ExplainType::Debug => {
+                // Simple and Debug modes: explain without execution
+                let selects = parse_query(query)?;
+                let mut results = Map::new();
+
+                for select in selects {
+                    let explanation = self.explain_select(&select, explain_type)?;
+                    let key = select.field.output_name();
+                    results.insert(key.to_string(), explanation);
+                }
+
+                Ok(serde_json::json!({ "explain": results }))
+            }
+            ExplainType::Execute => {
+                // Execute mode: run the query and collect metrics
+                self.execute_explain(query, caller_identity).await
+            }
+        }
+    }
+
+    /// Execute the query and return explain output with execution metrics.
+    async fn execute_explain(
+        &self,
+        query: &str,
+        caller_identity: Option<Did>,
     ) -> Result<JsonValue> {
         let selects = parse_query(query)?;
 
         let mut results = Map::new();
+        let mut total_executions: u64 = 0;
+        let mut total_docs: usize = 0;
+        let mut execution_success = true;
+        let mut execution_errors: Vec<String> = Vec::new();
 
         for select in selects {
-            let explanation = self.explain_select(&select)?;
-            let key = select.field.output_name();
-            results.insert(key.to_string(), explanation);
+            let key = select.field.output_name().to_string();
+
+            // Execute the select and collect metrics
+            match self
+                .execute_select_with_metrics(&select, caller_identity.clone())
+                .await
+            {
+                Ok((explanation, doc_count, exec_count)) => {
+                    results.insert(key, explanation);
+                    total_docs += doc_count;
+                    total_executions += exec_count;
+                }
+                Err(e) => {
+                    execution_success = false;
+                    execution_errors.push(format!("{}: {}", key, e));
+                }
+            }
         }
 
-        Ok(serde_json::json!({ "explain": results }))
+        let mut explain_result = serde_json::json!({
+            "executionSuccess": execution_success,
+            "planExecutions": total_executions,
+            "sizeOfResult": total_docs,
+        });
+
+        if !execution_errors.is_empty() {
+            explain_result["executionErrors"] = serde_json::json!(execution_errors);
+        }
+
+        // Merge results into explain output
+        if let Some(obj) = explain_result.as_object_mut() {
+            for (key, value) in results {
+                obj.insert(key, value);
+            }
+        }
+
+        Ok(serde_json::json!({ "explain": explain_result }))
+    }
+
+    /// Execute a select and return the explain output with metrics.
+    async fn execute_select_with_metrics(
+        &self,
+        select: &Select,
+        caller_identity: Option<Did>,
+    ) -> Result<(JsonValue, usize, u64)> {
+        // Get collection schema
+        let collection = self
+            .collections
+            .get(&select.collection_name)
+            .ok_or_else(|| QueryError::collection_not_found(&select.collection_name))?;
+
+        // Build document mapping and plan
+        let mapping = plan::build_mapping(select, collection, &self.collections)?;
+
+        // Fetch documents
+        let fetcher = self.fetcher.as_ref();
+        let docs = if let Some(ref doc_ids) = select.doc_ids {
+            let result = fetcher.get_by_ids(&select.collection_name, doc_ids).await?;
+            result.into_docs()
+        } else {
+            fetcher.get_all(&select.collection_name).await?
+        };
+
+        // Convert to plan docs
+        let plan_docs = documents_to_plan_docs(&docs, &mapping)?;
+        let doc_count = plan_docs.len();
+
+        // Build the plan
+        let mut plan =
+            plan::build_plan(select, plan_docs.clone(), mapping.clone(), &self.collections)?;
+
+        // Wrap with permission filter if needed
+        if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+            plan = Box::new(PermissionFilterNode::new(
+                plan,
+                acp.clone(),
+                Identity::from(caller_identity),
+                &policy.id,
+                &policy.resource_name,
+            ));
+        }
+
+        // Execute the plan and count iterations
+        plan.init().await?;
+        plan.start().await?;
+
+        let mut iterations: u64 = 0;
+        let mut result_count = 0;
+
+        while plan.next().await? {
+            iterations += 1;
+            result_count += 1;
+        }
+
+        plan.close().await?;
+
+        // Get the execution explain from the plan
+        let mut explanation = plan.explain();
+
+        // Add execution metrics to the explanation
+        if let Some(obj) = explanation.as_object_mut() {
+            obj.insert("iterations".to_string(), serde_json::json!(iterations));
+            obj.insert("docFetches".to_string(), serde_json::json!(doc_count));
+            obj.insert("resultCount".to_string(), serde_json::json!(result_count));
+        }
+
+        Ok((explanation, result_count, iterations))
     }
 
     /// Generate an explanation of a single Select operation.
-    fn explain_select(&self, select: &Select) -> Result<JsonValue> {
+    fn explain_select(&self, select: &Select, explain_type: ExplainType) -> Result<JsonValue> {
         // Get collection schema
         let collection = self
             .collections
@@ -73,15 +210,19 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 
         if has_nested {
             // Use the Planner for queries with nested selections
-            self.explain_nested_select(select)
+            self.explain_nested_select(select, explain_type)
         } else {
             // Explain simple query plan
-            self.explain_simple_select(select, collection)
+            self.explain_simple_select(select, collection, explain_type)
         }
     }
 
     /// Generate an explanation for a query with nested selections.
-    fn explain_nested_select(&self, select: &Select) -> Result<JsonValue> {
+    fn explain_nested_select(
+        &self,
+        select: &Select,
+        explain_type: ExplainType,
+    ) -> Result<JsonValue> {
         // Build the plan using the Planner
         let collections: Vec<CollectionVersion> =
             self.collections.values().map(|c| (**c).clone()).collect();
@@ -90,8 +231,11 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         let plan_result = planner.plan_with_index_info(select)?;
         let plan = plan_result.plan;
 
-        // Return the plan explanation
-        Ok(plan.explain())
+        // Return the plan explanation based on type
+        match explain_type {
+            ExplainType::Debug => Ok(plan.explain_debug()),
+            _ => Ok(plan.explain()),
+        }
     }
 
     /// Generate an explanation for a simple query without nested selections.
@@ -99,6 +243,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         &self,
         select: &Select,
         collection: &Arc<CollectionVersion>,
+        explain_type: ExplainType,
     ) -> Result<JsonValue> {
         // Build document mapping and plan
         let mapping = plan::build_mapping(select, collection, &self.collections)?;
@@ -106,8 +251,11 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         // Create an empty plan with no documents for explanation purposes
         let plan = plan::build_plan(select, vec![], mapping, &self.collections)?;
 
-        // Return the plan explanation
-        Ok(plan.explain())
+        // Return the plan explanation based on type
+        match explain_type {
+            ExplainType::Debug => Ok(plan.explain_debug()),
+            _ => Ok(plan.explain()),
+        }
     }
 
     /// Execute a GraphQL query with a specific fetcher and identity.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -71,6 +71,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     }
 
     /// Execute the query and return explain output with execution metrics.
+    /// Format matches Go DefraDB's executeAndExplainRequest output.
     async fn execute_explain(
         &self,
         query: &str,
@@ -78,53 +79,61 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     ) -> Result<JsonValue> {
         let selects = parse_query(query)?;
 
-        let mut results = Map::new();
+        let mut explain_result = Map::new();
         let mut total_executions: u64 = 0;
         let mut total_docs: usize = 0;
         let mut execution_success = true;
         let mut execution_errors: Vec<String> = Vec::new();
 
         for select in selects {
-            let key = select.field.output_name().to_string();
-
             // Execute the select and collect metrics
             match self
                 .execute_select_with_metrics(&select, caller_identity.clone())
                 .await
             {
                 Ok((explanation, doc_count, exec_count)) => {
-                    results.insert(key, explanation);
+                    // Merge the plan tree into explain result (Go format)
+                    if let Some(obj) = explanation.as_object() {
+                        for (key, value) in obj {
+                            explain_result.insert(key.clone(), value.clone());
+                        }
+                    }
                     total_docs += doc_count;
                     total_executions += exec_count;
                 }
                 Err(e) => {
                     execution_success = false;
-                    execution_errors.push(format!("{}: {}", key, e));
+                    execution_errors.push(e.to_string());
                 }
             }
         }
 
-        let mut explain_result = serde_json::json!({
-            "executionSuccess": execution_success,
-            "planExecutions": total_executions,
-            "sizeOfResult": total_docs,
-        });
+        // Add execution metrics (Go format)
+        explain_result.insert(
+            "executionSuccess".to_string(),
+            serde_json::json!(execution_success),
+        );
+        explain_result.insert(
+            "planExecutions".to_string(),
+            serde_json::json!(total_executions),
+        );
+        explain_result.insert(
+            "sizeOfResult".to_string(),
+            serde_json::json!(total_docs),
+        );
 
         if !execution_errors.is_empty() {
-            explain_result["executionErrors"] = serde_json::json!(execution_errors);
+            explain_result.insert(
+                "executionErrors".to_string(),
+                serde_json::json!(execution_errors),
+            );
         }
 
-        // Merge results into explain output
-        if let Some(obj) = explain_result.as_object_mut() {
-            for (key, value) in results {
-                obj.insert(key, value);
-            }
-        }
-
-        Ok(serde_json::json!({ "explain": explain_result }))
+        Ok(serde_json::json!({ "explain": JsonValue::Object(explain_result) }))
     }
 
     /// Execute a select and return the explain output with metrics.
+    /// Format matches Go DefraDB's collectExecuteExplainInfo output.
     async fn execute_select_with_metrics(
         &self,
         select: &Select,
@@ -181,17 +190,29 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
 
         plan.close().await?;
 
-        // Get the execution explain from the plan
-        let mut explanation = plan.explain();
+        // Get the execution explain from the plan (Go format: { "nodeKind": { ... } })
+        let explanation = plan.explain();
 
-        // Add execution metrics to the explanation
-        if let Some(obj) = explanation.as_object_mut() {
-            obj.insert("iterations".to_string(), serde_json::json!(iterations));
-            obj.insert("docFetches".to_string(), serde_json::json!(doc_count));
-            obj.insert("resultCount".to_string(), serde_json::json!(result_count));
-        }
+        // Go adds iterations to each node during execute explain
+        // For now, we add it to the outermost node
+        let explanation = Self::add_iterations_to_explain(explanation, iterations, doc_count);
 
         Ok((explanation, result_count, iterations))
+    }
+
+    /// Add execution metrics to the explain output (Go format).
+    fn add_iterations_to_explain(mut explanation: JsonValue, iterations: u64, doc_fetches: usize) -> JsonValue {
+        // The explanation is { "nodeKind": { ... } }
+        // We need to add iterations to the inner object
+        if let Some(obj) = explanation.as_object_mut() {
+            if let Some((_, inner)) = obj.iter_mut().next() {
+                if let Some(inner_obj) = inner.as_object_mut() {
+                    inner_obj.insert("iterations".to_string(), serde_json::json!(iterations));
+                    inner_obj.insert("docFetches".to_string(), serde_json::json!(doc_fetches));
+                }
+            }
+        }
+        explanation
     }
 
     /// Generate an explanation of a single Select operation.

--- a/crates/query/tests/go_behavioral_compatibility_tests.rs
+++ b/crates/query/tests/go_behavioral_compatibility_tests.rs
@@ -1,0 +1,518 @@
+//! Go Behavioral Compatibility Tests
+//!
+//! These tests verify that the Rust query engine produces the same results
+//! as Go DefraDB for equivalent queries. Each test documents:
+//! - The expected Go behavior
+//! - The scenario being tested
+//! - Why this matters for compatibility
+//!
+//! P0 = Same query produces different results (critical)
+//! P1 = Different error handling behavior
+//! P2 = Edge cases unlikely in production
+
+use query::document::DocumentMapping;
+use query::mapper::Filter;
+use query::plan::{AverageNode, ScanNode, SumNode, CountNode};
+use query::planner::{Doc, PlanNode};
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use serde_json::{json, Value as JsonValue};
+use std::collections::HashMap;
+
+// =============================================================================
+// P0: AVG of Empty Set
+// =============================================================================
+// Go DefraDB: Returns 0 (float64)
+// Rust (before fix): Returns null
+// Rust (after fix): Should return 0
+// =============================================================================
+
+#[tokio::test]
+async fn test_p0_avg_empty_set_returns_zero() {
+    // Go DefraDB behavior: AVG of empty set returns 0
+    // This is important for calculations that expect numeric results
+    let collection = CollectionVersion::new(
+        "Users",
+        "v1",
+        "coll-1",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "age", FieldKind::int()),
+        ],
+    );
+
+    let mut mapping = DocumentMapping::new();
+    mapping.add(0, "_docID");
+    mapping.add(1, "name");
+    mapping.add(2, "age");
+    mapping.add(3, "_avg");
+    mapping.add_render_key(3, "_avg");
+
+    // Empty document set
+    let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+    let mut avg_node = AverageNode::new(Box::new(scan), mapping, 2, 3);
+
+    avg_node.init().await.unwrap();
+    assert!(avg_node.next().await.unwrap());
+
+    let result = avg_node.value();
+    let avg_value = result.get(3).unwrap();
+
+    // Go DefraDB returns 0 for AVG of empty set
+    // This should be a number, not null
+    assert!(
+        avg_value.is_number(),
+        "AVG of empty set should return 0, not null. Got: {:?}",
+        avg_value
+    );
+    assert_eq!(
+        avg_value.as_f64().unwrap(),
+        0.0,
+        "AVG of empty set should be 0.0"
+    );
+
+    avg_node.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_p0_avg_all_nulls_returns_zero() {
+    // When all values are null, AVG should still return 0 (Go behavior)
+    let collection = CollectionVersion::new(
+        "Users",
+        "v1",
+        "coll-1",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "age", FieldKind::int()),
+        ],
+    );
+
+    let mut mapping = DocumentMapping::new();
+    mapping.add(0, "_docID");
+    mapping.add(1, "name");
+    mapping.add(2, "age");
+    mapping.add(3, "_avg");
+    mapping.add_render_key(3, "_avg");
+
+    // All documents have null age
+    let docs = vec![
+        Doc::with_fields(vec![
+            Some(json!("doc1")),
+            Some(json!("Alice")),
+            None, // null age
+        ]),
+        Doc::with_fields(vec![
+            Some(json!("doc2")),
+            Some(json!("Bob")),
+            None, // null age
+        ]),
+    ];
+
+    let scan = ScanNode::new(collection, mapping.clone()).with_docs(docs);
+    let mut avg_node = AverageNode::new(Box::new(scan), mapping, 2, 3);
+
+    avg_node.init().await.unwrap();
+    assert!(avg_node.next().await.unwrap());
+
+    let result = avg_node.value();
+    let avg_value = result.get(3).unwrap();
+
+    // Go DefraDB: when all values are null (skipped), returns 0
+    assert!(
+        avg_value.is_number(),
+        "AVG with all null values should return 0, not null. Got: {:?}",
+        avg_value
+    );
+    assert_eq!(avg_value.as_f64().unwrap(), 0.0);
+
+    avg_node.close().await.unwrap();
+}
+
+// =============================================================================
+// P0: Null Comparison Behavior
+// =============================================================================
+// Go DefraDB: null _gt 5 returns false (silent)
+// Rust (before fix): Returns TypeMismatch error
+// Rust (after fix): Should return false
+// =============================================================================
+
+fn make_filter_mapping() -> DocumentMapping {
+    let mut m = DocumentMapping::new();
+    m.add(0, "_docID");
+    m.add(1, "name");
+    m.add(2, "age");
+    m.add(3, "score");
+    m
+}
+
+#[test]
+fn test_p0_null_gt_comparison_returns_false() {
+    // Go DefraDB behavior: null _gt 5 returns false (not error)
+    // From gt.go: if data is nil, returns false
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_gt": 25}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(null)), // age is explicitly null
+        Some(json!(100)),
+    ];
+
+    // Should return false (Go behavior), not error
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok(), "null _gt comparison should not error, but got: {:?}", result);
+    assert!(!result.unwrap(), "null _gt 25 should return false");
+}
+
+#[test]
+fn test_p0_null_lt_comparison_returns_false() {
+    // Go DefraDB behavior: null _lt 5 returns false
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_lt": 25}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(null)), // age is null
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok(), "null _lt comparison should not error");
+    assert!(!result.unwrap(), "null _lt 25 should return false");
+}
+
+#[test]
+fn test_p0_null_gte_comparison_returns_false() {
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_gte": 25}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(null)),
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok());
+    assert!(!result.unwrap(), "null _gte 25 should return false");
+}
+
+#[test]
+fn test_p0_null_lte_comparison_returns_false() {
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_lte": 25}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(null)),
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok());
+    assert!(!result.unwrap(), "null _lte 25 should return false");
+}
+
+#[test]
+fn test_p0_missing_field_gt_returns_false() {
+    // Missing field (None) should also return false, not error
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_gt": 25}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        None, // age field is completely missing
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok(), "missing field _gt comparison should not error");
+    assert!(!result.unwrap(), "missing field _gt 25 should return false");
+}
+
+// =============================================================================
+// P0: Numeric Type Coercion
+// =============================================================================
+// Go DefraDB: Uses numbers.TryUpcast to convert int64 to float64 for comparison
+// Rust (before fix): Returns TypeMismatch error
+// Rust (after fix): Should upcast and compare successfully
+// =============================================================================
+
+#[test]
+fn test_p0_int_gt_float_coercion() {
+    // Go DefraDB: Comparing int field against float condition works
+    // From gt.go: numbers.TryUpcast handles int64 -> float64 conversion
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_gt": 25.5}), // float condition
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(30)), // integer value
+        Some(json!(100)),
+    ];
+
+    // Should work: 30 > 25.5 = true
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok(), "int vs float comparison should work, got: {:?}", result);
+    assert!(result.unwrap(), "30 > 25.5 should be true");
+}
+
+#[test]
+fn test_p0_float_gt_int_coercion() {
+    // Float field against int condition
+    let filter = Filter::from_conditions(HashMap::from([(
+        "score".to_string(),
+        json!({"_gt": 90}), // int condition
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(30)),
+        Some(json!(95.5)), // float value
+    ];
+
+    // Should work: 95.5 > 90 = true
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok(), "float vs int comparison should work");
+    assert!(result.unwrap(), "95.5 > 90 should be true");
+}
+
+#[test]
+fn test_p0_int_eq_float_coercion() {
+    // Integer 30 should equal float 30.0
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_eq": 30.0}), // float condition
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(30)), // integer value
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok(), "int _eq float comparison should work");
+    assert!(result.unwrap(), "30 == 30.0 should be true");
+}
+
+#[test]
+fn test_p0_int_lt_float_boundary() {
+    // Boundary test: 30 < 30.1 should be true
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_lt": 30.1}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(30)),
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok());
+    assert!(result.unwrap(), "30 < 30.1 should be true");
+}
+
+// =============================================================================
+// P1: Verified Compatible Behaviors
+// =============================================================================
+// These tests document behaviors that ARE compatible with Go DefraDB
+
+#[test]
+fn test_compatible_null_eq_null() {
+    // Both Go and Rust: null == null is true
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_eq": null}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(null)),
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok());
+    assert!(result.unwrap(), "null == null should be true");
+}
+
+#[test]
+fn test_compatible_null_ne_value() {
+    // Both Go and Rust: null != 25 is true
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_ne": 25}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(null)),
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok());
+    assert!(result.unwrap(), "null != 25 should be true");
+}
+
+#[test]
+fn test_compatible_value_eq_null_false() {
+    // Both Go and Rust: 30 == null is false
+    let filter = Filter::from_conditions(HashMap::from([(
+        "age".to_string(),
+        json!({"_eq": null}),
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")),
+        Some(json!(30)),
+        Some(json!(100)),
+    ];
+
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_ok());
+    assert!(!result.unwrap(), "30 == null should be false");
+}
+
+#[tokio::test]
+async fn test_compatible_sum_empty_returns_zero() {
+    // Both Go and Rust: SUM of empty set returns 0
+    let collection = CollectionVersion::new(
+        "Users",
+        "v1",
+        "coll-1",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "age", FieldKind::int()),
+        ],
+    );
+
+    let mut mapping = DocumentMapping::new();
+    mapping.add(0, "_docID");
+    mapping.add(1, "name");
+    mapping.add(2, "age");
+    mapping.add(3, "_sum");
+    mapping.add_render_key(3, "_sum");
+
+    let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+    let mut sum_node = SumNode::new(Box::new(scan), mapping, 2, 3);
+
+    sum_node.init().await.unwrap();
+    assert!(sum_node.next().await.unwrap());
+
+    let result = sum_node.value();
+    let sum_value = result.get(3).unwrap();
+
+    // Both Go and Rust return 0 for SUM of empty set
+    assert!(sum_value.is_number());
+    assert_eq!(sum_value.as_i64().unwrap(), 0);
+
+    sum_node.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_compatible_count_empty_returns_zero() {
+    // Both Go and Rust: COUNT of empty set returns 0
+    let collection = CollectionVersion::new(
+        "Users",
+        "v1",
+        "coll-1",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "age", FieldKind::int()),
+        ],
+    );
+
+    let mut mapping = DocumentMapping::new();
+    mapping.add(0, "_docID");
+    mapping.add(1, "name");
+    mapping.add(2, "age");
+    mapping.add(3, "_count");
+    mapping.add_render_key(3, "_count");
+
+    let scan = ScanNode::new(collection, mapping.clone()).with_docs(vec![]);
+    let mut count_node = CountNode::new(Box::new(scan), mapping, 3);
+
+    count_node.init().await.unwrap();
+    assert!(count_node.next().await.unwrap());
+
+    let result = count_node.value();
+    let count_value = result.get(3).unwrap();
+
+    assert!(count_value.is_number());
+    assert_eq!(count_value.as_i64().unwrap(), 0);
+
+    count_node.close().await.unwrap();
+}
+
+// =============================================================================
+// P2: String vs Number Comparison (Deliberate Difference)
+// =============================================================================
+// Go DefraDB: String "5" vs int 5 comparison fails silently
+// Rust: Returns TypeMismatch error (more explicit, arguably better)
+// This is documented as intentional - Rust is stricter
+
+#[test]
+fn test_p2_string_vs_int_comparison_strict() {
+    // Rust is intentionally stricter than Go here
+    // Comparing string field with numeric operator should fail
+    let filter = Filter::from_conditions(HashMap::from([(
+        "name".to_string(), // string field
+        json!({"_gt": 5}),  // numeric comparison
+    )]));
+
+    let mapping = make_filter_mapping();
+    let fields = vec![
+        Some(json!("doc1")),
+        Some(json!("Alice")), // string value
+        Some(json!(30)),
+        Some(json!(100)),
+    ];
+
+    // Rust returns error for string vs number comparison
+    // This is intentionally different from Go (which returns false)
+    let result = filter.matches(&fields, &mapping);
+    assert!(result.is_err(), "String vs number comparison should error in Rust");
+}

--- a/crates/query/tests/query_parse_tests.rs
+++ b/crates/query/tests/query_parse_tests.rs
@@ -273,6 +273,43 @@ fn test_parse_nested_fragment_works() {
 }
 
 #[test]
+fn test_parse_circular_fragment_returns_error() {
+    // Fragment A references B, B references A
+    let query = r#"
+        fragment A on User { name ...B }
+        fragment B on User { age ...A }
+        query { Users { ...A } }
+    "#;
+    let result = parse_query(query);
+    assert!(result.is_err(), "Circular fragment should error");
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("circular fragment reference"),
+        "Expected error about circular fragment"
+    );
+}
+
+#[test]
+fn test_parse_self_referential_fragment_returns_error() {
+    // Fragment that references itself
+    let query = r#"
+        fragment A on User { name ...A }
+        query { Users { ...A } }
+    "#;
+    let result = parse_query(query);
+    assert!(result.is_err(), "Self-referential fragment should error");
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("circular fragment reference"),
+        "Expected error about circular fragment"
+    );
+}
+
+#[test]
 fn test_parse_negative_limit_returns_error() {
     let query = "{ Users(limit: -1) { name } }";
     let result = parse_query(query);

--- a/crates/query/tests/query_parse_tests.rs
+++ b/crates/query/tests/query_parse_tests.rs
@@ -429,14 +429,66 @@ fn test_parse_filter_non_object_returns_error() {
 
 #[test]
 fn test_parse_explain_directive() {
-    use query::query_parse::{parse_request, ParsedOperation};
+    use query::query_parse::{parse_request, ExplainType, ParsedOperation};
 
     let query = "query @explain { Users { _docID name } }";
     let result = parse_request(query).unwrap();
 
     match result {
         ParsedOperation::Query { selects, explain } => {
-            assert!(explain, "Expected explain=true for @explain directive");
+            assert!(
+                explain.is_some(),
+                "Expected explain=Some for @explain directive"
+            );
+            assert_eq!(explain, Some(ExplainType::Simple));
+            assert_eq!(selects.len(), 1);
+        }
+        _ => panic!("Expected query"),
+    }
+}
+
+#[test]
+fn test_parse_explain_directive_with_type_simple() {
+    use query::query_parse::{parse_request, ExplainType, ParsedOperation};
+
+    let query = "query @explain(type: simple) { Users { _docID name } }";
+    let result = parse_request(query).unwrap();
+
+    match result {
+        ParsedOperation::Query { selects, explain } => {
+            assert_eq!(explain, Some(ExplainType::Simple));
+            assert_eq!(selects.len(), 1);
+        }
+        _ => panic!("Expected query"),
+    }
+}
+
+#[test]
+fn test_parse_explain_directive_with_type_execute() {
+    use query::query_parse::{parse_request, ExplainType, ParsedOperation};
+
+    let query = "query @explain(type: execute) { Users { _docID name } }";
+    let result = parse_request(query).unwrap();
+
+    match result {
+        ParsedOperation::Query { selects, explain } => {
+            assert_eq!(explain, Some(ExplainType::Execute));
+            assert_eq!(selects.len(), 1);
+        }
+        _ => panic!("Expected query"),
+    }
+}
+
+#[test]
+fn test_parse_explain_directive_with_type_debug() {
+    use query::query_parse::{parse_request, ExplainType, ParsedOperation};
+
+    let query = "query @explain(type: debug) { Users { _docID name } }";
+    let result = parse_request(query).unwrap();
+
+    match result {
+        ParsedOperation::Query { selects, explain } => {
+            assert_eq!(explain, Some(ExplainType::Debug));
             assert_eq!(selects.len(), 1);
         }
         _ => panic!("Expected query"),
@@ -453,8 +505,8 @@ fn test_parse_query_without_explain() {
     match result {
         ParsedOperation::Query { selects, explain } => {
             assert!(
-                !explain,
-                "Expected explain=false without @explain directive"
+                explain.is_none(),
+                "Expected explain=None without @explain directive"
             );
             assert_eq!(selects.len(), 1);
         }
@@ -472,7 +524,10 @@ fn test_parse_bare_query_without_explain() {
 
     match result {
         ParsedOperation::Query { selects, explain } => {
-            assert!(!explain, "Expected explain=false for bare selection set");
+            assert!(
+                explain.is_none(),
+                "Expected explain=None for bare selection set"
+            );
             assert_eq!(selects.len(), 1);
         }
         _ => panic!("Expected query"),

--- a/crates/query/tests/query_parse_tests.rs
+++ b/crates/query/tests/query_parse_tests.rs
@@ -189,25 +189,87 @@ fn test_parse_subscription_returns_error() {
 }
 
 #[test]
-fn test_parse_fragment_definition_returns_error() {
-    let query = "fragment UserFields on User { name } query { Users { ...UserFields } }";
+fn test_parse_fragment_definition_works() {
+    use query::mapper::Requestable;
+
+    let query = "fragment UserFields on User { name age } query { Users { _docID ...UserFields } }";
     let result = parse_query(query);
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("fragments not yet supported"));
+    assert!(result.is_ok(), "Fragment parsing should succeed");
+
+    let selects = result.unwrap();
+    assert_eq!(selects.len(), 1);
+    // Should have _docID + name + age from fragment
+    assert_eq!(selects[0].fields.len(), 3);
+
+    // Verify fields
+    let field_names: Vec<&str> = selects[0]
+        .fields
+        .iter()
+        .filter_map(|f| match f {
+            Requestable::Field(f) => Some(f.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(field_names.contains(&"_docID"));
+    assert!(field_names.contains(&"name"));
+    assert!(field_names.contains(&"age"));
 }
 
 #[test]
-fn test_parse_inline_fragment_returns_error() {
-    let query = "{ Users { ... on User { name } } }";
+fn test_parse_inline_fragment_works() {
+    use query::mapper::Requestable;
+
+    let query = "{ Users { _docID ... on User { name age } } }";
+    let result = parse_query(query);
+    assert!(result.is_ok(), "Inline fragment parsing should succeed");
+
+    let selects = result.unwrap();
+    assert_eq!(selects.len(), 1);
+    // Should have _docID + name + age from inline fragment
+    assert_eq!(selects[0].fields.len(), 3);
+
+    // Verify fields
+    let field_names: Vec<&str> = selects[0]
+        .fields
+        .iter()
+        .filter_map(|f| match f {
+            Requestable::Field(f) => Some(f.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(field_names.contains(&"_docID"));
+    assert!(field_names.contains(&"name"));
+    assert!(field_names.contains(&"age"));
+}
+
+#[test]
+fn test_parse_undefined_fragment_returns_error() {
+    let query = "query { Users { ...UndefinedFragment } }";
     let result = parse_query(query);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("inline fragments not yet supported"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("undefined fragment"),
+        "Expected error about undefined fragment"
+    );
+}
+
+#[test]
+fn test_parse_nested_fragment_works() {
+    let query = r#"
+        fragment NameField on User { name }
+        fragment UserInfo on User { ...NameField age }
+        query { Users { _docID ...UserInfo } }
+    "#;
+    let result = parse_query(query);
+    assert!(result.is_ok(), "Nested fragment parsing should succeed");
+
+    let selects = result.unwrap();
+    assert_eq!(selects.len(), 1);
+    // Should have _docID + name (from nested) + age
+    assert_eq!(selects[0].fields.len(), 3);
 }
 
 #[test]
@@ -285,4 +347,58 @@ fn test_parse_filter_non_object_returns_error() {
         .unwrap_err()
         .to_string()
         .contains("filter must be an object"));
+}
+
+// EXPLAIN tests
+
+#[test]
+fn test_parse_explain_directive() {
+    use query::query_parse::{parse_request, ParsedOperation};
+
+    let query = "query @explain { Users { _docID name } }";
+    let result = parse_request(query).unwrap();
+
+    match result {
+        ParsedOperation::Query { selects, explain } => {
+            assert!(explain, "Expected explain=true for @explain directive");
+            assert_eq!(selects.len(), 1);
+        }
+        _ => panic!("Expected query"),
+    }
+}
+
+#[test]
+fn test_parse_query_without_explain() {
+    use query::query_parse::{parse_request, ParsedOperation};
+
+    let query = "query { Users { _docID name } }";
+    let result = parse_request(query).unwrap();
+
+    match result {
+        ParsedOperation::Query { selects, explain } => {
+            assert!(
+                !explain,
+                "Expected explain=false without @explain directive"
+            );
+            assert_eq!(selects.len(), 1);
+        }
+        _ => panic!("Expected query"),
+    }
+}
+
+#[test]
+fn test_parse_bare_query_without_explain() {
+    use query::query_parse::{parse_request, ParsedOperation};
+
+    // Bare selection set (no 'query' keyword)
+    let query = "{ Users { _docID name } }";
+    let result = parse_request(query).unwrap();
+
+    match result {
+        ParsedOperation::Query { selects, explain } => {
+            assert!(!explain, "Expected explain=false for bare selection set");
+            assert_eq!(selects.len(), 1);
+        }
+        _ => panic!("Expected query"),
+    }
 }

--- a/crates/query/tests/query_parse_tests.rs
+++ b/crates/query/tests/query_parse_tests.rs
@@ -310,6 +310,45 @@ fn test_parse_self_referential_fragment_returns_error() {
 }
 
 #[test]
+fn test_parse_deeply_nested_fragments_succeeds() {
+    use query::mapper::Requestable;
+
+    // Create a chain of 10 fragments (non-circular but deep)
+    let query = r#"
+        fragment F10 on User { name }
+        fragment F9 on User { ...F10 }
+        fragment F8 on User { ...F9 }
+        fragment F7 on User { ...F8 }
+        fragment F6 on User { ...F7 }
+        fragment F5 on User { ...F6 }
+        fragment F4 on User { ...F5 }
+        fragment F3 on User { ...F4 }
+        fragment F2 on User { ...F3 }
+        fragment F1 on User { ...F2 }
+        query { Users { _docID ...F1 } }
+    "#;
+    let result = parse_query(query);
+    assert!(result.is_ok(), "Deep fragment nesting should work");
+
+    let selects = result.unwrap();
+    assert_eq!(selects.len(), 1);
+    // Should have _docID + name (from deeply nested fragment)
+    assert_eq!(selects[0].fields.len(), 2);
+
+    // Verify both fields are present
+    let field_names: Vec<&str> = selects[0]
+        .fields
+        .iter()
+        .filter_map(|f| match f {
+            Requestable::Field(f) => Some(f.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(field_names.contains(&"_docID"));
+    assert!(field_names.contains(&"name"));
+}
+
+#[test]
 fn test_parse_negative_limit_returns_error() {
     let query = "{ Users(limit: -1) { name } }";
     let result = parse_query(query);

--- a/crates/query/tests/runner_tests.rs
+++ b/crates/query/tests/runner_tests.rs
@@ -963,6 +963,56 @@ async fn test_execute_delete_mutation() {
 }
 
 #[tokio::test]
+async fn test_execute_delete_mutation_with_filter() {
+    let mut fetcher = MockFetcher::new();
+    let mutator = Arc::new(MockMutator::new());
+
+    // Add multiple documents
+    let mut doc1 = Document::new();
+    doc1.set("name", "Alice");
+    doc1.set("age", 30i64);
+    doc1.generate_and_set_doc_id().unwrap();
+    let doc1_id = doc1.id().unwrap().to_string();
+    mutator.add_doc("Users", doc1.clone());
+    fetcher.add_doc("Users", doc1);
+
+    let mut doc2 = Document::new();
+    doc2.set("name", "Bob");
+    doc2.set("age", 25i64);
+    doc2.generate_and_set_doc_id().unwrap();
+    let doc2_id = doc2.id().unwrap().to_string();
+    mutator.add_doc("Users", doc2.clone());
+    fetcher.add_doc("Users", doc2);
+
+    let mut doc3 = Document::new();
+    doc3.set("name", "Charlie");
+    doc3.set("age", 30i64);
+    doc3.generate_and_set_doc_id().unwrap();
+    let doc3_id = doc3.id().unwrap().to_string();
+    mutator.add_doc("Users", doc3.clone());
+    fetcher.add_doc("Users", doc3);
+
+    let runner =
+        QueryRunner::new(fetcher, vec![make_test_collection()]).with_mutator(mutator.clone());
+
+    // Delete all users with age = 30 (Alice and Charlie)
+    let mutation = r#"mutation { delete_Users(filter: {age: {_eq: 30}}) { _docID name } }"#;
+    let result = runner.execute_mutation(mutation).await.unwrap();
+
+    let users = result.get("Users").unwrap().as_array().unwrap();
+    assert_eq!(users.len(), 2, "Should delete 2 users with age=30");
+
+    // Verify deleted doc IDs
+    let deleted_ids: Vec<&str> = users
+        .iter()
+        .map(|u| u.get("_docID").unwrap().as_str().unwrap())
+        .collect();
+    assert!(deleted_ids.contains(&doc1_id.as_str()), "Alice should be deleted");
+    assert!(deleted_ids.contains(&doc3_id.as_str()), "Charlie should be deleted");
+    assert!(!deleted_ids.contains(&doc2_id.as_str()), "Bob should NOT be deleted");
+}
+
+#[tokio::test]
 async fn test_execute_update_mutation() {
     let fetcher = MockFetcher::new();
     let mutator = Arc::new(MockMutator::new());


### PR DESCRIPTION
## Summary

This PR implements five query engine features for #49 (Query Engine Feature Parity):

### 1. Case-insensitive pattern matching (Closes #146)
- `_ilike` and `_nilike` filter operators
- Same wildcard patterns as `_like`/`_nlike`: `prefix%`, `%suffix`, `%contains%`, exact match

### 2. Query variable support (Closes #145)
- `parse_request_with_variables(query, variables)` entry point
- Parse-time variable substitution
- Supports variables in filters, limit, offset, docIDs, cid, showDeleted, mutations

### 3. Array filter operators (Closes #147)
- `_contains`: Check if array field contains a value
- `_contained_in`: Check if array field is subset of given array
- `_has_key`: Check if object/map field has a key

### 4. EXPLAIN output (Closes #151)
- `@explain` directive on queries returns execution plan instead of results
- Plan nodes describe their type, filters, limits, ordering, etc.
- JSON output with recursive plan tree structure

### 5. GraphQL Fragments (Closes #149)
- Fragment definitions: `fragment UserFields on User { name age }`
- Fragment spreads: `...UserFields`
- Inline fragments: `... on Type { fields }`
- Nested fragment support

## Usage Examples

```graphql
# Case-insensitive filter
{ Users(filter: {name: {_ilike: "ALICE%"}}) { name } }

# Query with variables
query($name: String!, $limit: Int!) {
  Users(filter: {name: {_eq: $name}}, limit: $limit) { _docID name }
}

# Array operators
{ Article(filter: { tags: { _contains: "rust" } }) { title } }
{ Article(filter: { tags: { _contained_in: ["rust", "go"] } }) { title } }
{ Doc(filter: { metadata: { _has_key: "version" } }) { name } }

# EXPLAIN
query @explain { Users(filter: {age: {_gt: 21}}, limit: 10) { name } }

# Fragments
fragment UserFields on User { name age }
query { Users { _docID ...UserFields } }
```

## Test plan
- [x] Unit tests for _ilike pattern types (7 tests)
- [x] Variable substitution tests (10 tests)
- [x] Array operator tests (9 tests)
- [x] EXPLAIN directive tests (3 tests)
- [x] Fragment parsing tests (4 tests)
- [x] `cargo test -p query` passes (400+ tests)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)