### PR TITLE
feat(ffi): Add FFI wrapper for Go integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/identity",
     "crates/acp",
     "crates/events",
+    "crates/ffi",
 ]
 
 [workspace.package]

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "ffi"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "FFI bindings for DefraDB Rust implementation"
+
+[lib]
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[features]
+default = []
+
+[dependencies]
+# Async runtime
+tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Error handling
+thiserror.workspace = true
+
+# Logging
+tracing.workspace = true
+
+# Synchronization
+parking_lot.workspace = true
+
+# Internal crates
+db = { path = "../db" }
+storage = { path = "../storage" }
+query = { path = "../query" }
+schema = { path = "../schema" }
+identity = { path = "../identity" }
+acp = { path = "../acp" }
+
+[build-dependencies]
+cbindgen = "0.28"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/ffi/cbindgen.toml
+++ b/crates/ffi/cbindgen.toml
@@ -1,0 +1,37 @@
+# cbindgen configuration for defra FFI crate
+# Generate headers with: cbindgen --config cbindgen.toml --crate ffi --output defra.h
+
+language = "C"
+header = """
+/*
+ * DefraDB Rust FFI - Auto-generated header
+ *
+ * This header provides C bindings for the DefraDB Rust implementation.
+ * Use with CGO to integrate with Go code.
+ *
+ * Usage:
+ *   1. Build library: cargo build --release -p ffi
+ *   2. Link with: -L target/release -lffi
+ */
+"""
+include_guard = "DEFRA_H"
+cpp_compat = true
+documentation = true
+documentation_style = "c"
+
+[export]
+include = [
+    "FfiResult",
+    "NewNodeResult",
+    "NewTxnResult",
+    "NodeInitOptions",
+]
+
+[fn]
+rename_args = "SnakeCase"
+
+[struct]
+rename_fields = "SnakeCase"
+
+[enum]
+rename_variants = "ScreamingSnakeCase"

--- a/crates/ffi/defra.h
+++ b/crates/ffi/defra.h
@@ -1,0 +1,190 @@
+/*
+ * DefraDB Rust FFI - Auto-generated header
+ *
+ * This header provides C bindings for the DefraDB Rust implementation.
+ * Use with CGO to integrate with Go code.
+ *
+ * Usage:
+ *   1. Build library: cargo build --release -p ffi
+ *   2. Link with: -L target/release -lffi
+ */
+
+
+#ifndef DEFRA_H
+#define DEFRA_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+ FFI result for node creation, containing a node handle.
+
+ Matches Go's NewNodeResult struct.
+ */
+typedef struct NewNodeResult {
+  /*
+   Status code: 0=success, 1=error
+   */
+  int status;
+  /*
+   Error message (null on success). Caller must free with `defra_free_string`.
+   */
+  char *error;
+  /*
+   Handle to the node (0 on error).
+   */
+  uintptr_t node_ptr;
+} NewNodeResult;
+
+/*
+ Options for node initialization.
+
+ Matches Go's NodeInitOptions struct.
+ */
+typedef struct NodeInitOptions {
+  /*
+   Path to store directory (null for in-memory).
+   */
+  const char *db_path;
+  /*
+   Use in-memory storage (1=true, 0=false).
+   */
+  int in_memory;
+} NodeInitOptions;
+
+/*
+ FFI result type matching Go's Result struct.
+
+ Status codes:
+ - 0: Success
+ - 1: Error (message in error field)
+ - 2: Subscription (ID in value field, not yet implemented)
+ */
+typedef struct FfiResult {
+  /*
+   Status code: 0=success, 1=error, 2=subscription
+   */
+  int status;
+  /*
+   Error message (null on success). Caller must free with `defra_free_string`.
+   */
+  char *error;
+  /*
+   JSON value (null on error). Caller must free with `defra_free_string`.
+   */
+  char *value;
+} FfiResult;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/*
+ Initialize the FFI library.
+
+ This must be called once before any other FFI functions.
+ Safe to call multiple times.
+ */
+void defra_init(void);
+
+/*
+ Get the library version.
+
+ Returns a null-terminated string that must be freed with `defra_free_string`.
+ */
+char *defra_version(void);
+
+/*
+ Create a new DefraDB node.
+
+ This creates an in-memory database instance with a query runner.
+ The returned handle must be passed to `node_close` when done.
+
+ # Safety
+
+ The returned `node_ptr` must be freed by calling `node_close`.
+ */
+struct NewNodeResult new_node(struct NodeInitOptions options);
+
+/*
+ Close a DefraDB node and release resources.
+
+ # Safety
+
+ The `node_ptr` must be a valid handle returned by `new_node`.
+ After this call, the handle is no longer valid.
+ */
+struct FfiResult node_close(uintptr_t node_ptr);
+
+/*
+ Execute a GraphQL query or mutation.
+
+ Returns a JSON object with the query result in GraphQL format:
+ ```json
+ {
+     "data": { ... },
+     "errors": [ ... ]
+ }
+ ```
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+ * `request_query` - GraphQL query string (required)
+ * `operation_name` - Optional operation name for multi-operation documents (null if not used)
+ * `variables` - Optional JSON string of variables (null if not used)
+
+ # Safety
+
+ All string pointers must be either null or valid null-terminated UTF-8 strings.
+ */
+struct FfiResult exec_request(uintptr_t node_ptr,
+                              const char *request_query,
+                              const char *operation_name,
+                              const char *variables);
+
+/*
+ Add a schema to the database.
+
+ The schema should be a GraphQL SDL string defining types.
+
+ Returns a JSON array of CollectionVersion objects on success.
+
+ # Example SDL
+
+ ```graphql
+ type User {
+     name: String
+     age: Int
+ }
+ ```
+
+ # Safety
+
+ `schema_sdl` must be a valid null-terminated UTF-8 string.
+ */
+struct FfiResult add_schema(uintptr_t node_ptr, const char *schema_sdl);
+
+/*
+ Get all collections from the database.
+
+ Returns a JSON array of collection descriptions.
+ */
+struct FfiResult get_collections(uintptr_t node_ptr);
+
+/*
+ Free a string allocated by FFI functions.
+
+ # Safety
+
+ The pointer must have been allocated by an FFI function in this crate.
+ */
+void defra_free_string(char *ptr);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  /* DEFRA_H */

--- a/crates/ffi/defra.h
+++ b/crates/ffi/defra.h
@@ -77,6 +77,24 @@ typedef struct FfiResult {
   char *value;
 } FfiResult;
 
+/*
+ FFI result for transaction creation, containing a transaction ID.
+ */
+typedef struct NewTxnResult {
+  /*
+   Status code: 0=success, 1=error
+   */
+  int status;
+  /*
+   Error message (null on success). Caller must free with `defra_free_string`.
+   */
+  char *error;
+  /*
+   Transaction ID (null on error). Caller must free with `defra_free_string`.
+   */
+  char *txn_id;
+} NewTxnResult;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -173,6 +191,81 @@ struct FfiResult add_schema(uintptr_t node_ptr, const char *schema_sdl);
  Returns a JSON array of collection descriptions.
  */
 struct FfiResult get_collections(uintptr_t node_ptr);
+
+/*
+ Begin a new transaction.
+
+ Returns a transaction ID that can be used with `exec_request_in_txn`,
+ `commit_txn`, and `rollback_txn`.
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+ * `readonly` - If non-zero, creates a read-only transaction
+
+ # Returns
+
+ A `NewTxnResult` containing the transaction ID on success.
+ */
+struct NewTxnResult begin_txn(uintptr_t node_ptr, int32_t readonly);
+
+/*
+ Commit a transaction.
+
+ After commit, all operations performed within the transaction become permanent.
+ The transaction ID is no longer valid after this call.
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+ * `txn_id` - Transaction ID from `begin_txn`
+
+ # Safety
+
+ `txn_id` must be a valid null-terminated UTF-8 string.
+ */
+struct FfiResult commit_txn(uintptr_t node_ptr, const char *txn_id);
+
+/*
+ Rollback (discard) a transaction.
+
+ After rollback, all operations performed within the transaction are discarded.
+ The transaction ID is no longer valid after this call.
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+ * `txn_id` - Transaction ID from `begin_txn`
+
+ # Safety
+
+ `txn_id` must be a valid null-terminated UTF-8 string.
+ */
+struct FfiResult rollback_txn(uintptr_t node_ptr, const char *txn_id);
+
+/*
+ Execute a GraphQL query or mutation within a transaction.
+
+ The operation will be part of the specified transaction and will not
+ be visible to other transactions until committed.
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+ * `txn_id` - Transaction ID from `begin_txn`
+ * `request_query` - GraphQL query string (required)
+ * `operation_name` - Optional operation name (null if not used)
+ * `variables` - Optional JSON string of variables (null if not used)
+
+ # Safety
+
+ All string pointers must be either null or valid null-terminated UTF-8 strings.
+ */
+struct FfiResult exec_request_in_txn(uintptr_t node_ptr,
+                                     const char *txn_id,
+                                     const char *request_query,
+                                     const char *operation_name,
+                                     const char *variables);
 
 /*
  Free a string allocated by FFI functions.

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -54,7 +54,8 @@ pub use types::defra_free_string;
 /// Safe to call multiple times.
 #[no_mangle]
 pub extern "C" fn defra_init() {
-    runtime::init_runtime();
+    // Ignore return value - errors will surface when operations are attempted
+    let _ = runtime::init_runtime();
 }
 
 /// Get the library version.
@@ -63,7 +64,10 @@ pub extern "C" fn defra_init() {
 #[no_mangle]
 pub extern "C" fn defra_version() -> *mut c_char {
     let version = env!("CARGO_PKG_VERSION");
-    CString::new(version).unwrap().into_raw()
+    // CARGO_PKG_VERSION is a compile-time constant without null bytes
+    CString::new(version)
+        .unwrap_or_else(|_| CString::new("unknown").unwrap())
+        .into_raw()
 }
 
 #[cfg(test)]

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -38,6 +38,7 @@ pub mod query;
 pub mod runtime;
 pub mod schema;
 pub mod state;
+pub mod txn;
 pub mod types;
 
 use std::ffi::{c_char, CString};
@@ -46,6 +47,7 @@ use std::ffi::{c_char, CString};
 pub use node::{new_node, node_close};
 pub use query::exec_request;
 pub use schema::{add_schema, get_collections};
+pub use txn::{begin_txn, commit_txn, exec_request_in_txn, rollback_txn};
 pub use types::defra_free_string;
 
 /// Initialize the FFI library.

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -1,0 +1,147 @@
+//! FFI bindings for DefraDB Rust implementation.
+//!
+//! This crate provides C-compatible FFI functions that allow DefraDB.rs
+//! to be used from Go (and other languages). It matches the interface
+//! defined in Go's `cbindings/` directory.
+//!
+//! # Architecture
+//!
+//! ```text
+//! Go Code
+//!     ↓ CGO
+//! C Header (defra.h)
+//!     ↓ FFI
+//! This crate (staticlib)
+//!     ↓
+//! db, query, storage crates
+//! ```
+//!
+//! # Usage from Go
+//!
+//! 1. Build the static library: `cargo build --release -p ffi`
+//! 2. Generate headers: `cbindgen --crate ffi --output defra.h`
+//! 3. Link from Go with CGO directives
+//!
+//! # MVP Functions
+//!
+//! - `defra_init()` - Initialize the library
+//! - `defra_version()` - Get library version
+//! - `new_node()` - Create a new database node
+//! - `node_close()` - Close and cleanup a node
+//! - `add_schema()` - Add GraphQL SDL schema
+//! - `get_collections()` - List all collections
+//! - `exec_request()` - Execute GraphQL queries/mutations
+//! - `defra_free_string()` - Free strings allocated by FFI functions
+
+pub mod node;
+pub mod query;
+pub mod runtime;
+pub mod schema;
+pub mod state;
+pub mod types;
+
+use std::ffi::{c_char, CString};
+
+// Re-export FFI functions at crate root
+pub use node::{new_node, node_close};
+pub use query::exec_request;
+pub use schema::{add_schema, get_collections};
+pub use types::defra_free_string;
+
+/// Initialize the FFI library.
+///
+/// This must be called once before any other FFI functions.
+/// Safe to call multiple times.
+#[no_mangle]
+pub extern "C" fn defra_init() {
+    runtime::init_runtime();
+}
+
+/// Get the library version.
+///
+/// Returns a null-terminated string that must be freed with `defra_free_string`.
+#[no_mangle]
+pub extern "C" fn defra_version() -> *mut c_char {
+    let version = env!("CARGO_PKG_VERSION");
+    CString::new(version).unwrap().into_raw()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::ptr;
+
+    #[test]
+    fn test_defra_init() {
+        defra_init();
+        // Should be idempotent
+        defra_init();
+    }
+
+    #[test]
+    fn test_defra_version() {
+        let version = defra_version();
+        let version_str = unsafe { CStr::from_ptr(version).to_string_lossy() };
+        assert!(!version_str.is_empty());
+        // Should match Cargo.toml version
+        assert!(version_str.starts_with("0."));
+
+        // Clean up
+        unsafe { defra_free_string(version) };
+    }
+
+    #[test]
+    fn test_full_workflow() {
+        use std::ffi::CString;
+        use types::NodeInitOptions;
+
+        // Initialize
+        defra_init();
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0, "new_node failed");
+        let node = result.node_ptr;
+
+        // Add schema
+        let sdl = CString::new("type Person { name: String, age: Int }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0, "add_schema failed");
+        if !result.value.is_null() {
+            unsafe { defra_free_string(result.value) };
+        }
+
+        // Get collections
+        let result = get_collections(node);
+        assert_eq!(result.status, 0, "get_collections failed");
+        let value = unsafe { CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("Person"), "should contain Person collection");
+        unsafe { defra_free_string(result.value) };
+
+        // Create a person
+        let mutation = CString::new(
+            r#"mutation { create_Person(input: {name: "Bob", age: 30}) { _docID name age } }"#,
+        )
+        .unwrap();
+        let result = unsafe { exec_request(node, mutation.as_ptr(), ptr::null(), ptr::null()) };
+        assert_eq!(result.status, 0, "mutation failed");
+        let value = unsafe { CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("Bob"), "should contain Bob");
+        unsafe { defra_free_string(result.value) };
+
+        // Query people
+        let query_str = CString::new("{ Person { name age } }").unwrap();
+        let result = unsafe { exec_request(node, query_str.as_ptr(), ptr::null(), ptr::null()) };
+        assert_eq!(result.status, 0, "query failed");
+        let value = unsafe { CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("Bob"), "query should return Bob");
+        assert!(value.contains("30"), "query should return age 30");
+        unsafe { defra_free_string(result.value) };
+
+        // Close node
+        let result = node_close(node);
+        assert_eq!(result.status, 0, "node_close failed");
+    }
+}

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -88,7 +88,7 @@ pub extern "C" fn new_node(_options: NodeInitOptions) -> NewNodeResult {
 pub extern "C" fn node_close(node_ptr: usize) -> FfiResult {
     let rt = match RUNTIME.get() {
         Some(rt) => rt,
-        None => return FfiResult::error("runtime not initialized"),
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
     };
 
     // Remove from registry
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn test_node_lifecycle() {
         // Initialize runtime
-        crate::runtime::init_runtime();
+        assert!(crate::runtime::init_runtime());
 
         // Create node
         let options = NodeInitOptions::default();
@@ -130,5 +130,58 @@ mod tests {
         // Double close should fail
         let result = node_close(handle);
         assert_eq!(result.status, 1, "double close should fail");
+    }
+
+    // Edge case tests (H2)
+
+    #[test]
+    fn test_node_close_invalid_handle() {
+        assert!(crate::runtime::init_runtime());
+
+        // Closing an invalid handle should return error, not panic
+        let result = node_close(0);
+        assert_eq!(result.status, 1);
+        assert!(!result.error.is_null());
+
+        let error = unsafe { std::ffi::CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(error.contains("invalid"), "should indicate invalid handle");
+
+        unsafe { crate::types::defra_free_string(result.error) };
+    }
+
+    #[test]
+    fn test_node_close_nonexistent_handle() {
+        assert!(crate::runtime::init_runtime());
+
+        // Closing a random handle should return error
+        let result = node_close(999999);
+        assert_eq!(result.status, 1);
+        assert!(!result.error.is_null());
+
+        unsafe { crate::types::defra_free_string(result.error) };
+    }
+
+    #[test]
+    fn test_multiple_nodes() {
+        assert!(crate::runtime::init_runtime());
+
+        // Create multiple nodes
+        let options = NodeInitOptions::default();
+        let result1 = new_node(options);
+        assert_eq!(result1.status, 0);
+
+        let options = NodeInitOptions::default();
+        let result2 = new_node(options);
+        assert_eq!(result2.status, 0);
+
+        // Handles should be different
+        assert_ne!(result1.node_ptr, result2.node_ptr);
+
+        // Both should be closeable
+        let close1 = node_close(result1.node_ptr);
+        assert_eq!(close1.status, 0);
+
+        let close2 = node_close(result2.node_ptr);
+        assert_eq!(close2.status, 0);
     }
 }

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -1,0 +1,134 @@
+//! Node lifecycle management for FFI.
+//!
+//! This module provides the core node creation and management functions
+//! exposed via FFI to match Go's cbindings/node.go behavior.
+
+use std::sync::Arc;
+
+use crate::runtime::RUNTIME;
+use crate::state::{NodeState, NODES};
+use crate::types::{FfiResult, NewNodeResult, NodeInitOptions};
+
+/// Create a new DefraDB node.
+///
+/// This creates an in-memory database instance with a query runner.
+/// The returned handle must be passed to `node_close` when done.
+///
+/// # Safety
+///
+/// The returned `node_ptr` must be freed by calling `node_close`.
+#[no_mangle]
+pub extern "C" fn new_node(_options: NodeInitOptions) -> NewNodeResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return NewNodeResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let result = rt.block_on(async {
+        // Create in-memory storage (for MVP)
+        let store = Arc::new(storage::MemoryStore::new());
+
+        // Open database and load collections
+        let database = db::DB::open_from_arc(store.clone())
+            .await
+            .map_err(|e| format!("failed to open database: {}", e))?;
+        let database = Arc::new(database);
+
+        // Create auto-committing fetcher for non-transactional queries
+        let fetcher = db::AutoCommitFetcher::new(database.clone());
+
+        // Create collection provider for on-demand schema resolution
+        let collection_provider: Arc<dyn query::CollectionProvider> =
+            db::DbCollectionProvider::new_arc(database.clone());
+
+        // Create transaction registry for explicit transaction support
+        let registry = db::DbTransactionRegistry::new(database.clone());
+
+        // Create mutator for mutations
+        let mutator: Arc<dyn query::DocMutator> =
+            Arc::new(db::AutoCommitMutator::new(database.clone()));
+
+        // Create in-memory ACP store
+        let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
+        let document_acp: Arc<dyn acp::DocumentACP> =
+            Arc::new(acp::LocalDocumentACP::new(acp_store));
+
+        // Create query runner with transaction, mutation, and ACP support
+        let query_runner =
+            query::QueryRunner::with_registry_and_provider(fetcher, collection_provider, registry)
+                .with_mutator(mutator)
+                .with_acp(document_acp);
+
+        let runner: Arc<dyn query::QueryExecutor> = Arc::new(query_runner);
+
+        // Create node state
+        let state = NodeState {
+            database,
+            query_runner: runner,
+        };
+
+        // Register and get handle
+        let handle = NODES.insert(state);
+        Ok::<usize, String>(handle)
+    });
+
+    match result {
+        Ok(handle) => NewNodeResult::success(handle),
+        Err(e) => NewNodeResult::error(e),
+    }
+}
+
+/// Close a DefraDB node and release resources.
+///
+/// # Safety
+///
+/// The `node_ptr` must be a valid handle returned by `new_node`.
+/// After this call, the handle is no longer valid.
+#[no_mangle]
+pub extern "C" fn node_close(node_ptr: usize) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized"),
+    };
+
+    // Remove from registry
+    let state = match NODES.remove(node_ptr) {
+        Some(state) => state,
+        None => return FfiResult::error("invalid node handle"),
+    };
+
+    // Close the database
+    let result = rt.block_on(async { state.database.close().await });
+
+    match result {
+        Ok(()) => FfiResult::ok(),
+        Err(e) => FfiResult::error(format!("failed to close database: {}", e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_node_lifecycle() {
+        // Initialize runtime
+        crate::runtime::init_runtime();
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0, "new_node should succeed");
+        assert!(result.node_ptr > 0, "should have valid handle");
+
+        let handle = result.node_ptr;
+
+        // Close node
+        let result = node_close(handle);
+        assert_eq!(result.status, 0, "node_close should succeed");
+
+        // Double close should fail
+        let result = node_close(handle);
+        assert_eq!(result.status, 1, "double close should fail");
+    }
+}

--- a/crates/ffi/src/query.rs
+++ b/crates/ffi/src/query.rs
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn exec_request(
 ) -> FfiResult {
     let rt = match RUNTIME.get() {
         Some(rt) => rt,
-        None => return FfiResult::error("runtime not initialized"),
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
     };
 
     let query_str = match c_str_to_string(request_query) {
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn test_exec_request() {
         // Initialize runtime
-        crate::runtime::init_runtime();
+        assert!(crate::runtime::init_runtime());
 
         // Create node
         let options = NodeInitOptions::default();
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn test_exec_mutation() {
         // Initialize runtime
-        crate::runtime::init_runtime();
+        assert!(crate::runtime::init_runtime());
 
         // Create node
         let options = NodeInitOptions::default();
@@ -158,6 +158,79 @@ mod tests {
 
         // Cleanup
         unsafe { crate::types::defra_free_string(result.value) };
+        node_close(node);
+    }
+
+    // Edge case tests (H2)
+
+    #[test]
+    fn test_exec_request_null_query() {
+        assert!(crate::runtime::init_runtime());
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Null query should return error
+        let result = unsafe { exec_request(node, ptr::null(), ptr::null(), ptr::null()) };
+        assert_eq!(result.status, 1, "null query should fail");
+        assert!(!result.error.is_null());
+
+        let error = unsafe { std::ffi::CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(error.contains("null"), "should indicate null query");
+
+        unsafe { crate::types::defra_free_string(result.error) };
+        node_close(node);
+    }
+
+    #[test]
+    fn test_exec_request_invalid_handle() {
+        assert!(crate::runtime::init_runtime());
+
+        // Query with invalid handle should return error
+        let query_str = CString::new("{ User { name } }").unwrap();
+        let result = unsafe { exec_request(0, query_str.as_ptr(), ptr::null(), ptr::null()) };
+        assert_eq!(result.status, 1, "invalid handle should fail");
+        assert!(!result.error.is_null());
+
+        let error = unsafe { std::ffi::CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(error.contains("invalid"), "should indicate invalid handle");
+
+        unsafe { crate::types::defra_free_string(result.error) };
+    }
+
+    #[test]
+    fn test_exec_request_invalid_variables_json() {
+        assert!(crate::runtime::init_runtime());
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Add schema
+        let sdl = CString::new("type User { name: String }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+
+        // Query with invalid JSON variables should return error
+        let query_str = CString::new("{ User { name } }").unwrap();
+        let invalid_json = CString::new("not valid json").unwrap();
+        let result =
+            unsafe { exec_request(node, query_str.as_ptr(), ptr::null(), invalid_json.as_ptr()) };
+        assert_eq!(result.status, 1, "invalid JSON should fail");
+        assert!(!result.error.is_null());
+
+        let error = unsafe { std::ffi::CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(
+            error.contains("parse") || error.contains("variables"),
+            "should indicate parse error"
+        );
+
+        unsafe { crate::types::defra_free_string(result.error) };
         node_close(node);
     }
 }

--- a/crates/ffi/src/query.rs
+++ b/crates/ffi/src/query.rs
@@ -1,0 +1,163 @@
+//! Query execution for FFI.
+//!
+//! This module exposes GraphQL query execution that matches
+//! Go's cbindings/query.go behavior.
+
+use std::ffi::c_char;
+
+use crate::runtime::RUNTIME;
+use crate::state::NODES;
+use crate::types::{c_str_to_string, FfiResult};
+
+/// Execute a GraphQL query or mutation.
+///
+/// Returns a JSON object with the query result in GraphQL format:
+/// ```json
+/// {
+///     "data": { ... },
+///     "errors": [ ... ]
+/// }
+/// ```
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `request_query` - GraphQL query string (required)
+/// * `operation_name` - Optional operation name for multi-operation documents (null if not used)
+/// * `variables` - Optional JSON string of variables (null if not used)
+///
+/// # Safety
+///
+/// All string pointers must be either null or valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn exec_request(
+    node_ptr: usize,
+    request_query: *const c_char,
+    operation_name: *const c_char,
+    variables: *const c_char,
+) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized"),
+    };
+
+    let query_str = match c_str_to_string(request_query) {
+        Some(s) => s,
+        None => return FfiResult::error("request_query is null"),
+    };
+    let op_name = c_str_to_string(operation_name);
+    let vars_str = c_str_to_string(variables);
+
+    let result = rt.block_on(async {
+        // Get query runner
+        let runner = NODES
+            .get(node_ptr, |state| state.query_runner.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        // Build request
+        let mut request = query::QueryRequest::new(query_str);
+        if let Some(op) = op_name {
+            request = request.with_operation_name(op);
+        }
+        if let Some(vars) = vars_str {
+            let vars_json: serde_json::Value = serde_json::from_str(&vars)
+                .map_err(|e| format!("failed to parse variables: {}", e))?;
+            request = request.with_variables(vars_json);
+        }
+
+        // Execute
+        let response = runner.execute(request).await;
+
+        // Serialize response
+        let json = serde_json::to_string(&response)
+            .map_err(|e| format!("failed to serialize response: {}", e))?;
+
+        Ok::<String, String>(json)
+    });
+
+    match result {
+        Ok(json) => FfiResult::success(json),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::{new_node, node_close};
+    use crate::schema::add_schema;
+    use crate::types::NodeInitOptions;
+    use std::ffi::CString;
+    use std::ptr;
+
+    #[test]
+    fn test_exec_request() {
+        // Initialize runtime
+        crate::runtime::init_runtime();
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Add schema
+        let sdl = CString::new("type User { name: String }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+
+        // Query (should return empty array)
+        let query_str = CString::new("{ User { name } }").unwrap();
+        let result = unsafe { exec_request(node, query_str.as_ptr(), ptr::null(), ptr::null()) };
+        assert_eq!(result.status, 0, "exec_request should succeed");
+
+        let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("data"), "response should have data field");
+
+        // Cleanup
+        unsafe { crate::types::defra_free_string(result.value) };
+        node_close(node);
+    }
+
+    #[test]
+    fn test_exec_mutation() {
+        // Initialize runtime
+        crate::runtime::init_runtime();
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Add schema
+        let sdl = CString::new("type User { name: String }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+
+        // Create a user
+        let mutation =
+            CString::new(r#"mutation { create_User(input: {name: "Alice"}) { _docID name } }"#)
+                .unwrap();
+        let result = unsafe { exec_request(node, mutation.as_ptr(), ptr::null(), ptr::null()) };
+        assert_eq!(result.status, 0, "mutation should succeed");
+
+        let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("Alice"), "response should contain Alice");
+
+        // Cleanup
+        unsafe { crate::types::defra_free_string(result.value) };
+
+        // Query to verify
+        let query_str = CString::new("{ User { name } }").unwrap();
+        let result = unsafe { exec_request(node, query_str.as_ptr(), ptr::null(), ptr::null()) };
+        assert_eq!(result.status, 0, "query should succeed");
+
+        let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("Alice"), "query result should contain Alice");
+
+        // Cleanup
+        unsafe { crate::types::defra_free_string(result.value) };
+        node_close(node);
+    }
+}

--- a/crates/ffi/src/runtime.rs
+++ b/crates/ffi/src/runtime.rs
@@ -12,16 +12,46 @@ use tokio::runtime::Runtime;
 /// Initialized once on first use. All async operations from FFI run here.
 pub static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
+/// Error from runtime initialization.
+static RUNTIME_ERROR: OnceLock<String> = OnceLock::new();
+
 /// Initialize the global runtime.
 ///
 /// Safe to call multiple times - only the first call has an effect.
-pub fn init_runtime() {
-    RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .expect("failed to create Tokio runtime")
-    });
+/// Returns true on success, false on failure.
+/// On failure, call `runtime_init_error()` to get the error message.
+pub fn init_runtime() -> bool {
+    // If already initialized successfully, return true
+    if RUNTIME.get().is_some() {
+        return true;
+    }
+
+    // If we already had an error, don't retry
+    if RUNTIME_ERROR.get().is_some() {
+        return false;
+    }
+
+    // Try to initialize
+    match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => {
+            // Use get_or_init to handle race condition where another thread
+            // might have initialized between our check and this call
+            RUNTIME.get_or_init(|| rt);
+            true
+        }
+        Err(e) => {
+            RUNTIME_ERROR.get_or_init(|| format!("failed to create Tokio runtime: {}", e));
+            false
+        }
+    }
+}
+
+/// Get the runtime initialization error, if any.
+pub fn runtime_init_error() -> Option<&'static str> {
+    RUNTIME_ERROR.get().map(|s| s.as_str())
 }
 
 /// Get a handle to the global runtime.
@@ -37,18 +67,27 @@ mod tests {
 
     #[test]
     fn test_runtime_init() {
-        init_runtime();
+        assert!(init_runtime(), "runtime initialization should succeed");
         assert!(RUNTIME.get().is_some());
     }
 
     #[test]
     fn test_runtime_handle() {
-        init_runtime();
+        assert!(init_runtime(), "runtime initialization should succeed");
         let handle = runtime_handle();
         assert!(handle.is_some());
 
         // Can run async tasks
         let result = handle.unwrap().block_on(async { 42 });
         assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn test_runtime_init_idempotent() {
+        // Multiple calls should all succeed
+        assert!(init_runtime());
+        assert!(init_runtime());
+        assert!(init_runtime());
+        assert!(RUNTIME.get().is_some());
     }
 }

--- a/crates/ffi/src/runtime.rs
+++ b/crates/ffi/src/runtime.rs
@@ -1,0 +1,54 @@
+//! Global Tokio runtime for FFI async bridging.
+//!
+//! FFI functions are synchronous, but the Rust database API is async.
+//! This module provides a global Tokio runtime that bridges the gap.
+
+use std::sync::OnceLock;
+
+use tokio::runtime::Runtime;
+
+/// Global Tokio runtime.
+///
+/// Initialized once on first use. All async operations from FFI run here.
+pub static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+
+/// Initialize the global runtime.
+///
+/// Safe to call multiple times - only the first call has an effect.
+pub fn init_runtime() {
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create Tokio runtime")
+    });
+}
+
+/// Get a handle to the global runtime.
+///
+/// Returns None if the runtime hasn't been initialized.
+pub fn runtime_handle() -> Option<&'static Runtime> {
+    RUNTIME.get()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_runtime_init() {
+        init_runtime();
+        assert!(RUNTIME.get().is_some());
+    }
+
+    #[test]
+    fn test_runtime_handle() {
+        init_runtime();
+        let handle = runtime_handle();
+        assert!(handle.is_some());
+
+        // Can run async tasks
+        let result = handle.unwrap().block_on(async { 42 });
+        assert_eq!(result, 42);
+    }
+}

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -31,7 +31,7 @@ use crate::types::{c_str_to_string, FfiResult};
 pub unsafe extern "C" fn add_schema(node_ptr: usize, schema_sdl: *const c_char) -> FfiResult {
     let rt = match RUNTIME.get() {
         Some(rt) => rt,
-        None => return FfiResult::error("runtime not initialized"),
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
     };
 
     let schema_str = match c_str_to_string(schema_sdl) {
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn add_schema(node_ptr: usize, schema_sdl: *const c_char) 
 pub extern "C" fn get_collections(node_ptr: usize) -> FfiResult {
     let rt = match RUNTIME.get() {
         Some(rt) => rt,
-        None => return FfiResult::error("runtime not initialized"),
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
     };
 
     let result = rt.block_on(async {
@@ -94,11 +94,19 @@ pub extern "C" fn get_collections(node_ptr: usize) -> FfiResult {
             .list_collections()
             .map_err(|e| format!("failed to list collections: {}", e))?;
 
-        // Get schemas for each collection
+        // Get schemas for each collection, propagating errors
         let mut collections = Vec::new();
         for name in names {
-            if let Ok(Some(collection)) = database.get_collection(&name) {
-                collections.push(collection.schema().clone());
+            match database.get_collection(&name) {
+                Ok(Some(collection)) => {
+                    collections.push(collection.schema().clone());
+                }
+                Ok(None) => {
+                    // Collection was deleted between list and get - skip it
+                }
+                Err(e) => {
+                    return Err(format!("failed to get collection '{}': {}", name, e));
+                }
             }
         }
 
@@ -125,7 +133,7 @@ mod tests {
     #[test]
     fn test_add_schema_and_get_collections() {
         // Initialize runtime
-        crate::runtime::init_runtime();
+        assert!(crate::runtime::init_runtime());
 
         // Create node
         let options = NodeInitOptions::default();

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -1,0 +1,156 @@
+//! Schema operations for FFI.
+//!
+//! This module exposes schema management functions that match
+//! Go's cbindings/schema.go behavior.
+
+use std::ffi::c_char;
+
+use crate::runtime::RUNTIME;
+use crate::state::NODES;
+use crate::types::{c_str_to_string, FfiResult};
+
+/// Add a schema to the database.
+///
+/// The schema should be a GraphQL SDL string defining types.
+///
+/// Returns a JSON array of CollectionVersion objects on success.
+///
+/// # Example SDL
+///
+/// ```graphql
+/// type User {
+///     name: String
+///     age: Int
+/// }
+/// ```
+///
+/// # Safety
+///
+/// `schema_sdl` must be a valid null-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn add_schema(node_ptr: usize, schema_sdl: *const c_char) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized"),
+    };
+
+    let schema_str = match c_str_to_string(schema_sdl) {
+        Some(s) => s,
+        None => return FfiResult::error("schema_sdl is null"),
+    };
+
+    let result = rt.block_on(async {
+        // Get node state
+        let database = NODES
+            .get(node_ptr, |state| state.database.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        // Parse the SDL into collection versions
+        let collections =
+            query::parse_sdl(&schema_str).map_err(|e| format!("failed to parse schema: {}", e))?;
+
+        // Create each collection
+        let mut created_versions = Vec::new();
+        for schema in collections {
+            let version = schema.clone();
+            database
+                .create_collection(schema)
+                .await
+                .map_err(|e| format!("failed to create collection: {}", e))?;
+            created_versions.push(version);
+        }
+
+        // Return JSON array of created collection versions
+        let json = serde_json::to_string(&created_versions)
+            .map_err(|e| format!("failed to serialize result: {}", e))?;
+
+        Ok::<String, String>(json)
+    });
+
+    match result {
+        Ok(json) => FfiResult::success(json),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Get all collections from the database.
+///
+/// Returns a JSON array of collection descriptions.
+#[no_mangle]
+pub extern "C" fn get_collections(node_ptr: usize) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized"),
+    };
+
+    let result = rt.block_on(async {
+        // Get node state
+        let database = NODES
+            .get(node_ptr, |state| state.database.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        // Get collection names
+        let names = database
+            .list_collections()
+            .map_err(|e| format!("failed to list collections: {}", e))?;
+
+        // Get schemas for each collection
+        let mut collections = Vec::new();
+        for name in names {
+            if let Ok(Some(collection)) = database.get_collection(&name) {
+                collections.push(collection.schema().clone());
+            }
+        }
+
+        // Return JSON array
+        let json = serde_json::to_string(&collections)
+            .map_err(|e| format!("failed to serialize result: {}", e))?;
+
+        Ok::<String, String>(json)
+    });
+
+    match result {
+        Ok(json) => FfiResult::success(json),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::{new_node, node_close};
+    use crate::types::NodeInitOptions;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_add_schema_and_get_collections() {
+        // Initialize runtime
+        crate::runtime::init_runtime();
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Add schema
+        let sdl = CString::new("type User { name: String }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0, "add_schema should succeed");
+
+        // Get collections
+        let result = get_collections(node);
+        assert_eq!(result.status, 0, "get_collections should succeed");
+        assert!(!result.value.is_null());
+
+        // Check value contains User
+        let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("User"), "should contain User collection");
+
+        // Cleanup
+        unsafe {
+            crate::types::defra_free_string(result.value);
+        }
+        node_close(node);
+    }
+}

--- a/crates/ffi/src/state.rs
+++ b/crates/ffi/src/state.rs
@@ -1,0 +1,130 @@
+//! Node state management for FFI.
+//!
+//! This module manages the lifecycle of node instances and their handles.
+//! Go code receives opaque usize handles that map to actual node state.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
+use storage::MemoryStore;
+
+/// Type alias for the database type used in FFI.
+pub type FfiDatabase = db::DB<MemoryStore>;
+
+/// Type alias for node handles (opaque to FFI callers).
+pub type NodeHandle = usize;
+
+/// State held for each FFI node.
+pub struct NodeState {
+    /// The database instance.
+    pub database: std::sync::Arc<FfiDatabase>,
+    /// The query runner for executing GraphQL queries.
+    pub query_runner: std::sync::Arc<dyn query::QueryExecutor>,
+}
+
+/// Global registry of active nodes.
+///
+/// Uses RwLock for safe concurrent access from multiple threads.
+pub struct NodeRegistry {
+    nodes: RwLock<HashMap<NodeHandle, NodeState>>,
+    next_handle: AtomicUsize,
+}
+
+impl NodeRegistry {
+    /// Create a new empty registry.
+    fn new() -> Self {
+        Self {
+            nodes: RwLock::new(HashMap::new()),
+            next_handle: AtomicUsize::new(1), // Start at 1, 0 is invalid
+        }
+    }
+
+    /// Insert a new node state and return its handle.
+    pub fn insert(&self, state: NodeState) -> NodeHandle {
+        let handle = self.next_handle.fetch_add(1, Ordering::SeqCst);
+        let mut nodes = self.nodes.write();
+        nodes.insert(handle, state);
+        handle
+    }
+
+    /// Get a reference to a node state.
+    ///
+    /// Returns None if the handle is invalid.
+    pub fn get<F, R>(&self, handle: NodeHandle, f: F) -> Option<R>
+    where
+        F: FnOnce(&NodeState) -> R,
+    {
+        let nodes = self.nodes.read();
+        nodes.get(&handle).map(f)
+    }
+
+    /// Remove and return a node state.
+    ///
+    /// Returns None if the handle is invalid.
+    pub fn remove(&self, handle: NodeHandle) -> Option<NodeState> {
+        let mut nodes = self.nodes.write();
+        nodes.remove(&handle)
+    }
+
+    /// Check if a handle is valid.
+    pub fn contains(&self, handle: NodeHandle) -> bool {
+        let nodes = self.nodes.read();
+        nodes.contains_key(&handle)
+    }
+
+    /// Get the number of active nodes.
+    pub fn len(&self) -> usize {
+        let nodes = self.nodes.read();
+        nodes.len()
+    }
+
+    /// Check if the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Global node registry singleton, lazily initialized.
+static NODE_REGISTRY: OnceLock<NodeRegistry> = OnceLock::new();
+
+/// Access the global node registry.
+pub fn nodes() -> &'static NodeRegistry {
+    NODE_REGISTRY.get_or_init(NodeRegistry::new)
+}
+
+/// Convenience wrapper for NODES access (backwards compatibility).
+pub struct NodesAccess;
+
+impl NodesAccess {
+    pub fn insert(&self, state: NodeState) -> NodeHandle {
+        nodes().insert(state)
+    }
+
+    pub fn get<F, R>(&self, handle: NodeHandle, f: F) -> Option<R>
+    where
+        F: FnOnce(&NodeState) -> R,
+    {
+        nodes().get(handle, f)
+    }
+
+    pub fn remove(&self, handle: NodeHandle) -> Option<NodeState> {
+        nodes().remove(handle)
+    }
+}
+
+/// Global NODES accessor for backwards compatibility.
+pub static NODES: NodesAccess = NodesAccess;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_registry_handles() {
+        // Handles should be non-zero and incrementing
+        let registry = nodes();
+        assert!(registry.is_empty() || registry.len() > 0);
+    }
+}

--- a/crates/ffi/src/txn.rs
+++ b/crates/ffi/src/txn.rs
@@ -1,0 +1,379 @@
+//! Transaction operations for FFI.
+//!
+//! This module exposes transaction management functions that allow
+//! explicit transaction control from Go/C callers.
+
+use std::ffi::c_char;
+
+use crate::runtime::RUNTIME;
+use crate::state::NODES;
+use crate::types::{c_str_to_string, FfiResult, NewTxnResult};
+
+/// Begin a new transaction.
+///
+/// Returns a transaction ID that can be used with `exec_request_in_txn`,
+/// `commit_txn`, and `rollback_txn`.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `readonly` - If non-zero, creates a read-only transaction
+///
+/// # Returns
+///
+/// A `NewTxnResult` containing the transaction ID on success.
+#[no_mangle]
+pub extern "C" fn begin_txn(node_ptr: usize, readonly: i32) -> NewTxnResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return NewTxnResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let result = rt.block_on(async {
+        let runner = NODES
+            .get(node_ptr, |state| state.query_runner.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        let handle = runner
+            .begin_txn(readonly != 0)
+            .await
+            .map_err(|e| format!("failed to begin transaction: {}", e))?;
+
+        Ok::<String, String>(handle.to_string())
+    });
+
+    match result {
+        Ok(txn_id) => NewTxnResult::success(txn_id),
+        Err(e) => NewTxnResult::error(e),
+    }
+}
+
+/// Commit a transaction.
+///
+/// After commit, all operations performed within the transaction become permanent.
+/// The transaction ID is no longer valid after this call.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `txn_id` - Transaction ID from `begin_txn`
+///
+/// # Safety
+///
+/// `txn_id` must be a valid null-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn commit_txn(node_ptr: usize, txn_id: *const c_char) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let txn_str = match c_str_to_string(txn_id) {
+        Some(s) => s,
+        None => return FfiResult::error("txn_id is null"),
+    };
+
+    let result = rt.block_on(async {
+        let runner = NODES
+            .get(node_ptr, |state| state.query_runner.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        let handle: query::txn::TransactionHandle = txn_str
+            .parse()
+            .map_err(|e| format!("invalid transaction ID: {}", e))?;
+
+        runner
+            .commit_txn(&handle)
+            .await
+            .map_err(|e| format!("failed to commit transaction: {}", e))?;
+
+        Ok::<(), String>(())
+    });
+
+    match result {
+        Ok(()) => FfiResult::ok(),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Rollback (discard) a transaction.
+///
+/// After rollback, all operations performed within the transaction are discarded.
+/// The transaction ID is no longer valid after this call.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `txn_id` - Transaction ID from `begin_txn`
+///
+/// # Safety
+///
+/// `txn_id` must be a valid null-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn rollback_txn(node_ptr: usize, txn_id: *const c_char) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let txn_str = match c_str_to_string(txn_id) {
+        Some(s) => s,
+        None => return FfiResult::error("txn_id is null"),
+    };
+
+    let result = rt.block_on(async {
+        let runner = NODES
+            .get(node_ptr, |state| state.query_runner.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        let handle: query::txn::TransactionHandle = txn_str
+            .parse()
+            .map_err(|e| format!("invalid transaction ID: {}", e))?;
+
+        runner
+            .rollback_txn(&handle)
+            .await
+            .map_err(|e| format!("failed to rollback transaction: {}", e))?;
+
+        Ok::<(), String>(())
+    });
+
+    match result {
+        Ok(()) => FfiResult::ok(),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Execute a GraphQL query or mutation within a transaction.
+///
+/// The operation will be part of the specified transaction and will not
+/// be visible to other transactions until committed.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `txn_id` - Transaction ID from `begin_txn`
+/// * `request_query` - GraphQL query string (required)
+/// * `operation_name` - Optional operation name (null if not used)
+/// * `variables` - Optional JSON string of variables (null if not used)
+///
+/// # Safety
+///
+/// All string pointers must be either null or valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn exec_request_in_txn(
+    node_ptr: usize,
+    txn_id: *const c_char,
+    request_query: *const c_char,
+    operation_name: *const c_char,
+    variables: *const c_char,
+) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let txn_str = match c_str_to_string(txn_id) {
+        Some(s) => s,
+        None => return FfiResult::error("txn_id is null"),
+    };
+
+    let query_str = match c_str_to_string(request_query) {
+        Some(s) => s,
+        None => return FfiResult::error("request_query is null"),
+    };
+
+    let op_name = c_str_to_string(operation_name);
+    let vars_str = c_str_to_string(variables);
+
+    let result = rt.block_on(async {
+        let runner = NODES
+            .get(node_ptr, |state| state.query_runner.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        let handle: query::txn::TransactionHandle = txn_str
+            .parse()
+            .map_err(|e| format!("invalid transaction ID: {}", e))?;
+
+        // Build request
+        let mut request = query::QueryRequest::new(query_str);
+        if let Some(op) = op_name {
+            request = request.with_operation_name(op);
+        }
+        if let Some(vars) = vars_str {
+            let vars_json: serde_json::Value = serde_json::from_str(&vars)
+                .map_err(|e| format!("failed to parse variables: {}", e))?;
+            request = request.with_variables(vars_json);
+        }
+
+        // Execute in transaction
+        let response = runner.execute_in_txn(request, &handle).await;
+
+        // Serialize response
+        let json = serde_json::to_string(&response)
+            .map_err(|e| format!("failed to serialize response: {}", e))?;
+
+        Ok::<String, String>(json)
+    });
+
+    match result {
+        Ok(json) => FfiResult::success(json),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::{new_node, node_close};
+    use crate::schema::add_schema;
+    use crate::types::NodeInitOptions;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_transaction_lifecycle() {
+        assert!(crate::runtime::init_runtime());
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Add schema
+        let sdl = CString::new("type TxnTest { value: Int }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+
+        // Begin transaction
+        let result = begin_txn(node, 0);
+        assert_eq!(result.status, 0, "begin_txn should succeed");
+        assert!(!result.txn_id.is_null());
+
+        let txn_id = unsafe { std::ffi::CStr::from_ptr(result.txn_id).to_string_lossy() };
+        assert!(!txn_id.is_empty());
+
+        // Execute in transaction
+        let mutation = CString::new(
+            r#"mutation { create_TxnTest(input: {value: 42}) { _docID value } }"#,
+        )
+        .unwrap();
+        let txn_id_cstr = CString::new(txn_id.as_ref()).unwrap();
+        let result = unsafe {
+            exec_request_in_txn(
+                node,
+                txn_id_cstr.as_ptr(),
+                mutation.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        assert_eq!(result.status, 0, "exec_request_in_txn should succeed");
+
+        // Commit transaction
+        let result = unsafe { commit_txn(node, txn_id_cstr.as_ptr()) };
+        assert_eq!(result.status, 0, "commit_txn should succeed");
+
+        // Cleanup
+        node_close(node);
+    }
+
+    #[test]
+    fn test_transaction_rollback() {
+        assert!(crate::runtime::init_runtime());
+
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        let sdl = CString::new("type RollbackTest { value: Int }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+
+        // Begin transaction
+        let result = begin_txn(node, 0);
+        assert_eq!(result.status, 0);
+        let txn_id = unsafe { std::ffi::CStr::from_ptr(result.txn_id).to_string_lossy() };
+        let txn_id_cstr = CString::new(txn_id.as_ref()).unwrap();
+
+        // Execute in transaction
+        let mutation = CString::new(
+            r#"mutation { create_RollbackTest(input: {value: 99}) { _docID } }"#,
+        )
+        .unwrap();
+        let result = unsafe {
+            exec_request_in_txn(
+                node,
+                txn_id_cstr.as_ptr(),
+                mutation.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        assert_eq!(result.status, 0);
+
+        // Rollback transaction
+        let result = unsafe { rollback_txn(node, txn_id_cstr.as_ptr()) };
+        assert_eq!(result.status, 0, "rollback_txn should succeed");
+
+        node_close(node);
+    }
+
+    #[test]
+    fn test_invalid_txn_id() {
+        assert!(crate::runtime::init_runtime());
+
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Try to commit invalid transaction
+        let invalid_txn = CString::new("invalid-txn-id-12345").unwrap();
+        let result = unsafe { commit_txn(node, invalid_txn.as_ptr()) };
+        assert_eq!(result.status, 1, "commit with invalid txn should fail");
+
+        node_close(node);
+    }
+
+    #[test]
+    fn test_readonly_transaction() {
+        assert!(crate::runtime::init_runtime());
+
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        let sdl = CString::new("type ReadOnlyTest { value: Int }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+
+        // Begin readonly transaction
+        let result = begin_txn(node, 1); // readonly = true
+        assert_eq!(result.status, 0, "begin readonly txn should succeed");
+
+        let txn_id = unsafe { std::ffi::CStr::from_ptr(result.txn_id).to_string_lossy() };
+        let txn_id_cstr = CString::new(txn_id.as_ref()).unwrap();
+
+        // Query should work in readonly transaction
+        let query = CString::new("{ ReadOnlyTest { value } }").unwrap();
+        let result = unsafe {
+            exec_request_in_txn(
+                node,
+                txn_id_cstr.as_ptr(),
+                query.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        assert_eq!(result.status, 0, "query in readonly txn should succeed");
+
+        // Commit readonly transaction
+        let result = unsafe { commit_txn(node, txn_id_cstr.as_ptr()) };
+        assert_eq!(result.status, 0);
+
+        node_close(node);
+    }
+}

--- a/crates/ffi/src/types.rs
+++ b/crates/ffi/src/types.rs
@@ -117,6 +117,53 @@ impl NewNodeResult {
     }
 }
 
+/// FFI result for transaction creation, containing a transaction ID.
+#[repr(C)]
+pub struct NewTxnResult {
+    /// Status code: 0=success, 1=error
+    pub status: c_int,
+    /// Error message (null on success). Caller must free with `defra_free_string`.
+    pub error: *mut c_char,
+    /// Transaction ID (null on error). Caller must free with `defra_free_string`.
+    pub txn_id: *mut c_char,
+}
+
+impl NewTxnResult {
+    /// Create a success result with a transaction ID.
+    pub fn success(txn_id: impl Into<String>) -> Self {
+        let txn_str = txn_id.into();
+        let txn_cstring = match CString::new(txn_str.clone()) {
+            Ok(s) => s,
+            Err(_) => {
+                let sanitized = txn_str.replace('\0', "\u{FFFD}");
+                CString::new(sanitized).unwrap_or_else(|_| CString::new("unknown").unwrap())
+            }
+        };
+        Self {
+            status: 0,
+            error: ptr::null_mut(),
+            txn_id: txn_cstring.into_raw(),
+        }
+    }
+
+    /// Create an error result.
+    pub fn error(message: impl Into<String>) -> Self {
+        let msg_str = message.into();
+        let error_cstring = match CString::new(msg_str.clone()) {
+            Ok(s) => s,
+            Err(_) => {
+                let sanitized = msg_str.replace('\0', "\u{FFFD}");
+                CString::new(sanitized).unwrap_or_else(|_| CString::new("unknown error").unwrap())
+            }
+        };
+        Self {
+            status: 1,
+            error: error_cstring.into_raw(),
+            txn_id: ptr::null_mut(),
+        }
+    }
+}
+
 /// Options for node initialization.
 ///
 /// Matches Go's NodeInitOptions struct.

--- a/crates/ffi/src/types.rs
+++ b/crates/ffi/src/types.rs
@@ -21,8 +21,19 @@ pub struct FfiResult {
 
 impl FfiResult {
     /// Create a success result with a JSON value.
+    ///
+    /// If the value contains null bytes, they are replaced with the Unicode
+    /// replacement character to avoid panicking at the FFI boundary.
     pub fn success(value: impl Into<String>) -> Self {
-        let value_cstring = CString::new(value.into()).unwrap();
+        let value_str = value.into();
+        let value_cstring = match CString::new(value_str.clone()) {
+            Ok(s) => s,
+            Err(_) => {
+                // Value contains null bytes - replace them to avoid panic
+                let sanitized = value_str.replace('\0', "\u{FFFD}");
+                CString::new(sanitized).unwrap_or_else(|_| CString::new("{}").unwrap())
+            }
+        };
         Self {
             status: 0,
             error: ptr::null_mut(),
@@ -31,8 +42,19 @@ impl FfiResult {
     }
 
     /// Create an error result.
+    ///
+    /// If the message contains null bytes, they are replaced with the Unicode
+    /// replacement character to avoid panicking at the FFI boundary.
     pub fn error(message: impl Into<String>) -> Self {
-        let error_cstring = CString::new(message.into()).unwrap();
+        let msg_str = message.into();
+        let error_cstring = match CString::new(msg_str.clone()) {
+            Ok(s) => s,
+            Err(_) => {
+                // Message contains null bytes - replace them to avoid panic
+                let sanitized = msg_str.replace('\0', "\u{FFFD}");
+                CString::new(sanitized).unwrap_or_else(|_| CString::new("unknown error").unwrap())
+            }
+        };
         Self {
             status: 1,
             error: error_cstring.into_raw(),
@@ -74,8 +96,19 @@ impl NewNodeResult {
     }
 
     /// Create an error result.
+    ///
+    /// If the message contains null bytes, they are replaced with the Unicode
+    /// replacement character to avoid panicking at the FFI boundary.
     pub fn error(message: impl Into<String>) -> Self {
-        let error_cstring = CString::new(message.into()).unwrap();
+        let msg_str = message.into();
+        let error_cstring = match CString::new(msg_str.clone()) {
+            Ok(s) => s,
+            Err(_) => {
+                // Message contains null bytes - replace them to avoid panic
+                let sanitized = msg_str.replace('\0', "\u{FFFD}");
+                CString::new(sanitized).unwrap_or_else(|_| CString::new("unknown error").unwrap())
+            }
+        };
         Self {
             status: 1,
             error: error_cstring.into_raw(),
@@ -161,5 +194,75 @@ mod tests {
         assert_eq!(result.status, 0);
         assert_eq!(result.node_ptr, 42);
         assert!(result.error.is_null());
+    }
+
+    // Edge case tests for null byte handling (H2)
+
+    #[test]
+    fn test_ffi_result_success_with_null_bytes() {
+        // String with embedded null byte should not panic
+        let value_with_null = "hello\0world";
+        let result = FfiResult::success(value_with_null);
+        assert_eq!(result.status, 0);
+        assert!(!result.value.is_null());
+
+        // Value should have null bytes replaced
+        let value = unsafe { CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains('\u{FFFD}'), "null byte should be replaced");
+        assert!(!value.contains('\0'), "should not contain null byte");
+
+        unsafe { defra_free_string(result.value) };
+    }
+
+    #[test]
+    fn test_ffi_result_error_with_null_bytes() {
+        // Error message with embedded null byte should not panic
+        let error_with_null = "error\0message";
+        let result = FfiResult::error(error_with_null);
+        assert_eq!(result.status, 1);
+        assert!(!result.error.is_null());
+
+        // Error should have null bytes replaced
+        let error = unsafe { CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(error.contains('\u{FFFD}'), "null byte should be replaced");
+        assert!(!error.contains('\0'), "should not contain null byte");
+
+        unsafe { defra_free_string(result.error) };
+    }
+
+    #[test]
+    fn test_new_node_result_error_with_null_bytes() {
+        // Error message with embedded null byte should not panic
+        let error_with_null = "node\0error";
+        let result = NewNodeResult::error(error_with_null);
+        assert_eq!(result.status, 1);
+        assert!(!result.error.is_null());
+        assert_eq!(result.node_ptr, 0);
+
+        // Error should have null bytes replaced
+        let error = unsafe { CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(error.contains('\u{FFFD}'), "null byte should be replaced");
+
+        unsafe { defra_free_string(result.error) };
+    }
+
+    #[test]
+    fn test_c_str_to_string_null_ptr() {
+        let result = unsafe { c_str_to_string(ptr::null()) };
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_defra_free_string_null_ptr() {
+        // Should not panic when freeing null pointer
+        unsafe { defra_free_string(ptr::null_mut()) };
+    }
+
+    #[test]
+    fn test_ffi_result_ok() {
+        let result = FfiResult::ok();
+        assert_eq!(result.status, 0);
+        assert!(result.error.is_null());
+        assert!(result.value.is_null());
     }
 }

--- a/crates/ffi/src/types.rs
+++ b/crates/ffi/src/types.rs
@@ -1,0 +1,165 @@
+//! FFI type definitions matching Go's cbindings/defra_structs.h
+
+use std::ffi::{c_char, c_int, CStr, CString};
+use std::ptr;
+
+/// FFI result type matching Go's Result struct.
+///
+/// Status codes:
+/// - 0: Success
+/// - 1: Error (message in error field)
+/// - 2: Subscription (ID in value field, not yet implemented)
+#[repr(C)]
+pub struct FfiResult {
+    /// Status code: 0=success, 1=error, 2=subscription
+    pub status: c_int,
+    /// Error message (null on success). Caller must free with `defra_free_string`.
+    pub error: *mut c_char,
+    /// JSON value (null on error). Caller must free with `defra_free_string`.
+    pub value: *mut c_char,
+}
+
+impl FfiResult {
+    /// Create a success result with a JSON value.
+    pub fn success(value: impl Into<String>) -> Self {
+        let value_cstring = CString::new(value.into()).unwrap();
+        Self {
+            status: 0,
+            error: ptr::null_mut(),
+            value: value_cstring.into_raw(),
+        }
+    }
+
+    /// Create an error result.
+    pub fn error(message: impl Into<String>) -> Self {
+        let error_cstring = CString::new(message.into()).unwrap();
+        Self {
+            status: 1,
+            error: error_cstring.into_raw(),
+            value: ptr::null_mut(),
+        }
+    }
+
+    /// Create a success result with no value.
+    pub fn ok() -> Self {
+        Self {
+            status: 0,
+            error: ptr::null_mut(),
+            value: ptr::null_mut(),
+        }
+    }
+}
+
+/// FFI result for node creation, containing a node handle.
+///
+/// Matches Go's NewNodeResult struct.
+#[repr(C)]
+pub struct NewNodeResult {
+    /// Status code: 0=success, 1=error
+    pub status: c_int,
+    /// Error message (null on success). Caller must free with `defra_free_string`.
+    pub error: *mut c_char,
+    /// Handle to the node (0 on error).
+    pub node_ptr: usize,
+}
+
+impl NewNodeResult {
+    /// Create a success result with a node handle.
+    pub fn success(handle: usize) -> Self {
+        Self {
+            status: 0,
+            error: ptr::null_mut(),
+            node_ptr: handle,
+        }
+    }
+
+    /// Create an error result.
+    pub fn error(message: impl Into<String>) -> Self {
+        let error_cstring = CString::new(message.into()).unwrap();
+        Self {
+            status: 1,
+            error: error_cstring.into_raw(),
+            node_ptr: 0,
+        }
+    }
+}
+
+/// Options for node initialization.
+///
+/// Matches Go's NodeInitOptions struct.
+#[repr(C)]
+pub struct NodeInitOptions {
+    /// Path to store directory (null for in-memory).
+    pub db_path: *const c_char,
+    /// Use in-memory storage (1=true, 0=false).
+    pub in_memory: c_int,
+}
+
+impl Default for NodeInitOptions {
+    fn default() -> Self {
+        Self {
+            db_path: ptr::null(),
+            in_memory: 1, // Default to in-memory
+        }
+    }
+}
+
+/// Convert a C string pointer to a Rust String (or None if null).
+///
+/// # Safety
+///
+/// The pointer must be null or point to a valid null-terminated string.
+pub unsafe fn c_str_to_string(ptr: *const c_char) -> Option<String> {
+    if ptr.is_null() {
+        None
+    } else {
+        Some(CStr::from_ptr(ptr).to_string_lossy().into_owned())
+    }
+}
+
+/// Free a string allocated by FFI functions.
+///
+/// # Safety
+///
+/// The pointer must have been allocated by an FFI function in this crate.
+#[no_mangle]
+pub unsafe extern "C" fn defra_free_string(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        drop(CString::from_raw(ptr));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ffi_result_success() {
+        let result = FfiResult::success(r#"{"data": "test"}"#);
+        assert_eq!(result.status, 0);
+        assert!(result.error.is_null());
+        assert!(!result.value.is_null());
+
+        // Clean up
+        unsafe { defra_free_string(result.value) };
+    }
+
+    #[test]
+    fn test_ffi_result_error() {
+        let result = FfiResult::error("something went wrong");
+        assert_eq!(result.status, 1);
+        assert!(!result.error.is_null());
+        assert!(result.value.is_null());
+
+        // Clean up
+        unsafe { defra_free_string(result.error) };
+    }
+
+    #[test]
+    fn test_new_node_result() {
+        let result = NewNodeResult::success(42);
+        assert_eq!(result.status, 0);
+        assert_eq!(result.node_ptr, 42);
+        assert!(result.error.is_null());
+    }
+}

--- a/tests/interop/ffi/concurrency_test.go
+++ b/tests/interop/ffi/concurrency_test.go
@@ -1,0 +1,409 @@
+package ffi
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrentNodeCreation tests creating multiple nodes concurrently.
+func TestConcurrentNodeCreation(t *testing.T) {
+	Init()
+
+	const numNodes = 10
+	var wg sync.WaitGroup
+	nodes := make([]*Node, numNodes)
+	errs := make([]error, numNodes)
+
+	// Create nodes concurrently
+	for i := 0; i < numNodes; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			node, err := NewNode(NodeOptions{InMemory: true})
+			nodes[idx] = node
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify all succeeded
+	for i := 0; i < numNodes; i++ {
+		require.NoError(t, errs[i], "node %d creation failed", i)
+		require.NotNil(t, nodes[i], "node %d is nil", i)
+	}
+
+	// Close all nodes concurrently
+	for i := 0; i < numNodes; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = nodes[idx].Close()
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify all closed successfully
+	for i := 0; i < numNodes; i++ {
+		assert.NoError(t, errs[i], "node %d close failed", i)
+	}
+}
+
+// TestConcurrentQueriesSingleNode tests multiple goroutines querying the same node.
+func TestConcurrentQueriesSingleNode(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Counter { name: String, value: Int }")
+	require.NoError(t, err)
+
+	// Create some initial data
+	for i := 0; i < 5; i++ {
+		_, err := node.Mutate(fmt.Sprintf(
+			`mutation { create_Counter(input: {name: "counter_%d", value: %d}) { _docID } }`,
+			i, i*10,
+		))
+		require.NoError(t, err)
+	}
+
+	const numGoroutines = 20
+	const queriesPerGoroutine = 10
+	var wg sync.WaitGroup
+	var successCount atomic.Int64
+	var errorCount atomic.Int64
+
+	// Run concurrent queries
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for q := 0; q < queriesPerGoroutine; q++ {
+				result, err := node.Query("{ Counter { name value } }")
+				if err != nil {
+					errorCount.Add(1)
+					continue
+				}
+				if len(result.Errors) > 0 {
+					errorCount.Add(1)
+					continue
+				}
+				successCount.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	totalQueries := int64(numGoroutines * queriesPerGoroutine)
+	t.Logf("Concurrent queries: %d successful, %d errors out of %d total",
+		successCount.Load(), errorCount.Load(), totalQueries)
+
+	// All queries should succeed
+	assert.Equal(t, totalQueries, successCount.Load(), "all queries should succeed")
+	assert.Equal(t, int64(0), errorCount.Load(), "no queries should fail")
+}
+
+// TestConcurrentMutationsSingleNode tests multiple goroutines mutating the same node.
+func TestConcurrentMutationsSingleNode(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Item { name: String, seq: Int }")
+	require.NoError(t, err)
+
+	const numGoroutines = 10
+	const mutationsPerGoroutine = 5
+	var wg sync.WaitGroup
+	var successCount atomic.Int64
+	var errorCount atomic.Int64
+
+	// Run concurrent mutations
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+			for m := 0; m < mutationsPerGoroutine; m++ {
+				seq := goroutineID*mutationsPerGoroutine + m
+				mutation := fmt.Sprintf(
+					`mutation { create_Item(input: {name: "item_g%d_m%d", seq: %d}) { _docID } }`,
+					goroutineID, m, seq,
+				)
+				result, err := node.Mutate(mutation)
+				if err != nil {
+					errorCount.Add(1)
+					continue
+				}
+				if len(result.Errors) > 0 {
+					errorCount.Add(1)
+					continue
+				}
+				successCount.Add(1)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	totalMutations := int64(numGoroutines * mutationsPerGoroutine)
+	t.Logf("Concurrent mutations: %d successful, %d errors out of %d total",
+		successCount.Load(), errorCount.Load(), totalMutations)
+
+	// All mutations should succeed
+	assert.Equal(t, totalMutations, successCount.Load(), "all mutations should succeed")
+	assert.Equal(t, int64(0), errorCount.Load(), "no mutations should fail")
+
+	// Verify all items were created
+	result, err := node.Query("{ Item { name seq } }")
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+}
+
+// TestConcurrentMixedOperations tests concurrent reads and writes.
+func TestConcurrentMixedOperations(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Event { name: String, timestamp: Int }")
+	require.NoError(t, err)
+
+	const numWriters = 5
+	const numReaders = 10
+	const opsPerGoroutine = 10
+	var wg sync.WaitGroup
+	var writeSuccess atomic.Int64
+	var readSuccess atomic.Int64
+	var errors atomic.Int64
+
+	// Start writers
+	for w := 0; w < numWriters; w++ {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			for op := 0; op < opsPerGoroutine; op++ {
+				ts := writerID*1000 + op
+				mutation := fmt.Sprintf(
+					`mutation { create_Event(input: {name: "event_w%d", timestamp: %d}) { _docID } }`,
+					writerID, ts,
+				)
+				result, err := node.Mutate(mutation)
+				if err != nil || len(result.Errors) > 0 {
+					errors.Add(1)
+				} else {
+					writeSuccess.Add(1)
+				}
+			}
+		}(w)
+	}
+
+	// Start readers
+	for r := 0; r < numReaders; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for op := 0; op < opsPerGoroutine; op++ {
+				result, err := node.Query("{ Event { name timestamp } }")
+				if err != nil || len(result.Errors) > 0 {
+					errors.Add(1)
+				} else {
+					readSuccess.Add(1)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	totalWrites := int64(numWriters * opsPerGoroutine)
+	totalReads := int64(numReaders * opsPerGoroutine)
+	t.Logf("Mixed ops: %d/%d writes, %d/%d reads, %d errors",
+		writeSuccess.Load(), totalWrites,
+		readSuccess.Load(), totalReads,
+		errors.Load())
+
+	assert.Equal(t, totalWrites, writeSuccess.Load(), "all writes should succeed")
+	assert.Equal(t, totalReads, readSuccess.Load(), "all reads should succeed")
+	assert.Equal(t, int64(0), errors.Load(), "no operations should fail")
+}
+
+// TestConcurrentSchemaAndQueries tests adding schemas while querying.
+func TestConcurrentSchemaAndQueries(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add initial schema
+	_, err = node.AddSchema("type Base { name: String }")
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var schemaErrors atomic.Int64
+	var queryErrors atomic.Int64
+
+	// Query the base type while adding new schemas
+	const numQueries = 20
+	for i := 0; i < numQueries; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := node.Query("{ Base { name } }")
+			if err != nil {
+				queryErrors.Add(1)
+			}
+		}()
+	}
+
+	// Add additional schemas concurrently
+	const numSchemas = 3
+	for i := 0; i < numSchemas; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sdl := fmt.Sprintf("type Extra%d { value: Int }", idx)
+			_, err := node.AddSchema(sdl)
+			if err != nil {
+				schemaErrors.Add(1)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	t.Logf("Schema+Query: %d schema errors, %d query errors",
+		schemaErrors.Load(), queryErrors.Load())
+
+	// Queries should succeed even during schema changes
+	assert.Equal(t, int64(0), queryErrors.Load(), "queries should not fail during schema adds")
+}
+
+// TestConcurrentMultipleNodes tests operations across multiple nodes.
+func TestConcurrentMultipleNodes(t *testing.T) {
+	Init()
+
+	const numNodes = 5
+	nodes := make([]*Node, numNodes)
+
+	// Create nodes
+	for i := 0; i < numNodes; i++ {
+		node, err := NewNode(NodeOptions{InMemory: true})
+		require.NoError(t, err)
+		nodes[i] = node
+
+		// Each node gets its own schema
+		sdl := fmt.Sprintf("type Node%dData { value: Int }", i)
+		_, err = node.AddSchema(sdl)
+		require.NoError(t, err)
+	}
+	defer func() {
+		for _, n := range nodes {
+			n.Close()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	var errors atomic.Int64
+
+	// Run operations on all nodes concurrently
+	for i := 0; i < numNodes; i++ {
+		wg.Add(1)
+		go func(nodeIdx int) {
+			defer wg.Done()
+			node := nodes[nodeIdx]
+			typeName := fmt.Sprintf("Node%dData", nodeIdx)
+
+			// Create documents
+			for j := 0; j < 10; j++ {
+				mutation := fmt.Sprintf(
+					`mutation { create_%s(input: {value: %d}) { _docID } }`,
+					typeName, j,
+				)
+				result, err := node.Mutate(mutation)
+				if err != nil || len(result.Errors) > 0 {
+					errors.Add(1)
+				}
+			}
+
+			// Query documents
+			query := fmt.Sprintf("{ %s { value } }", typeName)
+			result, err := node.Query(query)
+			if err != nil || len(result.Errors) > 0 {
+				errors.Add(1)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, int64(0), errors.Load(), "all multi-node operations should succeed")
+}
+
+// TestStressHighConcurrency runs a high-concurrency stress test.
+func TestStressHighConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in short mode")
+	}
+
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type Stress { id: Int, data: String }")
+	require.NoError(t, err)
+
+	const numGoroutines = 50
+	const opsPerGoroutine = 20
+	var wg sync.WaitGroup
+	var totalOps atomic.Int64
+	var errors atomic.Int64
+
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for op := 0; op < opsPerGoroutine; op++ {
+				// Alternate between mutations and queries
+				if op%2 == 0 {
+					mutation := fmt.Sprintf(
+						`mutation { create_Stress(input: {id: %d, data: "g%d_op%d"}) { _docID } }`,
+						gid*1000+op, gid, op,
+					)
+					result, err := node.Mutate(mutation)
+					if err != nil || len(result.Errors) > 0 {
+						errors.Add(1)
+					}
+				} else {
+					result, err := node.Query("{ Stress { id data } }")
+					if err != nil || len(result.Errors) > 0 {
+						errors.Add(1)
+					}
+				}
+				totalOps.Add(1)
+			}
+		}(g)
+	}
+
+	wg.Wait()
+
+	expectedOps := int64(numGoroutines * opsPerGoroutine)
+	t.Logf("Stress test: %d total ops, %d errors", totalOps.Load(), errors.Load())
+
+	assert.Equal(t, expectedOps, totalOps.Load())
+	assert.Equal(t, int64(0), errors.Load(), "stress test should have no errors")
+}

--- a/tests/interop/ffi/defra.go
+++ b/tests/interop/ffi/defra.go
@@ -1,0 +1,227 @@
+// Package ffi provides Go bindings for the DefraDB Rust FFI.
+//
+// This package wraps the C FFI exposed by the Rust `ffi` crate,
+// providing a Go-native interface for integration testing.
+//
+// Build requirements:
+//   - Rust library must be built first: cargo build --release -p ffi
+//   - CGO must be enabled: CGO_ENABLED=1
+package ffi
+
+/*
+#cgo CFLAGS: -I../../../crates/ffi
+#cgo LDFLAGS: -L../../../target/release -lffi -ldl -lpthread -lm
+
+#include "defra.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"unsafe"
+)
+
+var (
+	// initOnce ensures Init is only called once
+	initOnce sync.Once
+
+	// ErrNotInitialized is returned when FFI functions are called before Init
+	ErrNotInitialized = errors.New("ffi: not initialized - call Init() first")
+)
+
+// Init initializes the FFI library.
+// Must be called before any other FFI functions.
+// Safe to call multiple times.
+func Init() {
+	initOnce.Do(func() {
+		C.defra_init()
+	})
+}
+
+// Version returns the library version string.
+func Version() string {
+	cstr := C.defra_version()
+	if cstr == nil {
+		return ""
+	}
+	defer C.defra_free_string(cstr)
+	return C.GoString(cstr)
+}
+
+// Node represents a DefraDB node handle.
+type Node struct {
+	ptr C.uintptr_t
+}
+
+// NodeOptions configures node creation.
+type NodeOptions struct {
+	// DBPath is the path to the database directory.
+	// If empty, an in-memory database is used.
+	DBPath string
+
+	// InMemory forces in-memory storage even if DBPath is set.
+	InMemory bool
+}
+
+// NewNode creates a new DefraDB node.
+// The node must be closed with Close() when done.
+func NewNode(opts NodeOptions) (*Node, error) {
+	var cOpts C.struct_NodeInitOptions
+
+	if opts.DBPath != "" {
+		cDBPath := C.CString(opts.DBPath)
+		defer C.free(unsafe.Pointer(cDBPath))
+		cOpts.db_path = cDBPath
+	}
+
+	if opts.InMemory || opts.DBPath == "" {
+		cOpts.in_memory = 1
+	} else {
+		cOpts.in_memory = 0
+	}
+
+	result := C.new_node(cOpts)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return nil, fmt.Errorf("ffi: new_node failed: %s", err)
+	}
+
+	return &Node{ptr: result.node_ptr}, nil
+}
+
+// Close closes the node and releases resources.
+// After calling Close, the node handle is no longer valid.
+func (n *Node) Close() error {
+	result := C.node_close(n.ptr)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return fmt.Errorf("ffi: node_close failed: %s", err)
+	}
+
+	return nil
+}
+
+// AddSchema adds a GraphQL SDL schema to the database.
+// Returns the JSON response containing created collection versions.
+func (n *Node) AddSchema(sdl string) (string, error) {
+	cSDL := C.CString(sdl)
+	defer C.free(unsafe.Pointer(cSDL))
+
+	result := C.add_schema(n.ptr, cSDL)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return "", fmt.Errorf("ffi: add_schema failed: %s", err)
+	}
+
+	value := C.GoString(result.value)
+	C.defra_free_string(result.value)
+	return value, nil
+}
+
+// GetCollections returns all collections in the database as JSON.
+func (n *Node) GetCollections() (string, error) {
+	result := C.get_collections(n.ptr)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return "", fmt.Errorf("ffi: get_collections failed: %s", err)
+	}
+
+	value := C.GoString(result.value)
+	C.defra_free_string(result.value)
+	return value, nil
+}
+
+// QueryResult represents a GraphQL query response.
+type QueryResult struct {
+	Data   json.RawMessage `json:"data,omitempty"`
+	Errors []QueryError    `json:"errors,omitempty"`
+}
+
+// QueryError represents a GraphQL error.
+type QueryError struct {
+	Message   string          `json:"message"`
+	Locations []ErrorLocation `json:"locations,omitempty"`
+	Path      []interface{}   `json:"path,omitempty"`
+}
+
+// ErrorLocation indicates where an error occurred in the query.
+type ErrorLocation struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+// ExecRequest executes a GraphQL query or mutation.
+// Returns the raw JSON response string.
+func (n *Node) ExecRequest(query string, operationName string, variables string) (string, error) {
+	cQuery := C.CString(query)
+	defer C.free(unsafe.Pointer(cQuery))
+
+	var cOpName *C.char
+	if operationName != "" {
+		cOpName = C.CString(operationName)
+		defer C.free(unsafe.Pointer(cOpName))
+	}
+
+	var cVars *C.char
+	if variables != "" {
+		cVars = C.CString(variables)
+		defer C.free(unsafe.Pointer(cVars))
+	}
+
+	result := C.exec_request(n.ptr, cQuery, cOpName, cVars)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return "", fmt.Errorf("ffi: exec_request failed: %s", err)
+	}
+
+	value := C.GoString(result.value)
+	C.defra_free_string(result.value)
+	return value, nil
+}
+
+// Query executes a GraphQL query and returns a parsed result.
+func (n *Node) Query(query string) (*QueryResult, error) {
+	return n.QueryWithVars(query, "", nil)
+}
+
+// QueryWithVars executes a GraphQL query with variables.
+func (n *Node) QueryWithVars(query string, operationName string, variables map[string]interface{}) (*QueryResult, error) {
+	var varsJSON string
+	if variables != nil {
+		varsBytes, err := json.Marshal(variables)
+		if err != nil {
+			return nil, fmt.Errorf("ffi: failed to marshal variables: %w", err)
+		}
+		varsJSON = string(varsBytes)
+	}
+
+	responseJSON, err := n.ExecRequest(query, operationName, varsJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	var result QueryResult
+	if err := json.Unmarshal([]byte(responseJSON), &result); err != nil {
+		return nil, fmt.Errorf("ffi: failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// Mutate executes a GraphQL mutation and returns a parsed result.
+func (n *Node) Mutate(mutation string) (*QueryResult, error) {
+	return n.Query(mutation)
+}

--- a/tests/interop/ffi/defra.go
+++ b/tests/interop/ffi/defra.go
@@ -225,3 +225,124 @@ func (n *Node) QueryWithVars(query string, operationName string, variables map[s
 func (n *Node) Mutate(mutation string) (*QueryResult, error) {
 	return n.Query(mutation)
 }
+
+// Transaction represents an active database transaction.
+type Transaction struct {
+	node *Node
+	id   string
+}
+
+// BeginTxn starts a new transaction.
+// If readonly is true, the transaction cannot perform write operations.
+// The transaction must be committed or rolled back when done.
+func (n *Node) BeginTxn(readonly bool) (*Transaction, error) {
+	var readonlyInt C.int32_t
+	if readonly {
+		readonlyInt = 1
+	}
+
+	result := C.begin_txn(n.ptr, readonlyInt)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return nil, fmt.Errorf("ffi: begin_txn failed: %s", err)
+	}
+
+	txnID := C.GoString(result.txn_id)
+	C.defra_free_string(result.txn_id)
+
+	return &Transaction{node: n, id: txnID}, nil
+}
+
+// ID returns the transaction ID.
+func (t *Transaction) ID() string {
+	return t.id
+}
+
+// Commit commits the transaction, making all changes permanent.
+// After commit, the transaction is no longer valid.
+func (t *Transaction) Commit() error {
+	cTxnID := C.CString(t.id)
+	defer C.free(unsafe.Pointer(cTxnID))
+
+	result := C.commit_txn(t.node.ptr, cTxnID)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return fmt.Errorf("ffi: commit_txn failed: %s", err)
+	}
+
+	return nil
+}
+
+// Rollback discards all changes made in the transaction.
+// After rollback, the transaction is no longer valid.
+func (t *Transaction) Rollback() error {
+	cTxnID := C.CString(t.id)
+	defer C.free(unsafe.Pointer(cTxnID))
+
+	result := C.rollback_txn(t.node.ptr, cTxnID)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return fmt.Errorf("ffi: rollback_txn failed: %s", err)
+	}
+
+	return nil
+}
+
+// ExecRequest executes a GraphQL query or mutation within the transaction.
+func (t *Transaction) ExecRequest(query string, operationName string, variables string) (string, error) {
+	cTxnID := C.CString(t.id)
+	defer C.free(unsafe.Pointer(cTxnID))
+
+	cQuery := C.CString(query)
+	defer C.free(unsafe.Pointer(cQuery))
+
+	var cOpName *C.char
+	if operationName != "" {
+		cOpName = C.CString(operationName)
+		defer C.free(unsafe.Pointer(cOpName))
+	}
+
+	var cVars *C.char
+	if variables != "" {
+		cVars = C.CString(variables)
+		defer C.free(unsafe.Pointer(cVars))
+	}
+
+	result := C.exec_request_in_txn(t.node.ptr, cTxnID, cQuery, cOpName, cVars)
+
+	if result.status != 0 {
+		err := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return "", fmt.Errorf("ffi: exec_request_in_txn failed: %s", err)
+	}
+
+	value := C.GoString(result.value)
+	C.defra_free_string(result.value)
+	return value, nil
+}
+
+// Query executes a GraphQL query within the transaction.
+func (t *Transaction) Query(query string) (*QueryResult, error) {
+	responseJSON, err := t.ExecRequest(query, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	var result QueryResult
+	if err := json.Unmarshal([]byte(responseJSON), &result); err != nil {
+		return nil, fmt.Errorf("ffi: failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// Mutate executes a GraphQL mutation within the transaction.
+func (t *Transaction) Mutate(mutation string) (*QueryResult, error) {
+	return t.Query(mutation)
+}

--- a/tests/interop/ffi/defra_test.go
+++ b/tests/interop/ffi/defra_test.go
@@ -1,0 +1,239 @@
+package ffi
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	// Should not panic
+	Init()
+	// Should be idempotent
+	Init()
+	Init()
+}
+
+func TestVersion(t *testing.T) {
+	Init()
+
+	version := Version()
+	assert.NotEmpty(t, version)
+	assert.True(t, strings.HasPrefix(version, "0."), "version should start with 0.")
+}
+
+func TestNewNodeAndClose(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	err = node.Close()
+	require.NoError(t, err)
+}
+
+func TestNodeDoubleClose(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+
+	err = node.Close()
+	require.NoError(t, err)
+
+	// Second close should fail
+	err = node.Close()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid")
+}
+
+func TestAddSchema(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add a simple schema
+	sdl := "type User { name: String, age: Int }"
+	result, err := node.AddSchema(sdl)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+
+	// Result should be valid JSON
+	var collections []interface{}
+	err = json.Unmarshal([]byte(result), &collections)
+	require.NoError(t, err)
+	assert.NotEmpty(t, collections)
+}
+
+func TestGetCollections(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add schema first
+	_, err = node.AddSchema("type Person { name: String }")
+	require.NoError(t, err)
+
+	// Get collections
+	result, err := node.GetCollections()
+	require.NoError(t, err)
+	assert.Contains(t, result, "Person")
+}
+
+func TestQuery(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type User { name: String }")
+	require.NoError(t, err)
+
+	// Query empty collection
+	result, err := node.Query("{ User { name } }")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotNil(t, result.Data)
+	assert.Empty(t, result.Errors)
+}
+
+func TestMutation(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type User { name: String, age: Int }")
+	require.NoError(t, err)
+
+	// Create a document
+	result, err := node.Mutate(`mutation { create_User(input: {name: "Alice", age: 30}) { _docID name age } }`)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Errors)
+
+	// Verify the data contains Alice
+	var data map[string]interface{}
+	err = json.Unmarshal(result.Data, &data)
+	require.NoError(t, err)
+
+	// create_User returns an array of created documents
+	createUserArr := data["create_User"].([]interface{})
+	require.Len(t, createUserArr, 1)
+	createUser := createUserArr[0].(map[string]interface{})
+	assert.Equal(t, "Alice", createUser["name"])
+	assert.Equal(t, float64(30), createUser["age"])
+}
+
+func TestQueryAfterMutation(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Book { title: String, author: String }")
+	require.NoError(t, err)
+
+	// Create documents
+	_, err = node.Mutate(`mutation { create_Book(input: {title: "1984", author: "Orwell"}) { _docID } }`)
+	require.NoError(t, err)
+
+	_, err = node.Mutate(`mutation { create_Book(input: {title: "Dune", author: "Herbert"}) { _docID } }`)
+	require.NoError(t, err)
+
+	// Query all books
+	result, err := node.Query("{ Book { title author } }")
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	var data map[string]interface{}
+	err = json.Unmarshal(result.Data, &data)
+	require.NoError(t, err)
+
+	books := data["Book"].([]interface{})
+	assert.Len(t, books, 2)
+}
+
+func TestExecRequestRaw(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Item { name: String }")
+	require.NoError(t, err)
+
+	// Test raw exec request returns valid JSON
+	responseJSON, err := node.ExecRequest(
+		`mutation { create_Item(input: {name: "RawTest"}) { _docID name } }`,
+		"",
+		"",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, responseJSON, "RawTest")
+	assert.Contains(t, responseJSON, "data")
+}
+
+func TestInvalidQuery(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Query without schema should return error in response
+	result, err := node.Query("{ NonExistent { field } }")
+	require.NoError(t, err) // FFI call succeeds
+	require.NotNil(t, result)
+	// But response should contain errors
+	assert.NotEmpty(t, result.Errors)
+}
+
+func TestMultipleNodes(t *testing.T) {
+	Init()
+
+	// Create two nodes
+	node1, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+
+	node2, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+
+	// Add different schemas
+	_, err = node1.AddSchema("type Foo { x: Int }")
+	require.NoError(t, err)
+
+	_, err = node2.AddSchema("type Bar { y: String }")
+	require.NoError(t, err)
+
+	// Each node should only see its own collections
+	cols1, err := node1.GetCollections()
+	require.NoError(t, err)
+	assert.Contains(t, cols1, "Foo")
+	assert.NotContains(t, cols1, "Bar")
+
+	cols2, err := node2.GetCollections()
+	require.NoError(t, err)
+	assert.Contains(t, cols2, "Bar")
+	assert.NotContains(t, cols2, "Foo")
+
+	// Clean up
+	require.NoError(t, node1.Close())
+	require.NoError(t, node2.Close())
+}

--- a/tests/interop/ffi/txn_test.go
+++ b/tests/interop/ffi/txn_test.go
@@ -1,0 +1,256 @@
+package ffi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Note: Currently execute_in_txn only supports queries, not mutations.
+// Mutation support in transactions requires query runner changes.
+// These tests focus on what's currently working.
+
+func TestTransactionQuery(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type TxnQueryItem { name: String, value: Int }")
+	require.NoError(t, err)
+
+	// Create some data first (outside transaction)
+	_, err = node.Mutate(`mutation { create_TxnQueryItem(input: {name: "test", value: 42}) { _docID } }`)
+	require.NoError(t, err)
+
+	// Begin transaction
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+	require.NotEmpty(t, txn.ID())
+
+	// Query within transaction
+	result, err := txn.Query("{ TxnQueryItem { name value } }")
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	var data map[string]interface{}
+	err = json.Unmarshal(result.Data, &data)
+	require.NoError(t, err)
+
+	items := data["TxnQueryItem"].([]interface{})
+	assert.Len(t, items, 1)
+	item := items[0].(map[string]interface{})
+	assert.Equal(t, "test", item["name"])
+	assert.Equal(t, float64(42), item["value"])
+
+	// Commit transaction
+	err = txn.Commit()
+	require.NoError(t, err)
+}
+
+func TestTransactionRollback(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type RollbackItem { name: String }")
+	require.NoError(t, err)
+
+	// Begin transaction
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	// Query within transaction (empty result expected)
+	result, err := txn.Query("{ RollbackItem { name } }")
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	// Rollback transaction
+	err = txn.Rollback()
+	require.NoError(t, err)
+}
+
+func TestTransactionReadOnly(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type ReadOnlyItem { name: String }")
+	require.NoError(t, err)
+
+	// Create initial data
+	_, err = node.Mutate(`mutation { create_ReadOnlyItem(input: {name: "existing"}) { _docID } }`)
+	require.NoError(t, err)
+
+	// Begin readonly transaction
+	txn, err := node.BeginTxn(true)
+	require.NoError(t, err)
+
+	// Query should work in readonly transaction
+	result, err := txn.Query("{ ReadOnlyItem { name } }")
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	var data map[string]interface{}
+	err = json.Unmarshal(result.Data, &data)
+	require.NoError(t, err)
+
+	items := data["ReadOnlyItem"].([]interface{})
+	assert.Len(t, items, 1)
+
+	// Commit readonly transaction
+	err = txn.Commit()
+	require.NoError(t, err)
+}
+
+func TestTransactionInvalidID(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	// Create a fake transaction with invalid ID
+	fakeTxn := &Transaction{node: node, id: "invalid-txn-id-12345"}
+
+	// Commit should fail
+	err = fakeTxn.Commit()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed")
+}
+
+func TestTransactionDoubleCommit(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type DoubleCommitItem { name: String }")
+	require.NoError(t, err)
+
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	// First commit should succeed
+	err = txn.Commit()
+	require.NoError(t, err)
+
+	// Second commit should fail (transaction no longer valid)
+	err = txn.Commit()
+	assert.Error(t, err)
+}
+
+func TestTransactionMultipleQueries(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type MultiQueryItem { seq: Int }")
+	require.NoError(t, err)
+
+	// Create some data
+	for i := 0; i < 3; i++ {
+		_, err = node.Mutate(`mutation { create_MultiQueryItem(input: {seq: ` + string(rune('0'+i)) + `}) { _docID } }`)
+		require.NoError(t, err)
+	}
+
+	// Begin transaction
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	// Execute multiple queries in same transaction
+	for i := 0; i < 5; i++ {
+		result, err := txn.Query("{ MultiQueryItem { seq } }")
+		require.NoError(t, err)
+		require.Empty(t, result.Errors, "query %d should succeed", i)
+	}
+
+	// Commit
+	err = txn.Commit()
+	require.NoError(t, err)
+}
+
+func TestConcurrentTransactions(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type ConcurrentItem { txn_id: Int, value: Int }")
+	require.NoError(t, err)
+
+	// Create some data
+	for i := 0; i < 5; i++ {
+		_, err = node.Mutate(`mutation { create_ConcurrentItem(input: {txn_id: ` + string(rune('0'+i)) + `, value: ` + string(rune('0'+i)) + `}) { _docID } }`)
+		require.NoError(t, err)
+	}
+
+	// Create multiple concurrent transactions (readonly queries)
+	const numTxns = 5
+	txns := make([]*Transaction, numTxns)
+	for i := 0; i < numTxns; i++ {
+		txn, err := node.BeginTxn(true) // readonly
+		require.NoError(t, err)
+		txns[i] = txn
+	}
+
+	// Each transaction queries
+	for _, txn := range txns {
+		result, err := txn.Query("{ ConcurrentItem { txn_id value } }")
+		require.NoError(t, err)
+		require.Empty(t, result.Errors)
+	}
+
+	// Commit all transactions
+	for _, txn := range txns {
+		err := txn.Commit()
+		require.NoError(t, err)
+	}
+}
+
+func TestTransactionQueryWithExistingData(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type ExistingDataItem { name: String, count: Int }")
+	require.NoError(t, err)
+
+	// Create multiple documents
+	names := []string{"Alice", "Bob", "Charlie"}
+	for i, name := range names {
+		_, err = node.Mutate(`mutation { create_ExistingDataItem(input: {name: "` + name + `", count: ` + string(rune('0'+i)) + `}) { _docID } }`)
+		require.NoError(t, err)
+	}
+
+	// Query in transaction
+	txn, err := node.BeginTxn(true)
+	require.NoError(t, err)
+
+	result, err := txn.Query("{ ExistingDataItem { name count } }")
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	var data map[string]interface{}
+	err = json.Unmarshal(result.Data, &data)
+	require.NoError(t, err)
+
+	items := data["ExistingDataItem"].([]interface{})
+	assert.Len(t, items, 3)
+
+	err = txn.Commit()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Adds new `crates/ffi` crate with C-compatible FFI bindings for DefraDB.rs
- Enables integration with Go code via CGO for running DefraDB Go integration tests against Rust implementation
- Fixes bug in query runner where explain methods referenced removed `self.collections` field

## FFI Functions

| Function | Purpose |
|----------|---------|
| `defra_init()` | Initialize the library (required first) |
| `defra_version()` | Get library version string |
| `new_node()` | Create in-memory database node |
| `node_close()` | Close and cleanup node |
| `add_schema()` | Add GraphQL SDL schema |
| `get_collections()` | List all collections |
| `exec_request()` | Execute GraphQL queries/mutations |
| `defra_free_string()` | Free allocated strings |

## Architecture

The FFI layer bridges async Rust with synchronous C by:
- Using a global Tokio runtime for async operations
- Managing node handles via a thread-safe registry
- Returning JSON strings for complex types (matching Go's cbindings pattern)
- Using Result structs with status/error/value fields

## Build

```bash
cargo build -p ffi --release  # Produces libffi.a + libffi.dylib
cbindgen --crate ffi --output defra.h  # Generate C header
```

## Test plan

- [x] All 13 FFI unit tests pass
- [x] Full workflow test: init → create node → add schema → create document → query → close
- [ ] Manual: Link from Go and verify CGO integration

Ref: Issue #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)