### PR TITLE
feat(ffi): Add index management APIs for Go integration

### DIFF
--- a/crates/ffi/defra.h
+++ b/crates/ffi/defra.h
@@ -276,6 +276,84 @@ struct FfiResult exec_request_in_txn(uintptr_t node_ptr,
  */
 void defra_free_string(char *ptr);
 
+/*
+ Create a new index on a collection.
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+ * `collection_name` - Name of the collection to create the index on
+ * `index_json` - JSON object describing the index to create
+
+ # Index JSON Format
+
+ ```json
+ {
+     "Name": "my_index",
+     "Fields": [
+         {"Name": "field1", "Descending": false},
+         {"Name": "field2", "Descending": true}
+     ],
+     "Unique": false
+ }
+ ```
+
+ # Safety
+
+ All string pointers must be valid null-terminated UTF-8 strings.
+ */
+struct FfiResult create_index(uintptr_t node_ptr,
+                              const char *collection_name,
+                              const char *index_json);
+
+/*
+ Drop an index from a collection.
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+ * `collection_name` - Name of the collection
+ * `index_name` - Name of the index to drop
+
+ # Safety
+
+ All string pointers must be valid null-terminated UTF-8 strings.
+ */
+struct FfiResult drop_index(uintptr_t node_ptr,
+                            const char *collection_name,
+                            const char *index_name);
+
+/*
+ Get all indexes for a collection.
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+ * `collection_name` - Name of the collection
+
+ # Returns
+
+ JSON array of index descriptions.
+
+ # Safety
+
+ `collection_name` must be a valid null-terminated UTF-8 string.
+ */
+struct FfiResult get_indexes(uintptr_t node_ptr, const char *collection_name);
+
+/*
+ Get all indexes across all collections.
+
+ # Arguments
+
+ * `node_ptr` - Handle to the node
+
+ # Returns
+
+ JSON object mapping collection names to their index arrays.
+ */
+struct FfiResult get_all_indexes(uintptr_t node_ptr);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/crates/ffi/src/index.rs
+++ b/crates/ffi/src/index.rs
@@ -1,0 +1,607 @@
+//! Index operations for FFI.
+//!
+//! This module exposes index management functions that allow creating,
+//! dropping, and querying indexes on collections via FFI.
+
+use std::ffi::c_char;
+use std::hash::{Hash, Hasher};
+
+use storage::corekv::Key;
+
+use crate::runtime::RUNTIME;
+use crate::state::NODES;
+use crate::types::{c_str_to_string, FfiResult};
+
+/// Derive a short u32 ID from a collection_id string.
+/// Uses a simple hash to ensure determinism and uniqueness.
+fn collection_short_id(collection_id: &str) -> u32 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    collection_id.hash(&mut hasher);
+    hasher.finish() as u32
+}
+
+/// Create a new index on a collection.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `collection_name` - Name of the collection to create the index on
+/// * `index_json` - JSON object describing the index to create
+///
+/// # Index JSON Format
+///
+/// ```json
+/// {
+///     "Name": "my_index",
+///     "Fields": [
+///         {"Name": "field1", "Descending": false},
+///         {"Name": "field2", "Descending": true}
+///     ],
+///     "Unique": false
+/// }
+/// ```
+///
+/// # Returns
+///
+/// JSON object containing the created index description with assigned ID.
+///
+/// # Safety
+///
+/// All string pointers must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn create_index(
+    node_ptr: usize,
+    collection_name: *const c_char,
+    index_json: *const c_char,
+) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let collection_name_str = match c_str_to_string(collection_name) {
+        Some(s) => s,
+        None => return FfiResult::error("collection_name is null"),
+    };
+
+    let index_json_str = match c_str_to_string(index_json) {
+        Some(s) => s,
+        None => return FfiResult::error("index_json is null"),
+    };
+
+    // Parse the index JSON
+    let index_input: IndexCreateInput = match serde_json::from_str(&index_json_str) {
+        Ok(idx) => idx,
+        Err(e) => return FfiResult::error(format!("failed to parse index JSON: {}", e)),
+    };
+
+    let result = rt.block_on(async {
+        // Get database from node state
+        let database = NODES
+            .get(node_ptr, |state| state.database.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        // Get the collection
+        let collection = database
+            .get_collection(&collection_name_str)
+            .map_err(|e| format!("failed to get collection: {}", e))?
+            .ok_or_else(|| format!("collection '{}' not found", collection_name_str))?;
+
+        // Build the fields list
+        let fields: Vec<schema::IndexedFieldDescription> = index_input
+            .fields
+            .into_iter()
+            .map(|f| schema::IndexedFieldDescription {
+                name: f.name,
+                descending: f.descending,
+            })
+            .collect();
+
+        // Create a transaction for the index creation
+        let txn = database
+            .new_txn(false)
+            .await
+            .map_err(|e| format!("failed to create transaction: {}", e))?;
+
+        // Do all datastore operations in a scope to drop references before commit
+        let (index_desc, _updated_schema) = {
+            let datastore = txn
+                .datastore()
+                .map_err(|e| format!("failed to get datastore: {}", e))?;
+
+            // Create the index manager
+            let mut index_manager = db::index_manager::IndexManager::from_collection(
+                collection_short_id(collection.schema().collection_id.as_str()),
+                collection.schema(),
+            )
+            .map_err(|e| format!("failed to create index manager: {}", e))?;
+
+            // Create the index
+            let index_desc = index_manager
+                .create_index(&datastore, index_input.name, fields, index_input.unique)
+                .await
+                .map_err(|e| format!("failed to create index: {}", e))?;
+
+            // Update the collection schema with the new index
+            let mut updated_schema = collection.schema().clone();
+            updated_schema.indexes.push(index_desc.clone());
+
+            // Save the updated schema
+            let schema_key =
+                storage::keys::systemstore::CollectionNameKey::new(&collection_name_str);
+            let schema_data = serde_json::to_vec(&updated_schema)
+                .map_err(|e| format!("failed to serialize schema: {}", e))?;
+
+            txn.systemstore()
+                .map_err(|e| format!("failed to get systemstore: {}", e))?
+                .set(&schema_key.bytes(), &schema_data)
+                .await
+                .map_err(|e| format!("failed to save schema: {}", e))?;
+
+            // Bulk index existing documents
+            let documents = collection
+                .get_all_with_datastore(&datastore)
+                .await
+                .map_err(|e| format!("failed to get documents: {}", e))?;
+
+            if !documents.is_empty() {
+                index_manager
+                    .bulk_index(
+                        &datastore,
+                        &index_desc.name,
+                        &documents,
+                        collection.schema(),
+                    )
+                    .await
+                    .map_err(|e| format!("failed to bulk index: {}", e))?;
+            }
+
+            (index_desc, updated_schema)
+        };
+
+        // Commit the transaction (datastore reference is now dropped)
+        txn.commit()
+            .await
+            .map_err(|e| format!("failed to commit: {}", e))?;
+
+        // Reload the collection cache to pick up the new index
+        database
+            .reload_cache()
+            .await
+            .map_err(|e| format!("failed to reload cache: {}", e))?;
+
+        // Return the created index description
+        let json = serde_json::to_string(&index_desc)
+            .map_err(|e| format!("failed to serialize result: {}", e))?;
+
+        Ok::<String, String>(json)
+    });
+
+    match result {
+        Ok(json) => FfiResult::success(json),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Drop an index from a collection.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `collection_name` - Name of the collection
+/// * `index_name` - Name of the index to drop
+///
+/// # Returns
+///
+/// Empty JSON object on success, error on failure.
+///
+/// # Safety
+///
+/// All string pointers must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn drop_index(
+    node_ptr: usize,
+    collection_name: *const c_char,
+    index_name: *const c_char,
+) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let collection_name_str = match c_str_to_string(collection_name) {
+        Some(s) => s,
+        None => return FfiResult::error("collection_name is null"),
+    };
+
+    let index_name_str = match c_str_to_string(index_name) {
+        Some(s) => s,
+        None => return FfiResult::error("index_name is null"),
+    };
+
+    let result = rt.block_on(async {
+        // Get database from node state
+        let database = NODES
+            .get(node_ptr, |state| state.database.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        // Get the collection
+        let collection = database
+            .get_collection(&collection_name_str)
+            .map_err(|e| format!("failed to get collection: {}", e))?
+            .ok_or_else(|| format!("collection '{}' not found", collection_name_str))?;
+
+        // Create a transaction
+        let txn = database
+            .new_txn(false)
+            .await
+            .map_err(|e| format!("failed to create transaction: {}", e))?;
+
+        // Do all datastore operations in a scope to drop references before commit
+        {
+            let datastore = txn
+                .datastore()
+                .map_err(|e| format!("failed to get datastore: {}", e))?;
+
+            // Create the index manager
+            let mut index_manager = db::index_manager::IndexManager::from_collection(
+                collection_short_id(collection.schema().collection_id.as_str()),
+                collection.schema(),
+            )
+            .map_err(|e| format!("failed to create index manager: {}", e))?;
+
+            // Drop the index
+            let dropped = index_manager
+                .drop_index(&datastore, &index_name_str)
+                .await
+                .map_err(|e| format!("failed to drop index: {}", e))?;
+
+            if !dropped {
+                return Err(format!("index '{}' not found", index_name_str));
+            }
+
+            // Update the collection schema to remove the index
+            let mut updated_schema = collection.schema().clone();
+            updated_schema
+                .indexes
+                .retain(|idx| idx.name != index_name_str);
+
+            // Save the updated schema
+            let schema_key =
+                storage::keys::systemstore::CollectionNameKey::new(&collection_name_str);
+            let schema_data = serde_json::to_vec(&updated_schema)
+                .map_err(|e| format!("failed to serialize schema: {}", e))?;
+
+            txn.systemstore()
+                .map_err(|e| format!("failed to get systemstore: {}", e))?
+                .set(&schema_key.bytes(), &schema_data)
+                .await
+                .map_err(|e| format!("failed to save schema: {}", e))?;
+        }
+
+        // Commit the transaction (datastore reference is now dropped)
+        txn.commit()
+            .await
+            .map_err(|e| format!("failed to commit: {}", e))?;
+
+        // Reload the collection cache
+        database
+            .reload_cache()
+            .await
+            .map_err(|e| format!("failed to reload cache: {}", e))?;
+
+        Ok::<String, String>("{}".to_string())
+    });
+
+    match result {
+        Ok(json) => FfiResult::success(json),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Get all indexes for a collection.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `collection_name` - Name of the collection
+///
+/// # Returns
+///
+/// JSON array of index descriptions.
+///
+/// # Safety
+///
+/// `collection_name` must be a valid null-terminated UTF-8 string.
+#[no_mangle]
+pub unsafe extern "C" fn get_indexes(node_ptr: usize, collection_name: *const c_char) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let collection_name_str = match c_str_to_string(collection_name) {
+        Some(s) => s,
+        None => return FfiResult::error("collection_name is null"),
+    };
+
+    let result = rt.block_on(async {
+        // Get database from node state
+        let database = NODES
+            .get(node_ptr, |state| state.database.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        // Get the collection
+        let collection = database
+            .get_collection(&collection_name_str)
+            .map_err(|e| format!("failed to get collection: {}", e))?
+            .ok_or_else(|| format!("collection '{}' not found", collection_name_str))?;
+
+        // Get indexes from the collection schema
+        let indexes = collection.get_indexes();
+
+        // Return JSON array
+        let json = serde_json::to_string(&indexes)
+            .map_err(|e| format!("failed to serialize result: {}", e))?;
+
+        Ok::<String, String>(json)
+    });
+
+    match result {
+        Ok(json) => FfiResult::success(json),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Get all indexes across all collections.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+///
+/// # Returns
+///
+/// JSON object mapping collection names to their index arrays.
+///
+/// ```json
+/// {
+///     "User": [{ "Name": "idx_email", ... }],
+///     "Post": [{ "Name": "idx_title", ... }]
+/// }
+/// ```
+#[no_mangle]
+pub extern "C" fn get_all_indexes(node_ptr: usize) -> FfiResult {
+    let rt = match RUNTIME.get() {
+        Some(rt) => rt,
+        None => return FfiResult::error("runtime not initialized - call defra_init() first"),
+    };
+
+    let result = rt.block_on(async {
+        // Get database from node state
+        let database = NODES
+            .get(node_ptr, |state| state.database.clone())
+            .ok_or_else(|| "invalid node handle".to_string())?;
+
+        // Get all collection names
+        let names = database
+            .list_collections()
+            .map_err(|e| format!("failed to list collections: {}", e))?;
+
+        // Build a map of collection name -> indexes
+        let mut all_indexes: std::collections::HashMap<String, Vec<schema::IndexDescription>> =
+            std::collections::HashMap::new();
+
+        for name in names {
+            match database.get_collection(&name) {
+                Ok(Some(collection)) => {
+                    let indexes = collection.get_indexes();
+                    if !indexes.is_empty() {
+                        all_indexes.insert(name, indexes.to_vec());
+                    }
+                }
+                Ok(None) => continue,
+                Err(e) => {
+                    return Err(format!("failed to get collection '{}': {}", name, e));
+                }
+            }
+        }
+
+        // Return JSON object
+        let json = serde_json::to_string(&all_indexes)
+            .map_err(|e| format!("failed to serialize result: {}", e))?;
+
+        Ok::<String, String>(json)
+    });
+
+    match result {
+        Ok(json) => FfiResult::success(json),
+        Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Input structure for creating an index via FFI.
+#[derive(serde::Deserialize)]
+struct IndexCreateInput {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Fields", default)]
+    fields: Vec<IndexFieldInput>,
+    #[serde(rename = "Unique", default)]
+    unique: bool,
+}
+
+/// Input structure for an indexed field.
+#[derive(serde::Deserialize)]
+struct IndexFieldInput {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Descending", default)]
+    descending: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::{new_node, node_close};
+    use crate::schema::add_schema;
+    use crate::types::NodeInitOptions;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_create_and_get_index() {
+        // Initialize runtime
+        assert!(crate::runtime::init_runtime());
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Add schema
+        let sdl = CString::new("type User { name: String, email: String }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0, "add_schema should succeed");
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        // Create index
+        let collection_name = CString::new("User").unwrap();
+        let index_json =
+            CString::new(r#"{"Name": "idx_email", "Fields": [{"Name": "email"}], "Unique": true}"#)
+                .unwrap();
+        let result = unsafe { create_index(node, collection_name.as_ptr(), index_json.as_ptr()) };
+        assert_eq!(result.status, 0, "create_index should succeed");
+
+        let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("idx_email"), "should contain index name");
+        unsafe { crate::types::defra_free_string(result.value) };
+
+        // Get indexes
+        let result = unsafe { get_indexes(node, collection_name.as_ptr()) };
+        assert_eq!(result.status, 0, "get_indexes should succeed");
+
+        let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("idx_email"), "should contain index name");
+        unsafe { crate::types::defra_free_string(result.value) };
+
+        // Cleanup
+        node_close(node);
+    }
+
+    #[test]
+    fn test_drop_index() {
+        // Initialize runtime
+        assert!(crate::runtime::init_runtime());
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Add schema
+        let sdl = CString::new("type Post { title: String }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        // Create index
+        let collection_name = CString::new("Post").unwrap();
+        let index_json =
+            CString::new(r#"{"Name": "idx_title", "Fields": [{"Name": "title"}]}"#).unwrap();
+        let result = unsafe { create_index(node, collection_name.as_ptr(), index_json.as_ptr()) };
+        assert_eq!(result.status, 0);
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        // Drop index
+        let index_name = CString::new("idx_title").unwrap();
+        let result = unsafe { drop_index(node, collection_name.as_ptr(), index_name.as_ptr()) };
+        assert_eq!(result.status, 0, "drop_index should succeed");
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        // Verify index is gone
+        let result = unsafe { get_indexes(node, collection_name.as_ptr()) };
+        assert_eq!(result.status, 0);
+        let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(!value.contains("idx_title"), "index should be removed");
+        unsafe { crate::types::defra_free_string(result.value) };
+
+        // Cleanup
+        node_close(node);
+    }
+
+    #[test]
+    fn test_get_all_indexes() {
+        // Initialize runtime
+        assert!(crate::runtime::init_runtime());
+
+        // Create node
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        // Add schemas
+        let sdl = CString::new("type Author { name: String }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        let sdl = CString::new("type Book { title: String }").unwrap();
+        let result = unsafe { add_schema(node, sdl.as_ptr()) };
+        assert_eq!(result.status, 0);
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        // Create indexes on both collections
+        let author_coll = CString::new("Author").unwrap();
+        let book_coll = CString::new("Book").unwrap();
+
+        let idx1 =
+            CString::new(r#"{"Name": "idx_author_name", "Fields": [{"Name": "name"}]}"#).unwrap();
+        let result = unsafe { create_index(node, author_coll.as_ptr(), idx1.as_ptr()) };
+        assert_eq!(result.status, 0);
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        let idx2 =
+            CString::new(r#"{"Name": "idx_book_title", "Fields": [{"Name": "title"}]}"#).unwrap();
+        let result = unsafe { create_index(node, book_coll.as_ptr(), idx2.as_ptr()) };
+        assert_eq!(result.status, 0);
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        // Get all indexes
+        let result = get_all_indexes(node);
+        assert_eq!(result.status, 0, "get_all_indexes should succeed");
+
+        let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
+        assert!(value.contains("Author"), "should contain Author collection");
+        assert!(value.contains("Book"), "should contain Book collection");
+        assert!(
+            value.contains("idx_author_name"),
+            "should contain author index"
+        );
+        assert!(
+            value.contains("idx_book_title"),
+            "should contain book index"
+        );
+        unsafe { crate::types::defra_free_string(result.value) };
+
+        // Cleanup
+        node_close(node);
+    }
+}

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -33,6 +33,7 @@
 //! - `exec_request()` - Execute GraphQL queries/mutations
 //! - `defra_free_string()` - Free strings allocated by FFI functions
 
+pub mod index;
 pub mod node;
 pub mod query;
 pub mod runtime;
@@ -44,6 +45,7 @@ pub mod types;
 use std::ffi::{c_char, CString};
 
 // Re-export FFI functions at crate root
+pub use index::{create_index, drop_index, get_all_indexes, get_indexes};
 pub use node::{new_node, node_close};
 pub use query::exec_request;
 pub use schema::{add_schema, get_collections};

--- a/crates/ffi/src/txn.rs
+++ b/crates/ffi/src/txn.rs
@@ -254,10 +254,9 @@ mod tests {
         assert!(!txn_id.is_empty());
 
         // Execute in transaction
-        let mutation = CString::new(
-            r#"mutation { create_TxnTest(input: {value: 42}) { _docID value } }"#,
-        )
-        .unwrap();
+        let mutation =
+            CString::new(r#"mutation { create_TxnTest(input: {value: 42}) { _docID value } }"#)
+                .unwrap();
         let txn_id_cstr = CString::new(txn_id.as_ref()).unwrap();
         let result = unsafe {
             exec_request_in_txn(
@@ -298,10 +297,9 @@ mod tests {
         let txn_id_cstr = CString::new(txn_id.as_ref()).unwrap();
 
         // Execute in transaction
-        let mutation = CString::new(
-            r#"mutation { create_RollbackTest(input: {value: 99}) { _docID } }"#,
-        )
-        .unwrap();
+        let mutation =
+            CString::new(r#"mutation { create_RollbackTest(input: {value: 99}) { _docID } }"#)
+                .unwrap();
         let result = unsafe {
             exec_request_in_txn(
                 node,

--- a/tests/interop/ffi/defra.go
+++ b/tests/interop/ffi/defra.go
@@ -346,3 +346,123 @@ func (t *Transaction) Query(query string) (*QueryResult, error) {
 func (t *Transaction) Mutate(mutation string) (*QueryResult, error) {
 	return t.Query(mutation)
 }
+
+// IndexField describes a field within an index.
+type IndexField struct {
+	Name       string `json:"Name"`
+	Descending bool   `json:"Descending,omitempty"`
+}
+
+// IndexDescription describes a secondary index on a collection.
+type IndexDescription struct {
+	Name   string       `json:"Name"`
+	ID     uint32       `json:"ID,omitempty"`
+	Fields []IndexField `json:"Fields"`
+	Unique bool         `json:"Unique,omitempty"`
+}
+
+// CreateIndex creates a new index on a collection.
+// Returns the created index description with assigned ID.
+func (n *Node) CreateIndex(collectionName string, indexName string, fields []IndexField, unique bool) (*IndexDescription, error) {
+	cCollName := C.CString(collectionName)
+	defer C.free(unsafe.Pointer(cCollName))
+
+	indexInput := IndexDescription{
+		Name:   indexName,
+		Fields: fields,
+		Unique: unique,
+	}
+	indexJSON, err := json.Marshal(indexInput)
+	if err != nil {
+		return nil, fmt.Errorf("ffi: failed to marshal index: %w", err)
+	}
+
+	cIndexJSON := C.CString(string(indexJSON))
+	defer C.free(unsafe.Pointer(cIndexJSON))
+
+	result := C.create_index(n.ptr, cCollName, cIndexJSON)
+
+	if result.status != 0 {
+		errMsg := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return nil, fmt.Errorf("ffi: create_index failed: %s", errMsg)
+	}
+
+	value := C.GoString(result.value)
+	C.defra_free_string(result.value)
+
+	var index IndexDescription
+	if err := json.Unmarshal([]byte(value), &index); err != nil {
+		return nil, fmt.Errorf("ffi: failed to parse index: %w", err)
+	}
+
+	return &index, nil
+}
+
+// DropIndex drops an index from a collection.
+func (n *Node) DropIndex(collectionName string, indexName string) error {
+	cCollName := C.CString(collectionName)
+	defer C.free(unsafe.Pointer(cCollName))
+
+	cIndexName := C.CString(indexName)
+	defer C.free(unsafe.Pointer(cIndexName))
+
+	result := C.drop_index(n.ptr, cCollName, cIndexName)
+
+	if result.status != 0 {
+		errMsg := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return fmt.Errorf("ffi: drop_index failed: %s", errMsg)
+	}
+
+	if result.value != nil {
+		C.defra_free_string(result.value)
+	}
+
+	return nil
+}
+
+// GetIndexes returns all indexes for a collection.
+func (n *Node) GetIndexes(collectionName string) ([]IndexDescription, error) {
+	cCollName := C.CString(collectionName)
+	defer C.free(unsafe.Pointer(cCollName))
+
+	result := C.get_indexes(n.ptr, cCollName)
+
+	if result.status != 0 {
+		errMsg := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return nil, fmt.Errorf("ffi: get_indexes failed: %s", errMsg)
+	}
+
+	value := C.GoString(result.value)
+	C.defra_free_string(result.value)
+
+	var indexes []IndexDescription
+	if err := json.Unmarshal([]byte(value), &indexes); err != nil {
+		return nil, fmt.Errorf("ffi: failed to parse indexes: %w", err)
+	}
+
+	return indexes, nil
+}
+
+// GetAllIndexes returns all indexes across all collections.
+func (n *Node) GetAllIndexes() (map[string][]IndexDescription, error) {
+	result := C.get_all_indexes(n.ptr)
+
+	if result.status != 0 {
+		errMsg := C.GoString(result.error)
+		C.defra_free_string(result.error)
+		return nil, fmt.Errorf("ffi: get_all_indexes failed: %s", errMsg)
+	}
+
+	value := C.GoString(result.value)
+	C.defra_free_string(result.value)
+
+	var indexes map[string][]IndexDescription
+	if err := json.Unmarshal([]byte(value), &indexes); err != nil {
+		return nil, fmt.Errorf("ffi: failed to parse indexes: %w", err)
+	}
+
+	return indexes, nil
+}

--- a/tests/interop/ffi/index_test.go
+++ b/tests/interop/ffi/index_test.go
@@ -1,0 +1,278 @@
+package ffi
+
+import (
+	"testing"
+)
+
+func TestCreateIndex(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type User { name: String, email: String }")
+	if err != nil {
+		t.Fatalf("Failed to add schema: %v", err)
+	}
+
+	// Create index
+	fields := []IndexField{{Name: "email"}}
+	index, err := node.CreateIndex("User", "idx_email", fields, true)
+	if err != nil {
+		t.Fatalf("Failed to create index: %v", err)
+	}
+
+	if index.Name != "idx_email" {
+		t.Errorf("Expected index name 'idx_email', got '%s'", index.Name)
+	}
+	if !index.Unique {
+		t.Error("Expected index to be unique")
+	}
+	if len(index.Fields) != 1 || index.Fields[0].Name != "email" {
+		t.Errorf("Expected field 'email', got %v", index.Fields)
+	}
+	if index.ID == 0 {
+		t.Error("Expected non-zero index ID")
+	}
+}
+
+func TestGetIndexes(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Product { name: String, price: Int }")
+	if err != nil {
+		t.Fatalf("Failed to add schema: %v", err)
+	}
+
+	// Create multiple indexes
+	_, err = node.CreateIndex("Product", "idx_name", []IndexField{{Name: "name"}}, false)
+	if err != nil {
+		t.Fatalf("Failed to create index: %v", err)
+	}
+
+	_, err = node.CreateIndex("Product", "idx_price", []IndexField{{Name: "price", Descending: true}}, false)
+	if err != nil {
+		t.Fatalf("Failed to create second index: %v", err)
+	}
+
+	// Get indexes
+	indexes, err := node.GetIndexes("Product")
+	if err != nil {
+		t.Fatalf("Failed to get indexes: %v", err)
+	}
+
+	if len(indexes) != 2 {
+		t.Fatalf("Expected 2 indexes, got %d", len(indexes))
+	}
+
+	// Check index names
+	names := make(map[string]bool)
+	for _, idx := range indexes {
+		names[idx.Name] = true
+	}
+	if !names["idx_name"] || !names["idx_price"] {
+		t.Errorf("Expected indexes idx_name and idx_price, got %v", names)
+	}
+}
+
+func TestDropIndex(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Post { title: String }")
+	if err != nil {
+		t.Fatalf("Failed to add schema: %v", err)
+	}
+
+	// Create index
+	_, err = node.CreateIndex("Post", "idx_title", []IndexField{{Name: "title"}}, false)
+	if err != nil {
+		t.Fatalf("Failed to create index: %v", err)
+	}
+
+	// Verify index exists
+	indexes, err := node.GetIndexes("Post")
+	if err != nil {
+		t.Fatalf("Failed to get indexes: %v", err)
+	}
+	if len(indexes) != 1 {
+		t.Fatalf("Expected 1 index, got %d", len(indexes))
+	}
+
+	// Drop index
+	err = node.DropIndex("Post", "idx_title")
+	if err != nil {
+		t.Fatalf("Failed to drop index: %v", err)
+	}
+
+	// Verify index is gone
+	indexes, err = node.GetIndexes("Post")
+	if err != nil {
+		t.Fatalf("Failed to get indexes after drop: %v", err)
+	}
+	if len(indexes) != 0 {
+		t.Errorf("Expected 0 indexes after drop, got %d", len(indexes))
+	}
+}
+
+func TestDropNonexistentIndex(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Comment { body: String }")
+	if err != nil {
+		t.Fatalf("Failed to add schema: %v", err)
+	}
+
+	// Drop non-existent index should error
+	err = node.DropIndex("Comment", "nonexistent")
+	if err == nil {
+		t.Error("Expected error when dropping non-existent index")
+	}
+}
+
+func TestGetAllIndexes(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	// Add multiple schemas
+	_, err = node.AddSchema("type Author { name: String }")
+	if err != nil {
+		t.Fatalf("Failed to add Author schema: %v", err)
+	}
+
+	_, err = node.AddSchema("type Book { title: String }")
+	if err != nil {
+		t.Fatalf("Failed to add Book schema: %v", err)
+	}
+
+	// Create indexes on both
+	_, err = node.CreateIndex("Author", "idx_author_name", []IndexField{{Name: "name"}}, false)
+	if err != nil {
+		t.Fatalf("Failed to create author index: %v", err)
+	}
+
+	_, err = node.CreateIndex("Book", "idx_book_title", []IndexField{{Name: "title"}}, true)
+	if err != nil {
+		t.Fatalf("Failed to create book index: %v", err)
+	}
+
+	// Get all indexes
+	allIndexes, err := node.GetAllIndexes()
+	if err != nil {
+		t.Fatalf("Failed to get all indexes: %v", err)
+	}
+
+	// Should have indexes for both collections
+	if len(allIndexes) != 2 {
+		t.Fatalf("Expected 2 collections with indexes, got %d", len(allIndexes))
+	}
+
+	// Check Author indexes
+	authorIndexes, ok := allIndexes["Author"]
+	if !ok {
+		t.Error("Expected Author collection in all indexes")
+	} else if len(authorIndexes) != 1 || authorIndexes[0].Name != "idx_author_name" {
+		t.Errorf("Expected idx_author_name, got %v", authorIndexes)
+	}
+
+	// Check Book indexes
+	bookIndexes, ok := allIndexes["Book"]
+	if !ok {
+		t.Error("Expected Book collection in all indexes")
+	} else if len(bookIndexes) != 1 || bookIndexes[0].Name != "idx_book_title" {
+		t.Errorf("Expected idx_book_title, got %v", bookIndexes)
+	}
+}
+
+func TestCreateCompositeIndex(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Order { customer: String, date: String, total: Int }")
+	if err != nil {
+		t.Fatalf("Failed to add schema: %v", err)
+	}
+
+	// Create composite index
+	fields := []IndexField{
+		{Name: "customer", Descending: false},
+		{Name: "date", Descending: true},
+	}
+	index, err := node.CreateIndex("Order", "idx_customer_date", fields, false)
+	if err != nil {
+		t.Fatalf("Failed to create composite index: %v", err)
+	}
+
+	if len(index.Fields) != 2 {
+		t.Fatalf("Expected 2 fields, got %d", len(index.Fields))
+	}
+	if index.Fields[0].Name != "customer" || index.Fields[0].Descending {
+		t.Errorf("First field incorrect: %v", index.Fields[0])
+	}
+	if index.Fields[1].Name != "date" || !index.Fields[1].Descending {
+		t.Errorf("Second field incorrect: %v", index.Fields[1])
+	}
+}
+
+func TestCreateDuplicateIndex(t *testing.T) {
+	Init()
+
+	node, err := NewNode(NodeOptions{InMemory: true})
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer node.Close()
+
+	// Add schema
+	_, err = node.AddSchema("type Article { title: String }")
+	if err != nil {
+		t.Fatalf("Failed to add schema: %v", err)
+	}
+
+	// Create index
+	_, err = node.CreateIndex("Article", "idx_title", []IndexField{{Name: "title"}}, false)
+	if err != nil {
+		t.Fatalf("Failed to create index: %v", err)
+	}
+
+	// Try to create duplicate
+	_, err = node.CreateIndex("Article", "idx_title", []IndexField{{Name: "title"}}, false)
+	if err == nil {
+		t.Error("Expected error when creating duplicate index")
+	}
+}


### PR DESCRIPTION
## Summary

- Add FFI exports for index management operations (`create_index`, `drop_index`, `get_indexes`, `get_all_indexes`)
- Add Go wrapper methods for easy integration
- Add comprehensive test coverage (7 Go tests, 3 Rust tests)

## Changes

| File | Description |
|------|-------------|
| `crates/ffi/src/index.rs` | New Rust FFI module with index operations |
| `crates/ffi/src/lib.rs` | Module declaration and re-exports |
| `crates/ffi/defra.h` | C header declarations |
| `tests/interop/ffi/defra.go` | Go wrapper methods |
| `tests/interop/ffi/index_test.go` | Go integration tests |

## API

```go
// Create a new index
index, err := node.CreateIndex("User", "idx_email", []IndexField{{Name: "email"}}, true)

// Get indexes for a collection
indexes, err := node.GetIndexes("User")

// Get all indexes across all collections
allIndexes, err := node.GetAllIndexes()

// Drop an index
err = node.DropIndex("User", "idx_email")
```

## Test plan

- [x] Rust FFI tests pass (33 total, 3 new index tests)
- [x] Go FFI tests pass (24 total, 7 new index tests)
- [x] Code formatted with `cargo fmt`

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)