### PR TITLE
feat(query): Query engine improvements for aggregate+selection, commit queries, and inline arrays

### DIFF
--- a/crates/db/src/auto_commit_mutator.rs
+++ b/crates/db/src/auto_commit_mutator.rs
@@ -215,11 +215,26 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
                         doc_id.to_string(),
                         cid,
                         collection.collection_id().to_string(),
-                        block,
+                        block.clone(),
                         false, // is_retry
                         false, // is_relay (local mutation)
                     );
                     bus.publish(Message::update(update));
+
+                    // For branchable collections, emit a second Update event for the
+                    // collection-level DAG. The test framework uses this to track
+                    // collection heads separately from document heads.
+                    if collection.schema().is_branchable {
+                        let col_update = Update::new(
+                            String::new(), // empty doc_id → keyed by collection_id
+                            cid,
+                            collection.collection_id().to_string(),
+                            block,
+                            false, // is_retry
+                            false, // is_relay
+                        );
+                        bus.publish(Message::update(col_update));
+                    }
                 }
 
                 // Return result with commit CID if available
@@ -401,11 +416,25 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
                             doc_id.to_string(),
                             cid,
                             collection.collection_id().to_string(),
-                            block,
+                            block.clone(),
                             false, // is_retry
                             false, // is_relay (local mutation)
                         );
                         bus.publish(Message::update(update));
+
+                        // For branchable collections, emit a second Update event for the
+                        // collection-level DAG.
+                        if collection.schema().is_branchable {
+                            let col_update = Update::new(
+                                String::new(), // empty doc_id → keyed by collection_id
+                                cid,
+                                collection.collection_id().to_string(),
+                                block,
+                                false,
+                                false,
+                            );
+                            bus.publish(Message::update(col_update));
+                        }
                     }
                 }
 
@@ -560,11 +589,25 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
                         doc_id.to_string(),
                         cid,
                         collection.collection_id().to_string(),
-                        block,
+                        block.clone(),
                         false, // is_retry
                         false, // is_relay (local mutation)
                     );
                     bus.publish(Message::update(update));
+
+                    // For branchable collections, emit a second Update event for the
+                    // collection-level DAG.
+                    if collection.schema().is_branchable {
+                        let col_update = Update::new(
+                            String::new(), // empty doc_id → keyed by collection_id
+                            cid,
+                            collection.collection_id().to_string(),
+                            block,
+                            false,
+                            false,
+                        );
+                        bus.publish(Message::update(col_update));
+                    }
                 }
 
                 Ok(DeleteResult::new(doc_id.clone(), existed))

--- a/crates/db/src/block_builder.rs
+++ b/crates/db/src/block_builder.rs
@@ -873,6 +873,7 @@ pub async fn write_collection_block(
     };
 
     // The collection block links to the document composite block
+    // Go uses empty string for link name here, fieldName comes from linked block's delta
     let links = vec![DAGLink::new(String::new(), doc_composite_cid)];
 
     // Create the collection block

--- a/crates/db/src/commits_fetcher.rs
+++ b/crates/db/src/commits_fetcher.rs
@@ -400,50 +400,81 @@ impl<S: Store> CommitsFetcher<S> {
                 .unwrap_or(JsonValue::Null),
         );
 
-        // links - array of {cid, fieldName, height}
-        // Load each linked block to get its priority/height and fieldName from delta
+        // links - array with full commit data for nested queries
+        // Load each linked block to get all fields (supports queries like links { docID, heads { ... } })
         let mut links: Vec<JsonValue> = Vec::new();
         if let Some(block_links) = &block.links {
             for link in block_links {
-                let (height, field_name) = match self.load_block(txn, &link.link).await {
+                match self.load_block(txn, &link.link).await {
                     Ok(linked_block) => {
-                        let h = json!(linked_block.delta.priority() as i64);
+                        let height = linked_block.delta.priority() as i64;
                         // Get fieldName from linked block's delta (not from DAGLink's name)
-                        // This is important for collection-level commits where link.name is empty
-                        // but the linked block has a proper fieldName (e.g., "_C" for composite)
                         let fn_from_delta = self.get_field_name(&linked_block.delta);
-                        // Use link.name if non-empty, otherwise fall back to delta's fieldName
-                        let fn_val = if link.name.is_empty() {
-                            fn_from_delta.unwrap_or_default()
+                        let field_name = if link.name.is_empty() {
+                            fn_from_delta.clone().unwrap_or_default()
                         } else {
                             link.name.clone()
                         };
-                        (h, fn_val)
+                        let doc_id = self.get_doc_id(&linked_block.delta);
+
+                        // Build nested links (one level deep)
+                        let nested_links = self.build_simple_links(txn, &linked_block).await;
+                        // Build nested heads (one level deep)
+                        let nested_heads = self.build_simple_heads(txn, &linked_block).await;
+
+                        links.push(json!({
+                            "cid": link.link.to_string(),
+                            "fieldName": field_name,
+                            "height": height,
+                            "docID": doc_id,
+                            "links": nested_links,
+                            "heads": nested_heads,
+                        }));
                     }
-                    Err(_) => (JsonValue::Null, link.name.clone()),
+                    Err(_) => {
+                        links.push(json!({
+                            "cid": link.link.to_string(),
+                            "fieldName": link.name,
+                            "height": JsonValue::Null,
+                        }));
+                    }
                 };
-                links.push(json!({
-                    "cid": link.link.to_string(),
-                    "fieldName": field_name,
-                    "height": height,
-                }));
             }
         }
         map.insert("links".to_string(), json!(links));
 
-        // heads - array of {cid, height}
-        // Load each head block to get its priority/height
+        // heads - array with full commit data for nested queries
+        // Load each head block to get all fields (supports queries like heads { docID, links { ... } })
         let mut heads: Vec<JsonValue> = Vec::new();
         if let Some(block_heads) = &block.heads {
             for head_cid in block_heads {
-                let height = match self.load_block(txn, head_cid).await {
-                    Ok(head_block) => json!(head_block.delta.priority() as i64),
-                    Err(_) => JsonValue::Null,
+                match self.load_block(txn, head_cid).await {
+                    Ok(head_block) => {
+                        let height = head_block.delta.priority() as i64;
+                        let field_name = self.get_field_name(&head_block.delta);
+                        let doc_id = self.get_doc_id(&head_block.delta);
+
+                        // Build nested links (one level deep)
+                        let nested_links = self.build_simple_links(txn, &head_block).await;
+                        // Build nested heads (one level deep)
+                        let nested_heads = self.build_simple_heads(txn, &head_block).await;
+
+                        heads.push(json!({
+                            "cid": head_cid.to_string(),
+                            "height": height,
+                            "fieldName": field_name,
+                            "docID": doc_id,
+                            "links": nested_links,
+                            "heads": nested_heads,
+                        }));
+                    }
+                    Err(_) => {
+                        heads.push(json!({
+                            "cid": head_cid.to_string(),
+                            "height": JsonValue::Null,
+                        }));
+                    }
                 };
-                heads.push(json!({
-                    "cid": head_cid.to_string(),
-                    "height": height,
-                }));
             }
         }
         map.insert("heads".to_string(), json!(heads));
@@ -498,6 +529,63 @@ impl<S: Store> CommitsFetcher<S> {
         delta
             .doc_id()
             .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+    }
+
+    /// Build simple links array (without recursive nesting) for nested queries.
+    /// Returns array of {cid, fieldName, height} for each link.
+    async fn build_simple_links(&self, txn: &mut DbTxn<S>, block: &Block) -> Vec<JsonValue> {
+        let mut links = Vec::new();
+        if let Some(block_links) = &block.links {
+            for link in block_links {
+                let (height, field_name) = match self.load_block(txn, &link.link).await {
+                    Ok(linked_block) => {
+                        let h = linked_block.delta.priority() as i64;
+                        let fn_from_delta = self.get_field_name(&linked_block.delta);
+                        let fn_val = if link.name.is_empty() {
+                            fn_from_delta.unwrap_or_default()
+                        } else {
+                            link.name.clone()
+                        };
+                        (json!(h), fn_val)
+                    }
+                    Err(_) => (JsonValue::Null, link.name.clone()),
+                };
+                links.push(json!({
+                    "cid": link.link.to_string(),
+                    "fieldName": field_name,
+                    "height": height,
+                }));
+            }
+        }
+        links
+    }
+
+    /// Build simple heads array (without recursive nesting) for nested queries.
+    /// Returns array of {cid, fieldName, height} for each head.
+    async fn build_simple_heads(&self, txn: &mut DbTxn<S>, block: &Block) -> Vec<JsonValue> {
+        let mut heads = Vec::new();
+        if let Some(block_heads) = &block.heads {
+            for head_cid in block_heads {
+                match self.load_block(txn, head_cid).await {
+                    Ok(head_block) => {
+                        let height = head_block.delta.priority() as i64;
+                        let field_name = self.get_field_name(&head_block.delta);
+                        heads.push(json!({
+                            "cid": head_cid.to_string(),
+                            "height": height,
+                            "fieldName": field_name,
+                        }));
+                    }
+                    Err(_) => {
+                        heads.push(json!({
+                            "cid": head_cid.to_string(),
+                            "height": JsonValue::Null,
+                        }));
+                    }
+                };
+            }
+        }
+        heads
     }
 
     /// Get delta data from delta

--- a/crates/db/src/commits_fetcher.rs
+++ b/crates/db/src/commits_fetcher.rs
@@ -257,18 +257,18 @@ impl<S: Store> CommitsFetcher<S> {
         options: &CommitsQueryOptions,
     ) -> Result<Vec<Cid>> {
         let headstore = txn.headstore()?;
+        let mut cids = Vec::new();
 
-        let prefix = if let Some(ref doc_id) = options.doc_id {
+        // Query document-level heads
+        let doc_prefix = if let Some(ref doc_id) = options.doc_id {
             format!("/d/{}/", doc_id).into_bytes()
         } else {
             // All document heads start with /d/
             b"/d/".to_vec()
         };
 
-        let opts = IterOptions::new().with_prefix(prefix);
+        let opts = IterOptions::new().with_prefix(doc_prefix);
         let mut iter = headstore.iterator(opts).await.map_err(Error::Storage)?;
-
-        let mut cids = Vec::new();
 
         while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
             // Parse CID from key: /d/{doc_id}/{field_id}/{cid}
@@ -281,8 +281,28 @@ impl<S: Store> CommitsFetcher<S> {
                 }
             }
         }
-
         iter.close().await.map_err(Error::Storage)?;
+
+        // Also query collection-level heads when no specific doc_id filter
+        // (branchable collections have collection-level commits at /c/{collection_id}/{cid})
+        if options.doc_id.is_none() {
+            let col_opts = IterOptions::new().with_prefix(b"/c/".to_vec());
+            let mut col_iter = headstore.iterator(col_opts).await.map_err(Error::Storage)?;
+
+            while let Some(pair) = col_iter.next().await.map_err(Error::Storage)? {
+                // Parse CID from key: /c/{collection_id}/{cid}
+                let key_str = String::from_utf8_lossy(&pair.key);
+                let parts: Vec<&str> = key_str.split('/').collect();
+                if parts.len() >= 4 {
+                    // parts: ["", "c", collection_id, cid]
+                    if let Ok(cid) = Cid::from_str(parts[3]) {
+                        cids.push(cid);
+                    }
+                }
+            }
+            col_iter.close().await.map_err(Error::Storage)?;
+        }
+
         Ok(cids)
     }
 
@@ -381,17 +401,30 @@ impl<S: Store> CommitsFetcher<S> {
         );
 
         // links - array of {cid, fieldName, height}
-        // Load each linked block to get its priority/height
+        // Load each linked block to get its priority/height and fieldName from delta
         let mut links: Vec<JsonValue> = Vec::new();
         if let Some(block_links) = &block.links {
             for link in block_links {
-                let height = match self.load_block(txn, &link.link).await {
-                    Ok(linked_block) => json!(linked_block.delta.priority() as i64),
-                    Err(_) => JsonValue::Null,
+                let (height, field_name) = match self.load_block(txn, &link.link).await {
+                    Ok(linked_block) => {
+                        let h = json!(linked_block.delta.priority() as i64);
+                        // Get fieldName from linked block's delta (not from DAGLink's name)
+                        // This is important for collection-level commits where link.name is empty
+                        // but the linked block has a proper fieldName (e.g., "_C" for composite)
+                        let fn_from_delta = self.get_field_name(&linked_block.delta);
+                        // Use link.name if non-empty, otherwise fall back to delta's fieldName
+                        let fn_val = if link.name.is_empty() {
+                            fn_from_delta.unwrap_or_default()
+                        } else {
+                            link.name.clone()
+                        };
+                        (h, fn_val)
+                    }
+                    Err(_) => (JsonValue::Null, link.name.clone()),
                 };
                 links.push(json!({
                     "cid": link.link.to_string(),
-                    "fieldName": link.name,
+                    "fieldName": field_name,
                     "height": height,
                 }));
             }

--- a/crates/db/src/merge_handler.rs
+++ b/crates/db/src/merge_handler.rs
@@ -426,6 +426,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let mut field_values: HashMap<String, NormalValue> = HashMap::new();
         let mut any_field_applied = false;
         let mut process_error: Option<MergeError> = None;
+        let mut is_branchable = false;
 
         // Process linked blocks within the transaction scope
         // Use a scoped block to ensure datastore is dropped before commit/discard
@@ -577,6 +578,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
 
                 match collection_lookup {
                     Some(collection) => {
+                        is_branchable = collection.schema().is_branchable;
                         if is_delete {
                             // Handle delete: write the deletion marker so queries
                             // exclude this document (or show _deleted:true).
@@ -777,6 +779,26 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                         true,   // is_relay (P2P update)
                     );
                     bus.publish(Message::update(update));
+
+                    // For branchable collections, emit a collection-level merge_complete
+                    // event so the test framework (and Go event system) can track
+                    // collection DAG heads separately from document DAG heads.
+                    if is_branchable {
+                        let by_peer = metadata
+                            .creator
+                            .unwrap_or("")
+                            .to_string();
+                        let mc = MergeCompleteData {
+                            doc_id: String::new(), // empty → keyed by collection_id
+                            cid: *cid,
+                            collection_id: metadata
+                                .collection_id
+                                .unwrap_or(&payload.schema_version_id)
+                                .to_string(),
+                            by_peer,
+                        };
+                        bus.publish(Message::merge_complete(mc));
+                    }
                 }
 
                 Ok(MergeOutcome::Merged)

--- a/crates/ffi/src/index.rs
+++ b/crates/ffi/src/index.rs
@@ -671,3 +671,6 @@ mod tests {
         node_close(node);
     }
 }
+
+// Stub implementations for encrypted index operations (not yet supported)
+

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -2111,26 +2111,3 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
     }
 }
 
-/// Sync specific collection versions from peers.
-///
-/// Fetches and merges the specified collection versions from connected peers.
-///
-/// # Arguments
-///
-/// * `node_ptr` - Handle to the node
-/// * `identity_did` - DID of the requestor for access control
-/// * `version_ids_json` - JSON array of CID strings to sync, e.g. `["bafyrei...", "bafyrei..."]`
-///
-/// # Safety
-///
-/// `identity_did` and `version_ids_json` must be valid null-terminated UTF-8 strings.
-#[no_mangle]
-pub unsafe extern "C" fn p2p_sync_collection_versions(
-    _node_ptr: usize,
-    _identity_did: *const c_char,
-    _version_ids_json: *const c_char,
-) -> FfiResult {
-    // Stub: collection version syncing not yet implemented in Rust
-    // Return success as a no-op for now to allow query tests to compile
-    FfiResult::ok()
-}

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -2110,3 +2110,27 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
         Err(e) => FfiResult::error(e),
     }
 }
+
+/// Sync specific collection versions from peers.
+///
+/// Fetches and merges the specified collection versions from connected peers.
+///
+/// # Arguments
+///
+/// * `node_ptr` - Handle to the node
+/// * `identity_did` - DID of the requestor for access control
+/// * `version_ids_json` - JSON array of CID strings to sync, e.g. `["bafyrei...", "bafyrei..."]`
+///
+/// # Safety
+///
+/// `identity_did` and `version_ids_json` must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn p2p_sync_collection_versions(
+    _node_ptr: usize,
+    _identity_did: *const c_char,
+    _version_ids_json: *const c_char,
+) -> FfiResult {
+    // Stub: collection version syncing not yet implemented in Rust
+    // Return success as a no-op for now to allow query tests to compile
+    FfiResult::ok()
+}

--- a/crates/ffi/src/subscription.rs
+++ b/crates/ffi/src/subscription.rs
@@ -320,11 +320,17 @@ pub extern "C" fn close_graphql_subscription(
 ) -> CloseSubscriptionResult {
     let id_str = match unsafe { c_str_to_string(subscription_id) } {
         Some(s) => s,
-        None => return CloseSubscriptionResult::error("invalid subscription id: null or invalid UTF-8"),
+        None => {
+            return CloseSubscriptionResult::error(
+                "invalid subscription id: null or invalid UTF-8",
+            )
+        }
     };
     let handle = match id_str.parse::<usize>() {
         Ok(h) => h,
-        Err(_) => return CloseSubscriptionResult::error("invalid subscription id: not a number"),
+        Err(_) => {
+            return CloseSubscriptionResult::error("invalid subscription id: not a number")
+        }
     };
     close_subscription(handle)
 }

--- a/crates/query/src/mapper/types.rs
+++ b/crates/query/src/mapper/types.rs
@@ -343,6 +343,9 @@ pub struct AggregateTarget {
     pub limit: Option<Limit>,
     /// Order for the target
     pub order: Option<OrderBy>,
+    /// Internal key for looking up relation data when there's a collision
+    /// (e.g., when both a relation selection and an aggregate use the same relation)
+    pub internal_key: Option<String>,
 }
 
 impl AggregateTarget {
@@ -353,6 +356,7 @@ impl AggregateTarget {
             filter: None,
             limit: None,
             order: None,
+            internal_key: None,
         }
     }
 
@@ -363,7 +367,13 @@ impl AggregateTarget {
             filter: None,
             limit: None,
             order: None,
+            internal_key: None,
         }
+    }
+
+    pub fn with_internal_key(mut self, key: impl Into<String>) -> Self {
+        self.internal_key = Some(key.into());
+        self
     }
 }
 

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -44,6 +44,10 @@ pub struct PlanResult {
     /// Each entry is (parent_relation_field_name, child_field_name).
     /// These fields appear in the document but should be stripped from output.
     pub ordering_only_fields: Vec<(String, String)>,
+    /// Internal render keys for aggregate relation data when there's a collision
+    /// with a relation selection (e.g., both `_count(published: {})` and `published(limit: 2)`).
+    /// Maps: aggregate_output_name -> (relation_field_name, internal_key)
+    pub aggregate_internal_keys: HashMap<String, (String, String)>,
 }
 
 impl PlanResult {
@@ -259,6 +263,10 @@ impl Planner {
                 result
             })
             .unwrap_or_default();
+
+        // Internal keys for aggregate relation data when there's a collision with a relation selection.
+        // Maps: aggregate_output_name -> (relation_field_name, internal_key)
+        let mut aggregate_internal_keys: HashMap<String, (String, String)> = HashMap::new();
 
         // Check if GROUP BY references relation fields (needs full schema mapping for joins)
         let group_by_has_relations = select
@@ -675,8 +683,11 @@ impl Planner {
         } else {
             filter_for_plan.as_ref()
         };
-        (plan, scan_mapping) =
+        let joins_result =
             self.apply_joins(plan, select, &collection, scan_mapping, 0, filter_for_joins)?;
+        plan = joins_result.0;
+        scan_mapping = joins_result.1;
+        aggregate_internal_keys = joins_result.2;
 
         // 3b. Apply joins for multi-level relation filter paths where the first relation
         // is NOT in the selection set. If the first relation IS selected, then apply_joins
@@ -1252,6 +1263,7 @@ impl Planner {
             plan,
             index_scan,
             ordering_only_fields,
+            aggregate_internal_keys,
         })
     }
 
@@ -1671,7 +1683,10 @@ impl Planner {
         mut mapping: DocumentMapping,
         depth: usize,
         parent_filter: Option<&crate::mapper::Filter>,
-    ) -> Result<(Box<dyn PlanNode>, DocumentMapping)> {
+    ) -> Result<(Box<dyn PlanNode>, DocumentMapping, HashMap<String, (String, String)>)> {
+        // Internal keys for aggregate relation data when there's a collision with a relation selection.
+        let mut aggregate_internal_keys: HashMap<String, (String, String)> = HashMap::new();
+
         // Check recursion depth to prevent stack overflow
         if depth > MAX_NESTING_DEPTH {
             return Err(QueryError::execution(format!(
@@ -2120,7 +2135,7 @@ impl Planner {
             // Recursively apply joins for any nested selections within this nested select.
             // This handles multi-level nesting like Users -> Posts -> Comments.
             // Note: We pass None for parent_filter since relation filters only apply at the top level.
-            (child_plan, child_scan_mapping) = self.apply_joins(
+            let nested_joins_result = self.apply_joins(
                 child_plan,
                 nested_select,
                 &target_collection,
@@ -2128,6 +2143,10 @@ impl Planner {
                 depth + 1,
                 None, // Nested relation filters handled differently
             )?;
+            child_plan = nested_joins_result.0;
+            child_scan_mapping = nested_joins_result.1;
+            // Merge nested aggregate internal keys into our collection
+            aggregate_internal_keys.extend(nested_joins_result.2);
 
             // Apply sub-joins for order_by references to relation fields within this nested select.
             // For example, if the nested select is `book(order: {publisher: {yearOpened: ASC}})`,
@@ -3087,6 +3106,8 @@ impl Planner {
                     // Determine the mapping index for this aggregate's relation data.
                     // When a selection already uses this relation (e.g., `books2020: book(...)`),
                     // we need a separate index so the aggregate gets independent, unfiltered data.
+                    // We also need a unique internal key to avoid collision with the selection's
+                    // limited/filtered data.
                     let selection_has_relation = select.fields.iter().any(|f| {
                         if let Requestable::Select(s) = f {
                             s.field.name == *relation_field_name
@@ -3096,10 +3117,18 @@ impl Planner {
                     });
                     let effective_relation_index = if selection_has_relation {
                         // Selection already uses relation_field_index with its own filter/limit.
-                        // Use a new index for the aggregate's independent data.
+                        // Use a new index and a unique internal key for the aggregate's data
+                        // to avoid collision with the selection's data in rendered JSON.
                         let idx = mapping.next_index();
+                        let internal_key =
+                            format!("__agg_{}_{}", relation_field_name, agg.output_name());
                         mapping.add(idx, relation_field_name);
-                        mapping.add_render_key(idx, relation_field_name);
+                        mapping.add_render_key(idx, &internal_key);
+                        // Store the mapping so the runner can look up data using the internal key
+                        aggregate_internal_keys.insert(
+                            agg.output_name().to_string(),
+                            (relation_field_name.clone(), internal_key),
+                        );
                         idx
                     } else {
                         if mapping.first_index_of_name(relation_field_name).is_none() {
@@ -3317,7 +3346,7 @@ impl Planner {
             }
         }
 
-        Ok((plan, mapping))
+        Ok((plan, mapping, aggregate_internal_keys))
     }
 
     /// Build a scan mapping for join child plans that includes ALL fields at schema indices.
@@ -4253,6 +4282,7 @@ impl Planner {
             plan,
             index_scan: None,
             ordering_only_fields: Vec::new(),
+            aggregate_internal_keys: HashMap::new(),
         })
     }
 }

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -2759,9 +2759,11 @@ impl Planner {
                     None
                 };
 
-                // Build a minimal child mapping (just _docID for the reverse lookup)
+                // Build a minimal child mapping (just _docID for the reverse lookup).
+                // Include render_key so the merged child renders with _docID for groupBy.
                 let mut child_mapping = DocumentMapping::new();
                 child_mapping.add(0, "_docID");
+                child_mapping.add_render_key(0, "_docID");
 
                 // Build scan mapping for the child
                 let child_scan_mapping =

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -606,6 +606,12 @@ impl Planner {
                             continue;
                         }
                     }
+                    // Skip logical operators (_and, _or, _not) that contain relation filters.
+                    // These were put in relation_filter by split_by_relation() because they
+                    // contain relation conditions. They must be evaluated AFTER joins, not here.
+                    if field_name == "_and" || field_name == "_or" || field_name == "_not" {
+                        continue;
+                    }
                     // Not a relation field - treat as scalar (could be JSON, etc.)
                     combined_conditions.insert(field_name.clone(), condition.clone());
                 }
@@ -2562,6 +2568,7 @@ impl Planner {
                 // Include _docID and the FK field for the join to work correctly
                 let mut child_mapping = DocumentMapping::new();
                 child_mapping.add(0, "_docID");
+                child_mapping.add_render_key(0, "_docID");
 
                 // Add the FK field (e.g., _authorID) - needed for TypeJoinMany cache indexing
                 let fk_field_name = if let Some(ref target_rel) = target_relation_field {
@@ -2575,6 +2582,7 @@ impl Planner {
                     .position(|f| f.name == fk_field_name)
                 {
                     child_mapping.add(fk_idx, &fk_field_name);
+                    child_mapping.add_render_key(fk_idx, &fk_field_name);
                 }
 
                 // Add any fields referenced by the filter
@@ -2586,6 +2594,7 @@ impl Planner {
                             .position(|f| f.name == field_name)
                         {
                             child_mapping.add(idx, &field_name);
+                            child_mapping.add_render_key(idx, &field_name);
                         }
                     }
                 }
@@ -2621,6 +2630,8 @@ impl Planner {
                         mapping.add(idx, &relation_name);
                         idx
                     });
+
+                mapping.set_child_at(relation_field_index, child_mapping.clone());
 
                 // Find child relation index
                 let child_relation_index = target_relation_field

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -2135,16 +2135,21 @@ impl Planner {
             // Recursively apply joins for any nested selections within this nested select.
             // This handles multi-level nesting like Users -> Posts -> Comments.
             // Note: We pass None for parent_filter since relation filters only apply at the top level.
+            //
+            // IMPORTANT: We do NOT reassign child_scan_mapping from the recursive result.
+            // The recursive call may modify the mapping's nested child mappings (for deeper relations),
+            // but the render_keys at THIS level were already correctly set when child_scan_mapping
+            // was built. Reassigning would lose those render_keys, causing empty selection items
+            // when both an aggregate and selection target the same relation.
             let nested_joins_result = self.apply_joins(
                 child_plan,
                 nested_select,
                 &target_collection,
-                child_scan_mapping,
+                child_scan_mapping.clone(),
                 depth + 1,
                 None, // Nested relation filters handled differently
             )?;
             child_plan = nested_joins_result.0;
-            child_scan_mapping = nested_joins_result.1;
             // Merge nested aggregate internal keys into our collection
             aggregate_internal_keys.extend(nested_joins_result.2);
 

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -1757,11 +1757,33 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             }
         });
 
+        // Check if any aggregate targets have filters with relation conditions.
+        // If so, we need the planner to join relation data before filtering.
+        let aggregate_filter_has_relations = select.fields.iter().any(|f| {
+            if let Requestable::Aggregate(agg) = f {
+                agg.targets.iter().any(|t| {
+                    t.filter
+                        .as_ref()
+                        .map(|f| f.has_relation_filters())
+                        .unwrap_or(false)
+                })
+            } else {
+                false
+            }
+        });
+
         // Handle top-level aggregates specially - return single value, not array
         if is_top_level_aggregate {
-            return self
-                .execute_top_level_aggregate(select, fetcher, &collection, caller_identity)
-                .await;
+            if aggregate_filter_has_relations {
+                // Use planner path to join relation data before filtering
+                return self
+                    .execute_top_level_aggregate_with_planner(select, fetcher, caller_identity)
+                    .await;
+            } else {
+                return self
+                    .execute_top_level_aggregate(select, fetcher, &collection, caller_identity)
+                    .await;
+            }
         }
 
         // Check if any secondary relation ID fields are selected (e.g., `_authorID` for a secondary `author` relation).
@@ -1873,13 +1895,15 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let is_view = collection.query.is_some();
 
         // Use Planner if there are nested selections, filter through relations,
-        // order through relations, aggregates on relations, secondary relation ID fields,
-        // similarity computations, when an index can provide ordering, or when querying a view
+        // order through relations, aggregates on relations, aggregate filters with relations,
+        // secondary relation ID fields, similarity computations, when an index can provide
+        // ordering, or when querying a view
         let needs_planner = is_view
             || has_nested
             || filter_has_relations
             || order_has_relations
             || aggregates_have_relations
+            || aggregate_filter_has_relations
             || has_secondary_relation_id
             || has_ordering_index
             || has_similarity;
@@ -3670,6 +3694,190 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         } else {
             Ok(JsonValue::Null)
         }
+    }
+
+    /// Execute a top-level aggregate with filters that reference relations.
+    ///
+    /// This function uses the planner to build a join plan so relation data is
+    /// available for filter evaluation, then counts the filtered results.
+    /// Unlike `execute_top_level_aggregate`, this handles filters like:
+    /// `_count(Book: {filter: {author: {age: {_gt: 30}}}})`
+    async fn execute_top_level_aggregate_with_planner(
+        &self,
+        select: &Select,
+        fetcher: &dyn DocFetcher,
+        identity: Option<Did>,
+    ) -> Result<JsonValue> {
+        use crate::mapper::AggregateType;
+
+        // Get the aggregate info
+        let agg = match select.fields.first() {
+            Some(Requestable::Aggregate(a)) => a,
+            _ => return Ok(JsonValue::Null),
+        };
+        let output_name = agg.output_name().to_string();
+        let target = agg.targets.first();
+        let target_filter = target.and_then(|t| t.filter.as_ref());
+        let field_name = target.and_then(|t| t.field_name.as_ref());
+
+        // Create a modified select that fetches the collection with the filter applied.
+        // This select returns documents (not aggregates), so the planner will build
+        // a proper join plan with the relation filter.
+        let collection_name = target
+            .map(|t| t.host_name.clone())
+            .unwrap_or_else(|| select.collection_name.clone());
+        let filter_select = Select {
+            collection_name: collection_name.clone(),
+            field: crate::mapper::Field::new(collection_name.clone()),
+            fields: if let Some(fname) = field_name {
+                // For sum/avg/etc., we need the field value
+                vec![Requestable::Field(crate::mapper::Field::new(fname.clone()))]
+            } else {
+                // For count, we just need any field to count docs
+                vec![Requestable::Field(crate::mapper::Field::new("_docID".to_string()))]
+            },
+            filter: target_filter.cloned(),
+            order_by: None,
+            limit: None,
+            group_by: None,
+            doc_ids: None,
+            cid: None,
+            depth: None,
+            show_deleted: false,
+            is_encrypted: false,
+            selection_type: crate::mapper::SelectionType::Object,
+            document_mapping: crate::document::DocumentMapping::default(),
+        };
+
+        // Execute with the planner to get filtered documents
+        let fetcher_arc = FetcherWrapper::new(fetcher);
+        let collections_map = self.collections_map().await?;
+        let collections: Vec<CollectionVersion> =
+            collections_map.values().map(|c| (**c).clone()).collect();
+
+        let mut planner = Planner::new(collections).with_fetcher(Arc::new(fetcher_arc));
+        if let Some(ref acp) = self.acp {
+            planner = planner.with_acp(acp.clone(), identity);
+        }
+        if let Some(ref lens_store) = self.lens_store {
+            planner = planner.with_lens_store(lens_store.clone());
+        }
+        let plan_result = planner.plan_with_index_info(&filter_select)?;
+        let mut plan = plan_result.plan;
+        let mapping = plan.document_map().clone();
+
+        // Execute the plan and collect results
+        plan.init().await?;
+        plan.start().await?;
+
+        let mut docs = Vec::new();
+        while plan.next().await? {
+            let doc = plan.value().deep_clone();
+            docs.push(doc);
+        }
+        plan.close().await?;
+
+        // Compute the aggregate based on type
+        let value = match agg.aggregate_type {
+            AggregateType::Count => {
+                let count = docs.len() as i64;
+                JsonValue::Number(count.into())
+            }
+            AggregateType::Sum => {
+                if let Some(fname) = field_name {
+                    if let Some(field_idx) = mapping.first_index_of_name(fname) {
+                        let sum: f64 = docs
+                            .iter()
+                            .filter_map(|doc| doc.get(field_idx))
+                            .filter_map(|v| v.as_f64().or_else(|| v.as_i64().map(|i| i as f64)))
+                            .sum();
+                        if sum == sum.floor() {
+                            JsonValue::Number((sum as i64).into())
+                        } else {
+                            JsonValue::Number(
+                                serde_json::Number::from_f64(sum).unwrap_or_else(|| 0.into()),
+                            )
+                        }
+                    } else {
+                        JsonValue::Number(0.into())
+                    }
+                } else {
+                    JsonValue::Number(0.into())
+                }
+            }
+            AggregateType::Average => {
+                if let Some(fname) = field_name {
+                    if let Some(field_idx) = mapping.first_index_of_name(fname) {
+                        let values: Vec<f64> = docs
+                            .iter()
+                            .filter_map(|doc| doc.get(field_idx))
+                            .filter_map(|v| v.as_f64().or_else(|| v.as_i64().map(|i| i as f64)))
+                            .collect();
+                        if values.is_empty() {
+                            JsonValue::Number(0.into())
+                        } else {
+                            let avg = values.iter().sum::<f64>() / values.len() as f64;
+                            JsonValue::Number(
+                                serde_json::Number::from_f64(avg).unwrap_or_else(|| 0.into()),
+                            )
+                        }
+                    } else {
+                        JsonValue::Number(0.into())
+                    }
+                } else {
+                    JsonValue::Number(0.into())
+                }
+            }
+            AggregateType::Min => {
+                if let Some(fname) = field_name {
+                    if let Some(field_idx) = mapping.first_index_of_name(fname) {
+                        let min: Option<f64> = docs
+                            .iter()
+                            .filter_map(|doc| doc.get(field_idx))
+                            .filter_map(|v| v.as_f64().or_else(|| v.as_i64().map(|i| i as f64)))
+                            .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                        match min {
+                            Some(v) if v == v.floor() => JsonValue::Number((v as i64).into()),
+                            Some(v) => JsonValue::Number(
+                                serde_json::Number::from_f64(v).unwrap_or_else(|| 0.into()),
+                            ),
+                            None => JsonValue::Null,
+                        }
+                    } else {
+                        JsonValue::Null
+                    }
+                } else {
+                    JsonValue::Null
+                }
+            }
+            AggregateType::Max => {
+                if let Some(fname) = field_name {
+                    if let Some(field_idx) = mapping.first_index_of_name(fname) {
+                        let max: Option<f64> = docs
+                            .iter()
+                            .filter_map(|doc| doc.get(field_idx))
+                            .filter_map(|v| v.as_f64().or_else(|| v.as_i64().map(|i| i as f64)))
+                            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                        match max {
+                            Some(v) if v == v.floor() => JsonValue::Number((v as i64).into()),
+                            Some(v) => JsonValue::Number(
+                                serde_json::Number::from_f64(v).unwrap_or_else(|| 0.into()),
+                            ),
+                            None => JsonValue::Null,
+                        }
+                    } else {
+                        JsonValue::Null
+                    }
+                } else {
+                    JsonValue::Null
+                }
+            }
+        };
+
+        // Return just the value (not wrapped in an object with output_name)
+        // The caller will insert this with the correct key
+        let _ = output_name; // suppress unused warning
+        Ok(value)
     }
 
     /// Execute a _commits system collection query.

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -2015,6 +2015,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let plan_result = planner.plan_with_index_info(select)?;
         let mut plan = plan_result.plan;
         let ordering_only_fields = plan_result.ordering_only_fields;
+        let aggregate_internal_keys = plan_result.aggregate_internal_keys;
 
         // Get the mapping from the plan
         let mapping = plan.document_map().clone();
@@ -2048,7 +2049,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         // Post-process relation-based aggregates
         // For aggregates like _count(books: {}), compute the value from joined data
-        let results = self.compute_relation_aggregates(results, select)?;
+        let results =
+            self.compute_relation_aggregates(results, select, &aggregate_internal_keys)?;
 
         // Strip fields from relation data that were added for filter evaluation
         // but not explicitly requested in the selection set.
@@ -2072,6 +2074,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         &self,
         mut results: Vec<JsonValue>,
         select: &Select,
+        aggregate_internal_keys: &std::collections::HashMap<String, (String, String)>,
     ) -> Result<Vec<JsonValue>> {
         use crate::mapper::AggregateType;
 
@@ -2195,9 +2198,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         let relation_name = &target.host_name;
                         let field_name = target.field_name.as_deref();
 
-                        // Try the direct relation name first, then fall back to alias
-                        let relation_data = obj
-                            .get(relation_name.as_str())
+                        // Try internal key first (when selection and aggregate use same relation),
+                        // then direct relation name, then fall back to alias
+                        let relation_data = aggregate_internal_keys
+                            .get(output_name)
+                            .and_then(|(_, internal_key)| obj.get(internal_key.as_str()))
+                            .or_else(|| obj.get(relation_name.as_str()))
                             .or_else(|| {
                                 relation_alias_map
                                     .get(relation_name.as_str())
@@ -2591,6 +2597,17 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     }
                     std::cmp::Ordering::Equal
                 });
+            }
+        }
+
+        // Clean up internal aggregate keys from output (keys like "__agg_published__count")
+        // These are only used for looking up relation data when there's a collision with
+        // a relation selection.
+        if !aggregate_internal_keys.is_empty() {
+            for result in &mut results {
+                if let JsonValue::Object(ref mut obj) = result {
+                    obj.retain(|k, _| !k.starts_with("__agg_"));
+                }
             }
         }
 

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -3921,6 +3921,85 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                                             JsonValue::Null,
                                                         );
                                                     }
+                                                } else if let Requestable::Select(inner_nested) =
+                                                    nested_field
+                                                {
+                                                    // Handle double-nested selects (e.g., heads { links { cid } })
+                                                    let inner_name = &inner_nested.field.name;
+                                                    let inner_output =
+                                                        inner_nested.field.output_name();
+                                                    if let Some(inner_val) = item.get(inner_name) {
+                                                        if let Some(inner_arr) = inner_val.as_array()
+                                                        {
+                                                            // Apply filter and extract requested fields
+                                                            let inner_results: Vec<JsonValue> =
+                                                                inner_arr
+                                                                    .iter()
+                                                                    .filter(|inner_item| {
+                                                                        if let Some(ref filter) =
+                                                                            inner_nested.filter
+                                                                        {
+                                                                            Self::matches_json_filter(
+                                                                                inner_item, filter,
+                                                                            )
+                                                                        } else {
+                                                                            true
+                                                                        }
+                                                                    })
+                                                                    .map(|inner_item| {
+                                                                        let mut inner_obj =
+                                                                            serde_json::Map::new();
+                                                                        for inner_field in
+                                                                            &inner_nested.fields
+                                                                        {
+                                                                            if let Requestable::Field(
+                                                                                inf,
+                                                                            ) = inner_field
+                                                                            {
+                                                                                let inf_name =
+                                                                                    &inf.name;
+                                                                                let inf_output =
+                                                                                    inf.output_name(
+                                                                                    );
+                                                                                if let Some(inv) =
+                                                                                    inner_item
+                                                                                        .get(inf_name)
+                                                                                {
+                                                                                    inner_obj.insert(
+                                                                                        inf_output
+                                                                                            .to_string(
+                                                                                            ),
+                                                                                        inv.clone(),
+                                                                                    );
+                                                                                } else {
+                                                                                    inner_obj.insert(
+                                                                                        inf_output
+                                                                                            .to_string(
+                                                                                            ),
+                                                                                        JsonValue::Null,
+                                                                                    );
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                        JsonValue::Object(inner_obj)
+                                                                    })
+                                                                    .collect();
+                                                            nested_obj.insert(
+                                                                inner_output.to_string(),
+                                                                JsonValue::Array(inner_results),
+                                                            );
+                                                        } else {
+                                                            nested_obj.insert(
+                                                                inner_output.to_string(),
+                                                                inner_val.clone(),
+                                                            );
+                                                        }
+                                                    } else {
+                                                        nested_obj.insert(
+                                                            inner_output.to_string(),
+                                                            JsonValue::Array(vec![]),
+                                                        );
+                                                    }
                                                 }
                                             }
                                             JsonValue::Object(nested_obj)

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -2229,7 +2229,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                         ordered_items.sort_by(|a, b| {
                                             let resolve_value =
                                                 |item: &&JsonValue| -> Option<JsonValue> {
-                                                    if fields.is_empty() {
+                                                    // For scalar inline arrays, order: ASC/DESC has no field path
+                                                    // (fields is either empty or contains a single empty string)
+                                                    if fields.is_empty()
+                                                        || (fields.len() == 1 && fields[0].is_empty())
+                                                    {
                                                         return Some((*item).clone());
                                                     }
                                                     // Start with the first field

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -3791,7 +3791,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         let field_name = &f.name;
                         let output_name = f.output_name();
 
-                        if let Some(value) = commit.get(field_name) {
+                        // Handle __typename specially for commits (Go returns "Commit")
+                        if field_name == "__typename" {
+                            obj.insert(output_name.to_string(), JsonValue::String("Commit".to_string()));
+                        } else if let Some(value) = commit.get(field_name) {
                             let json_value = crate::json_convert::normal_value_to_json(value)
                                 .unwrap_or(JsonValue::Null);
                             obj.insert(output_name.to_string(), json_value);
@@ -3890,8 +3893,17 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             if let Ok(json_val) = crate::json_convert::normal_value_to_json(value) {
                                 if let Some(arr) = json_val.as_array() {
                                     // Handle array nested selects (e.g., links { cid }, heads { cid })
+                                    // Apply filter if present (e.g., links(filter: {fieldName: {_eq: "age"}}))
                                     let nested_results: Vec<JsonValue> = arr
                                         .iter()
+                                        .filter(|item| {
+                                            // Apply nested filter if present
+                                            if let Some(ref filter) = nested.filter {
+                                                Self::matches_json_filter(item, filter)
+                                            } else {
+                                                true
+                                            }
+                                        })
                                         .map(|item: &JsonValue| {
                                             let mut nested_obj = serde_json::Map::new();
                                             for nested_field in &nested.fields {
@@ -4010,6 +4022,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 )
             }
         }
+    }
+
+    /// Check if a JSON value matches a filter.
+    /// Used for filtering nested arrays like links and heads in commit queries.
+    fn matches_json_filter(value: &JsonValue, filter: &crate::Filter) -> bool {
+        filter.matches_json_object(value).unwrap_or(false)
     }
 
     /// Build a DocumentMapping for commit fields.


### PR DESCRIPTION
## Summary

- Fix empty selection items when aggregate and selection target the same relation (e.g., `_count(published: {})` + `published(limit: 2) { name }`)
- Fix compound filters with relation conditions
- Fix top-level aggregate filters with relations and groupBy rendering
- Add internal keys for aggregate/selection relation collisions
- Improve commits query support (double-nested links/heads)
- Handle scalar inline array ordering in aggregates
- Emit collection-level events for branchable collections

## Test Results

| Package | Status |
|---------|--------|
| query/one_to_many | 81/87 (93%) |
| query/commits | 90/94 (96%) |
| query/inline_array | 172/172 (100%) |

## Test plan
- [x] `cargo build --release -p ffi`
- [x] FFI tests: query/one_to_many (81/87)
- [x] FFI tests: query/commits (90/94)
- [x] FFI tests: query/inline_array (172/172)

🤖 Generated with [Claude Code](https://claude.com/claude-code)