### PR TITLE
feat(interop): Add mutation tests and implement Go-compatible upsert

### DIFF
--- a/crates/query/src/plan/mutation/upsert.rs
+++ b/crates/query/src/plan/mutation/upsert.rs
@@ -22,7 +22,7 @@ use super::create::{json_to_normal_value, normal_value_to_json, CreateInput};
 /// Input for an upsert mutation - field values for create or update.
 #[derive(Debug, Clone)]
 pub struct UpsertInput {
-    /// Field values keyed by field name (used for update when doc exists)
+    /// Field values keyed by field name (used for both create and update operations)
     pub fields: std::collections::HashMap<String, JsonValue>,
 }
 
@@ -115,7 +115,7 @@ pub struct UpsertNode {
     mutator: Arc<dyn DocMutator>,
     /// Document mapping for field positions
     document_mapping: DocumentMapping,
-    /// Input documents to upsert (for batch operations without docIDs) - legacy
+    /// Input documents to upsert (for batch operations without docIDs)
     inputs: Vec<UpsertInput>,
     /// Document IDs to upsert (from resolved filter)
     doc_ids: Option<Vec<String>>,
@@ -123,7 +123,7 @@ pub struct UpsertNode {
     create_input: Option<UpsertInput>,
     /// Input for updating existing document (Go's 'update' argument)
     update_input: Option<UpsertInput>,
-    /// Legacy: Single input to apply to all doc_ids (for backward compat)
+    /// Single input to apply to all doc_ids (same fields for create and update)
     single_input: Option<UpsertInput>,
     /// Upserted documents (populated after first next())
     upserted_docs: Vec<Doc>,
@@ -178,8 +178,8 @@ impl UpsertNode {
         self
     }
 
-    /// Legacy: Add an input document to upsert (creates new document).
-    /// For backward compatibility - use with_create_input/with_update_input for Go semantics.
+    /// Add a single input to apply to all operations (same fields for create and update).
+    /// For Go DefraDB's separate create/update semantics, use with_create_input/with_update_input.
     pub fn with_input(mut self, input: UpsertInput) -> Self {
         self.single_input = Some(input);
         self
@@ -341,13 +341,21 @@ impl PlanNode for UpsertNode {
                     }
                     Some(ref doc_ids) if doc_ids.len() == 1 => {
                         // Exactly one match - UPDATE with update_input
-                        let update_input = self.update_input.clone().unwrap_or_default();
+                        let update_input = self.update_input.clone().ok_or_else(|| {
+                            QueryError::execution(
+                                "upsert matched existing document but no 'update' input was provided",
+                            )
+                        })?;
                         let doc_id = doc_ids[0].clone();
                         self.upsert_by_id(&doc_id, &update_input).await?;
                     }
                     _ => {
                         // No matches - CREATE with create_input
-                        let create_input = self.create_input.clone().unwrap_or_default();
+                        let create_input = self.create_input.clone().ok_or_else(|| {
+                            QueryError::execution(
+                                "upsert filter matched no documents but no 'create' input was provided",
+                            )
+                        })?;
                         self.create_new(&create_input).await?;
                     }
                 }

--- a/crates/query/src/plan/mutation/upsert.rs
+++ b/crates/query/src/plan/mutation/upsert.rs
@@ -1,7 +1,9 @@
 //! UpsertNode for conditional create-or-update operations
 //!
-//! This node implements upsert semantics: if a document with the specified ID
-//! exists, it updates it; otherwise, it creates a new document.
+//! This node implements upsert semantics following Go DefraDB's behavior:
+//! - If filter matches 0 documents: CREATE with `create` fields
+//! - If filter matches 1 document: UPDATE with `update` fields
+//! - If filter matches >1 document: Return error
 
 use std::sync::Arc;
 
@@ -20,7 +22,7 @@ use super::create::{json_to_normal_value, normal_value_to_json, CreateInput};
 /// Input for an upsert mutation - field values for create or update.
 #[derive(Debug, Clone)]
 pub struct UpsertInput {
-    /// Field values keyed by field name
+    /// Field values keyed by field name (used for update when doc exists)
     pub fields: std::collections::HashMap<String, JsonValue>,
 }
 
@@ -78,20 +80,25 @@ pub enum UpsertAction {
 
 /// UpsertNode performs conditional create-or-update operations.
 ///
-/// For each input document:
-/// 1. If a docID is provided, check if it exists
-/// 2. If exists: update the document with the input fields
-/// 3. If not exists: create a new document with the input fields
+/// Following Go DefraDB's semantics:
+/// - If filter matches 0 documents: CREATE with `create_input` fields
+/// - If filter matches 1 document: UPDATE with `update_input` fields
+/// - If filter matches >1 document: Return error
 ///
 /// # Example
 ///
 /// ```ignore
-/// let input = UpsertInput::new()
+/// let create_input = UpsertInput::new()
 ///     .with_field("name", json!("Alice"))
-///     .with_field("email", json!("alice@example.com"));
+///     .with_field("age", json!(30));
+///
+/// let update_input = UpsertInput::new()
+///     .with_field("age", json!(31));
 ///
 /// let mut node = UpsertNode::new("Users", mutator, mapping)
-///     .with_input(input);
+///     .with_create_input(create_input)
+///     .with_update_input(update_input)
+///     .with_doc_ids(vec!["bae-123".to_string()]);
 ///
 /// node.init().await?;
 /// node.start().await?;
@@ -108,11 +115,15 @@ pub struct UpsertNode {
     mutator: Arc<dyn DocMutator>,
     /// Document mapping for field positions
     document_mapping: DocumentMapping,
-    /// Input documents to upsert (for batch operations without docIDs)
+    /// Input documents to upsert (for batch operations without docIDs) - legacy
     inputs: Vec<UpsertInput>,
-    /// Document IDs to upsert (update if exists, create if not)
+    /// Document IDs to upsert (from resolved filter)
     doc_ids: Option<Vec<String>>,
-    /// Single input to apply to all doc_ids
+    /// Input for creating new document (Go's 'create' argument)
+    create_input: Option<UpsertInput>,
+    /// Input for updating existing document (Go's 'update' argument)
+    update_input: Option<UpsertInput>,
+    /// Legacy: Single input to apply to all doc_ids (for backward compat)
     single_input: Option<UpsertInput>,
     /// Upserted documents (populated after first next())
     upserted_docs: Vec<Doc>,
@@ -141,6 +152,8 @@ impl UpsertNode {
             document_mapping,
             inputs: Vec::new(),
             doc_ids: None,
+            create_input: None,
+            update_input: None,
             single_input: None,
             upserted_docs: Vec::new(),
             actions: Vec::new(),
@@ -151,7 +164,22 @@ impl UpsertNode {
         }
     }
 
-    /// Add an input document to upsert (creates new document).
+    /// Set the create input (used when no matching document found).
+    /// This follows Go DefraDB's 'create' argument semantics.
+    pub fn with_create_input(mut self, input: UpsertInput) -> Self {
+        self.create_input = Some(input);
+        self
+    }
+
+    /// Set the update input (used when matching document found).
+    /// This follows Go DefraDB's 'update' argument semantics.
+    pub fn with_update_input(mut self, input: UpsertInput) -> Self {
+        self.update_input = Some(input);
+        self
+    }
+
+    /// Legacy: Add an input document to upsert (creates new document).
+    /// For backward compatibility - use with_create_input/with_update_input for Go semantics.
     pub fn with_input(mut self, input: UpsertInput) -> Self {
         self.single_input = Some(input);
         self
@@ -163,8 +191,7 @@ impl UpsertNode {
         self
     }
 
-    /// Set document IDs to upsert.
-    /// Combined with single_input: updates if exists, creates if not.
+    /// Set document IDs to upsert (typically from resolved filter).
     pub fn with_doc_ids(mut self, doc_ids: Vec<String>) -> Self {
         self.doc_ids = Some(doc_ids);
         self
@@ -301,7 +328,32 @@ impl PlanNode for UpsertNode {
 
         // On first call, perform all upserts
         if !self.did_upsert {
-            if let Some(ref doc_ids) = self.doc_ids {
+            // Go DefraDB upsert semantics (with create_input and update_input)
+            if self.create_input.is_some() || self.update_input.is_some() {
+                // Clone doc_ids to avoid borrow conflict
+                let doc_ids_clone = self.doc_ids.clone();
+                match doc_ids_clone {
+                    Some(ref doc_ids) if doc_ids.len() > 1 => {
+                        // Go returns error when filter matches multiple documents
+                        return Err(QueryError::execution(
+                            "cannot upsert multiple matching documents",
+                        ));
+                    }
+                    Some(ref doc_ids) if doc_ids.len() == 1 => {
+                        // Exactly one match - UPDATE with update_input
+                        let update_input = self.update_input.clone().unwrap_or_default();
+                        let doc_id = doc_ids[0].clone();
+                        self.upsert_by_id(&doc_id, &update_input).await?;
+                    }
+                    _ => {
+                        // No matches - CREATE with create_input
+                        let create_input = self.create_input.clone().unwrap_or_default();
+                        self.create_new(&create_input).await?;
+                    }
+                }
+            }
+            // Legacy behavior (single_input for both create and update)
+            else if let Some(ref doc_ids) = self.doc_ids {
                 // Upsert by document IDs
                 let input = self.single_input.clone().unwrap_or_else(|| {
                     tracing::warn!(

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -1115,15 +1115,28 @@ fn parse_field_to_mutation(
                 mutation.create_input = input;
             }
 
-            // UPDATE/UPSERT: input is patch object
-            (MutationType::Update | MutationType::Upsert, "input") => {
+            // UPDATE: input is patch object
+            (MutationType::Update, "input") => {
                 let input = parse_update_input(arg_value, variables)?;
                 mutation.update_input = input;
             }
 
-            // UPDATE/DELETE/UPSERT: docID or docIDs to target (Go uses singular docID)
+            // UPSERT: create is the document to create if no match (single object, not array)
+            (MutationType::Upsert, "create") => {
+                let input = parse_update_input(arg_value, variables)?;
+                // Store create input as single-element array for consistency
+                mutation.create_input = vec![input];
+            }
+
+            // UPSERT: update is the fields to update if match found
+            (MutationType::Upsert, "update") => {
+                let input = parse_update_input(arg_value, variables)?;
+                mutation.update_input = input;
+            }
+
+            // UPDATE/DELETE: docID or docIDs to target (Go uses singular docID)
             (
-                MutationType::Update | MutationType::Delete | MutationType::Upsert,
+                MutationType::Update | MutationType::Delete,
                 "docID" | "docIDs" | "_docIDs",
             ) => {
                 let doc_ids = parse_doc_ids_value(arg_value, variables)?;
@@ -1181,13 +1194,25 @@ fn parse_field_to_mutation(
             }
         }
         MutationType::Upsert => {
-            if mutation.update_input.is_empty() {
+            // Go DefraDB requires all three: filter, create, update
+            if mutation.filter.is_none() {
                 return Err(QueryError::parse(format!(
-                    "upsert_{} mutation requires 'input' argument with fields to set",
+                    "upsert_{} mutation requires 'filter' argument",
                     collection_name
                 )));
             }
-            // Note: docIDs/filter are optional for upsert - if not provided, creates a new document
+            if mutation.create_input.is_empty() {
+                return Err(QueryError::parse(format!(
+                    "upsert_{} mutation requires 'create' argument with document to create if no match",
+                    collection_name
+                )));
+            }
+            if mutation.update_input.is_empty() {
+                return Err(QueryError::parse(format!(
+                    "upsert_{} mutation requires 'update' argument with fields to update if match found",
+                    collection_name
+                )));
+            }
         }
     }
 
@@ -1505,12 +1530,18 @@ mod mutation_tests {
     }
 
     #[test]
-    fn test_parse_upsert_mutation_with_doc_ids() {
+    fn test_parse_upsert_mutation_go_style() {
+        // Go DefraDB upsert syntax: filter, create, update (all required)
         let query = r#"
             mutation {
-                upsert_Users(docIDs: ["bae-123"], input: {name: "Alice", age: 30}) {
+                upsert_Users(
+                    filter: {name: {_eq: "Bob"}},
+                    create: {name: "Bob", age: 40},
+                    update: {age: 40}
+                ) {
                     _docID
                     name
+                    age
                 }
             }
         "#;
@@ -1521,58 +1552,29 @@ mod mutation_tests {
         let m = &mutations[0];
         assert_eq!(m.mutation_type, MutationType::Upsert);
         assert_eq!(m.collection_name, "Users");
-        assert_eq!(m.doc_ids, Some(vec!["bae-123".to_string()]));
-        assert_eq!(
-            m.update_input.get("name"),
-            Some(&JsonValue::String("Alice".to_string()))
-        );
-    }
-
-    #[test]
-    fn test_parse_upsert_mutation_with_filter() {
-        let query = r#"
-            mutation {
-                upsert_Users(filter: {name: {_eq: "Alice"}}, input: {age: 31}) {
-                    _docID
-                }
-            }
-        "#;
-
-        let mutations = parse_mutations(query).unwrap();
-        let m = &mutations[0];
-        assert_eq!(m.mutation_type, MutationType::Upsert);
         assert!(m.filter.is_some());
-        assert!(m.doc_ids.is_none());
-    }
-
-    #[test]
-    fn test_parse_upsert_mutation_create_new() {
-        // Upsert without docIDs/filter creates a new document
-        let query = r#"
-            mutation {
-                upsert_Users(input: {name: "NewUser", email: "new@example.com"}) {
-                    _docID
-                    name
-                }
-            }
-        "#;
-
-        let mutations = parse_mutations(query).unwrap();
-        let m = &mutations[0];
-        assert_eq!(m.mutation_type, MutationType::Upsert);
-        assert!(m.doc_ids.is_none());
-        assert!(m.filter.is_none());
+        // create_input is stored as a single-element vec
+        assert_eq!(m.create_input.len(), 1);
         assert_eq!(
-            m.update_input.get("name"),
-            Some(&JsonValue::String("NewUser".to_string()))
+            m.create_input[0].get("name"),
+            Some(&JsonValue::String("Bob".to_string()))
+        );
+        // update_input is the fields to update
+        assert_eq!(
+            m.update_input.get("age"),
+            Some(&JsonValue::Number(40.into()))
         );
     }
 
     #[test]
-    fn test_upsert_missing_input_error() {
+    fn test_upsert_missing_filter_error() {
+        // Go style requires filter
         let query = r#"
             mutation {
-                upsert_Users(docIDs: ["bae-123"]) {
+                upsert_Users(
+                    create: {name: "Bob", age: 40},
+                    update: {age: 40}
+                ) {
                     _docID
                 }
             }
@@ -1580,7 +1582,45 @@ mod mutation_tests {
 
         let result = parse_mutations(query);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("requires 'input'"));
+        assert!(result.unwrap_err().to_string().contains("filter"));
+    }
+
+    #[test]
+    fn test_upsert_missing_create_error() {
+        // Go style requires create
+        let query = r#"
+            mutation {
+                upsert_Users(
+                    filter: {name: {_eq: "Bob"}},
+                    update: {age: 40}
+                ) {
+                    _docID
+                }
+            }
+        "#;
+
+        let result = parse_mutations(query);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("create"));
+    }
+
+    #[test]
+    fn test_upsert_missing_update_error() {
+        // Go style requires update
+        let query = r#"
+            mutation {
+                upsert_Users(
+                    filter: {name: {_eq: "Bob"}},
+                    create: {name: "Bob", age: 40}
+                ) {
+                    _docID
+                }
+            }
+        "#;
+
+        let result = parse_mutations(query);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("update"));
     }
 }
 

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -450,19 +450,6 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         Ok(update_input)
     }
 
-    /// Build UpsertInput from mutation input (legacy).
-    #[allow(dead_code)]
-    fn build_upsert_input(&self, mutation: &Mutation) -> Result<UpsertInput> {
-        let mut upsert_input = UpsertInput::new();
-
-        // Upsert uses update_input for the field values
-        for (field_name, value) in &mutation.update_input {
-            upsert_input = upsert_input.with_field(field_name.clone(), value.clone());
-        }
-
-        Ok(upsert_input)
-    }
-
     /// Build UpsertInput from a field-value map.
     fn build_upsert_input_from_map(
         &self,

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -239,9 +239,21 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
                 Box::new(node)
             }
             MutationType::Upsert => {
-                let input = self.build_upsert_input(mutation)?;
-                let mut node = UpsertNode::new(&mutation.collection_name, mutator, mapping.clone())
-                    .with_input(input);
+                let mut node =
+                    UpsertNode::new(&mutation.collection_name, mutator, mapping.clone());
+
+                // Set create_input (from Go's 'create' argument)
+                if !mutation.create_input.is_empty() {
+                    let create_input =
+                        self.build_upsert_input_from_map(&mutation.create_input[0])?;
+                    node = node.with_create_input(create_input);
+                }
+
+                // Set update_input (from Go's 'update' argument)
+                if !mutation.update_input.is_empty() {
+                    let update_input = self.build_upsert_input_from_map(&mutation.update_input)?;
+                    node = node.with_update_input(update_input);
+                }
 
                 // Use resolved doc_ids (from filter) or original doc_ids
                 if let Some(ref doc_ids) = resolved_doc_ids {
@@ -438,12 +450,27 @@ impl<F: DocFetcher, R: TransactionRegistry> QueryRunner<F, R> {
         Ok(update_input)
     }
 
-    /// Build UpsertInput from mutation input.
+    /// Build UpsertInput from mutation input (legacy).
+    #[allow(dead_code)]
     fn build_upsert_input(&self, mutation: &Mutation) -> Result<UpsertInput> {
         let mut upsert_input = UpsertInput::new();
 
         // Upsert uses update_input for the field values
         for (field_name, value) in &mutation.update_input {
+            upsert_input = upsert_input.with_field(field_name.clone(), value.clone());
+        }
+
+        Ok(upsert_input)
+    }
+
+    /// Build UpsertInput from a field-value map.
+    fn build_upsert_input_from_map(
+        &self,
+        input: &std::collections::HashMap<String, JsonValue>,
+    ) -> Result<UpsertInput> {
+        let mut upsert_input = UpsertInput::new();
+
+        for (field_name, value) in input {
             upsert_input = upsert_input.with_field(field_name.clone(), value.clone());
         }
 

--- a/crates/query/src/schema_gen/generator.rs
+++ b/crates/query/src/schema_gen/generator.rs
@@ -343,20 +343,26 @@ pub fn generate_mutation_type(collections: &[&CollectionVersion]) -> GqlObjectTy
 
         // Create mutation
         mutation = mutation.with_field(GqlField::new(
-            format!("create_{}", type_name.to_lowercase()),
-            GqlType::named(type_name),
+            format!("create_{}", type_name),
+            GqlType::list(GqlType::named(type_name)),
         ));
 
         // Update mutation
         mutation = mutation.with_field(GqlField::new(
-            format!("update_{}", type_name.to_lowercase()),
-            GqlType::named(type_name),
+            format!("update_{}", type_name),
+            GqlType::list(GqlType::named(type_name)),
         ));
 
         // Delete mutation
         mutation = mutation.with_field(GqlField::new(
-            format!("delete_{}", type_name.to_lowercase()),
-            GqlType::named(type_name),
+            format!("delete_{}", type_name),
+            GqlType::list(GqlType::named(type_name)),
+        ));
+
+        // Upsert mutation (Go syntax: filter, create, update)
+        mutation = mutation.with_field(GqlField::new(
+            format!("upsert_{}", type_name),
+            GqlType::list(GqlType::named(type_name)),
         ));
     }
 
@@ -462,14 +468,17 @@ mod tests {
 
         assert_eq!(mutation.name, "Mutation");
 
-        let create = mutation.fields.iter().find(|f| f.name == "create_user");
+        let create = mutation.fields.iter().find(|f| f.name == "create_User");
         assert!(create.is_some());
 
-        let update = mutation.fields.iter().find(|f| f.name == "update_user");
+        let update = mutation.fields.iter().find(|f| f.name == "update_User");
         assert!(update.is_some());
 
-        let delete = mutation.fields.iter().find(|f| f.name == "delete_user");
+        let delete = mutation.fields.iter().find(|f| f.name == "delete_User");
         assert!(delete.is_some());
+
+        let upsert = mutation.fields.iter().find(|f| f.name == "upsert_User");
+        assert!(upsert.is_some());
     }
 
     #[test]

--- a/tests/interop/integration/mutation_test.go
+++ b/tests/interop/integration/mutation_test.go
@@ -1,0 +1,1164 @@
+// Package integration tests DefraDB mutation patterns against the Rust FFI implementation.
+//
+// These tests are ported from DefraDB's tests/integration/mutation/ directory
+// and validate behavioral compatibility between Go and Rust implementations.
+package integration
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/defradb/tests/action"
+	testUtils "github.com/sourcenetwork/defradb/tests/integration"
+)
+
+// =============================================================================
+// CREATE MUTATIONS
+// =============================================================================
+
+// TestMutationCreate tests basic document creation.
+// Ported from: tests/integration/mutation/create/simple_test.go
+func TestMutationCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"age": 27
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": "John",
+							"age":  int64(27),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationCreate_WithMultipleFields tests creating a document with various field types.
+func TestMutationCreate_WithMultipleFields(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+						points: Float
+						verified: Boolean
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 30,
+					"points": 99.5,
+					"verified": true
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+						points
+						verified
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name":     "Alice",
+							"age":      int64(30),
+							"points":   99.5,
+							"verified": true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationCreate_WithNullFields tests creating a document with null/missing fields.
+func TestMutationCreate_WithNullFields(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+						email: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+						email
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name":  "Bob",
+							"age":   nil,
+							"email": nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationCreate_MultipleDocuments tests creating multiple documents.
+func TestMutationCreate_MultipleDocuments(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"age": 21
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob",
+					"age": 32
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 28
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "John", "age": int64(21)},
+						{"name": "Bob", "age": int64(32)},
+						{"name": "Alice", "age": int64(28)},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationCreate_WithEmptyInput tests creating a document with empty input.
+func TestMutationCreate_WithEmptyInput(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			// Create document with empty JSON object
+			testUtils.CreateDoc{
+				Doc: `{}`,
+			},
+			// Verify the document was created by querying
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name": nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationCreate_WithRelationship tests creating documents with relationships.
+func TestMutationCreate_WithRelationship(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						books: [Book]
+					}
+					type Book {
+						title: String
+						author: Author
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0, // Author
+				DocMap: map[string]any{
+					"name": "Jane Austen",
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1, // Book
+				DocMap: map[string]any{
+					"title":     "Pride and Prejudice",
+					"author_id": testUtils.DocIndex{CollectionIndex: 0, Index: 0},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						books {
+							title
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "Jane Austen",
+							"books": []map[string]any{
+								{"title": "Pride and Prejudice"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// =============================================================================
+// UPDATE MUTATIONS
+// =============================================================================
+
+// TestMutationUpdate_WithDocID tests updating a document by ID.
+// Ported from: tests/integration/mutation/update/with_id_test.go
+func TestMutationUpdate_WithDocID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						points: Float
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"points": 42.1
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob",
+					"points": 66.6
+				}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0, // John
+				Doc:          `{points: 59.0}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users(order: {name: ASC}) {
+						name
+						points
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name":   "Bob",
+							"points": 66.6,
+						},
+						{
+							"name":   "John",
+							"points": 59.0,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationUpdate_MultipleFields tests updating multiple fields at once.
+func TestMutationUpdate_MultipleFields(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+						verified: Boolean
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 25,
+					"verified": false
+				}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{age: 26, verified: true}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+						verified
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name":     "Alice",
+							"age":      int64(26),
+							"verified": true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationUpdate_StringField tests updating a string field.
+func TestMutationUpdate_StringField(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						email: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"email": "john@old.com"
+				}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{email: "john@new.com"}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						email
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name":  "John",
+							"email": "john@new.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationUpdate_IntField tests updating an integer field.
+func TestMutationUpdate_IntField(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Counter {
+						name: String
+						value: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "clicks",
+					"value": 100
+				}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{value: 150}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Counter {
+						name
+						value
+					}
+				}`,
+				Results: map[string]any{
+					"Counter": []map[string]any{
+						{
+							"name":  "clicks",
+							"value": int64(150),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationUpdate_FloatField tests updating a float field.
+func TestMutationUpdate_FloatField(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Measurement {
+						name: String
+						value: Float
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "temperature",
+					"value": 22.5
+				}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{value: 23.7}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Measurement {
+						name
+						value
+					}
+				}`,
+				Results: map[string]any{
+					"Measurement": []map[string]any{
+						{
+							"name":  "temperature",
+							"value": 23.7,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationUpdate_BoolField tests updating a boolean field.
+func TestMutationUpdate_BoolField(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Task {
+						title: String
+						completed: Boolean
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"title": "Write tests",
+					"completed": false
+				}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{completed: true}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Task {
+						title
+						completed
+					}
+				}`,
+				Results: map[string]any{
+					"Task": []map[string]any{
+						{
+							"title":     "Write tests",
+							"completed": true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationUpdate_SetFieldToNull tests setting a field to null.
+func TestMutationUpdate_SetFieldToNull(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						nickname: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John",
+					"nickname": "Johnny"
+				}`,
+			},
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{nickname: null}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						nickname
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{
+							"name":     "John",
+							"nickname": nil,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// =============================================================================
+// DELETE MUTATIONS
+// =============================================================================
+
+// TestMutationDelete_WithDocID tests deleting a document by ID.
+// Ported from: tests/integration/mutation/delete/with_id_test.go
+func TestMutationDelete_WithDocID(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob"
+				}`,
+			},
+			testUtils.DeleteDoc{
+				CollectionID: 0,
+				DocID:        0, // Delete John
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Bob"},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationDelete_AllDocuments tests deleting all documents.
+func TestMutationDelete_AllDocuments(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob"
+				}`,
+			},
+			testUtils.DeleteDoc{
+				CollectionID: 0,
+				DocID:        0,
+			},
+			testUtils.DeleteDoc{
+				CollectionID: 0,
+				DocID:        1,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationDelete_FromMultipleCollections tests that deleting from one collection
+// doesn't affect another collection.
+func TestMutationDelete_FromMultipleCollections(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type User {
+						name: String
+					}
+					type Product {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				CollectionID: 0, // User
+				DocMap: map[string]any{
+					"name": "John",
+				},
+			},
+			testUtils.CreateDoc{
+				CollectionID: 1, // Product
+				DocMap: map[string]any{
+					"name": "Widget",
+				},
+			},
+			testUtils.DeleteDoc{
+				CollectionID: 1, // Delete Product
+				DocID:        0,
+			},
+			// User should still exist
+			testUtils.Request{
+				Request: `query {
+					User {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"User": []map[string]any{
+						{"name": "John"},
+					},
+				},
+			},
+			// Product should be empty
+			testUtils.Request{
+				Request: `query {
+					Product {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Product": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationDelete_ThenCreate tests creating a new document after deletion.
+func TestMutationDelete_ThenCreate(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "John"
+				}`,
+			},
+			testUtils.DeleteDoc{
+				CollectionID: 0,
+				DocID:        0,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Alice"},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// =============================================================================
+// UPSERT MUTATIONS (via GraphQL)
+// Go DefraDB upsert syntax: filter, create, update (all required)
+// =============================================================================
+
+// TestMutationUpsert_CreateNew tests upsert creating a new document when no match.
+// Ported from: tests/integration/mutation/upsert/simple_test.go
+func TestMutationUpsert_CreateNew(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 40
+				}`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {name: {_eq: "Bob"}},
+						create: {name: "Bob", age: 40},
+						update: {age: 40}
+					) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"upsert_Users": []map[string]any{
+						{
+							"name": "Bob",
+							"age":  int64(40),
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Alice", "age": int64(40)},
+						{"name": "Bob", "age": int64(40)},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationUpsert_UpdateExisting tests upsert updating when a match exists.
+func TestMutationUpsert_UpdateExisting(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 40
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob",
+					"age": 30
+				}`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {name: {_eq: "Bob"}},
+						create: {name: "Bob", age: 40},
+						update: {age: 40}
+					) {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"upsert_Users": []map[string]any{
+						{
+							"name": "Bob",
+							"age":  int64(40),
+						},
+					},
+				},
+			},
+			testUtils.Request{
+				Request: `query {
+					Users {
+						name
+						age
+					}
+				}`,
+				Results: map[string]any{
+					"Users": []map[string]any{
+						{"name": "Alice", "age": int64(40)},
+						{"name": "Bob", "age": int64(40)},
+					},
+				},
+				NonOrderedResults: true,
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutationUpsert_MultipleMatches_Error tests that upsert fails when multiple docs match.
+func TestMutationUpsert_MultipleMatches_Error(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Users {
+						name: String
+						age: Int
+					}
+				`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Bob",
+					"age": 30
+				}`,
+			},
+			testUtils.CreateDoc{
+				Doc: `{
+					"name": "Alice",
+					"age": 40
+				}`,
+			},
+			testUtils.Request{
+				Request: `mutation {
+					upsert_Users(
+						filter: {},
+						create: {name: "Alice", age: 40},
+						update: {age: 50}
+					) {
+						name
+						age
+					}
+				}`,
+				ExpectedError: "cannot upsert multiple matching documents",
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// =============================================================================
+// COMBINED MUTATIONS
+// =============================================================================
+
+// TestMutation_CreateUpdateDelete tests a full lifecycle of create, update, delete.
+func TestMutation_CreateUpdateDelete(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Task {
+						title: String
+						status: String
+					}
+				`,
+			},
+			// Create
+			testUtils.CreateDoc{
+				Doc: `{
+					"title": "Write documentation",
+					"status": "pending"
+				}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Task {
+						title
+						status
+					}
+				}`,
+				Results: map[string]any{
+					"Task": []map[string]any{
+						{"title": "Write documentation", "status": "pending"},
+					},
+				},
+			},
+			// Update
+			testUtils.UpdateDoc{
+				CollectionID: 0,
+				DocID:        0,
+				Doc:          `{status: "completed"}`,
+			},
+			testUtils.Request{
+				Request: `query {
+					Task {
+						title
+						status
+					}
+				}`,
+				Results: map[string]any{
+					"Task": []map[string]any{
+						{"title": "Write documentation", "status": "completed"},
+					},
+				},
+			},
+			// Delete
+			testUtils.DeleteDoc{
+				CollectionID: 0,
+				DocID:        0,
+			},
+			testUtils.Request{
+				Request: `query {
+					Task {
+						title
+					}
+				}`,
+				Results: map[string]any{
+					"Task": []map[string]any{},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}
+
+// TestMutation_WithRelationships tests mutations involving relationships.
+func TestMutation_WithRelationships(t *testing.T) {
+	test := testUtils.TestCase{
+		Actions: []any{
+			&action.AddSchema{
+				Schema: `
+					type Author {
+						name: String
+						books: [Book]
+					}
+					type Book {
+						title: String
+						author: Author
+					}
+				`,
+			},
+			// Create author
+			testUtils.CreateDoc{
+				CollectionID: 0, // Author
+				DocMap: map[string]any{
+					"name": "George Orwell",
+				},
+			},
+			// Create first book
+			testUtils.CreateDoc{
+				CollectionID: 1, // Book
+				DocMap: map[string]any{
+					"title":     "1984",
+					"author_id": testUtils.DocIndex{CollectionIndex: 0, Index: 0},
+				},
+			},
+			// Create second book
+			testUtils.CreateDoc{
+				CollectionID: 1, // Book
+				DocMap: map[string]any{
+					"title":     "Animal Farm",
+					"author_id": testUtils.DocIndex{CollectionIndex: 0, Index: 0},
+				},
+			},
+			// Query author with books
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						books {
+							title
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "George Orwell",
+							"books": []map[string]any{
+								{"title": "1984"},
+								{"title": "Animal Farm"},
+							},
+						},
+					},
+				},
+				NonOrderedResults: true,
+			},
+			// Delete one book
+			testUtils.DeleteDoc{
+				CollectionID: 1,
+				DocID:        0, // Delete 1984
+			},
+			// Query should show remaining book
+			testUtils.Request{
+				Request: `query {
+					Author {
+						name
+						books {
+							title
+						}
+					}
+				}`,
+				Results: map[string]any{
+					"Author": []map[string]any{
+						{
+							"name": "George Orwell",
+							"books": []map[string]any{
+								{"title": "Animal Farm"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExecuteTestCase(t, test)
+}


### PR DESCRIPTION
## Summary

- Add comprehensive mutation tests for CREATE, UPDATE, DELETE, and UPSERT operations
- Implement Go-compatible upsert syntax (`filter`, `create`, `update` arguments)
- Port tests from Go DefraDB's `tests/integration/mutation/` directory

## Test Coverage

**22 mutation tests total:**

| Category | Tests | Description |
|----------|-------|-------------|
| CREATE | 6 | Basic create, multiple fields, null fields, empty input, relationships |
| UPDATE | 7 | By docID, multiple fields, string/int/float/bool fields, set to null |
| DELETE | 4 | By docID, all docs, collection isolation, create after delete |
| UPSERT | 3 | Create new, update existing, multiple matches error |
| Combined | 2 | Full lifecycle, relationships with mutations |

## Upsert Implementation

Updated Rust implementation to match Go DefraDB's upsert semantics:

```graphql
mutation {
  upsert_Users(
    filter: {name: {_eq: "Bob"}},
    create: {name: "Bob", age: 40},
    update: {age: 40}
  ) {
    _docID name age
  }
}
```

**Behavior:**
- Filter matches 0 docs → CREATE with `create` fields
- Filter matches 1 doc → UPDATE with `update` fields
- Filter matches >1 docs → Return error ("cannot upsert multiple matching documents")

## Files Changed

- `crates/query/src/query_parse.rs` - Updated upsert parsing for Go-style arguments
- `crates/query/src/schema_gen/generator.rs` - Added upsert mutation field generation
- `crates/query/src/plan/mutation/upsert.rs` - Implemented Go-compatible upsert logic
- `crates/query/src/runner/mutation.rs` - Updated mutation runner for new upsert inputs
- `tests/interop/integration/mutation_test.go` - New mutation test file

## Test Plan

- [x] All 22 mutation tests pass
- [x] All 43 integration tests pass
- [x] Rust unit tests pass (`cargo test -p query upsert schema_gen`)

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)