### PR TITLE
feat(storage): Add write-write conflict detection for transaction isolation

### DIFF
--- a/crates/storage/src/backends/memory.rs
+++ b/crates/storage/src/backends/memory.rs
@@ -33,6 +33,8 @@
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -41,14 +43,85 @@ use crate::corekv::{
     TxnCallback, Writer,
 };
 
+/// Tracks committed write sets for optimistic conflict detection.
+///
+/// Each committed transaction's write set is recorded along with the version
+/// at which it was committed. When a new transaction commits, it checks whether
+/// any of its written keys were also written by transactions that committed
+/// after this transaction's snapshot was taken.
+pub(crate) struct ConflictTracker {
+    /// Monotonically increasing version counter.
+    version: AtomicU64,
+    /// Write sets from committed transactions: (commit_version, keys_written).
+    /// Protected by a mutex since we only access it during commit (not hot path).
+    committed_writes: Mutex<Vec<(u64, HashSet<Vec<u8>>)>>,
+}
+
+impl ConflictTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            version: AtomicU64::new(0),
+            committed_writes: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Get the current version for a new transaction's snapshot.
+    pub(crate) fn current_version(&self) -> u64 {
+        self.version.load(Ordering::SeqCst)
+    }
+
+    /// Check for conflicts and record the write set if no conflict.
+    /// Returns Err(TxnConflict) if any key in `write_set` was written by a
+    /// transaction that committed after `read_version`.
+    pub(crate) fn check_and_record(
+        &self,
+        read_version: u64,
+        write_set: HashSet<Vec<u8>>,
+    ) -> std::result::Result<(), Error> {
+        if write_set.is_empty() {
+            return Ok(());
+        }
+
+        let mut committed = self.committed_writes.lock();
+
+        // Check for conflicts: any key we wrote was also written by a
+        // transaction committed after our snapshot
+        for (commit_ver, keys) in committed.iter() {
+            if *commit_ver > read_version {
+                for key in &write_set {
+                    if keys.contains(key) {
+                        return Err(Error::TxnConflict);
+                    }
+                }
+            }
+        }
+
+        // No conflict - record our write set
+        let new_version = self.version.fetch_add(1, Ordering::SeqCst) + 1;
+        committed.push((new_version, write_set));
+
+        // Prune old entries that can no longer conflict (optional GC).
+        // Keep entries that are newer than the oldest possible active transaction.
+        // For simplicity, keep last 1000 entries.
+        if committed.len() > 1000 {
+            let drain_count = committed.len() - 1000;
+            committed.drain(..drain_count);
+        }
+
+        Ok(())
+    }
+}
+
 /// In-memory key-value store using BTreeMap.
 ///
 /// Data is stored in a BTreeMap wrapped in Arc<RwLock<>> for thread-safe
-/// concurrent access. The store provides snapshot isolation for transactions.
+/// concurrent access. The store provides snapshot isolation for transactions
+/// with optimistic write-write conflict detection.
 #[derive(Clone)]
 pub struct MemoryStore {
     data: Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
     closed: Arc<RwLock<bool>>,
+    conflict_tracker: Arc<ConflictTracker>,
 }
 
 impl MemoryStore {
@@ -57,6 +130,7 @@ impl MemoryStore {
         Self {
             data: Arc::new(RwLock::new(BTreeMap::new())),
             closed: Arc::new(RwLock::new(false)),
+            conflict_tracker: Arc::new(ConflictTracker::new()),
         }
     }
 
@@ -79,11 +153,16 @@ impl Store for MemoryStore {
             return Err(Error::DBClosed);
         }
 
+        // Record version before taking snapshot for conflict detection
+        let read_version = self.conflict_tracker.current_version();
+
         // Take a snapshot of current data for isolation
         let snapshot = self.data.read().await.clone();
 
         Ok(Box::new(MemoryTxn {
             store: Arc::clone(&self.data),
+            conflict_tracker: Arc::clone(&self.conflict_tracker),
+            read_version,
             snapshot,
             pending: Mutex::new(BTreeMap::new()),
             readonly,
@@ -119,13 +198,20 @@ impl Dropable for MemoryStore {
     }
 }
 
-/// In-memory transaction with snapshot isolation.
+/// In-memory transaction with snapshot isolation and conflict detection.
 ///
 /// Transactions maintain a snapshot of the store at creation time and track
-/// pending changes. Changes are applied atomically on commit.
+/// pending changes. On commit, write-write conflicts are detected using
+/// optimistic concurrency control.
 struct MemoryTxn {
     /// Reference to the store's data
     store: Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
+
+    /// Conflict tracker for write-write conflict detection
+    conflict_tracker: Arc<ConflictTracker>,
+
+    /// Version at which this transaction's snapshot was taken
+    read_version: u64,
 
     /// Snapshot of store at transaction start (for reads)
     snapshot: BTreeMap<Vec<u8>, Vec<u8>>,
@@ -337,11 +423,23 @@ impl Txn for MemoryTxn {
             return Err(Error::Other("Transaction already committed".into()));
         }
 
-        // Mark as committed
-        *self.committed.lock() = true;
-
         // Clone pending changes before awaiting (can't hold MutexGuard across await)
         let pending = self.pending.lock().clone();
+
+        // Check for write-write conflicts before applying
+        if !pending.is_empty() {
+            let write_set: HashSet<Vec<u8>> = pending.keys().cloned().collect();
+            if let Err(e) = self.conflict_tracker.check_and_record(self.read_version, write_set) {
+                let on_error = std::mem::take(&mut *self.on_error.lock());
+                let on_error_async = std::mem::take(&mut *self.on_error_async.lock());
+                Self::execute_callbacks(on_error);
+                Self::execute_async_callbacks(on_error_async).await;
+                return Err(e);
+            }
+        }
+
+        // Mark as committed
+        *self.committed.lock() = true;
 
         // Apply pending changes to store
         if !pending.is_empty() {

--- a/crates/storage/src/backends/redb.rs
+++ b/crates/storage/src/backends/redb.rs
@@ -71,11 +71,14 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 use redb::{Database, ReadTransaction, ReadableTable, TableDefinition};
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::ops::Bound;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+use super::memory::ConflictTracker;
 
 use crate::corekv::{
     AsyncTxnCallback, Dropable, Error, IterOptions, Iterator, KvPair, Reader, Result, Store, Txn,
@@ -107,6 +110,8 @@ pub struct RedbStore {
     db_path: std::path::PathBuf,
     /// Maximum keys allowed in a snapshot (OOM safeguard)
     max_snapshot_keys: Option<usize>,
+    /// Conflict tracker for write-write conflict detection
+    conflict_tracker: Arc<ConflictTracker>,
 }
 
 impl RedbStore {
@@ -221,6 +226,7 @@ impl RedbStore {
             close_timeout: opts.close_timeout(),
             db_path,
             max_snapshot_keys: opts.max_snapshot_keys(),
+            conflict_tracker: Arc::new(ConflictTracker::new()),
         })
     }
 
@@ -355,6 +361,9 @@ impl Store for RedbStore {
         }
         let mut guard = NewTxnGuard(&self.active_txn_count, false);
 
+        // Record version before taking snapshot for conflict detection
+        let read_version = self.conflict_tracker.current_version();
+
         // Capture a snapshot for read isolation
         let read_txn = self.db.begin_read()?;
         let snapshot = capture_snapshot(&read_txn, self.max_snapshot_keys)?;
@@ -365,6 +374,8 @@ impl Store for RedbStore {
         Ok(Box::new(RedbTxn {
             db: Arc::clone(&self.db),
             active_txn_count: Arc::clone(&self.active_txn_count),
+            conflict_tracker: Arc::clone(&self.conflict_tracker),
+            read_version,
             snapshot,
             pending: Mutex::new(BTreeMap::new()),
             readonly,
@@ -620,6 +631,12 @@ struct RedbTxn {
 
     /// Reference to the active transaction counter (for decrement on complete)
     active_txn_count: Arc<AtomicUsize>,
+
+    /// Conflict tracker for write-write conflict detection
+    conflict_tracker: Arc<ConflictTracker>,
+
+    /// Version at which this transaction's snapshot was taken
+    read_version: u64,
 
     /// Snapshot of store at transaction start (for reads)
     snapshot: BTreeMap<Vec<u8>, Vec<u8>>,
@@ -997,6 +1014,18 @@ impl Txn for RedbTxn {
 
         // Clone pending changes before any async operations
         let pending = self.pending.lock().clone();
+
+        // Check for write-write conflicts before applying
+        if !pending.is_empty() {
+            let write_set: HashSet<Vec<u8>> = pending.keys().cloned().collect();
+            if let Err(e) = self.conflict_tracker.check_and_record(self.read_version, write_set) {
+                let on_error = std::mem::take(&mut *self.on_error.lock());
+                let on_error_async = std::mem::take(&mut *self.on_error_async.lock());
+                Self::execute_callbacks(on_error);
+                Self::execute_async_callbacks(on_error_async).await;
+                return Err(e);
+            }
+        }
 
         // Apply pending changes to the database if there are any
         if !pending.is_empty() {

--- a/crates/storage/src/backends/test_suite.rs
+++ b/crates/storage/src/backends/test_suite.rs
@@ -1526,19 +1526,28 @@ pub async fn test_concurrent_writes_different_keys<S: Store + 'static>(store: Ar
 
 /// Test concurrent writes to the SAME key (last writer wins)
 pub async fn test_concurrent_writes_same_key<S: Store + 'static>(store: Arc<S>) {
-    let commit_count = Arc::new(AtomicUsize::new(0));
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let conflict_count = Arc::new(AtomicUsize::new(0));
     let mut handles = vec![];
 
     for i in 0..10 {
         let store = store.clone();
-        let commit_count = commit_count.clone();
+        let success_count = success_count.clone();
+        let conflict_count = conflict_count.clone();
         handles.push(tokio::spawn(async move {
             let mut txn = store.new_txn(false).await.unwrap();
             txn.set(b"contended_key", format!("value_{}", i).as_bytes())
                 .await
                 .unwrap();
-            txn.commit().await.unwrap();
-            commit_count.fetch_add(1, Ordering::SeqCst);
+            match txn.commit().await {
+                Ok(()) => {
+                    success_count.fetch_add(1, Ordering::SeqCst);
+                }
+                Err(Error::TxnConflict) => {
+                    conflict_count.fetch_add(1, Ordering::SeqCst);
+                }
+                Err(e) => panic!("unexpected error: {}", e),
+            }
         }));
     }
 
@@ -1546,8 +1555,11 @@ pub async fn test_concurrent_writes_same_key<S: Store + 'static>(store: Arc<S>) 
         handle.await.unwrap();
     }
 
-    // All commits should succeed (no OCC = no conflicts)
-    assert_eq!(commit_count.load(Ordering::SeqCst), 10);
+    // At least one commit should succeed, others may conflict
+    let successes = success_count.load(Ordering::SeqCst);
+    let conflicts = conflict_count.load(Ordering::SeqCst);
+    assert!(successes >= 1, "At least one commit should succeed");
+    assert_eq!(successes + conflicts, 10, "All transactions should complete");
 
     // Key should have SOME value
     let txn = store.new_txn(true).await.unwrap();
@@ -1562,19 +1574,27 @@ pub async fn test_last_writer_wins<S: Store + 'static>(store: Arc<S>) {
     txn1.set(b"shared", b"from_txn1").await.unwrap();
     txn2.set(b"shared", b"from_txn2").await.unwrap();
 
-    // Commit order determines winner
+    // First commit succeeds, second detects conflict
     txn1.commit().await.unwrap();
-    txn2.commit().await.unwrap();
+    let result = txn2.commit().await;
+    assert!(
+        result.is_err(),
+        "Second commit should fail with conflict"
+    );
+    assert!(
+        matches!(result.unwrap_err(), Error::TxnConflict),
+        "Error should be TxnConflict"
+    );
 
     let txn = store.new_txn(true).await.unwrap();
     assert_eq!(
         txn.get(b"shared").await.unwrap(),
-        Some(b"from_txn2".to_vec()),
-        "Last commit should win"
+        Some(b"from_txn1".to_vec()),
+        "First commit should win (second conflicted)"
     );
 }
 
-/// Test reverse commit order
+/// Test reverse commit order - second commit conflicts
 pub async fn test_last_writer_wins_reverse<S: Store + 'static>(store: Arc<S>) {
     let mut txn1 = store.new_txn(false).await.unwrap();
     let mut txn2 = store.new_txn(false).await.unwrap();
@@ -1582,14 +1602,23 @@ pub async fn test_last_writer_wins_reverse<S: Store + 'static>(store: Arc<S>) {
     txn1.set(b"shared", b"from_txn1").await.unwrap();
     txn2.set(b"shared", b"from_txn2").await.unwrap();
 
-    // Reverse order
+    // Reverse order: txn2 commits first, txn1 conflicts
     txn2.commit().await.unwrap();
-    txn1.commit().await.unwrap();
+    let result = txn1.commit().await;
+    assert!(
+        result.is_err(),
+        "Second commit should fail with conflict"
+    );
+    assert!(
+        matches!(result.unwrap_err(), Error::TxnConflict),
+        "Error should be TxnConflict"
+    );
 
     let txn = store.new_txn(true).await.unwrap();
     assert_eq!(
         txn.get(b"shared").await.unwrap(),
-        Some(b"from_txn1".to_vec())
+        Some(b"from_txn2".to_vec()),
+        "First commit should win (second conflicted)"
     );
 }
 
@@ -1818,15 +1847,23 @@ pub async fn test_write_write_isolation<S: Store + 'static>(store: Arc<S>) {
         "Writer2 should see its own write, not writer1's commit"
     );
 
-    // Commit writer2 (last writer wins)
-    writer2.commit().await.unwrap();
+    // Commit writer2 - conflicts on shared_key which writer1 already committed
+    let result = writer2.commit().await;
+    assert!(
+        result.is_err(),
+        "Writer2 commit should fail due to conflict on shared_key"
+    );
+    assert!(
+        matches!(result.unwrap_err(), Error::TxnConflict),
+        "Error should be TxnConflict"
+    );
 
-    // New transaction should see writer2's final state
+    // New transaction should see writer1's state (writer2 was rejected)
     let reader = store.new_txn(true).await.unwrap();
     assert_eq!(
         reader.get(b"shared_key").await.unwrap(),
-        Some(b"from_writer2".to_vec()),
-        "Final value should be from writer2 (last commit)"
+        Some(b"from_writer1".to_vec()),
+        "Final value should be from writer1 (writer2 conflicted)"
     );
     assert_eq!(
         reader.get(b"writer1_only").await.unwrap(),
@@ -1835,8 +1872,8 @@ pub async fn test_write_write_isolation<S: Store + 'static>(store: Arc<S>) {
     );
     assert_eq!(
         reader.get(b"writer2_only").await.unwrap(),
-        Some(b"exclusive".to_vec()),
-        "writer2_only key should exist"
+        None,
+        "writer2_only key should not exist (writer2 conflicted)"
     );
 }
 

--- a/crates/storage/src/corekv/errors.rs
+++ b/crates/storage/src/corekv/errors.rs
@@ -49,7 +49,7 @@ pub enum Error {
     ///
     /// This occurs when two transactions attempt to modify the same keys concurrently.
     /// The transaction should typically be retried.
-    #[error("transaction conflict, retry required")]
+    #[error("transaction conflict. Please retry")]
     TxnConflict,
 
     /// Attempted a write operation on a read-only transaction.
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(Error::ValueNil.to_string(), "value is nil");
         assert_eq!(
             Error::TxnConflict.to_string(),
-            "transaction conflict, retry required"
+            "transaction conflict. Please retry"
         );
     }
 


### PR DESCRIPTION
## Summary

- Implement optimistic concurrency control (OCC) with conflict detection at commit time for MemoryStore and RedbStore backends
- Add `ConflictTracker` to track committed write sets with version numbers
- Each transaction records its `read_version` at snapshot creation time
- On commit, detect if any pending write conflicts with a transaction that committed after this transaction's snapshot was taken
- Return `Error::TxnConflict` on write-write conflicts
- Update error message to match Go DefraDB format ("transaction conflict. Please retry")

This enables proper transaction isolation for explicit transactions, achieving **100% parity for mutation/mix tests (5/5 passing)**.

## Test plan

- [x] All storage unit tests pass (`cargo test -p storage --lib` - 357 tests)
- [x] All mutation/mix FFI compat tests pass (5/5)
- [x] Conflict detection test cases updated in test_suite.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)