### PR TITLE
feat(ffi): Add mutation support to execute_in_txn

### DIFF
--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -84,4 +84,12 @@ impl<S: Store + 'static> TransactionContext for DbTransactionContext<S> {
     fn doc_fetcher(&self) -> Arc<dyn DocFetcher> {
         self.fetcher.clone()
     }
+
+    fn doc_mutator(&self) -> Option<Arc<dyn DocMutator>> {
+        if self.readonly {
+            None
+        } else {
+            Some(self.doc_mutator())
+        }
+    }
 }

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -101,15 +101,69 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryExecutor for QueryRunner<F, R> 
             }
         };
 
+        // Parse the request to determine if it's a query or mutation
+        let parsed = match parse_request(&request.query) {
+            Ok(p) => p,
+            Err(e) => {
+                return QueryResponse {
+                    data: None,
+                    errors: vec![QueryResponseError {
+                        message: format!("parse error: {}", e),
+                        path: None,
+                        locations: None,
+                    }],
+                };
+            }
+        };
+
         // Resolve effective identity: request identity takes precedence over default
         let identity = self.resolve_identity(request.identity);
 
-        // Get the transaction-scoped fetcher and execute with identity for ACP
-        let fetcher = txn_ctx.doc_fetcher();
-        match self
-            .execute_query_internal(&request.query, fetcher.as_ref(), identity)
-            .await
-        {
+        // Route to appropriate handler based on operation type
+        let result = match parsed {
+            ParsedOperation::Query { explain, .. } => {
+                // Get the transaction-scoped fetcher and execute with identity for ACP
+                let fetcher = txn_ctx.doc_fetcher();
+                if let Some(explain_type) = explain {
+                    // Return query plan instead of executing
+                    self.explain_query_with_identity(&request.query, identity, explain_type)
+                        .await
+                } else {
+                    self.execute_query_internal(&request.query, fetcher.as_ref(), identity)
+                        .await
+                }
+            }
+            ParsedOperation::Mutation(_) => {
+                // Check if this is a read-only transaction
+                if txn_ctx.is_readonly() {
+                    return QueryResponse::error(
+                        "cannot execute mutation in read-only transaction".to_string(),
+                    );
+                }
+
+                // Get the transaction-scoped mutator
+                let mutator = match txn_ctx.doc_mutator() {
+                    Some(m) => m,
+                    None => {
+                        return QueryResponse::error(
+                            "mutations not supported in this transaction context".to_string(),
+                        );
+                    }
+                };
+
+                self.execute_mutation_internal(&request.query, mutator, identity)
+                    .await
+            }
+            ParsedOperation::Subscription { .. } => {
+                // Subscriptions require SSE transport
+                Err(crate::error::QueryError::parse(
+                    "Subscriptions must be executed via Server-Sent Events (SSE). \
+                     Send the request with Accept: text/event-stream header.",
+                ))
+            }
+        };
+
+        match result {
             Ok(data) => QueryResponse {
                 data: Some(data),
                 errors: vec![],

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -63,7 +63,7 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
     }
 
     /// Execute a GraphQL mutation with a specific mutator and caller_identity.
-    async fn execute_mutation_internal(
+    pub(crate) async fn execute_mutation_internal(
         &self,
         mutation_str: &str,
         mutator: Arc<dyn DocMutator>,

--- a/crates/query/src/txn/context.rs
+++ b/crates/query/src/txn/context.rs
@@ -2,12 +2,13 @@
 
 use std::sync::Arc;
 
+use crate::mutator::DocMutator;
 use crate::runner::DocFetcher;
 
 /// Transaction context that provides storage access within a transaction.
 ///
 /// This is implemented by the database layer to provide transaction-scoped
-/// document fetching.
+/// document fetching and mutation.
 pub trait TransactionContext: Send + Sync {
     /// Get the transaction ID.
     fn id(&self) -> &str;
@@ -17,6 +18,17 @@ pub trait TransactionContext: Send + Sync {
 
     /// Get a document fetcher scoped to this transaction.
     fn doc_fetcher(&self) -> Arc<dyn DocFetcher>;
+
+    /// Get a document mutator scoped to this transaction.
+    ///
+    /// Returns `None` if this is a read-only transaction or if mutators
+    /// are not supported by this context implementation.
+    ///
+    /// The mutator shares the same underlying transaction as the fetcher,
+    /// so all read and write operations are within the same transaction context.
+    fn doc_mutator(&self) -> Option<Arc<dyn DocMutator>> {
+        None
+    }
 
     /// Check if the transaction is still active (not yet committed or rolled back).
     ///

--- a/tests/interop/ffi/txn_test.go
+++ b/tests/interop/ffi/txn_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Note: Currently execute_in_txn only supports queries, not mutations.
-// Mutation support in transactions requires query runner changes.
-// These tests focus on what's currently working.
-
 func TestTransactionQuery(t *testing.T) {
 	Init()
 
@@ -253,4 +249,322 @@ func TestTransactionQueryWithExistingData(t *testing.T) {
 
 	err = txn.Commit()
 	require.NoError(t, err)
+}
+
+// ============================================================================
+// Transaction Mutation Tests
+// ============================================================================
+
+func TestTransactionMutationCreate(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type TxnCreateItem { name: String, value: Int }")
+	require.NoError(t, err)
+
+	// Begin transaction
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	// Create document within transaction
+	result, err := txn.Mutate(`mutation { create_TxnCreateItem(input: {name: "txn-item", value: 123}) { _docID name value } }`)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors, "mutation should succeed")
+
+	var data map[string]interface{}
+	err = json.Unmarshal(result.Data, &data)
+	require.NoError(t, err)
+
+	items := data["create_TxnCreateItem"].([]interface{})
+	assert.Len(t, items, 1)
+	item := items[0].(map[string]interface{})
+	assert.Equal(t, "txn-item", item["name"])
+	assert.Equal(t, float64(123), item["value"])
+	docID := item["_docID"].(string)
+	assert.NotEmpty(t, docID)
+
+	// Query within same transaction should see the new document
+	queryResult, err := txn.Query("{ TxnCreateItem { name value } }")
+	require.NoError(t, err)
+	require.Empty(t, queryResult.Errors)
+
+	var queryData map[string]interface{}
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	queryItems := queryData["TxnCreateItem"].([]interface{})
+	assert.Len(t, queryItems, 1)
+
+	// Commit transaction
+	err = txn.Commit()
+	require.NoError(t, err)
+
+	// Verify data persisted after commit
+	queryResult, err = node.Query("{ TxnCreateItem { name value } }")
+	require.NoError(t, err)
+	require.Empty(t, queryResult.Errors)
+
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	queryItems = queryData["TxnCreateItem"].([]interface{})
+	assert.Len(t, queryItems, 1)
+}
+
+func TestTransactionMutationCreateRollback(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type RollbackCreateItem { name: String }")
+	require.NoError(t, err)
+
+	// Begin transaction
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	// Create document within transaction
+	result, err := txn.Mutate(`mutation { create_RollbackCreateItem(input: {name: "will-be-rolled-back"}) { _docID } }`)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors, "mutation should succeed")
+
+	// Rollback transaction
+	err = txn.Rollback()
+	require.NoError(t, err)
+
+	// Verify data was NOT persisted
+	queryResult, err := node.Query("{ RollbackCreateItem { name } }")
+	require.NoError(t, err)
+	require.Empty(t, queryResult.Errors)
+
+	var queryData map[string]interface{}
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	items := queryData["RollbackCreateItem"].([]interface{})
+	assert.Len(t, items, 0, "rolled back document should not be visible")
+}
+
+func TestTransactionMutationUpdate(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type TxnUpdateItem { name: String, value: Int }")
+	require.NoError(t, err)
+
+	// Create initial document outside transaction
+	createResult, err := node.Mutate(`mutation { create_TxnUpdateItem(input: {name: "original", value: 1}) { _docID } }`)
+	require.NoError(t, err)
+	require.Empty(t, createResult.Errors)
+
+	var createData map[string]interface{}
+	err = json.Unmarshal(createResult.Data, &createData)
+	require.NoError(t, err)
+	docID := createData["create_TxnUpdateItem"].([]interface{})[0].(map[string]interface{})["_docID"].(string)
+
+	// Begin transaction and update
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	// Update document within transaction
+	result, err := txn.Mutate(`mutation { update_TxnUpdateItem(docIDs: ["` + docID + `"], input: {value: 999}) { _docID name value } }`)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors, "update mutation should succeed")
+
+	var updateData map[string]interface{}
+	err = json.Unmarshal(result.Data, &updateData)
+	require.NoError(t, err)
+
+	items := updateData["update_TxnUpdateItem"].([]interface{})
+	assert.Len(t, items, 1)
+	item := items[0].(map[string]interface{})
+	assert.Equal(t, "original", item["name"]) // name unchanged
+	assert.Equal(t, float64(999), item["value"])
+
+	// Commit transaction
+	err = txn.Commit()
+	require.NoError(t, err)
+
+	// Verify update persisted
+	queryResult, err := node.Query("{ TxnUpdateItem { name value } }")
+	require.NoError(t, err)
+
+	var queryData map[string]interface{}
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	queryItems := queryData["TxnUpdateItem"].([]interface{})
+	assert.Len(t, queryItems, 1)
+	assert.Equal(t, float64(999), queryItems[0].(map[string]interface{})["value"])
+}
+
+func TestTransactionMutationDelete(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type TxnDeleteItem { name: String }")
+	require.NoError(t, err)
+
+	// Create document outside transaction
+	createResult, err := node.Mutate(`mutation { create_TxnDeleteItem(input: {name: "to-delete"}) { _docID } }`)
+	require.NoError(t, err)
+	require.Empty(t, createResult.Errors)
+
+	var createData map[string]interface{}
+	err = json.Unmarshal(createResult.Data, &createData)
+	require.NoError(t, err)
+	docID := createData["create_TxnDeleteItem"].([]interface{})[0].(map[string]interface{})["_docID"].(string)
+
+	// Begin transaction and delete
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	// Delete document within transaction
+	result, err := txn.Mutate(`mutation { delete_TxnDeleteItem(docIDs: ["` + docID + `"]) { _docID } }`)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors, "delete mutation should succeed")
+
+	// Commit transaction
+	err = txn.Commit()
+	require.NoError(t, err)
+
+	// Verify document was deleted
+	queryResult, err := node.Query("{ TxnDeleteItem { name } }")
+	require.NoError(t, err)
+
+	var queryData map[string]interface{}
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	items := queryData["TxnDeleteItem"].([]interface{})
+	assert.Len(t, items, 0, "deleted document should not be visible")
+}
+
+func TestTransactionMutationMultipleOperations(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type TxnMultiItem { name: String, count: Int }")
+	require.NoError(t, err)
+
+	// Begin transaction
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	// Create multiple documents in same transaction
+	for i := 0; i < 5; i++ {
+		result, err := txn.Mutate(`mutation { create_TxnMultiItem(input: {name: "item-` + string(rune('0'+i)) + `", count: ` + string(rune('0'+i)) + `}) { _docID } }`)
+		require.NoError(t, err)
+		require.Empty(t, result.Errors, "mutation %d should succeed", i)
+	}
+
+	// Query within transaction
+	queryResult, err := txn.Query("{ TxnMultiItem { name count } }")
+	require.NoError(t, err)
+	require.Empty(t, queryResult.Errors)
+
+	var queryData map[string]interface{}
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	items := queryData["TxnMultiItem"].([]interface{})
+	assert.Len(t, items, 5)
+
+	// Commit transaction
+	err = txn.Commit()
+	require.NoError(t, err)
+
+	// Verify all documents persisted
+	queryResult, err = node.Query("{ TxnMultiItem { name } }")
+	require.NoError(t, err)
+
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	items = queryData["TxnMultiItem"].([]interface{})
+	assert.Len(t, items, 5)
+}
+
+func TestTransactionMutationReadOnlyFails(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type ReadOnlyMutateItem { name: String }")
+	require.NoError(t, err)
+
+	// Begin readonly transaction
+	txn, err := node.BeginTxn(true)
+	require.NoError(t, err)
+
+	// Attempt mutation in readonly transaction - should fail
+	result, err := txn.Mutate(`mutation { create_ReadOnlyMutateItem(input: {name: "should-fail"}) { _docID } }`)
+	require.NoError(t, err) // FFI call succeeds
+	assert.NotEmpty(t, result.Errors, "mutation in readonly txn should return errors")
+	assert.Contains(t, result.Errors[0].Message, "read-only", "error should mention read-only")
+
+	// Rollback since commit would fail anyway
+	err = txn.Rollback()
+	require.NoError(t, err)
+}
+
+func TestTransactionMutationIsolation(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	require.NoError(t, err)
+	defer node.Close()
+
+	_, err = node.AddSchema("type IsolationItem { name: String }")
+	require.NoError(t, err)
+
+	// Begin transaction and create document
+	txn, err := node.BeginTxn(false)
+	require.NoError(t, err)
+
+	result, err := txn.Mutate(`mutation { create_IsolationItem(input: {name: "isolated"}) { _docID } }`)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	// Query outside transaction - should NOT see uncommitted data
+	queryResult, err := node.Query("{ IsolationItem { name } }")
+	require.NoError(t, err)
+	require.Empty(t, queryResult.Errors)
+
+	var queryData map[string]interface{}
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	items := queryData["IsolationItem"].([]interface{})
+	assert.Len(t, items, 0, "uncommitted data should not be visible outside transaction")
+
+	// Now commit
+	err = txn.Commit()
+	require.NoError(t, err)
+
+	// Query again - should now see the data
+	queryResult, err = node.Query("{ IsolationItem { name } }")
+	require.NoError(t, err)
+
+	err = json.Unmarshal(queryResult.Data, &queryData)
+	require.NoError(t, err)
+
+	items = queryData["IsolationItem"].([]interface{})
+	assert.Len(t, items, 1, "committed data should be visible")
 }


### PR DESCRIPTION
## Summary

- Enable CREATE, UPDATE, and DELETE mutations within FFI transactions
- Previously `exec_request_in_txn` only supported queries - now it fully supports mutations
- Read-only transactions properly reject mutation attempts with clear error messages

## Changes

**Core Implementation:**
- Add `doc_mutator()` method to `TransactionContext` trait with default `None` implementation
- Implement `doc_mutator()` in `DbTransactionContext` - returns `Some(mutator)` for read-write, `None` for read-only
- Update `execute_in_txn` to parse requests and route to query or mutation handler
- Make `execute_mutation_internal` visible within crate (`pub(crate)`)

**Tests Added:**
- `TestTransactionMutationCreate` - Create documents within transactions
- `TestTransactionMutationCreateRollback` - Verify rollback discards changes
- `TestTransactionMutationUpdate` - Update existing documents in transactions
- `TestTransactionMutationDelete` - Delete documents in transactions
- `TestTransactionMutationMultipleOperations` - Multiple mutations in single transaction
- `TestTransactionMutationReadOnlyFails` - Verify read-only transactions reject mutations
- `TestTransactionMutationIsolation` - Verify uncommitted changes aren't visible outside transaction

## Test plan

- [x] All 31 Go FFI tests pass
- [x] All 30 Rust FFI tests pass
- [x] All 26 Rust transaction tests pass
- [x] Code compiles without errors

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)