### PR TITLE
fix(ffi): Preserve DateTime timezone for Go CID compatibility

### DIFF
--- a/crates/document/src/normal.rs
+++ b/crates/document/src/normal.rs
@@ -3,7 +3,7 @@
 //! NormalValue represents all possible field values in a type-safe enum.
 //! This avoids runtime type assertions and provides compile-time guarantees.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
 
 /// Normalized value type representing all possible field values.
@@ -30,7 +30,7 @@ pub enum NormalValue {
     /// Binary data
     Bytes(Vec<u8>),
     /// Timestamp with timezone
-    Time(DateTime<Utc>),
+    Time(DateTime<FixedOffset>),
     /// Nested document
     Document(Box<crate::Document>),
     /// JSON value (for schemaless fields)
@@ -50,7 +50,7 @@ pub enum NormalValue {
     /// Nillable bytes
     NillableBytes(Option<Vec<u8>>),
     /// Nillable timestamp
-    NillableTime(Option<DateTime<Utc>>),
+    NillableTime(Option<DateTime<FixedOffset>>),
     /// Nillable document
     NillableDocument(Option<Box<crate::Document>>),
 
@@ -68,7 +68,7 @@ pub enum NormalValue {
     /// Array of byte arrays
     BytesArray(Vec<Vec<u8>>),
     /// Array of timestamps
-    TimeArray(Vec<DateTime<Utc>>),
+    TimeArray(Vec<DateTime<FixedOffset>>),
     /// Array of documents
     DocumentArray(Vec<crate::Document>),
     /// Array of JSON values
@@ -88,7 +88,7 @@ pub enum NormalValue {
     /// Nillable array of bytes
     NillableBytesArray(Option<Vec<Vec<u8>>>),
     /// Nillable array of timestamps
-    NillableTimeArray(Option<Vec<DateTime<Utc>>>),
+    NillableTimeArray(Option<Vec<DateTime<FixedOffset>>>),
     /// Nillable array of documents
     NillableDocumentArray(Option<Vec<crate::Document>>),
 
@@ -106,7 +106,7 @@ pub enum NormalValue {
     /// Array of nillable bytes
     NillableBytesElementArray(Vec<Option<Vec<u8>>>),
     /// Array of nillable timestamps
-    NillableTimeElementArray(Vec<Option<DateTime<Utc>>>),
+    NillableTimeElementArray(Vec<Option<DateTime<FixedOffset>>>),
     /// Array of nillable documents
     NillableDocumentElementArray(Vec<Option<crate::Document>>),
 }
@@ -265,7 +265,7 @@ impl NormalValue {
     }
 
     /// Get as DateTime if this is a Time variant.
-    pub fn as_time(&self) -> Option<&DateTime<Utc>> {
+    pub fn as_time(&self) -> Option<&DateTime<FixedOffset>> {
         match self {
             NormalValue::Time(v) => Some(v),
             NormalValue::NillableTime(Some(v)) => Some(v),
@@ -341,8 +341,8 @@ impl From<Vec<u8>> for NormalValue {
     }
 }
 
-impl From<DateTime<Utc>> for NormalValue {
-    fn from(v: DateTime<Utc>) -> Self {
+impl From<DateTime<FixedOffset>> for NormalValue {
+    fn from(v: DateTime<FixedOffset>) -> Self {
         NormalValue::Time(v)
     }
 }

--- a/crates/ffi/defra.h
+++ b/crates/ffi/defra.h
@@ -274,6 +274,36 @@ struct FfiResult delete_nac_actor_relationship(uintptr_t node_ptr,
 
  All string parameters must be valid null-terminated UTF-8 strings.
  */
+/*
+ Add a DAC policy to the node.
+
+ Registers a policy document and returns its content-addressed ID.
+
+ Returns JSON with the policy ID:
+ ```json
+ { "PolicyID": "bafyreigh..." }
+ ```
+
+ # Safety
+
+ All string parameters must be valid null-terminated UTF-8 strings.
+ */
+struct FfiResult add_dac_policy(uintptr_t node_ptr,
+                                const char *identity_did,
+                                const char *policy);
+
+/*
+ Get a DAC policy by ID.
+
+ Returns JSON with the policy definition.
+
+ # Safety
+
+ All string parameters must be valid null-terminated UTF-8 strings.
+ */
+struct FfiResult get_dac_policy(uintptr_t node_ptr,
+                                const char *policy_id);
+
 struct FfiResult add_dac_actor_relationship(uintptr_t node_ptr,
                                             const char *requestor_did,
                                             const char *target_did,

--- a/crates/ffi/src/acp.rs
+++ b/crates/ffi/src/acp.rs
@@ -293,6 +293,44 @@ pub unsafe extern "C" fn delete_nac_actor_relationship(
 // DAC (Document Access Control) Functions
 // ============================================================================
 
+/// Add a DAC policy to the node.
+///
+/// Registers a policy document and returns its content-addressed ID.
+///
+/// Returns JSON with the policy ID:
+/// ```json
+/// { "PolicyID": "bafyreigh..." }
+/// ```
+///
+/// # Safety
+///
+/// All string parameters must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn add_dac_policy(
+    _node_ptr: usize,
+    _identity_did: *const c_char,
+    _policy: *const c_char,
+) -> FfiResult {
+    // DAC policies are not yet implemented in the Rust FFI
+    FfiResult::error("add_dac_policy is not yet implemented - see issue #179")
+}
+
+/// Get a DAC policy by ID.
+///
+/// Returns JSON with the policy definition.
+///
+/// # Safety
+///
+/// All string parameters must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn get_dac_policy(
+    _node_ptr: usize,
+    _policy_id: *const c_char,
+) -> FfiResult {
+    // DAC policies are not yet implemented in the Rust FFI
+    FfiResult::error("get_dac_policy is not yet implemented - see issue #179")
+}
+
 /// Add a DAC actor relationship (share document access with target).
 ///
 /// The requestor must be the document owner. Relation can be:

--- a/crates/query/src/plan/mutation/create.rs
+++ b/crates/query/src/plan/mutation/create.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset, Utc};
 use document::Document;
 use schema::{CollectionVersion, FieldKind, ScalarArrayKind, ScalarKind};
 use serde_json::Value as JsonValue;
@@ -218,15 +218,19 @@ pub fn json_to_normal_value_with_kind(
             // This matches Go DefraDB behavior where JSON fields accept any value type
             FieldKind::Scalar(ScalarKind::Json) => Ok(NormalValue::Json(value.clone())),
             // DateTime fields: parse RFC 3339 strings or special values like UTC_NOW
+            // CRITICAL: Must preserve original timezone to match Go's CID calculation
             FieldKind::Scalar(ScalarKind::DateTime) => {
                 match value {
                     JsonValue::String(s) => {
-                        // Handle special value UTC_NOW - return current time
+                        // Handle special value UTC_NOW - return current time in UTC
                         if s == "UTC_NOW" {
-                            return Ok(NormalValue::Time(Utc::now()));
+                            // Convert to FixedOffset for consistent type
+                            let utc_offset = FixedOffset::east_opt(0).unwrap();
+                            return Ok(NormalValue::Time(Utc::now().with_timezone(&utc_offset)));
                         }
-                        // Parse RFC 3339 string to DateTime (matching Go's time.Parse(time.RFC3339, s))
-                        let dt: DateTime<Utc> = s.parse().map_err(|e| {
+                        // Parse RFC 3339 string to DateTime, preserving original timezone
+                        // Go's time.Parse(time.RFC3339, s) preserves the original timezone
+                        let dt = DateTime::parse_from_rfc3339(s).map_err(|e| {
                             QueryError::execution(format!(
                                 "Invalid DateTime format '{}': expected RFC 3339 (e.g., '2024-01-15T10:30:00Z'). Error: {}",
                                 s, e
@@ -240,7 +244,9 @@ pub fn json_to_normal_value_with_kind(
                             let dt = DateTime::from_timestamp(ts, 0).ok_or_else(|| {
                                 QueryError::execution(format!("Invalid Unix timestamp: {}", ts))
                             })?;
-                            Ok(NormalValue::Time(dt))
+                            // Convert to FixedOffset in UTC
+                            let utc_offset = FixedOffset::east_opt(0).unwrap();
+                            Ok(NormalValue::Time(dt.with_timezone(&utc_offset)))
                         } else {
                             Err(QueryError::execution(format!(
                                 "Expected DateTime string or Unix timestamp, got: {:?}",
@@ -259,6 +265,35 @@ pub fn json_to_normal_value_with_kind(
                 JsonValue::Array(arr) => json_array_to_normal_value_with_kind(arr, *array_kind),
                 _ => Err(QueryError::execution(format!(
                     "Expected array, got: {:?}",
+                    value
+                ))),
+            },
+            // Float64 fields: convert integers to float64 for Go compatibility
+            // Go DefraDB coerces JSON integers to the schema's float type
+            FieldKind::Scalar(ScalarKind::Float64) => match value {
+                JsonValue::Number(n) => {
+                    // Convert any numeric value to f64
+                    let f = n.as_f64().ok_or_else(|| {
+                        QueryError::execution(format!("Cannot convert number to f64: {:?}", n))
+                    })?;
+                    Ok(NormalValue::Float64(f))
+                }
+                _ => Err(QueryError::execution(format!(
+                    "Expected number for Float64 field, got: {:?}",
+                    value
+                ))),
+            },
+            // Float32 fields: convert integers to float32 for Go compatibility
+            FieldKind::Scalar(ScalarKind::Float32) => match value {
+                JsonValue::Number(n) => {
+                    // Convert any numeric value to f32
+                    let f = n.as_f64().ok_or_else(|| {
+                        QueryError::execution(format!("Cannot convert number to f32: {:?}", n))
+                    })? as f32;
+                    Ok(NormalValue::Float32(f))
+                }
+                _ => Err(QueryError::execution(format!(
+                    "Expected number for Float32 field, got: {:?}",
                     value
                 ))),
             },

--- a/crates/storage/src/field_value.rs
+++ b/crates/storage/src/field_value.rs
@@ -3,7 +3,7 @@
 //! This module provides encoding/decoding of document field values
 //! using order-preserving encoding for use in secondary index keys.
 
-use chrono::{TimeZone, Utc};
+use chrono::{FixedOffset, TimeZone, Utc};
 use document::NormalValue;
 use schema::FieldKind;
 
@@ -217,12 +217,15 @@ pub fn decode_field_value<'a>(
                 let nsecs = ((nanos % 1_000_000_000) + 1_000_000_000) % 1_000_000_000;
                 (secs, nsecs as u32)
             };
-            let dt = Utc.timestamp_opt(secs, nsecs).single().ok_or_else(|| {
+            let dt_utc = Utc.timestamp_opt(secs, nsecs).single().ok_or_else(|| {
                 crate::corekv::Error::Other(format!(
                     "invalid timestamp: cannot construct DateTime from secs={}, nsecs={}",
                     secs, nsecs
                 ))
             })?;
+            // Convert to FixedOffset (UTC+0) since storage doesn't preserve timezone
+            let utc_offset = FixedOffset::east_opt(0).unwrap();
+            let dt = dt_utc.with_timezone(&utc_offset);
             Ok((rest, NormalValue::Time(dt)))
         }
         _ => Err(crate::corekv::Error::Other(format!(


### PR DESCRIPTION
## Summary

- Fix DateTime CID mismatch between Go and Rust implementations by preserving original timezone
- Add Float32/Float64 type coercion for JSON integer inputs
- Add stub functions for `add_dac_policy` and `get_dac_policy` FFI

## Problem

DateTime values were producing different CIDs (Content IDentifiers) between Go and Rust because:
- **Go**: Preserved original timezone from RFC3339 input (e.g., `-05:00`)
- **Rust**: Normalized all DateTime values to UTC with `Z` suffix

This caused "unexpected document update" errors when the Rust FFI created documents with different CIDs than Go expected.

## Solution

Changed Rust's DateTime handling from `DateTime<Utc>` to `DateTime<FixedOffset>` to preserve the original timezone, ensuring CBOR encoding produces identical byte representations.

## Test plan

- [x] All query/simple tests passing (437/437)
- [x] All mutation/create tests passing
- [x] All mutation/update tests passing  
- [x] All mutation/delete tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)