### PR TITLE
fix(commits): Improve _commits query Go compatibility

### DIFF
--- a/crates/db/src/auto_commit_mutator.rs
+++ b/crates/db/src/auto_commit_mutator.rs
@@ -120,8 +120,9 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
                     // Use collection_id as schema_version_id (matches how Go stores it)
                     let schema_version_id = collection.collection_id();
 
+                    // For create operations, all fields are new - pass None for modified_fields
                     if let Err(e) =
-                        write_document_blocks(&blockstore, &headstore, &doc, schema_version_id)
+                        write_document_blocks(&blockstore, &headstore, &doc, schema_version_id, None)
                             .await
                     {
                         warn!(
@@ -180,6 +181,7 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
         &self,
         collection_name: &str,
         doc: Document,
+        modified_fields: std::collections::HashSet<String>,
     ) -> query::error::Result<UpdateResult> {
         // Get collection from DB cache
         let collection = self
@@ -240,8 +242,10 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
                     // Use collection_id as schema_version_id (matches how Go stores it)
                     let schema_version_id = collection.collection_id();
 
+                    // For update operations, pass the modified fields to only create blocks
+                    // for the fields that actually changed
                     if let Err(e) =
-                        write_document_blocks(&blockstore, &headstore, &doc, schema_version_id)
+                        write_document_blocks(&blockstore, &headstore, &doc, schema_version_id, Some(&modified_fields))
                             .await
                     {
                         warn!(

--- a/crates/db/src/block_builder.rs
+++ b/crates/db/src/block_builder.rs
@@ -387,21 +387,12 @@ pub async fn write_document_blocks(
                 "Stored LWW field block and head"
             );
 
-            // Add link to composite
+            // Add link to composite - only new blocks get linked
             field_links.push(DAGLink::new(field_name.clone(), field_cid));
             field_cids.push(field_cid);
-        } else {
-            // Field was not modified - use existing head CID in composite links
-            if let Some(existing_cid) = field_head.cid {
-                tracing::debug!(
-                    field_name = %field_name,
-                    cid = %existing_cid,
-                    "Using existing field head for unchanged field"
-                );
-                field_links.push(DAGLink::new(field_name.clone(), existing_cid));
-                // Note: don't add to field_cids since we didn't create a new block
-            }
         }
+        // Note: Unchanged fields are NOT added to composite links.
+        // Go only includes newly created field blocks in the composite's links array.
     }
 
     // Get existing composite head (if any) to build proper DAG links

--- a/crates/db/src/block_builder.rs
+++ b/crates/db/src/block_builder.rs
@@ -284,6 +284,9 @@ async fn get_max_priority(headstore: &NamespaceView, doc_id: &str) -> Result<u64
 /// * `headstore` - Transaction headstore view
 /// * `doc` - The document to build blocks from
 /// * `schema_version_id` - The schema version ID for CRDT deltas
+/// * `modified_fields` - Optional set of field names that were modified.
+///   If Some, only these fields will have new blocks created.
+///   If None (for create operations), all fields get new blocks.
 ///
 /// # Returns
 ///
@@ -293,6 +296,7 @@ pub async fn write_document_blocks(
     headstore: &NamespaceView,
     doc: &Document,
     schema_version_id: &str,
+    modified_fields: Option<&std::collections::HashSet<String>>,
 ) -> Result<BlockResult, String> {
     let doc_id = doc
         .id()
@@ -309,72 +313,95 @@ pub async fn write_document_blocks(
     let max_priority = get_max_priority(headstore, &doc_id_str).await?;
     let priority: u64 = max_priority + 1;
 
-    // Create an LWW block for each field
+    // Create LWW blocks for each field
+    // For updates with modified_fields, only create blocks for changed fields.
+    // For unchanged fields, use their existing head CID in the composite links.
     for (field_name, field_value) in doc.values() {
         // Skip internal fields like _docID
         if field_name.starts_with('_') {
             continue;
         }
 
-        // Get existing head for this field (if any) to build proper DAG links
-        let field_head = get_field_head(headstore, &doc_id_str, field_name).await?;
-        let heads: Vec<Cid> = field_head.cid.into_iter().collect();
-
-        // Encode the field value as CBOR
-        let value_bytes = encode_value_as_cbor(field_value.value())?;
-
-        // Create LWW delta payload
-        let lww_payload = LwwDeltaPayload {
-            doc_id: doc_id_bytes.clone(),
-            field_name: field_name.clone(),
-            priority,
-            schema_version_id: schema_version_id.to_string(),
-            data: value_bytes,
+        // Check if this field should have a new block created
+        let should_create_block = match modified_fields {
+            None => true, // Create operation: all fields get new blocks
+            Some(fields) => fields.contains(field_name), // Update: only modified fields
         };
 
-        // Create the field block with heads linking to previous version
-        let field_block = Block::new(CrdtDelta::Lww(lww_payload), heads, vec![]);
+        // Get existing head for this field (if any)
+        let field_head = get_field_head(headstore, &doc_id_str, field_name).await?;
 
-        // Serialize and generate CID
-        let field_block_bytes = field_block
-            .to_dag_cbor()
-            .map_err(|e| format!("Failed to encode field block: {}", e))?;
-        let field_cid = field_block
-            .generate_cid()
-            .map_err(|e| format!("Failed to generate field CID: {}", e))?;
+        if should_create_block {
+            // Create new LWW block for this field
+            let heads: Vec<Cid> = field_head.cid.into_iter().collect();
 
-        // Store the field block in blockstore
-        blockstore
-            .set(&field_cid.to_bytes(), &field_block_bytes)
-            .await
-            .map_err(|e| format!("Failed to store field block: {}", e))?;
+            // Encode the field value as CBOR
+            let value_bytes = encode_value_as_cbor(field_value.value())?;
 
-        // Delete old head entry if it exists (replace, not accumulate)
-        if let Some(old_key) = field_head.key {
-            headstore
-                .delete(&old_key)
+            // Create LWW delta payload
+            let lww_payload = LwwDeltaPayload {
+                doc_id: doc_id_bytes.clone(),
+                field_name: field_name.clone(),
+                priority,
+                schema_version_id: schema_version_id.to_string(),
+                data: value_bytes,
+            };
+
+            // Create the field block with heads linking to previous version
+            let field_block = Block::new(CrdtDelta::Lww(lww_payload), heads, vec![]);
+
+            // Serialize and generate CID
+            let field_block_bytes = field_block
+                .to_dag_cbor()
+                .map_err(|e| format!("Failed to encode field block: {}", e))?;
+            let field_cid = field_block
+                .generate_cid()
+                .map_err(|e| format!("Failed to generate field CID: {}", e))?;
+
+            // Store the field block in blockstore
+            blockstore
+                .set(&field_cid.to_bytes(), &field_block_bytes)
                 .await
-                .map_err(|e| format!("Failed to delete old field head: {}", e))?;
+                .map_err(|e| format!("Failed to store field block: {}", e))?;
+
+            // Delete old head entry if it exists (replace, not accumulate)
+            if let Some(old_key) = field_head.key {
+                headstore
+                    .delete(&old_key)
+                    .await
+                    .map_err(|e| format!("Failed to delete old field head: {}", e))?;
+            }
+
+            // Write new head CID to headstore: /d/{doc_id}/{field_name}/{cid} → priority
+            let head_key = HeadstoreDocKey::new(&doc_id_str, field_name, field_cid);
+            let priority_bytes = encode_priority_varint(priority);
+            headstore
+                .set(&head_key.bytes(), &priority_bytes)
+                .await
+                .map_err(|e| format!("Failed to write field head: {}", e))?;
+
+            tracing::debug!(
+                field_name = %field_name,
+                cid = %field_cid,
+                has_prev_head = field_head.cid.is_some(),
+                "Stored LWW field block and head"
+            );
+
+            // Add link to composite
+            field_links.push(DAGLink::new(field_name.clone(), field_cid));
+            field_cids.push(field_cid);
+        } else {
+            // Field was not modified - use existing head CID in composite links
+            if let Some(existing_cid) = field_head.cid {
+                tracing::debug!(
+                    field_name = %field_name,
+                    cid = %existing_cid,
+                    "Using existing field head for unchanged field"
+                );
+                field_links.push(DAGLink::new(field_name.clone(), existing_cid));
+                // Note: don't add to field_cids since we didn't create a new block
+            }
         }
-
-        // Write new head CID to headstore: /d/{doc_id}/{field_name}/{cid} → priority
-        let head_key = HeadstoreDocKey::new(&doc_id_str, field_name, field_cid);
-        let priority_bytes = encode_priority_varint(priority);
-        headstore
-            .set(&head_key.bytes(), &priority_bytes)
-            .await
-            .map_err(|e| format!("Failed to write field head: {}", e))?;
-
-        tracing::debug!(
-            field_name = %field_name,
-            cid = %field_cid,
-            has_prev_head = field_head.cid.is_some(),
-            "Stored LWW field block and head"
-        );
-
-        // Add link to composite
-        field_links.push(DAGLink::new(field_name.clone(), field_cid));
-        field_cids.push(field_cid);
     }
 
     // Get existing composite head (if any) to build proper DAG links

--- a/crates/db/src/broadcast_mutator.rs
+++ b/crates/db/src/broadcast_mutator.rs
@@ -167,6 +167,7 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
         &self,
         collection_name: &str,
         doc: Document,
+        modified_fields: std::collections::HashSet<String>,
     ) -> query::error::Result<UpdateResult> {
         // Get collection ID for broadcast
         let collection = self
@@ -177,7 +178,7 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
         let collection_id = collection.collection_id().to_string();
 
         // Execute the update mutation
-        let result = self.inner.update(collection_name, doc).await?;
+        let result = self.inner.update(collection_name, doc, modified_fields).await?;
 
         // Build proper Block structures for P2P sync
         let block_result = match build_blocks_from_document(

--- a/crates/db/src/commits_fetcher.rs
+++ b/crates/db/src/commits_fetcher.rs
@@ -151,9 +151,13 @@ impl<S: Store> CommitsFetcher<S> {
                 commits.push(commit_doc);
 
                 // Check depth limit
+                // Go's depth semantics: depth=1 means only heads (no traversal),
+                // depth=2 means heads + their parents, etc.
+                // So we check current_depth + 1 < max_depth to decide if we should
+                // traverse to the next level.
                 let should_traverse = match options.depth {
                     None => true, // No limit
-                    Some(max_depth) => current_depth < max_depth,
+                    Some(max_depth) => current_depth + 1 < max_depth,
                 };
 
                 if should_traverse {
@@ -175,17 +179,28 @@ impl<S: Store> CommitsFetcher<S> {
 
     /// Sort commits to match Go DefraDB's ordering.
     ///
+    /// Go's ordering for commits:
+    /// 1. Group by docID first (documents in order they were created/discovered)
+    /// 2. Within each document, sort by field ID: regular fields first (by name),
+    ///    composite field (_C) last
+    ///
     /// Go stores field IDs as numeric short IDs in headstore keys, which gives
     /// lexicographic order: "1" < "2" < "C" (composite comes after regular fields).
-    /// Rust uses field names, so we need to sort to match Go's behavior:
-    /// - Regular fields first, sorted by field name
-    /// - Composite field (_C) last
     fn sort_commits_go_order(&self, commits: &mut Vec<Document>) {
         commits.sort_by(|a, b| {
+            // Primary sort: docID
+            let doc_id_a = a.get("docID").and_then(|v| v.as_str()).unwrap_or("");
+            let doc_id_b = b.get("docID").and_then(|v| v.as_str()).unwrap_or("");
+
+            if doc_id_a != doc_id_b {
+                return doc_id_a.cmp(doc_id_b);
+            }
+
+            // Secondary sort: fieldName (composite last)
             let field_a = a.get("fieldName").and_then(|v| v.as_str()).unwrap_or("");
             let field_b = b.get("fieldName").and_then(|v| v.as_str()).unwrap_or("");
 
-            // Composite (_C) should come last
+            // Composite (_C) should come last within each document
             match (field_a == "_C", field_b == "_C") {
                 (true, false) => std::cmp::Ordering::Greater,
                 (false, true) => std::cmp::Ordering::Less,

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -110,6 +110,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         &self,
         collection_name: &str,
         doc: Document,
+        modified_fields: std::collections::HashSet<String>,
     ) -> query::error::Result<UpdateResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
@@ -120,8 +121,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("update error: {}", e)))?;
 
-        // Count modified fields (for now, return the total field count)
-        let fields_modified = doc.values().len();
+        // Return count of actually modified fields
+        let fields_modified = modified_fields.len();
 
         Ok(UpdateResult::new(doc, fields_modified))
     }

--- a/crates/query/src/mutator.rs
+++ b/crates/query/src/mutator.rs
@@ -201,6 +201,7 @@ pub trait DocMutator: Send + Sync {
     ///
     /// * `collection_name` - The name of the collection
     /// * `doc` - The document with updated fields
+    /// * `modified_fields` - The set of field names that were modified
     ///
     /// # Returns
     ///
@@ -213,7 +214,12 @@ pub trait DocMutator: Send + Sync {
     /// - The document does not have an ID
     /// - The document does not exist in the collection
     /// - The document fails schema validation
-    async fn update(&self, collection_name: &str, doc: Document) -> Result<UpdateResult>;
+    async fn update(
+        &self,
+        collection_name: &str,
+        doc: Document,
+        modified_fields: std::collections::HashSet<String>,
+    ) -> Result<UpdateResult>;
 
     /// Delete a document by ID.
     ///

--- a/crates/query/src/plan/mutation/update.rs
+++ b/crates/query/src/plan/mutation/update.rs
@@ -263,8 +263,15 @@ impl PlanNode for UpdateNode {
                     // Apply update input
                     self.input.apply_to(&mut doc)?;
 
-                    // Persist update
-                    let result = self.mutator.update(&self.collection_name, doc).await?;
+                    // Collect the modified field names for block creation
+                    let modified_fields: std::collections::HashSet<String> =
+                        self.input.fields.keys().cloned().collect();
+
+                    // Persist update with modified field tracking
+                    let result = self
+                        .mutator
+                        .update(&self.collection_name, doc, modified_fields)
+                        .await?;
 
                     // Convert to plan Doc
                     let plan_doc = self.update_result_to_doc(&result)?;

--- a/crates/query/src/plan/mutation/upsert.rs
+++ b/crates/query/src/plan/mutation/upsert.rs
@@ -238,7 +238,15 @@ impl UpsertNode {
             );
 
             input.apply_to(&mut doc)?;
-            let result = self.mutator.update(&self.collection_name, doc).await?;
+
+            // Collect the modified field names for block creation
+            let modified_fields: std::collections::HashSet<String> =
+                input.fields.keys().cloned().collect();
+
+            let result = self
+                .mutator
+                .update(&self.collection_name, doc, modified_fields)
+                .await?;
 
             let plan_doc = self.result_to_doc(&result.document)?;
             self.upserted_docs.push(plan_doc);

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -1079,12 +1079,57 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             });
         }
 
+        // Apply groupBy if present - this changes how we process commits
+        // Each entry is (representative_commit, all_commits_in_group)
+        let grouped: Option<Vec<(document::Document, Vec<document::Document>)>> =
+            if let Some(ref group_by) = select.group_by {
+                if !group_by.fields.is_empty() {
+                    let mut groups: Vec<(String, document::Document, Vec<document::Document>)> =
+                        Vec::new();
+                    let mut group_map: std::collections::HashMap<String, usize> =
+                        std::collections::HashMap::new();
+
+                    for commit in commits.drain(..) {
+                        let key = Self::generate_commit_group_key(&commit, &group_by.fields);
+                        if let Some(&idx) = group_map.get(&key) {
+                            groups[idx].2.push(commit);
+                        } else {
+                            let idx = groups.len();
+                            group_map.insert(key.clone(), idx);
+                            groups.push((key, commit.clone(), vec![commit]));
+                        }
+                    }
+
+                    Some(
+                        groups
+                            .into_iter()
+                            .map(|(_, rep, docs)| (rep, docs))
+                            .collect(),
+                    )
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+        // Get the list of commits to process (either grouped representatives or all commits)
+        let mut work_items: Vec<(document::Document, Option<Vec<document::Document>>)> =
+            if let Some(grouped) = grouped {
+                grouped
+                    .into_iter()
+                    .map(|(rep, all)| (rep, Some(all)))
+                    .collect()
+            } else {
+                commits.into_iter().map(|c| (c, None)).collect()
+            };
+
         // Apply ordering if present
         if let Some(ref order_by) = select.order_by {
             for condition in order_by.conditions.iter().rev() {
                 if let Some(field_name) = condition.fields.first() {
                     let desc = matches!(condition.direction, OrderDirection::Desc);
-                    commits.sort_by(|a, b| {
+                    work_items.sort_by(|(a, _), (b, _)| {
                         let val_a = a.get(field_name);
                         let val_b = b.get(field_name);
                         let cmp = Self::compare_json_values(val_a, val_b);
@@ -1101,19 +1146,19 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Apply limit and offset if present
         if let Some(ref limit_spec) = select.limit {
             let offset = limit_spec.offset as usize;
-            if offset > 0 && offset < commits.len() {
-                commits = commits.split_off(offset);
-            } else if offset >= commits.len() {
-                commits.clear();
+            if offset > 0 && offset < work_items.len() {
+                work_items = work_items.split_off(offset);
+            } else if offset >= work_items.len() {
+                work_items.clear();
             }
             if let Some(limit) = limit_spec.limit {
-                commits.truncate(limit as usize);
+                work_items.truncate(limit as usize);
             }
         }
 
         // Build results
         let mut results = Vec::new();
-        for commit in &commits {
+        for (commit, group_docs) in &work_items {
             let mut obj = serde_json::Map::new();
 
             // Map requested fields from the commit document
@@ -1178,12 +1223,45 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         obj.insert(output_name.to_string(), JsonValue::Number(count.into()));
                     }
                     Requestable::Select(nested) => {
-                        // Handle nested selects (e.g., links { cid })
                         let field_name = &nested.field.name;
                         let output_name = nested.field.output_name();
 
-                        if let Some(value) = commit.get(field_name) {
-                            // Convert NormalValue to JSON first
+                        // Handle _group special field for grouped results
+                        if field_name == "_group" {
+                            if let Some(docs) = group_docs {
+                                // Build array of group documents with requested fields
+                                let group_array: Vec<JsonValue> = docs
+                                    .iter()
+                                    .map(|doc: &document::Document| {
+                                        let mut nested_obj = serde_json::Map::new();
+                                        for nested_field in &nested.fields {
+                                            if let Requestable::Field(nf) = nested_field {
+                                                let nf_name = &nf.name;
+                                                let nf_output = nf.output_name();
+                                                if let Some(val) = doc.get(nf_name) {
+                                                    let json_val =
+                                                        crate::json_convert::normal_value_to_json(
+                                                            val,
+                                                        )
+                                                        .unwrap_or(JsonValue::Null);
+                                                    nested_obj
+                                                        .insert(nf_output.to_string(), json_val);
+                                                } else {
+                                                    nested_obj
+                                                        .insert(nf_output.to_string(), JsonValue::Null);
+                                                }
+                                            }
+                                        }
+                                        JsonValue::Object(nested_obj)
+                                    })
+                                    .collect();
+                                obj.insert(output_name.to_string(), JsonValue::Array(group_array));
+                            } else {
+                                // Not grouped, _group is empty
+                                obj.insert(output_name.to_string(), JsonValue::Array(vec![]));
+                            }
+                        } else if let Some(value) = commit.get(field_name) {
+                            // Handle nested selects (e.g., links { cid })
                             if let Ok(json_val) = crate::json_convert::normal_value_to_json(value) {
                                 if let Some(arr) = json_val.as_array() {
                                     let nested_results: Vec<JsonValue> = arr
@@ -1231,6 +1309,54 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         Ok(JsonValue::Array(results))
+    }
+
+    /// Generate a group key from commit field values.
+    /// Format matches Go DefraDB: `{index}_{value}_` for each field.
+    fn generate_commit_group_key(commit: &document::Document, fields: &[String]) -> String {
+        let mut key = String::new();
+        for (i, field_name) in fields.iter().enumerate() {
+            key.push_str(&format!("{}_", i));
+            if let Some(value) = commit.get(field_name) {
+                if let Ok(json_val) = crate::json_convert::normal_value_to_json(value) {
+                    key.push_str(&Self::json_value_to_key(&json_val));
+                } else {
+                    key.push_str("null");
+                }
+            } else {
+                key.push_str("null");
+            }
+            key.push('_');
+        }
+        key
+    }
+
+    /// Convert a JSON value to a string for use in group key.
+    fn json_value_to_key(value: &JsonValue) -> String {
+        match value {
+            JsonValue::Null => "null".to_string(),
+            JsonValue::Bool(b) => b.to_string(),
+            JsonValue::Number(n) => n.to_string(),
+            JsonValue::String(s) => s.clone(),
+            JsonValue::Array(arr) => {
+                format!(
+                    "[{}]",
+                    arr.iter()
+                        .map(Self::json_value_to_key)
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+            JsonValue::Object(obj) => {
+                format!(
+                    "{{{}}}",
+                    obj.iter()
+                        .map(|(k, v)| format!("{}:{}", k, Self::json_value_to_key(v)))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+        }
     }
 
     /// Build a DocumentMapping for commit fields.


### PR DESCRIPTION
## Summary

- Fix depth filter semantics to match Go's behavior (depth=1 returns only heads)
- Fix ordering for multiple documents (docID as primary sort key)
- Track modified fields during updates to prevent duplicate blocks for unchanged fields

## Test plan

- [ ] Run query/commits FFI tests
- [ ] Verify depth filtering returns correct number of results
- [ ] Verify update operations only create blocks for changed fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)