### PR TITLE
feat(query): Improve one-to-many query support

### DIFF
--- a/crates/query/src/document/mapping.rs
+++ b/crates/query/src/document/mapping.rs
@@ -155,6 +155,13 @@ impl DocumentMapping {
             .and_then(|opt| opt.as_ref().map(|b| b.as_ref()))
     }
 
+    /// Get a mutable reference to a child mapping at the given index
+    pub fn child_at_mut(&mut self, index: usize) -> Option<&mut DocumentMapping> {
+        self.child_mappings
+            .get_mut(index)
+            .and_then(|opt| opt.as_mut().map(|b| b.as_mut()))
+    }
+
     /// Render a document to a JSON object using this mapping's render keys.
     ///
     /// Iterates over render_keys and extracts the corresponding values from the document

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -172,6 +172,32 @@ impl Filter {
         self.conditions.is_empty()
     }
 
+    /// Check if the filter has field-based conditions (as opposed to operator-only conditions).
+    ///
+    /// Field-based: `{rating: {_gt: 4.8}}` - the key "rating" is a field name
+    /// Operator-only: `{_gt: 4.8}` - the key "_gt" is an operator
+    ///
+    /// This is used to determine whether to use `matches_json_object` (field-based)
+    /// or `matches_scalar_value` (operator-only) when filtering relation aggregates.
+    pub fn has_field_conditions(&self) -> bool {
+        self.conditions.keys().any(|k| FilterOp::parse(k).is_none())
+    }
+
+    /// Combine this filter with another filter using AND logic.
+    ///
+    /// Returns a new filter where both conditions must be satisfied.
+    pub fn and(&self, other: Filter) -> Filter {
+        let mut combined_conditions = HashMap::new();
+        combined_conditions.insert(
+            "_and".to_string(),
+            serde_json::json!([
+                self.conditions,
+                other.conditions
+            ]),
+        );
+        Filter::from_conditions(combined_conditions)
+    }
+
     /// Get a reference to the conditions map
     pub fn conditions(&self) -> &HashMap<String, JsonValue> {
         &self.conditions
@@ -480,6 +506,14 @@ impl Filter {
         None
     }
 
+    /// Check if this filter contains an `_alias` directive.
+    ///
+    /// `_alias` filters reference aliased fields/relations and must be evaluated after joins
+    /// because the alias may reference a relation whose data hasn't been joined yet.
+    pub fn has_alias_filter(&self) -> bool {
+        self.conditions.contains_key("_alias")
+    }
+
     /// Check if this filter is "complex" - contains relation conditions inside logical operators.
     ///
     /// A filter is complex when `_and`, `_or`, or `_not` contains a mix of scalar and relation
@@ -643,6 +677,37 @@ impl Filter {
         };
 
         (non_alias_filter, alias_filter)
+    }
+
+    /// Strip _alias conditions from the filter that reference aggregate field names.
+    ///
+    /// This is used to prevent _alias conditions on computed aggregates from being
+    /// evaluated during plan execution (when aggregate values don't exist yet).
+    /// The stripped conditions should be applied in post-processing after aggregates are computed.
+    ///
+    /// Returns (filtered, has_aggregate_alias) where:
+    /// - filtered: Filter without _alias conditions referencing the given aggregate names
+    /// - has_aggregate_alias: true if any _alias conditions were referencing aggregates
+    pub fn strip_aggregate_alias_conditions(&self, aggregate_names: &[&str]) -> (Filter, bool) {
+        let mut new_conditions = HashMap::new();
+        let mut has_aggregate_alias = false;
+
+        for (key, value) in &self.conditions {
+            if key == "_alias" {
+                // Check if this _alias block references any aggregate names
+                if let Some(alias_obj) = value.as_object() {
+                    let refs_aggregate = alias_obj.keys().any(|k| aggregate_names.contains(&k.as_str()));
+                    if refs_aggregate {
+                        has_aggregate_alias = true;
+                        // Skip this _alias condition - it will be applied in post-processing
+                        continue;
+                    }
+                }
+            }
+            new_conditions.insert(key.clone(), value.clone());
+        }
+
+        (Filter::from_conditions(new_conditions), has_aggregate_alias)
     }
 
     /// Evaluate the filter against document fields
@@ -1378,6 +1443,114 @@ impl Filter {
                     "unknown operator in scalar filter: {}",
                     key
                 )));
+            }
+        }
+        Ok(true)
+    }
+
+    /// Evaluate the filter against a JSON object (document).
+    ///
+    /// Used for relation aggregate filters where each related document is tested
+    /// against field-based conditions like `{rating: {_gt: 4.8}}`.
+    ///
+    /// Unlike `matches_scalar_value` which only handles operator conditions,
+    /// this method handles:
+    /// - Field-based conditions: `{rating: {_gt: 4.8}}` extracts `rating` from the object
+    /// - Operator-only conditions: `{_gt: 4.8}` (falls back to matches_scalar_value)
+    /// - Compound conditions: `{_and: [...]}`, `{_or: [...]}`, `{_not: {...}}`
+    pub fn matches_json_object(&self, obj: &JsonValue) -> Result<bool> {
+        if self.conditions.is_empty() {
+            return Ok(true);
+        }
+
+        for (key, expected) in &self.conditions {
+            if let Some(op) = FilterOp::parse(key) {
+                // Operator condition
+                match op {
+                    FilterOp::And => {
+                        let arr = expected
+                            .as_array()
+                            .ok_or_else(|| QueryError::invalid_filter("_and requires array"))?;
+                        for item in arr {
+                            let sub: HashMap<String, JsonValue> =
+                                serde_json::from_value(item.clone())
+                                    .map_err(|e| QueryError::invalid_filter(e.to_string()))?;
+                            let f = Filter::from_conditions(sub);
+                            if !f.matches_json_object(obj)? {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                    FilterOp::Or => {
+                        let arr = expected
+                            .as_array()
+                            .ok_or_else(|| QueryError::invalid_filter("_or requires array"))?;
+                        let mut any_match = false;
+                        for item in arr {
+                            let sub: HashMap<String, JsonValue> =
+                                serde_json::from_value(item.clone())
+                                    .map_err(|e| QueryError::invalid_filter(e.to_string()))?;
+                            let f = Filter::from_conditions(sub);
+                            if f.matches_json_object(obj)? {
+                                any_match = true;
+                                break;
+                            }
+                        }
+                        if !any_match {
+                            return Ok(false);
+                        }
+                    }
+                    FilterOp::Not => {
+                        let sub: HashMap<String, JsonValue> =
+                            serde_json::from_value(expected.clone())
+                                .map_err(|e| QueryError::invalid_filter(e.to_string()))?;
+                        let f = Filter::from_conditions(sub);
+                        if f.matches_json_object(obj)? {
+                            return Ok(false);
+                        }
+                    }
+                    _ => {
+                        // Direct operator on the object itself - use scalar matching
+                        if !self.eval_op(obj, op, expected)? {
+                            return Ok(false);
+                        }
+                    }
+                }
+            } else {
+                // Field-based condition: key is a field name
+                let field_value = obj
+                    .as_object()
+                    .and_then(|o| o.get(key))
+                    .unwrap_or(&JsonValue::Null);
+
+                // expected should be an object with operator conditions
+                if let Some(conditions_obj) = expected.as_object() {
+                    // Check if the nested conditions are operators or field-based
+                    // If they're operators, use matches_scalar_value on the field value
+                    // If they're field-based, recursively use matches_json_object
+                    let has_field_conditions = conditions_obj.keys().any(|k| FilterOp::parse(k).is_none());
+                    let sub_conditions: HashMap<String, JsonValue> = conditions_obj
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    let f = Filter::from_conditions(sub_conditions);
+                    if has_field_conditions {
+                        // Nested field access - recursively match
+                        if !f.matches_json_object(field_value)? {
+                            return Ok(false);
+                        }
+                    } else {
+                        // Operator conditions on the field value
+                        if !f.matches_scalar_value(field_value)? {
+                            return Ok(false);
+                        }
+                    }
+                } else {
+                    // Direct equality check: {field: value}
+                    if field_value != expected {
+                        return Ok(false);
+                    }
+                }
             }
         }
         Ok(true)

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -298,6 +298,24 @@ impl Filter {
         }
     }
 
+    /// Get all relation filter conditions.
+    ///
+    /// Returns an iterator over (relation_name, nested_filter) pairs for each relation
+    /// referenced in the filter.
+    ///
+    /// For a filter like `{author: {verified: {_eq: true}}, rating: {_gt: 4}}`:
+    /// - Returns: [("author", Filter({verified: {_eq: true}}))]
+    /// - "rating" is not a relation filter (it has operators, not nested fields)
+    pub fn relation_conditions(&self) -> Vec<(String, Filter)> {
+        let mut result = Vec::new();
+        for name in self.relation_field_names() {
+            if let Some(filter) = self.extract_relation_filter(&name) {
+                result.push((name, filter));
+            }
+        }
+        result
+    }
+
     fn check_for_relation_filters(conditions: &HashMap<String, JsonValue>) -> bool {
         for (key, value) in conditions {
             // Check logical operators recursively

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -287,6 +287,9 @@ impl Filter {
                     }
                     _ => {}
                 }
+            } else if key == "_alias" {
+                // _alias is a special filter directive, not a relation field
+                continue;
             } else if let JsonValue::Object(obj) = value {
                 // This is a field condition - check if it contains operators or nested fields
                 // If any key in the object is NOT an operator, it's a relation filter
@@ -345,6 +348,9 @@ impl Filter {
                     }
                     _ => {}
                 }
+            } else if key == "_alias" {
+                // _alias is a special filter directive, not a relation filter
+                continue;
             } else if let JsonValue::Object(obj) = value {
                 // This is a field condition - check if it contains operators or nested fields
                 // If any key in the object is NOT an operator, it's a relation filter
@@ -416,6 +422,11 @@ impl Filter {
                         _ => {}
                     }
                 }
+                continue;
+            }
+
+            // _alias is a special filter directive, not a relation path
+            if key == "_alias" {
                 continue;
             }
 
@@ -633,6 +644,9 @@ impl Filter {
                         scalar_conditions.insert(key.clone(), value.clone());
                     }
                 }
+            } else if key == "_alias" {
+                // _alias is a special filter directive evaluated by eval_conditions, not a relation
+                scalar_conditions.insert(key.clone(), value.clone());
             } else if let JsonValue::Object(obj) = value {
                 // Field condition - check if it's a relation filter
                 let is_relation = obj.keys().any(|k| FilterOp::parse(k).is_none());
@@ -1729,16 +1743,50 @@ impl Filter {
                 QueryError::invalid_filter("alias field condition must be object")
             })?;
 
-            for (op_key, op_value) in ops {
-                if let Some(op) = FilterOp::parse(op_key) {
-                    if !self.eval_op(&field_value, op, op_value)? {
+            // Check if this is a relation filter (nested field conditions) or operator conditions
+            let is_relation_filter = ops.keys().any(|k| FilterOp::parse(k).is_none());
+
+            if is_relation_filter {
+                // Relation-style alias: {_alias: {books: {rating: {_gt: 4.8}}}}
+                // The alias points to a relation field (array or object)
+                if field_value.is_null() {
+                    // Null relation → no match
+                    return Ok(false);
+                } else if let Some(arr) = field_value.as_array() {
+                    // One-to-many: existential semantics (any element matches)
+                    let mut any_match = false;
+                    for elem in arr {
+                        if let Some(obj) = elem.as_object() {
+                            if self.eval_relation_conditions(ops, obj)? {
+                                any_match = true;
+                                break;
+                            }
+                        }
+                    }
+                    if !any_match {
+                        return Ok(false);
+                    }
+                } else if let Some(obj) = field_value.as_object() {
+                    // One-to-one: direct match
+                    if !self.eval_relation_conditions(ops, obj)? {
                         return Ok(false);
                     }
                 } else {
-                    return Err(QueryError::invalid_filter(format!(
-                        "unknown operator '{}' in _alias filter",
-                        op_key
-                    )));
+                    return Ok(false);
+                }
+            } else {
+                // Scalar-style alias: {_alias: {myAge: {_gt: 20}}}
+                for (op_key, op_value) in ops {
+                    if let Some(op) = FilterOp::parse(op_key) {
+                        if !self.eval_op(&field_value, op, op_value)? {
+                            return Ok(false);
+                        }
+                    } else {
+                        return Err(QueryError::invalid_filter(format!(
+                            "unknown operator '{}' in _alias filter",
+                            op_key
+                        )));
+                    }
                 }
             }
         }

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -33,4 +33,6 @@ pub use permission_filter::PermissionFilterNode;
 pub use scan::ScanNode;
 pub use select::SelectNode;
 pub use sum::SumNode;
-pub use type_join::{JoinDirection, JoinSide, RelationFilter, TypeJoinMany, TypeJoinOne};
+pub use type_join::{
+    compare_json_values, JoinDirection, JoinSide, RelationFilter, TypeJoinMany, TypeJoinOne,
+};

--- a/crates/query/src/plan/type_join/mod.rs
+++ b/crates/query/src/plan/type_join/mod.rs
@@ -11,7 +11,7 @@ mod type_join_one;
 
 pub use direction::JoinDirection;
 pub use join_side::JoinSide;
-pub use type_join_many::TypeJoinMany;
+pub use type_join_many::{compare_json_values, TypeJoinMany};
 pub use type_join_one::{RelationFilter, TypeJoinOne};
 
 // Tests extracted to crates/query/tests/type_join_tests.rs

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -195,6 +195,9 @@ impl TypeJoinMany {
 
     /// Find all child documents that match the parent's _docID using the cache.
     /// Applies ordering, offset, and limit per-parent.
+    /// Find all child docs for a parent, applying ordering but NOT limit/offset.
+    /// Limit/offset are deferred to the runner's post-processing step so that
+    /// relation aggregates (e.g., _count) can see ALL children.
     fn find_child_docs(&self, parent_doc_id: &str) -> Vec<Doc> {
         let Some(docs) = self.child_cache.get(parent_doc_id) else {
             return Vec::new();
@@ -207,8 +210,6 @@ impl TypeJoinMany {
             let child_mapping = self.child_plan.document_map();
             children.sort_by(|a, b| {
                 for condition in &order_by.conditions {
-                    // For nested selections, the order field should be a simple field name
-                    // (not a compound path through relations)
                     let field_name = condition.fields.first().map(|s| s.as_str()).unwrap_or("");
                     let field_idx = child_mapping.first_index_of_name(field_name);
 
@@ -229,19 +230,10 @@ impl TypeJoinMany {
             });
         }
 
-        // Apply offset
-        if self.child_offset > 0 {
-            let offset = self.child_offset as usize;
-            if offset >= children.len() {
-                return Vec::new();
-            }
-            children = children.into_iter().skip(offset).collect();
-        }
-
-        // Apply limit
-        if let Some(limit) = self.child_limit {
-            children.truncate(limit as usize);
-        }
+        // NOTE: Limit/offset are NOT applied here. They are applied in the runner's
+        // apply_relation_limits() after compute_relation_aggregates() has counted
+        // all children. This ensures _count(published: {}) sees all children even
+        // when published(limit: 1) limits the rendered output.
 
         children
     }

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -2,11 +2,13 @@
 
 use async_trait::async_trait;
 use serde_json::Value as JsonValue;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use tracing::warn;
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
+use crate::mapper::{OrderBy, OrderDirection};
 use crate::planner::{Doc, PlanNode};
 
 use super::JoinSide;
@@ -52,6 +54,12 @@ pub struct TypeJoinMany {
     /// Cached child documents indexed by FK field value.
     /// Key is the child's FK value (points to parent's _docID).
     child_cache: HashMap<String, Vec<Doc>>,
+    /// Per-parent limit on children (None = no limit)
+    child_limit: Option<u64>,
+    /// Per-parent offset on children
+    child_offset: u64,
+    /// Order by specification for children
+    child_order_by: Option<OrderBy>,
 }
 
 impl std::fmt::Debug for TypeJoinMany {
@@ -112,15 +120,81 @@ impl TypeJoinMany {
             child_fk_index,
             initialized: false,
             child_cache: HashMap::new(),
+            child_limit: None,
+            child_offset: 0,
+            child_order_by: None,
         })
     }
 
+    /// Set the per-parent limit on children.
+    pub fn with_limit(mut self, limit: u64) -> Self {
+        self.child_limit = Some(limit);
+        self
+    }
+
+    /// Set the per-parent offset on children.
+    pub fn with_offset(mut self, offset: u64) -> Self {
+        self.child_offset = offset;
+        self
+    }
+
+    /// Set the order by specification for children.
+    pub fn with_order_by(mut self, order_by: OrderBy) -> Self {
+        self.child_order_by = Some(order_by);
+        self
+    }
+
     /// Find all child documents that match the parent's _docID using the cache.
+    /// Applies ordering, offset, and limit per-parent.
     fn find_child_docs(&self, parent_doc_id: &str) -> Vec<Doc> {
-        self.child_cache
-            .get(parent_doc_id)
-            .map(|docs| docs.iter().map(|d| d.deep_clone()).collect())
-            .unwrap_or_default()
+        let Some(docs) = self.child_cache.get(parent_doc_id) else {
+            return Vec::new();
+        };
+
+        let mut children: Vec<Doc> = docs.iter().map(|d| d.deep_clone()).collect();
+
+        // Apply ordering if specified
+        if let Some(ref order_by) = self.child_order_by {
+            let child_mapping = self.child_plan.document_map();
+            children.sort_by(|a, b| {
+                for condition in &order_by.conditions {
+                    // For nested selections, the order field should be a simple field name
+                    // (not a compound path through relations)
+                    let field_name = condition.fields.first().map(|s| s.as_str()).unwrap_or("");
+                    let field_idx = child_mapping.first_index_of_name(field_name);
+
+                    if let Some(idx) = field_idx {
+                        let val_a = a.get(idx);
+                        let val_b = b.get(idx);
+                        let cmp = compare_json_values(val_a, val_b);
+                        let cmp = match condition.direction {
+                            OrderDirection::Asc => cmp,
+                            OrderDirection::Desc => cmp.reverse(),
+                        };
+                        if cmp != Ordering::Equal {
+                            return cmp;
+                        }
+                    }
+                }
+                Ordering::Equal
+            });
+        }
+
+        // Apply offset
+        if self.child_offset > 0 {
+            let offset = self.child_offset as usize;
+            if offset >= children.len() {
+                return Vec::new();
+            }
+            children = children.into_iter().skip(offset).collect();
+        }
+
+        // Apply limit
+        if let Some(limit) = self.child_limit {
+            children.truncate(limit as usize);
+        }
+
+        children
     }
 
     /// Build the child cache by scanning child_plan once.
@@ -270,5 +344,40 @@ impl PlanNode for TypeJoinMany {
 
     fn kind(&self) -> &'static str {
         "typeJoinMany"
+    }
+}
+
+/// Compare two JSON values for ordering.
+/// Follows SQL-like ordering: NULL < bool < number < string < array < object
+fn compare_json_values(a: Option<&JsonValue>, b: Option<&JsonValue>) -> Ordering {
+    match (a, b) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(JsonValue::Null), Some(JsonValue::Null)) => Ordering::Equal,
+        (Some(JsonValue::Null), Some(_)) => Ordering::Less,
+        (Some(_), Some(JsonValue::Null)) => Ordering::Greater,
+        (Some(JsonValue::Bool(a)), Some(JsonValue::Bool(b))) => a.cmp(b),
+        (Some(JsonValue::Number(a)), Some(JsonValue::Number(b))) => {
+            // Compare as f64 for numeric ordering
+            let fa = a.as_f64().unwrap_or(0.0);
+            let fb = b.as_f64().unwrap_or(0.0);
+            fa.partial_cmp(&fb).unwrap_or(Ordering::Equal)
+        }
+        (Some(JsonValue::String(a)), Some(JsonValue::String(b))) => a.cmp(b),
+        // Different types: order by type precedence
+        (Some(a), Some(b)) => type_precedence(a).cmp(&type_precedence(b)),
+    }
+}
+
+/// Get type precedence for ordering (lower = comes first)
+fn type_precedence(v: &JsonValue) -> u8 {
+    match v {
+        JsonValue::Null => 0,
+        JsonValue::Bool(_) => 1,
+        JsonValue::Number(_) => 2,
+        JsonValue::String(_) => 3,
+        JsonValue::Array(_) => 4,
+        JsonValue::Object(_) => 5,
     }
 }

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -597,7 +597,7 @@ impl PlanNode for TypeJoinMany {
 
 /// Compare two JSON values for ordering.
 /// Follows SQL-like ordering: NULL < bool < number < string < array < object
-fn compare_json_values(a: Option<&JsonValue>, b: Option<&JsonValue>) -> Ordering {
+pub fn compare_json_values(a: Option<&JsonValue>, b: Option<&JsonValue>) -> Ordering {
     match (a, b) {
         (None, None) => Ordering::Equal,
         (None, Some(_)) => Ordering::Less,

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -11,7 +11,7 @@ use crate::error::{QueryError, Result};
 use crate::mapper::{OrderBy, OrderDirection};
 use crate::planner::{Doc, PlanNode};
 
-use super::JoinSide;
+use super::{JoinSide, RelationFilter};
 
 /// TypeJoinMany implements one-to-many relation joins.
 ///
@@ -60,6 +60,11 @@ pub struct TypeJoinMany {
     child_offset: u64,
     /// Order by specification for children
     child_order_by: Option<OrderBy>,
+    /// Optional relation filter to apply during join.
+    /// When set, only include parents that have at least one child passing this filter.
+    /// Example: `Author(filter: {published: {rating: {_gt: 4}}})` means only include
+    /// authors who have at least one book with rating > 4.
+    relation_filter: Option<RelationFilter>,
 }
 
 impl std::fmt::Debug for TypeJoinMany {
@@ -123,6 +128,7 @@ impl TypeJoinMany {
             child_limit: None,
             child_offset: 0,
             child_order_by: None,
+            relation_filter: None,
         })
     }
 
@@ -141,6 +147,17 @@ impl TypeJoinMany {
     /// Set the order by specification for children.
     pub fn with_order_by(mut self, order_by: OrderBy) -> Self {
         self.child_order_by = Some(order_by);
+        self
+    }
+
+    /// Set a relation filter to apply during the join.
+    ///
+    /// When set, parent documents will only be included if they have at least one
+    /// child document that passes this filter. This is used for queries like
+    /// `Author(filter: {published: {rating: {_gt: 4}}})` - only include authors
+    /// who have published at least one book with rating > 4.
+    pub fn with_relation_filter(mut self, filter: RelationFilter) -> Self {
+        self.relation_filter = Some(filter);
         self
     }
 
@@ -271,6 +288,41 @@ impl TypeJoinMany {
             JsonValue::Array(array),
         );
     }
+
+    /// Check if at least one child document passes the relation filter.
+    ///
+    /// Returns true if:
+    /// - There's no filter (always pass)
+    /// - At least one child document passes the filter conditions
+    ///
+    /// Returns false if:
+    /// - There are no child documents (empty relation can't pass any filter)
+    /// - No child document passes the filter conditions
+    fn check_relation_filter(&self, children: &[Doc], rel_filter: &RelationFilter) -> Result<bool> {
+        if children.is_empty() {
+            // No children - relation filter cannot pass
+            return Ok(false);
+        }
+
+        // Check if any child passes the filter
+        let child_mapping = self.child_plan.document_map();
+        for child in children {
+            if rel_filter.conditions.matches(child.fields(), child_mapping)? {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Get all children for a parent (unfiltered, for filter checking).
+    /// This returns all children before limit/offset is applied.
+    fn get_all_children(&self, parent_doc_id: &str) -> Vec<Doc> {
+        self.child_cache
+            .get(parent_doc_id)
+            .map(|docs| docs.iter().map(|d| d.deep_clone()).collect())
+            .unwrap_or_default()
+    }
 }
 
 #[async_trait]
@@ -295,31 +347,53 @@ impl PlanNode for TypeJoinMany {
             ));
         }
 
-        if !self.parent_plan.next().await? {
-            return Ok(false);
-        }
-
-        let mut parent_doc = self.parent_plan.value().deep_clone();
-
-        // Get parent's _docID for the lookup (O(1) cache lookup)
-        let children = match parent_doc.doc_id() {
-            Some(id) => self.find_child_docs(id),
-            None => {
-                warn!(
-                    parent_collection = %self.parent_side.collection().name,
-                    relation_field = %self.parent_side.relation_field().name,
-                    "Parent document missing _docID - returning empty children array. \
-                     This may indicate data corruption or a schema mismatch."
-                );
-                Vec::new()
+        // Loop to skip parents that don't pass relation filter
+        loop {
+            if !self.parent_plan.next().await? {
+                return Ok(false);
             }
-        };
 
-        // Merge children array into parent
-        self.merge_children(&mut parent_doc, children);
-        self.current_doc = parent_doc;
+            let mut parent_doc = self.parent_plan.value().deep_clone();
 
-        Ok(true)
+            // Get parent's _docID for the lookup (O(1) cache lookup)
+            let parent_doc_id = match parent_doc.doc_id() {
+                Some(id) => id.to_string(),
+                None => {
+                    warn!(
+                        parent_collection = %self.parent_side.collection().name,
+                        relation_field = %self.parent_side.relation_field().name,
+                        "Parent document missing _docID - returning empty children array. \
+                         This may indicate data corruption or a schema mismatch."
+                    );
+                    // No docID means no children can match - skip if filter is present
+                    if self.relation_filter.is_some() {
+                        continue;
+                    }
+                    // No filter, return with empty children
+                    self.merge_children(&mut parent_doc, Vec::new());
+                    self.current_doc = parent_doc;
+                    return Ok(true);
+                }
+            };
+
+            // Apply relation filter if present (check against ALL children, not just limited)
+            if let Some(ref rel_filter) = self.relation_filter {
+                let all_children = self.get_all_children(&parent_doc_id);
+                if !self.check_relation_filter(&all_children, rel_filter)? {
+                    // No children pass the filter - skip this parent
+                    continue;
+                }
+            }
+
+            // Get children (with ordering, offset, limit applied)
+            let children = self.find_child_docs(&parent_doc_id);
+
+            // Merge children array into parent
+            self.merge_children(&mut parent_doc, children);
+            self.current_doc = parent_doc;
+
+            return Ok(true);
+        }
     }
 
     fn value(&self) -> &Doc {

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
-use crate::mapper::{OrderBy, OrderDirection};
+use crate::mapper::{GroupBy, OrderBy, OrderDirection};
 use crate::planner::{Doc, PlanNode};
 
 use super::{JoinSide, RelationFilter};
@@ -65,6 +65,14 @@ pub struct TypeJoinMany {
     /// Example: `Author(filter: {published: {rating: {_gt: 4}}})` means only include
     /// authors who have at least one book with rating > 4.
     relation_filter: Option<RelationFilter>,
+    /// Optional groupBy for nested grouping of children.
+    /// When set, children are grouped by the specified fields and output includes
+    /// a `_group` array containing the grouped documents.
+    /// Example: `published(groupBy: [rating]) { rating, _group { name } }`
+    child_group_by: Option<GroupBy>,
+    /// Mapping for rendering documents inside the _group array.
+    /// Only used when child_group_by is set.
+    group_mapping: Option<DocumentMapping>,
 }
 
 impl std::fmt::Debug for TypeJoinMany {
@@ -129,6 +137,8 @@ impl TypeJoinMany {
             child_offset: 0,
             child_order_by: None,
             relation_filter: None,
+            child_group_by: None,
+            group_mapping: None,
         })
     }
 
@@ -158,6 +168,28 @@ impl TypeJoinMany {
     /// who have published at least one book with rating > 4.
     pub fn with_relation_filter(mut self, filter: RelationFilter) -> Self {
         self.relation_filter = Some(filter);
+        self
+    }
+
+    /// Set a groupBy specification for grouping children.
+    ///
+    /// When set, children will be grouped by the specified fields. The output
+    /// will be an array of objects, each containing the groupBy field values
+    /// and a `_group` array of documents in that group.
+    ///
+    /// Example: `published(groupBy: [rating]) { rating, _group { name } }`
+    /// Groups books by rating, outputting: `[{rating: 4.9, _group: [{name: "..."}]}, ...]`
+    pub fn with_group_by(mut self, group_by: GroupBy) -> Self {
+        self.child_group_by = Some(group_by);
+        self
+    }
+
+    /// Set the mapping for rendering documents inside the _group array.
+    ///
+    /// This mapping determines which fields are rendered for documents inside _group.
+    /// Only used when child_group_by is set.
+    pub fn with_group_mapping(mut self, mapping: DocumentMapping) -> Self {
+        self.group_mapping = Some(mapping);
         self
     }
 
@@ -269,24 +301,174 @@ impl TypeJoinMany {
     }
 
     /// Merge child documents into parent as an array.
+    ///
+    /// If `child_group_by` is set, groups children by the specified fields and
+    /// outputs an array of group objects with `_group` arrays.
+    /// Otherwise, outputs a simple array of child documents.
     fn merge_children(&self, parent_doc: &mut Doc, children: Vec<Doc>) {
-        // Get child mapping. Falls back to child plan's mapping if not explicitly
-        // set in parent mapping - this happens for simple queries where child
-        // mapping was not pre-configured during planning.
-        let child_mapping = self
-            .document_mapping
-            .child_at(self.parent_side.relation_field_index())
-            .unwrap_or(self.child_plan.document_map());
-
-        let array: Vec<JsonValue> = children
-            .iter()
-            .map(|doc| child_mapping.render_doc_to_json(doc))
-            .collect();
+        let array = if let Some(ref group_by) = self.child_group_by {
+            self.build_grouped_array(&children, group_by)
+        } else {
+            self.build_simple_array(&children)
+        };
 
         parent_doc.set(
             self.parent_side.relation_field_index(),
             JsonValue::Array(array),
         );
+    }
+
+    /// Build a simple array of child documents (no grouping).
+    fn build_simple_array(&self, children: &[Doc]) -> Vec<JsonValue> {
+        let child_mapping = self
+            .document_mapping
+            .child_at(self.parent_side.relation_field_index())
+            .unwrap_or(self.child_plan.document_map());
+
+        children
+            .iter()
+            .map(|doc| child_mapping.render_doc_to_json(doc))
+            .collect()
+    }
+
+    /// Build a grouped array where children are grouped by the specified fields.
+    ///
+    /// Output format for each group:
+    /// `{groupByField1: value1, groupByField2: value2, _group: [doc1, doc2, ...]}`
+    fn build_grouped_array(&self, children: &[Doc], group_by: &GroupBy) -> Vec<JsonValue> {
+        if children.is_empty() {
+            return Vec::new();
+        }
+
+        // Get the child mapping for looking up field indices
+        let child_mapping = self.child_plan.document_map();
+
+        // Group children by the groupBy field values
+        let mut groups: Vec<(String, Vec<&Doc>)> = Vec::new();
+        let mut group_map: HashMap<String, usize> = HashMap::new();
+
+        for child in children {
+            let key = self.generate_group_key(child, group_by, child_mapping);
+            if let Some(&idx) = group_map.get(&key) {
+                groups[idx].1.push(child);
+            } else {
+                let idx = groups.len();
+                group_map.insert(key.clone(), idx);
+                groups.push((key, vec![child]));
+            }
+        }
+
+        // Get the mapping for rendering. Use the child mapping from document_mapping
+        // if available, otherwise fall back to child_plan's mapping.
+        let render_mapping = self
+            .document_mapping
+            .child_at(self.parent_side.relation_field_index())
+            .unwrap_or(child_mapping);
+
+        // Build output array: one object per group
+        let mut result = Vec::with_capacity(groups.len());
+        for (_key, group_docs) in &groups {
+            let mut obj = serde_json::Map::new();
+
+            // Add groupBy field values from the first document in the group
+            if let Some(first_doc) = group_docs.first() {
+                for field_name in &group_by.fields {
+                    if let Some(idx) = child_mapping.first_index_of_name(field_name) {
+                        if let Some(value) = first_doc.get(idx) {
+                            obj.insert(field_name.clone(), value.clone());
+                        }
+                    }
+                }
+            }
+
+            // Build the _group array
+            let group_array: Vec<JsonValue> = if let Some(ref group_mapping) = self.group_mapping {
+                // Use explicit group mapping for rendering _group contents
+                group_docs
+                    .iter()
+                    .map(|doc| group_mapping.render_doc_to_json(doc))
+                    .collect()
+            } else {
+                // Fall back to render mapping, excluding groupBy fields
+                group_docs
+                    .iter()
+                    .map(|doc| {
+                        self.render_doc_excluding_fields(doc, render_mapping, &group_by.fields)
+                    })
+                    .collect()
+            };
+
+            obj.insert("_group".to_string(), JsonValue::Array(group_array));
+            result.push(JsonValue::Object(obj));
+        }
+
+        result
+    }
+
+    /// Generate a group key from a document based on groupBy fields.
+    fn generate_group_key(
+        &self,
+        doc: &Doc,
+        group_by: &GroupBy,
+        mapping: &DocumentMapping,
+    ) -> String {
+        let mut key = String::new();
+        for field_name in &group_by.fields {
+            if let Some(idx) = mapping.first_index_of_name(field_name) {
+                key.push_str(&format!("{}_", idx));
+                let value = doc.get(idx);
+                key.push_str(&format!("{}_", Self::value_to_key(value)));
+            }
+        }
+        key
+    }
+
+    /// Convert a JSON value to a string key component.
+    fn value_to_key(value: Option<&JsonValue>) -> String {
+        match value {
+            None | Some(JsonValue::Null) => "null".to_string(),
+            Some(JsonValue::Bool(b)) => b.to_string(),
+            Some(JsonValue::Number(n)) => n.to_string(),
+            Some(JsonValue::String(s)) => s.clone(),
+            Some(JsonValue::Array(arr)) => {
+                format!(
+                    "[{}]",
+                    arr.iter()
+                        .map(|v| Self::value_to_key(Some(v)))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+            Some(JsonValue::Object(obj)) => {
+                format!(
+                    "{{{}}}",
+                    obj.iter()
+                        .map(|(k, v)| format!("{}:{}", k, Self::value_to_key(Some(v))))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+        }
+    }
+
+    /// Render a document excluding the specified fields.
+    fn render_doc_excluding_fields(
+        &self,
+        doc: &Doc,
+        mapping: &DocumentMapping,
+        exclude_fields: &[String],
+    ) -> JsonValue {
+        let mut obj = serde_json::Map::new();
+        for rk in &mapping.render_keys {
+            // Skip excluded fields (groupBy fields) and _group pseudo-field
+            if exclude_fields.contains(&rk.key) || rk.key == "_group" {
+                continue;
+            }
+            if let Some(value) = doc.get(rk.index) {
+                obj.insert(rk.key.clone(), value.clone());
+            }
+        }
+        JsonValue::Object(obj)
     }
 
     /// Check if at least one child document passes the relation filter.

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -200,10 +200,46 @@ impl Planner {
             })
             .unwrap_or_default();
 
-        // Build scan mapping: for queries with nested selections, relation filters, or relation ordering,
-        // use full schema mapping so that FK fields are available for TypeJoin lookups.
+        // Check if GROUP BY references relation fields (needs full schema mapping for joins)
+        let group_by_has_relations = select
+            .group_by
+            .as_ref()
+            .map(|gb| {
+                gb.fields.iter().any(|field_name| {
+                    collection
+                        .field_by_name(field_name)
+                        .map(|f| f.kind.is_relation())
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+
+        // Check if aggregates reference relation fields (needs full schema mapping for joins)
+        let aggregates_have_relations = select.fields.iter().any(|f| {
+            if let Requestable::Aggregate(agg) = f {
+                agg.targets.iter().any(|t| {
+                    if t.host_name.is_empty() || t.host_name == "_group" {
+                        return false;
+                    }
+                    collection
+                        .field_by_name(&t.host_name)
+                        .map(|f| f.kind.is_relation())
+                        .unwrap_or(false)
+                })
+            } else {
+                false
+            }
+        });
+
+        // Build scan mapping: for queries with nested selections, relation filters, relation ordering,
+        // relation aggregates, or relation groupBy fields, use full schema mapping so that FK fields
+        // are available for TypeJoin lookups and schema indices don't collide with sequential render indices.
         // For simple queries, use the render_mapping directly.
-        let needs_joins = has_nested || filter_has_relations || order_has_relations;
+        let needs_joins = has_nested
+            || filter_has_relations
+            || order_has_relations
+            || aggregates_have_relations
+            || group_by_has_relations;
         let mut scan_mapping = if needs_joins {
             self.build_scan_mapping_for_join(&collection, &render_mapping)
         } else {
@@ -1964,19 +2000,15 @@ impl Planner {
                     if already_joined {
                         if let Some(ref filter) = target.filter {
                             for filter_field in filter.referenced_fields() {
-                                // Skip special fields
                                 if filter_field.starts_with('_') {
                                     continue;
                                 }
-                                // Find the field index in the target collection
                                 if let Some(idx) = target_collection
                                     .fields
                                     .iter()
                                     .position(|f| f.name == filter_field)
                                 {
-                                    // Get the existing child mapping from the parent's mapping
                                     if let Some(child_mapping) = mapping.child_at_mut(relation_field_index) {
-                                        // Add the filter field to child mapping if not present
                                         if child_mapping.first_index_of_name(&filter_field).is_none() {
                                             child_mapping.add(idx, &filter_field);
                                             child_mapping.add_render_key(idx, &filter_field);
@@ -1985,7 +2017,29 @@ impl Planner {
                                 }
                             }
                         }
-                        continue; // Don't create a new join, just added filter fields to existing
+                        // Add order fields from aggregate target to existing child mapping
+                        if let Some(ref order) = target.order {
+                            for condition in &order.conditions {
+                                if let Some(order_field) = condition.fields.first() {
+                                    if order_field.starts_with('_') {
+                                        continue;
+                                    }
+                                    if let Some(idx) = target_collection
+                                        .fields
+                                        .iter()
+                                        .position(|f| f.name == *order_field)
+                                    {
+                                        if let Some(child_mapping) = mapping.child_at_mut(relation_field_index) {
+                                            if child_mapping.first_index_of_name(order_field).is_none() {
+                                                child_mapping.add(idx, order_field);
+                                                child_mapping.add_render_key(idx, order_field);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        continue;
                     }
 
                     // Build a minimal child mapping for the aggregate
@@ -2025,6 +2079,28 @@ impl Planner {
                                 if child_mapping.first_index_of_name(&filter_field).is_none() {
                                     child_mapping.add(idx, &filter_field);
                                     child_mapping.add_render_key(idx, &filter_field);
+                                }
+                            }
+                        }
+                    }
+
+                    // Add fields referenced by the order so they appear in the output
+                    // for post-processing sort before limit/offset
+                    if let Some(ref order) = target.order {
+                        for condition in &order.conditions {
+                            if let Some(order_field) = condition.fields.first() {
+                                if order_field.starts_with('_') {
+                                    continue;
+                                }
+                                if let Some(idx) = target_collection
+                                    .fields
+                                    .iter()
+                                    .position(|f| f.name == *order_field)
+                                {
+                                    if child_mapping.first_index_of_name(order_field).is_none() {
+                                        child_mapping.add(idx, order_field);
+                                        child_mapping.add_render_key(idx, order_field);
+                                    }
                                 }
                             }
                         }
@@ -2305,11 +2381,18 @@ impl Planner {
             child_relation_index,
         )?;
 
-        // Create TypeJoinOne (filter relations are typically one-to-one)
-        // No relation filter here - the complex filter is applied after all joins
-        let join = TypeJoinOne::new(plan, child_plan, parent_side, child_side, mapping.clone());
-
-        Ok((Box::new(join), mapping))
+        // Create the appropriate join type based on the relation cardinality.
+        // One-to-many relations need TypeJoinMany to collect all children into an array,
+        // one-to-one relations use TypeJoinOne.
+        if relation_field.kind.is_array() {
+            let join_many =
+                TypeJoinMany::new(plan, child_plan, parent_side, child_side, mapping.clone())?;
+            Ok((Box::new(join_many), mapping))
+        } else {
+            let join =
+                TypeJoinOne::new(plan, child_plan, parent_side, child_side, mapping.clone());
+            Ok((Box::new(join), mapping))
+        }
     }
 
     /// Apply sub-joins for remaining elements of a multi-level filter path.

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -1482,7 +1482,7 @@ impl Planner {
                 // Note: We pass child_render_mapping as the output mapping (for TypeJoin to render children)
                 // but the child_plan uses child_scan_mapping internally (for FK lookups)
                 if relation_field.kind.is_array() {
-                    // One-to-many: TypeJoinMany (relation filter support tracked in #187)
+                    // One-to-many: TypeJoinMany
                     let mut join_many = TypeJoinMany::new(
                         plan,
                         child_plan,
@@ -1490,6 +1490,11 @@ impl Planner {
                         child_side,
                         mapping.clone(),
                     )?;
+
+                    // Apply relation filter (filters parents by children)
+                    if let Some(rel_filter) = relation_filter {
+                        join_many = join_many.with_relation_filter(rel_filter);
+                    }
 
                     // Apply per-parent limit/offset/ordering
                     if let Some(limit) = nested_limit {
@@ -1515,6 +1520,161 @@ impl Planner {
                     if let Some(rel_filter) = relation_filter {
                         join = join.with_relation_filter(rel_filter);
                     }
+                    plan = Box::new(join);
+                }
+            }
+        }
+
+        // Handle relation filters without corresponding selections.
+        // When a filter references a relation (e.g., `Author(filter: {published: {_docID: ...}})`),
+        // but the relation is not selected, we still need to create a join to filter the parent.
+        if let Some(filter) = parent_filter {
+            // Get relations referenced by the filter
+            for (relation_name, nested_conditions) in filter.relation_conditions() {
+                // Skip if already joined via selection
+                let already_joined = select.fields.iter().any(|f| {
+                    matches!(f, Requestable::Select(s) if s.field.name == relation_name)
+                });
+                if already_joined {
+                    continue;
+                }
+
+                // Find the relation field in the parent collection
+                let relation_field = match parent_collection.field_by_name(&relation_name) {
+                    Some(f) if f.kind.is_relation() => f,
+                    _ => continue, // Not a relation field
+                };
+
+                // Get the target collection
+                let target_collection_id = match relation_field.kind.relation_collection_id() {
+                    Some(id) => id,
+                    None => continue,
+                };
+
+                let target_collection = if target_collection_id.is_empty() {
+                    Arc::new(parent_collection.clone())
+                } else {
+                    match self.get_collection(target_collection_id) {
+                        Some(c) => c,
+                        None => continue,
+                    }
+                };
+
+                // Find the target relation field (the other side of the relation)
+                let target_relation_field = if let Some(rel_name) = &relation_field.relation_name {
+                    target_collection.field_by_relation(
+                        rel_name,
+                        &parent_collection.name,
+                        &relation_name,
+                    )
+                } else {
+                    None
+                };
+
+                // Build child mapping for filter-only join
+                // Include _docID and the FK field for the join to work correctly
+                let mut child_mapping = DocumentMapping::new();
+                child_mapping.add(0, "_docID");
+
+                // Add the FK field (e.g., _authorID) - needed for TypeJoinMany cache indexing
+                let fk_field_name = if let Some(ref target_rel) = target_relation_field {
+                    schema::CollectionVersion::relation_id_field_name(&target_rel.name)
+                } else {
+                    schema::CollectionVersion::relation_id_field_name(&relation_name)
+                };
+                if let Some(fk_idx) = target_collection
+                    .fields
+                    .iter()
+                    .position(|f| f.name == fk_field_name)
+                {
+                    child_mapping.add(fk_idx, &fk_field_name);
+                }
+
+                // Add any fields referenced by the filter
+                for field_name in nested_conditions.referenced_fields() {
+                    if field_name != "_docID" && field_name != fk_field_name {
+                        if let Some(idx) = target_collection
+                            .fields
+                            .iter()
+                            .position(|f| f.name == field_name)
+                        {
+                            child_mapping.add(idx, &field_name);
+                        }
+                    }
+                }
+
+                // Build child scan (with fetcher for data access)
+                let mut child_scan =
+                    ScanNode::new((*target_collection).clone(), child_mapping.clone());
+                if let Some(ref fetcher) = self.fetcher {
+                    child_scan = child_scan.with_fetcher(fetcher.clone());
+                }
+                let child_plan: Box<dyn PlanNode> = Box::new(child_scan);
+
+                // Get field indices
+                let relation_field_index = mapping
+                    .first_index_of_name(&relation_name)
+                    .unwrap_or_else(|| {
+                        // Add to mapping if not present
+                        let idx = mapping.next_index();
+                        mapping.add(idx, &relation_name);
+                        idx
+                    });
+
+                // Find child relation index
+                let child_relation_index = target_relation_field
+                    .as_ref()
+                    .and_then(|f| {
+                        target_collection
+                            .fields
+                            .iter()
+                            .position(|tf| tf.name == f.name)
+                    })
+                    .unwrap_or(0);
+
+                // Create join sides
+                let parent_side = JoinSide::new(
+                    parent_collection.clone(),
+                    relation_field.clone(),
+                    relation_field_index,
+                )?;
+
+                let child_side = JoinSide::new(
+                    (*target_collection).clone(),
+                    target_relation_field
+                        .cloned()
+                        .unwrap_or_else(|| relation_field.clone()),
+                    child_relation_index,
+                )?;
+
+                // Create the relation filter
+                let rel_filter = RelationFilter {
+                    relation_field: relation_name.clone(),
+                    conditions: nested_conditions.clone(),
+                };
+
+                // Create the appropriate join node based on cardinality
+                if relation_field.kind.is_array() {
+                    // One-to-many: TypeJoinMany with filter
+                    let join_many = TypeJoinMany::new(
+                        plan,
+                        child_plan,
+                        parent_side,
+                        child_side,
+                        mapping.clone(),
+                    )?
+                    .with_relation_filter(rel_filter);
+                    plan = Box::new(join_many);
+                } else {
+                    // One-to-one: TypeJoinOne with filter
+                    let join = TypeJoinOne::new(
+                        plan,
+                        child_plan,
+                        parent_side,
+                        child_side,
+                        mapping.clone(),
+                    )
+                    .with_relation_filter(rel_filter);
                     plan = Box::new(join);
                 }
             }

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -1503,8 +1503,39 @@ impl Planner {
                     if nested_offset > 0 {
                         join_many = join_many.with_offset(nested_offset);
                     }
-                    if let Some(order_by) = nested_order_by {
+                    if let Some(order_by) = nested_order_by.clone() {
                         join_many = join_many.with_order_by(order_by);
+                    }
+
+                    // Apply nested groupBy if present
+                    if let Some(ref group_by) = nested_select.group_by {
+                        join_many = join_many.with_group_by(group_by.clone());
+
+                        // Find the _group nested select and build its mapping
+                        // Use indices from child_scan_mapping so the mapping matches
+                        // the child document's field array indices.
+                        for field in &nested_select.fields {
+                            if let Requestable::Select(group_select) = field {
+                                if group_select.field.name == "_group" {
+                                    // Build mapping for _group contents using child_scan_mapping indices
+                                    let mut group_mapping = DocumentMapping::new();
+                                    for group_field in &group_select.fields {
+                                        if let Requestable::Field(f) = group_field {
+                                            // Use the index from child_scan_mapping
+                                            if let Some(idx) =
+                                                child_scan_mapping.first_index_of_name(&f.name)
+                                            {
+                                                let output_name = f.output_name().to_string();
+                                                group_mapping.add(idx, &output_name);
+                                                group_mapping.add_render_key(idx, output_name);
+                                            }
+                                        }
+                                    }
+                                    join_many = join_many.with_group_mapping(group_mapping);
+                                    break;
+                                }
+                            }
+                        }
                     }
 
                     plan = Box::new(join_many);

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -332,17 +332,41 @@ impl Planner {
 
         // Check if filter is complex (has relation conditions inside logical operators)
         // or has multi-level relation paths (e.g., {author: {published: {rating: ...}}})
-        let is_complex_filter = select
-            .filter
+        // Collect aggregate output names to detect _alias conditions that should be deferred
+        let aggregate_names: Vec<&str> = select
+            .fields
+            .iter()
+            .filter_map(|f| {
+                if let Requestable::Aggregate(agg) = f {
+                    Some(agg.output_name())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Strip _alias conditions that reference computed aggregates from the filter.
+        // These must be evaluated after aggregates are computed, not during plan execution.
+        let filter_for_plan = select.filter.as_ref().map(|f| {
+            let (stripped, _) = f.strip_aggregate_alias_conditions(&aggregate_names);
+            stripped
+        });
+
+        // Check if filter is complex (has relation conditions inside logical operators)
+        // or has multi-level relation paths (e.g., {author: {published: {rating: ...}}})
+        let is_complex_filter = filter_for_plan
             .as_ref()
-            .map(|f| f.is_complex() || !f.get_multi_level_relation_paths().is_empty())
+            .map(|f| {
+                f.is_complex()
+                    || !f.get_multi_level_relation_paths().is_empty()
+                    || f.has_alias_filter()
+            })
             .unwrap_or(false);
 
         // Split filter into scalar and relation parts (only useful for non-complex filters)
         // Note: JSON field nested access looks like relation filters structurally, but should
         // be treated as scalar filters. We recombine them below based on schema info.
-        let (scalar_filter_raw, relation_filter) = select
-            .filter
+        let (scalar_filter_raw, relation_filter) = filter_for_plan
             .as_ref()
             .map(|f| f.split_by_relation())
             .unwrap_or((None, None));
@@ -350,6 +374,10 @@ impl Planner {
         // Move JSON field conditions from relation_filter back to scalar_filter.
         // The split_by_relation function can't distinguish JSON nested access from relation
         // traversal without schema info. Here we have the collection, so we can fix it.
+        //
+        // Also transform {relationField: {_docID: {...}}} to {_relationFieldID: {...}}.
+        // This allows relation _docID filters to work as scalar filters without requiring a join.
+        // Example: {author: {_docID: {_eq: "bae-..."}}} → {_authorID: {_eq: "bae-..."}}
         let scalar_filter = {
             let mut combined_conditions: HashMap<String, JsonValue> = scalar_filter_raw
                 .as_ref()
@@ -358,13 +386,34 @@ impl Planner {
 
             if let Some(ref rel_filter) = relation_filter {
                 for (field_name, condition) in rel_filter.conditions() {
-                    // Check if this field is NOT a relation (could be JSON, etc.)
-                    if !collection
-                        .field_by_name(field_name)
-                        .is_some_and(|f| f.kind.is_relation())
-                    {
-                        combined_conditions.insert(field_name.clone(), condition.clone());
+                    // Check if this field is a relation
+                    if let Some(field) = collection.field_by_name(field_name) {
+                        if field.kind.is_relation() {
+                            // Check if this is a {_docID: {...}} pattern AND the FK field exists locally.
+                            // For "primary" relations (FK on this side), we can transform to use the FK.
+                            // For "secondary" relations (FK on other side), we can't transform - need join.
+                            let fk_field_name =
+                                schema::CollectionVersion::relation_id_field_name(field_name);
+                            let has_local_fk = collection.field_by_name(&fk_field_name).is_some();
+
+                            if has_local_fk {
+                                if let Some(obj) = condition.as_object() {
+                                    if obj.len() == 1 {
+                                        if let Some(docid_condition) = obj.get("_docID") {
+                                            // Transform {relationField: {_docID: {...}}} to {_relationFieldID: {...}}
+                                            combined_conditions
+                                                .insert(fk_field_name, docid_condition.clone());
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+                            // Not a _docID-only pattern or no local FK, keep as relation filter
+                            continue;
+                        }
                     }
+                    // Not a relation field - treat as scalar (could be JSON, etc.)
+                    combined_conditions.insert(field_name.clone(), condition.clone());
                 }
             }
 
@@ -425,13 +474,13 @@ impl Planner {
         let filter_for_joins = if is_complex_filter {
             None // Don't pass filter to TypeJoin for complex filters
         } else {
-            select.filter.as_ref()
+            filter_for_plan.as_ref()
         };
-        plan = self.apply_joins(
+        (plan, scan_mapping) = self.apply_joins(
             plan,
             select,
             &collection,
-            scan_mapping.clone(),
+            scan_mapping,
             0,
             filter_for_joins,
         )?;
@@ -441,7 +490,7 @@ impl Planner {
         // already handles it via apply_multi_level_sub_joins.
         // Example: Book(filter: {author: {published: {rating: {_eq: 4.9}}}}) { name }
         // (no author selection, so we need to add the full join chain here)
-        if let Some(ref filter) = select.filter {
+        if let Some(ref filter) = filter_for_plan {
             // Get relation names from selection
             let selected_relation_names: Vec<&str> = select
                 .fields
@@ -1046,7 +1095,7 @@ impl Planner {
         mut mapping: DocumentMapping,
         depth: usize,
         parent_filter: Option<&crate::mapper::Filter>,
-    ) -> Result<Box<dyn PlanNode>> {
+    ) -> Result<(Box<dyn PlanNode>, DocumentMapping)> {
         // Check recursion depth to prevent stack overflow
         if depth > MAX_NESTING_DEPTH {
             return Err(QueryError::execution(format!(
@@ -1113,6 +1162,71 @@ impl Planner {
                 // so the doc fields must be at their schema positions for FK lookups to work.
                 let mut child_scan_mapping =
                     self.build_scan_mapping_for_join(&target_collection, &child_render_mapping);
+
+                // Check if aggregates reference this relation and need additional fields for filters.
+                // For example, _count(published: {filter: {rating: {_gt: 4.8}}}) needs the 'rating'
+                // field to be included even if it's not in the selection set.
+                for requestable in &select.fields {
+                    if let Requestable::Aggregate(agg) = requestable {
+                        for target in &agg.targets {
+                            if target.host_name == *relation_field_name {
+                                // This aggregate references this relation - add filter fields
+                                if let Some(ref filter) = target.filter {
+                                    for filter_field in filter.referenced_fields() {
+                                        // Skip special fields
+                                        if filter_field.starts_with('_') {
+                                            continue;
+                                        }
+                                        // Find the field index in the target collection
+                                        if let Some(idx) = target_collection
+                                            .fields
+                                            .iter()
+                                            .position(|f| f.name == filter_field)
+                                        {
+                                            // Add the field to child_scan_mapping if not present
+                                            if child_scan_mapping
+                                                .first_index_of_name(&filter_field)
+                                                .is_none()
+                                            {
+                                                child_scan_mapping.add(idx, &filter_field);
+                                            }
+                                            // Add render_key so the field appears in the output
+                                            if !child_scan_mapping
+                                                .render_keys
+                                                .iter()
+                                                .any(|rk| rk.key == filter_field)
+                                            {
+                                                child_scan_mapping.add_render_key(idx, &filter_field);
+                                            }
+                                        }
+                                    }
+                                }
+                                // Also add the aggregate target field if specified
+                                if let Some(ref field_name) = target.field_name {
+                                    if let Some(idx) = target_collection
+                                        .fields
+                                        .iter()
+                                        .position(|f| f.name == *field_name)
+                                    {
+                                        if child_scan_mapping
+                                            .first_index_of_name(field_name)
+                                            .is_none()
+                                        {
+                                            child_scan_mapping.add(idx, field_name);
+                                        }
+                                        if !child_scan_mapping
+                                            .render_keys
+                                            .iter()
+                                            .any(|rk| rk.key == *field_name)
+                                        {
+                                            child_scan_mapping.add_render_key(idx, field_name);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 // Check if parent's order_by references fields in this relation.
                 // If so, add those fields to child_scan_mapping.render_keys so they're
@@ -1201,36 +1315,56 @@ impl Planner {
                     child_scan = child_scan.with_fetcher(fetcher.clone());
                 }
 
-                // Reject unsupported arguments on nested selections.
-                // Order and limit on nested selections require per-parent ordering/limiting
-                // which is not yet implemented. Return a clear error rather than silently ignoring.
-                if nested_select.order_by.is_some() {
-                    return Err(QueryError::execution(format!(
-                        "order on nested selection '{}' is not yet supported. \
-                         Use separate queries to order nested results.",
-                        relation_field_name
-                    )));
-                }
-                if nested_select.limit.is_some() {
-                    return Err(QueryError::execution(format!(
-                        "limit/offset on nested selection '{}' is not yet supported. \
-                         Use separate queries to limit nested results.",
-                        relation_field_name
-                    )));
-                }
+                // Extract nested limit/offset and order_by for per-parent application in TypeJoin.
+                let nested_limit = nested_select.limit.as_ref().and_then(|l| l.limit);
+                let nested_offset = nested_select.limit.as_ref().map(|l| l.offset).unwrap_or(0);
+                let nested_order_by = nested_select.order_by.clone();
 
-                // Wrap in SelectNode if there's a filter on the nested select
+                // Build a combined filter from doc_ids and explicit filter
+                let doc_ids_filter = if let Some(ref doc_ids) = nested_select.doc_ids {
+                    // Create a filter: _docID IN [...]
+                    if doc_ids.len() == 1 {
+                        // Single ID: _docID == "..."
+                        let mut conditions = HashMap::new();
+                        conditions.insert(
+                            "_docID".to_string(),
+                            serde_json::json!({"_eq": doc_ids[0]}),
+                        );
+                        Some(Filter::from_conditions(conditions))
+                    } else {
+                        // Multiple IDs: _docID IN [...]
+                        let mut conditions = HashMap::new();
+                        conditions.insert("_docID".to_string(), serde_json::json!({"_in": doc_ids}));
+                        Some(Filter::from_conditions(conditions))
+                    }
+                } else {
+                    None
+                };
+
+                // Combine doc_ids filter with explicit filter
+                let combined_filter = match (&doc_ids_filter, &nested_select.filter) {
+                    (Some(doc_filter), Some(explicit_filter)) => {
+                        // Both: AND them together
+                        Some(doc_filter.and(explicit_filter.clone()))
+                    }
+                    (Some(doc_filter), None) => Some(doc_filter.clone()),
+                    (None, Some(explicit_filter)) => Some(explicit_filter.clone()),
+                    (None, None) => None,
+                };
+
+                // Wrap in SelectNode if there's any filter
                 let mut child_plan: Box<dyn PlanNode> =
-                    if let Some(ref filter) = nested_select.filter {
-                        // Validate that all filter-referenced fields exist in the render mapping.
-                        // We validate against render_mapping (user-selected fields), not scan_mapping,
-                        // because filtering on unselected fields is likely a user error.
-                        for field in filter.referenced_fields() {
-                            if !child_render_mapping.has_field(&field) {
-                                return Err(QueryError::filter_field_not_selected(
-                                    &field,
-                                    &target_collection.name,
-                                ));
+                    if let Some(ref filter) = combined_filter {
+                        // Validate that all explicitly-filtered fields exist in the render mapping.
+                        // Skip doc_ids filter fields since _docID is always available.
+                        if let Some(ref explicit_filter) = nested_select.filter {
+                            for field in explicit_filter.referenced_fields() {
+                                if !child_render_mapping.has_field(&field) {
+                                    return Err(QueryError::filter_field_not_selected(
+                                        &field,
+                                        &target_collection.name,
+                                    ));
+                                }
                             }
                         }
 
@@ -1245,11 +1379,11 @@ impl Planner {
                 // Recursively apply joins for any nested selections within this nested select.
                 // This handles multi-level nesting like Users -> Posts -> Comments.
                 // Note: We pass None for parent_filter since relation filters only apply at the top level.
-                child_plan = self.apply_joins(
+                (child_plan, child_scan_mapping) = self.apply_joins(
                     child_plan,
                     nested_select,
                     &target_collection,
-                    child_scan_mapping.clone(),
+                    child_scan_mapping,
                     depth + 1,
                     None, // Nested relation filters handled differently
                 )?;
@@ -1349,13 +1483,26 @@ impl Planner {
                 // but the child_plan uses child_scan_mapping internally (for FK lookups)
                 if relation_field.kind.is_array() {
                     // One-to-many: TypeJoinMany (relation filter support tracked in #187)
-                    plan = Box::new(TypeJoinMany::new(
+                    let mut join_many = TypeJoinMany::new(
                         plan,
                         child_plan,
                         parent_side,
                         child_side,
                         mapping.clone(),
-                    )?);
+                    )?;
+
+                    // Apply per-parent limit/offset/ordering
+                    if let Some(limit) = nested_limit {
+                        join_many = join_many.with_limit(limit);
+                    }
+                    if nested_offset > 0 {
+                        join_many = join_many.with_offset(nested_offset);
+                    }
+                    if let Some(order_by) = nested_order_by {
+                        join_many = join_many.with_order_by(order_by);
+                    }
+
+                    plan = Box::new(join_many);
                 } else {
                     // One-to-one: TypeJoinOne
                     let mut join = TypeJoinOne::new(
@@ -1537,10 +1684,6 @@ impl Planner {
                         }
                     });
 
-                    if already_joined {
-                        continue; // Data already available, aggregate will use it
-                    }
-
                     // Find the field in the parent collection
                     let relation_field = match parent_collection.field_by_name(relation_field_name)
                     {
@@ -1569,9 +1712,47 @@ impl Planner {
                         }
                     };
 
+                    // Get relation field index in parent collection (needed in both paths)
+                    let relation_field_index = parent_collection
+                        .fields
+                        .iter()
+                        .position(|f| f.name == *relation_field_name)
+                        .unwrap_or(0);
+
+                    // If the relation is already joined via a selection, we still need to
+                    // ensure the filter fields are available in the output for post-processing.
+                    // Add filter fields to the existing child mapping.
+                    if already_joined {
+                        if let Some(ref filter) = target.filter {
+                            for filter_field in filter.referenced_fields() {
+                                // Skip special fields
+                                if filter_field.starts_with('_') {
+                                    continue;
+                                }
+                                // Find the field index in the target collection
+                                if let Some(idx) = target_collection
+                                    .fields
+                                    .iter()
+                                    .position(|f| f.name == filter_field)
+                                {
+                                    // Get the existing child mapping from the parent's mapping
+                                    if let Some(child_mapping) = mapping.child_at_mut(relation_field_index) {
+                                        // Add the filter field to child mapping if not present
+                                        if child_mapping.first_index_of_name(&filter_field).is_none() {
+                                            child_mapping.add(idx, &filter_field);
+                                            child_mapping.add_render_key(idx, &filter_field);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        continue; // Don't create a new join, just added filter fields to existing
+                    }
+
                     // Build a minimal child mapping for the aggregate
                     // For count, we just need to fetch the documents
                     // For sum/avg, we need the specific field
+                    // For any aggregate with filter, we need the filter fields
                     let mut child_mapping = DocumentMapping::new();
                     child_mapping.add(0, "_docID");
 
@@ -1587,16 +1768,32 @@ impl Planner {
                         }
                     }
 
+                    // Add fields referenced by the filter so they appear in the output
+                    // for post-processing filter evaluation
+                    if let Some(ref filter) = target.filter {
+                        for filter_field in filter.referenced_fields() {
+                            // Skip special fields
+                            if filter_field.starts_with('_') {
+                                continue;
+                            }
+                            // Find the field in the target collection
+                            if let Some(idx) = target_collection
+                                .fields
+                                .iter()
+                                .position(|f| f.name == filter_field)
+                            {
+                                // Add to child mapping if not already present
+                                if child_mapping.first_index_of_name(&filter_field).is_none() {
+                                    child_mapping.add(idx, &filter_field);
+                                    child_mapping.add_render_key(idx, &filter_field);
+                                }
+                            }
+                        }
+                    }
+
                     // Build scan mapping for the child
                     let child_scan_mapping =
                         self.build_scan_mapping_for_join(&target_collection, &child_mapping);
-
-                    // Get relation field index in parent collection
-                    let relation_field_index = parent_collection
-                        .fields
-                        .iter()
-                        .position(|f| f.name == *relation_field_name)
-                        .unwrap_or(0);
 
                     // Set up child mapping in parent for TypeJoin
                     mapping.set_child_at(relation_field_index, child_scan_mapping.clone());
@@ -1677,7 +1874,7 @@ impl Planner {
             }
         }
 
-        Ok(plan)
+        Ok((plan, mapping))
     }
 
     /// Build a scan mapping for join child plans that includes ALL fields at schema indices.
@@ -1737,6 +1934,27 @@ impl Planner {
                         // First render_key for this schema_index
                         mapping.add_render_key(schema_index, &render_key.key);
                         indices_with_render_keys.insert(schema_index);
+                    }
+                }
+            }
+        }
+
+        // Copy type_info from render_mapping if set (for __typename support)
+        // Also need to copy the __typename render_key since it's a virtual field not in schema
+        // IMPORTANT: Use collection.name as the type name, not the one from render_mapping,
+        // because nested selects have collection_name=field_name (e.g., "author") not the
+        // actual collection name (e.g., "Author")
+        if render_mapping.type_name().is_some() {
+            mapping.set_type_name(&collection.name);
+            // Find the __typename render_key in render_mapping and copy it
+            if let Some(typename_index) = mapping.first_index_of_name("__typename") {
+                for rk in &render_mapping.render_keys {
+                    // Find the render_key for __typename (key might be __typename or an alias)
+                    if let Some(field_name) = render_mapping.try_find_name_from_index(rk.index) {
+                        if field_name == "__typename" {
+                            mapping.add_render_key(typename_index, &rk.key);
+                            break;
+                        }
                     }
                 }
             }

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -1105,17 +1105,46 @@ impl Planner {
             )));
         }
 
+        // Collect all Select items to process, including those inside _group.
+        // Track the _group index for relation fields inside _group so we can update
+        // the _group child mapping with the correct relation field index later.
+        // Tuple: (select, _group_index if from inside _group)
+        let mut selects_to_process: Vec<(&Select, Option<usize>)> = Vec::new();
         for requestable in &select.fields {
             if let Requestable::Select(nested_select) = requestable {
-                let relation_field_name = &nested_select.field.name;
-
-                // Skip _group - it's a virtual field for groupBy results, not a relation
-                if relation_field_name == "_group" {
-                    continue;
+                if nested_select.field.name == "_group" {
+                    // Get the _group index in the parent mapping
+                    let group_index = mapping.first_index_of_name("_group");
+                    // _group is a virtual field - process its inner relation fields
+                    for inner_requestable in &nested_select.fields {
+                        if let Requestable::Select(inner_select) = inner_requestable {
+                            // Skip special fields
+                            if !inner_select.field.name.starts_with('_') {
+                                selects_to_process.push((inner_select, group_index));
+                            }
+                        }
+                    }
+                } else {
+                    selects_to_process.push((nested_select, None));
                 }
+            }
+        }
 
-                // Find the relation field in the parent collection
-                let relation_field = parent_collection
+        for (nested_select, group_index) in selects_to_process {
+            let relation_field_name = &nested_select.field.name;
+            let output_name = nested_select.field.output_name();
+
+            // Ensure the relation field is in the parent mapping.
+            // This is especially important for relation fields inside _group
+            // which aren't direct children of the select.
+            if mapping.first_index_of_name(relation_field_name).is_none() {
+                let index = mapping.next_index();
+                mapping.add(index, relation_field_name);
+                // Don't add render_key - for _group fields, rendering is handled by GroupByNode
+            }
+
+            // Find the relation field in the parent collection
+            let relation_field = parent_collection
                     .field_by_name(relation_field_name)
                     .ok_or_else(|| QueryError::unknown_field(relation_field_name))?;
 
@@ -1290,18 +1319,38 @@ impl Planner {
                 }
 
                 // Get the relation field index in the parent mapping.
-                // Use output_name (alias if set) to find the correct index.
-                // This ensures aliased fields like "p1: published" and "p2: published"
-                // get distinct indices and separate child mappings/filters.
-                let output_name = nested_select.field.output_name();
+                // First try by render_key (for aliased fields), then fall back to name lookup.
+                // The fallback handles relation fields inside _group which are added without render_keys.
                 let relation_field_index = mapping
                     .try_find_index_from_render_key(output_name)
+                    .or_else(|| mapping.first_index_of_name(relation_field_name))
                     .ok_or_else(|| {
                         QueryError::internal(format!(
                             "relation field '{}' (output name '{}') not in mapping",
                             relation_field_name, output_name
                         ))
                     })?;
+
+                // If this relation field is inside _group, update the _group child mapping
+                // to use the correct index for rendering. TypeJoinMany stores the relation
+                // data at relation_field_index, so the child mapping must use the same index.
+                if let Some(grp_idx) = group_index {
+                    if let Some(group_child_mapping) = mapping.child_at_mut(grp_idx) {
+                        // Update the child mapping: replace the dynamic index with relation_field_index
+                        // First, find and remove any existing entry for this field
+                        let old_index =
+                            group_child_mapping.first_index_of_name(relation_field_name);
+                        if let Some(old_idx) = old_index {
+                            // Remove old render_key with the wrong index
+                            group_child_mapping
+                                .render_keys
+                                .retain(|rk| rk.index != old_idx);
+                        }
+                        // Add with the correct index
+                        group_child_mapping.add(relation_field_index, relation_field_name);
+                        group_child_mapping.add_render_key(relation_field_index, output_name);
+                    }
+                }
 
                 // Set up child scan mapping in parent (for TypeJoin to render children).
                 // We use child_scan_mapping (not child_render_mapping) because child docs
@@ -1553,7 +1602,6 @@ impl Planner {
                     }
                     plan = Box::new(join);
                 }
-            }
         }
 
         // Handle relation filters without corresponding selections.
@@ -2730,6 +2778,15 @@ impl Planner {
                         let inner_child_mapping =
                             self.build_group_child_mapping(nested_select, collection)?;
                         child_mapping.set_child_at(index, inner_child_mapping);
+                    } else {
+                        // Relation field inside _group (e.g., published {...})
+                        // Add it to the child mapping so it can be rendered.
+                        // The actual index must match where TypeJoinMany will populate the data.
+                        // TypeJoinMany will use the parent mapping's index for this field.
+                        // We need to find or allocate an index for this relation field.
+                        let index = child_mapping.next_index();
+                        child_mapping.add(index, &nested_select.field.name);
+                        child_mapping.add_render_key(index, nested_select.field.output_name());
                     }
                 }
                 Requestable::Aggregate(_) => {

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -200,6 +200,9 @@ pub fn parse_query_with_variables(
         ParsedOperation::Subscription { .. } => Err(QueryError::parse(
             "Expected query but got subscription.",
         )),
+        ParsedOperation::Introspection { .. } => Err(QueryError::parse(
+            "Expected query but got introspection.",
+        )),
     }
 }
 

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -611,6 +611,29 @@ fn parse_field_to_select(
     select.fields = fields;
     select.document_mapping = mapping;
 
+    // Validate groupBy field selection: when groupBy is specified, only group-by fields,
+    // their FK counterparts (e.g. _authorID for groupBy [author]), and aggregate fields
+    // are allowed at the group level (nested selects like _group are fine).
+    if let Some(ref group_by) = select.group_by {
+        for field in &select.fields {
+            if let Requestable::Field(f) = field {
+                if group_by.fields.contains(&f.name) {
+                    continue;
+                }
+                // Allow FK fields for relation groupBy fields (e.g. _authorID for author)
+                let is_fk_for_group = group_by.fields.iter().any(|gb_field| {
+                    f.name == format!("_{}ID", gb_field)
+                });
+                if is_fk_for_group {
+                    continue;
+                }
+                return Err(QueryError::parse(
+                    "cannot select a non-group-by field at group-level",
+                ));
+            }
+        }
+    }
+
     Ok(select)
 }
 

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -94,11 +94,19 @@ pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -
                     if name == "_docID" || name == "_group" || name == "__typename" {
                         continue;
                     }
-                    if !group_fields.contains(&name) {
-                        return Err(QueryError::parse(
-                            "cannot select a non-group-by field at group-level",
-                        ));
+                    if group_fields.contains(&name) {
+                        continue;
                     }
+                    // Allow FK fields for relation groupBy fields (e.g. _authorID for author)
+                    let is_fk_for_group = group_fields.iter().any(|gb_field| {
+                        name == format!("_{}ID", gb_field)
+                    });
+                    if is_fk_for_group {
+                        continue;
+                    }
+                    return Err(QueryError::parse(
+                        "cannot select a non-group-by field at group-level",
+                    ));
                 }
                 Requestable::Select(nested) => {
                     if nested.field.name == "_group" {
@@ -156,7 +164,56 @@ pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -
         }
     }
 
+    // Validate top-level filter field names exist in schema
+    if let Some(ref filter) = select.filter {
+        for key in filter.conditions().keys() {
+            // Skip logical operators and special filter directives
+            if key == "_and" || key == "_or" || key == "_not" || key == "_alias" {
+                continue;
+            }
+            if !field_exists(key) {
+                let filter_repr = format_graphql_conditions(filter.conditions());
+                return Err(QueryError::parse(format!(
+                    "Argument \"filter\" has invalid value {}.\nIn field \"{}\": Unknown field.",
+                    filter_repr, key
+                )));
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// Format filter conditions in Go graphql-go style (unquoted keys).
+fn format_graphql_conditions(
+    conditions: &std::collections::HashMap<String, JsonValue>,
+) -> String {
+    let entries: Vec<String> = conditions
+        .iter()
+        .map(|(k, v)| format!("{}: {}", k, format_graphql_value(v)))
+        .collect();
+    format!("{{{}}}", entries.join(", "))
+}
+
+/// Format a JSON value in Go graphql-go style.
+fn format_graphql_value(val: &JsonValue) -> String {
+    match val {
+        JsonValue::Object(obj) => {
+            let entries: Vec<String> = obj
+                .iter()
+                .map(|(k, v)| format!("{}: {}", k, format_graphql_value(v)))
+                .collect();
+            format!("{{{}}}", entries.join(", "))
+        }
+        JsonValue::String(s) => format!("\"{}\"", s),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        JsonValue::Null => "null".to_string(),
+        JsonValue::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(format_graphql_value).collect();
+            format!("[{}]", items.join(", "))
+        }
+    }
 }
 
 /// Build the document mapping for a select operation.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -673,6 +673,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // For aggregates like _count(books: {}), compute the value from joined data
         let results = self.compute_relation_aggregates(results, select)?;
 
+        // Apply deferred limit/offset to relation fields.
+        // TypeJoinMany stores ALL children (for aggregates to count), so we apply
+        // the select's limit/offset here after aggregates have been computed.
+        let results = Self::apply_relation_limits(results, select);
+
         Ok(JsonValue::Array(results))
     }
 
@@ -1139,6 +1144,67 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         Ok(results)
+    }
+
+    /// Apply deferred limit/offset to relation fields in query results.
+    ///
+    /// TypeJoinMany stores ALL children so that relation aggregates (e.g., _count)
+    /// can see the full set. This function applies the limit/offset from the select's
+    /// nested relation fields after aggregates have been computed.
+    fn apply_relation_limits(mut results: Vec<JsonValue>, select: &Select) -> Vec<JsonValue> {
+        // Collect relation fields with limits
+        let mut relation_limits: Vec<(String, u64, u64)> = Vec::new(); // (field_name, limit, offset)
+        for requestable in &select.fields {
+            if let Requestable::Select(nested_select) = requestable {
+                if nested_select.field.name == "_group" {
+                    continue; // _group is handled by GroupByNode
+                }
+                if let Some(ref limit) = nested_select.limit {
+                    let limit_val = limit.limit.unwrap_or(0); // 0 means no limit
+                    let offset_val = limit.offset;
+                    if limit_val > 0 || offset_val > 0 {
+                        relation_limits.push((
+                            nested_select.field.output_name().to_string(),
+                            limit_val,
+                            offset_val,
+                        ));
+                    }
+                }
+            }
+        }
+
+        if relation_limits.is_empty() {
+            return results;
+        }
+
+        for result in &mut results {
+            if let JsonValue::Object(ref mut obj) = result {
+                for (field_name, limit, offset) in &relation_limits {
+                    if let Some(relation_data) = obj.get_mut(field_name) {
+                        if let JsonValue::Array(items) = relation_data {
+                            let offset = *offset as usize;
+                            let total = items.len();
+                            if offset >= total {
+                                *items = Vec::new();
+                            } else {
+                                let remaining: Vec<JsonValue> =
+                                    items.drain(offset..).collect();
+                                *items = if *limit > 0 {
+                                    remaining
+                                        .into_iter()
+                                        .take(*limit as usize)
+                                        .collect()
+                                } else {
+                                    remaining
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        results
     }
 
     /// Execute a simple query without nested selections.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -820,36 +820,38 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                     };
 
                                 // Step 2: Apply order (sort array elements before limit/offset)
+                                // The order field may differ from the aggregate field (e.g., order by "name", sum "rating")
                                 let mut ordered_items = filtered_items;
                                 if let Some(ref order) = target.order {
                                     if let Some(condition) = order.conditions.first() {
+                                        let order_field = condition.fields.first().map(|s| s.as_str());
                                         let desc = matches!(
                                             condition.direction,
                                             crate::mapper::OrderDirection::Desc
                                         );
                                         ordered_items.sort_by(|a, b| {
-                                            let a_val = match field_name {
+                                            let a_val = match order_field {
                                                 Some(f) => a
                                                     .as_object()
                                                     .and_then(|o| o.get(f))
                                                     .unwrap_or(&JsonValue::Null),
                                                 None => *a,
                                             };
-                                            let b_val = match field_name {
+                                            let b_val = match order_field {
                                                 Some(f) => b
                                                     .as_object()
                                                     .and_then(|o| o.get(f))
                                                     .unwrap_or(&JsonValue::Null),
                                                 None => *b,
                                             };
-                                            let a_f = a_val.as_f64().unwrap_or(0.0);
-                                            let b_f = b_val.as_f64().unwrap_or(0.0);
+                                            let cmp = crate::plan::compare_json_values(
+                                                Some(a_val),
+                                                Some(b_val),
+                                            );
                                             if desc {
-                                                b_f.partial_cmp(&a_f)
-                                                    .unwrap_or(std::cmp::Ordering::Equal)
+                                                cmp.reverse()
                                             } else {
-                                                a_f.partial_cmp(&b_f)
-                                                    .unwrap_or(std::cmp::Ordering::Equal)
+                                                cmp
                                             }
                                         });
                                     }
@@ -1361,28 +1363,34 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Get collection schema for building the mapping
         let collection = self.get_collection(&select.collection_name).await?;
 
-        // Build a modified select without _version for the mapping
-        // (build_mapping doesn't handle nested selects like _version)
-        let select_without_version = Select {
-            fields: select
-                .fields
-                .iter()
-                .filter(|f| {
-                    if let Requestable::Select(s) = f {
-                        s.field.name != "_version"
-                    } else {
-                        true
+        // Separate nested selects (relation fields) from scalar fields.
+        // build_mapping can't handle nested selects, so we strip them and resolve relations separately.
+        let mut nested_selects: Vec<&Select> = Vec::new();
+        let scalar_fields: Vec<Requestable> = select
+            .fields
+            .iter()
+            .filter(|f| {
+                if let Requestable::Select(s) = f {
+                    if s.field.name == "_version" {
+                        return false;
                     }
-                })
-                .cloned()
-                .collect(),
+                    nested_selects.push(s);
+                    return false;
+                }
+                true
+            })
+            .cloned()
+            .collect();
+
+        let select_for_mapping = Select {
+            fields: scalar_fields,
             ..select.clone()
         };
 
-        // Build mapping for the requested fields (excluding _version)
-        let mapping = plan::build_mapping(&select_without_version, &collection)?;
+        // Build mapping for scalar fields only
+        let mapping = plan::build_mapping(&select_for_mapping, &collection)?;
 
-        // Convert the document to JSON with only the requested fields
+        // Convert the document to JSON with only the requested scalar fields
         let mut obj = serde_json::Map::new();
 
         for render_key in &mapping.render_keys {
@@ -1405,6 +1413,41 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             };
 
             obj.insert(render_key.key.clone(), value);
+        }
+
+        // Resolve nested selects (relation fields like `author { name }`)
+        for nested_select in &nested_selects {
+            let relation_name = &nested_select.field.name;
+            let output_name = nested_select.field.output_name();
+            let related_collection = &nested_select.collection_name;
+
+            // Many-to-one: parent has FK field (e.g., Book._authorID → Author)
+            let fk_field_name = CollectionVersion::relation_id_field_name(relation_name);
+            if let Some(fk_value) = document.get(&fk_field_name) {
+                let fk_doc_id = crate::json_convert::normal_value_to_json(fk_value)
+                    .ok()
+                    .and_then(|v| v.as_str().map(|s| s.to_string()))
+                    .unwrap_or_default();
+
+                if !fk_doc_id.is_empty() {
+                    let result = fetcher
+                        .get_by_ids(related_collection, &[fk_doc_id])
+                        .await?;
+
+                    if let Some(related_doc) = result.docs().first() {
+                        let related_obj =
+                            self.render_document_fields(related_doc, nested_select);
+                        obj.insert(output_name.to_string(), JsonValue::Object(related_obj));
+                    } else {
+                        obj.insert(output_name.to_string(), JsonValue::Null);
+                    }
+                } else {
+                    obj.insert(output_name.to_string(), JsonValue::Null);
+                }
+            } else {
+                // One-to-many or no FK found: return null for now
+                obj.insert(output_name.to_string(), JsonValue::Null);
+            }
         }
 
         // Add _version data if requested
@@ -1546,6 +1589,36 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         Ok(JsonValue::Array(enriched_results))
+    }
+
+    /// Render a Document's fields as a JSON object using only the fields requested by a Select.
+    fn render_document_fields(&self, doc: &Document, select: &Select) -> serde_json::Map<String, JsonValue> {
+        let mut obj = serde_json::Map::new();
+        for field in &select.fields {
+            if let Requestable::Field(f) = field {
+                let fname = &f.name;
+                let output = f.output_name();
+                if fname == "_docID" {
+                    if let Some(id) = doc.id() {
+                        obj.insert(output.to_string(), JsonValue::String(id.to_string()));
+                    } else {
+                        obj.insert(output.to_string(), JsonValue::Null);
+                    }
+                } else if fname == "__typename" {
+                    obj.insert(
+                        output.to_string(),
+                        JsonValue::String(select.collection_name.clone()),
+                    );
+                } else if let Some(nv) = doc.get(fname) {
+                    let json_val = crate::json_convert::normal_value_to_json(nv)
+                        .unwrap_or(JsonValue::Null);
+                    obj.insert(output.to_string(), json_val);
+                } else {
+                    obj.insert(output.to_string(), JsonValue::Null);
+                }
+            }
+        }
+        obj
     }
 
     /// Fetch version (commit) data for a document.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -716,13 +716,43 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             return Ok(results);
         }
 
-        // Collect which relation fields are explicitly selected (for cleanup later)
+        // Collect which relation fields are explicitly selected and their requested fields (for cleanup later)
         let selected_relations: std::collections::HashSet<String> = select
             .fields
             .iter()
             .filter_map(|f| {
                 if let Requestable::Select(s) = f {
                     Some(s.field.name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // For each selected relation, collect the fields that were explicitly requested.
+        // Any fields NOT in this set were added for aggregate filter evaluation and should be cleaned up.
+        let selected_relation_fields: std::collections::HashMap<String, std::collections::HashSet<String>> = select
+            .fields
+            .iter()
+            .filter_map(|f| {
+                if let Requestable::Select(s) = f {
+                    let mut fields = std::collections::HashSet::new();
+                    // Always include _docID as it's implicit
+                    fields.insert("_docID".to_string());
+                    for requestable in &s.fields {
+                        match requestable {
+                            Requestable::Field(f) => {
+                                fields.insert(f.output_name().to_string());
+                            }
+                            Requestable::Select(nested) => {
+                                fields.insert(nested.field.output_name().to_string());
+                            }
+                            Requestable::Aggregate(agg) => {
+                                fields.insert(agg.output_name().to_string());
+                            }
+                        }
+                    }
+                    Some((s.field.name.clone(), fields))
                 } else {
                     None
                 }
@@ -755,17 +785,29 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 // Step 1: Apply filter to array elements
                                 let filtered_items: Vec<&JsonValue> =
                                     if let Some(ref filter) = target.filter {
+                                        // Check if the filter has field-based conditions
+                                        // (keys that are not operators like _gt, _eq, etc.)
+                                        let has_field_conditions = filter.has_field_conditions();
+
                                         items
                                             .iter()
                                             .filter(|item| {
-                                                let val = match field_name {
-                                                    Some(f) => item
-                                                        .as_object()
-                                                        .and_then(|o| o.get(f))
-                                                        .unwrap_or(&JsonValue::Null),
-                                                    None => *item,
-                                                };
-                                                filter.matches_scalar_value(val).unwrap_or(false)
+                                                if has_field_conditions {
+                                                    // Field-based filter like {rating: {_gt: 4.8}}
+                                                    // Match against the entire item object
+                                                    filter.matches_json_object(item).unwrap_or(false)
+                                                } else {
+                                                    // Operator-only filter like {_gt: 4.8}
+                                                    // Extract the field value and match against it
+                                                    let val = match field_name {
+                                                        Some(f) => item
+                                                            .as_object()
+                                                            .and_then(|o| o.get(f))
+                                                            .unwrap_or(&JsonValue::Null),
+                                                        None => *item,
+                                                    };
+                                                    filter.matches_scalar_value(val).unwrap_or(false)
+                                                }
                                             })
                                             .collect()
                                     } else {
@@ -947,6 +989,108 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 for relation_name in &aggregate_relation_names {
                     if !selected_relations.contains(relation_name) {
                         obj.remove(relation_name);
+                    }
+                }
+
+                // Clean up extra fields from relation data that were added for aggregate filter evaluation
+                // but weren't in the original selection. For example, if the selection was
+                // `published { name }` but the aggregate filter needed `rating`, we need to remove
+                // `rating` from each item in `published` after aggregate computation.
+                for (relation_name, allowed_fields) in &selected_relation_fields {
+                    if let Some(relation_data) = obj.get_mut(relation_name) {
+                        if let JsonValue::Array(items) = relation_data {
+                            for item in items.iter_mut() {
+                                if let JsonValue::Object(item_obj) = item {
+                                    // Remove fields that weren't in the original selection
+                                    item_obj.retain(|k, _| allowed_fields.contains(k));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Apply post-aggregate filtering if needed
+        // When filter uses _alias to reference computed aggregates, the SelectNode can't
+        // filter during plan execution since aggregate values don't exist yet.
+        // Example: filter: {_alias: {publishedCount: {_gt: 0}}}
+        if let Some(ref filter) = select.filter {
+            let aggregate_output_names: std::collections::HashSet<&str> = aggregates_info
+                .iter()
+                .map(|(name, _, _)| name.as_str())
+                .collect();
+
+            // Check if filter has _alias conditions referencing aggregate names
+            if let Some(alias_conditions) = filter.conditions().get("_alias") {
+                if let Some(alias_obj) = alias_conditions.as_object() {
+                    let needs_post_filter = alias_obj
+                        .keys()
+                        .any(|k| aggregate_output_names.contains(k.as_str()));
+
+                    if needs_post_filter {
+                        results.retain(|result| {
+                            if let Some(obj) = result.as_object() {
+                                // Evaluate each alias condition
+                                for (alias_name, condition) in alias_obj {
+                                    if let Some(value) = obj.get(alias_name) {
+                                        // Parse and evaluate the operator conditions
+                                        if let Some(cond_obj) = condition.as_object() {
+                                            for (op_str, expected) in cond_obj {
+                                                if let Some(op) = crate::mapper::FilterOp::parse(op_str)
+                                                {
+                                                    match op {
+                                                        crate::mapper::FilterOp::Eq => {
+                                                            if value != expected {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Ne => {
+                                                            if value == expected {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Gt => {
+                                                            let v = value.as_f64().unwrap_or(0.0);
+                                                            let e = expected.as_f64().unwrap_or(0.0);
+                                                            if v <= e {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Gte => {
+                                                            let v = value.as_f64().unwrap_or(0.0);
+                                                            let e = expected.as_f64().unwrap_or(0.0);
+                                                            if v < e {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Lt => {
+                                                            let v = value.as_f64().unwrap_or(0.0);
+                                                            let e = expected.as_f64().unwrap_or(0.0);
+                                                            if v >= e {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Lte => {
+                                                            let v = value.as_f64().unwrap_or(0.0);
+                                                            let e = expected.as_f64().unwrap_or(0.0);
+                                                            if v > e {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        _ => {}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        // Alias field not found in result, filter it out
+                                        return false;
+                                    }
+                                }
+                            }
+                            true
+                        });
                     }
                 }
             }

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -8,7 +8,7 @@ pub type Result<T> = std::result::Result<T, SchemaError>;
 /// Schema-specific errors
 #[derive(Debug, Error)]
 pub enum SchemaError {
-    #[error("duplicate field name: {0}")]
+    #[error("duplicate field. Name: {0}")]
     DuplicateFieldName(String),
 
     #[error("invalid CRDT type for field kind: {field_name} cannot use {crdt_type} (only numeric fields support counters)")]
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn test_error_display() {
         let err = SchemaError::DuplicateFieldName("name".into());
-        assert_eq!(err.to_string(), "duplicate field name: name");
+        assert_eq!(err.to_string(), "duplicate field. Name: name");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Major improvements to one-to-many relationship query handling, improving FFI test parity from 26% to 55%.

- Add per-parent limit/offset/ordering in TypeJoinMany
- Fix `__typename` to use correct PascalCase collection names  
- Transform `{relation: {_docID: ...}}` filters to `{_relationID: ...}` for optimization
- Fix aggregate ordering by returning updated mapping from `apply_joins`
- Add post-aggregate filtering and ordering support
- Various filter evaluation improvements

## Test Results

**Before:** 23/87 tests passing (26%)
**After:** 48/87 tests passing (55%)

### Remaining failures by category:
- CID tests (4): CID-based queries not implemented
- Aggregates + nested limit (15): Requires separating aggregate computation from selection rendering
- Single-side filter (2): TypeJoinMany relation filter support (#187)
- Compound/alias filter (3): Complex filter handling
- GroupBy on nested (13): Nested groupBy support
- ID field (1): _docID field handling

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [x] FFI integration tests show improvement

🤖 Generated with [Claude Code](https://claude.ai/code)