### PR TITLE
feat(query): query/simple FFI parity — 411/433 (94.9%)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,12 @@
+[build]
+# Use all available cores
+jobs = 16
+
+[profile.dev]
+# Split debug info for faster incremental builds on macOS
+split-debuginfo = "unpacked"
+
+[profile.dev.package."*"]
+# Optimize all dependencies even in dev builds
+# Crypto libs (ed25519-dalek, k256, sha2) are unusably slow without optimization
+opt-level = 2

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -33,6 +33,9 @@ multihash.workspace = true
 # Hashing
 sha2.workspace = true
 
+# Random number generation (for Counter CRDT nonces)
+rand = "0.8"
+
 # Encoding
 base64.workspace = true
 

--- a/crates/db/src/auto_commit_fetcher.rs
+++ b/crates/db/src/auto_commit_fetcher.rs
@@ -10,9 +10,12 @@ use document::Document;
 use query::runner::{DocFetcher, FetchByIdsResult};
 use std::sync::Arc;
 use storage::corekv::Store;
+use tokio::sync::Mutex as TokioMutex;
 use tracing::warn;
 
 use crate::database::DB;
+use crate::txn::DbTxn;
+use crate::versioned_fetcher::VersionedFetcher;
 
 /// Document fetcher that auto-commits transactions for each operation.
 ///
@@ -198,5 +201,33 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
         }
 
         Ok(matching_docs)
+    }
+
+    async fn get_document_at_cid(
+        &self,
+        cid: &str,
+        expected_doc_id: Option<&str>,
+    ) -> query::error::Result<Document> {
+        // Create a read-only transaction for the versioned fetcher
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        // Wrap in Arc<Mutex<Option>> for VersionedFetcher
+        let txn_holder: Arc<TokioMutex<Option<DbTxn<S>>>> =
+            Arc::new(TokioMutex::new(Some(txn)));
+
+        let versioned_fetcher = VersionedFetcher::new(txn_holder.clone());
+        let result = versioned_fetcher
+            .get_document_at_cid(cid, expected_doc_id)
+            .await
+            .map_err(|e| query::error::QueryError::execution(e.to_string()));
+
+        // Clean up transaction
+        if let Some(txn) = txn_holder.lock().await.take() {
+            let _ = txn.discard();
+        }
+
+        result
     }
 }

--- a/crates/db/src/auto_commit_fetcher.rs
+++ b/crates/db/src/auto_commit_fetcher.rs
@@ -214,8 +214,7 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
         })?;
 
         // Wrap in Arc<Mutex<Option>> for VersionedFetcher
-        let txn_holder: Arc<TokioMutex<Option<DbTxn<S>>>> =
-            Arc::new(TokioMutex::new(Some(txn)));
+        let txn_holder: Arc<TokioMutex<Option<DbTxn<S>>>> = Arc::new(TokioMutex::new(Some(txn)));
 
         let versioned_fetcher = VersionedFetcher::new(txn_holder.clone());
         let result = versioned_fetcher

--- a/crates/db/src/block_builder.rs
+++ b/crates/db/src/block_builder.rs
@@ -10,7 +10,9 @@
 use blockstore::Blockstore;
 use cid::Cid;
 use datastore::NamespaceView;
-use defra_core::block::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
+use defra_core::block::{
+    Block, CompositeDeltaPayload, CounterDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload,
+};
 use document::{Document, NormalValue};
 use std::sync::Arc;
 use storage::corekv::Key;
@@ -58,7 +60,7 @@ pub async fn build_blocks_from_document<B: Blockstore>(
     let mut field_links: Vec<DAGLink> = Vec::new();
     let mut field_cids: Vec<Cid> = Vec::new();
 
-    // Create an LWW block for each field
+    // Create a block for each field (LWW or Counter depending on CRDT type)
     for (field_name, field_value) in doc.values() {
         // Skip internal fields like _docID
         if field_name.starts_with('_') {
@@ -68,17 +70,35 @@ pub async fn build_blocks_from_document<B: Blockstore>(
         // Encode the field value as CBOR
         let value_bytes = encode_value_as_cbor(field_value.value())?;
 
-        // Create LWW delta payload
-        let lww_payload = LwwDeltaPayload {
-            doc_id: doc_id_bytes.clone(),
-            field_name: field_name.clone(),
-            priority: 1, // Initial priority for new documents
-            schema_version_id: schema_version_id.to_string(),
-            data: value_bytes,
+        // Check if this field is a Counter type
+        let is_counter = doc
+            .fields()
+            .get(field_name)
+            .map(|f| f.crdt_type().is_counter())
+            .unwrap_or(false);
+
+        // Create the appropriate delta based on CRDT type
+        let delta = if is_counter {
+            CrdtDelta::Counter(CounterDeltaPayload {
+                doc_id: doc_id_bytes.clone(),
+                field_name: field_name.clone(),
+                priority: 1, // Initial priority for new documents
+                nonce: 0,    // Go uses nonce=0 for initial creation (deterministic CID)
+                schema_version_id: schema_version_id.to_string(),
+                data: value_bytes,
+            })
+        } else {
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: doc_id_bytes.clone(),
+                field_name: field_name.clone(),
+                priority: 1, // Initial priority for new documents
+                schema_version_id: schema_version_id.to_string(),
+                data: value_bytes,
+            })
         };
 
         // Create the field block
-        let field_block = Block::new(CrdtDelta::Lww(lww_payload), vec![], vec![]);
+        let field_block = Block::new(delta, vec![], vec![]);
 
         // Serialize and generate CID
         let field_block_bytes = field_block
@@ -97,7 +117,8 @@ pub async fn build_blocks_from_document<B: Blockstore>(
         tracing::debug!(
             field_name = %field_name,
             cid = %field_cid,
-            "Stored LWW field block"
+            is_counter = is_counter,
+            "Stored field block"
         );
 
         // Add link to composite
@@ -333,23 +354,51 @@ pub async fn write_document_blocks(
         let field_head = get_field_head(headstore, &doc_id_str, field_name).await?;
 
         if should_create_block {
-            // Create new LWW block for this field
+            // Create new block for this field (LWW or Counter depending on CRDT type)
             let heads: Vec<Cid> = field_head.cid.into_iter().collect();
 
             // Encode the field value as CBOR
             let value_bytes = encode_value_as_cbor(field_value.value())?;
 
-            // Create LWW delta payload
-            let lww_payload = LwwDeltaPayload {
-                doc_id: doc_id_bytes.clone(),
-                field_name: field_name.clone(),
-                priority,
-                schema_version_id: schema_version_id.to_string(),
-                data: value_bytes,
+            // Check if this field is a Counter type
+            let is_counter = doc
+                .fields()
+                .get(field_name)
+                .map(|f| f.crdt_type().is_counter())
+                .unwrap_or(false);
+
+            // For Counter fields, use nonce=0 for initial creation (heads empty),
+            // random nonce for updates (heads non-empty) - matches Go behavior
+            let nonce: i64 = if is_counter && !heads.is_empty() {
+                // Update operation: use random nonce
+                rand::random()
+            } else {
+                // Initial creation: use deterministic nonce=0
+                0
+            };
+
+            // Create the appropriate delta based on CRDT type
+            let delta = if is_counter {
+                CrdtDelta::Counter(CounterDeltaPayload {
+                    doc_id: doc_id_bytes.clone(),
+                    field_name: field_name.clone(),
+                    priority,
+                    nonce,
+                    schema_version_id: schema_version_id.to_string(),
+                    data: value_bytes,
+                })
+            } else {
+                CrdtDelta::Lww(LwwDeltaPayload {
+                    doc_id: doc_id_bytes.clone(),
+                    field_name: field_name.clone(),
+                    priority,
+                    schema_version_id: schema_version_id.to_string(),
+                    data: value_bytes,
+                })
             };
 
             // Create the field block with heads linking to previous version
-            let field_block = Block::new(CrdtDelta::Lww(lww_payload), heads, vec![]);
+            let field_block = Block::new(delta, heads.clone(), vec![]);
 
             // Serialize and generate CID
             let field_block_bytes = field_block
@@ -384,8 +433,9 @@ pub async fn write_document_blocks(
             tracing::debug!(
                 field_name = %field_name,
                 cid = %field_cid,
-                has_prev_head = field_head.cid.is_some(),
-                "Stored LWW field block and head"
+                is_counter = is_counter,
+                has_prev_head = !heads.is_empty(),
+                "Stored field block and head"
             );
 
             // Add link to composite - only new blocks get linked

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -13,6 +13,7 @@ use tracing::warn;
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::commits_fetcher::{CommitsFetcher, CommitsQueryOptions as DbCommitsOptions};
 use crate::txn::DbTxn;
+use crate::versioned_fetcher::VersionedFetcher;
 
 /// Document fetcher that uses a database transaction.
 ///
@@ -272,5 +273,17 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
 
     fn supports_index_queries(&self) -> bool {
         true
+    }
+
+    async fn get_document_at_cid(
+        &self,
+        cid: &str,
+        expected_doc_id: Option<&str>,
+    ) -> query::error::Result<Document> {
+        let versioned_fetcher = VersionedFetcher::new(self.txn.clone());
+        versioned_fetcher
+            .get_document_at_cid(cid, expected_doc_id)
+            .await
+            .map_err(|e| query::error::QueryError::execution(e.to_string()))
     }
 }

--- a/crates/db/src/lensed_auto_commit_fetcher.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher.rs
@@ -25,6 +25,7 @@ use crate::database::DB;
 use crate::index_manager::IndexManager;
 use crate::schema_loader::get_collections_by_collection_id;
 use crate::txn::DbTxn;
+use crate::versioned_fetcher::VersionedFetcher;
 
 /// Document fetcher that auto-commits and applies lens migrations.
 ///
@@ -559,5 +560,33 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
 
     fn supports_index_queries(&self) -> bool {
         true
+    }
+
+    async fn get_document_at_cid(
+        &self,
+        cid: &str,
+        expected_doc_id: Option<&str>,
+    ) -> query::error::Result<Document> {
+        // Create a read-only transaction for the versioned fetcher
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        // Wrap in Arc<Mutex<Option>> for VersionedFetcher
+        let txn_holder: std::sync::Arc<TokioMutex<Option<DbTxn<S>>>> =
+            std::sync::Arc::new(TokioMutex::new(Some(txn)));
+
+        let versioned_fetcher = VersionedFetcher::new(txn_holder.clone());
+        let result = versioned_fetcher
+            .get_document_at_cid(cid, expected_doc_id)
+            .await
+            .map_err(|e| query::error::QueryError::execution(e.to_string()));
+
+        // Clean up transaction
+        if let Some(txn) = txn_holder.lock().await.take() {
+            let _ = txn.discard();
+        }
+
+        result
     }
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -69,6 +69,7 @@ pub mod schema_loader;
 pub mod txn;
 pub mod txn_context;
 pub mod txn_registry;
+pub mod versioned_fetcher;
 
 // Re-export commonly used types
 pub use acp_merge_handler::{AcpMergeError, AcpMergeHandler};
@@ -107,6 +108,7 @@ pub use schema_loader::{
 pub use txn::DbTxn;
 pub use txn_context::DbTransactionContext;
 pub use txn_registry::{CleanupResult, DbTransactionRegistry};
+pub use versioned_fetcher::VersionedFetcher;
 
 // NAC exports
 pub use nac::{create_memory_nac_manager, NacConfig, NacInfo, NacManager};

--- a/crates/db/src/merge_handler.rs
+++ b/crates/db/src/merge_handler.rs
@@ -8,12 +8,13 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use cid::Cid;
-use crdt::traits::{Context, ReplicatedData};
-use crdt::{Lww, LwwDelta};
+use crdt::traits::{Context, ReplicatedData, ValueReader};
+use crdt::{Counter, CounterDelta, Lww, LwwDelta, NumericKind};
 use datastore::NamespaceView;
 use defra_core::block::{Block, CrdtDelta};
 use defra_core::types::DocId;
 use document::{DocID, Document, NormalValue};
+use schema;
 use events::{Message, Update};
 use p2p::sync::{BlockMetadata, MergeHandler, MergeOutcome};
 use storage::corekv::Store;
@@ -55,6 +56,15 @@ struct LwwMergeResult {
     /// Whether the merge was applied (vs rejected/skipped)
     applied: bool,
     /// The winning value for document reconstruction (if applied, use incoming; else read from store)
+    value: Option<NormalValue>,
+}
+
+/// Result of processing a Counter delta, including whether it was applied
+/// and the accumulated value for document reconstruction.
+struct CounterMergeResult {
+    /// Whether the merge was applied (vs skipped due to nonce)
+    applied: bool,
+    /// The accumulated counter value after merge
     value: Option<NormalValue>,
 }
 
@@ -426,12 +436,30 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                             }
                         }
                         CrdtDelta::Counter(counter_payload) => {
-                            // Counter deltas are not yet supported - return error
-                            process_error = Some(MergeError::UnsupportedDelta(format!(
-                                "Counter CRDT merge not yet implemented for field '{}'",
-                                counter_payload.field_name
-                            )));
-                            break;
+                            // Process the Counter delta within our transaction
+                            match self
+                                .process_counter_delta_in_txn(
+                                    &mut datastore,
+                                    link_cid,
+                                    counter_payload,
+                                )
+                                .await
+                            {
+                                Ok(result) => {
+                                    if result.applied {
+                                        any_field_applied = true;
+                                    }
+                                    // Collect the accumulated value for document reconstruction
+                                    if let Some(value) = result.value {
+                                        field_values
+                                            .insert(counter_payload.field_name.clone(), value);
+                                    }
+                                }
+                                Err(e) => {
+                                    process_error = Some(e);
+                                    break;
+                                }
+                            }
                         }
                         other => {
                             tracing::error!(
@@ -542,7 +570,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         }
     }
 
-    /// Process a Counter delta from a block.
+    /// Process a Counter delta from a block (standalone, with its own transaction).
     async fn process_counter_delta(
         &self,
         cid: &Cid,
@@ -551,21 +579,296 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
     ) -> std::result::Result<MergeOutcome, MergeError> {
         let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
 
-        tracing::error!(
+        tracing::debug!(
             cid = %cid,
             field_name = %payload.field_name,
             doc_id = %doc_id_str,
             priority = payload.priority,
             nonce = payload.nonce,
-            "Counter CRDT merge not yet implemented - rejecting block"
+            "Processing Counter delta"
         );
 
-        // Return an error instead of silently skipping
-        // This ensures callers know counter sync is not functional
-        Err(MergeError::UnsupportedDelta(format!(
-            "Counter CRDT merge not yet implemented for field '{}'",
-            payload.field_name
-        )))
+        // Look up the collection to determine field kind and counter type
+        let collection = self
+            .db
+            .find_collection_by_id(&payload.schema_version_id)?
+            .ok_or_else(|| {
+                MergeError::MissingMetadata(format!(
+                    "Collection not found for schema_version_id: {}",
+                    payload.schema_version_id
+                ))
+            })?;
+
+        // Get field definition to determine numeric kind and allow_decrement
+        let field = collection.schema().field_by_name(&payload.field_name).ok_or_else(|| {
+            MergeError::MissingMetadata(format!(
+                "Field '{}' not found in collection",
+                payload.field_name
+            ))
+        })?;
+
+        // Determine numeric kind from field type
+        let numeric_kind = self.get_numeric_kind_from_field(field)?;
+
+        // Determine if decrement is allowed (PnCounter allows, PCounter doesn't)
+        let allow_decrement = field.crdt_type.allows_decrement();
+
+        // Create a new transaction for this merge
+        let txn = self.db.new_txn(false).await?;
+
+        // Create the Counter CRDT
+        let counter = Counter::new(
+            payload.schema_version_id.clone(),
+            &payload.doc_id,
+            payload.field_name.clone(),
+            allow_decrement,
+            numeric_kind,
+        )
+        .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
+
+        // Create the CounterDelta from payload
+        let delta = self.create_counter_delta(payload, numeric_kind)?;
+
+        // Create the context
+        let ctx = Context {
+            doc_id: DocId::new(&doc_id_str),
+            schema_version: payload.schema_version_id.clone(),
+        };
+
+        // Perform the merge in a scoped block
+        let result = {
+            let mut datastore = txn.datastore()?;
+            counter.merge(&mut datastore, &ctx, &delta).await
+        };
+
+        match result {
+            Ok(merge_result) => {
+                if merge_result.was_applied() {
+                    txn.force_commit().await?;
+                    tracing::info!(
+                        cid = %cid,
+                        field_name = %payload.field_name,
+                        doc_id = %doc_id_str,
+                        "Counter delta merged successfully"
+                    );
+                    Ok(MergeOutcome::Merged)
+                } else {
+                    // Skipped (nonce already applied)
+                    if let Err(e) = txn.force_discard() {
+                        tracing::error!(
+                            cid = %cid,
+                            error = %e,
+                            "Failed to discard transaction after skip"
+                        );
+                    }
+                    tracing::debug!(
+                        cid = %cid,
+                        field_name = %payload.field_name,
+                        "Counter delta skipped (nonce already applied)"
+                    );
+                    Ok(MergeOutcome::skipped("nonce already applied"))
+                }
+            }
+            Err(e) => {
+                if let Err(discard_err) = txn.force_discard() {
+                    tracing::error!(
+                        cid = %cid,
+                        discard_error = %discard_err,
+                        merge_error = %e,
+                        "Failed to discard transaction after merge error"
+                    );
+                }
+                Err(MergeError::MergeFailed(e.to_string()))
+            }
+        }
+    }
+
+    /// Process a Counter delta within an existing transaction, returning the merge result
+    /// and the accumulated value for document reconstruction.
+    async fn process_counter_delta_in_txn(
+        &self,
+        datastore: &mut NamespaceView,
+        cid: &Cid,
+        payload: &defra_core::block::CounterDeltaPayload,
+    ) -> std::result::Result<CounterMergeResult, MergeError> {
+        tracing::debug!(
+            cid = %cid,
+            field_name = %payload.field_name,
+            priority = payload.priority,
+            nonce = payload.nonce,
+            "Processing Counter delta in transaction"
+        );
+
+        // Look up the collection to determine field kind and counter type
+        let collection = self
+            .db
+            .find_collection_by_id(&payload.schema_version_id)?
+            .ok_or_else(|| {
+                MergeError::MissingMetadata(format!(
+                    "Collection not found for schema_version_id: {}",
+                    payload.schema_version_id
+                ))
+            })?;
+
+        // Get field definition
+        let field = collection.schema().field_by_name(&payload.field_name).ok_or_else(|| {
+            MergeError::MissingMetadata(format!(
+                "Field '{}' not found in collection",
+                payload.field_name
+            ))
+        })?;
+
+        // Determine numeric kind and allow_decrement
+        let numeric_kind = self.get_numeric_kind_from_field(field)?;
+        let allow_decrement = field.crdt_type.allows_decrement();
+
+        // Create the Counter CRDT
+        let counter = Counter::new(
+            payload.schema_version_id.clone(),
+            &payload.doc_id,
+            payload.field_name.clone(),
+            allow_decrement,
+            numeric_kind,
+        )
+        .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
+
+        // Create the CounterDelta from payload
+        let delta = self.create_counter_delta(payload, numeric_kind)?;
+
+        // Create the context
+        let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
+        let ctx = Context {
+            doc_id: DocId::new(&doc_id_str),
+            schema_version: payload.schema_version_id.clone(),
+        };
+
+        // Perform the merge
+        let merge_result = counter
+            .merge(datastore, &ctx, &delta)
+            .await
+            .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
+
+        // Read the accumulated value (counters always accumulate, so we always read current)
+        let value = match ValueReader::value(&counter, datastore).await {
+            Ok(bytes) => {
+                if bytes.is_empty() {
+                    None
+                } else {
+                    // Convert raw bytes to NormalValue based on kind
+                    match numeric_kind {
+                        NumericKind::Int64 => {
+                            if bytes.len() == 8 {
+                                let arr: [u8; 8] = bytes[..8].try_into().unwrap();
+                                Some(NormalValue::Int(i64::from_be_bytes(arr)))
+                            } else {
+                                tracing::warn!(
+                                    field_name = %payload.field_name,
+                                    "Invalid counter value length for Int64"
+                                );
+                                None
+                            }
+                        }
+                        NumericKind::Float64 => {
+                            if bytes.len() == 8 {
+                                let arr: [u8; 8] = bytes[..8].try_into().unwrap();
+                                Some(NormalValue::Float64(f64::from_be_bytes(arr)))
+                            } else {
+                                tracing::warn!(
+                                    field_name = %payload.field_name,
+                                    "Invalid counter value length for Float64"
+                                );
+                                None
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    field_name = %payload.field_name,
+                    error = %e,
+                    "Could not read counter value"
+                );
+                None
+            }
+        };
+
+        Ok(CounterMergeResult {
+            applied: merge_result.was_applied(),
+            value,
+        })
+    }
+
+    /// Determine numeric kind from field definition
+    fn get_numeric_kind_from_field(
+        &self,
+        field: &schema::FieldDescription,
+    ) -> std::result::Result<NumericKind, MergeError> {
+        use schema::FieldKind;
+
+        match &field.kind {
+            FieldKind::Scalar(scalar_kind) => {
+                use schema::ScalarKind;
+                match scalar_kind {
+                    ScalarKind::Int => Ok(NumericKind::Int64),
+                    ScalarKind::Float64 | ScalarKind::Float32 => Ok(NumericKind::Float64),
+                    other => Err(MergeError::UnsupportedDelta(format!(
+                        "Counter field '{}' has unsupported scalar kind: {:?}",
+                        field.name, other
+                    ))),
+                }
+            }
+            other => Err(MergeError::UnsupportedDelta(format!(
+                "Counter field '{}' has unsupported kind: {:?}",
+                field.name, other
+            ))),
+        }
+    }
+
+    /// Create a CounterDelta from the block payload
+    fn create_counter_delta(
+        &self,
+        payload: &defra_core::block::CounterDeltaPayload,
+        kind: NumericKind,
+    ) -> std::result::Result<CounterDelta, MergeError> {
+        // Go encodes counter data as CBOR. We need to decode it first.
+        // The payload.data contains CBOR-encoded i64 or f64
+        match kind {
+            NumericKind::Int64 => {
+                let increment: i64 = ciborium::from_reader(&payload.data[..]).map_err(|e| {
+                    MergeError::BlockDecode(format!(
+                        "Failed to decode Counter Int64 increment: {}",
+                        e
+                    ))
+                })?;
+                CounterDelta::new_int64(
+                    payload.doc_id.clone(),
+                    payload.field_name.clone(),
+                    payload.priority,
+                    payload.nonce,
+                    payload.schema_version_id.clone(),
+                    increment,
+                )
+                .map_err(|e| MergeError::MergeFailed(e.to_string()))
+            }
+            NumericKind::Float64 => {
+                let increment: f64 = ciborium::from_reader(&payload.data[..]).map_err(|e| {
+                    MergeError::BlockDecode(format!(
+                        "Failed to decode Counter Float64 increment: {}",
+                        e
+                    ))
+                })?;
+                CounterDelta::new_float64(
+                    payload.doc_id.clone(),
+                    payload.field_name.clone(),
+                    payload.priority,
+                    payload.nonce,
+                    payload.schema_version_id.clone(),
+                    increment,
+                )
+                .map_err(|e| MergeError::MergeFailed(e.to_string()))
+            }
+        }
     }
 }
 

--- a/crates/db/src/merge_handler.rs
+++ b/crates/db/src/merge_handler.rs
@@ -14,9 +14,9 @@ use datastore::NamespaceView;
 use defra_core::block::{Block, CrdtDelta};
 use defra_core::types::DocId;
 use document::{DocID, Document, NormalValue};
-use schema;
 use events::{Message, Update};
 use p2p::sync::{BlockMetadata, MergeHandler, MergeOutcome};
+use schema;
 use storage::corekv::Store;
 
 use crate::database::DB;
@@ -600,12 +600,15 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             })?;
 
         // Get field definition to determine numeric kind and allow_decrement
-        let field = collection.schema().field_by_name(&payload.field_name).ok_or_else(|| {
-            MergeError::MissingMetadata(format!(
-                "Field '{}' not found in collection",
-                payload.field_name
-            ))
-        })?;
+        let field = collection
+            .schema()
+            .field_by_name(&payload.field_name)
+            .ok_or_else(|| {
+                MergeError::MissingMetadata(format!(
+                    "Field '{}' not found in collection",
+                    payload.field_name
+                ))
+            })?;
 
         // Determine numeric kind from field type
         let numeric_kind = self.get_numeric_kind_from_field(field)?;
@@ -711,12 +714,15 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             })?;
 
         // Get field definition
-        let field = collection.schema().field_by_name(&payload.field_name).ok_or_else(|| {
-            MergeError::MissingMetadata(format!(
-                "Field '{}' not found in collection",
-                payload.field_name
-            ))
-        })?;
+        let field = collection
+            .schema()
+            .field_by_name(&payload.field_name)
+            .ok_or_else(|| {
+                MergeError::MissingMetadata(format!(
+                    "Field '{}' not found in collection",
+                    payload.field_name
+                ))
+            })?;
 
         // Determine numeric kind and allow_decrement
         let numeric_kind = self.get_numeric_kind_from_field(field)?;

--- a/crates/db/src/versioned_fetcher.rs
+++ b/crates/db/src/versioned_fetcher.rs
@@ -1,0 +1,348 @@
+//! Versioned document fetcher for CID-based time-travel queries.
+//!
+//! This module reconstructs documents at specific historical versions by:
+//! 1. Walking the merkle DAG backwards from target CID to genesis
+//! 2. Collecting all blocks in the path
+//! 3. Replaying CRDT deltas forward to reconstruct document state
+
+use cid::Cid;
+use defra_core::block::{Block, CrdtDelta};
+use document::{Document, NormalValue};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::str::FromStr;
+use std::sync::Arc;
+use storage::corekv::Store;
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::error::{Error, Result};
+use crate::txn::DbTxn;
+
+/// Fetcher for reconstructing documents at specific historical versions.
+///
+/// Given a CID, this fetcher walks backwards through the merkle DAG,
+/// collects all blocks from the target CID to genesis, then replays
+/// the CRDT deltas in forward order to reconstruct the document state.
+pub struct VersionedFetcher<S: Store> {
+    txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
+}
+
+impl<S: Store> VersionedFetcher<S> {
+    /// Create a new versioned fetcher with a shared transaction
+    pub fn new(txn: Arc<TokioMutex<Option<DbTxn<S>>>>) -> Self {
+        Self { txn }
+    }
+
+    /// Reconstruct a document at the specified CID.
+    ///
+    /// Returns the document state as it existed when the commit at `cid` was created.
+    /// If `expected_doc_id` is provided, validates that the CID belongs to that document.
+    pub async fn get_document_at_cid(
+        &self,
+        cid_str: &str,
+        expected_doc_id: Option<&str>,
+    ) -> Result<Document> {
+        let mut guard = self.txn.lock().await;
+        let txn = guard.as_mut().ok_or(Error::TxnNotActive)?;
+
+        // Parse the CID
+        let target_cid = Self::parse_cid(cid_str)?;
+
+        // Load the target block first to validate and get doc info
+        let target_block = self.load_block(txn, &target_cid).await?;
+
+        // Extract and validate document ID
+        let doc_id = Self::extract_doc_id(&target_block.delta)?;
+
+        if let Some(expected) = expected_doc_id {
+            if doc_id != expected {
+                return Err(Error::Serialization(
+                    "cid either does not exist or belong to document".to_string(),
+                ));
+            }
+        }
+
+        // Collect all blocks from target CID back to genesis
+        let blocks = self
+            .collect_blocks_to_genesis(txn, &target_cid, &target_block)
+            .await?;
+
+        // Sort blocks by priority (ascending) for forward replay
+        let mut sorted_blocks: Vec<(Cid, Block)> = blocks.into_iter().collect();
+        sorted_blocks.sort_by_key(|(_, block)| block.delta.priority());
+
+        // Replay deltas to reconstruct document
+        let document = self.replay_deltas(&sorted_blocks, &doc_id)?;
+
+        Ok(document)
+    }
+
+    /// Parse a CID string, returning appropriate errors for invalid/unknown CIDs.
+    fn parse_cid(cid_str: &str) -> Result<Cid> {
+        Cid::from_str(cid_str).map_err(|e| {
+            // Go's CID library is more lenient. If it looks like a valid CIDv1
+            // format, treat as "not found" rather than "invalid".
+            if Self::looks_like_cidv1(cid_str) {
+                Error::Serialization("cid either does not exist or belong to document".to_string())
+            } else {
+                Error::Serialization(format!("invalid cid: {}", e))
+            }
+        })
+    }
+
+    /// Check if a string looks like a CIDv1.
+    fn looks_like_cidv1(s: &str) -> bool {
+        if s.len() < 40 {
+            return false;
+        }
+        s.starts_with("bafy")
+            || s.starts_with("bafk")
+            || s.starts_with("bafz")
+            || s.starts_with("bafr")
+            || s.starts_with("Qm")
+    }
+
+    /// Extract document ID from a delta.
+    fn extract_doc_id(delta: &CrdtDelta) -> Result<String> {
+        delta
+            .doc_id()
+            .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+            .ok_or_else(|| {
+                Error::Serialization(
+                    "cid either does not exist or belong to document".to_string(),
+                )
+            })
+    }
+
+    /// Collect all blocks from target CID back to genesis using BFS.
+    ///
+    /// Returns a map of CID -> Block for all blocks in the history.
+    async fn collect_blocks_to_genesis(
+        &self,
+        txn: &mut DbTxn<S>,
+        start_cid: &Cid,
+        start_block: &Block,
+    ) -> Result<HashMap<Cid, Block>> {
+        let mut blocks = HashMap::new();
+        let mut visited = HashSet::new();
+        let mut queue: VecDeque<Cid> = VecDeque::new();
+
+        // Start with the target block
+        blocks.insert(*start_cid, start_block.clone());
+        visited.insert(start_cid.to_string());
+
+        // Queue up heads for traversal
+        if let Some(ref heads) = start_block.heads {
+            for head_cid in heads {
+                queue.push_back(*head_cid);
+            }
+        }
+
+        // Also traverse links (for composite blocks that link to field blocks)
+        if let Some(ref links) = start_block.links {
+            for link in links {
+                if !visited.contains(&link.link.to_string()) {
+                    queue.push_back(link.link);
+                }
+            }
+        }
+
+        // BFS traversal
+        while let Some(cid) = queue.pop_front() {
+            let cid_str = cid.to_string();
+            if visited.contains(&cid_str) {
+                continue;
+            }
+            visited.insert(cid_str);
+
+            let block = match self.load_block(txn, &cid).await {
+                Ok(b) => b,
+                Err(_) => continue, // Skip missing blocks (genesis reached)
+            };
+
+            // Queue heads for further traversal
+            if let Some(ref heads) = block.heads {
+                for head_cid in heads {
+                    if !visited.contains(&head_cid.to_string()) {
+                        queue.push_back(*head_cid);
+                    }
+                }
+            }
+
+            // Queue links for composite blocks
+            if let Some(ref links) = block.links {
+                for link in links {
+                    if !visited.contains(&link.link.to_string()) {
+                        queue.push_back(link.link);
+                    }
+                }
+            }
+
+            blocks.insert(cid, block);
+        }
+
+        Ok(blocks)
+    }
+
+    /// Load a block from blockstore by CID.
+    async fn load_block(&self, txn: &mut DbTxn<S>, cid: &Cid) -> Result<Block> {
+        let blockstore = txn.blockstore()?;
+
+        let key = cid.to_bytes();
+        let data = blockstore
+            .get(&key)
+            .await
+            .map_err(Error::Storage)?
+            .ok_or_else(|| {
+                Error::Serialization("cid either does not exist or belong to document".to_string())
+            })?;
+
+        Block::from_dag_cbor(&data)
+            .map_err(|e| Error::Serialization(format!("Failed to decode block: {}", e)))
+    }
+
+    /// Replay CRDT deltas to reconstruct document state.
+    ///
+    /// Blocks should be sorted by priority (ascending) before calling this method.
+    fn replay_deltas(&self, blocks: &[(Cid, Block)], doc_id: &str) -> Result<Document> {
+        let mut field_values: HashMap<String, (u64, NormalValue)> = HashMap::new();
+
+        for (_cid, block) in blocks {
+            match &block.delta {
+                CrdtDelta::Lww(payload) => {
+                    // Check if this delta belongs to our document
+                    let delta_doc_id = String::from_utf8_lossy(&payload.doc_id);
+                    if delta_doc_id != doc_id {
+                        continue;
+                    }
+
+                    let field_name = &payload.field_name;
+                    let priority = payload.priority;
+
+                    // LWW merge: higher priority wins, on tie, lexicographic comparison
+                    let should_apply = match field_values.get(field_name) {
+                        None => true,
+                        Some((current_priority, current_value)) => {
+                            if priority > *current_priority {
+                                true
+                            } else if priority == *current_priority {
+                                // Tie-break: lexicographic comparison of encoded data
+                                let current_encoded = Self::encode_value(current_value);
+                                payload.data > current_encoded
+                            } else {
+                                false
+                            }
+                        }
+                    };
+
+                    if should_apply {
+                        if payload.data.is_empty() {
+                            // Tombstone - remove field
+                            field_values.remove(field_name);
+                        } else {
+                            // Decode and store value
+                            match ciborium::from_reader::<NormalValue, _>(&payload.data[..]) {
+                                Ok(value) => {
+                                    field_values
+                                        .insert(field_name.clone(), (priority, value));
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        field_name = %field_name,
+                                        error = %e,
+                                        "Failed to decode LWW value during replay"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                CrdtDelta::Counter(payload) => {
+                    // Check if this delta belongs to our document
+                    let delta_doc_id = String::from_utf8_lossy(&payload.doc_id);
+                    if delta_doc_id != doc_id {
+                        continue;
+                    }
+
+                    let field_name = &payload.field_name;
+
+                    // Counter: accumulate increments
+                    // Note: Counter replay needs nonce tracking for idempotency
+                    // For now, we apply all deltas (may double-count on concurrent updates)
+                    if !payload.data.is_empty() {
+                        match ciborium::from_reader::<i64, _>(&payload.data[..]) {
+                            Ok(increment) => {
+                                let current: i64 = field_values
+                                    .get(field_name)
+                                    .and_then(|(_, v)| v.as_int())
+                                    .unwrap_or(0);
+                                let new_value = current.saturating_add(increment);
+                                field_values.insert(
+                                    field_name.clone(),
+                                    (payload.priority, NormalValue::Int(new_value)),
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    field_name = %field_name,
+                                    error = %e,
+                                    "Failed to decode Counter value during replay"
+                                );
+                            }
+                        }
+                    }
+                }
+                CrdtDelta::Composite(_) => {
+                    // Composite blocks link to field blocks, they don't contain data themselves
+                    // The field blocks are already collected via the links traversal
+                }
+                _ => {
+                    // Collection and schema definition deltas are not relevant for document reconstruction
+                }
+            }
+        }
+
+        // Build document from collected field values
+        let mut document = Document::new();
+        for (field_name, (_priority, value)) in field_values {
+            document.set(&field_name, value);
+        }
+
+        // Set document ID
+        if let Ok(doc_id_obj) = document::DocID::from_string(doc_id) {
+            document.set_id(doc_id_obj);
+        }
+
+        Ok(document)
+    }
+
+    /// Encode a NormalValue to bytes for comparison.
+    fn encode_value(value: &NormalValue) -> Vec<u8> {
+        let mut buf = Vec::new();
+        if ciborium::into_writer(value, &mut buf).is_ok() {
+            buf
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_looks_like_cidv1() {
+        assert!(VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
+            "bafyreiajq6jmyblg2b6vupjdapzkaodbt7kkwqp4fijekdvydnyxvr4y7q"
+        ));
+        assert!(VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
+            "bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist"
+        ));
+        assert!(!VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
+            "fhbnjfahfhfhanfhga"
+        ));
+        assert!(!VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
+            "short"
+        ));
+    }
+}

--- a/crates/db/src/versioned_fetcher.rs
+++ b/crates/db/src/versioned_fetcher.rs
@@ -193,7 +193,9 @@ impl<S: Store> VersionedFetcher<S> {
             .await
             .map_err(Error::Storage)?
             .ok_or_else(|| {
-                Error::Serialization("cid either does not exist or belong to document".to_string())
+                Error::Serialization(
+                    "failed to get block in blockstore: ipld: could not find".to_string(),
+                )
             })?;
 
         Block::from_dag_cbor(&data)

--- a/crates/db/src/versioned_fetcher.rs
+++ b/crates/db/src/versioned_fetcher.rs
@@ -269,17 +269,52 @@ impl<S: Store> VersionedFetcher<S> {
                     // Note: Counter replay needs nonce tracking for idempotency
                     // For now, we apply all deltas (may double-count on concurrent updates)
                     if !payload.data.is_empty() {
-                        match ciborium::from_reader::<i64, _>(&payload.data[..]) {
-                            Ok(increment) => {
-                                let current: i64 = field_values
-                                    .get(field_name)
-                                    .and_then(|(_, v)| v.as_int())
-                                    .unwrap_or(0);
-                                let new_value = current.saturating_add(increment);
-                                field_values.insert(
-                                    field_name.clone(),
-                                    (payload.priority, NormalValue::Int(new_value)),
-                                );
+                        // Try decoding as NormalValue to handle both Int and Float counters
+                        match ciborium::from_reader::<NormalValue, _>(&payload.data[..]) {
+                            Ok(increment_value) => {
+                                // Handle both Int and Float counter values
+                                match &increment_value {
+                                    NormalValue::Int(increment) => {
+                                        let current: i64 = field_values
+                                            .get(field_name)
+                                            .and_then(|(_, v)| v.as_int())
+                                            .unwrap_or(0);
+                                        let new_value = current.saturating_add(*increment);
+                                        field_values.insert(
+                                            field_name.clone(),
+                                            (payload.priority, NormalValue::Int(new_value)),
+                                        );
+                                    }
+                                    NormalValue::Float64(increment) => {
+                                        let current: f64 = field_values
+                                            .get(field_name)
+                                            .and_then(|(_, v)| v.as_float64())
+                                            .unwrap_or(0.0);
+                                        let new_value = current + increment;
+                                        field_values.insert(
+                                            field_name.clone(),
+                                            (payload.priority, NormalValue::Float64(new_value)),
+                                        );
+                                    }
+                                    NormalValue::Float32(increment) => {
+                                        let current: f32 = field_values
+                                            .get(field_name)
+                                            .and_then(|(_, v)| v.as_float32())
+                                            .unwrap_or(0.0);
+                                        let new_value = current + increment;
+                                        field_values.insert(
+                                            field_name.clone(),
+                                            (payload.priority, NormalValue::Float32(new_value)),
+                                        );
+                                    }
+                                    other => {
+                                        tracing::warn!(
+                                            field_name = %field_name,
+                                            value_type = ?other,
+                                            "Unexpected Counter value type during replay"
+                                        );
+                                    }
+                                }
                             }
                             Err(e) => {
                                 tracing::warn!(

--- a/crates/db/src/versioned_fetcher.rs
+++ b/crates/db/src/versioned_fetcher.rs
@@ -107,9 +107,7 @@ impl<S: Store> VersionedFetcher<S> {
             .doc_id()
             .map(|bytes| String::from_utf8_lossy(bytes).to_string())
             .ok_or_else(|| {
-                Error::Serialization(
-                    "cid either does not exist or belong to document".to_string(),
-                )
+                Error::Serialization("cid either does not exist or belong to document".to_string())
             })
     }
 
@@ -242,8 +240,7 @@ impl<S: Store> VersionedFetcher<S> {
                             // Decode and store value
                             match ciborium::from_reader::<NormalValue, _>(&payload.data[..]) {
                                 Ok(value) => {
-                                    field_values
-                                        .insert(field_name.clone(), (priority, value));
+                                    field_values.insert(field_name.clone(), (priority, value));
                                 }
                                 Err(e) => {
                                     tracing::warn!(
@@ -367,17 +364,23 @@ mod tests {
 
     #[test]
     fn test_looks_like_cidv1() {
-        assert!(VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
-            "bafyreiajq6jmyblg2b6vupjdapzkaodbt7kkwqp4fijekdvydnyxvr4y7q"
-        ));
-        assert!(VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
-            "bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist"
-        ));
-        assert!(!VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
-            "fhbnjfahfhfhanfhga"
-        ));
-        assert!(!VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
-            "short"
-        ));
+        assert!(
+            VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
+                "bafyreiajq6jmyblg2b6vupjdapzkaodbt7kkwqp4fijekdvydnyxvr4y7q"
+            )
+        );
+        assert!(
+            VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
+                "bafybeid57gpbwi4i6bg7g35hhhhhhhhhhhhhhhhhhhhhhhdoesnotexist"
+            )
+        );
+        assert!(
+            !VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1(
+                "fhbnjfahfhfhanfhga"
+            )
+        );
+        assert!(
+            !VersionedFetcher::<storage::backends::memory::MemoryStore>::looks_like_cidv1("short")
+        );
     }
 }

--- a/crates/defra-core/src/ipld/to_ipld.rs
+++ b/crates/defra-core/src/ipld/to_ipld.rs
@@ -133,8 +133,9 @@ impl From<&CounterDeltaPayload> for Ipld {
             Ipld::Integer(payload.priority as i128),
         );
         map.insert("nonce".to_string(), Ipld::Integer(payload.nonce as i128));
+        // Go's CounterDelta uses "collectionVersionID" (not "schemaVersionID")
         map.insert(
-            "schemaVersionID".to_string(),
+            "collectionVersionID".to_string(),
             Ipld::String(payload.schema_version_id.clone()),
         );
         map.insert("data".to_string(), Ipld::Bytes(payload.data.clone()));

--- a/crates/document/src/document.rs
+++ b/crates/document/src/document.rs
@@ -528,10 +528,14 @@ mod tests {
 
         // Verify the CBOR bytes match Go's JSON-type encoding
         let cbor_bytes = doc.to_cbor().expect("should encode");
-        let expected_cbor = "a2646e616d65644a6f686e66637573746f6da263616765f95bd06474726565656d61706c65";
+        let expected_cbor =
+            "a2646e616d65644a6f686e66637573746f6da263616765f95bd06474726565656d61706c65";
         let actual_cbor: String = cbor_bytes.iter().map(|b| format!("{:02x}", b)).collect();
 
-        assert_eq!(actual_cbor, expected_cbor, "CBOR should match Go's JSON-type encoding");
+        assert_eq!(
+            actual_cbor, expected_cbor,
+            "CBOR should match Go's JSON-type encoding"
+        );
         assert_eq!(
             cid_str, "bafkreigwbnjspcyc35aenffolbvrfoefk7ponl2mtcy7d7d6gcuyfedarq",
             "CID should match Go"
@@ -560,7 +564,8 @@ mod tests {
         // f9 5bd0            - float16(250.0)
         // 64 74726565        - text(4) "tree"
         // 65 6d61706c65      - text(5) "maple"
-        let expected_hex = "a2646e616d65644a6f686e66637573746f6da263616765f95bd06474726565656d61706c65";
+        let expected_hex =
+            "a2646e616d65644a6f686e66637573746f6da263616765f95bd06474726565656d61706c65";
         let expected_bytes: Vec<u8> = (0..expected_hex.len())
             .step_by(2)
             .map(|i| u8::from_str_radix(&expected_hex[i..i + 2], 16).unwrap())

--- a/crates/document/src/encoding.rs
+++ b/crates/document/src/encoding.rs
@@ -1,9 +1,28 @@
 //! Encoding helpers for JSON and CBOR conversion
 
-use chrono::SecondsFormat;
+use chrono::{DateTime, FixedOffset, SecondsFormat, Timelike};
 
 use crate::error::{Error, Result};
 use crate::NormalValue;
+
+/// Format a DateTime to RFC3339 matching Go's time.RFC3339Nano behavior.
+///
+/// Go's RFC3339Nano format omits fractional seconds when nanoseconds are zero,
+/// but includes all 9 digits when non-zero. This is critical for docID compatibility
+/// since the time string is embedded in the CBOR encoding used to compute the hash.
+///
+/// Examples:
+/// - No nanoseconds: "2017-07-23T03:46:56-05:00"
+/// - With nanoseconds: "2017-07-23T03:46:56.123456789-05:00"
+pub fn format_time_rfc3339_nano(t: &DateTime<FixedOffset>) -> String {
+    if t.nanosecond() % 1_000_000_000 == 0 {
+        // No fractional seconds - use Secs format
+        t.to_rfc3339_opts(SecondsFormat::Secs, true)
+    } else {
+        // Has fractional seconds - use full nanosecond precision
+        t.to_rfc3339_opts(SecondsFormat::Nanos, true)
+    }
+}
 
 /// Convert a JSON value to a NormalValue.
 ///
@@ -102,9 +121,7 @@ pub fn normal_value_to_json(value: &NormalValue) -> Result<serde_json::Value> {
             // Encode bytes as base64
             Ok(serde_json::Value::String(base64_encode(b)))
         }
-        NormalValue::Time(t) => Ok(serde_json::Value::String(
-            t.to_rfc3339_opts(SecondsFormat::Nanos, true),
-        )),
+        NormalValue::Time(t) => Ok(serde_json::Value::String(format_time_rfc3339_nano(t))),
         NormalValue::Json(v) => Ok(v.clone()),
         NormalValue::IntArray(arr) => Ok(serde_json::Value::Array(
             arr.iter()
@@ -192,9 +209,7 @@ pub fn normal_value_to_cbor(value: &NormalValue) -> Result<ciborium::Value> {
         NormalValue::Float32(f) => Ok(ciborium::Value::Float(*f as f64)),
         NormalValue::String(s) => Ok(ciborium::Value::Text(s.clone())),
         NormalValue::Bytes(b) => Ok(ciborium::Value::Bytes(b.clone())),
-        NormalValue::Time(t) => Ok(ciborium::Value::Text(
-            t.to_rfc3339_opts(SecondsFormat::Nanos, true),
-        )),
+        NormalValue::Time(t) => Ok(ciborium::Value::Text(format_time_rfc3339_nano(t))),
         NormalValue::Json(v) => json_to_cbor_value(v),
         NormalValue::IntArray(arr) => Ok(ciborium::Value::Array(
             arr.iter()
@@ -244,7 +259,7 @@ pub fn normal_value_to_cbor(value: &NormalValue) -> Result<ciborium::Value> {
             .map(|b| ciborium::Value::Bytes(b.clone()))
             .unwrap_or(ciborium::Value::Null)),
         NormalValue::NillableTime(opt) => Ok(opt
-            .map(|t| ciborium::Value::Text(t.to_rfc3339_opts(SecondsFormat::Nanos, true)))
+            .map(|t| ciborium::Value::Text(format_time_rfc3339_nano(&t)))
             .unwrap_or(ciborium::Value::Null)),
         // Document value - propagate errors instead of silently converting to null
         NormalValue::Document(doc) => {
@@ -268,7 +283,7 @@ pub fn normal_value_to_cbor(value: &NormalValue) -> Result<ciborium::Value> {
         )),
         NormalValue::TimeArray(arr) => Ok(ciborium::Value::Array(
             arr.iter()
-                .map(|t| ciborium::Value::Text(t.to_rfc3339_opts(SecondsFormat::Nanos, true)))
+                .map(|t| ciborium::Value::Text(format_time_rfc3339_nano(t)))
                 .collect(),
         )),
         NormalValue::DocumentArray(arr) => {
@@ -339,9 +354,7 @@ pub fn normal_value_to_cbor(value: &NormalValue) -> Result<ciborium::Value> {
             .map(|arr| {
                 ciborium::Value::Array(
                     arr.iter()
-                        .map(|t| {
-                            ciborium::Value::Text(t.to_rfc3339_opts(SecondsFormat::Nanos, true))
-                        })
+                        .map(|t| ciborium::Value::Text(format_time_rfc3339_nano(t)))
                         .collect(),
                 )
             })
@@ -400,7 +413,7 @@ pub fn normal_value_to_cbor(value: &NormalValue) -> Result<ciborium::Value> {
         NormalValue::NillableTimeElementArray(arr) => Ok(ciborium::Value::Array(
             arr.iter()
                 .map(|opt| {
-                    opt.map(|t| ciborium::Value::Text(t.to_rfc3339_opts(SecondsFormat::Nanos, true)))
+                    opt.map(|t| ciborium::Value::Text(format_time_rfc3339_nano(&t)))
                         .unwrap_or(ciborium::Value::Null)
                 })
                 .collect(),

--- a/crates/document/src/encoding.rs
+++ b/crates/document/src/encoding.rs
@@ -185,7 +185,9 @@ fn float64_to_json(f: f64) -> Result<serde_json::Value> {
     // Match Go's json.Marshal behavior: float64 values that are whole numbers
     // are serialized without a decimal point (e.g., float64(21.0) → "21").
     if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
-        return Ok(serde_json::Value::Number(serde_json::Number::from(f as i64)));
+        return Ok(serde_json::Value::Number(serde_json::Number::from(
+            f as i64,
+        )));
     }
     serde_json::Number::from_f64(f)
         .map(serde_json::Value::Number)

--- a/crates/document/tests/encoding_tests.rs
+++ b/crates/document/tests/encoding_tests.rs
@@ -227,8 +227,16 @@ fn test_time_format_matches_go_rfc3339_nano() {
     let s1 = map1.get("timestamp").unwrap().as_str().unwrap();
 
     // Should NOT have .000000000
-    assert!(!s1.contains(".000000000"), "Expected no fractional seconds for zero nanos, got: {}", s1);
-    assert!(s1.ends_with("-05:00"), "Expected -05:00 timezone, got: {}", s1);
+    assert!(
+        !s1.contains(".000000000"),
+        "Expected no fractional seconds for zero nanos, got: {}",
+        s1
+    );
+    assert!(
+        s1.ends_with("-05:00"),
+        "Expected -05:00 timezone, got: {}",
+        s1
+    );
 
     // Test 2: Time with nanoseconds (Go: "2017-07-23T03:46:56.123456789-05:00")
     let t2 = t1.with_nanosecond(123456789).unwrap();
@@ -240,5 +248,9 @@ fn test_time_format_matches_go_rfc3339_nano() {
     let s2 = map2.get("timestamp").unwrap().as_str().unwrap();
 
     // Should have .123456789
-    assert!(s2.contains(".123456789"), "Expected .123456789, got: {}", s2);
+    assert!(
+        s2.contains(".123456789"),
+        "Expected .123456789, got: {}",
+        s2
+    );
 }

--- a/crates/document/tests/encoding_tests.rs
+++ b/crates/document/tests/encoding_tests.rs
@@ -213,25 +213,32 @@ fn test_time_to_json_with_nanoseconds() {
 }
 
 #[test]
-fn test_canonical_key_order() {
-    // Test that keys are sorted by length first, then lexicographically
-    let mut doc = document::Document::new();
-    doc.set("ab", 3i64);
-    doc.set("z", 1i64);
-    doc.set("aa", 2i64);
+fn test_time_format_matches_go_rfc3339_nano() {
+    // Go's time.RFC3339Nano omits fractional seconds when zero but includes all 9 digits when present.
+    // Verify our Document's CBOR encoding matches this behavior.
 
-    let cbor = doc.to_cbor().unwrap();
+    // Test 1: Time without nanoseconds (Go: "2017-07-23T03:46:56-05:00")
+    let t1 = Utc.with_ymd_and_hms(2017, 7, 23, 3, 46, 56).unwrap();
+    let t1_fixed = t1.with_timezone(&chrono::FixedOffset::west_opt(5 * 3600).unwrap());
 
-    // Expected order: z (1 char), aa (2 chars), ab (2 chars)
-    // a3 = map with 3 entries
-    // 61 7a = "z"
-    // 01 = 1
-    // 62 61 61 = "aa"
-    // 02 = 2
-    // 62 61 62 = "ab"
-    // 03 = 3
-    let expected = &[
-        0xa3, 0x61, 0x7a, 0x01, 0x62, 0x61, 0x61, 0x02, 0x62, 0x61, 0x62, 0x03,
-    ];
-    assert_eq!(cbor, expected);
+    let mut doc1 = document::Document::new();
+    doc1.set("timestamp", NormalValue::Time(t1_fixed));
+    let map1 = doc1.to_map().unwrap();
+    let s1 = map1.get("timestamp").unwrap().as_str().unwrap();
+
+    // Should NOT have .000000000
+    assert!(!s1.contains(".000000000"), "Expected no fractional seconds for zero nanos, got: {}", s1);
+    assert!(s1.ends_with("-05:00"), "Expected -05:00 timezone, got: {}", s1);
+
+    // Test 2: Time with nanoseconds (Go: "2017-07-23T03:46:56.123456789-05:00")
+    let t2 = t1.with_nanosecond(123456789).unwrap();
+    let t2_fixed = t2.with_timezone(&chrono::FixedOffset::west_opt(5 * 3600).unwrap());
+
+    let mut doc2 = document::Document::new();
+    doc2.set("timestamp", NormalValue::Time(t2_fixed));
+    let map2 = doc2.to_map().unwrap();
+    let s2 = map2.get("timestamp").unwrap().as_str().unwrap();
+
+    // Should have .123456789
+    assert!(s2.contains(".123456789"), "Expected .123456789, got: {}", s2);
 }

--- a/crates/query/src/document/mapping.rs
+++ b/crates/query/src/document/mapping.rs
@@ -155,6 +155,13 @@ impl DocumentMapping {
             .and_then(|opt| opt.as_ref().map(|b| b.as_ref()))
     }
 
+    /// Get a mutable reference to a child mapping at the given index
+    pub fn child_at_mut(&mut self, index: usize) -> Option<&mut DocumentMapping> {
+        self.child_mappings
+            .get_mut(index)
+            .and_then(|opt| opt.as_mut().map(|b| b.as_mut()))
+    }
+
     /// Render a document to a JSON object using this mapping's render keys.
     ///
     /// Iterates over render_keys and extracts the corresponding values from the document

--- a/crates/query/src/fetcher.rs
+++ b/crates/query/src/fetcher.rs
@@ -158,6 +158,36 @@ pub trait DocFetcher: Send + Sync {
     fn supports_index_queries(&self) -> bool {
         false
     }
+
+    /// Get a document at a specific historical version (CID-based time-travel query).
+    ///
+    /// This method reconstructs the document as it existed when the commit at `cid`
+    /// was created by walking the merkle DAG backwards and replaying CRDT deltas.
+    ///
+    /// # Arguments
+    ///
+    /// * `cid` - The CID of the commit to reconstruct state at
+    /// * `expected_doc_id` - Optional document ID to validate the CID belongs to
+    ///
+    /// # Returns
+    ///
+    /// The document state at that commit, or an error if:
+    /// - The CID is invalid format: `"invalid cid: {parse_error}"`
+    /// - The CID doesn't exist or doesn't belong to the document:
+    ///   `"cid either does not exist or belong to document"`
+    ///
+    /// Default implementation returns an error - implementations that support
+    /// CID-based queries should override this.
+    async fn get_document_at_cid(
+        &self,
+        cid: &str,
+        expected_doc_id: Option<&str>,
+    ) -> Result<Document> {
+        let _ = (cid, expected_doc_id);
+        Err(crate::error::QueryError::execution(
+            "CID-based time-travel queries are not supported by this fetcher".to_string(),
+        ))
+    }
 }
 
 /// Options for _commits queries

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -609,6 +609,42 @@ impl Filter {
         (scalar, relation)
     }
 
+    /// Split the filter into non-alias and alias parts.
+    ///
+    /// Returns (non_alias_filter, alias_filter) where:
+    /// - non_alias_filter contains all conditions except `_alias`
+    /// - alias_filter contains only the `_alias` condition
+    ///
+    /// This is used to apply alias filters after aggregation in grouped queries,
+    /// since alias filters on aggregate fields can only be evaluated after the
+    /// aggregate values have been computed.
+    pub fn split_alias(&self) -> (Option<Filter>, Option<Filter>) {
+        let mut non_alias = HashMap::new();
+        let mut alias_only = HashMap::new();
+
+        for (key, value) in &self.conditions {
+            if key == "_alias" {
+                alias_only.insert(key.clone(), value.clone());
+            } else {
+                non_alias.insert(key.clone(), value.clone());
+            }
+        }
+
+        let non_alias_filter = if non_alias.is_empty() {
+            None
+        } else {
+            Some(Filter::from_conditions(non_alias))
+        };
+
+        let alias_filter = if alias_only.is_empty() {
+            None
+        } else {
+            Some(Filter::from_conditions(alias_only))
+        };
+
+        (non_alias_filter, alias_filter)
+    }
+
     /// Evaluate the filter against document fields
     pub fn matches(&self, fields: &[Option<JsonValue>], mapping: &DocumentMapping) -> Result<bool> {
         if self.conditions.is_empty() {

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -172,6 +172,32 @@ impl Filter {
         self.conditions.is_empty()
     }
 
+    /// Check if the filter has field-based conditions (as opposed to operator-only conditions).
+    ///
+    /// Field-based: `{rating: {_gt: 4.8}}` - the key "rating" is a field name
+    /// Operator-only: `{_gt: 4.8}` - the key "_gt" is an operator
+    ///
+    /// This is used to determine whether to use `matches_json_object` (field-based)
+    /// or `matches_scalar_value` (operator-only) when filtering relation aggregates.
+    pub fn has_field_conditions(&self) -> bool {
+        self.conditions.keys().any(|k| FilterOp::parse(k).is_none())
+    }
+
+    /// Combine this filter with another filter using AND logic.
+    ///
+    /// Returns a new filter where both conditions must be satisfied.
+    pub fn and(&self, other: Filter) -> Filter {
+        let mut combined_conditions = HashMap::new();
+        combined_conditions.insert(
+            "_and".to_string(),
+            serde_json::json!([
+                self.conditions,
+                other.conditions
+            ]),
+        );
+        Filter::from_conditions(combined_conditions)
+    }
+
     /// Get a reference to the conditions map
     pub fn conditions(&self) -> &HashMap<String, JsonValue> {
         &self.conditions
@@ -480,6 +506,14 @@ impl Filter {
         None
     }
 
+    /// Check if this filter contains an `_alias` directive.
+    ///
+    /// `_alias` filters reference aliased fields/relations and must be evaluated after joins
+    /// because the alias may reference a relation whose data hasn't been joined yet.
+    pub fn has_alias_filter(&self) -> bool {
+        self.conditions.contains_key("_alias")
+    }
+
     /// Check if this filter is "complex" - contains relation conditions inside logical operators.
     ///
     /// A filter is complex when `_and`, `_or`, or `_not` contains a mix of scalar and relation
@@ -643,6 +677,37 @@ impl Filter {
         };
 
         (non_alias_filter, alias_filter)
+    }
+
+    /// Strip _alias conditions from the filter that reference aggregate field names.
+    ///
+    /// This is used to prevent _alias conditions on computed aggregates from being
+    /// evaluated during plan execution (when aggregate values don't exist yet).
+    /// The stripped conditions should be applied in post-processing after aggregates are computed.
+    ///
+    /// Returns (filtered, has_aggregate_alias) where:
+    /// - filtered: Filter without _alias conditions referencing the given aggregate names
+    /// - has_aggregate_alias: true if any _alias conditions were referencing aggregates
+    pub fn strip_aggregate_alias_conditions(&self, aggregate_names: &[&str]) -> (Filter, bool) {
+        let mut new_conditions = HashMap::new();
+        let mut has_aggregate_alias = false;
+
+        for (key, value) in &self.conditions {
+            if key == "_alias" {
+                // Check if this _alias block references any aggregate names
+                if let Some(alias_obj) = value.as_object() {
+                    let refs_aggregate = alias_obj.keys().any(|k| aggregate_names.contains(&k.as_str()));
+                    if refs_aggregate {
+                        has_aggregate_alias = true;
+                        // Skip this _alias condition - it will be applied in post-processing
+                        continue;
+                    }
+                }
+            }
+            new_conditions.insert(key.clone(), value.clone());
+        }
+
+        (Filter::from_conditions(new_conditions), has_aggregate_alias)
     }
 
     /// Evaluate the filter against document fields
@@ -1378,6 +1443,114 @@ impl Filter {
                     "unknown operator in scalar filter: {}",
                     key
                 )));
+            }
+        }
+        Ok(true)
+    }
+
+    /// Evaluate the filter against a JSON object (document).
+    ///
+    /// Used for relation aggregate filters where each related document is tested
+    /// against field-based conditions like `{rating: {_gt: 4.8}}`.
+    ///
+    /// Unlike `matches_scalar_value` which only handles operator conditions,
+    /// this method handles:
+    /// - Field-based conditions: `{rating: {_gt: 4.8}}` extracts `rating` from the object
+    /// - Operator-only conditions: `{_gt: 4.8}` (falls back to matches_scalar_value)
+    /// - Compound conditions: `{_and: [...]}`, `{_or: [...]}`, `{_not: {...}}`
+    pub fn matches_json_object(&self, obj: &JsonValue) -> Result<bool> {
+        if self.conditions.is_empty() {
+            return Ok(true);
+        }
+
+        for (key, expected) in &self.conditions {
+            if let Some(op) = FilterOp::parse(key) {
+                // Operator condition
+                match op {
+                    FilterOp::And => {
+                        let arr = expected
+                            .as_array()
+                            .ok_or_else(|| QueryError::invalid_filter("_and requires array"))?;
+                        for item in arr {
+                            let sub: HashMap<String, JsonValue> =
+                                serde_json::from_value(item.clone())
+                                    .map_err(|e| QueryError::invalid_filter(e.to_string()))?;
+                            let f = Filter::from_conditions(sub);
+                            if !f.matches_json_object(obj)? {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                    FilterOp::Or => {
+                        let arr = expected
+                            .as_array()
+                            .ok_or_else(|| QueryError::invalid_filter("_or requires array"))?;
+                        let mut any_match = false;
+                        for item in arr {
+                            let sub: HashMap<String, JsonValue> =
+                                serde_json::from_value(item.clone())
+                                    .map_err(|e| QueryError::invalid_filter(e.to_string()))?;
+                            let f = Filter::from_conditions(sub);
+                            if f.matches_json_object(obj)? {
+                                any_match = true;
+                                break;
+                            }
+                        }
+                        if !any_match {
+                            return Ok(false);
+                        }
+                    }
+                    FilterOp::Not => {
+                        let sub: HashMap<String, JsonValue> =
+                            serde_json::from_value(expected.clone())
+                                .map_err(|e| QueryError::invalid_filter(e.to_string()))?;
+                        let f = Filter::from_conditions(sub);
+                        if f.matches_json_object(obj)? {
+                            return Ok(false);
+                        }
+                    }
+                    _ => {
+                        // Direct operator on the object itself - use scalar matching
+                        if !self.eval_op(obj, op, expected)? {
+                            return Ok(false);
+                        }
+                    }
+                }
+            } else {
+                // Field-based condition: key is a field name
+                let field_value = obj
+                    .as_object()
+                    .and_then(|o| o.get(key))
+                    .unwrap_or(&JsonValue::Null);
+
+                // expected should be an object with operator conditions
+                if let Some(conditions_obj) = expected.as_object() {
+                    // Check if the nested conditions are operators or field-based
+                    // If they're operators, use matches_scalar_value on the field value
+                    // If they're field-based, recursively use matches_json_object
+                    let has_field_conditions = conditions_obj.keys().any(|k| FilterOp::parse(k).is_none());
+                    let sub_conditions: HashMap<String, JsonValue> = conditions_obj
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    let f = Filter::from_conditions(sub_conditions);
+                    if has_field_conditions {
+                        // Nested field access - recursively match
+                        if !f.matches_json_object(field_value)? {
+                            return Ok(false);
+                        }
+                    } else {
+                        // Operator conditions on the field value
+                        if !f.matches_scalar_value(field_value)? {
+                            return Ok(false);
+                        }
+                    }
+                } else {
+                    // Direct equality check: {field: value}
+                    if field_value != expected {
+                        return Ok(false);
+                    }
+                }
             }
         }
         Ok(true)

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -298,6 +298,24 @@ impl Filter {
         }
     }
 
+    /// Get all relation filter conditions.
+    ///
+    /// Returns an iterator over (relation_name, nested_filter) pairs for each relation
+    /// referenced in the filter.
+    ///
+    /// For a filter like `{author: {verified: {_eq: true}}, rating: {_gt: 4}}`:
+    /// - Returns: [("author", Filter({verified: {_eq: true}}))]
+    /// - "rating" is not a relation filter (it has operators, not nested fields)
+    pub fn relation_conditions(&self) -> Vec<(String, Filter)> {
+        let mut result = Vec::new();
+        for name in self.relation_field_names() {
+            if let Some(filter) = self.extract_relation_filter(&name) {
+                result.push((name, filter));
+            }
+        }
+        result
+    }
+
     fn check_for_relation_filters(conditions: &HashMap<String, JsonValue>) -> bool {
         for (key, value) in conditions {
             // Check logical operators recursively

--- a/crates/query/src/mapper/filter.rs
+++ b/crates/query/src/mapper/filter.rs
@@ -287,6 +287,9 @@ impl Filter {
                     }
                     _ => {}
                 }
+            } else if key == "_alias" {
+                // _alias is a special filter directive, not a relation field
+                continue;
             } else if let JsonValue::Object(obj) = value {
                 // This is a field condition - check if it contains operators or nested fields
                 // If any key in the object is NOT an operator, it's a relation filter
@@ -345,6 +348,9 @@ impl Filter {
                     }
                     _ => {}
                 }
+            } else if key == "_alias" {
+                // _alias is a special filter directive, not a relation filter
+                continue;
             } else if let JsonValue::Object(obj) = value {
                 // This is a field condition - check if it contains operators or nested fields
                 // If any key in the object is NOT an operator, it's a relation filter
@@ -416,6 +422,11 @@ impl Filter {
                         _ => {}
                     }
                 }
+                continue;
+            }
+
+            // _alias is a special filter directive, not a relation path
+            if key == "_alias" {
                 continue;
             }
 
@@ -633,6 +644,9 @@ impl Filter {
                         scalar_conditions.insert(key.clone(), value.clone());
                     }
                 }
+            } else if key == "_alias" {
+                // _alias is a special filter directive evaluated by eval_conditions, not a relation
+                scalar_conditions.insert(key.clone(), value.clone());
             } else if let JsonValue::Object(obj) = value {
                 // Field condition - check if it's a relation filter
                 let is_relation = obj.keys().any(|k| FilterOp::parse(k).is_none());
@@ -1729,16 +1743,50 @@ impl Filter {
                 QueryError::invalid_filter("alias field condition must be object")
             })?;
 
-            for (op_key, op_value) in ops {
-                if let Some(op) = FilterOp::parse(op_key) {
-                    if !self.eval_op(&field_value, op, op_value)? {
+            // Check if this is a relation filter (nested field conditions) or operator conditions
+            let is_relation_filter = ops.keys().any(|k| FilterOp::parse(k).is_none());
+
+            if is_relation_filter {
+                // Relation-style alias: {_alias: {books: {rating: {_gt: 4.8}}}}
+                // The alias points to a relation field (array or object)
+                if field_value.is_null() {
+                    // Null relation → no match
+                    return Ok(false);
+                } else if let Some(arr) = field_value.as_array() {
+                    // One-to-many: existential semantics (any element matches)
+                    let mut any_match = false;
+                    for elem in arr {
+                        if let Some(obj) = elem.as_object() {
+                            if self.eval_relation_conditions(ops, obj)? {
+                                any_match = true;
+                                break;
+                            }
+                        }
+                    }
+                    if !any_match {
+                        return Ok(false);
+                    }
+                } else if let Some(obj) = field_value.as_object() {
+                    // One-to-one: direct match
+                    if !self.eval_relation_conditions(ops, obj)? {
                         return Ok(false);
                     }
                 } else {
-                    return Err(QueryError::invalid_filter(format!(
-                        "unknown operator '{}' in _alias filter",
-                        op_key
-                    )));
+                    return Ok(false);
+                }
+            } else {
+                // Scalar-style alias: {_alias: {myAge: {_gt: 20}}}
+                for (op_key, op_value) in ops {
+                    if let Some(op) = FilterOp::parse(op_key) {
+                        if !self.eval_op(&field_value, op, op_value)? {
+                            return Ok(false);
+                        }
+                    } else {
+                        return Err(QueryError::invalid_filter(format!(
+                            "unknown operator '{}' in _alias filter",
+                            op_key
+                        )));
+                    }
                 }
             }
         }

--- a/crates/query/src/plan/groupby.rs
+++ b/crates/query/src/plan/groupby.rs
@@ -23,6 +23,24 @@ pub struct InnerAggregateDef {
     pub field_index: usize,
 }
 
+/// Definition of a _group alias with its specific rendering arguments.
+///
+/// Each _group reference in a query (including aliases like `G1: _group(limit: 1)`)
+/// gets its own GroupAlias with its specific filter, limit, order, and docID filter.
+#[derive(Debug, Clone)]
+pub struct GroupAlias {
+    /// Index in the document mapping where this alias's array should be stored
+    pub index: usize,
+    /// Optional filter for this alias
+    pub filter: Option<Filter>,
+    /// Optional limit for this alias
+    pub limit: Option<Limit>,
+    /// Optional order for this alias
+    pub order: Option<OrderBy>,
+    /// Optional docID filter for this alias
+    pub doc_ids: Option<Vec<String>>,
+}
+
 /// A group of documents with the same group key
 #[derive(Debug)]
 pub struct DocumentGroup {
@@ -67,18 +85,22 @@ pub struct GroupByNode {
     current_doc: Doc,
     /// Whether start() has been called
     started: bool,
-    /// Optional limit for _group child rendering
-    group_limit: Option<Limit>,
-    /// Optional filter for _group child rendering
-    group_filter: Option<Filter>,
-    /// Optional order for _group child rendering
-    group_order: Option<OrderBy>,
+    /// Group alias definitions - one per _group reference in the query
+    group_aliases: Vec<GroupAlias>,
     /// Inner aggregate definitions to compute during nested _group rendering
     inner_aggregates: Vec<InnerAggregateDef>,
     /// Collection name (for __typename support in _group rendering)
     collection_name: Option<String>,
     /// Inner group-by field names (from the nested _group Select's groupBy clause)
     inner_group_by_fields: Vec<String>,
+    /// Inner _group filter (for second-level nesting)
+    inner_group_filter: Option<Filter>,
+    /// Inner _group order (for second-level nesting)
+    inner_group_order: Option<OrderBy>,
+    /// Third-level group-by field names (from 3rd-level _group's groupBy clause)
+    third_level_group_by_fields: Vec<String>,
+    /// Third-level aggregate definitions (from 3rd-level _group's aggregates)
+    third_level_aggregates: Vec<InnerAggregateDef>,
 }
 
 impl GroupByNode {
@@ -96,27 +118,29 @@ impl GroupByNode {
             position: 0,
             current_doc: Doc::default(),
             started: false,
-            group_limit: None,
-            group_filter: None,
-            group_order: None,
+            group_aliases: Vec::new(),
             inner_aggregates: Vec::new(),
             collection_name: None,
             inner_group_by_fields: Vec::new(),
+            inner_group_filter: None,
+            inner_group_order: None,
+            third_level_group_by_fields: Vec::new(),
+            third_level_aggregates: Vec::new(),
         }
     }
 
-    pub fn with_group_limit(mut self, limit: Limit) -> Self {
-        self.group_limit = Some(limit);
+    pub fn with_group_aliases(mut self, aliases: Vec<GroupAlias>) -> Self {
+        self.group_aliases = aliases;
         self
     }
 
-    pub fn with_group_filter(mut self, filter: Filter) -> Self {
-        self.group_filter = Some(filter);
+    pub fn with_inner_group_filter(mut self, filter: Filter) -> Self {
+        self.inner_group_filter = Some(filter);
         self
     }
 
-    pub fn with_group_order(mut self, order: OrderBy) -> Self {
-        self.group_order = Some(order);
+    pub fn with_inner_group_order(mut self, order: OrderBy) -> Self {
+        self.inner_group_order = Some(order);
         self
     }
 
@@ -132,6 +156,16 @@ impl GroupByNode {
 
     pub fn with_inner_group_by_fields(mut self, fields: Vec<String>) -> Self {
         self.inner_group_by_fields = fields;
+        self
+    }
+
+    pub fn with_third_level_group_by_fields(mut self, fields: Vec<String>) -> Self {
+        self.third_level_group_by_fields = fields;
+        self
+    }
+
+    pub fn with_third_level_aggregates(mut self, aggregates: Vec<InnerAggregateDef>) -> Self {
+        self.third_level_aggregates = aggregates;
         self
     }
 
@@ -209,13 +243,23 @@ impl GroupByNode {
         }
     }
 
-    /// Build a JSON array of documents for the _group field
-    fn build_group_array(&self, docs: &[Doc], group_index: usize) -> JsonValue {
+    /// Build a JSON array of documents for the _group field.
+    ///
+    /// Each alias can have its own filter, order, limit, and docID filter.
+    fn build_group_array(
+        &self,
+        docs: &[Doc],
+        group_index: usize,
+        alias_filter: Option<&Filter>,
+        alias_order: Option<&OrderBy>,
+        alias_limit: Option<&Limit>,
+        alias_doc_ids: Option<&[String]>,
+    ) -> JsonValue {
         // Get the child mapping for _group to determine which fields to render
         let child_mapping = self.document_mapping.child_at(group_index);
 
         // Apply filter to docs if present
-        let filtered_docs: Vec<&Doc> = if let Some(ref filter) = self.group_filter {
+        let filtered_docs: Vec<&Doc> = if let Some(filter) = alias_filter {
             docs.iter()
                 .filter(|d| {
                     filter
@@ -227,8 +271,29 @@ impl GroupByNode {
             docs.iter().collect()
         };
 
+        // Apply docID/docIDs filter if present
+        let filtered_docs: Vec<&Doc> = if let Some(doc_ids) = alias_doc_ids {
+            // _docID is at index 0 in the document mapping
+            let docid_idx = self
+                .document_mapping
+                .first_index_of_name("_docID")
+                .unwrap_or(0);
+            filtered_docs
+                .into_iter()
+                .filter(|d| {
+                    if let Some(Some(JsonValue::String(id))) = d.fields().get(docid_idx) {
+                        doc_ids.contains(id)
+                    } else {
+                        false
+                    }
+                })
+                .collect()
+        } else {
+            filtered_docs
+        };
+
         // Apply order
-        let ordered_docs: Vec<&Doc> = if let Some(ref order) = self.group_order {
+        let ordered_docs: Vec<&Doc> = if let Some(order) = alias_order {
             let mut sorted = filtered_docs;
             sorted.sort_by(|a, b| {
                 for cond in &order.conditions {
@@ -255,7 +320,7 @@ impl GroupByNode {
         };
 
         // Apply limit and offset
-        let docs_to_render: Vec<&Doc> = if let Some(ref limit) = self.group_limit {
+        let docs_to_render: Vec<&Doc> = if let Some(limit) = alias_limit {
             let offset = limit.offset as usize;
             let effective_limit = limit.limit.map(|l| l as usize);
             match (effective_limit, offset) {
@@ -389,13 +454,142 @@ impl GroupByNode {
                     } else {
                         &mapping.render_keys
                     };
-                    let inner_array = Self::render_docs_with_keys(
-                        sub_group_docs,
-                        inner_render_keys,
-                        self.collection_name.as_deref(),
-                    );
+
+                    // Apply inner _group filter
+                    let inner_filtered: Vec<&Doc> =
+                        if let Some(ref filter) = self.inner_group_filter {
+                            sub_group_docs
+                                .iter()
+                                .filter(|d| {
+                                    filter
+                                        .matches(d.fields(), &self.document_mapping)
+                                        .unwrap_or(false)
+                                })
+                                .copied()
+                                .collect()
+                        } else {
+                            sub_group_docs.clone()
+                        };
+
+                    // Apply inner _group order
+                    let inner_ordered: Vec<&Doc> =
+                        if let Some(ref order) = self.inner_group_order {
+                            let mut sorted = inner_filtered;
+                            sorted.sort_by(|a, b| {
+                                for cond in &order.conditions {
+                                    if let Some(field_name) = cond.fields.first() {
+                                        if let Some(idx) =
+                                            self.document_mapping.first_index_of_name(field_name)
+                                        {
+                                            let cmp = Self::compare_field_values(
+                                                a.get(idx),
+                                                b.get(idx),
+                                            );
+                                            let cmp = match cond.direction {
+                                                OrderDirection::Asc => cmp,
+                                                OrderDirection::Desc => cmp.reverse(),
+                                            };
+                                            if cmp != std::cmp::Ordering::Equal {
+                                                return cmp;
+                                            }
+                                        }
+                                    }
+                                }
+                                std::cmp::Ordering::Equal
+                            });
+                            sorted
+                        } else {
+                            inner_filtered
+                        };
+
+                    let inner_array = if !self.third_level_group_by_fields.is_empty() {
+                        self.build_innermost_group_array(
+                            &inner_ordered,
+                            inner_child_mapping,
+                        )
+                    } else {
+                        Self::render_docs_with_keys(
+                            &inner_ordered,
+                            inner_render_keys,
+                            self.collection_name.as_deref(),
+                        )
+                    };
                     obj.insert("_group".to_string(), inner_array);
                 }
+            }
+
+            array.push(JsonValue::Object(obj));
+        }
+
+        JsonValue::Array(array)
+    }
+
+    /// Build the innermost (3rd-level) _group array with sub-grouping and aggregates.
+    ///
+    /// Sub-groups documents by `third_level_group_by_fields`, computes
+    /// `third_level_aggregates` per sub-group, and renders the result.
+    fn build_innermost_group_array(
+        &self,
+        docs: &[&Doc],
+        child_mapping: Option<&DocumentMapping>,
+    ) -> JsonValue {
+        // Sub-group documents by the third-level groupBy fields
+        let mut sub_groups: Vec<(String, Vec<&Doc>)> = Vec::new();
+        let mut sub_group_map: HashMap<String, usize> = HashMap::new();
+
+        for doc in docs {
+            let mut key = String::new();
+            for field_name in &self.third_level_group_by_fields {
+                if let Some(idx) = self.document_mapping.first_index_of_name(field_name) {
+                    key.push_str(&format!("{}_", idx));
+                    let value = doc.get(idx);
+                    key.push_str(&format!("{}_", Self::value_to_key(value)));
+                }
+            }
+
+            if let Some(&idx) = sub_group_map.get(&key) {
+                sub_groups[idx].1.push(doc);
+            } else {
+                let idx = sub_groups.len();
+                sub_group_map.insert(key.clone(), idx);
+                sub_groups.push((key, vec![doc]));
+            }
+        }
+
+        let render_keys = child_mapping.map(|m| &m.render_keys);
+
+        let mut array = Vec::with_capacity(sub_groups.len());
+        for (_key, sub_group_docs) in &sub_groups {
+            let mut obj = serde_json::Map::new();
+
+            // Render field values from the first doc in the sub-group
+            if let Some(first_doc) = sub_group_docs.first() {
+                if let Some(rks) = render_keys {
+                    for rk in rks {
+                        if rk.key == "_group" || rk.key == "__typename" {
+                            continue;
+                        }
+                        let value = first_doc
+                            .get(rk.index)
+                            .cloned()
+                            .unwrap_or(JsonValue::Null);
+                        obj.insert(rk.key.clone(), value);
+                    }
+                } else {
+                    // Fallback: render groupBy fields
+                    for field_name in &self.third_level_group_by_fields {
+                        if let Some(idx) = self.document_mapping.first_index_of_name(field_name) {
+                            let value = first_doc.get(idx).cloned().unwrap_or(JsonValue::Null);
+                            obj.insert(field_name.clone(), value);
+                        }
+                    }
+                }
+            }
+
+            // Compute 3rd-level aggregates for this sub-group
+            for agg_def in &self.third_level_aggregates {
+                let value = Self::compute_inline_aggregate(agg_def, sub_group_docs);
+                obj.insert(agg_def.output_key.clone(), value);
             }
 
             array.push(JsonValue::Object(obj));
@@ -673,11 +867,18 @@ impl PlanNode for GroupByNode {
         // Return the representative document for the current group
         self.current_doc = self.groups[self.position].1.representative.deep_clone();
 
-        // Populate _group field if it's in the mapping
-        if let Some(group_index) = self.document_mapping.first_index_of_name("_group") {
-            let group_docs = &self.groups[self.position].1.docs;
-            let group_array = self.build_group_array(group_docs, group_index);
-            self.current_doc.set(group_index, group_array);
+        // Populate _group field(s) — one per alias
+        let group_docs = &self.groups[self.position].1.docs;
+        for alias in &self.group_aliases {
+            let group_array = self.build_group_array(
+                group_docs,
+                alias.index,
+                alias.filter.as_ref(),
+                alias.order.as_ref(),
+                alias.limit.as_ref(),
+                alias.doc_ids.as_deref(),
+            );
+            self.current_doc.set(alias.index, group_array);
         }
 
         self.position += 1;

--- a/crates/query/src/plan/index_scan.rs
+++ b/crates/query/src/plan/index_scan.rs
@@ -49,6 +49,8 @@ pub struct IndexScanNode {
     fetcher: Option<Arc<dyn DocFetcher>>,
     /// Whether docs were explicitly provided (even if empty)
     docs_provided: bool,
+    /// Number of index key lookups performed (for explain output)
+    index_fetches: u64,
 }
 
 impl IndexScanNode {
@@ -70,6 +72,7 @@ impl IndexScanNode {
             initialized: false,
             fetcher: None,
             docs_provided: false,
+            index_fetches: 0,
         }
     }
 
@@ -92,6 +95,7 @@ impl IndexScanNode {
     ///
     /// Providing an empty vector is valid and represents an empty result set.
     pub fn with_docs(mut self, docs: Vec<Doc>) -> Self {
+        self.index_fetches = docs.len() as u64;
         self.docs = docs;
         self.docs_provided = true;
         self
@@ -134,6 +138,9 @@ impl PlanNode for IndexScanNode {
                 let doc_ids = fetcher
                     .get_by_index_scan(&self.collection.name, &self.index_params)
                     .await?;
+
+                // Track number of index key lookups (matches Go's IndexesFetched)
+                self.index_fetches = doc_ids.len() as u64;
 
                 if !doc_ids.is_empty() {
                     // Fetch the actual documents by their IDs
@@ -226,6 +233,12 @@ impl PlanNode for IndexScanNode {
         obj.insert(
             "indexName".to_string(),
             serde_json::Value::String(self.index_params.index_name.clone()),
+        );
+
+        // Index fetch count (set during init, used by explain metrics)
+        obj.insert(
+            "indexFetches".to_string(),
+            serde_json::json!(self.index_fetches),
         );
 
         if let Some(ref filter) = self.residual_filter {

--- a/crates/query/src/plan/index_scan.rs
+++ b/crates/query/src/plan/index_scan.rs
@@ -204,6 +204,38 @@ impl PlanNode for IndexScanNode {
     }
 
     fn kind(&self) -> &'static str {
-        "indexScanNode"
+        // Use "scanNode" for explain compatibility with Go DefraDB asserter.
+        // The index-specific info (indexName) distinguishes this from a regular scan.
+        "scanNode"
+    }
+
+    fn explain_inner(&self) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+
+        // Go DefraDB uses "collectionName" and "collectionID"
+        obj.insert(
+            "collectionName".to_string(),
+            serde_json::Value::String(self.collection.name.clone()),
+        );
+        obj.insert(
+            "collectionID".to_string(),
+            serde_json::Value::String(self.collection.collection_id.clone()),
+        );
+
+        // Index-specific info - presence of indexName indicates this is an index scan
+        obj.insert(
+            "indexName".to_string(),
+            serde_json::Value::String(self.index_params.index_name.clone()),
+        );
+
+        if let Some(ref filter) = self.residual_filter {
+            obj.insert("filter".to_string(), serde_json::json!(filter.conditions()));
+        }
+
+        if self.show_deleted {
+            obj.insert("showDeleted".to_string(), serde_json::Value::Bool(true));
+        }
+
+        serde_json::Value::Object(obj)
     }
 }

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -33,4 +33,6 @@ pub use permission_filter::PermissionFilterNode;
 pub use scan::ScanNode;
 pub use select::SelectNode;
 pub use sum::SumNode;
-pub use type_join::{JoinDirection, JoinSide, RelationFilter, TypeJoinMany, TypeJoinOne};
+pub use type_join::{
+    compare_json_values, JoinDirection, JoinSide, RelationFilter, TypeJoinMany, TypeJoinOne,
+};

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -19,7 +19,7 @@ mod type_join;
 pub use alldocs::AllDocsNode;
 pub use average::AverageNode;
 pub use count::CountNode;
-pub use groupby::{DocumentGroup, GroupByNode, InnerAggregateDef};
+pub use groupby::{DocumentGroup, GroupAlias, GroupByNode, InnerAggregateDef};
 pub use index_scan::IndexScanNode;
 pub use limit::LimitNode;
 pub use max::MaxNode;

--- a/crates/query/src/plan/mutation/create.rs
+++ b/crates/query/src/plan/mutation/create.rs
@@ -55,8 +55,11 @@ impl CreateInput {
     ///
     /// This method uses the collection schema to properly coerce values,
     /// such as parsing RFC 3339 strings as DateTime values when the field
-    /// type is DateTime (matching Go DefraDB behavior).
+    /// type is DateTime (matching Go DefraDB behavior). It also preserves
+    /// the CRDT type from the schema (e.g., PnCounter, PCounter).
     pub fn to_document_with_schema(&self, collection: &CollectionVersion) -> Result<Document> {
+        use schema::CType;
+
         let mut doc = Document::new();
 
         // Set collection on document for proper docID generation.
@@ -64,16 +67,23 @@ impl CreateInput {
         doc.set_collection(collection.clone());
 
         for (field_name, value) in &self.fields {
-            // Look up the field in the schema to get its kind
-            let field_kind = collection
-                .fields
-                .iter()
-                .find(|f| f.name == *field_name)
-                .map(|f| &f.kind);
+            // Look up the field in the schema to get its kind and CRDT type
+            let field_def = collection.fields.iter().find(|f| f.name == *field_name);
+            let field_kind = field_def.map(|f| &f.kind);
+            let crdt_type = field_def.map(|f| f.crdt_type).unwrap_or(CType::LwwRegister);
 
             // Convert JsonValue to appropriate NormalValue, using schema for type coercion
             let normal_value = json_to_normal_value_with_kind(value, field_kind)?;
-            doc.set(field_name.clone(), normal_value);
+
+            // Use set_with_crdt to preserve the CRDT type from the schema
+            // This is critical for Counter fields to generate correct block CIDs
+            doc.set_with_crdt(field_name.clone(), crdt_type, normal_value)
+                .map_err(|e| {
+                    QueryError::execution(format!(
+                        "Failed to set field '{}' with CRDT type {:?}: {}",
+                        field_name, crdt_type, e
+                    ))
+                })?;
         }
 
         Ok(doc)

--- a/crates/query/src/plan/mutation/update.rs
+++ b/crates/query/src/plan/mutation/update.rs
@@ -385,8 +385,7 @@ impl PlanNode for UpdateNode {
                                 let idx = filter_mapping.next_index();
                                 filter_mapping.add(idx, &field.name);
                             }
-                            let full_doc =
-                                document_to_plan_doc(&result.document, &filter_mapping)?;
+                            let full_doc = document_to_plan_doc(&result.document, &filter_mapping)?;
                             if !filter.matches(full_doc.fields(), &filter_mapping)? {
                                 continue;
                             }

--- a/crates/query/src/plan/type_join/mod.rs
+++ b/crates/query/src/plan/type_join/mod.rs
@@ -11,7 +11,7 @@ mod type_join_one;
 
 pub use direction::JoinDirection;
 pub use join_side::JoinSide;
-pub use type_join_many::TypeJoinMany;
+pub use type_join_many::{compare_json_values, TypeJoinMany};
 pub use type_join_one::{RelationFilter, TypeJoinOne};
 
 // Tests extracted to crates/query/tests/type_join_tests.rs

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -195,6 +195,9 @@ impl TypeJoinMany {
 
     /// Find all child documents that match the parent's _docID using the cache.
     /// Applies ordering, offset, and limit per-parent.
+    /// Find all child docs for a parent, applying ordering but NOT limit/offset.
+    /// Limit/offset are deferred to the runner's post-processing step so that
+    /// relation aggregates (e.g., _count) can see ALL children.
     fn find_child_docs(&self, parent_doc_id: &str) -> Vec<Doc> {
         let Some(docs) = self.child_cache.get(parent_doc_id) else {
             return Vec::new();
@@ -207,8 +210,6 @@ impl TypeJoinMany {
             let child_mapping = self.child_plan.document_map();
             children.sort_by(|a, b| {
                 for condition in &order_by.conditions {
-                    // For nested selections, the order field should be a simple field name
-                    // (not a compound path through relations)
                     let field_name = condition.fields.first().map(|s| s.as_str()).unwrap_or("");
                     let field_idx = child_mapping.first_index_of_name(field_name);
 
@@ -229,19 +230,10 @@ impl TypeJoinMany {
             });
         }
 
-        // Apply offset
-        if self.child_offset > 0 {
-            let offset = self.child_offset as usize;
-            if offset >= children.len() {
-                return Vec::new();
-            }
-            children = children.into_iter().skip(offset).collect();
-        }
-
-        // Apply limit
-        if let Some(limit) = self.child_limit {
-            children.truncate(limit as usize);
-        }
+        // NOTE: Limit/offset are NOT applied here. They are applied in the runner's
+        // apply_relation_limits() after compute_relation_aggregates() has counted
+        // all children. This ensures _count(published: {}) sees all children even
+        // when published(limit: 1) limits the rendered output.
 
         children
     }

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -2,11 +2,13 @@
 
 use async_trait::async_trait;
 use serde_json::Value as JsonValue;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use tracing::warn;
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
+use crate::mapper::{OrderBy, OrderDirection};
 use crate::planner::{Doc, PlanNode};
 
 use super::JoinSide;
@@ -52,6 +54,12 @@ pub struct TypeJoinMany {
     /// Cached child documents indexed by FK field value.
     /// Key is the child's FK value (points to parent's _docID).
     child_cache: HashMap<String, Vec<Doc>>,
+    /// Per-parent limit on children (None = no limit)
+    child_limit: Option<u64>,
+    /// Per-parent offset on children
+    child_offset: u64,
+    /// Order by specification for children
+    child_order_by: Option<OrderBy>,
 }
 
 impl std::fmt::Debug for TypeJoinMany {
@@ -112,15 +120,81 @@ impl TypeJoinMany {
             child_fk_index,
             initialized: false,
             child_cache: HashMap::new(),
+            child_limit: None,
+            child_offset: 0,
+            child_order_by: None,
         })
     }
 
+    /// Set the per-parent limit on children.
+    pub fn with_limit(mut self, limit: u64) -> Self {
+        self.child_limit = Some(limit);
+        self
+    }
+
+    /// Set the per-parent offset on children.
+    pub fn with_offset(mut self, offset: u64) -> Self {
+        self.child_offset = offset;
+        self
+    }
+
+    /// Set the order by specification for children.
+    pub fn with_order_by(mut self, order_by: OrderBy) -> Self {
+        self.child_order_by = Some(order_by);
+        self
+    }
+
     /// Find all child documents that match the parent's _docID using the cache.
+    /// Applies ordering, offset, and limit per-parent.
     fn find_child_docs(&self, parent_doc_id: &str) -> Vec<Doc> {
-        self.child_cache
-            .get(parent_doc_id)
-            .map(|docs| docs.iter().map(|d| d.deep_clone()).collect())
-            .unwrap_or_default()
+        let Some(docs) = self.child_cache.get(parent_doc_id) else {
+            return Vec::new();
+        };
+
+        let mut children: Vec<Doc> = docs.iter().map(|d| d.deep_clone()).collect();
+
+        // Apply ordering if specified
+        if let Some(ref order_by) = self.child_order_by {
+            let child_mapping = self.child_plan.document_map();
+            children.sort_by(|a, b| {
+                for condition in &order_by.conditions {
+                    // For nested selections, the order field should be a simple field name
+                    // (not a compound path through relations)
+                    let field_name = condition.fields.first().map(|s| s.as_str()).unwrap_or("");
+                    let field_idx = child_mapping.first_index_of_name(field_name);
+
+                    if let Some(idx) = field_idx {
+                        let val_a = a.get(idx);
+                        let val_b = b.get(idx);
+                        let cmp = compare_json_values(val_a, val_b);
+                        let cmp = match condition.direction {
+                            OrderDirection::Asc => cmp,
+                            OrderDirection::Desc => cmp.reverse(),
+                        };
+                        if cmp != Ordering::Equal {
+                            return cmp;
+                        }
+                    }
+                }
+                Ordering::Equal
+            });
+        }
+
+        // Apply offset
+        if self.child_offset > 0 {
+            let offset = self.child_offset as usize;
+            if offset >= children.len() {
+                return Vec::new();
+            }
+            children = children.into_iter().skip(offset).collect();
+        }
+
+        // Apply limit
+        if let Some(limit) = self.child_limit {
+            children.truncate(limit as usize);
+        }
+
+        children
     }
 
     /// Build the child cache by scanning child_plan once.
@@ -270,5 +344,40 @@ impl PlanNode for TypeJoinMany {
 
     fn kind(&self) -> &'static str {
         "typeJoinMany"
+    }
+}
+
+/// Compare two JSON values for ordering.
+/// Follows SQL-like ordering: NULL < bool < number < string < array < object
+fn compare_json_values(a: Option<&JsonValue>, b: Option<&JsonValue>) -> Ordering {
+    match (a, b) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (Some(JsonValue::Null), Some(JsonValue::Null)) => Ordering::Equal,
+        (Some(JsonValue::Null), Some(_)) => Ordering::Less,
+        (Some(_), Some(JsonValue::Null)) => Ordering::Greater,
+        (Some(JsonValue::Bool(a)), Some(JsonValue::Bool(b))) => a.cmp(b),
+        (Some(JsonValue::Number(a)), Some(JsonValue::Number(b))) => {
+            // Compare as f64 for numeric ordering
+            let fa = a.as_f64().unwrap_or(0.0);
+            let fb = b.as_f64().unwrap_or(0.0);
+            fa.partial_cmp(&fb).unwrap_or(Ordering::Equal)
+        }
+        (Some(JsonValue::String(a)), Some(JsonValue::String(b))) => a.cmp(b),
+        // Different types: order by type precedence
+        (Some(a), Some(b)) => type_precedence(a).cmp(&type_precedence(b)),
+    }
+}
+
+/// Get type precedence for ordering (lower = comes first)
+fn type_precedence(v: &JsonValue) -> u8 {
+    match v {
+        JsonValue::Null => 0,
+        JsonValue::Bool(_) => 1,
+        JsonValue::Number(_) => 2,
+        JsonValue::String(_) => 3,
+        JsonValue::Array(_) => 4,
+        JsonValue::Object(_) => 5,
     }
 }

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -597,7 +597,7 @@ impl PlanNode for TypeJoinMany {
 
 /// Compare two JSON values for ordering.
 /// Follows SQL-like ordering: NULL < bool < number < string < array < object
-fn compare_json_values(a: Option<&JsonValue>, b: Option<&JsonValue>) -> Ordering {
+pub fn compare_json_values(a: Option<&JsonValue>, b: Option<&JsonValue>) -> Ordering {
     match (a, b) {
         (None, None) => Ordering::Equal,
         (None, Some(_)) => Ordering::Less,

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -11,7 +11,7 @@ use crate::error::{QueryError, Result};
 use crate::mapper::{OrderBy, OrderDirection};
 use crate::planner::{Doc, PlanNode};
 
-use super::JoinSide;
+use super::{JoinSide, RelationFilter};
 
 /// TypeJoinMany implements one-to-many relation joins.
 ///
@@ -60,6 +60,11 @@ pub struct TypeJoinMany {
     child_offset: u64,
     /// Order by specification for children
     child_order_by: Option<OrderBy>,
+    /// Optional relation filter to apply during join.
+    /// When set, only include parents that have at least one child passing this filter.
+    /// Example: `Author(filter: {published: {rating: {_gt: 4}}})` means only include
+    /// authors who have at least one book with rating > 4.
+    relation_filter: Option<RelationFilter>,
 }
 
 impl std::fmt::Debug for TypeJoinMany {
@@ -123,6 +128,7 @@ impl TypeJoinMany {
             child_limit: None,
             child_offset: 0,
             child_order_by: None,
+            relation_filter: None,
         })
     }
 
@@ -141,6 +147,17 @@ impl TypeJoinMany {
     /// Set the order by specification for children.
     pub fn with_order_by(mut self, order_by: OrderBy) -> Self {
         self.child_order_by = Some(order_by);
+        self
+    }
+
+    /// Set a relation filter to apply during the join.
+    ///
+    /// When set, parent documents will only be included if they have at least one
+    /// child document that passes this filter. This is used for queries like
+    /// `Author(filter: {published: {rating: {_gt: 4}}})` - only include authors
+    /// who have published at least one book with rating > 4.
+    pub fn with_relation_filter(mut self, filter: RelationFilter) -> Self {
+        self.relation_filter = Some(filter);
         self
     }
 
@@ -271,6 +288,41 @@ impl TypeJoinMany {
             JsonValue::Array(array),
         );
     }
+
+    /// Check if at least one child document passes the relation filter.
+    ///
+    /// Returns true if:
+    /// - There's no filter (always pass)
+    /// - At least one child document passes the filter conditions
+    ///
+    /// Returns false if:
+    /// - There are no child documents (empty relation can't pass any filter)
+    /// - No child document passes the filter conditions
+    fn check_relation_filter(&self, children: &[Doc], rel_filter: &RelationFilter) -> Result<bool> {
+        if children.is_empty() {
+            // No children - relation filter cannot pass
+            return Ok(false);
+        }
+
+        // Check if any child passes the filter
+        let child_mapping = self.child_plan.document_map();
+        for child in children {
+            if rel_filter.conditions.matches(child.fields(), child_mapping)? {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Get all children for a parent (unfiltered, for filter checking).
+    /// This returns all children before limit/offset is applied.
+    fn get_all_children(&self, parent_doc_id: &str) -> Vec<Doc> {
+        self.child_cache
+            .get(parent_doc_id)
+            .map(|docs| docs.iter().map(|d| d.deep_clone()).collect())
+            .unwrap_or_default()
+    }
 }
 
 #[async_trait]
@@ -295,31 +347,53 @@ impl PlanNode for TypeJoinMany {
             ));
         }
 
-        if !self.parent_plan.next().await? {
-            return Ok(false);
-        }
-
-        let mut parent_doc = self.parent_plan.value().deep_clone();
-
-        // Get parent's _docID for the lookup (O(1) cache lookup)
-        let children = match parent_doc.doc_id() {
-            Some(id) => self.find_child_docs(id),
-            None => {
-                warn!(
-                    parent_collection = %self.parent_side.collection().name,
-                    relation_field = %self.parent_side.relation_field().name,
-                    "Parent document missing _docID - returning empty children array. \
-                     This may indicate data corruption or a schema mismatch."
-                );
-                Vec::new()
+        // Loop to skip parents that don't pass relation filter
+        loop {
+            if !self.parent_plan.next().await? {
+                return Ok(false);
             }
-        };
 
-        // Merge children array into parent
-        self.merge_children(&mut parent_doc, children);
-        self.current_doc = parent_doc;
+            let mut parent_doc = self.parent_plan.value().deep_clone();
 
-        Ok(true)
+            // Get parent's _docID for the lookup (O(1) cache lookup)
+            let parent_doc_id = match parent_doc.doc_id() {
+                Some(id) => id.to_string(),
+                None => {
+                    warn!(
+                        parent_collection = %self.parent_side.collection().name,
+                        relation_field = %self.parent_side.relation_field().name,
+                        "Parent document missing _docID - returning empty children array. \
+                         This may indicate data corruption or a schema mismatch."
+                    );
+                    // No docID means no children can match - skip if filter is present
+                    if self.relation_filter.is_some() {
+                        continue;
+                    }
+                    // No filter, return with empty children
+                    self.merge_children(&mut parent_doc, Vec::new());
+                    self.current_doc = parent_doc;
+                    return Ok(true);
+                }
+            };
+
+            // Apply relation filter if present (check against ALL children, not just limited)
+            if let Some(ref rel_filter) = self.relation_filter {
+                let all_children = self.get_all_children(&parent_doc_id);
+                if !self.check_relation_filter(&all_children, rel_filter)? {
+                    // No children pass the filter - skip this parent
+                    continue;
+                }
+            }
+
+            // Get children (with ordering, offset, limit applied)
+            let children = self.find_child_docs(&parent_doc_id);
+
+            // Merge children array into parent
+            self.merge_children(&mut parent_doc, children);
+            self.current_doc = parent_doc;
+
+            return Ok(true);
+        }
     }
 
     fn value(&self) -> &Doc {

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -8,7 +8,7 @@ use tracing::warn;
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
-use crate::mapper::{OrderBy, OrderDirection};
+use crate::mapper::{GroupBy, OrderBy, OrderDirection};
 use crate::planner::{Doc, PlanNode};
 
 use super::{JoinSide, RelationFilter};
@@ -65,6 +65,14 @@ pub struct TypeJoinMany {
     /// Example: `Author(filter: {published: {rating: {_gt: 4}}})` means only include
     /// authors who have at least one book with rating > 4.
     relation_filter: Option<RelationFilter>,
+    /// Optional groupBy for nested grouping of children.
+    /// When set, children are grouped by the specified fields and output includes
+    /// a `_group` array containing the grouped documents.
+    /// Example: `published(groupBy: [rating]) { rating, _group { name } }`
+    child_group_by: Option<GroupBy>,
+    /// Mapping for rendering documents inside the _group array.
+    /// Only used when child_group_by is set.
+    group_mapping: Option<DocumentMapping>,
 }
 
 impl std::fmt::Debug for TypeJoinMany {
@@ -129,6 +137,8 @@ impl TypeJoinMany {
             child_offset: 0,
             child_order_by: None,
             relation_filter: None,
+            child_group_by: None,
+            group_mapping: None,
         })
     }
 
@@ -158,6 +168,28 @@ impl TypeJoinMany {
     /// who have published at least one book with rating > 4.
     pub fn with_relation_filter(mut self, filter: RelationFilter) -> Self {
         self.relation_filter = Some(filter);
+        self
+    }
+
+    /// Set a groupBy specification for grouping children.
+    ///
+    /// When set, children will be grouped by the specified fields. The output
+    /// will be an array of objects, each containing the groupBy field values
+    /// and a `_group` array of documents in that group.
+    ///
+    /// Example: `published(groupBy: [rating]) { rating, _group { name } }`
+    /// Groups books by rating, outputting: `[{rating: 4.9, _group: [{name: "..."}]}, ...]`
+    pub fn with_group_by(mut self, group_by: GroupBy) -> Self {
+        self.child_group_by = Some(group_by);
+        self
+    }
+
+    /// Set the mapping for rendering documents inside the _group array.
+    ///
+    /// This mapping determines which fields are rendered for documents inside _group.
+    /// Only used when child_group_by is set.
+    pub fn with_group_mapping(mut self, mapping: DocumentMapping) -> Self {
+        self.group_mapping = Some(mapping);
         self
     }
 
@@ -269,24 +301,174 @@ impl TypeJoinMany {
     }
 
     /// Merge child documents into parent as an array.
+    ///
+    /// If `child_group_by` is set, groups children by the specified fields and
+    /// outputs an array of group objects with `_group` arrays.
+    /// Otherwise, outputs a simple array of child documents.
     fn merge_children(&self, parent_doc: &mut Doc, children: Vec<Doc>) {
-        // Get child mapping. Falls back to child plan's mapping if not explicitly
-        // set in parent mapping - this happens for simple queries where child
-        // mapping was not pre-configured during planning.
-        let child_mapping = self
-            .document_mapping
-            .child_at(self.parent_side.relation_field_index())
-            .unwrap_or(self.child_plan.document_map());
-
-        let array: Vec<JsonValue> = children
-            .iter()
-            .map(|doc| child_mapping.render_doc_to_json(doc))
-            .collect();
+        let array = if let Some(ref group_by) = self.child_group_by {
+            self.build_grouped_array(&children, group_by)
+        } else {
+            self.build_simple_array(&children)
+        };
 
         parent_doc.set(
             self.parent_side.relation_field_index(),
             JsonValue::Array(array),
         );
+    }
+
+    /// Build a simple array of child documents (no grouping).
+    fn build_simple_array(&self, children: &[Doc]) -> Vec<JsonValue> {
+        let child_mapping = self
+            .document_mapping
+            .child_at(self.parent_side.relation_field_index())
+            .unwrap_or(self.child_plan.document_map());
+
+        children
+            .iter()
+            .map(|doc| child_mapping.render_doc_to_json(doc))
+            .collect()
+    }
+
+    /// Build a grouped array where children are grouped by the specified fields.
+    ///
+    /// Output format for each group:
+    /// `{groupByField1: value1, groupByField2: value2, _group: [doc1, doc2, ...]}`
+    fn build_grouped_array(&self, children: &[Doc], group_by: &GroupBy) -> Vec<JsonValue> {
+        if children.is_empty() {
+            return Vec::new();
+        }
+
+        // Get the child mapping for looking up field indices
+        let child_mapping = self.child_plan.document_map();
+
+        // Group children by the groupBy field values
+        let mut groups: Vec<(String, Vec<&Doc>)> = Vec::new();
+        let mut group_map: HashMap<String, usize> = HashMap::new();
+
+        for child in children {
+            let key = self.generate_group_key(child, group_by, child_mapping);
+            if let Some(&idx) = group_map.get(&key) {
+                groups[idx].1.push(child);
+            } else {
+                let idx = groups.len();
+                group_map.insert(key.clone(), idx);
+                groups.push((key, vec![child]));
+            }
+        }
+
+        // Get the mapping for rendering. Use the child mapping from document_mapping
+        // if available, otherwise fall back to child_plan's mapping.
+        let render_mapping = self
+            .document_mapping
+            .child_at(self.parent_side.relation_field_index())
+            .unwrap_or(child_mapping);
+
+        // Build output array: one object per group
+        let mut result = Vec::with_capacity(groups.len());
+        for (_key, group_docs) in &groups {
+            let mut obj = serde_json::Map::new();
+
+            // Add groupBy field values from the first document in the group
+            if let Some(first_doc) = group_docs.first() {
+                for field_name in &group_by.fields {
+                    if let Some(idx) = child_mapping.first_index_of_name(field_name) {
+                        if let Some(value) = first_doc.get(idx) {
+                            obj.insert(field_name.clone(), value.clone());
+                        }
+                    }
+                }
+            }
+
+            // Build the _group array
+            let group_array: Vec<JsonValue> = if let Some(ref group_mapping) = self.group_mapping {
+                // Use explicit group mapping for rendering _group contents
+                group_docs
+                    .iter()
+                    .map(|doc| group_mapping.render_doc_to_json(doc))
+                    .collect()
+            } else {
+                // Fall back to render mapping, excluding groupBy fields
+                group_docs
+                    .iter()
+                    .map(|doc| {
+                        self.render_doc_excluding_fields(doc, render_mapping, &group_by.fields)
+                    })
+                    .collect()
+            };
+
+            obj.insert("_group".to_string(), JsonValue::Array(group_array));
+            result.push(JsonValue::Object(obj));
+        }
+
+        result
+    }
+
+    /// Generate a group key from a document based on groupBy fields.
+    fn generate_group_key(
+        &self,
+        doc: &Doc,
+        group_by: &GroupBy,
+        mapping: &DocumentMapping,
+    ) -> String {
+        let mut key = String::new();
+        for field_name in &group_by.fields {
+            if let Some(idx) = mapping.first_index_of_name(field_name) {
+                key.push_str(&format!("{}_", idx));
+                let value = doc.get(idx);
+                key.push_str(&format!("{}_", Self::value_to_key(value)));
+            }
+        }
+        key
+    }
+
+    /// Convert a JSON value to a string key component.
+    fn value_to_key(value: Option<&JsonValue>) -> String {
+        match value {
+            None | Some(JsonValue::Null) => "null".to_string(),
+            Some(JsonValue::Bool(b)) => b.to_string(),
+            Some(JsonValue::Number(n)) => n.to_string(),
+            Some(JsonValue::String(s)) => s.clone(),
+            Some(JsonValue::Array(arr)) => {
+                format!(
+                    "[{}]",
+                    arr.iter()
+                        .map(|v| Self::value_to_key(Some(v)))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+            Some(JsonValue::Object(obj)) => {
+                format!(
+                    "{{{}}}",
+                    obj.iter()
+                        .map(|(k, v)| format!("{}:{}", k, Self::value_to_key(Some(v))))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            }
+        }
+    }
+
+    /// Render a document excluding the specified fields.
+    fn render_doc_excluding_fields(
+        &self,
+        doc: &Doc,
+        mapping: &DocumentMapping,
+        exclude_fields: &[String],
+    ) -> JsonValue {
+        let mut obj = serde_json::Map::new();
+        for rk in &mapping.render_keys {
+            // Skip excluded fields (groupBy fields) and _group pseudo-field
+            if exclude_fields.contains(&rk.key) || rk.key == "_group" {
+                continue;
+            }
+            if let Some(value) = doc.get(rk.index) {
+                obj.insert(rk.key.clone(), value.clone());
+            }
+        }
+        JsonValue::Object(obj)
     }
 
     /// Check if at least one child document passes the relation filter.

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -13,9 +13,9 @@ use crate::error::{QueryError, Result};
 use crate::fetcher::DocFetcher;
 use crate::mapper::{AggregateType, Filter, Requestable, Select};
 use crate::plan::{
-    AllDocsNode, AverageNode, CountNode, GroupByNode, IndexScanNode, InnerAggregateDef, JoinSide,
-    LimitNode, MaxNode, MinNode, OrderByNode, RelationFilter, ScanNode, SelectNode, SumNode,
-    TypeJoinMany, TypeJoinOne,
+    AllDocsNode, AverageNode, CountNode, GroupAlias, GroupByNode, IndexScanNode,
+    InnerAggregateDef, JoinSide, LimitNode, MaxNode, MinNode, OrderByNode, RelationFilter,
+    ScanNode, SelectNode, SumNode, TypeJoinMany, TypeJoinOne,
 };
 use crate::planner::index_selection::{filter_to_index_scan, select_best_index, IndexScanParams};
 use crate::planner::PlanNode;
@@ -210,23 +210,25 @@ impl Planner {
             render_mapping.clone()
         };
 
-        // Add _group field to scan_mapping if present in render_mapping.
+        // Add _group fields to scan_mapping if present in render_mapping.
         // _group is a virtual field (not in schema) that needs to be explicitly copied.
-        if let Some(group_index) = render_mapping.first_index_of_name("_group") {
-            let scan_index = scan_mapping.next_index();
-            scan_mapping.add(scan_index, "_group");
-            // Copy render_key from render_mapping
-            for rk in &render_mapping.render_keys {
-                if rk.key == "_group"
-                    || render_mapping.try_find_name_from_index(rk.index) == Some("_group")
-                {
-                    scan_mapping.add_render_key(scan_index, &rk.key);
-                    break;
+        // Multiple _group entries may exist when aliases are used (e.g., G1: _group(...), G2: _group(...)).
+        if let Some(group_indices) = render_mapping.indexes_of_name("_group") {
+            let group_indices = group_indices.to_vec();
+            for render_index in group_indices {
+                let scan_index = scan_mapping.next_index();
+                scan_mapping.add(scan_index, "_group");
+                // Copy the render_key for this specific _group entry
+                for rk in &render_mapping.render_keys {
+                    if rk.index == render_index {
+                        scan_mapping.add_render_key(scan_index, &rk.key);
+                        break;
+                    }
                 }
-            }
-            // Copy child mapping if present (for _group { field1, field2 } syntax)
-            if let Some(child) = render_mapping.child_at(group_index) {
-                scan_mapping.set_child_at(scan_index, child.clone());
+                // Copy child mapping if present (for _group { field1, field2 } syntax)
+                if let Some(child) = render_mapping.child_at(render_index) {
+                    scan_mapping.set_child_at(scan_index, child.clone());
+                }
             }
         }
 
@@ -371,6 +373,14 @@ impl Planner {
             } else {
                 Some(Filter::from_conditions(combined_conditions))
             }
+        };
+
+        // For grouped queries, strip _alias conditions from the pre-aggregation filter.
+        // Alias filters on aggregate fields must be applied AFTER aggregation.
+        let scalar_filter = if select.group_by.is_some() {
+            scalar_filter.and_then(|f| f.split_alias().0)
+        } else {
+            scalar_filter
         };
 
         // 1. Choose between IndexScanNode and ScanNode based on index availability
@@ -577,9 +587,17 @@ impl Planner {
         // that must be evaluated together on the merged document.
         if is_complex_filter {
             if let Some(ref filter) = select.filter {
-                plan = Box::new(
-                    SelectNode::new(plan, scan_mapping.clone()).with_filter(filter.clone()),
-                );
+                // For grouped queries, strip _alias from pre-aggregation filter
+                let pre_agg_filter = if select.group_by.is_some() {
+                    filter.split_alias().0
+                } else {
+                    Some(filter.clone())
+                };
+                if let Some(f) = pre_agg_filter {
+                    plan = Box::new(
+                        SelectNode::new(plan, scan_mapping.clone()).with_filter(f),
+                    );
+                }
             }
         }
 
@@ -595,65 +613,157 @@ impl Planner {
                 let mut group_node = GroupByNode::new(plan, group_by.clone(), scan_mapping.clone())
                     .with_collection_name(select.collection_name.clone());
 
-                // Extract _group child's limit/filter/order from the nested Select
-                // Also extract inner aggregate definitions for nested group rendering
+                // Extract _group alias definitions and inner groupBy/aggregate info.
+                // Each _group reference (including aliases like G1: _group(limit: 1))
+                // gets its own GroupAlias with per-alias filter/limit/order/docIDs.
+                let group_indices = scan_mapping
+                    .indexes_of_name("_group")
+                    .map(|s| s.to_vec())
+                    .unwrap_or_default();
+                let mut group_aliases = Vec::new();
+                let mut alias_count = 0;
+                let mut inner_extracted = false;
+
                 for field in &select.fields {
                     if let Requestable::Select(nested) = field {
                         if nested.field.name == "_group" {
-                            if let Some(ref limit) = nested.limit {
-                                group_node = group_node.with_group_limit(limit.clone());
-                            }
-                            if let Some(ref filter) = nested.filter {
-                                group_node = group_node.with_group_filter(filter.clone());
-                            }
-                            if let Some(ref order) = nested.order_by {
-                                group_node = group_node.with_group_order(order.clone());
-                            }
+                            let alias_index =
+                                group_indices.get(alias_count).copied().unwrap_or(0);
+                            alias_count += 1;
 
-                            // Extract inner groupBy fields from the nested _group
-                            if let Some(ref inner_group_by) = nested.group_by {
-                                group_node = group_node
-                                    .with_inner_group_by_fields(inner_group_by.fields.clone());
-                            }
+                            group_aliases.push(GroupAlias {
+                                index: alias_index,
+                                filter: nested.filter.clone(),
+                                limit: nested.limit.clone(),
+                                order: nested.order_by.clone(),
+                                doc_ids: nested.doc_ids.clone(),
+                            });
 
-                            // Extract inner aggregate definitions from the nested _group
-                            let mut inner_aggs = Vec::new();
-                            for inner_field in &nested.fields {
-                                if let Requestable::Aggregate(inner_agg) = inner_field {
-                                    // Get the target field index from the scan mapping
-                                    let field_index = if !inner_agg.targets.is_empty() {
-                                        if let Some(ref field_name) =
-                                            inner_agg.targets[0].field_name
-                                        {
-                                            scan_mapping
-                                                .first_index_of_name(field_name)
-                                                .unwrap_or(0)
+                            // Extract inner groupBy/aggregates from the first _group
+                            // that has a groupBy clause (only once)
+                            if !inner_extracted && nested.group_by.is_some() {
+                                inner_extracted = true;
+
+                                if let Some(ref inner_group_by) = nested.group_by {
+                                    group_node = group_node.with_inner_group_by_fields(
+                                        inner_group_by.fields.clone(),
+                                    );
+                                }
+
+                                // Extract inner aggregate definitions
+                                let mut inner_aggs = Vec::new();
+                                for inner_field in &nested.fields {
+                                    if let Requestable::Aggregate(inner_agg) = inner_field {
+                                        let field_index = if !inner_agg.targets.is_empty() {
+                                            if let Some(ref field_name) =
+                                                inner_agg.targets[0].field_name
+                                            {
+                                                scan_mapping
+                                                    .first_index_of_name(field_name)
+                                                    .unwrap_or(0)
+                                            } else {
+                                                0
+                                            }
                                         } else {
                                             0
+                                        };
+                                        inner_aggs.push(InnerAggregateDef {
+                                            aggregate_type: inner_agg.aggregate_type,
+                                            output_key: inner_agg.output_name().to_string(),
+                                            field_index,
+                                        });
+                                    }
+                                }
+                                if !inner_aggs.is_empty() {
+                                    group_node = group_node.with_inner_aggregates(inner_aggs);
+                                }
+
+                                // Extract inner _group filter/order (2nd nesting level)
+                                // and 3rd-level groupBy/aggregates
+                                for inner_field in &nested.fields {
+                                    if let Requestable::Select(inner_nested) = inner_field {
+                                        if inner_nested.field.name == "_group" {
+                                            if let Some(ref inner_filter) = inner_nested.filter {
+                                                group_node = group_node
+                                                    .with_inner_group_filter(inner_filter.clone());
+                                            }
+                                            if let Some(ref inner_order) = inner_nested.order_by {
+                                                group_node = group_node
+                                                    .with_inner_group_order(inner_order.clone());
+                                            }
+
+                                            // 3rd level: extract groupBy fields
+                                            if let Some(ref third_gb) = inner_nested.group_by {
+                                                group_node = group_node
+                                                    .with_third_level_group_by_fields(
+                                                        third_gb.fields.clone(),
+                                                    );
+                                            }
+
+                                            // 3rd level: extract aggregate definitions
+                                            let mut third_aggs = Vec::new();
+                                            for third_field in &inner_nested.fields {
+                                                if let Requestable::Aggregate(third_agg) =
+                                                    third_field
+                                                {
+                                                    let field_index =
+                                                        if !third_agg.targets.is_empty() {
+                                                            if let Some(ref field_name) =
+                                                                third_agg.targets[0].field_name
+                                                            {
+                                                                scan_mapping
+                                                                    .first_index_of_name(
+                                                                        field_name,
+                                                                    )
+                                                                    .unwrap_or(0)
+                                                            } else {
+                                                                0
+                                                            }
+                                                        } else {
+                                                            0
+                                                        };
+                                                    third_aggs.push(InnerAggregateDef {
+                                                        aggregate_type: third_agg.aggregate_type,
+                                                        output_key: third_agg
+                                                            .output_name()
+                                                            .to_string(),
+                                                        field_index,
+                                                    });
+                                                }
+                                            }
+                                            if !third_aggs.is_empty() {
+                                                group_node = group_node
+                                                    .with_third_level_aggregates(third_aggs);
+                                            }
+
+                                            break;
                                         }
-                                    } else {
-                                        0
-                                    };
-                                    inner_aggs.push(InnerAggregateDef {
-                                        aggregate_type: inner_agg.aggregate_type,
-                                        output_key: inner_agg.output_name().to_string(),
-                                        field_index,
-                                    });
+                                    }
                                 }
                             }
-                            if !inner_aggs.is_empty() {
-                                group_node = group_node.with_inner_aggregates(inner_aggs);
-                            }
-
-                            break;
                         }
                     }
+                }
+                if !group_aliases.is_empty() {
+                    group_node = group_node.with_group_aliases(group_aliases);
                 }
                 plan = Box::new(group_node);
             }
 
             // 5. Add aggregate nodes (after grouping)
             plan = self.add_aggregate_nodes(plan, select, &scan_mapping)?;
+
+            // 5b. Apply _alias filter AFTER aggregation
+            // Alias filters on aggregate fields (e.g., filter: {_alias: {Total: {_gt: 100}}})
+            // can only be evaluated after aggregate values have been computed.
+            if let Some(ref filter) = select.filter {
+                let (_non_alias, alias_filter) = filter.split_alias();
+                if let Some(alias_f) = alias_filter {
+                    plan = Box::new(
+                        SelectNode::new(plan, scan_mapping.clone()).with_filter(alias_f),
+                    );
+                }
+            }
 
             // 6. Apply order by (after grouping/aggregation)
             if let Some(ref order_by) = select.order_by {

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -200,10 +200,46 @@ impl Planner {
             })
             .unwrap_or_default();
 
-        // Build scan mapping: for queries with nested selections, relation filters, or relation ordering,
-        // use full schema mapping so that FK fields are available for TypeJoin lookups.
+        // Check if GROUP BY references relation fields (needs full schema mapping for joins)
+        let group_by_has_relations = select
+            .group_by
+            .as_ref()
+            .map(|gb| {
+                gb.fields.iter().any(|field_name| {
+                    collection
+                        .field_by_name(field_name)
+                        .map(|f| f.kind.is_relation())
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+
+        // Check if aggregates reference relation fields (needs full schema mapping for joins)
+        let aggregates_have_relations = select.fields.iter().any(|f| {
+            if let Requestable::Aggregate(agg) = f {
+                agg.targets.iter().any(|t| {
+                    if t.host_name.is_empty() || t.host_name == "_group" {
+                        return false;
+                    }
+                    collection
+                        .field_by_name(&t.host_name)
+                        .map(|f| f.kind.is_relation())
+                        .unwrap_or(false)
+                })
+            } else {
+                false
+            }
+        });
+
+        // Build scan mapping: for queries with nested selections, relation filters, relation ordering,
+        // relation aggregates, or relation groupBy fields, use full schema mapping so that FK fields
+        // are available for TypeJoin lookups and schema indices don't collide with sequential render indices.
         // For simple queries, use the render_mapping directly.
-        let needs_joins = has_nested || filter_has_relations || order_has_relations;
+        let needs_joins = has_nested
+            || filter_has_relations
+            || order_has_relations
+            || aggregates_have_relations
+            || group_by_has_relations;
         let mut scan_mapping = if needs_joins {
             self.build_scan_mapping_for_join(&collection, &render_mapping)
         } else {
@@ -1964,19 +2000,15 @@ impl Planner {
                     if already_joined {
                         if let Some(ref filter) = target.filter {
                             for filter_field in filter.referenced_fields() {
-                                // Skip special fields
                                 if filter_field.starts_with('_') {
                                     continue;
                                 }
-                                // Find the field index in the target collection
                                 if let Some(idx) = target_collection
                                     .fields
                                     .iter()
                                     .position(|f| f.name == filter_field)
                                 {
-                                    // Get the existing child mapping from the parent's mapping
                                     if let Some(child_mapping) = mapping.child_at_mut(relation_field_index) {
-                                        // Add the filter field to child mapping if not present
                                         if child_mapping.first_index_of_name(&filter_field).is_none() {
                                             child_mapping.add(idx, &filter_field);
                                             child_mapping.add_render_key(idx, &filter_field);
@@ -1985,7 +2017,29 @@ impl Planner {
                                 }
                             }
                         }
-                        continue; // Don't create a new join, just added filter fields to existing
+                        // Add order fields from aggregate target to existing child mapping
+                        if let Some(ref order) = target.order {
+                            for condition in &order.conditions {
+                                if let Some(order_field) = condition.fields.first() {
+                                    if order_field.starts_with('_') {
+                                        continue;
+                                    }
+                                    if let Some(idx) = target_collection
+                                        .fields
+                                        .iter()
+                                        .position(|f| f.name == *order_field)
+                                    {
+                                        if let Some(child_mapping) = mapping.child_at_mut(relation_field_index) {
+                                            if child_mapping.first_index_of_name(order_field).is_none() {
+                                                child_mapping.add(idx, order_field);
+                                                child_mapping.add_render_key(idx, order_field);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        continue;
                     }
 
                     // Build a minimal child mapping for the aggregate
@@ -2025,6 +2079,28 @@ impl Planner {
                                 if child_mapping.first_index_of_name(&filter_field).is_none() {
                                     child_mapping.add(idx, &filter_field);
                                     child_mapping.add_render_key(idx, &filter_field);
+                                }
+                            }
+                        }
+                    }
+
+                    // Add fields referenced by the order so they appear in the output
+                    // for post-processing sort before limit/offset
+                    if let Some(ref order) = target.order {
+                        for condition in &order.conditions {
+                            if let Some(order_field) = condition.fields.first() {
+                                if order_field.starts_with('_') {
+                                    continue;
+                                }
+                                if let Some(idx) = target_collection
+                                    .fields
+                                    .iter()
+                                    .position(|f| f.name == *order_field)
+                                {
+                                    if child_mapping.first_index_of_name(order_field).is_none() {
+                                        child_mapping.add(idx, order_field);
+                                        child_mapping.add_render_key(idx, order_field);
+                                    }
                                 }
                             }
                         }
@@ -2305,11 +2381,18 @@ impl Planner {
             child_relation_index,
         )?;
 
-        // Create TypeJoinOne (filter relations are typically one-to-one)
-        // No relation filter here - the complex filter is applied after all joins
-        let join = TypeJoinOne::new(plan, child_plan, parent_side, child_side, mapping.clone());
-
-        Ok((Box::new(join), mapping))
+        // Create the appropriate join type based on the relation cardinality.
+        // One-to-many relations need TypeJoinMany to collect all children into an array,
+        // one-to-one relations use TypeJoinOne.
+        if relation_field.kind.is_array() {
+            let join_many =
+                TypeJoinMany::new(plan, child_plan, parent_side, child_side, mapping.clone())?;
+            Ok((Box::new(join_many), mapping))
+        } else {
+            let join =
+                TypeJoinOne::new(plan, child_plan, parent_side, child_side, mapping.clone());
+            Ok((Box::new(join), mapping))
+        }
     }
 
     /// Apply sub-joins for remaining elements of a multi-level filter path.

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -918,8 +918,9 @@ impl Planner {
         // Select the best index for this filter
         let best_index = select_best_index(filter, &collection.indexes)?;
 
-        // Convert filter to index scan parameters
-        filter_to_index_scan(filter, best_index)
+        // Convert filter to index scan parameters, passing ordering info
+        // so the scan direction can be set correctly
+        filter_to_index_scan(filter, best_index, select.order_by.as_ref())
     }
 
     /// Apply join nodes for nested selects (relation fields)

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -17,7 +17,10 @@ use crate::plan::{
     LimitNode, MaxNode, MinNode, OrderByNode, RelationFilter, ScanNode, SelectNode, SumNode,
     TypeJoinMany, TypeJoinOne,
 };
-use crate::planner::index_selection::{filter_to_index_scan, select_best_index, IndexScanParams};
+use crate::planner::index_selection::{
+    can_be_ordered_by_index, filter_to_index_scan, select_best_index, IndexScanParams,
+    IndexScanType,
+};
 use crate::planner::PlanNode;
 use serde_json::Value as JsonValue;
 
@@ -300,12 +303,14 @@ impl Planner {
             }
         }
 
-        // Check if an index can be used for the filter.
+        // Check if an index can be used for the filter or ordering.
         // Index selection works for both pre-loaded docs and fetcher-based loading.
-        let index_scan = if let Some(ref fetcher) = self.fetcher {
+        let (index_scan, index_provides_ordering) = if let Some(ref fetcher) = self.fetcher {
             // Only use index if fetcher supports index queries
             if fetcher.supports_index_queries() {
                 self.try_select_index(select, &collection)
+                    .map(|(p, o)| (Some(p), o))
+                    .unwrap_or((None, false))
             } else {
                 if select.filter.is_some() && !collection.indexes.is_empty() {
                     debug!(
@@ -314,10 +319,12 @@ impl Planner {
                         "Index selection disabled - fetcher does not support index queries"
                     );
                 }
-                None
+                (None, false)
             }
         } else {
             self.try_select_index(select, &collection)
+                .map(|(p, o)| (Some(p), o))
+                .unwrap_or((None, false))
         };
 
         // Build the plan tree bottom-up:
@@ -656,12 +663,15 @@ impl Planner {
             plan = self.add_aggregate_nodes(plan, select, &scan_mapping)?;
 
             // 6. Apply order by (after grouping/aggregation)
+            // Skip if index already provides the ordering
             if let Some(ref order_by) = select.order_by {
-                plan = Box::new(OrderByNode::new(
-                    plan,
-                    order_by.clone(),
-                    scan_mapping.clone(),
-                ));
+                if !index_provides_ordering {
+                    plan = Box::new(OrderByNode::new(
+                        plan,
+                        order_by.clone(),
+                        scan_mapping.clone(),
+                    ));
+                }
             }
 
             // 7. Apply limit/offset
@@ -678,12 +688,15 @@ impl Planner {
             // WITHOUT GROUP BY: OrderBy → Limit → [AllDocsNode] → Aggregates
 
             // 5. Apply order by (before limit)
+            // Skip if index already provides the ordering
             if let Some(ref order_by) = select.order_by {
-                plan = Box::new(OrderByNode::new(
-                    plan,
-                    order_by.clone(),
-                    scan_mapping.clone(),
-                ));
+                if !index_provides_ordering {
+                    plan = Box::new(OrderByNode::new(
+                        plan,
+                        order_by.clone(),
+                        scan_mapping.clone(),
+                    ));
+                }
             }
 
             // 6. Apply limit/offset
@@ -901,26 +914,53 @@ impl Planner {
 
     /// Try to select an index for the given query.
     ///
-    /// Returns `Some(IndexScanParams)` if an index can be used, `None` otherwise.
+    /// Returns `Some((IndexScanParams, index_provides_ordering))` if an index
+    /// can be used, `None` otherwise. Tries filter-based selection first,
+    /// then falls back to ordering-based selection (matching Go behavior).
     fn try_select_index(
         &self,
         select: &Select,
         collection: &CollectionVersion,
-    ) -> Option<IndexScanParams> {
-        // Only try index selection if there's a filter
-        let filter = select.filter.as_ref()?;
-
-        // Get available indexes for this collection
+    ) -> Option<(IndexScanParams, bool)> {
         if collection.indexes.is_empty() {
             return None;
         }
 
-        // Select the best index for this filter
-        let best_index = select_best_index(filter, &collection.indexes)?;
+        // Try filter-based index selection first
+        if let Some(filter) = select.filter.as_ref() {
+            if let Some(best_index) = select_best_index(filter, &collection.indexes) {
+                if let Some(params) =
+                    filter_to_index_scan(filter, best_index, select.order_by.as_ref())
+                {
+                    // Check if this index also provides ordering
+                    let provides_ordering = select
+                        .order_by
+                        .as_ref()
+                        .map(|o| can_be_ordered_by_index(o, best_index).0)
+                        .unwrap_or(false);
+                    return Some((params, provides_ordering));
+                }
+            }
+        }
 
-        // Convert filter to index scan parameters, passing ordering info
-        // so the scan direction can be set correctly
-        filter_to_index_scan(filter, best_index, select.order_by.as_ref())
+        // Fallback: try ordering-based index selection (no filter needed)
+        if let Some(ref order_by) = select.order_by {
+            for index in &collection.indexes {
+                let (can_order, needs_reverse) = can_be_ordered_by_index(order_by, index);
+                if can_order {
+                    let params = IndexScanParams {
+                        index_name: index.name.clone(),
+                        scan_type: IndexScanType::PrefixScan {
+                            prefix_values: vec![],
+                            reverse: needs_reverse,
+                        },
+                    };
+                    return Some((params, true));
+                }
+            }
+        }
+
+        None
     }
 
     /// Apply join nodes for nested selects (relation fields)
@@ -2498,12 +2538,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_plan_no_index_for_ne_filter() {
+    async fn test_plan_uses_index_for_ne_filter() {
         use std::collections::HashMap;
 
         let planner = Planner::new(vec![make_test_collection_with_index()]);
 
-        // _ne is not index-friendly
+        // _ne uses full index scan (matching Go behavior)
         let filter = Filter::from_conditions(HashMap::from([(
             "name".to_string(),
             serde_json::json!({"_ne": "Alice"}),
@@ -2515,8 +2555,8 @@ mod tests {
 
         let result = planner.plan_with_index_info(&select).unwrap();
 
-        // _ne cannot use index efficiently
-        assert!(!result.uses_index());
+        // _ne uses full index scan
+        assert!(result.uses_index());
     }
 
     #[tokio::test]

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -1482,7 +1482,7 @@ impl Planner {
                 // Note: We pass child_render_mapping as the output mapping (for TypeJoin to render children)
                 // but the child_plan uses child_scan_mapping internally (for FK lookups)
                 if relation_field.kind.is_array() {
-                    // One-to-many: TypeJoinMany (relation filter support tracked in #187)
+                    // One-to-many: TypeJoinMany
                     let mut join_many = TypeJoinMany::new(
                         plan,
                         child_plan,
@@ -1490,6 +1490,11 @@ impl Planner {
                         child_side,
                         mapping.clone(),
                     )?;
+
+                    // Apply relation filter (filters parents by children)
+                    if let Some(rel_filter) = relation_filter {
+                        join_many = join_many.with_relation_filter(rel_filter);
+                    }
 
                     // Apply per-parent limit/offset/ordering
                     if let Some(limit) = nested_limit {
@@ -1515,6 +1520,161 @@ impl Planner {
                     if let Some(rel_filter) = relation_filter {
                         join = join.with_relation_filter(rel_filter);
                     }
+                    plan = Box::new(join);
+                }
+            }
+        }
+
+        // Handle relation filters without corresponding selections.
+        // When a filter references a relation (e.g., `Author(filter: {published: {_docID: ...}})`),
+        // but the relation is not selected, we still need to create a join to filter the parent.
+        if let Some(filter) = parent_filter {
+            // Get relations referenced by the filter
+            for (relation_name, nested_conditions) in filter.relation_conditions() {
+                // Skip if already joined via selection
+                let already_joined = select.fields.iter().any(|f| {
+                    matches!(f, Requestable::Select(s) if s.field.name == relation_name)
+                });
+                if already_joined {
+                    continue;
+                }
+
+                // Find the relation field in the parent collection
+                let relation_field = match parent_collection.field_by_name(&relation_name) {
+                    Some(f) if f.kind.is_relation() => f,
+                    _ => continue, // Not a relation field
+                };
+
+                // Get the target collection
+                let target_collection_id = match relation_field.kind.relation_collection_id() {
+                    Some(id) => id,
+                    None => continue,
+                };
+
+                let target_collection = if target_collection_id.is_empty() {
+                    Arc::new(parent_collection.clone())
+                } else {
+                    match self.get_collection(target_collection_id) {
+                        Some(c) => c,
+                        None => continue,
+                    }
+                };
+
+                // Find the target relation field (the other side of the relation)
+                let target_relation_field = if let Some(rel_name) = &relation_field.relation_name {
+                    target_collection.field_by_relation(
+                        rel_name,
+                        &parent_collection.name,
+                        &relation_name,
+                    )
+                } else {
+                    None
+                };
+
+                // Build child mapping for filter-only join
+                // Include _docID and the FK field for the join to work correctly
+                let mut child_mapping = DocumentMapping::new();
+                child_mapping.add(0, "_docID");
+
+                // Add the FK field (e.g., _authorID) - needed for TypeJoinMany cache indexing
+                let fk_field_name = if let Some(ref target_rel) = target_relation_field {
+                    schema::CollectionVersion::relation_id_field_name(&target_rel.name)
+                } else {
+                    schema::CollectionVersion::relation_id_field_name(&relation_name)
+                };
+                if let Some(fk_idx) = target_collection
+                    .fields
+                    .iter()
+                    .position(|f| f.name == fk_field_name)
+                {
+                    child_mapping.add(fk_idx, &fk_field_name);
+                }
+
+                // Add any fields referenced by the filter
+                for field_name in nested_conditions.referenced_fields() {
+                    if field_name != "_docID" && field_name != fk_field_name {
+                        if let Some(idx) = target_collection
+                            .fields
+                            .iter()
+                            .position(|f| f.name == field_name)
+                        {
+                            child_mapping.add(idx, &field_name);
+                        }
+                    }
+                }
+
+                // Build child scan (with fetcher for data access)
+                let mut child_scan =
+                    ScanNode::new((*target_collection).clone(), child_mapping.clone());
+                if let Some(ref fetcher) = self.fetcher {
+                    child_scan = child_scan.with_fetcher(fetcher.clone());
+                }
+                let child_plan: Box<dyn PlanNode> = Box::new(child_scan);
+
+                // Get field indices
+                let relation_field_index = mapping
+                    .first_index_of_name(&relation_name)
+                    .unwrap_or_else(|| {
+                        // Add to mapping if not present
+                        let idx = mapping.next_index();
+                        mapping.add(idx, &relation_name);
+                        idx
+                    });
+
+                // Find child relation index
+                let child_relation_index = target_relation_field
+                    .as_ref()
+                    .and_then(|f| {
+                        target_collection
+                            .fields
+                            .iter()
+                            .position(|tf| tf.name == f.name)
+                    })
+                    .unwrap_or(0);
+
+                // Create join sides
+                let parent_side = JoinSide::new(
+                    parent_collection.clone(),
+                    relation_field.clone(),
+                    relation_field_index,
+                )?;
+
+                let child_side = JoinSide::new(
+                    (*target_collection).clone(),
+                    target_relation_field
+                        .cloned()
+                        .unwrap_or_else(|| relation_field.clone()),
+                    child_relation_index,
+                )?;
+
+                // Create the relation filter
+                let rel_filter = RelationFilter {
+                    relation_field: relation_name.clone(),
+                    conditions: nested_conditions.clone(),
+                };
+
+                // Create the appropriate join node based on cardinality
+                if relation_field.kind.is_array() {
+                    // One-to-many: TypeJoinMany with filter
+                    let join_many = TypeJoinMany::new(
+                        plan,
+                        child_plan,
+                        parent_side,
+                        child_side,
+                        mapping.clone(),
+                    )?
+                    .with_relation_filter(rel_filter);
+                    plan = Box::new(join_many);
+                } else {
+                    // One-to-one: TypeJoinOne with filter
+                    let join = TypeJoinOne::new(
+                        plan,
+                        child_plan,
+                        parent_side,
+                        child_side,
+                        mapping.clone(),
+                    )
+                    .with_relation_filter(rel_filter);
                     plan = Box::new(join);
                 }
             }

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -1503,8 +1503,39 @@ impl Planner {
                     if nested_offset > 0 {
                         join_many = join_many.with_offset(nested_offset);
                     }
-                    if let Some(order_by) = nested_order_by {
+                    if let Some(order_by) = nested_order_by.clone() {
                         join_many = join_many.with_order_by(order_by);
+                    }
+
+                    // Apply nested groupBy if present
+                    if let Some(ref group_by) = nested_select.group_by {
+                        join_many = join_many.with_group_by(group_by.clone());
+
+                        // Find the _group nested select and build its mapping
+                        // Use indices from child_scan_mapping so the mapping matches
+                        // the child document's field array indices.
+                        for field in &nested_select.fields {
+                            if let Requestable::Select(group_select) = field {
+                                if group_select.field.name == "_group" {
+                                    // Build mapping for _group contents using child_scan_mapping indices
+                                    let mut group_mapping = DocumentMapping::new();
+                                    for group_field in &group_select.fields {
+                                        if let Requestable::Field(f) = group_field {
+                                            // Use the index from child_scan_mapping
+                                            if let Some(idx) =
+                                                child_scan_mapping.first_index_of_name(&f.name)
+                                            {
+                                                let output_name = f.output_name().to_string();
+                                                group_mapping.add(idx, &output_name);
+                                                group_mapping.add_render_key(idx, output_name);
+                                            }
+                                        }
+                                    }
+                                    join_many = join_many.with_group_mapping(group_mapping);
+                                    break;
+                                }
+                            }
+                        }
                     }
 
                     plan = Box::new(join_many);

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -332,17 +332,41 @@ impl Planner {
 
         // Check if filter is complex (has relation conditions inside logical operators)
         // or has multi-level relation paths (e.g., {author: {published: {rating: ...}}})
-        let is_complex_filter = select
-            .filter
+        // Collect aggregate output names to detect _alias conditions that should be deferred
+        let aggregate_names: Vec<&str> = select
+            .fields
+            .iter()
+            .filter_map(|f| {
+                if let Requestable::Aggregate(agg) = f {
+                    Some(agg.output_name())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Strip _alias conditions that reference computed aggregates from the filter.
+        // These must be evaluated after aggregates are computed, not during plan execution.
+        let filter_for_plan = select.filter.as_ref().map(|f| {
+            let (stripped, _) = f.strip_aggregate_alias_conditions(&aggregate_names);
+            stripped
+        });
+
+        // Check if filter is complex (has relation conditions inside logical operators)
+        // or has multi-level relation paths (e.g., {author: {published: {rating: ...}}})
+        let is_complex_filter = filter_for_plan
             .as_ref()
-            .map(|f| f.is_complex() || !f.get_multi_level_relation_paths().is_empty())
+            .map(|f| {
+                f.is_complex()
+                    || !f.get_multi_level_relation_paths().is_empty()
+                    || f.has_alias_filter()
+            })
             .unwrap_or(false);
 
         // Split filter into scalar and relation parts (only useful for non-complex filters)
         // Note: JSON field nested access looks like relation filters structurally, but should
         // be treated as scalar filters. We recombine them below based on schema info.
-        let (scalar_filter_raw, relation_filter) = select
-            .filter
+        let (scalar_filter_raw, relation_filter) = filter_for_plan
             .as_ref()
             .map(|f| f.split_by_relation())
             .unwrap_or((None, None));
@@ -350,6 +374,10 @@ impl Planner {
         // Move JSON field conditions from relation_filter back to scalar_filter.
         // The split_by_relation function can't distinguish JSON nested access from relation
         // traversal without schema info. Here we have the collection, so we can fix it.
+        //
+        // Also transform {relationField: {_docID: {...}}} to {_relationFieldID: {...}}.
+        // This allows relation _docID filters to work as scalar filters without requiring a join.
+        // Example: {author: {_docID: {_eq: "bae-..."}}} → {_authorID: {_eq: "bae-..."}}
         let scalar_filter = {
             let mut combined_conditions: HashMap<String, JsonValue> = scalar_filter_raw
                 .as_ref()
@@ -358,13 +386,34 @@ impl Planner {
 
             if let Some(ref rel_filter) = relation_filter {
                 for (field_name, condition) in rel_filter.conditions() {
-                    // Check if this field is NOT a relation (could be JSON, etc.)
-                    if !collection
-                        .field_by_name(field_name)
-                        .is_some_and(|f| f.kind.is_relation())
-                    {
-                        combined_conditions.insert(field_name.clone(), condition.clone());
+                    // Check if this field is a relation
+                    if let Some(field) = collection.field_by_name(field_name) {
+                        if field.kind.is_relation() {
+                            // Check if this is a {_docID: {...}} pattern AND the FK field exists locally.
+                            // For "primary" relations (FK on this side), we can transform to use the FK.
+                            // For "secondary" relations (FK on other side), we can't transform - need join.
+                            let fk_field_name =
+                                schema::CollectionVersion::relation_id_field_name(field_name);
+                            let has_local_fk = collection.field_by_name(&fk_field_name).is_some();
+
+                            if has_local_fk {
+                                if let Some(obj) = condition.as_object() {
+                                    if obj.len() == 1 {
+                                        if let Some(docid_condition) = obj.get("_docID") {
+                                            // Transform {relationField: {_docID: {...}}} to {_relationFieldID: {...}}
+                                            combined_conditions
+                                                .insert(fk_field_name, docid_condition.clone());
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+                            // Not a _docID-only pattern or no local FK, keep as relation filter
+                            continue;
+                        }
                     }
+                    // Not a relation field - treat as scalar (could be JSON, etc.)
+                    combined_conditions.insert(field_name.clone(), condition.clone());
                 }
             }
 
@@ -425,13 +474,13 @@ impl Planner {
         let filter_for_joins = if is_complex_filter {
             None // Don't pass filter to TypeJoin for complex filters
         } else {
-            select.filter.as_ref()
+            filter_for_plan.as_ref()
         };
-        plan = self.apply_joins(
+        (plan, scan_mapping) = self.apply_joins(
             plan,
             select,
             &collection,
-            scan_mapping.clone(),
+            scan_mapping,
             0,
             filter_for_joins,
         )?;
@@ -441,7 +490,7 @@ impl Planner {
         // already handles it via apply_multi_level_sub_joins.
         // Example: Book(filter: {author: {published: {rating: {_eq: 4.9}}}}) { name }
         // (no author selection, so we need to add the full join chain here)
-        if let Some(ref filter) = select.filter {
+        if let Some(ref filter) = filter_for_plan {
             // Get relation names from selection
             let selected_relation_names: Vec<&str> = select
                 .fields
@@ -1046,7 +1095,7 @@ impl Planner {
         mut mapping: DocumentMapping,
         depth: usize,
         parent_filter: Option<&crate::mapper::Filter>,
-    ) -> Result<Box<dyn PlanNode>> {
+    ) -> Result<(Box<dyn PlanNode>, DocumentMapping)> {
         // Check recursion depth to prevent stack overflow
         if depth > MAX_NESTING_DEPTH {
             return Err(QueryError::execution(format!(
@@ -1113,6 +1162,71 @@ impl Planner {
                 // so the doc fields must be at their schema positions for FK lookups to work.
                 let mut child_scan_mapping =
                     self.build_scan_mapping_for_join(&target_collection, &child_render_mapping);
+
+                // Check if aggregates reference this relation and need additional fields for filters.
+                // For example, _count(published: {filter: {rating: {_gt: 4.8}}}) needs the 'rating'
+                // field to be included even if it's not in the selection set.
+                for requestable in &select.fields {
+                    if let Requestable::Aggregate(agg) = requestable {
+                        for target in &agg.targets {
+                            if target.host_name == *relation_field_name {
+                                // This aggregate references this relation - add filter fields
+                                if let Some(ref filter) = target.filter {
+                                    for filter_field in filter.referenced_fields() {
+                                        // Skip special fields
+                                        if filter_field.starts_with('_') {
+                                            continue;
+                                        }
+                                        // Find the field index in the target collection
+                                        if let Some(idx) = target_collection
+                                            .fields
+                                            .iter()
+                                            .position(|f| f.name == filter_field)
+                                        {
+                                            // Add the field to child_scan_mapping if not present
+                                            if child_scan_mapping
+                                                .first_index_of_name(&filter_field)
+                                                .is_none()
+                                            {
+                                                child_scan_mapping.add(idx, &filter_field);
+                                            }
+                                            // Add render_key so the field appears in the output
+                                            if !child_scan_mapping
+                                                .render_keys
+                                                .iter()
+                                                .any(|rk| rk.key == filter_field)
+                                            {
+                                                child_scan_mapping.add_render_key(idx, &filter_field);
+                                            }
+                                        }
+                                    }
+                                }
+                                // Also add the aggregate target field if specified
+                                if let Some(ref field_name) = target.field_name {
+                                    if let Some(idx) = target_collection
+                                        .fields
+                                        .iter()
+                                        .position(|f| f.name == *field_name)
+                                    {
+                                        if child_scan_mapping
+                                            .first_index_of_name(field_name)
+                                            .is_none()
+                                        {
+                                            child_scan_mapping.add(idx, field_name);
+                                        }
+                                        if !child_scan_mapping
+                                            .render_keys
+                                            .iter()
+                                            .any(|rk| rk.key == *field_name)
+                                        {
+                                            child_scan_mapping.add_render_key(idx, field_name);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 // Check if parent's order_by references fields in this relation.
                 // If so, add those fields to child_scan_mapping.render_keys so they're
@@ -1201,36 +1315,56 @@ impl Planner {
                     child_scan = child_scan.with_fetcher(fetcher.clone());
                 }
 
-                // Reject unsupported arguments on nested selections.
-                // Order and limit on nested selections require per-parent ordering/limiting
-                // which is not yet implemented. Return a clear error rather than silently ignoring.
-                if nested_select.order_by.is_some() {
-                    return Err(QueryError::execution(format!(
-                        "order on nested selection '{}' is not yet supported. \
-                         Use separate queries to order nested results.",
-                        relation_field_name
-                    )));
-                }
-                if nested_select.limit.is_some() {
-                    return Err(QueryError::execution(format!(
-                        "limit/offset on nested selection '{}' is not yet supported. \
-                         Use separate queries to limit nested results.",
-                        relation_field_name
-                    )));
-                }
+                // Extract nested limit/offset and order_by for per-parent application in TypeJoin.
+                let nested_limit = nested_select.limit.as_ref().and_then(|l| l.limit);
+                let nested_offset = nested_select.limit.as_ref().map(|l| l.offset).unwrap_or(0);
+                let nested_order_by = nested_select.order_by.clone();
 
-                // Wrap in SelectNode if there's a filter on the nested select
+                // Build a combined filter from doc_ids and explicit filter
+                let doc_ids_filter = if let Some(ref doc_ids) = nested_select.doc_ids {
+                    // Create a filter: _docID IN [...]
+                    if doc_ids.len() == 1 {
+                        // Single ID: _docID == "..."
+                        let mut conditions = HashMap::new();
+                        conditions.insert(
+                            "_docID".to_string(),
+                            serde_json::json!({"_eq": doc_ids[0]}),
+                        );
+                        Some(Filter::from_conditions(conditions))
+                    } else {
+                        // Multiple IDs: _docID IN [...]
+                        let mut conditions = HashMap::new();
+                        conditions.insert("_docID".to_string(), serde_json::json!({"_in": doc_ids}));
+                        Some(Filter::from_conditions(conditions))
+                    }
+                } else {
+                    None
+                };
+
+                // Combine doc_ids filter with explicit filter
+                let combined_filter = match (&doc_ids_filter, &nested_select.filter) {
+                    (Some(doc_filter), Some(explicit_filter)) => {
+                        // Both: AND them together
+                        Some(doc_filter.and(explicit_filter.clone()))
+                    }
+                    (Some(doc_filter), None) => Some(doc_filter.clone()),
+                    (None, Some(explicit_filter)) => Some(explicit_filter.clone()),
+                    (None, None) => None,
+                };
+
+                // Wrap in SelectNode if there's any filter
                 let mut child_plan: Box<dyn PlanNode> =
-                    if let Some(ref filter) = nested_select.filter {
-                        // Validate that all filter-referenced fields exist in the render mapping.
-                        // We validate against render_mapping (user-selected fields), not scan_mapping,
-                        // because filtering on unselected fields is likely a user error.
-                        for field in filter.referenced_fields() {
-                            if !child_render_mapping.has_field(&field) {
-                                return Err(QueryError::filter_field_not_selected(
-                                    &field,
-                                    &target_collection.name,
-                                ));
+                    if let Some(ref filter) = combined_filter {
+                        // Validate that all explicitly-filtered fields exist in the render mapping.
+                        // Skip doc_ids filter fields since _docID is always available.
+                        if let Some(ref explicit_filter) = nested_select.filter {
+                            for field in explicit_filter.referenced_fields() {
+                                if !child_render_mapping.has_field(&field) {
+                                    return Err(QueryError::filter_field_not_selected(
+                                        &field,
+                                        &target_collection.name,
+                                    ));
+                                }
                             }
                         }
 
@@ -1245,11 +1379,11 @@ impl Planner {
                 // Recursively apply joins for any nested selections within this nested select.
                 // This handles multi-level nesting like Users -> Posts -> Comments.
                 // Note: We pass None for parent_filter since relation filters only apply at the top level.
-                child_plan = self.apply_joins(
+                (child_plan, child_scan_mapping) = self.apply_joins(
                     child_plan,
                     nested_select,
                     &target_collection,
-                    child_scan_mapping.clone(),
+                    child_scan_mapping,
                     depth + 1,
                     None, // Nested relation filters handled differently
                 )?;
@@ -1349,13 +1483,26 @@ impl Planner {
                 // but the child_plan uses child_scan_mapping internally (for FK lookups)
                 if relation_field.kind.is_array() {
                     // One-to-many: TypeJoinMany (relation filter support tracked in #187)
-                    plan = Box::new(TypeJoinMany::new(
+                    let mut join_many = TypeJoinMany::new(
                         plan,
                         child_plan,
                         parent_side,
                         child_side,
                         mapping.clone(),
-                    )?);
+                    )?;
+
+                    // Apply per-parent limit/offset/ordering
+                    if let Some(limit) = nested_limit {
+                        join_many = join_many.with_limit(limit);
+                    }
+                    if nested_offset > 0 {
+                        join_many = join_many.with_offset(nested_offset);
+                    }
+                    if let Some(order_by) = nested_order_by {
+                        join_many = join_many.with_order_by(order_by);
+                    }
+
+                    plan = Box::new(join_many);
                 } else {
                     // One-to-one: TypeJoinOne
                     let mut join = TypeJoinOne::new(
@@ -1537,10 +1684,6 @@ impl Planner {
                         }
                     });
 
-                    if already_joined {
-                        continue; // Data already available, aggregate will use it
-                    }
-
                     // Find the field in the parent collection
                     let relation_field = match parent_collection.field_by_name(relation_field_name)
                     {
@@ -1569,9 +1712,47 @@ impl Planner {
                         }
                     };
 
+                    // Get relation field index in parent collection (needed in both paths)
+                    let relation_field_index = parent_collection
+                        .fields
+                        .iter()
+                        .position(|f| f.name == *relation_field_name)
+                        .unwrap_or(0);
+
+                    // If the relation is already joined via a selection, we still need to
+                    // ensure the filter fields are available in the output for post-processing.
+                    // Add filter fields to the existing child mapping.
+                    if already_joined {
+                        if let Some(ref filter) = target.filter {
+                            for filter_field in filter.referenced_fields() {
+                                // Skip special fields
+                                if filter_field.starts_with('_') {
+                                    continue;
+                                }
+                                // Find the field index in the target collection
+                                if let Some(idx) = target_collection
+                                    .fields
+                                    .iter()
+                                    .position(|f| f.name == filter_field)
+                                {
+                                    // Get the existing child mapping from the parent's mapping
+                                    if let Some(child_mapping) = mapping.child_at_mut(relation_field_index) {
+                                        // Add the filter field to child mapping if not present
+                                        if child_mapping.first_index_of_name(&filter_field).is_none() {
+                                            child_mapping.add(idx, &filter_field);
+                                            child_mapping.add_render_key(idx, &filter_field);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        continue; // Don't create a new join, just added filter fields to existing
+                    }
+
                     // Build a minimal child mapping for the aggregate
                     // For count, we just need to fetch the documents
                     // For sum/avg, we need the specific field
+                    // For any aggregate with filter, we need the filter fields
                     let mut child_mapping = DocumentMapping::new();
                     child_mapping.add(0, "_docID");
 
@@ -1587,16 +1768,32 @@ impl Planner {
                         }
                     }
 
+                    // Add fields referenced by the filter so they appear in the output
+                    // for post-processing filter evaluation
+                    if let Some(ref filter) = target.filter {
+                        for filter_field in filter.referenced_fields() {
+                            // Skip special fields
+                            if filter_field.starts_with('_') {
+                                continue;
+                            }
+                            // Find the field in the target collection
+                            if let Some(idx) = target_collection
+                                .fields
+                                .iter()
+                                .position(|f| f.name == filter_field)
+                            {
+                                // Add to child mapping if not already present
+                                if child_mapping.first_index_of_name(&filter_field).is_none() {
+                                    child_mapping.add(idx, &filter_field);
+                                    child_mapping.add_render_key(idx, &filter_field);
+                                }
+                            }
+                        }
+                    }
+
                     // Build scan mapping for the child
                     let child_scan_mapping =
                         self.build_scan_mapping_for_join(&target_collection, &child_mapping);
-
-                    // Get relation field index in parent collection
-                    let relation_field_index = parent_collection
-                        .fields
-                        .iter()
-                        .position(|f| f.name == *relation_field_name)
-                        .unwrap_or(0);
 
                     // Set up child mapping in parent for TypeJoin
                     mapping.set_child_at(relation_field_index, child_scan_mapping.clone());
@@ -1677,7 +1874,7 @@ impl Planner {
             }
         }
 
-        Ok(plan)
+        Ok((plan, mapping))
     }
 
     /// Build a scan mapping for join child plans that includes ALL fields at schema indices.
@@ -1737,6 +1934,27 @@ impl Planner {
                         // First render_key for this schema_index
                         mapping.add_render_key(schema_index, &render_key.key);
                         indices_with_render_keys.insert(schema_index);
+                    }
+                }
+            }
+        }
+
+        // Copy type_info from render_mapping if set (for __typename support)
+        // Also need to copy the __typename render_key since it's a virtual field not in schema
+        // IMPORTANT: Use collection.name as the type name, not the one from render_mapping,
+        // because nested selects have collection_name=field_name (e.g., "author") not the
+        // actual collection name (e.g., "Author")
+        if render_mapping.type_name().is_some() {
+            mapping.set_type_name(&collection.name);
+            // Find the __typename render_key in render_mapping and copy it
+            if let Some(typename_index) = mapping.first_index_of_name("__typename") {
+                for rk in &render_mapping.render_keys {
+                    // Find the render_key for __typename (key might be __typename or an alias)
+                    if let Some(field_name) = render_mapping.try_find_name_from_index(rk.index) {
+                        if field_name == "__typename" {
+                            mapping.add_render_key(typename_index, &rk.key);
+                            break;
+                        }
                     }
                 }
             }

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -736,9 +736,10 @@ impl Planner {
             if let Requestable::Aggregate(agg) = field {
                 // Skip relation and inline-array aggregates — they are computed
                 // in compute_relation_aggregates() after plan execution.
-                let is_host_aggregate = agg.targets.iter().any(|t| {
-                    !t.host_name.is_empty() && t.host_name != "_group"
-                });
+                let is_host_aggregate = agg
+                    .targets
+                    .iter()
+                    .any(|t| !t.host_name.is_empty() && t.host_name != "_group");
                 if is_host_aggregate {
                     continue;
                 }

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -1105,17 +1105,46 @@ impl Planner {
             )));
         }
 
+        // Collect all Select items to process, including those inside _group.
+        // Track the _group index for relation fields inside _group so we can update
+        // the _group child mapping with the correct relation field index later.
+        // Tuple: (select, _group_index if from inside _group)
+        let mut selects_to_process: Vec<(&Select, Option<usize>)> = Vec::new();
         for requestable in &select.fields {
             if let Requestable::Select(nested_select) = requestable {
-                let relation_field_name = &nested_select.field.name;
-
-                // Skip _group - it's a virtual field for groupBy results, not a relation
-                if relation_field_name == "_group" {
-                    continue;
+                if nested_select.field.name == "_group" {
+                    // Get the _group index in the parent mapping
+                    let group_index = mapping.first_index_of_name("_group");
+                    // _group is a virtual field - process its inner relation fields
+                    for inner_requestable in &nested_select.fields {
+                        if let Requestable::Select(inner_select) = inner_requestable {
+                            // Skip special fields
+                            if !inner_select.field.name.starts_with('_') {
+                                selects_to_process.push((inner_select, group_index));
+                            }
+                        }
+                    }
+                } else {
+                    selects_to_process.push((nested_select, None));
                 }
+            }
+        }
 
-                // Find the relation field in the parent collection
-                let relation_field = parent_collection
+        for (nested_select, group_index) in selects_to_process {
+            let relation_field_name = &nested_select.field.name;
+            let output_name = nested_select.field.output_name();
+
+            // Ensure the relation field is in the parent mapping.
+            // This is especially important for relation fields inside _group
+            // which aren't direct children of the select.
+            if mapping.first_index_of_name(relation_field_name).is_none() {
+                let index = mapping.next_index();
+                mapping.add(index, relation_field_name);
+                // Don't add render_key - for _group fields, rendering is handled by GroupByNode
+            }
+
+            // Find the relation field in the parent collection
+            let relation_field = parent_collection
                     .field_by_name(relation_field_name)
                     .ok_or_else(|| QueryError::unknown_field(relation_field_name))?;
 
@@ -1290,18 +1319,38 @@ impl Planner {
                 }
 
                 // Get the relation field index in the parent mapping.
-                // Use output_name (alias if set) to find the correct index.
-                // This ensures aliased fields like "p1: published" and "p2: published"
-                // get distinct indices and separate child mappings/filters.
-                let output_name = nested_select.field.output_name();
+                // First try by render_key (for aliased fields), then fall back to name lookup.
+                // The fallback handles relation fields inside _group which are added without render_keys.
                 let relation_field_index = mapping
                     .try_find_index_from_render_key(output_name)
+                    .or_else(|| mapping.first_index_of_name(relation_field_name))
                     .ok_or_else(|| {
                         QueryError::internal(format!(
                             "relation field '{}' (output name '{}') not in mapping",
                             relation_field_name, output_name
                         ))
                     })?;
+
+                // If this relation field is inside _group, update the _group child mapping
+                // to use the correct index for rendering. TypeJoinMany stores the relation
+                // data at relation_field_index, so the child mapping must use the same index.
+                if let Some(grp_idx) = group_index {
+                    if let Some(group_child_mapping) = mapping.child_at_mut(grp_idx) {
+                        // Update the child mapping: replace the dynamic index with relation_field_index
+                        // First, find and remove any existing entry for this field
+                        let old_index =
+                            group_child_mapping.first_index_of_name(relation_field_name);
+                        if let Some(old_idx) = old_index {
+                            // Remove old render_key with the wrong index
+                            group_child_mapping
+                                .render_keys
+                                .retain(|rk| rk.index != old_idx);
+                        }
+                        // Add with the correct index
+                        group_child_mapping.add(relation_field_index, relation_field_name);
+                        group_child_mapping.add_render_key(relation_field_index, output_name);
+                    }
+                }
 
                 // Set up child scan mapping in parent (for TypeJoin to render children).
                 // We use child_scan_mapping (not child_render_mapping) because child docs
@@ -1553,7 +1602,6 @@ impl Planner {
                     }
                     plan = Box::new(join);
                 }
-            }
         }
 
         // Handle relation filters without corresponding selections.
@@ -2730,6 +2778,15 @@ impl Planner {
                         let inner_child_mapping =
                             self.build_group_child_mapping(nested_select, collection)?;
                         child_mapping.set_child_at(index, inner_child_mapping);
+                    } else {
+                        // Relation field inside _group (e.g., published {...})
+                        // Add it to the child mapping so it can be rendered.
+                        // The actual index must match where TypeJoinMany will populate the data.
+                        // TypeJoinMany will use the parent mapping's index for this field.
+                        // We need to find or allocate an index for this relation field.
+                        let index = child_mapping.next_index();
+                        child_mapping.add(index, &nested_select.field.name);
+                        child_mapping.add_render_key(index, nested_select.field.output_name());
                     }
                 }
                 Requestable::Aggregate(_) => {

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -665,27 +665,27 @@ mod tests {
     }
 
     #[test]
-    fn test_cannot_use_index_ne() {
-        // _ne is not index-friendly
+    fn test_can_use_index_ne() {
+        // _ne uses full index scan (matching Go behavior)
         let filter = make_filter(HashMap::from([(
             "name".to_string(),
             json!({"_ne": "alice"}),
         )]));
         let index = single_field_index("name");
 
-        assert!(!can_use_index(&filter, &index));
+        assert!(can_use_index(&filter, &index));
     }
 
     #[test]
-    fn test_cannot_use_index_like() {
-        // _like is not always index-friendly
+    fn test_can_use_index_like() {
+        // _like uses full index scan (matching Go behavior)
         let filter = make_filter(HashMap::from([(
             "name".to_string(),
             json!({"_like": "%alice%"}),
         )]));
         let index = single_field_index("name");
 
-        assert!(!can_use_index(&filter, &index));
+        assert!(can_use_index(&filter, &index));
     }
 
     #[test]

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -468,6 +468,14 @@ pub fn filter_to_index_scan(
         .map(|(can_order, needs_reverse)| can_order && needs_reverse)
         .unwrap_or(false);
 
+    // For descending indexes, range bounds must be swapped because the encoding
+    // reverses the byte order: higher values have lower encoded bytes.
+    // e.g., _gt:30 on DESC index → upper_bound (not lower) in byte order.
+    let first_field_descending = index.fields.first().map(|f| f.descending).unwrap_or(false);
+    if first_field_descending {
+        std::mem::swap(&mut lower_bound, &mut upper_bound);
+    }
+
     // Determine scan type (narrowing scans take priority over full scans)
     let scan_type = if has_eq {
         IndexScanType::ExactMatch {

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -273,7 +273,9 @@ pub fn can_use_index(filter: &Filter, index: &IndexDescription) -> bool {
             return false;
         }
 
-        // Check if the operator is index-compatible
+        // Check if the operator is index-compatible.
+        // Go DefraDB uses indexes for _ne/_like too (full scan + matcher),
+        // not just narrowing operators. This matches Go's behavior.
         let base_op_compatible = matches!(
             cond.op,
             FilterOp::Eq
@@ -282,6 +284,11 @@ pub fn can_use_index(filter: &Filter, index: &IndexDescription) -> bool {
                 | FilterOp::Lt
                 | FilterOp::Lte
                 | FilterOp::In
+                | FilterOp::Ne
+                | FilterOp::Like
+                | FilterOp::Nlike
+                | FilterOp::Ilike
+                | FilterOp::Nilike
         );
 
         // For array operators, check if the combination is index-friendly
@@ -403,6 +410,7 @@ pub fn filter_to_index_scan(
     let mut eq_value = None;
     let mut has_in = false;
     let mut in_values = None;
+    let mut has_scan_all = false;
     let mut lower_bound = Bound::Unbounded;
     let mut upper_bound = Bound::Unbounded;
 
@@ -445,6 +453,11 @@ pub fn filter_to_index_scan(
                     upper_bound = Bound::Inclusive(v.clone());
                 }
             }
+            // _ne/_like use full index scan with post-filtering (matches Go behavior)
+            FilterOp::Ne | FilterOp::Like | FilterOp::Nlike | FilterOp::Ilike
+            | FilterOp::Nilike => {
+                has_scan_all = true;
+            }
             _ => {}
         }
     }
@@ -455,7 +468,7 @@ pub fn filter_to_index_scan(
         .map(|(can_order, needs_reverse)| can_order && needs_reverse)
         .unwrap_or(false);
 
-    // Determine scan type
+    // Determine scan type (narrowing scans take priority over full scans)
     let scan_type = if has_eq {
         IndexScanType::ExactMatch {
             values: vec![eq_value.unwrap()],
@@ -469,6 +482,12 @@ pub fn filter_to_index_scan(
             prefix_values: vec![],
             lower: lower_bound,
             upper: upper_bound,
+            reverse,
+        }
+    } else if has_scan_all {
+        // Full index scan with residual filter (for _ne, _like, etc.)
+        IndexScanType::PrefixScan {
+            prefix_values: vec![],
             reverse,
         }
     } else {

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -10,7 +10,7 @@ use schema::IndexDescription;
 use serde_json::Value as JsonValue;
 use storage::index::Bound;
 
-use crate::mapper::{Filter, FilterOp};
+use crate::mapper::{Filter, FilterOp, OrderBy, OrderDirection};
 
 /// Parameters for executing an index scan.
 #[derive(Debug, Clone)]
@@ -304,9 +304,70 @@ pub fn can_use_index(filter: &Filter, index: &IndexDescription) -> bool {
     })
 }
 
+/// Determine if an index can be used to satisfy the query ordering.
+///
+/// Returns a tuple of (can_use_index, needs_reverse):
+/// - `can_use_index`: true if the index can satisfy the ordering
+/// - `needs_reverse`: true if the index scan should be reversed
+///
+/// The index can satisfy ordering if:
+/// - All ORDER BY fields are covered by the first N fields of the index (in order)
+/// - Either all field directions match, OR all field directions are opposite
+///
+/// This matches Go DefraDB's `CanBeOrderedByIndex` behavior.
+pub fn can_be_ordered_by_index(order_by: &OrderBy, index: &IndexDescription) -> (bool, bool) {
+    if order_by.is_empty() || order_by.conditions.len() > index.fields.len() {
+        return (false, false);
+    }
+
+    let mut mismatch_count = 0;
+
+    for (i, condition) in order_by.conditions.iter().enumerate() {
+        // Only consider simple field ordering (not nested relation paths)
+        if condition.fields.len() != 1 {
+            return (false, false);
+        }
+
+        let order_field = &condition.fields[0];
+        let index_field = &index.fields[i];
+
+        // Field names must match in order
+        if order_field != &index_field.name {
+            return (false, false);
+        }
+
+        // Check direction match
+        let order_is_desc = condition.direction == OrderDirection::Desc;
+        if index_field.descending != order_is_desc {
+            mismatch_count += 1;
+        }
+    }
+
+    // Can use index if:
+    // - All directions match (mismatch_count == 0) → no reversal needed
+    // - All directions are opposite (mismatch_count == len) → reverse needed
+    let all_match = mismatch_count == 0;
+    let all_mismatch = mismatch_count == order_by.conditions.len();
+
+    if all_match {
+        (true, false)
+    } else if all_mismatch {
+        (true, true)
+    } else {
+        (false, false)
+    }
+}
+
 /// Convert a filter to index scan parameters.
 ///
 /// Returns None if the filter cannot use the index efficiently.
+///
+/// # Ordering Support
+///
+/// If `order_by` is provided, the scan direction will be set based on whether
+/// the index can satisfy the ordering:
+/// - If ordering matches index direction: forward scan
+/// - If ordering is opposite of index direction: reverse scan
 ///
 /// # Array Field Support
 ///
@@ -314,7 +375,11 @@ pub fn can_use_index(filter: &Filter, index: &IndexDescription) -> bool {
 /// by the inner operator. For example:
 /// - `{numbers: {_any: {_eq: 30}}}` → ExactMatch{values: [30]}
 /// - `{tags: {_any: {_in: ["red", "blue"]}}}` → InScan{values: ["red", "blue"]}
-pub fn filter_to_index_scan(filter: &Filter, index: &IndexDescription) -> Option<IndexScanParams> {
+pub fn filter_to_index_scan(
+    filter: &Filter,
+    index: &IndexDescription,
+    order_by: Option<&OrderBy>,
+) -> Option<IndexScanParams> {
     if !can_use_index(filter, index) {
         return None;
     }
@@ -384,6 +449,12 @@ pub fn filter_to_index_scan(filter: &Filter, index: &IndexDescription) -> Option
         }
     }
 
+    // Determine if we need to reverse the scan based on ordering
+    let reverse = order_by
+        .map(|o| can_be_ordered_by_index(o, index))
+        .map(|(can_order, needs_reverse)| can_order && needs_reverse)
+        .unwrap_or(false);
+
     // Determine scan type
     let scan_type = if has_eq {
         IndexScanType::ExactMatch {
@@ -398,7 +469,7 @@ pub fn filter_to_index_scan(filter: &Filter, index: &IndexDescription) -> Option
             prefix_values: vec![],
             lower: lower_bound,
             upper: upper_bound,
-            reverse: false,
+            reverse,
         }
     } else {
         return None;
@@ -598,7 +669,7 @@ mod tests {
         )]));
         let index = single_field_index("name");
 
-        let params = filter_to_index_scan(&filter, &index).unwrap();
+        let params = filter_to_index_scan(&filter, &index, None).unwrap();
         assert_eq!(params.index_name, "name_idx");
 
         match params.scan_type {
@@ -618,7 +689,7 @@ mod tests {
         )]));
         let index = single_field_index("status");
 
-        let params = filter_to_index_scan(&filter, &index).unwrap();
+        let params = filter_to_index_scan(&filter, &index, None).unwrap();
 
         match params.scan_type {
             IndexScanType::InScan { values } => {
@@ -636,7 +707,7 @@ mod tests {
         )]));
         let index = single_field_index("age");
 
-        let params = filter_to_index_scan(&filter, &index).unwrap();
+        let params = filter_to_index_scan(&filter, &index, None).unwrap();
 
         match params.scan_type {
             IndexScanType::RangeScan {
@@ -823,7 +894,7 @@ mod tests {
         )]));
         let index = single_field_index("numbers");
 
-        let params = filter_to_index_scan(&filter, &index).unwrap();
+        let params = filter_to_index_scan(&filter, &index, None).unwrap();
         assert_eq!(params.index_name, "numbers_idx");
 
         match params.scan_type {

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -192,7 +192,7 @@ pub fn parse_query_with_variables(
     query: &str,
     variables: Option<&HashMap<String, JsonValue>>,
 ) -> Result<Vec<Select>> {
-    match parse_request_with_variables(query, variables)? {
+    match parse_request_with_variables(query, variables, None)? {
         ParsedOperation::Query { selects, .. } => Ok(selects),
         ParsedOperation::Mutation(_) => Err(QueryError::parse(
             "Expected query but got mutation. Use parse_mutations_with_variables() for mutations.",
@@ -217,7 +217,7 @@ pub fn parse_mutations_with_variables(
     query: &str,
     variables: Option<&HashMap<String, JsonValue>>,
 ) -> Result<Vec<Mutation>> {
-    match parse_request_with_variables(query, variables)? {
+    match parse_request_with_variables(query, variables, None)? {
         ParsedOperation::Mutation(mutations) => Ok(mutations),
         ParsedOperation::Query { .. } => Err(QueryError::parse("Expected mutation but got query")),
         ParsedOperation::Subscription { .. } => {
@@ -234,7 +234,7 @@ pub fn parse_mutations_with_variables(
 /// This is the main entry point for parsing GraphQL requests.
 /// For queries with variables, use `parse_request_with_variables` instead.
 pub fn parse_request(query: &str) -> Result<ParsedOperation> {
-    parse_request_with_variables(query, None)
+    parse_request_with_variables(query, None, None)
 }
 
 /// Parse a GraphQL request with variable substitution.
@@ -279,6 +279,7 @@ fn is_introspection_query(doc: &Document<'_, String>) -> bool {
 pub fn parse_request_with_variables(
     query: &str,
     variables: Option<&HashMap<String, JsonValue>>,
+    operation_name: Option<&str>,
 ) -> Result<ParsedOperation> {
     let doc: Document<'_, String> =
         graphql_parser::parse_query(query).map_err(|e| QueryError::parse(e.to_string()))?;
@@ -299,6 +300,18 @@ pub fn parse_request_with_variables(
         }
     }
 
+    // Count operations (not fragments) to validate operation_name
+    let operation_count = doc
+        .definitions
+        .iter()
+        .filter(|d| matches!(d, Definition::Operation(_)))
+        .count();
+    if operation_count > 1 && operation_name.is_none() {
+        return Err(QueryError::parse(
+            "Must provide operation name if query contains multiple operations.",
+        ));
+    }
+
     let mut selects = Vec::new();
     let mut mutations = Vec::new();
     let mut subscription_selects = Vec::new();
@@ -311,6 +324,19 @@ pub fn parse_request_with_variables(
     for def in &doc.definitions {
         match def {
             Definition::Operation(op) => {
+                // If operation_name is specified, skip operations that don't match
+                if let Some(target_name) = operation_name {
+                    let op_name = match op {
+                        OperationDefinition::Query(q) => q.name.as_deref(),
+                        OperationDefinition::Mutation(m) => m.name.as_deref(),
+                        OperationDefinition::Subscription(s) => s.name.as_deref(),
+                        OperationDefinition::SelectionSet(_) => None,
+                    };
+                    if op_name != Some(target_name) {
+                        continue;
+                    }
+                }
+
                 match op {
                     OperationDefinition::Query(q) => {
                         has_query = true;
@@ -459,6 +485,23 @@ fn parse_field_to_select(
             "filter" => {
                 // Null filter is valid and means "no filter" (operate on all docs)
                 if !matches!(arg_value, Value::Null) {
+                    // Validate _and/_or arrays don't contain null elements
+                    if let Value::Object(obj) = arg_value {
+                        for (key, val) in obj {
+                            if key == "_and" || key == "_or" {
+                                if let Value::List(items) = val {
+                                    for item in items {
+                                        if matches!(item, Value::Null) {
+                                            return Err(QueryError::parse(format!(
+                                                "Expected \"{}FilterArg!\", found null",
+                                                collection_name
+                                            )));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                     let filter = parse_filter_value(arg_value, variables)?;
                     select.filter = Some(filter);
                 }
@@ -725,6 +768,24 @@ fn parse_filter_value(
             let conditions = parse_filter_object(obj, variables)?;
             Ok(Filter::from_conditions(conditions))
         }
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            let json_val = vars.get(name.as_str()).ok_or_else(|| {
+                QueryError::parse(format!("Variable \"${}\" was not provided", name))
+            })?;
+            if let JsonValue::Object(obj) = json_val {
+                let conditions: HashMap<String, JsonValue> =
+                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                Ok(Filter::from_conditions(conditions))
+            } else {
+                Err(QueryError::parse("filter must be an object"))
+            }
+        }
         _ => Err(QueryError::parse("filter must be an object")),
     }
 }
@@ -947,6 +1008,11 @@ fn parse_order_value(
             // Array of order objects: [{rating: ASC}, {publisher: {yearOpened: DESC}}]
             for item in items {
                 if let Value::Object(obj) = item {
+                    if obj.len() > 1 {
+                        return Err(QueryError::parse(
+                            "each order argument can only define one field",
+                        ));
+                    }
                     for (field_name, direction_val) in obj {
                         if let Some(condition) =
                             parse_order_condition(field_name.clone(), direction_val, variables)?
@@ -2207,7 +2273,7 @@ mod variable_tests {
 
         let variables = HashMap::from([("name".to_string(), json!("Alice"))]);
 
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects.len(), 1);
@@ -2232,7 +2298,7 @@ mod variable_tests {
 
         let variables = HashMap::from([("lim".to_string(), json!(10))]);
 
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(10));
@@ -2254,7 +2320,7 @@ mod variable_tests {
 
         let variables = HashMap::from([("ids".to_string(), json!(["bae-123", "bae-456"]))]);
 
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 assert_eq!(
@@ -2281,7 +2347,7 @@ mod variable_tests {
             ("userAge".to_string(), json!(25)),
         ]);
 
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Mutation(mutations) => {
                 assert_eq!(mutations.len(), 1);
@@ -2305,7 +2371,7 @@ mod variable_tests {
 
         let variables = HashMap::from([("id".to_string(), json!("bae-999"))]);
 
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Mutation(mutations) => {
                 assert_eq!(mutations[0].doc_ids, Some(vec!["bae-999".to_string()]));
@@ -2325,7 +2391,7 @@ mod variable_tests {
         "#;
 
         let variables = HashMap::new();
-        let result = parse_request_with_variables(query, Some(&variables));
+        let result = parse_request_with_variables(query, Some(&variables), None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("was not provided"));
     }
@@ -2340,7 +2406,7 @@ mod variable_tests {
             }
         "#;
 
-        let result = parse_request_with_variables(query, None);
+        let result = parse_request_with_variables(query, None, None);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -2360,7 +2426,7 @@ mod variable_tests {
         "#;
 
         // No variables provided
-        let result = parse_request_with_variables(query, None).unwrap();
+        let result = parse_request_with_variables(query, None, None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects.len(), 1);
@@ -2385,7 +2451,7 @@ mod variable_tests {
 
         // Provide string instead of int
         let variables = HashMap::from([("lim".to_string(), json!("not an int"))]);
-        let result = parse_request_with_variables(query, Some(&variables));
+        let result = parse_request_with_variables(query, Some(&variables), None);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -2411,7 +2477,7 @@ mod variable_tests {
             ("lim".to_string(), json!(5)),
         ]);
 
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(5));
@@ -2443,7 +2509,7 @@ mod variable_tests {
 
         // Provide string instead of bool
         let variables = HashMap::from([("deleted".to_string(), json!("true"))]);
-        let result = parse_request_with_variables(query, Some(&variables));
+        let result = parse_request_with_variables(query, Some(&variables), None);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -2463,7 +2529,7 @@ mod variable_tests {
 
         // Provide integer instead of string
         let variables = HashMap::from([("c".to_string(), json!(12345))]);
-        let result = parse_request_with_variables(query, Some(&variables));
+        let result = parse_request_with_variables(query, Some(&variables), None);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -2483,7 +2549,7 @@ mod variable_tests {
         "#;
 
         let variables = HashMap::from([("dir".to_string(), json!("DESC"))]);
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 let order = selects[0].order_by.as_ref().unwrap();
@@ -2507,7 +2573,7 @@ mod variable_tests {
         "#;
 
         let variables = HashMap::from([("dir".to_string(), json!("INVALID"))]);
-        let result = parse_request_with_variables(query, Some(&variables));
+        let result = parse_request_with_variables(query, Some(&variables), None);
         assert!(result.is_err());
         // Error format matches Go DefraDB
         assert!(result
@@ -2532,7 +2598,7 @@ mod variable_tests {
         "#;
 
         // Don't provide the variable - should use default
-        let result = parse_request_with_variables(query, None).unwrap();
+        let result = parse_request_with_variables(query, None, None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 let filter = selects[0].filter.as_ref().unwrap();
@@ -2559,7 +2625,7 @@ mod variable_tests {
 
         // Provide a value - should override default
         let variables = HashMap::from([("name".to_string(), json!("ProvidedName"))]);
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 let filter = selects[0].filter.as_ref().unwrap();
@@ -2584,7 +2650,7 @@ mod variable_tests {
         "#;
 
         // Don't provide the variable - should use default 50
-        let result = parse_request_with_variables(query, None).unwrap();
+        let result = parse_request_with_variables(query, None, None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(50));
@@ -2604,7 +2670,7 @@ mod variable_tests {
         "#;
 
         // Don't provide the variable - should use default true
-        let result = parse_request_with_variables(query, None).unwrap();
+        let result = parse_request_with_variables(query, None, None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 assert!(selects[0].show_deleted);
@@ -2626,7 +2692,7 @@ mod variable_tests {
 
         // Only provide $name, use defaults for $minAge and $lim
         let variables = HashMap::from([("name".to_string(), json!("Alice"))]);
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 assert_eq!(selects[0].limit.as_ref().unwrap().limit, Some(10));
@@ -2653,7 +2719,7 @@ mod variable_tests {
         "#;
 
         // Don't provide the variable - should use default
-        let result = parse_request_with_variables(query, None).unwrap();
+        let result = parse_request_with_variables(query, None, None).unwrap();
         match result {
             ParsedOperation::Mutation(mutations) => {
                 let input = &mutations[0].create_input;
@@ -2674,7 +2740,7 @@ mod variable_tests {
         "#;
 
         // Don't provide the variable - should use default array
-        let result = parse_request_with_variables(query, None).unwrap();
+        let result = parse_request_with_variables(query, None, None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 let doc_ids = selects[0].doc_ids.as_ref().unwrap();
@@ -2697,7 +2763,7 @@ mod variable_tests {
         "#;
 
         // Don't provide the variable - should use default null
-        let result = parse_request_with_variables(query, None).unwrap();
+        let result = parse_request_with_variables(query, None, None).unwrap();
         match result {
             ParsedOperation::Query { selects, .. } => {
                 let filter = selects[0].filter.as_ref().unwrap();
@@ -2723,7 +2789,7 @@ mod variable_tests {
             }
         "#;
 
-        let result = parse_request_with_variables(query, None);
+        let result = parse_request_with_variables(query, None, None);
         // graphql-parser rejects this at the parse level since variable references
         // aren't allowed in default value position per the GraphQL spec
         assert!(
@@ -2793,7 +2859,7 @@ mod subscription_tests {
         "#;
 
         let variables = HashMap::from([("active".to_string(), serde_json::json!(true))]);
-        let result = parse_request_with_variables(query, Some(&variables)).unwrap();
+        let result = parse_request_with_variables(query, Some(&variables), None).unwrap();
         match result {
             ParsedOperation::Subscription { select } => {
                 assert_eq!(select.collection_name, "User");
@@ -2914,7 +2980,7 @@ mod subscription_tests {
         "#;
 
         // Don't provide the variable - should use default
-        let result = parse_request_with_variables(query, None).unwrap();
+        let result = parse_request_with_variables(query, None, None).unwrap();
         match result {
             ParsedOperation::Subscription { select } => {
                 assert_eq!(select.limit.as_ref().unwrap().limit, Some(10));

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -200,6 +200,9 @@ pub fn parse_query_with_variables(
         ParsedOperation::Subscription { .. } => Err(QueryError::parse(
             "Expected query but got subscription.",
         )),
+        ParsedOperation::Introspection { .. } => Err(QueryError::parse(
+            "Expected query but got introspection.",
+        )),
     }
 }
 

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -185,9 +185,9 @@ pub fn parse_query_with_variables(
         ParsedOperation::Mutation(_) => Err(QueryError::parse(
             "Expected query but got mutation. Use parse_mutations_with_variables() for mutations.",
         )),
-        ParsedOperation::Subscription { .. } => Err(QueryError::parse(
-            "Expected query but got subscription.",
-        )),
+        ParsedOperation::Subscription { .. } => {
+            Err(QueryError::parse("Expected query but got subscription."))
+        }
     }
 }
 

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -961,9 +961,54 @@ fn parse_order_value(
                 }
             }
         }
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            let json_val = vars.get(name).ok_or_else(|| {
+                QueryError::parse(format!("Variable \"${}\" was not provided", name))
+            })?;
+            return parse_order_from_json(json_val);
+        }
         _ => return Err(QueryError::parse("order must be an object or array")),
     }
 
+    Ok(order_by)
+}
+
+/// Parse order from a resolved JSON variable value.
+fn parse_order_from_json(json: &JsonValue) -> Result<OrderBy> {
+    let mut order_by = OrderBy::new();
+    match json {
+        JsonValue::Object(obj) => {
+            for (field_name, dir_val) in obj {
+                if let Some(dir_str) = dir_val.as_str() {
+                    if let Some(direction) = OrderDirection::parse(dir_str) {
+                        order_by = order_by.with_condition(OrderCondition::new(field_name, direction));
+                    }
+                }
+            }
+        }
+        JsonValue::Array(items) => {
+            for item in items {
+                if let JsonValue::Object(obj) = item {
+                    for (field_name, dir_val) in obj {
+                        if let Some(dir_str) = dir_val.as_str() {
+                            if let Some(direction) = OrderDirection::parse(dir_str) {
+                                order_by = order_by.with_condition(OrderCondition::new(
+                                    field_name, direction,
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        _ => return Err(QueryError::parse("order variable must be an object or array")),
+    }
     Ok(order_by)
 }
 
@@ -1107,6 +1152,108 @@ fn parse_group_by_value(
     }
 }
 
+/// Parse an aggregate target from a GraphQL Object value.
+fn parse_aggregate_target_obj(
+    arg_name: &str,
+    obj: &BTreeMap<String, Value<'_, String>>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<AggregateTarget> {
+    let mut target = AggregateTarget::new(arg_name.to_string());
+    for (key, val) in obj {
+        match key.as_str() {
+            "field" => {
+                let field_name = match val {
+                    Value::String(s) => s.clone(),
+                    Value::Enum(s) => s.clone(),
+                    _ => {
+                        return Err(QueryError::parse(
+                            "field in relation aggregate must be a string",
+                        ))
+                    }
+                };
+                target.field_name = Some(field_name);
+            }
+            "filter" => {
+                let filter = parse_filter_value(val, variables)?;
+                target.filter = Some(filter);
+            }
+            "limit" => {
+                let limit_val = parse_int_value(val, variables)?;
+                target.limit = Some(Limit::new(Some(limit_val as u64), 0));
+            }
+            "offset" => {
+                let offset_val = parse_int_value(val, variables)?;
+                if let Some(ref mut limit) = target.limit {
+                    limit.offset = offset_val as u64;
+                } else {
+                    target.limit = Some(Limit::new(None, offset_val as u64));
+                }
+            }
+            "order" => {
+                let order = match val {
+                    Value::Enum(s) | Value::String(s) => {
+                        let direction = OrderDirection::parse(s).ok_or_else(|| {
+                            QueryError::parse(format!("invalid order direction: {}", s))
+                        })?;
+                        OrderBy::new().with_condition(OrderCondition::new("", direction))
+                    }
+                    _ => parse_order_value(val, variables)?,
+                };
+                target.order = Some(order);
+            }
+            _ => {}
+        }
+    }
+    Ok(target)
+}
+
+/// Parse an aggregate target from a resolved JSON variable value.
+fn parse_aggregate_target_from_json(
+    arg_name: &str,
+    json: &JsonValue,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<AggregateTarget> {
+    let mut target = AggregateTarget::new(arg_name.to_string());
+    if let JsonValue::Object(obj) = json {
+        for (key, val) in obj {
+            match key.as_str() {
+                "field" => {
+                    if let Some(s) = val.as_str() {
+                        target.field_name = Some(s.to_string());
+                    }
+                }
+                "filter" => {
+                    // Convert JSON filter to a Filter
+                    if let JsonValue::Object(filter_obj) = val {
+                        let conditions: HashMap<String, JsonValue> =
+                            filter_obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                        target.filter = Some(Filter::from_conditions(conditions));
+                    }
+                }
+                "limit" => {
+                    if let Some(n) = val.as_i64() {
+                        target.limit = Some(Limit::new(Some(n as u64), 0));
+                    }
+                }
+                "offset" => {
+                    if let Some(n) = val.as_i64() {
+                        if let Some(ref mut limit) = target.limit {
+                            limit.offset = n as u64;
+                        } else {
+                            target.limit = Some(Limit::new(None, n as u64));
+                        }
+                    }
+                }
+                "order" => {
+                    target.order = Some(parse_order_from_json(val)?);
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(target)
+}
+
 /// Parse an aggregate field into an Aggregate.
 ///
 /// Handles aggregate functions like `_count`, `_sum(field: "age")`, etc.
@@ -1151,79 +1298,37 @@ fn parse_aggregate_field(
             }
             _ => {
                 // This might be a relation name argument like `books: {field: score}`
-                // Relation arguments take an object value with optional field, filter, limit, order
-                if let Value::Object(obj) = arg_value {
-                    let relation_name = arg_name.clone();
-                    let mut target = AggregateTarget::new(relation_name);
-
-                    // Parse the object to extract field, filter, limit, order
-                    for (key, val) in obj {
-                        match key.as_str() {
-                            "field" => {
-                                let field_name = match val {
-                                    Value::String(s) => s.clone(),
-                                    Value::Enum(s) => s.clone(),
-                                    _ => {
-                                        return Err(QueryError::parse(
-                                            "field in relation aggregate must be a string",
-                                        ))
-                                    }
-                                };
-                                target.field_name = Some(field_name);
-                            }
-                            "filter" => {
-                                // Parse filter condition
-                                let filter = parse_filter_value(val, variables)?;
-                                target.filter = Some(filter);
-                            }
-                            "limit" => {
-                                let limit_val = parse_int_value(val, variables)?;
-                                target.limit = Some(Limit::new(Some(limit_val as u64), 0));
-                            }
-                            "offset" => {
-                                // Offset is combined with limit
-                                let offset_val = parse_int_value(val, variables)?;
-                                if let Some(ref mut limit) = target.limit {
-                                    limit.offset = offset_val as u64;
-                                } else {
-                                    target.limit = Some(Limit::new(None, offset_val as u64));
-                                }
-                            }
-                            "order" => {
-                                // For inline array aggregates, order can be a bare
-                                // direction enum (e.g., `order: ASC`) rather than
-                                // the structured `order: {field: ASC}` used by queries.
-                                let order = match val {
-                                    Value::Enum(s) | Value::String(s) => {
-                                        let direction =
-                                            OrderDirection::parse(s).ok_or_else(|| {
-                                                QueryError::parse(format!(
-                                                    "invalid order direction: {}",
-                                                    s
-                                                ))
-                                            })?;
-                                        OrderBy::new().with_condition(OrderCondition::new(
-                                            "",
-                                            direction,
-                                        ))
-                                    }
-                                    _ => parse_order_value(val, variables)?,
-                                };
-                                target.order = Some(order);
-                            }
-                            _ => {
-                                // Unknown key in relation aggregate - ignore for compatibility
-                            }
-                        }
+                // Relation arguments take an object value with optional field, filter, limit, order.
+                // Also handle variables that resolve to objects.
+                match arg_value {
+                    Value::Object(obj) => {
+                        let target = parse_aggregate_target_obj(arg_name, obj, variables)?;
+                        relation_targets.push(target);
                     }
-
-                    relation_targets.push(target);
-                } else {
-                    return Err(QueryError::parse(format!(
-                        "unknown argument '{}' on aggregate '{}', expected an object value for relation aggregates",
-                        arg_name,
-                        agg_type.as_str()
-                    )));
+                    Value::Variable(name) => {
+                        let vars = variables.ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "variable '{}' used but no variables provided",
+                                name
+                            ))
+                        })?;
+                        let json_val = vars.get(name).ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "Variable \"${}\" was not provided",
+                                name
+                            ))
+                        })?;
+                        let target =
+                            parse_aggregate_target_from_json(arg_name, json_val, variables)?;
+                        relation_targets.push(target);
+                    }
+                    _ => {
+                        return Err(QueryError::parse(format!(
+                            "unknown argument '{}' on aggregate '{}', expected an object value for relation aggregates",
+                            arg_name,
+                            agg_type.as_str()
+                        )));
+                    }
                 }
             }
         }
@@ -1291,6 +1396,25 @@ fn parse_top_level_aggregate(
     variables: Option<&HashMap<String, JsonValue>>,
 ) -> Result<Select> {
     let mut aggregate = parse_aggregate_field(field, agg_type, variables)?;
+
+    // Top-level numeric aggregates require a field argument on each target.
+    // This matches Go's GraphQL schema validation where collection args require
+    // the "field" key (e.g., _avg(Users: {field: Age}) not _avg(Users: {})).
+    if agg_type != AggregateType::Count {
+        for target in &aggregate.targets {
+            if target.field_name.is_none() {
+                let type_name = format!(
+                    "{}NumericFieldsArg!",
+                    capitalize_first(&target.host_name)
+                );
+                return Err(QueryError::parse(format!(
+                    "Argument \"{}\" has invalid value {{}}.\nIn field \"field\": Expected \"{}\", found null.",
+                    target.host_name,
+                    type_name
+                )));
+            }
+        }
+    }
 
     // Set alias if provided
     if let Some(ref a) = field.alias {
@@ -1704,6 +1828,15 @@ fn parse_document_input(
         fields.insert(key.clone(), json_value);
     }
     Ok(fields)
+}
+
+/// Capitalize the first character of a string.
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -1155,10 +1155,8 @@ fn parse_aggregate_field(
                                                     s
                                                 ))
                                             })?;
-                                        OrderBy::new().with_condition(OrderCondition::new(
-                                            "",
-                                            direction,
-                                        ))
+                                        OrderBy::new()
+                                            .with_condition(OrderCondition::new("", direction))
                                     }
                                     _ => parse_order_value(val, variables)?,
                                 };

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -172,11 +172,40 @@ pub fn parse_query(query: &str) -> Result<Vec<Select>> {
     }
 }
 
+/// Parse a GraphQL query string with variable substitution.
+///
+/// Returns a vector of Select operations, one for each top-level field in the query.
+/// For mutations, use `parse_mutations_with_variables` instead.
+pub fn parse_query_with_variables(
+    query: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Vec<Select>> {
+    match parse_request_with_variables(query, variables)? {
+        ParsedOperation::Query { selects, .. } => Ok(selects),
+        ParsedOperation::Mutation(_) => Err(QueryError::parse(
+            "Expected query but got mutation. Use parse_mutations_with_variables() for mutations.",
+        )),
+        ParsedOperation::Subscription { .. } => Err(QueryError::parse(
+            "Expected query but got subscription.",
+        )),
+    }
+}
+
 /// Parse a GraphQL mutation string into Mutation operations.
 ///
 /// Returns a vector of Mutation operations, one for each top-level field in the mutation.
 pub fn parse_mutations(query: &str) -> Result<Vec<Mutation>> {
-    match parse_request(query)? {
+    parse_mutations_with_variables(query, None)
+}
+
+/// Parse a GraphQL mutation string with variable substitution.
+///
+/// Returns a vector of Mutation operations, one for each top-level field in the mutation.
+pub fn parse_mutations_with_variables(
+    query: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Vec<Mutation>> {
+    match parse_request_with_variables(query, variables)? {
         ParsedOperation::Mutation(mutations) => Ok(mutations),
         ParsedOperation::Query { .. } => Err(QueryError::parse("Expected mutation but got query")),
         ParsedOperation::Subscription { .. } => {

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -184,11 +184,40 @@ pub fn parse_query(query: &str) -> Result<Vec<Select>> {
     }
 }
 
+/// Parse a GraphQL query string with variable substitution.
+///
+/// Returns a vector of Select operations, one for each top-level field in the query.
+/// For mutations, use `parse_mutations_with_variables` instead.
+pub fn parse_query_with_variables(
+    query: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Vec<Select>> {
+    match parse_request_with_variables(query, variables)? {
+        ParsedOperation::Query { selects, .. } => Ok(selects),
+        ParsedOperation::Mutation(_) => Err(QueryError::parse(
+            "Expected query but got mutation. Use parse_mutations_with_variables() for mutations.",
+        )),
+        ParsedOperation::Subscription { .. } => Err(QueryError::parse(
+            "Expected query but got subscription.",
+        )),
+    }
+}
+
 /// Parse a GraphQL mutation string into Mutation operations.
 ///
 /// Returns a vector of Mutation operations, one for each top-level field in the mutation.
 pub fn parse_mutations(query: &str) -> Result<Vec<Mutation>> {
-    match parse_request(query)? {
+    parse_mutations_with_variables(query, None)
+}
+
+/// Parse a GraphQL mutation string with variable substitution.
+///
+/// Returns a vector of Mutation operations, one for each top-level field in the mutation.
+pub fn parse_mutations_with_variables(
+    query: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Vec<Mutation>> {
+    match parse_request_with_variables(query, variables)? {
         ParsedOperation::Mutation(mutations) => Ok(mutations),
         ParsedOperation::Query { .. } => Err(QueryError::parse("Expected mutation but got query")),
         ParsedOperation::Subscription { .. } => {

--- a/crates/query/src/query_parse.rs
+++ b/crates/query/src/query_parse.rs
@@ -611,6 +611,29 @@ fn parse_field_to_select(
     select.fields = fields;
     select.document_mapping = mapping;
 
+    // Validate groupBy field selection: when groupBy is specified, only group-by fields,
+    // their FK counterparts (e.g. _authorID for groupBy [author]), and aggregate fields
+    // are allowed at the group level (nested selects like _group are fine).
+    if let Some(ref group_by) = select.group_by {
+        for field in &select.fields {
+            if let Requestable::Field(f) = field {
+                if group_by.fields.contains(&f.name) {
+                    continue;
+                }
+                // Allow FK fields for relation groupBy fields (e.g. _authorID for author)
+                let is_fk_for_group = group_by.fields.iter().any(|gb_field| {
+                    f.name == format!("_{}ID", gb_field)
+                });
+                if is_fk_for_group {
+                    continue;
+                }
+                return Err(QueryError::parse(
+                    "cannot select a non-group-by field at group-level",
+                ));
+            }
+        }
+    }
+
     Ok(select)
 }
 

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -49,21 +49,34 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         let identity = self.resolve_identity(request.identity);
 
         // Route to appropriate handler based on operation type
-        // Pass identity through for ACP permission checks
+        // Pass identity and variables through for ACP permission checks and variable substitution
         let result = match parsed {
             ParsedOperation::Query { explain, .. } => {
                 if let Some(explain_type) = explain {
                     // Return query plan instead of executing
-                    self.explain_query_with_identity(&request.query, identity, explain_type)
-                        .await
+                    self.explain_query_with_identity_and_vars(
+                        &request.query,
+                        identity,
+                        explain_type,
+                        variables.as_ref(),
+                    )
+                    .await
                 } else {
-                    self.execute_query_with_identity(&request.query, identity)
-                        .await
+                    self.execute_query_with_identity_and_vars(
+                        &request.query,
+                        identity,
+                        variables.as_ref(),
+                    )
+                    .await
                 }
             }
             ParsedOperation::Mutation(_) => {
-                self.execute_mutation_with_identity(&request.query, identity)
-                    .await
+                self.execute_mutation_with_identity_and_vars(
+                    &request.query,
+                    identity,
+                    variables.as_ref(),
+                )
+                .await
             }
             ParsedOperation::Subscription { .. } => {
                 // Subscriptions require SSE transport - they cannot be executed via regular request/response
@@ -147,11 +160,21 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                 let fetcher = txn_ctx.doc_fetcher();
                 if let Some(explain_type) = explain {
                     // Return query plan instead of executing
-                    self.explain_query_with_identity(&request.query, identity, explain_type)
-                        .await
+                    self.explain_query_with_identity_and_vars(
+                        &request.query,
+                        identity,
+                        explain_type,
+                        variables.as_ref(),
+                    )
+                    .await
                 } else {
-                    self.execute_query_internal(&request.query, fetcher.as_ref(), identity)
-                        .await
+                    self.execute_query_internal_with_vars(
+                        &request.query,
+                        fetcher.as_ref(),
+                        identity,
+                        variables.as_ref(),
+                    )
+                    .await
                 }
             }
             ParsedOperation::Mutation(_) => {
@@ -172,8 +195,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                     }
                 };
 
-                self.execute_mutation_internal(&request.query, mutator, identity)
-                    .await
+                self.execute_mutation_internal_with_vars(
+                    &request.query,
+                    mutator,
+                    identity,
+                    variables.as_ref(),
+                )
+                .await
             }
             ParsedOperation::Subscription { .. } => {
                 // Subscriptions require SSE transport

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -49,21 +49,34 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         let identity = self.resolve_identity(request.identity);
 
         // Route to appropriate handler based on operation type
-        // Pass identity through for ACP permission checks
+        // Pass identity and variables through for ACP permission checks and variable substitution
         let result = match parsed {
             ParsedOperation::Query { explain, .. } => {
                 if let Some(explain_type) = explain {
                     // Return query plan instead of executing
-                    self.explain_query_with_identity(&request.query, identity, explain_type)
-                        .await
+                    self.explain_query_with_identity_and_vars(
+                        &request.query,
+                        identity,
+                        explain_type,
+                        variables.as_ref(),
+                    )
+                    .await
                 } else {
-                    self.execute_query_with_identity(&request.query, identity)
-                        .await
+                    self.execute_query_with_identity_and_vars(
+                        &request.query,
+                        identity,
+                        variables.as_ref(),
+                    )
+                    .await
                 }
             }
             ParsedOperation::Mutation(_) => {
-                self.execute_mutation_with_identity(&request.query, identity)
-                    .await
+                self.execute_mutation_with_identity_and_vars(
+                    &request.query,
+                    identity,
+                    variables.as_ref(),
+                )
+                .await
             }
             ParsedOperation::Subscription { .. } => {
                 // Subscriptions require SSE transport - they cannot be executed via regular request/response
@@ -151,11 +164,21 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                 let fetcher = txn_ctx.doc_fetcher();
                 if let Some(explain_type) = explain {
                     // Return query plan instead of executing
-                    self.explain_query_with_identity(&request.query, identity, explain_type)
-                        .await
+                    self.explain_query_with_identity_and_vars(
+                        &request.query,
+                        identity,
+                        explain_type,
+                        variables.as_ref(),
+                    )
+                    .await
                 } else {
-                    self.execute_query_internal(&request.query, fetcher.as_ref(), identity)
-                        .await
+                    self.execute_query_internal_with_vars(
+                        &request.query,
+                        fetcher.as_ref(),
+                        identity,
+                        variables.as_ref(),
+                    )
+                    .await
                 }
             }
             ParsedOperation::Mutation(_) => {
@@ -176,8 +199,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                     }
                 };
 
-                self.execute_mutation_internal(&request.query, mutator, identity)
-                    .await
+                self.execute_mutation_internal_with_vars(
+                    &request.query,
+                    mutator,
+                    identity,
+                    variables.as_ref(),
+                )
+                .await
             }
             ParsedOperation::Subscription { .. } => {
                 // Subscriptions require SSE transport

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -31,7 +31,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         let variables = convert_variables(&request.variables);
 
         // First, parse the request to determine if it's a query or mutation
-        let parsed = match parse_request_with_variables(&request.query, variables.as_ref()) {
+        let parsed = match parse_request_with_variables(
+            &request.query,
+            variables.as_ref(),
+            request.operation_name.as_deref(),
+        ) {
             Ok(p) => p,
             Err(e) => {
                 return QueryResponse {
@@ -51,7 +55,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         // Route to appropriate handler based on operation type
         // Pass identity and variables through for ACP permission checks and variable substitution
         let result = match parsed {
-            ParsedOperation::Query { explain, .. } => {
+            ParsedOperation::Query { selects, explain } => {
                 if let Some(explain_type) = explain {
                     // Return query plan instead of executing
                     self.explain_query_with_identity_and_vars(
@@ -62,10 +66,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                     )
                     .await
                 } else {
-                    self.execute_query_with_identity_and_vars(
-                        &request.query,
+                    self.execute_selects_internal(
+                        selects,
+                        self.fetcher.as_ref(),
                         identity,
-                        variables.as_ref(),
                     )
                     .await
                 }
@@ -140,7 +144,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         let variables = convert_variables(&request.variables);
 
         // Parse the request to determine if it's a query or mutation
-        let parsed = match parse_request_with_variables(&request.query, variables.as_ref()) {
+        let parsed = match parse_request_with_variables(
+            &request.query,
+            variables.as_ref(),
+            request.operation_name.as_deref(),
+        ) {
             Ok(p) => p,
             Err(e) => {
                 return QueryResponse {
@@ -159,7 +167,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
 
         // Route to appropriate handler based on operation type
         let result = match parsed {
-            ParsedOperation::Query { explain, .. } => {
+            ParsedOperation::Query { selects, explain } => {
                 // Get the transaction-scoped fetcher and execute with identity for ACP
                 let fetcher = txn_ctx.doc_fetcher();
                 if let Some(explain_type) = explain {
@@ -172,11 +180,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                     )
                     .await
                 } else {
-                    self.execute_query_internal_with_vars(
-                        &request.query,
+                    self.execute_selects_internal(
+                        selects,
                         fetcher.as_ref(),
                         identity,
-                        variables.as_ref(),
                     )
                     .await
                 }

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -13,7 +13,7 @@ use crate::plan::{
     CreateInput, CreateNode, DeleteNode, UpdateInput, UpdateNode, UpsertInput, UpsertNode,
 };
 use crate::planner::PlanNode;
-use crate::query_parse::parse_mutations;
+use crate::query_parse::{parse_mutations, parse_mutations_with_variables};
 use crate::txn::TransactionRegistry;
 
 use super::{DocFetcher, QueryRunner};
@@ -54,12 +54,28 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         mutation_str: &str,
         caller_identity: Option<Did>,
     ) -> Result<JsonValue> {
+        self.execute_mutation_with_identity_and_vars(mutation_str, caller_identity, None)
+            .await
+    }
+
+    /// Execute a GraphQL mutation with identity and variables.
+    pub async fn execute_mutation_with_identity_and_vars(
+        &self,
+        mutation_str: &str,
+        caller_identity: Option<Did>,
+        variables: Option<&std::collections::HashMap<String, JsonValue>>,
+    ) -> Result<JsonValue> {
         let mutator = self.mutator.as_ref().ok_or_else(|| {
             QueryError::execution("mutations require a mutator; call with_mutator() first")
         })?;
 
-        self.execute_mutation_internal(mutation_str, mutator.clone(), caller_identity)
-            .await
+        self.execute_mutation_internal_with_vars(
+            mutation_str,
+            mutator.clone(),
+            caller_identity,
+            variables,
+        )
+        .await
     }
 
     /// Execute a GraphQL mutation with a specific mutator and caller_identity.
@@ -69,7 +85,19 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         mutator: Arc<dyn DocMutator>,
         caller_identity: Option<Did>,
     ) -> Result<JsonValue> {
-        let mutations = parse_mutations(mutation_str)?;
+        self.execute_mutation_internal_with_vars(mutation_str, mutator, caller_identity, None)
+            .await
+    }
+
+    /// Execute a GraphQL mutation with a specific mutator, caller_identity, and variables.
+    pub(crate) async fn execute_mutation_internal_with_vars(
+        &self,
+        mutation_str: &str,
+        mutator: Arc<dyn DocMutator>,
+        caller_identity: Option<Did>,
+        variables: Option<&std::collections::HashMap<String, JsonValue>>,
+    ) -> Result<JsonValue> {
+        let mutations = parse_mutations_with_variables(mutation_str, variables)?;
 
         let mut results = Map::new();
 

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -13,7 +13,7 @@ use crate::plan::{
     CreateInput, CreateNode, DeleteNode, UpdateInput, UpdateNode, UpsertInput, UpsertNode,
 };
 use crate::planner::PlanNode;
-use crate::query_parse::{parse_mutations, parse_mutations_with_variables};
+use crate::query_parse::parse_mutations_with_variables;
 use crate::txn::TransactionRegistry;
 
 use super::{DocFetcher, QueryRunner};
@@ -76,17 +76,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             variables,
         )
         .await
-    }
-
-    /// Execute a GraphQL mutation with a specific mutator and caller_identity.
-    pub(crate) async fn execute_mutation_internal(
-        &self,
-        mutation_str: &str,
-        mutator: Arc<dyn DocMutator>,
-        caller_identity: Option<Did>,
-    ) -> Result<JsonValue> {
-        self.execute_mutation_internal_with_vars(mutation_str, mutator, caller_identity, None)
-            .await
     }
 
     /// Execute a GraphQL mutation with a specific mutator, caller_identity, and variables.

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -229,11 +229,13 @@ pub(crate) fn build_plan(
 
     let mut plan: Box<dyn PlanNode> = Box::new(scan);
 
-    // Add SelectNode for filtering
-    if let Some(ref filter) = select.filter {
-        let select_node = SelectNode::new(plan, mapping.clone()).with_filter(filter.clone());
-        plan = Box::new(select_node);
-    }
+    // Add SelectNode (Go always wraps in selectNode, even without a filter)
+    let select_node = if let Some(ref filter) = select.filter {
+        SelectNode::new(plan, mapping.clone()).with_filter(filter.clone())
+    } else {
+        SelectNode::new(plan, mapping.clone())
+    };
+    plan = Box::new(select_node);
 
     // Check if we have GROUP BY
     let has_group_by = select.group_by.is_some();

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -94,11 +94,19 @@ pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -
                     if name == "_docID" || name == "_group" || name == "__typename" {
                         continue;
                     }
-                    if !group_fields.contains(&name) {
-                        return Err(QueryError::parse(
-                            "cannot select a non-group-by field at group-level",
-                        ));
+                    if group_fields.contains(&name) {
+                        continue;
                     }
+                    // Allow FK fields for relation groupBy fields (e.g. _authorID for author)
+                    let is_fk_for_group = group_fields.iter().any(|gb_field| {
+                        name == format!("_{}ID", gb_field)
+                    });
+                    if is_fk_for_group {
+                        continue;
+                    }
+                    return Err(QueryError::parse(
+                        "cannot select a non-group-by field at group-level",
+                    ));
                 }
                 Requestable::Select(nested) => {
                     if nested.field.name == "_group" {
@@ -156,7 +164,56 @@ pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -
         }
     }
 
+    // Validate top-level filter field names exist in schema
+    if let Some(ref filter) = select.filter {
+        for key in filter.conditions().keys() {
+            // Skip logical operators and special filter directives
+            if key == "_and" || key == "_or" || key == "_not" || key == "_alias" {
+                continue;
+            }
+            if !field_exists(key) {
+                let filter_repr = format_graphql_conditions(filter.conditions());
+                return Err(QueryError::parse(format!(
+                    "Argument \"filter\" has invalid value {}.\nIn field \"{}\": Unknown field.",
+                    filter_repr, key
+                )));
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// Format filter conditions in Go graphql-go style (unquoted keys).
+fn format_graphql_conditions(
+    conditions: &std::collections::HashMap<String, JsonValue>,
+) -> String {
+    let entries: Vec<String> = conditions
+        .iter()
+        .map(|(k, v)| format!("{}: {}", k, format_graphql_value(v)))
+        .collect();
+    format!("{{{}}}", entries.join(", "))
+}
+
+/// Format a JSON value in Go graphql-go style.
+fn format_graphql_value(val: &JsonValue) -> String {
+    match val {
+        JsonValue::Object(obj) => {
+            let entries: Vec<String> = obj
+                .iter()
+                .map(|(k, v)| format!("{}: {}", k, format_graphql_value(v)))
+                .collect();
+            format!("{{{}}}", entries.join(", "))
+        }
+        JsonValue::String(s) => format!("\"{}\"", s),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        JsonValue::Null => "null".to_string(),
+        JsonValue::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(format_graphql_value).collect();
+            format!("[{}]", items.join(", "))
+        }
+    }
 }
 
 /// Build the document mapping for a select operation.

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -7,8 +7,8 @@ use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
 use crate::mapper::{AggregateType, Requestable, Select};
 use crate::plan::{
-    AllDocsNode, AverageNode, CountNode, GroupByNode, LimitNode, MaxNode, MinNode, OrderByNode,
-    ScanNode, SelectNode, SumNode,
+    AllDocsNode, AverageNode, CountNode, GroupAlias, GroupByNode, LimitNode, MaxNode, MinNode,
+    OrderByNode, ScanNode, SelectNode, SumNode,
 };
 use crate::planner::{Doc, PlanNode};
 
@@ -81,6 +81,77 @@ pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -
                     "GROUP BY field '{}' not found in collection '{}'",
                     field_name, select.collection_name
                 )));
+            }
+        }
+
+        // Validate that non-special fields selected at group level are in the groupBy list
+        let group_fields: Vec<&str> = group_by.fields.iter().map(|s| s.as_str()).collect();
+        for requestable in &select.fields {
+            match requestable {
+                Requestable::Field(field) => {
+                    let name = field.name.as_str();
+                    // Skip special fields
+                    if name == "_docID" || name == "_group" || name == "__typename" {
+                        continue;
+                    }
+                    if !group_fields.contains(&name) {
+                        return Err(QueryError::parse(
+                            "cannot select a non-group-by field at group-level",
+                        ));
+                    }
+                }
+                Requestable::Select(nested) => {
+                    if nested.field.name == "_group" {
+                        // _group is always allowed in groupBy queries
+                        continue;
+                    }
+                }
+                Requestable::Aggregate(_) => {
+                    // Aggregates are allowed at group level
+                }
+            }
+        }
+    }
+
+    // Validate _group references only appear within groupBy context
+    let has_group_by = select.group_by.is_some();
+    for requestable in &select.fields {
+        // Check for _count(_group: {}) or similar aggregates referencing _group
+        if let Requestable::Aggregate(agg) = requestable {
+            for target in &agg.targets {
+                if target.host_name == "_group" && !has_group_by {
+                    return Err(QueryError::parse(
+                        "_group may only be referenced when within a groupBy request",
+                    ));
+                }
+            }
+        }
+
+        // Check for _group references inside nested _group selections
+        if let Requestable::Select(nested) = requestable {
+            if nested.field.name == "_group" {
+                for inner in &nested.fields {
+                    if let Requestable::Aggregate(inner_agg) = inner {
+                        for target in &inner_agg.targets {
+                            if target.host_name == "_group" && nested.group_by.is_none() {
+                                return Err(QueryError::parse(
+                                    "_group may only be referenced when within a groupBy request",
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Validate bare aggregates have a property to aggregate
+    for requestable in &select.fields {
+        if let Requestable::Aggregate(agg) = requestable {
+            if agg.targets.is_empty() {
+                return Err(QueryError::parse(
+                    "aggregate must be provided with a property to aggregate",
+                ));
             }
         }
     }
@@ -244,22 +315,31 @@ pub(crate) fn build_plan(
         // Add GroupByNode
         if let Some(ref group_by) = select.group_by {
             let mut group_node = GroupByNode::new(plan, group_by.clone(), mapping.clone());
-            // Extract _group child's limit/filter/order from the nested Select
+            // Extract _group alias definitions with per-alias filter/limit/order
+            let group_indices = mapping
+                .indexes_of_name("_group")
+                .map(|s| s.to_vec())
+                .unwrap_or_default();
+            let mut group_aliases = Vec::new();
+            let mut alias_count = 0;
             for field in &select.fields {
                 if let Requestable::Select(nested) = field {
                     if nested.field.name == "_group" {
-                        if let Some(ref limit) = nested.limit {
-                            group_node = group_node.with_group_limit(limit.clone());
-                        }
-                        if let Some(ref filter) = nested.filter {
-                            group_node = group_node.with_group_filter(filter.clone());
-                        }
-                        if let Some(ref order) = nested.order_by {
-                            group_node = group_node.with_group_order(order.clone());
-                        }
-                        break;
+                        let alias_index =
+                            group_indices.get(alias_count).copied().unwrap_or(0);
+                        alias_count += 1;
+                        group_aliases.push(GroupAlias {
+                            index: alias_index,
+                            filter: nested.filter.clone(),
+                            limit: nested.limit.clone(),
+                            order: nested.order_by.clone(),
+                            doc_ids: nested.doc_ids.clone(),
+                        });
                     }
                 }
+            }
+            if !group_aliases.is_empty() {
+                group_node = group_node.with_group_aliases(group_aliases);
             }
             plan = Box::new(group_node);
         }

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -14,11 +14,7 @@ use crate::planner::{Doc, PlanNode};
 
 /// Validate that the select doesn't use unsupported features.
 pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -> Result<()> {
-    if select.cid.is_some() {
-        return Err(QueryError::execution(
-            "CID-based queries are not yet implemented; remove the 'cid' argument",
-        ));
-    }
+    // Note: CID-based queries are now handled by execute_cid_query() before this validation
 
     // Note: Nested selections (relations) are now supported via the Planner
 

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -346,9 +346,14 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     scan_obj.insert("fieldFetches".to_string(), serde_json::json!(field_fetches));
 
                     // indexFetches is set by IndexScanNode::explain_inner() with
-                    // the actual index key lookup count. Only add it if not already present
-                    // (for regular scans without an index, there's no indexFetches).
-                    // This is already set correctly by IndexScanNode, so no override needed.
+                    // the actual index key lookup count. For regular scans without an
+                    // index, default to 0 (Go always includes this property).
+                    if !scan_obj.contains_key("indexFetches") {
+                        scan_obj.insert(
+                            "indexFetches".to_string(),
+                            serde_json::json!(0u64),
+                        );
+                    }
                     return;
                 }
             }

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -421,6 +421,26 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         Ok(JsonValue::Object(results))
     }
 
+    /// Execute already-parsed Select operations with a specific fetcher and identity.
+    pub(crate) async fn execute_selects_internal(
+        &self,
+        selects: Vec<Select>,
+        fetcher: &dyn DocFetcher,
+        caller_identity: Option<Did>,
+    ) -> Result<JsonValue> {
+        let mut results = Map::new();
+
+        for select in selects {
+            let result = self
+                .execute_select_internal(&select, fetcher, caller_identity.clone())
+                .await?;
+            let key = select.field.output_name();
+            results.insert(key.to_string(), result);
+        }
+
+        Ok(JsonValue::Object(results))
+    }
+
     /// Execute a single Select operation with a specific fetcher and identity.
     async fn execute_select_internal(
         &self,

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -731,6 +731,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
                         if let Some(relation_data) = obj.get(relation_name) {
                             if let JsonValue::Array(items) = relation_data {
+                                // Array data: relation or inline array aggregate
                                 // Step 1: Apply filter to array elements
                                 let filtered_items: Vec<&JsonValue> =
                                     if let Some(ref filter) = target.filter {
@@ -837,6 +838,32 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                                 }
                                                 total_count += 1;
                                             }
+                                        }
+                                    }
+                                }
+                            } else {
+                                // Scalar data: multi-field per-document aggregate
+                                // e.g., _avg(HeightM: {}, Age: {}) where HeightM is a scalar
+                                if let Some(n) = relation_data.as_f64() {
+                                    match agg_type {
+                                        AggregateType::Count => {
+                                            total_count += 1;
+                                        }
+                                        AggregateType::Sum | AggregateType::Average => {
+                                            total_value += n;
+                                            total_count += 1;
+                                        }
+                                        AggregateType::Min => {
+                                            if total_count == 0 || n < total_value {
+                                                total_value = n;
+                                            }
+                                            total_count += 1;
+                                        }
+                                        AggregateType::Max => {
+                                            if total_count == 0 || n > total_value {
+                                                total_value = n;
+                                            }
+                                            total_count += 1;
                                         }
                                     }
                                 }

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -1,6 +1,7 @@
 //! Query execution methods for QueryRunner.
 
 use acp::Identity;
+use document::Document;
 use identity::Did;
 use schema::CollectionVersion;
 use serde_json::{Map, Value as JsonValue};
@@ -432,20 +433,28 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             return self.execute_commits_query(select).await;
         }
 
-        // Handle CID-based time-travel queries
-        // Note: CID queries with _version selections need to go through the Planner
-        // because _version returns commit objects (nested structure).
-        let has_version_selection = select.fields.iter().any(|f| {
+        // Check if _version is selected - it needs special handling since it's commit data
+        // not a schema field. Extract the _version Select for later use.
+        let version_selection: Option<&Select> = select.fields.iter().find_map(|f| {
             if let Requestable::Select(s) = f {
-                s.field.name == "_version"
-            } else {
-                false
+                if s.field.name == "_version" {
+                    return Some(s.as_ref());
+                }
             }
+            None
         });
 
-        if select.cid.is_some() && !has_version_selection {
+        // Handle CID-based time-travel queries
+        if select.cid.is_some() {
             return self
-                .execute_cid_query(select, fetcher, caller_identity)
+                .execute_cid_query_with_version(select, fetcher, caller_identity, version_selection)
+                .await;
+        }
+
+        // For queries with _version, execute documents first then add version data
+        if version_selection.is_some() {
+            return self
+                .execute_query_with_version(select, fetcher, caller_identity, version_selection)
                 .await;
         }
 
@@ -1053,18 +1062,19 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         Ok(JsonValue::Array(results))
     }
 
-    /// Execute a CID-based time-travel query.
+    /// Execute a CID-based time-travel query with optional _version support.
     ///
     /// Reconstructs the document as it existed at the specified commit CID
     /// by walking the merkle DAG backwards and replaying CRDT deltas.
     ///
     /// CID queries require `cid` argument and optionally `docID` for validation.
     /// Returns a single-element array containing the document at that version.
-    async fn execute_cid_query(
+    async fn execute_cid_query_with_version(
         &self,
         select: &Select,
         fetcher: &dyn DocFetcher,
         _caller_identity: Option<Did>,
+        version_selection: Option<&Select>,
     ) -> Result<JsonValue> {
         let cid = select.cid.as_ref().ok_or_else(|| {
             QueryError::internal("execute_cid_query called without CID - this is a bug")
@@ -1074,15 +1084,46 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let expected_doc_id = select.doc_ids.as_ref().and_then(|ids| ids.first());
 
         // Fetch document at the specified CID
-        let document = fetcher
+        // If docID validation fails, Go DefraDB returns empty results instead of an error
+        let document = match fetcher
             .get_document_at_cid(cid, expected_doc_id.map(|s| s.as_str()))
-            .await?;
+            .await
+        {
+            Ok(doc) => doc,
+            Err(e) => {
+                // Check if this is a "CID not found" or "docID mismatch" error
+                // In these cases, Go returns empty results
+                let err_msg = e.to_string();
+                if err_msg.contains("cid either does not exist or belong to document") {
+                    return Ok(JsonValue::Array(vec![]));
+                }
+                return Err(e);
+            }
+        };
 
         // Get collection schema for building the mapping
         let collection = self.get_collection(&select.collection_name).await?;
 
-        // Build mapping for the requested fields
-        let mapping = plan::build_mapping(select, &collection)?;
+        // Build a modified select without _version for the mapping
+        // (build_mapping doesn't handle nested selects like _version)
+        let select_without_version = Select {
+            fields: select
+                .fields
+                .iter()
+                .filter(|f| {
+                    if let Requestable::Select(s) = f {
+                        s.field.name != "_version"
+                    } else {
+                        true
+                    }
+                })
+                .cloned()
+                .collect(),
+            ..select.clone()
+        };
+
+        // Build mapping for the requested fields (excluding _version)
+        let mapping = plan::build_mapping(&select_without_version, &collection)?;
 
         // Convert the document to JSON with only the requested fields
         let mut obj = serde_json::Map::new();
@@ -1109,8 +1150,461 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             obj.insert(render_key.key.clone(), value);
         }
 
+        // Add _version data if requested
+        if let Some(version_select) = version_selection {
+            let doc_id = document.id().map(|id| id.to_string());
+            if let Some(doc_id_str) = doc_id {
+                let version_data = self
+                    .fetch_version_data(fetcher, &doc_id_str, version_select, Some(cid))
+                    .await?;
+                let output_name = version_select.field.output_name();
+                obj.insert(output_name.to_string(), version_data);
+            }
+        }
+
         // Return as single-element array (Go compatibility)
         Ok(JsonValue::Array(vec![JsonValue::Object(obj)]))
+    }
+
+    /// Execute a regular query with _version field support.
+    ///
+    /// This handles queries that include _version selection but don't have a CID argument.
+    /// For each document result, fetches the commit history and adds _version data.
+    async fn execute_query_with_version(
+        &self,
+        select: &Select,
+        fetcher: &dyn DocFetcher,
+        caller_identity: Option<Did>,
+        version_selection: Option<&Select>,
+    ) -> Result<JsonValue> {
+        // Get collection schema
+        let collection = self.get_collection(&select.collection_name).await?;
+
+        // Check if _docID is already in the selection (we need it to fetch version data)
+        let has_doc_id = select.fields.iter().any(|f| {
+            if let Requestable::Field(field) = f {
+                field.name == "_docID"
+            } else {
+                false
+            }
+        });
+
+        // Build a modified select without _version for the regular query
+        // (We'll add _version data after fetching documents)
+        // Also add _docID if not already present (needed to fetch version data)
+        let mut fields_without_version: Vec<Requestable> = select
+            .fields
+            .iter()
+            .filter(|f| {
+                if let Requestable::Select(s) = f {
+                    s.field.name != "_version"
+                } else {
+                    true
+                }
+            })
+            .cloned()
+            .collect();
+
+        // Add _docID field if not already present
+        if !has_doc_id {
+            fields_without_version.push(Requestable::Field(crate::mapper::Field {
+                name: "_docID".to_string(),
+                alias: None,
+            }));
+        }
+
+        let select_without_version = Select {
+            fields: fields_without_version,
+            ..select.clone()
+        };
+
+        // Check if remaining fields need the Planner (has real nested selections)
+        let has_nested = select_without_version.fields.iter().any(|f| {
+            matches!(f, Requestable::Select(_))
+        });
+
+        let filter_has_relations = select
+            .filter
+            .as_ref()
+            .map(|f| f.has_relation_filters())
+            .unwrap_or(false);
+
+        let order_has_relations = select
+            .order_by
+            .as_ref()
+            .map(|o| o.has_relation_order())
+            .unwrap_or(false);
+
+        // Execute the query for document data (without _version)
+        let result = if has_nested || filter_has_relations || order_has_relations {
+            self.execute_nested_select_with_planner(&select_without_version, fetcher, caller_identity)
+                .await?
+        } else {
+            self.execute_simple_select(&select_without_version, fetcher, &collection, caller_identity)
+                .await?
+        };
+
+        // If no _version selection, return as-is
+        let version_select = match version_selection {
+            Some(v) => v,
+            None => return Ok(result),
+        };
+
+        // Add _version data to each document result
+        let results = result
+            .as_array()
+            .ok_or_else(|| QueryError::internal("Expected array result"))?;
+
+        let mut enriched_results = Vec::new();
+        for doc_json in results {
+            let mut doc_obj = doc_json
+                .as_object()
+                .ok_or_else(|| QueryError::internal("Expected object in result"))?
+                .clone();
+
+            // Get document ID from the result
+            let doc_id = doc_obj
+                .get("_docID")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            // Remove _docID if it wasn't originally requested
+            if !has_doc_id {
+                doc_obj.remove("_docID");
+            }
+
+            if let Some(doc_id_str) = doc_id {
+                let version_data = self
+                    .fetch_version_data(fetcher, &doc_id_str, version_select, None)
+                    .await?;
+                let output_name = version_select.field.output_name();
+                doc_obj.insert(output_name.to_string(), version_data);
+            } else {
+                // No docID available - return empty version array
+                let output_name = version_select.field.output_name();
+                doc_obj.insert(output_name.to_string(), JsonValue::Array(vec![]));
+            }
+
+            enriched_results.push(JsonValue::Object(doc_obj));
+        }
+
+        Ok(JsonValue::Array(enriched_results))
+    }
+
+    /// Fetch version (commit) data for a document.
+    ///
+    /// Returns an array of commit objects filtered to composite commits (fieldName = "_C")
+    /// and rendered with the requested fields from the _version selection.
+    async fn fetch_version_data(
+        &self,
+        fetcher: &dyn DocFetcher,
+        doc_id: &str,
+        version_select: &Select,
+        target_cid: Option<&str>,
+    ) -> Result<JsonValue> {
+        use crate::fetcher::CommitsQueryOptions;
+
+        // Fetch commits for this document
+        let options = CommitsQueryOptions {
+            doc_id: Some(doc_id.to_string()),
+            cid: target_cid.map(|s| s.to_string()),
+            depth: None,
+            field_name: None,
+        };
+
+        let commits = fetcher.get_commits(&options).await?;
+
+        // Filter to composite commits only (fieldName = "_C")
+        // and render the requested fields
+        let mut version_results: Vec<JsonValue> = Vec::new();
+
+        for commit in commits {
+            // Filter to composite commits
+            let field_name = commit
+                .get("fieldName")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if field_name != "_C" {
+                continue;
+            }
+
+            let commit_json = self.render_commit(&commit, version_select)?;
+            version_results.push(commit_json);
+        }
+
+        // Sort by height descending (newest first)
+        version_results.sort_by(|a, b| {
+            let h_a = a.get("height").and_then(|v| v.as_i64()).unwrap_or(0);
+            let h_b = b.get("height").and_then(|v| v.as_i64()).unwrap_or(0);
+            h_b.cmp(&h_a)
+        });
+
+        Ok(JsonValue::Array(version_results))
+    }
+
+    /// Render a commit document according to the _version selection fields.
+    fn render_commit(&self, commit: &Document, version_select: &Select) -> Result<JsonValue> {
+        let mut obj = serde_json::Map::new();
+
+        for requestable in &version_select.fields {
+            match requestable {
+                Requestable::Field(f) => {
+                    let field_name = &f.name;
+                    let output_name = f.output_name();
+
+                    if let Some(value) = commit.get(field_name) {
+                        let json_value = crate::json_convert::normal_value_to_json(value)
+                            .unwrap_or(JsonValue::Null);
+                        obj.insert(output_name.to_string(), json_value);
+                    } else {
+                        obj.insert(output_name.to_string(), JsonValue::Null);
+                    }
+                }
+                Requestable::Select(nested) => {
+                    let field_name = &nested.field.name;
+                    let output_name = nested.field.output_name();
+
+                    // Handle nested selections (links, heads) with optional filter
+                    if let Some(value) = commit.get(field_name) {
+                        if let Ok(json_val) = crate::json_convert::normal_value_to_json(value) {
+                            if let Some(arr) = json_val.as_array() {
+                                // Apply filter if present on the nested selection
+                                let filtered_items: Vec<&JsonValue> = if let Some(ref filter) = nested.filter {
+                                    arr.iter()
+                                        .filter(|item| {
+                                            // Check each filter condition against the item
+                                            self.json_item_matches_filter(item, filter)
+                                        })
+                                        .collect()
+                                } else {
+                                    arr.iter().collect()
+                                };
+
+                                let nested_results: Vec<JsonValue> = filtered_items
+                                    .into_iter()
+                                    .map(|item| {
+                                        let mut nested_obj = serde_json::Map::new();
+                                        for nested_field in &nested.fields {
+                                            if let Requestable::Field(nf) = nested_field {
+                                                let nf_name = &nf.name;
+                                                let nf_output = nf.output_name();
+                                                if let Some(nv) = item.get(nf_name) {
+                                                    nested_obj
+                                                        .insert(nf_output.to_string(), nv.clone());
+                                                } else {
+                                                    nested_obj
+                                                        .insert(nf_output.to_string(), JsonValue::Null);
+                                                }
+                                            }
+                                        }
+                                        JsonValue::Object(nested_obj)
+                                    })
+                                    .collect();
+                                obj.insert(output_name.to_string(), JsonValue::Array(nested_results));
+                            } else {
+                                obj.insert(output_name.to_string(), JsonValue::Null);
+                            }
+                        } else {
+                            obj.insert(output_name.to_string(), JsonValue::Null);
+                        }
+                    } else {
+                        obj.insert(output_name.to_string(), JsonValue::Array(vec![]));
+                    }
+                }
+                Requestable::Aggregate(agg) => {
+                    // Handle aggregates on commit fields (e.g., _count(links: {}))
+                    let output_name = agg.output_name();
+                    if let Some(target) = agg.targets.first() {
+                        let target_field = target
+                            .field_name
+                            .as_deref()
+                            .filter(|s| !s.is_empty())
+                            .or_else(|| Some(target.host_name.as_str()).filter(|s| !s.is_empty()));
+
+                        if let Some(field) = target_field {
+                            if let Some(val) = commit.get(field) {
+                                if let Ok(json_val) = crate::json_convert::normal_value_to_json(val)
+                                {
+                                    if let Some(arr) = json_val.as_array() {
+                                        obj.insert(
+                                            output_name.to_string(),
+                                            JsonValue::Number((arr.len() as i64).into()),
+                                        );
+                                    } else {
+                                        obj.insert(
+                                            output_name.to_string(),
+                                            JsonValue::Number(0.into()),
+                                        );
+                                    }
+                                } else {
+                                    obj.insert(
+                                        output_name.to_string(),
+                                        JsonValue::Number(0.into()),
+                                    );
+                                }
+                            } else {
+                                obj.insert(output_name.to_string(), JsonValue::Number(0.into()));
+                            }
+                        } else {
+                            obj.insert(output_name.to_string(), JsonValue::Number(1.into()));
+                        }
+                    } else {
+                        obj.insert(output_name.to_string(), JsonValue::Number(1.into()));
+                    }
+                }
+            }
+        }
+
+        Ok(JsonValue::Object(obj))
+    }
+
+    /// Check if a JSON object matches a filter for nested commit selections.
+    ///
+    /// This is a simplified filter matcher for nested selections like `links(filter: {fieldName: {_eq: "Age"}})`.
+    /// The filter conditions are stored as `{field_name: {_op: value}}`.
+    fn json_item_matches_filter(&self, item: &JsonValue, filter: &crate::mapper::Filter) -> bool {
+        use crate::mapper::FilterOp;
+
+        // Get the filter conditions - a map of field_name -> operator conditions
+        let conditions = filter.conditions();
+
+        for (field_name, condition_value) in conditions {
+            // Check if this is a logical operator (_and, _or, _not)
+            if let Some(op) = FilterOp::parse(field_name) {
+                match op {
+                    FilterOp::And => {
+                        if let JsonValue::Array(arr) = condition_value {
+                            for sub_cond in arr {
+                                if let JsonValue::Object(obj) = sub_cond {
+                                    let sub_map: std::collections::HashMap<String, JsonValue> =
+                                        obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                                    let sub_filter = crate::mapper::Filter::from_conditions(sub_map);
+                                    if !self.json_item_matches_filter(item, &sub_filter) {
+                                        return false;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    FilterOp::Or => {
+                        if let JsonValue::Array(arr) = condition_value {
+                            let mut any_match = false;
+                            for sub_cond in arr {
+                                if let JsonValue::Object(obj) = sub_cond {
+                                    let sub_map: std::collections::HashMap<String, JsonValue> =
+                                        obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                                    let sub_filter = crate::mapper::Filter::from_conditions(sub_map);
+                                    if self.json_item_matches_filter(item, &sub_filter) {
+                                        any_match = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if !any_match {
+                                return false;
+                            }
+                        }
+                    }
+                    FilterOp::Not => {
+                        if let JsonValue::Object(obj) = condition_value {
+                            let sub_map: std::collections::HashMap<String, JsonValue> =
+                                obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                            let sub_filter = crate::mapper::Filter::from_conditions(sub_map);
+                            if self.json_item_matches_filter(item, &sub_filter) {
+                                return false;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
+            // This is a field condition: field_name -> {_op: value}
+            let item_value = item.get(field_name);
+
+            // The condition_value should be an object like {"_eq": "Age"}
+            if let JsonValue::Object(ops) = condition_value {
+                for (op_name, expected_value) in ops {
+                    if let Some(op) = FilterOp::parse(op_name) {
+                        let matches = self.check_filter_op(item_value, op, expected_value);
+                        if !matches {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Check if an item value matches a filter operator condition.
+    fn check_filter_op(
+        &self,
+        item_value: Option<&JsonValue>,
+        op: crate::mapper::FilterOp,
+        expected: &JsonValue,
+    ) -> bool {
+        use crate::mapper::FilterOp;
+
+        match op {
+            FilterOp::Eq => match (item_value, expected) {
+                (Some(JsonValue::String(a)), JsonValue::String(b)) => a == b,
+                (Some(JsonValue::Number(a)), JsonValue::Number(b)) => a == b,
+                (Some(JsonValue::Bool(a)), JsonValue::Bool(b)) => a == b,
+                (Some(JsonValue::Null), JsonValue::Null) => true,
+                (None, JsonValue::Null) => true,
+                _ => false,
+            },
+            FilterOp::Ne => match (item_value, expected) {
+                (Some(JsonValue::String(a)), JsonValue::String(b)) => a != b,
+                (Some(JsonValue::Number(a)), JsonValue::Number(b)) => a != b,
+                (Some(JsonValue::Bool(a)), JsonValue::Bool(b)) => a != b,
+                (Some(JsonValue::Null), JsonValue::Null) => false,
+                (None, _) => true,
+                _ => true,
+            },
+            FilterOp::Gt => {
+                match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
+                    (Some(a), Some(b)) => a > b,
+                    _ => false,
+                }
+            }
+            FilterOp::Gte => {
+                match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
+                    (Some(a), Some(b)) => a >= b,
+                    _ => false,
+                }
+            }
+            FilterOp::Lt => {
+                match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
+                    (Some(a), Some(b)) => a < b,
+                    _ => false,
+                }
+            }
+            FilterOp::Lte => {
+                match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
+                    (Some(a), Some(b)) => a <= b,
+                    _ => false,
+                }
+            }
+            FilterOp::In => {
+                if let JsonValue::Array(values) = expected {
+                    item_value.map(|v| values.contains(v)).unwrap_or(false)
+                } else {
+                    false
+                }
+            }
+            FilterOp::Nin => {
+                if let JsonValue::Array(values) = expected {
+                    item_value.map(|v| !values.contains(v)).unwrap_or(true)
+                } else {
+                    true
+                }
+            }
+            _ => true, // For unsupported operators, default to matching
+        }
     }
 
     /// Execute a top-level aggregate query (e.g., `{ _avg(Users: {field: Age}) }`).

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -13,7 +13,9 @@ use crate::document::documents_to_plan_docs;
 use crate::error::{QueryError, Result};
 use crate::mapper::{Requestable, Select};
 use crate::plan::PermissionFilterNode;
-use crate::planner::index_selection::{filter_to_index_scan, select_best_index};
+use crate::planner::index_selection::{
+    can_be_ordered_by_index, filter_to_index_scan, select_best_index,
+};
 use crate::planner::Planner;
 use crate::query_parse::{parse_query_with_variables, ExplainType};
 use crate::txn::TransactionRegistry;
@@ -192,8 +194,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         let fetcher = self.fetcher.as_ref();
 
-        // Check if we can use an index (only when not fetching by specific doc_ids)
-        let can_use_index = select.doc_ids.is_none()
+        // Check if we can use an index (filter-based or ordering-based)
+        let can_use_filter_index = select.doc_ids.is_none()
             && select.filter.is_some()
             && !collection.indexes.is_empty()
             && fetcher.supports_index_queries()
@@ -202,6 +204,24 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 .as_ref()
                 .map(|f| select_best_index(f, &collection.indexes).is_some())
                 .unwrap_or(false);
+
+        // Also use index when it can provide ordering (even without a filter)
+        let can_use_ordering_index = select.doc_ids.is_none()
+            && select.order_by.is_some()
+            && !collection.indexes.is_empty()
+            && fetcher.supports_index_queries()
+            && select
+                .order_by
+                .as_ref()
+                .map(|o| {
+                    collection
+                        .indexes
+                        .iter()
+                        .any(|idx| can_be_ordered_by_index(o, idx).0)
+                })
+                .unwrap_or(false);
+
+        let can_use_index = can_use_filter_index || can_use_ordering_index;
 
         if can_use_index {
             // Use Planner path for index-based queries (shows indexScanNode in explain)
@@ -384,8 +404,33 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             .iter()
             .any(|f| matches!(f, Requestable::Select(_)));
 
-        if has_nested {
-            // Use the Planner for queries with nested selections
+        // Check if an ordering-only index can be used (planner needed for IndexScanNode)
+        let has_ordering_index = !has_nested
+            && select.order_by.is_some()
+            && !collection.indexes.is_empty()
+            && select
+                .order_by
+                .as_ref()
+                .map(|o| {
+                    collection
+                        .indexes
+                        .iter()
+                        .any(|idx| can_be_ordered_by_index(o, idx).0)
+                })
+                .unwrap_or(false);
+
+        // Check if a filter-based index can be used
+        let has_filter_index = !has_nested
+            && select.filter.is_some()
+            && !collection.indexes.is_empty()
+            && select
+                .filter
+                .as_ref()
+                .map(|f| select_best_index(f, &collection.indexes).is_some())
+                .unwrap_or(false);
+
+        if has_nested || has_ordering_index || has_filter_index {
+            // Use the Planner for queries with nested selections or index usage
             self.explain_nested_select(select, explain_type).await
         } else {
             // Explain simple query plan
@@ -597,13 +642,30 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             false
         });
 
+        // Check if an ordering-only index can be used (planner needed for IndexScanNode)
+        let has_ordering_index = select.order_by.is_some()
+            && fetcher.supports_index_queries()
+            && !collection.indexes.is_empty()
+            && select
+                .order_by
+                .as_ref()
+                .map(|o| {
+                    collection
+                        .indexes
+                        .iter()
+                        .any(|idx| can_be_ordered_by_index(o, idx).0)
+                })
+                .unwrap_or(false);
+
         // Use Planner if there are nested selections, filter through relations,
-        // order through relations, aggregates on relations, or secondary relation ID fields
+        // order through relations, aggregates on relations, secondary relation ID fields,
+        // or when an index can provide ordering
         let needs_planner = has_nested
             || filter_has_relations
             || order_has_relations
             || aggregates_have_relations
-            || has_secondary_relation_id;
+            || has_secondary_relation_id
+            || has_ordering_index;
 
         // SECURITY: Block nested queries on ACP-protected collections until Planner ACP is implemented.
         // See issue #114 for tracking the full fix.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -433,7 +433,17 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         // Handle CID-based time-travel queries
-        if select.cid.is_some() {
+        // Note: CID queries with _version selections need to go through the Planner
+        // because _version returns commit objects (nested structure).
+        let has_version_selection = select.fields.iter().any(|f| {
+            if let Requestable::Select(s) = f {
+                s.field.name == "_version"
+            } else {
+                false
+            }
+        });
+
+        if select.cid.is_some() && !has_version_selection {
             return self
                 .execute_cid_query(select, fetcher, caller_identity)
                 .await;

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -720,8 +720,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         use crate::mapper::AggregateType;
 
         // Collect info about relation aggregates with full target references
-        let mut aggregates_info: Vec<(String, AggregateType, Vec<&crate::mapper::AggregateTarget>)> =
-            Vec::new();
+        let mut aggregates_info: Vec<(
+            String,
+            AggregateType,
+            Vec<&crate::mapper::AggregateTarget>,
+        )> = Vec::new();
 
         for requestable in &select.fields {
             if let Requestable::Aggregate(agg) = requestable {
@@ -735,7 +738,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 if !relation_targets.is_empty() {
                     aggregates_info.push((
                         agg.output_name().to_string(),
-                        agg.aggregate_type.clone(),
+                        agg.aggregate_type,
                         relation_targets,
                     ));
                 }
@@ -779,114 +782,110 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         let relation_name = &target.host_name;
                         let field_name = target.field_name.as_deref();
 
-                        if let Some(relation_data) = obj.get(relation_name) {
-                            if let JsonValue::Array(items) = relation_data {
-                                // Step 1: Apply filter to array elements
-                                let filtered_items: Vec<&JsonValue> =
-                                    if let Some(ref filter) = target.filter {
-                                        items
-                                            .iter()
-                                            .filter(|item| {
-                                                let val = match field_name {
-                                                    Some(f) => item
-                                                        .as_object()
-                                                        .and_then(|o| o.get(f))
-                                                        .unwrap_or(&JsonValue::Null),
-                                                    None => *item,
-                                                };
-                                                filter.matches_scalar_value(val).unwrap_or(false)
-                                            })
-                                            .collect()
-                                    } else {
-                                        items.iter().collect()
-                                    };
+                        if let Some(JsonValue::Array(items)) = obj.get(relation_name) {
+                            // Step 1: Apply filter to array elements
+                            let filtered_items: Vec<&JsonValue> =
+                                if let Some(ref filter) = target.filter {
+                                    items
+                                        .iter()
+                                        .filter(|item| {
+                                            let val = match field_name {
+                                                Some(f) => item
+                                                    .as_object()
+                                                    .and_then(|o| o.get(f))
+                                                    .unwrap_or(&JsonValue::Null),
+                                                None => *item,
+                                            };
+                                            filter.matches_scalar_value(val).unwrap_or(false)
+                                        })
+                                        .collect()
+                                } else {
+                                    items.iter().collect()
+                                };
 
-                                // Step 2: Apply order (sort array elements before limit/offset)
-                                let mut ordered_items = filtered_items;
-                                if let Some(ref order) = target.order {
-                                    if let Some(condition) = order.conditions.first() {
-                                        let desc = matches!(
-                                            condition.direction,
-                                            crate::mapper::OrderDirection::Desc
-                                        );
-                                        ordered_items.sort_by(|a, b| {
-                                            let a_val = match field_name {
-                                                Some(f) => a
-                                                    .as_object()
-                                                    .and_then(|o| o.get(f))
-                                                    .unwrap_or(&JsonValue::Null),
-                                                None => *a,
-                                            };
-                                            let b_val = match field_name {
-                                                Some(f) => b
-                                                    .as_object()
-                                                    .and_then(|o| o.get(f))
-                                                    .unwrap_or(&JsonValue::Null),
-                                                None => *b,
-                                            };
-                                            let a_f = a_val.as_f64().unwrap_or(0.0);
-                                            let b_f = b_val.as_f64().unwrap_or(0.0);
-                                            if desc {
-                                                b_f.partial_cmp(&a_f)
-                                                    .unwrap_or(std::cmp::Ordering::Equal)
-                                            } else {
-                                                a_f.partial_cmp(&b_f)
-                                                    .unwrap_or(std::cmp::Ordering::Equal)
-                                            }
-                                        });
+                            // Step 2: Apply order (sort array elements before limit/offset)
+                            let mut ordered_items = filtered_items;
+                            if let Some(ref order) = target.order {
+                                if let Some(condition) = order.conditions.first() {
+                                    let desc = matches!(
+                                        condition.direction,
+                                        crate::mapper::OrderDirection::Desc
+                                    );
+                                    ordered_items.sort_by(|a, b| {
+                                        let a_val = match field_name {
+                                            Some(f) => a
+                                                .as_object()
+                                                .and_then(|o| o.get(f))
+                                                .unwrap_or(&JsonValue::Null),
+                                            None => *a,
+                                        };
+                                        let b_val = match field_name {
+                                            Some(f) => b
+                                                .as_object()
+                                                .and_then(|o| o.get(f))
+                                                .unwrap_or(&JsonValue::Null),
+                                            None => *b,
+                                        };
+                                        let a_f = a_val.as_f64().unwrap_or(0.0);
+                                        let b_f = b_val.as_f64().unwrap_or(0.0);
+                                        if desc {
+                                            b_f.partial_cmp(&a_f)
+                                                .unwrap_or(std::cmp::Ordering::Equal)
+                                        } else {
+                                            a_f.partial_cmp(&b_f)
+                                                .unwrap_or(std::cmp::Ordering::Equal)
+                                        }
+                                    });
+                                }
+                            }
+
+                            // Step 3: Apply limit/offset
+                            let final_items: Vec<&JsonValue> = if let Some(ref limit) = target.limit
+                            {
+                                let offset = limit.offset as usize;
+                                let sliced = if offset < ordered_items.len() {
+                                    &ordered_items[offset..]
+                                } else {
+                                    &[][..]
+                                };
+                                match limit.limit {
+                                    Some(l) => sliced.iter().take(l as usize).copied().collect(),
+                                    None => sliced.to_vec(),
+                                }
+                            } else {
+                                ordered_items
+                            };
+
+                            // Step 4: Compute aggregate over final items
+                            match agg_type {
+                                AggregateType::Count => {
+                                    total_count += final_items.len() as i64;
+                                }
+                                AggregateType::Sum | AggregateType::Average => {
+                                    for item in &final_items {
+                                        if let Some(n) = extract_numeric(item, field_name) {
+                                            total_value += n;
+                                            total_count += 1;
+                                        }
                                     }
                                 }
-
-                                // Step 3: Apply limit/offset
-                                let final_items: Vec<&JsonValue> =
-                                    if let Some(ref limit) = target.limit {
-                                        let offset = limit.offset as usize;
-                                        let sliced = if offset < ordered_items.len() {
-                                            &ordered_items[offset..]
-                                        } else {
-                                            &[][..]
-                                        };
-                                        match limit.limit {
-                                            Some(l) => {
-                                                sliced.iter().take(l as usize).copied().collect()
+                                AggregateType::Min => {
+                                    for item in &final_items {
+                                        if let Some(n) = extract_numeric(item, field_name) {
+                                            if total_count == 0 || n < total_value {
+                                                total_value = n;
                                             }
-                                            None => sliced.to_vec(),
-                                        }
-                                    } else {
-                                        ordered_items
-                                    };
-
-                                // Step 4: Compute aggregate over final items
-                                match agg_type {
-                                    AggregateType::Count => {
-                                        total_count += final_items.len() as i64;
-                                    }
-                                    AggregateType::Sum | AggregateType::Average => {
-                                        for item in &final_items {
-                                            if let Some(n) = extract_numeric(item, field_name) {
-                                                total_value += n;
-                                                total_count += 1;
-                                            }
+                                            total_count += 1;
                                         }
                                     }
-                                    AggregateType::Min => {
-                                        for item in &final_items {
-                                            if let Some(n) = extract_numeric(item, field_name) {
-                                                if total_count == 0 || n < total_value {
-                                                    total_value = n;
-                                                }
-                                                total_count += 1;
+                                }
+                                AggregateType::Max => {
+                                    for item in &final_items {
+                                        if let Some(n) = extract_numeric(item, field_name) {
+                                            if total_count == 0 || n > total_value {
+                                                total_value = n;
                                             }
-                                        }
-                                    }
-                                    AggregateType::Max => {
-                                        for item in &final_items {
-                                            if let Some(n) = extract_numeric(item, field_name) {
-                                                if total_count == 0 || n > total_value {
-                                                    total_value = n;
-                                                }
-                                                total_count += 1;
-                                            }
+                                            total_count += 1;
                                         }
                                     }
                                 }
@@ -980,14 +979,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         let a_f = a_val.and_then(|v| v.as_f64()).unwrap_or(0.0);
                         let b_f = b_val.and_then(|v| v.as_f64()).unwrap_or(0.0);
                         let ord = a_f.partial_cmp(&b_f).unwrap_or(std::cmp::Ordering::Equal);
-                        let ord = if matches!(
-                            condition.direction,
-                            crate::mapper::OrderDirection::Desc
-                        ) {
-                            ord.reverse()
-                        } else {
-                            ord
-                        };
+                        let ord =
+                            if matches!(condition.direction, crate::mapper::OrderDirection::Desc) {
+                                ord.reverse()
+                            } else {
+                                ord
+                            };
                         if ord != std::cmp::Ordering::Equal {
                             return ord;
                         }
@@ -2166,7 +2163,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             .iter()
             .map(|name| {
                 commit
-                    .get(*name)
+                    .get(name)
                     .and_then(|v| crate::json_convert::normal_value_to_json(v).ok())
             })
             .collect()

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -1034,7 +1034,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             // Try to use an index if available
             if fetcher.supports_index_queries() && !collection.indexes.is_empty() {
                 if let Some(best_index) = select_best_index(filter, &collection.indexes) {
-                    if let Some(params) = filter_to_index_scan(filter, best_index) {
+                    if let Some(params) =
+                        filter_to_index_scan(filter, best_index, select.order_by.as_ref())
+                    {
                         debug!(
                             collection = %select.collection_name,
                             index = %params.index_name,

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -1091,12 +1091,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         {
             Ok(doc) => doc,
             Err(e) => {
-                // Check if this is a "CID not found" or "docID mismatch" error
-                // In these cases, Go returns empty results
                 let err_msg = e.to_string();
+                // docID mismatch: Go returns empty results
                 if err_msg.contains("cid either does not exist or belong to document") {
                     return Ok(JsonValue::Array(vec![]));
                 }
+                // Block not found in blockstore: propagate as error (Go does the same)
                 return Err(e);
             }
         };
@@ -1305,10 +1305,19 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         use crate::fetcher::CommitsQueryOptions;
 
         // Fetch commits for this document
+        // When we have a target CID, we need to traverse all commits back to genesis
+        // by setting a large depth. Without a target CID (regular query), depth=None
+        // traverses all heads to genesis anyway.
+        let depth = if target_cid.is_some() {
+            Some(1000) // Reasonable max depth for version history traversal
+        } else {
+            None
+        };
+
         let options = CommitsQueryOptions {
             doc_id: Some(doc_id.to_string()),
             cid: target_cid.map(|s| s.to_string()),
-            depth: None,
+            depth,
             field_name: None,
         };
 

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -673,6 +673,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // For aggregates like _count(books: {}), compute the value from joined data
         let results = self.compute_relation_aggregates(results, select)?;
 
+        // Apply deferred limit/offset to relation fields.
+        // TypeJoinMany stores ALL children (for aggregates to count), so we apply
+        // the select's limit/offset here after aggregates have been computed.
+        let results = Self::apply_relation_limits(results, select);
+
         Ok(JsonValue::Array(results))
     }
 
@@ -1139,6 +1144,67 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         Ok(results)
+    }
+
+    /// Apply deferred limit/offset to relation fields in query results.
+    ///
+    /// TypeJoinMany stores ALL children so that relation aggregates (e.g., _count)
+    /// can see the full set. This function applies the limit/offset from the select's
+    /// nested relation fields after aggregates have been computed.
+    fn apply_relation_limits(mut results: Vec<JsonValue>, select: &Select) -> Vec<JsonValue> {
+        // Collect relation fields with limits
+        let mut relation_limits: Vec<(String, u64, u64)> = Vec::new(); // (field_name, limit, offset)
+        for requestable in &select.fields {
+            if let Requestable::Select(nested_select) = requestable {
+                if nested_select.field.name == "_group" {
+                    continue; // _group is handled by GroupByNode
+                }
+                if let Some(ref limit) = nested_select.limit {
+                    let limit_val = limit.limit.unwrap_or(0); // 0 means no limit
+                    let offset_val = limit.offset;
+                    if limit_val > 0 || offset_val > 0 {
+                        relation_limits.push((
+                            nested_select.field.output_name().to_string(),
+                            limit_val,
+                            offset_val,
+                        ));
+                    }
+                }
+            }
+        }
+
+        if relation_limits.is_empty() {
+            return results;
+        }
+
+        for result in &mut results {
+            if let JsonValue::Object(ref mut obj) = result {
+                for (field_name, limit, offset) in &relation_limits {
+                    if let Some(relation_data) = obj.get_mut(field_name) {
+                        if let JsonValue::Array(items) = relation_data {
+                            let offset = *offset as usize;
+                            let total = items.len();
+                            if offset >= total {
+                                *items = Vec::new();
+                            } else {
+                                let remaining: Vec<JsonValue> =
+                                    items.drain(offset..).collect();
+                                *items = if *limit > 0 {
+                                    remaining
+                                        .into_iter()
+                                        .take(*limit as usize)
+                                        .collect()
+                                } else {
+                                    remaining
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        results
     }
 
     /// Execute a simple query without nested selections.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -14,7 +14,7 @@ use crate::mapper::{Requestable, Select};
 use crate::plan::PermissionFilterNode;
 use crate::planner::index_selection::{filter_to_index_scan, select_best_index};
 use crate::planner::Planner;
-use crate::query_parse::{parse_query, ExplainType};
+use crate::query_parse::{parse_query, parse_query_with_variables, ExplainType};
 use crate::txn::TransactionRegistry;
 
 use super::fetcher::FetcherWrapper;
@@ -38,6 +38,22 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             .await
     }
 
+    /// Execute a GraphQL query with identity and variables.
+    pub async fn execute_query_with_identity_and_vars(
+        &self,
+        query: &str,
+        caller_identity: Option<Did>,
+        variables: Option<&std::collections::HashMap<String, JsonValue>>,
+    ) -> Result<JsonValue> {
+        self.execute_query_internal_with_vars(
+            query,
+            self.fetcher.as_ref(),
+            caller_identity,
+            variables,
+        )
+        .await
+    }
+
     /// Generate an explanation of the query plan.
     ///
     /// Used when queries include the @explain directive.
@@ -51,10 +67,22 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         caller_identity: Option<Did>,
         explain_type: ExplainType,
     ) -> Result<JsonValue> {
+        self.explain_query_with_identity_and_vars(query, caller_identity, explain_type, None)
+            .await
+    }
+
+    /// Generate an explanation of the query plan with variable support.
+    pub async fn explain_query_with_identity_and_vars(
+        &self,
+        query: &str,
+        caller_identity: Option<Did>,
+        explain_type: ExplainType,
+        variables: Option<&std::collections::HashMap<String, JsonValue>>,
+    ) -> Result<JsonValue> {
         match explain_type {
             ExplainType::Simple | ExplainType::Debug => {
                 // Simple and Debug modes: explain without execution
-                let selects = parse_query(query)?;
+                let selects = parse_query_with_variables(query, variables)?;
                 let mut results = Map::new();
 
                 for select in selects {
@@ -67,7 +95,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             }
             ExplainType::Execute => {
                 // Execute mode: run the query and collect metrics
-                self.execute_explain(query, caller_identity).await
+                self.execute_explain_with_vars(query, caller_identity, variables)
+                    .await
             }
         }
     }
@@ -79,7 +108,17 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         query: &str,
         caller_identity: Option<Did>,
     ) -> Result<JsonValue> {
-        let selects = parse_query(query)?;
+        self.execute_explain_with_vars(query, caller_identity, None).await
+    }
+
+    /// Execute the query with variables and return explain output with execution metrics.
+    async fn execute_explain_with_vars(
+        &self,
+        query: &str,
+        caller_identity: Option<Did>,
+        variables: Option<&std::collections::HashMap<String, JsonValue>>,
+    ) -> Result<JsonValue> {
+        let selects = parse_query_with_variables(query, variables)?;
 
         let mut explain_result = Map::new();
         let mut total_executions: u64 = 0;
@@ -363,7 +402,19 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         fetcher: &dyn DocFetcher,
         caller_identity: Option<Did>,
     ) -> Result<JsonValue> {
-        let selects = parse_query(query)?;
+        self.execute_query_internal_with_vars(query, fetcher, caller_identity, None)
+            .await
+    }
+
+    /// Execute a GraphQL query with a specific fetcher, identity, and variables.
+    pub(crate) async fn execute_query_internal_with_vars(
+        &self,
+        query: &str,
+        fetcher: &dyn DocFetcher,
+        caller_identity: Option<Did>,
+        variables: Option<&std::collections::HashMap<String, JsonValue>>,
+    ) -> Result<JsonValue> {
+        let selects = parse_query_with_variables(query, variables)?;
 
         let mut results = Map::new();
 

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -113,6 +113,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let selects = parse_query_with_variables(query, variables)?;
 
         let mut explain_result = Map::new();
+        let mut operation_nodes: Vec<JsonValue> = Vec::new();
         let mut total_executions: u64 = 0;
         let mut total_docs: usize = 0;
         let mut execution_success = true;
@@ -125,12 +126,21 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 .await
             {
                 Ok((explanation, doc_count, exec_count)) => {
-                    // Merge the plan tree into explain result (Go format)
+                    // Wrap the plan tree in selectTopNode (Go format)
+                    let mut select_top_node = Map::new();
                     if let Some(obj) = explanation.as_object() {
                         for (key, value) in obj {
-                            explain_result.insert(key.clone(), value.clone());
+                            select_top_node.insert(key.clone(), value.clone());
                         }
                     }
+
+                    let mut operation_node = Map::new();
+                    operation_node.insert(
+                        "selectTopNode".to_string(),
+                        JsonValue::Object(select_top_node),
+                    );
+                    operation_nodes.push(JsonValue::Object(operation_node));
+
                     total_docs += doc_count;
                     total_executions += exec_count;
                 }
@@ -151,6 +161,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             serde_json::json!(total_executions),
         );
         explain_result.insert("sizeOfResult".to_string(), serde_json::json!(total_docs));
+        explain_result.insert(
+            "operationNode".to_string(),
+            JsonValue::Array(operation_nodes),
+        );
 
         if !execution_errors.is_empty() {
             explain_result.insert(
@@ -228,7 +242,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             plan.close().await?;
 
             let explanation = plan.explain();
-            let explanation = Self::add_iterations_to_explain(explanation, iterations, doc_count);
+            // fieldCount = user fields accessed per document (exclude _docID)
+            // Go counts only user-defined fields, not the system _docID field
+            let field_count = collection.fields.len().saturating_sub(1);
+            let explanation =
+                Self::add_iterations_to_explain(explanation, iterations, doc_count, field_count);
 
             Ok((explanation, result_count, iterations))
         } else {
@@ -285,29 +303,61 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             plan.close().await?;
 
             let explanation = plan.explain();
-            let explanation = Self::add_iterations_to_explain(explanation, iterations, doc_count);
+            // fieldCount = user fields accessed per document (exclude _docID)
+            // Go counts only user-defined fields, not the system _docID field
+            let field_count = collection.fields.len().saturating_sub(1);
+            let explanation =
+                Self::add_iterations_to_explain(explanation, iterations, doc_count, field_count);
 
             Ok((explanation, result_count, iterations))
         }
     }
 
     /// Add execution metrics to the explain output (Go format).
+    /// Metrics are added to the scanNode, not the selectNode.
     fn add_iterations_to_explain(
         mut explanation: JsonValue,
         iterations: u64,
         doc_fetches: usize,
+        field_count: usize,
     ) -> JsonValue {
-        // The explanation is { "nodeKind": { ... } }
-        // We need to add iterations to the inner object
-        if let Some(obj) = explanation.as_object_mut() {
-            if let Some((_, inner)) = obj.iter_mut().next() {
-                if let Some(inner_obj) = inner.as_object_mut() {
-                    inner_obj.insert("iterations".to_string(), serde_json::json!(iterations));
-                    inner_obj.insert("docFetches".to_string(), serde_json::json!(doc_fetches));
+        // The explanation is { "selectNode": { "scanNode": { ... } } }
+        // We need to add metrics to the scanNode
+        Self::add_metrics_to_scan_node(&mut explanation, iterations, doc_fetches, field_count);
+        explanation
+    }
+
+    /// Recursively find and add metrics to scanNode.
+    /// If the scanNode has an indexName field, it's an index scan and gets indexFetches.
+    fn add_metrics_to_scan_node(
+        value: &mut JsonValue,
+        iterations: u64,
+        doc_fetches: usize,
+        field_count: usize,
+    ) {
+        if let Some(obj) = value.as_object_mut() {
+            // Check if this object contains scanNode
+            if let Some(scan_node) = obj.get_mut("scanNode") {
+                if let Some(scan_obj) = scan_node.as_object_mut() {
+                    scan_obj.insert("iterations".to_string(), serde_json::json!(iterations));
+                    scan_obj.insert("docFetches".to_string(), serde_json::json!(doc_fetches));
+                    // fieldFetches = number of fields per doc * number of docs fetched
+                    let field_fetches = field_count * doc_fetches;
+                    scan_obj.insert("fieldFetches".to_string(), serde_json::json!(field_fetches));
+
+                    // If this scanNode has an indexName, it's an index scan - add indexFetches
+                    if scan_obj.contains_key("indexName") {
+                        scan_obj.insert("indexFetches".to_string(), serde_json::json!(iterations));
+                    }
+                    return;
                 }
             }
+
+            // Recurse into child objects
+            for (_, child) in obj.iter_mut() {
+                Self::add_metrics_to_scan_node(child, iterations, doc_fetches, field_count);
+            }
         }
-        explanation
     }
 
     /// Generate an explanation of a single Select operation.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -14,7 +14,7 @@ use crate::mapper::{Requestable, Select};
 use crate::plan::PermissionFilterNode;
 use crate::planner::index_selection::{filter_to_index_scan, select_best_index};
 use crate::planner::Planner;
-use crate::query_parse::{parse_query, parse_query_with_variables, ExplainType};
+use crate::query_parse::{parse_query_with_variables, ExplainType};
 use crate::txn::TransactionRegistry;
 
 use super::fetcher::FetcherWrapper;
@@ -101,17 +101,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
     }
 
-    /// Execute the query and return explain output with execution metrics.
-    /// Format matches Go DefraDB's executeAndExplainRequest output.
-    async fn execute_explain(
-        &self,
-        query: &str,
-        caller_identity: Option<Did>,
-    ) -> Result<JsonValue> {
-        self.execute_explain_with_vars(query, caller_identity, None).await
-    }
-
     /// Execute the query with variables and return explain output with execution metrics.
+    /// Format matches Go DefraDB's executeAndExplainRequest output.
     async fn execute_explain_with_vars(
         &self,
         query: &str,

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -820,36 +820,38 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                     };
 
                                 // Step 2: Apply order (sort array elements before limit/offset)
+                                // The order field may differ from the aggregate field (e.g., order by "name", sum "rating")
                                 let mut ordered_items = filtered_items;
                                 if let Some(ref order) = target.order {
                                     if let Some(condition) = order.conditions.first() {
+                                        let order_field = condition.fields.first().map(|s| s.as_str());
                                         let desc = matches!(
                                             condition.direction,
                                             crate::mapper::OrderDirection::Desc
                                         );
                                         ordered_items.sort_by(|a, b| {
-                                            let a_val = match field_name {
+                                            let a_val = match order_field {
                                                 Some(f) => a
                                                     .as_object()
                                                     .and_then(|o| o.get(f))
                                                     .unwrap_or(&JsonValue::Null),
                                                 None => *a,
                                             };
-                                            let b_val = match field_name {
+                                            let b_val = match order_field {
                                                 Some(f) => b
                                                     .as_object()
                                                     .and_then(|o| o.get(f))
                                                     .unwrap_or(&JsonValue::Null),
                                                 None => *b,
                                             };
-                                            let a_f = a_val.as_f64().unwrap_or(0.0);
-                                            let b_f = b_val.as_f64().unwrap_or(0.0);
+                                            let cmp = crate::plan::compare_json_values(
+                                                Some(a_val),
+                                                Some(b_val),
+                                            );
                                             if desc {
-                                                b_f.partial_cmp(&a_f)
-                                                    .unwrap_or(std::cmp::Ordering::Equal)
+                                                cmp.reverse()
                                             } else {
-                                                a_f.partial_cmp(&b_f)
-                                                    .unwrap_or(std::cmp::Ordering::Equal)
+                                                cmp
                                             }
                                         });
                                     }
@@ -1361,28 +1363,34 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Get collection schema for building the mapping
         let collection = self.get_collection(&select.collection_name).await?;
 
-        // Build a modified select without _version for the mapping
-        // (build_mapping doesn't handle nested selects like _version)
-        let select_without_version = Select {
-            fields: select
-                .fields
-                .iter()
-                .filter(|f| {
-                    if let Requestable::Select(s) = f {
-                        s.field.name != "_version"
-                    } else {
-                        true
+        // Separate nested selects (relation fields) from scalar fields.
+        // build_mapping can't handle nested selects, so we strip them and resolve relations separately.
+        let mut nested_selects: Vec<&Select> = Vec::new();
+        let scalar_fields: Vec<Requestable> = select
+            .fields
+            .iter()
+            .filter(|f| {
+                if let Requestable::Select(s) = f {
+                    if s.field.name == "_version" {
+                        return false;
                     }
-                })
-                .cloned()
-                .collect(),
+                    nested_selects.push(s);
+                    return false;
+                }
+                true
+            })
+            .cloned()
+            .collect();
+
+        let select_for_mapping = Select {
+            fields: scalar_fields,
             ..select.clone()
         };
 
-        // Build mapping for the requested fields (excluding _version)
-        let mapping = plan::build_mapping(&select_without_version, &collection)?;
+        // Build mapping for scalar fields only
+        let mapping = plan::build_mapping(&select_for_mapping, &collection)?;
 
-        // Convert the document to JSON with only the requested fields
+        // Convert the document to JSON with only the requested scalar fields
         let mut obj = serde_json::Map::new();
 
         for render_key in &mapping.render_keys {
@@ -1405,6 +1413,41 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             };
 
             obj.insert(render_key.key.clone(), value);
+        }
+
+        // Resolve nested selects (relation fields like `author { name }`)
+        for nested_select in &nested_selects {
+            let relation_name = &nested_select.field.name;
+            let output_name = nested_select.field.output_name();
+            let related_collection = &nested_select.collection_name;
+
+            // Many-to-one: parent has FK field (e.g., Book._authorID → Author)
+            let fk_field_name = CollectionVersion::relation_id_field_name(relation_name);
+            if let Some(fk_value) = document.get(&fk_field_name) {
+                let fk_doc_id = crate::json_convert::normal_value_to_json(fk_value)
+                    .ok()
+                    .and_then(|v| v.as_str().map(|s| s.to_string()))
+                    .unwrap_or_default();
+
+                if !fk_doc_id.is_empty() {
+                    let result = fetcher
+                        .get_by_ids(related_collection, &[fk_doc_id])
+                        .await?;
+
+                    if let Some(related_doc) = result.docs().first() {
+                        let related_obj =
+                            self.render_document_fields(related_doc, nested_select);
+                        obj.insert(output_name.to_string(), JsonValue::Object(related_obj));
+                    } else {
+                        obj.insert(output_name.to_string(), JsonValue::Null);
+                    }
+                } else {
+                    obj.insert(output_name.to_string(), JsonValue::Null);
+                }
+            } else {
+                // One-to-many or no FK found: return null for now
+                obj.insert(output_name.to_string(), JsonValue::Null);
+            }
         }
 
         // Add _version data if requested
@@ -1546,6 +1589,36 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         Ok(JsonValue::Array(enriched_results))
+    }
+
+    /// Render a Document's fields as a JSON object using only the fields requested by a Select.
+    fn render_document_fields(&self, doc: &Document, select: &Select) -> serde_json::Map<String, JsonValue> {
+        let mut obj = serde_json::Map::new();
+        for field in &select.fields {
+            if let Requestable::Field(f) = field {
+                let fname = &f.name;
+                let output = f.output_name();
+                if fname == "_docID" {
+                    if let Some(id) = doc.id() {
+                        obj.insert(output.to_string(), JsonValue::String(id.to_string()));
+                    } else {
+                        obj.insert(output.to_string(), JsonValue::Null);
+                    }
+                } else if fname == "__typename" {
+                    obj.insert(
+                        output.to_string(),
+                        JsonValue::String(select.collection_name.clone()),
+                    );
+                } else if let Some(nv) = doc.get(fname) {
+                    let json_val = crate::json_convert::normal_value_to_json(nv)
+                        .unwrap_or(JsonValue::Null);
+                    obj.insert(output.to_string(), json_val);
+                } else {
+                    obj.insert(output.to_string(), JsonValue::Null);
+                }
+            }
+        }
+        obj
     }
 
     /// Fetch version (commit) data for a document.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -345,10 +345,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     let field_fetches = field_count * doc_fetches;
                     scan_obj.insert("fieldFetches".to_string(), serde_json::json!(field_fetches));
 
-                    // If this scanNode has an indexName, it's an index scan - add indexFetches
-                    if scan_obj.contains_key("indexName") {
-                        scan_obj.insert("indexFetches".to_string(), serde_json::json!(iterations));
-                    }
+                    // indexFetches is set by IndexScanNode::explain_inner() with
+                    // the actual index key lookup count. Only add it if not already present
+                    // (for regular scans without an index, there's no indexFetches).
+                    // This is already set correctly by IndexScanNode, so no override needed.
                     return;
                 }
             }
@@ -1190,8 +1190,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     .map(|id| JsonValue::String(id.to_string()))
                     .unwrap_or(JsonValue::Null)
             } else if let Some(nv) = document.get(field_name) {
-                crate::json_convert::normal_value_to_json(nv)
-                    .unwrap_or(JsonValue::Null)
+                crate::json_convert::normal_value_to_json(nv).unwrap_or(JsonValue::Null)
             } else {
                 JsonValue::Null
             };
@@ -1268,9 +1267,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         };
 
         // Check if remaining fields need the Planner (has real nested selections)
-        let has_nested = select_without_version.fields.iter().any(|f| {
-            matches!(f, Requestable::Select(_))
-        });
+        let has_nested = select_without_version
+            .fields
+            .iter()
+            .any(|f| matches!(f, Requestable::Select(_)));
 
         let filter_has_relations = select
             .filter
@@ -1286,11 +1286,20 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         // Execute the query for document data (without _version)
         let result = if has_nested || filter_has_relations || order_has_relations {
-            self.execute_nested_select_with_planner(&select_without_version, fetcher, caller_identity)
-                .await?
+            self.execute_nested_select_with_planner(
+                &select_without_version,
+                fetcher,
+                caller_identity,
+            )
+            .await?
         } else {
-            self.execute_simple_select(&select_without_version, fetcher, &collection, caller_identity)
-                .await?
+            self.execute_simple_select(
+                &select_without_version,
+                fetcher,
+                &collection,
+                caller_identity,
+            )
+            .await?
         };
 
         // If no _version selection, return as-is
@@ -1418,16 +1427,17 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         if let Ok(json_val) = crate::json_convert::normal_value_to_json(value) {
                             if let Some(arr) = json_val.as_array() {
                                 // Apply filter if present on the nested selection
-                                let filtered_items: Vec<&JsonValue> = if let Some(ref filter) = nested.filter {
-                                    arr.iter()
-                                        .filter(|item| {
-                                            // Check each filter condition against the item
-                                            self.json_item_matches_filter(item, filter)
-                                        })
-                                        .collect()
-                                } else {
-                                    arr.iter().collect()
-                                };
+                                let filtered_items: Vec<&JsonValue> =
+                                    if let Some(ref filter) = nested.filter {
+                                        arr.iter()
+                                            .filter(|item| {
+                                                // Check each filter condition against the item
+                                                self.json_item_matches_filter(item, filter)
+                                            })
+                                            .collect()
+                                    } else {
+                                        arr.iter().collect()
+                                    };
 
                                 let nested_results: Vec<JsonValue> = filtered_items
                                     .into_iter()
@@ -1441,15 +1451,20 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                                     nested_obj
                                                         .insert(nf_output.to_string(), nv.clone());
                                                 } else {
-                                                    nested_obj
-                                                        .insert(nf_output.to_string(), JsonValue::Null);
+                                                    nested_obj.insert(
+                                                        nf_output.to_string(),
+                                                        JsonValue::Null,
+                                                    );
                                                 }
                                             }
                                         }
                                         JsonValue::Object(nested_obj)
                                     })
                                     .collect();
-                                obj.insert(output_name.to_string(), JsonValue::Array(nested_results));
+                                obj.insert(
+                                    output_name.to_string(),
+                                    JsonValue::Array(nested_results),
+                                );
                             } else {
                                 obj.insert(output_name.to_string(), JsonValue::Null);
                             }
@@ -1527,7 +1542,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 if let JsonValue::Object(obj) = sub_cond {
                                     let sub_map: std::collections::HashMap<String, JsonValue> =
                                         obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                                    let sub_filter = crate::mapper::Filter::from_conditions(sub_map);
+                                    let sub_filter =
+                                        crate::mapper::Filter::from_conditions(sub_map);
                                     if !self.json_item_matches_filter(item, &sub_filter) {
                                         return false;
                                     }
@@ -1542,7 +1558,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 if let JsonValue::Object(obj) = sub_cond {
                                     let sub_map: std::collections::HashMap<String, JsonValue> =
                                         obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                                    let sub_filter = crate::mapper::Filter::from_conditions(sub_map);
+                                    let sub_filter =
+                                        crate::mapper::Filter::from_conditions(sub_map);
                                     if self.json_item_matches_filter(item, &sub_filter) {
                                         any_match = true;
                                         break;
@@ -1614,30 +1631,22 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 (None, _) => true,
                 _ => true,
             },
-            FilterOp::Gt => {
-                match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
-                    (Some(a), Some(b)) => a > b,
-                    _ => false,
-                }
-            }
-            FilterOp::Gte => {
-                match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
-                    (Some(a), Some(b)) => a >= b,
-                    _ => false,
-                }
-            }
-            FilterOp::Lt => {
-                match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
-                    (Some(a), Some(b)) => a < b,
-                    _ => false,
-                }
-            }
-            FilterOp::Lte => {
-                match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
-                    (Some(a), Some(b)) => a <= b,
-                    _ => false,
-                }
-            }
+            FilterOp::Gt => match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
+                (Some(a), Some(b)) => a > b,
+                _ => false,
+            },
+            FilterOp::Gte => match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
+                (Some(a), Some(b)) => a >= b,
+                _ => false,
+            },
+            FilterOp::Lt => match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
+                (Some(a), Some(b)) => a < b,
+                _ => false,
+            },
+            FilterOp::Lte => match (item_value.and_then(|v| v.as_f64()), expected.as_f64()) {
+                (Some(a), Some(b)) => a <= b,
+                _ => false,
+            },
             FilterOp::In => {
                 if let JsonValue::Array(values) = expected {
                     item_value.map(|v| values.contains(v)).unwrap_or(false)

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -432,6 +432,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             return self.execute_commits_query(select).await;
         }
 
+        // Handle CID-based time-travel queries
+        if select.cid.is_some() {
+            return self
+                .execute_cid_query(select, fetcher, caller_identity)
+                .await;
+        }
+
         // Get collection schema on-demand from provider
         let collection = self.get_collection(&select.collection_name).await?;
 
@@ -1034,6 +1041,66 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         plan.close().await?;
 
         Ok(JsonValue::Array(results))
+    }
+
+    /// Execute a CID-based time-travel query.
+    ///
+    /// Reconstructs the document as it existed at the specified commit CID
+    /// by walking the merkle DAG backwards and replaying CRDT deltas.
+    ///
+    /// CID queries require `cid` argument and optionally `docID` for validation.
+    /// Returns a single-element array containing the document at that version.
+    async fn execute_cid_query(
+        &self,
+        select: &Select,
+        fetcher: &dyn DocFetcher,
+        _caller_identity: Option<Did>,
+    ) -> Result<JsonValue> {
+        let cid = select.cid.as_ref().ok_or_else(|| {
+            QueryError::internal("execute_cid_query called without CID - this is a bug")
+        })?;
+
+        // Get expected docID from select.doc_ids (optional validation)
+        let expected_doc_id = select.doc_ids.as_ref().and_then(|ids| ids.first());
+
+        // Fetch document at the specified CID
+        let document = fetcher
+            .get_document_at_cid(cid, expected_doc_id.map(|s| s.as_str()))
+            .await?;
+
+        // Get collection schema for building the mapping
+        let collection = self.get_collection(&select.collection_name).await?;
+
+        // Build mapping for the requested fields
+        let mapping = plan::build_mapping(select, &collection)?;
+
+        // Convert the document to JSON with only the requested fields
+        let mut obj = serde_json::Map::new();
+
+        for render_key in &mapping.render_keys {
+            let field_name = mapping
+                .try_find_name_from_index(render_key.index)
+                .unwrap_or("");
+
+            let value = if field_name == "__typename" {
+                JsonValue::String(select.collection_name.clone())
+            } else if field_name == "_docID" {
+                document
+                    .id()
+                    .map(|id| JsonValue::String(id.to_string()))
+                    .unwrap_or(JsonValue::Null)
+            } else if let Some(nv) = document.get(field_name) {
+                crate::json_convert::normal_value_to_json(nv)
+                    .unwrap_or(JsonValue::Null)
+            } else {
+                JsonValue::Null
+            };
+
+            obj.insert(render_key.key.clone(), value);
+        }
+
+        // Return as single-element array (Go compatibility)
+        Ok(JsonValue::Array(vec![JsonValue::Object(obj)]))
     }
 
     /// Execute a top-level aggregate query (e.g., `{ _avg(Users: {field: Age}) }`).

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -716,13 +716,43 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             return Ok(results);
         }
 
-        // Collect which relation fields are explicitly selected (for cleanup later)
+        // Collect which relation fields are explicitly selected and their requested fields (for cleanup later)
         let selected_relations: std::collections::HashSet<String> = select
             .fields
             .iter()
             .filter_map(|f| {
                 if let Requestable::Select(s) = f {
                     Some(s.field.name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // For each selected relation, collect the fields that were explicitly requested.
+        // Any fields NOT in this set were added for aggregate filter evaluation and should be cleaned up.
+        let selected_relation_fields: std::collections::HashMap<String, std::collections::HashSet<String>> = select
+            .fields
+            .iter()
+            .filter_map(|f| {
+                if let Requestable::Select(s) = f {
+                    let mut fields = std::collections::HashSet::new();
+                    // Always include _docID as it's implicit
+                    fields.insert("_docID".to_string());
+                    for requestable in &s.fields {
+                        match requestable {
+                            Requestable::Field(f) => {
+                                fields.insert(f.output_name().to_string());
+                            }
+                            Requestable::Select(nested) => {
+                                fields.insert(nested.field.output_name().to_string());
+                            }
+                            Requestable::Aggregate(agg) => {
+                                fields.insert(agg.output_name().to_string());
+                            }
+                        }
+                    }
+                    Some((s.field.name.clone(), fields))
                 } else {
                     None
                 }
@@ -755,17 +785,29 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 // Step 1: Apply filter to array elements
                                 let filtered_items: Vec<&JsonValue> =
                                     if let Some(ref filter) = target.filter {
+                                        // Check if the filter has field-based conditions
+                                        // (keys that are not operators like _gt, _eq, etc.)
+                                        let has_field_conditions = filter.has_field_conditions();
+
                                         items
                                             .iter()
                                             .filter(|item| {
-                                                let val = match field_name {
-                                                    Some(f) => item
-                                                        .as_object()
-                                                        .and_then(|o| o.get(f))
-                                                        .unwrap_or(&JsonValue::Null),
-                                                    None => *item,
-                                                };
-                                                filter.matches_scalar_value(val).unwrap_or(false)
+                                                if has_field_conditions {
+                                                    // Field-based filter like {rating: {_gt: 4.8}}
+                                                    // Match against the entire item object
+                                                    filter.matches_json_object(item).unwrap_or(false)
+                                                } else {
+                                                    // Operator-only filter like {_gt: 4.8}
+                                                    // Extract the field value and match against it
+                                                    let val = match field_name {
+                                                        Some(f) => item
+                                                            .as_object()
+                                                            .and_then(|o| o.get(f))
+                                                            .unwrap_or(&JsonValue::Null),
+                                                        None => *item,
+                                                    };
+                                                    filter.matches_scalar_value(val).unwrap_or(false)
+                                                }
                                             })
                                             .collect()
                                     } else {
@@ -947,6 +989,108 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 for relation_name in &aggregate_relation_names {
                     if !selected_relations.contains(relation_name) {
                         obj.remove(relation_name);
+                    }
+                }
+
+                // Clean up extra fields from relation data that were added for aggregate filter evaluation
+                // but weren't in the original selection. For example, if the selection was
+                // `published { name }` but the aggregate filter needed `rating`, we need to remove
+                // `rating` from each item in `published` after aggregate computation.
+                for (relation_name, allowed_fields) in &selected_relation_fields {
+                    if let Some(relation_data) = obj.get_mut(relation_name) {
+                        if let JsonValue::Array(items) = relation_data {
+                            for item in items.iter_mut() {
+                                if let JsonValue::Object(item_obj) = item {
+                                    // Remove fields that weren't in the original selection
+                                    item_obj.retain(|k, _| allowed_fields.contains(k));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Apply post-aggregate filtering if needed
+        // When filter uses _alias to reference computed aggregates, the SelectNode can't
+        // filter during plan execution since aggregate values don't exist yet.
+        // Example: filter: {_alias: {publishedCount: {_gt: 0}}}
+        if let Some(ref filter) = select.filter {
+            let aggregate_output_names: std::collections::HashSet<&str> = aggregates_info
+                .iter()
+                .map(|(name, _, _)| name.as_str())
+                .collect();
+
+            // Check if filter has _alias conditions referencing aggregate names
+            if let Some(alias_conditions) = filter.conditions().get("_alias") {
+                if let Some(alias_obj) = alias_conditions.as_object() {
+                    let needs_post_filter = alias_obj
+                        .keys()
+                        .any(|k| aggregate_output_names.contains(k.as_str()));
+
+                    if needs_post_filter {
+                        results.retain(|result| {
+                            if let Some(obj) = result.as_object() {
+                                // Evaluate each alias condition
+                                for (alias_name, condition) in alias_obj {
+                                    if let Some(value) = obj.get(alias_name) {
+                                        // Parse and evaluate the operator conditions
+                                        if let Some(cond_obj) = condition.as_object() {
+                                            for (op_str, expected) in cond_obj {
+                                                if let Some(op) = crate::mapper::FilterOp::parse(op_str)
+                                                {
+                                                    match op {
+                                                        crate::mapper::FilterOp::Eq => {
+                                                            if value != expected {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Ne => {
+                                                            if value == expected {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Gt => {
+                                                            let v = value.as_f64().unwrap_or(0.0);
+                                                            let e = expected.as_f64().unwrap_or(0.0);
+                                                            if v <= e {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Gte => {
+                                                            let v = value.as_f64().unwrap_or(0.0);
+                                                            let e = expected.as_f64().unwrap_or(0.0);
+                                                            if v < e {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Lt => {
+                                                            let v = value.as_f64().unwrap_or(0.0);
+                                                            let e = expected.as_f64().unwrap_or(0.0);
+                                                            if v >= e {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        crate::mapper::FilterOp::Lte => {
+                                                            let v = value.as_f64().unwrap_or(0.0);
+                                                            let e = expected.as_f64().unwrap_or(0.0);
+                                                            if v > e {
+                                                                return false;
+                                                            }
+                                                        }
+                                                        _ => {}
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        // Alias field not found in result, filter it out
+                                        return false;
+                                    }
+                                }
+                            }
+                            true
+                        });
                     }
                 }
             }

--- a/crates/query/src/sdl_parse/parser.rs
+++ b/crates/query/src/sdl_parse/parser.rs
@@ -411,7 +411,14 @@ impl<'a> SdlParser<'a> {
 
             match name {
                 "index" => {
-                    let fields = get_directive_string_list(directive, "fields");
+                    // Try "fields" argument first (simple format: ["name", "age"])
+                    let mut fields = get_directive_string_list(directive, "fields");
+
+                    // If "fields" is empty, try "includes" argument (Go format: [{field: "name"}, ...])
+                    if fields.is_empty() {
+                        fields = self.parse_includes_argument(directive);
+                    }
+
                     let idx_name = get_directive_string(directive, "name");
                     let unique = self
                         .get_bool_with_warning(directive, "unique", &type_name, None)
@@ -488,6 +495,37 @@ impl<'a> SdlParser<'a> {
             unique,
             direction,
         })
+    }
+
+    /// Parse the `includes` argument for composite indexes.
+    ///
+    /// Go format: `@index(includes: [{field: "name"}, {field: "numbers"}, {field: "age"}])`
+    /// Returns the list of field names extracted from the objects.
+    fn parse_includes_argument(&self, directive: &Directive<'_, String>) -> Vec<String> {
+        let Some(value) = get_directive_arg(directive, "includes") else {
+            return Vec::new();
+        };
+
+        let graphql_parser::schema::Value::List(items) = value else {
+            return Vec::new();
+        };
+
+        items
+            .iter()
+            .filter_map(|item| {
+                // Each item should be an object like {field: "name"}
+                let graphql_parser::schema::Value::Object(obj) = item else {
+                    return None;
+                };
+
+                // Find the "field" key and extract its string value
+                obj.get("field").and_then(|v| match v {
+                    graphql_parser::schema::Value::String(s)
+                    | graphql_parser::schema::Value::Enum(s) => Some(s.clone()),
+                    _ => None,
+                })
+            })
+            .collect()
     }
 
     fn parse_default_directive(

--- a/crates/query/src/sdl_parse/parser.rs
+++ b/crates/query/src/sdl_parse/parser.rs
@@ -104,7 +104,7 @@ struct PolicyConfig {
 
 #[derive(Debug)]
 struct CompositeIndex {
-    fields: Vec<String>,
+    fields: Vec<(String, bool)>, // (field_name, descending)
     name: Option<String>,
     unique: bool,
 }
@@ -412,12 +412,13 @@ impl<'a> SdlParser<'a> {
             match name {
                 "index" => {
                     // Try "fields" argument first (simple format: ["name", "age"])
-                    let mut fields = get_directive_string_list(directive, "fields");
-
-                    // If "fields" is empty, try "includes" argument (Go format: [{field: "name"}, ...])
-                    if fields.is_empty() {
-                        fields = self.parse_includes_argument(directive);
-                    }
+                    let simple_fields = get_directive_string_list(directive, "fields");
+                    let fields: Vec<(String, bool)> = if !simple_fields.is_empty() {
+                        simple_fields.into_iter().map(|f| (f, false)).collect()
+                    } else {
+                        // Try "includes" argument (Go format: [{field: "name", direction: DESC}, ...])
+                        self.parse_includes_argument(directive)
+                    };
 
                     let idx_name = get_directive_string(directive, "name");
                     let unique = self
@@ -499,9 +500,12 @@ impl<'a> SdlParser<'a> {
 
     /// Parse the `includes` argument for composite indexes.
     ///
-    /// Go format: `@index(includes: [{field: "name"}, {field: "numbers"}, {field: "age"}])`
-    /// Returns the list of field names extracted from the objects.
-    fn parse_includes_argument(&self, directive: &Directive<'_, String>) -> Vec<String> {
+    /// Go format: `@index(includes: [{field: "name"}, {field: "age", direction: DESC}])`
+    /// Returns (field_name, descending) tuples extracted from the objects.
+    fn parse_includes_argument(
+        &self,
+        directive: &Directive<'_, String>,
+    ) -> Vec<(String, bool)> {
         let Some(value) = get_directive_arg(directive, "includes") else {
             return Vec::new();
         };
@@ -513,17 +517,31 @@ impl<'a> SdlParser<'a> {
         items
             .iter()
             .filter_map(|item| {
-                // Each item should be an object like {field: "name"}
+                // Each item should be an object like {field: "name", direction: DESC}
                 let graphql_parser::schema::Value::Object(obj) = item else {
                     return None;
                 };
 
-                // Find the "field" key and extract its string value
-                obj.get("field").and_then(|v| match v {
+                // Extract field name
+                let field_name = obj.get("field").and_then(|v| match v {
                     graphql_parser::schema::Value::String(s)
                     | graphql_parser::schema::Value::Enum(s) => Some(s.clone()),
                     _ => None,
-                })
+                })?;
+
+                // Extract direction (defaults to ASC)
+                let descending = obj
+                    .get("direction")
+                    .map(|v| match v {
+                        graphql_parser::schema::Value::String(s)
+                        | graphql_parser::schema::Value::Enum(s) => {
+                            matches!(s.as_str(), "DESC" | "desc" | "Descending")
+                        }
+                        _ => false,
+                    })
+                    .unwrap_or(false);
+
+                Some((field_name, descending))
             })
             .collect()
     }
@@ -1195,7 +1213,7 @@ impl<'a> SdlParser<'a> {
 
         for composite_idx in &type_def.directives.indexes {
             // Validate that all referenced fields exist
-            for field_ref in &composite_idx.fields {
+            for (field_ref, _) in &composite_idx.fields {
                 if !valid_field_names.contains(field_ref.as_str()) {
                     return Err(QueryError::parse(format!(
                         "@index on type {} references unknown field '{}'",
@@ -1205,15 +1223,17 @@ impl<'a> SdlParser<'a> {
             }
 
             let idx_name = composite_idx.name.clone().unwrap_or_else(|| {
-                format!("{}_{}_idx", type_def.name, composite_idx.fields.join("_"))
+                let field_names: Vec<&str> =
+                    composite_idx.fields.iter().map(|(n, _)| n.as_str()).collect();
+                format!("{}_{}_idx", type_def.name, field_names.join("_"))
             });
 
             let indexed_fields: Vec<IndexedFieldDescription> = composite_idx
                 .fields
                 .iter()
-                .map(|f| IndexedFieldDescription {
-                    name: f.clone(),
-                    descending: false,
+                .map(|(name, descending)| IndexedFieldDescription {
+                    name: name.clone(),
+                    descending: *descending,
                 })
                 .collect();
 

--- a/crates/query/src/sdl_parse/parser.rs
+++ b/crates/query/src/sdl_parse/parser.rs
@@ -992,7 +992,7 @@ impl<'a> SdlParser<'a> {
             let root = find_root(type_name, &mut component);
             components
                 .entry(root)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(type_name.clone());
         }
 
@@ -1300,7 +1300,7 @@ impl<'a> SdlParser<'a> {
             // use SelfRef with the target's relative index
             if let Some(&target_idx) = collection_set.get(base) {
                 return Ok(FieldKind::self_ref(
-                    &target_idx.to_string(),
+                    target_idx.to_string(),
                     parsed_type.is_list,
                 ));
             }

--- a/crates/query/src/sdl_parse/parser.rs
+++ b/crates/query/src/sdl_parse/parser.rs
@@ -990,10 +990,7 @@ impl<'a> SdlParser<'a> {
             std::collections::HashMap::new();
         for type_name in cycle_edges.keys() {
             let root = find_root(type_name, &mut component);
-            components
-                .entry(root)
-                .or_default()
-                .push(type_name.clone());
+            components.entry(root).or_default().push(type_name.clone());
         }
 
         // Build result: each type gets index within its component

--- a/crates/schema/src/ctype.rs
+++ b/crates/schema/src/ctype.rs
@@ -100,6 +100,14 @@ impl CType {
     pub fn is_counter(&self) -> bool {
         matches!(self, CType::PnCounter | CType::PCounter)
     }
+
+    /// Returns true if this counter type allows decrement (negative increments)
+    ///
+    /// - PnCounter (Positive-Negative Counter): allows both increment and decrement
+    /// - PCounter (Positive Counter): only allows increment
+    pub fn allows_decrement(&self) -> bool {
+        matches!(self, CType::PnCounter)
+    }
 }
 
 impl fmt::Display for CType {

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -8,7 +8,7 @@ pub type Result<T> = std::result::Result<T, SchemaError>;
 /// Schema-specific errors
 #[derive(Debug, Error)]
 pub enum SchemaError {
-    #[error("duplicate field name: {0}")]
+    #[error("duplicate field. Name: {0}")]
     DuplicateFieldName(String),
 
     #[error("invalid CRDT type for field kind: {field_name} cannot use {crdt_type} (only numeric fields support counters)")]
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn test_error_display() {
         let err = SchemaError::DuplicateFieldName("name".into());
-        assert_eq!(err.to_string(), "duplicate field name: name");
+        assert_eq!(err.to_string(), "duplicate field. Name: name");
     }
 
     #[test]

--- a/crates/storage/src/index/range_iterator.rs
+++ b/crates/storage/src/index/range_iterator.rs
@@ -25,8 +25,9 @@ use crate::keys::IndexDataStoreKey;
 pub struct RangeIterator {
     /// The underlying KV iterator
     inner: Box<dyn Iterator>,
-    /// The base key prefix (collection/index prefix, possibly with some field values)
-    key_prefix: Vec<u8>,
+    /// Length of the index prefix (collection_id + index_id only, without field values).
+    /// Used to find where encoded field values start in a key.
+    index_prefix_len: usize,
     /// Index description for decoding field values
     desc: IndexDescription,
     /// Whether this is a unique index
@@ -57,6 +58,7 @@ impl RangeIterator {
         reverse: bool,
     ) -> Result<Self> {
         let key_prefix = IndexDataStoreKey::index_prefix(collection_short_id, desc.id);
+        let index_prefix_len = key_prefix.len();
 
         let opts = IterOptions::default()
             .with_prefix(key_prefix.clone())
@@ -65,7 +67,7 @@ impl RangeIterator {
 
         Ok(Self {
             inner,
-            key_prefix,
+            index_prefix_len,
             desc: desc.clone(),
             is_unique,
             lower_bound_key: None,
@@ -91,6 +93,7 @@ impl RangeIterator {
     ) -> Result<Self> {
         // Build key prefix with the exact field values
         let mut key_prefix = IndexDataStoreKey::index_prefix(collection_short_id, desc.id);
+        let index_prefix_len = key_prefix.len();
 
         // Encode prefix field values
         for (i, value) in prefix_values.iter().enumerate() {
@@ -105,7 +108,7 @@ impl RangeIterator {
 
         Ok(Self {
             inner,
-            key_prefix,
+            index_prefix_len,
             desc: desc.clone(),
             is_unique,
             lower_bound_key: None,
@@ -134,6 +137,7 @@ impl RangeIterator {
     ) -> Result<Self> {
         // Build base key prefix with collection/index and prefix values
         let mut key_prefix = IndexDataStoreKey::index_prefix(collection_short_id, desc.id);
+        let index_prefix_len = key_prefix.len();
 
         // Encode prefix field values
         for (i, value) in prefix_values.iter().enumerate() {
@@ -199,7 +203,7 @@ impl RangeIterator {
 
         Ok(Self {
             inner,
-            key_prefix,
+            index_prefix_len,
             desc: desc.clone(),
             is_unique,
             lower_bound_key,
@@ -235,13 +239,7 @@ impl RangeIterator {
     ///
     /// The remaining bytes after decoding all field values contain the doc_id suffix.
     fn decode_field_values<'a>(&self, key: &'a [u8]) -> Result<(Vec<NormalValue>, &'a [u8])> {
-        // Get the index prefix to know where field values start
-        let index_prefix = IndexDataStoreKey::index_prefix(
-            extract_collection_id(&self.key_prefix)?,
-            extract_index_id(&self.key_prefix)?,
-        );
-
-        let mut buf = &key[index_prefix.len()..];
+        let mut buf = &key[self.index_prefix_len..];
         let mut values = Vec::with_capacity(self.desc.fields.len());
 
         for field_desc in &self.desc.fields {
@@ -249,9 +247,6 @@ impl RangeIterator {
                 break;
             }
             // Use blob kind as default - the encoded type marker determines the actual type.
-            // Note: String values will be decoded as Bytes since we don't have field type
-            // information at decode time. This is acceptable for index operations where
-            // we primarily need byte-level comparison semantics.
             let kind = FieldKind::blob();
             let (rest, value) = decode_field_value(buf, field_desc.descending, &kind)?;
             values.push(value);
@@ -419,80 +414,6 @@ impl IndexIterator for RangeIterator {
         self.exhausted = false;
         Ok(())
     }
-}
-
-/// Extract collection_short_id from the key prefix.
-fn extract_collection_id(prefix: &[u8]) -> Result<u32> {
-    if prefix.is_empty() {
-        return Err(crate::corekv::Error::Other(
-            "cannot extract collection_id: prefix is empty".to_string(),
-        ));
-    }
-    if prefix.len() < 2 {
-        return Err(crate::corekv::Error::Other(format!(
-            "cannot extract collection_id: prefix too short ({} bytes)",
-            prefix.len()
-        )));
-    }
-
-    let pos = 1; // Skip initial separator
-    let (val, _) = decode_varint(&prefix[pos..]);
-    if val > u32::MAX as u64 {
-        return Err(crate::corekv::Error::Other(format!(
-            "collection_id {} exceeds maximum u32 value",
-            val
-        )));
-    }
-    Ok(val as u32)
-}
-
-/// Extract index_id from the key prefix.
-fn extract_index_id(prefix: &[u8]) -> Result<u32> {
-    if prefix.is_empty() {
-        return Err(crate::corekv::Error::Other(
-            "cannot extract index_id: prefix is empty".to_string(),
-        ));
-    }
-
-    let mut pos = 1; // Skip initial separator
-    let (_col_id, bytes_read) = decode_varint(&prefix[pos..]);
-    pos += bytes_read;
-    pos += 1; // Skip separator after col_id
-
-    if pos >= prefix.len() {
-        return Err(crate::corekv::Error::Other(format!(
-            "cannot extract index_id: prefix too short (pos {} >= len {})",
-            pos,
-            prefix.len()
-        )));
-    }
-
-    let (idx_id, _) = decode_varint(&prefix[pos..]);
-    if idx_id > u32::MAX as u64 {
-        return Err(crate::corekv::Error::Other(format!(
-            "index_id {} exceeds maximum u32 value",
-            idx_id
-        )));
-    }
-    Ok(idx_id as u32)
-}
-
-/// Decode a varint from bytes.
-fn decode_varint(buf: &[u8]) -> (u64, usize) {
-    let mut result: u64 = 0;
-    let mut shift = 0;
-    let mut bytes_read = 0;
-
-    for &byte in buf {
-        bytes_read += 1;
-        result |= ((byte & 0x7F) as u64) << shift;
-        if byte & 0x80 == 0 {
-            break;
-        }
-        shift += 7;
-    }
-
-    (result, bytes_read)
 }
 
 #[cfg(test)]

--- a/crates/storage/src/index/range_iterator.rs
+++ b/crates/storage/src/index/range_iterator.rs
@@ -213,8 +213,8 @@ impl RangeIterator {
 
     /// Extract document ID and field values from an index key.
     fn extract_entry(&self, key: &[u8], value: &[u8]) -> Result<IndexEntry> {
-        // First, decode the field values from the key
-        let values = self.decode_field_values(key)?;
+        // Decode field values and get remaining bytes (doc_id suffix)
+        let (values, doc_id_bytes) = self.decode_field_values(key)?;
 
         // Determine if this is a NULL entry (doc_id in key suffix)
         let has_nil = values.iter().any(|v| v.is_nil());
@@ -225,14 +225,16 @@ impl RangeIterator {
                 .map_err(|e| crate::corekv::Error::Other(format!("invalid doc_id: {}", e)))?
         } else {
             // Simple index or unique with NULL: doc_id is in key suffix
-            self.extract_doc_id_from_key(key, &values)?
+            self.extract_doc_id_from_key(doc_id_bytes)?
         };
 
         Ok(IndexEntry::new(doc_id, values))
     }
 
-    /// Decode field values from an index key.
-    fn decode_field_values(&self, key: &[u8]) -> Result<Vec<NormalValue>> {
+    /// Decode field values from an index key, returning values and remaining bytes.
+    ///
+    /// The remaining bytes after decoding all field values contain the doc_id suffix.
+    fn decode_field_values<'a>(&self, key: &'a [u8]) -> Result<(Vec<NormalValue>, &'a [u8])> {
         // Get the index prefix to know where field values start
         let index_prefix = IndexDataStoreKey::index_prefix(
             extract_collection_id(&self.key_prefix)?,
@@ -268,36 +270,18 @@ impl RangeIterator {
             )));
         }
 
-        Ok(values)
+        // Return values and remaining bytes (the doc_id suffix)
+        Ok((values, buf))
     }
 
-    /// Extract doc_id from key suffix (after encoded field values).
-    fn extract_doc_id_from_key(&self, key: &[u8], values: &[NormalValue]) -> Result<String> {
-        // Rebuild the key without doc_id to find where doc_id starts
-        let index_prefix = IndexDataStoreKey::index_prefix(
-            extract_collection_id(&self.key_prefix)?,
-            extract_index_id(&self.key_prefix)?,
-        );
-
-        let mut encoded_values = index_prefix;
-        for (i, value) in values.iter().enumerate() {
-            let descending = self
-                .desc
-                .fields
-                .get(i)
-                .map(|f| f.descending)
-                .unwrap_or(false);
-            encoded_values = encode_field_value(encoded_values, value, descending)?;
-        }
-
-        if key.len() <= encoded_values.len() {
-            // No doc_id suffix - this shouldn't happen for simple index
+    /// Extract doc_id from key suffix (the remaining bytes after field values).
+    fn extract_doc_id_from_key(&self, doc_id_bytes: &[u8]) -> Result<String> {
+        if doc_id_bytes.is_empty() {
             return Err(crate::corekv::Error::Other(
                 "index key missing doc_id suffix".to_string(),
             ));
         }
 
-        let doc_id_bytes = &key[encoded_values.len()..];
         String::from_utf8(doc_id_bytes.to_vec())
             .map_err(|e| crate::corekv::Error::Other(format!("invalid doc_id: {}", e)))
     }


### PR DESCRIPTION
## Summary

- Achieve **411/433 (94.9%)** test parity on `query/simple` integration tests against Go DefraDB
- Builds on the collection-version branch's FFI infrastructure

## Changes

- **CID time-travel queries**: VersionedFetcher for reconstructing documents at historical CIDs via merkle DAG traversal and CRDT delta replay
- **Counter CRDT**: Block CID parity with Go for counter merge operations
- **`_version` field support**: Commit history queries with depth traversal
- **GroupBy/aggregate fixes**: Multiple `_group` aliases, 3rd-level nested aggregates, inner aggregate definitions
- **Parser validation**: Null element checks in `_and`/`_or` filters, multi-field order array validation
- **Operation name support**: Multi-operation document selection, fragment variable resolution, eliminated double-parse bug
- **Dead code cleanup**: Removed unused imports and unreachable code paths

## Remaining Failures (22 tests)

All remaining failures require major new features tracked in issues:

| Issue | Category | Tests |
|-------|----------|-------|
| #220 | CID-based time-travel (branchable collections) | 6 |
| #221 | Similarity/vector search | 9 |
| #222 | Latest commit embedding | 4 |
| #223 | Document update events (delete) | 2 |
| #224 | GroupBy outer ordering (storage scan order) | 1 |

## Test plan

- [x] `cargo build --release -p ffi` compiles cleanly
- [x] Full `query/simple` suite: 411/433 passing
- [ ] Verify no regressions on `collection_version` suite after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)