### PR TITLE
feat(acp): ACP filter wrapping, relation filter fix, encrypted index stubs

### DIFF
--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -1319,84 +1319,91 @@ impl<S: Store> DB<S> {
 
         // Load the target collection from persistent store by version_id
         let txn = self.new_txn(false).await?;
-        let systemstore = txn.systemstore()?;
 
-        let collection_key = CollectionKey::new(version_id);
-        let target_bytes = systemstore
-            .get(&collection_key.bytes())
-            .await
-            .map_err(Error::Storage)?
-            .ok_or_else(|| Error::CollectionVersionNotFound(version_id.to_string()))?;
+        // Extract the target schema and perform all systemstore operations in a block
+        // so the systemstore reference is dropped before calling txn.commit()
+        let (target_schema, name) = {
+            let systemstore = txn.systemstore()?;
 
-        let target_schema: CollectionVersion =
-            serde_json::from_slice(&target_bytes).map_err(|e| {
-                Error::Serialization(format!(
-                    "failed to deserialize collection version '{}': {}",
-                    version_id, e
-                ))
-            })?;
-
-        let collection_id = target_schema.collection_id.clone();
-        let name = target_schema.name.clone();
-
-        // Load all versions sharing the same collection_id
-        let version_prefix = CollectionVersionKey::collection_prefix(&collection_id);
-        let mut iter = systemstore
-            .iterator(IterOptions::new().with_prefix(version_prefix))
-            .await
-            .map_err(Error::Storage)?;
-
-        let mut sibling_version_ids = Vec::new();
-        while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
-            let key_str = String::from_utf8_lossy(&pair.key);
-            // Key format: /collection/version/{collection_id}/{version_id}
-            if let Some(vid) = key_str.rsplit('/').next() {
-                sibling_version_ids.push(vid.to_string());
-            }
-        }
-        drop(iter);
-
-        // For each sibling version, activate the target and deactivate others
-        for vid in &sibling_version_ids {
-            let sibling_key = CollectionKey::new(vid.as_str());
-            if let Some(sibling_bytes) = systemstore
-                .get(&sibling_key.bytes())
+            let collection_key = CollectionKey::new(version_id);
+            let target_bytes = systemstore
+                .get(&collection_key.bytes())
                 .await
                 .map_err(Error::Storage)?
-            {
-                let mut sibling_schema: CollectionVersion =
-                    serde_json::from_slice(&sibling_bytes).map_err(|e| {
+                .ok_or_else(|| Error::CollectionVersionNotFound(version_id.to_string()))?;
+
+            let target_schema: CollectionVersion =
+                serde_json::from_slice(&target_bytes).map_err(|e| {
+                    Error::Serialization(format!(
+                        "failed to deserialize collection version '{}': {}",
+                        version_id, e
+                    ))
+                })?;
+
+            let collection_id = target_schema.collection_id.clone();
+            let name = target_schema.name.clone();
+
+            // Load all versions sharing the same collection_id
+            let version_prefix = CollectionVersionKey::collection_prefix(&collection_id);
+            let mut iter = systemstore
+                .iterator(IterOptions::new().with_prefix(version_prefix))
+                .await
+                .map_err(Error::Storage)?;
+
+            let mut sibling_version_ids = Vec::new();
+            while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
+                let key_str = String::from_utf8_lossy(&pair.key);
+                // Key format: /collection/version/{collection_id}/{version_id}
+                if let Some(vid) = key_str.rsplit('/').next() {
+                    sibling_version_ids.push(vid.to_string());
+                }
+            }
+            drop(iter);
+
+            // For each sibling version, activate the target and deactivate others
+            for vid in &sibling_version_ids {
+                let sibling_key = CollectionKey::new(vid.as_str());
+                if let Some(sibling_bytes) = systemstore
+                    .get(&sibling_key.bytes())
+                    .await
+                    .map_err(Error::Storage)?
+                {
+                    let mut sibling_schema: CollectionVersion =
+                        serde_json::from_slice(&sibling_bytes).map_err(|e| {
+                            Error::Serialization(format!(
+                                "failed to deserialize sibling collection '{}': {}",
+                                vid, e
+                            ))
+                        })?;
+
+                    let should_be_active = vid == version_id;
+                    if sibling_schema.is_active == should_be_active {
+                        continue;
+                    }
+
+                    sibling_schema.is_active = should_be_active;
+                    let data = serde_json::to_vec(&sibling_schema).map_err(|e| {
                         Error::Serialization(format!(
-                            "failed to deserialize sibling collection '{}': {}",
+                            "failed to serialize schema for collection '{}': {}",
                             vid, e
                         ))
                     })?;
-
-                let should_be_active = vid == version_id;
-                if sibling_schema.is_active == should_be_active {
-                    continue;
+                    systemstore
+                        .set(&sibling_key.bytes(), &data)
+                        .await
+                        .map_err(Error::Storage)?;
                 }
-
-                sibling_schema.is_active = should_be_active;
-                let data = serde_json::to_vec(&sibling_schema).map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to serialize schema for collection '{}': {}",
-                        vid, e
-                    ))
-                })?;
-                systemstore
-                    .set(&sibling_key.bytes(), &data)
-                    .await
-                    .map_err(Error::Storage)?;
             }
-        }
 
-        // Update the name → version_id mapping to point to the new active version
-        let name_key = CollectionNameKey::new(&name);
-        systemstore
-            .set(&name_key.bytes(), version_id.as_bytes())
-            .await
-            .map_err(Error::Storage)?;
+            // Update the name → version_id mapping to point to the new active version
+            let name_key = CollectionNameKey::new(&name);
+            systemstore
+                .set(&name_key.bytes(), version_id.as_bytes())
+                .await
+                .map_err(Error::Storage)?;
+
+            (target_schema, name)
+        }; // systemstore reference dropped here
 
         txn.commit().await?;
 

--- a/crates/ffi/src/block.rs
+++ b/crates/ffi/src/block.rs
@@ -4,7 +4,10 @@
 
 use std::ffi::c_char;
 
+use acp::nac::NodePermission;
+
 use crate::get_runtime;
+use crate::nac_check::check_nac_for_node;
 use crate::state::NODES;
 use crate::types::{c_str_to_string, FfiResult};
 use crate::ERR_INVALID_NODE_HANDLE;
@@ -21,7 +24,7 @@ use crate::ERR_INVALID_NODE_HANDLE;
 /// * `key_type` - Key type string (e.g., "ed25519", "secp256k1")
 /// * `public_key` - Hex-encoded public key string
 /// * `block_cid` - CID string of the block to verify
-/// * `identity_did` - Optional DID of the caller (unused, reserved for future ACP checks)
+/// * `identity_did` - DID of the caller for NAC permission check
 ///
 /// # Safety
 ///
@@ -32,9 +35,14 @@ pub unsafe extern "C" fn block_verify_signature(
     key_type: *const c_char,
     public_key: *const c_char,
     block_cid: *const c_char,
-    _identity_did: *const c_char,
+    identity_did: *const c_char,
 ) -> FfiResult {
     let rt = get_runtime!(FfiResult);
+
+    // Check NAC permission for signature verification
+    if let Err(e) = check_nac_for_node(rt, node_ptr, identity_did, NodePermission::SignatureVerify) {
+        return e;
+    }
 
     let key_type_str = match c_str_to_string(key_type) {
         Some(s) if !s.is_empty() => s,

--- a/crates/ffi/src/encrypted_index.rs
+++ b/crates/ffi/src/encrypted_index.rs
@@ -1,0 +1,65 @@
+//! Encrypted index operations for FFI.
+//!
+//! This module provides stub implementations for encrypted index operations.
+//! Full implementation is pending.
+
+use std::ffi::c_char;
+
+use crate::types::FfiResult;
+
+/// Create an encrypted index on a collection.
+///
+/// # Safety
+///
+/// All string pointers must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn create_encrypted_index(
+    _node_ptr: usize,
+    _identity_did: *const c_char,
+    _collection_name: *const c_char,
+    _field_name: *const c_char,
+) -> FfiResult {
+    FfiResult::error("encrypted indexes not yet implemented in Rust FFI")
+}
+
+/// Delete an encrypted index from a collection.
+///
+/// # Safety
+///
+/// All string pointers must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn delete_encrypted_index(
+    _node_ptr: usize,
+    _identity_did: *const c_char,
+    _collection_name: *const c_char,
+    _field_name: *const c_char,
+) -> FfiResult {
+    FfiResult::error("encrypted indexes not yet implemented in Rust FFI")
+}
+
+/// List encrypted indexes for a collection.
+///
+/// # Safety
+///
+/// All string pointers must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn list_encrypted_indexes(
+    _node_ptr: usize,
+    _identity_did: *const c_char,
+    _collection_name: *const c_char,
+) -> FfiResult {
+    FfiResult::error("encrypted indexes not yet implemented in Rust FFI")
+}
+
+/// List all encrypted indexes across all collections.
+///
+/// # Safety
+///
+/// All string pointers must be valid null-terminated UTF-8 strings.
+#[no_mangle]
+pub unsafe extern "C" fn list_all_encrypted_indexes(
+    _node_ptr: usize,
+    _identity_did: *const c_char,
+) -> FfiResult {
+    FfiResult::error("encrypted indexes not yet implemented in Rust FFI")
+}

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -38,6 +38,7 @@ pub mod backup;
 pub mod block;
 pub mod collection;
 pub mod document;
+pub mod encrypted_index;
 pub mod index;
 pub mod lens;
 pub mod nac_check;
@@ -88,6 +89,10 @@ pub use collection::{
     set_active_collection_version, set_migration, truncate_collection,
 };
 pub use document::{collection_create, is_json_array, parse_duration, parse_string_array};
+pub use encrypted_index::{
+    create_encrypted_index, delete_encrypted_index, list_all_encrypted_indexes,
+    list_encrypted_indexes,
+};
 pub use index::{create_index, drop_index, get_all_indexes, get_indexes};
 pub use lens::{lens_add, lens_list};
 pub use node::{new_node, node_close};

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -515,7 +515,6 @@ impl TypeJoinMany {
     /// - No child document passes the filter conditions
     fn check_relation_filter(&self, children: &[Doc], rel_filter: &RelationFilter) -> Result<bool> {
         if children.is_empty() {
-            // No children - relation filter cannot pass
             return Ok(false);
         }
 

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -1822,6 +1822,43 @@ impl Planner {
                 }
             }
 
+            // Check if parent's filter has a relation filter for this relation.
+            // If so, add those fields to child_scan_mapping so the filter can be evaluated.
+            // For example, Author(filter: {published: {rating: {_gt: 3}}}) needs the 'rating'
+            // field to be included even if it's not in the selection set.
+            if let Some(ref pf) = parent_filter {
+                if let Some(nested_filter) = pf.extract_relation_filter(relation_field_name) {
+                    for filter_field in nested_filter.referenced_fields() {
+                        // Skip special fields
+                        if filter_field.starts_with('_') {
+                            continue;
+                        }
+                        // Find the field index in the target collection
+                        if let Some(idx) = target_collection
+                            .fields
+                            .iter()
+                            .position(|f| f.name == filter_field)
+                        {
+                            // Add the field to child_scan_mapping if not present
+                            if child_scan_mapping
+                                .first_index_of_name(&filter_field)
+                                .is_none()
+                            {
+                                child_scan_mapping.add(idx, &filter_field);
+                            }
+                            // Add render_key so the field appears in the output
+                            if !child_scan_mapping
+                                .render_keys
+                                .iter()
+                                .any(|rk| rk.key == filter_field)
+                            {
+                                child_scan_mapping.add_render_key(idx, &filter_field);
+                            }
+                        }
+                    }
+                }
+            }
+
             // Check if parent's order_by references fields in this relation.
             // If so, add those fields to child_scan_mapping.render_keys so they're
             // available in the merged JSON for ordering. The fields won't appear in

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -3358,7 +3358,10 @@ impl Planner {
         if let Some(ref fetcher) = self.fetcher {
             child_scan = child_scan.with_fetcher(fetcher.clone());
         }
-        let child_plan: Box<dyn PlanNode> = Box::new(child_scan);
+        let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
+
+        // Insert ACP permission filter for the child collection (if ACP-protected).
+        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
 
         // Find the other side of the relation
         let target_relation_field = if let Some(rel_name) = &relation_field.relation_name {
@@ -3492,7 +3495,10 @@ impl Planner {
             if let Some(ref fetcher) = self.fetcher {
                 child_scan = child_scan.with_fetcher(fetcher.clone());
             }
-            let child_plan: Box<dyn PlanNode> = Box::new(child_scan);
+            let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
+
+            // Insert ACP permission filter for the child collection (if ACP-protected).
+            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
 
             // Find the other side of the relation
             let target_relation_field = if let Some(rel_name) = &relation_field.relation_name {
@@ -3614,6 +3620,9 @@ impl Planner {
             child_scan = child_scan.with_fetcher(fetcher.clone());
         }
         let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
+
+        // Insert ACP permission filter for the child collection (if ACP-protected).
+        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
 
         // Add sub-joins for remaining path levels within the child plan
         if path.len() > 1 {


### PR DESCRIPTION
## Summary

- Fix NAC signature verification and transaction leak
- Add ACP permission filter wrapping for relation joins (TypeJoinOne/TypeJoinMany)
- Fix relation filter fields not being added to child scan mapping
- Add encrypted index FFI stubs for searchable-encryption branch compatibility

## Key Changes

- **ACP filter wrapping**: Relation join child plans are now wrapped with PermissionFilterNode for DAC-protected collections
- **Relation filter fix**: When a query uses a relation filter (e.g., `Author(filter: {published: {rating: {_gt: 3}}})`), the filter's referenced fields are now correctly added to the child scan mapping's render keys
- **Encrypted index stubs**: Added stub FFI functions for `create_encrypted_index`, `delete_encrypted_index`, `list_encrypted_indexes`, `list_all_encrypted_indexes`

## Test Status

- acp: **324/324 (100%)**
- All DAC index relation query tests passing (6/6 fixed)
- All NAC tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)