### PR TITLE
fix(ffi): Fix signature verification and P2P signing support

### DIFF
--- a/crates/ffi/src/block.rs
+++ b/crates/ffi/src/block.rs
@@ -86,48 +86,55 @@ pub unsafe extern "C" fn block_verify_signature(
     };
 
     let result = rt.block_on(async {
-        // Create a read-only transaction to access the blockstore
+        // Create a read-only transaction to access the blockstore.
+        // Load block and signature data inside a scope so the blockstore
+        // borrow is dropped before we discard the transaction.
         let txn = database
             .new_txn(true)
             .await
             .map_err(|e| format!("failed to create transaction: {}", e))?;
 
-        // Load the block from blockstore
-        let blockstore = txn
-            .blockstore()
-            .map_err(|e| format!("failed to get blockstore: {}", e))?;
+        let (block, signature) = {
+            let blockstore = txn
+                .blockstore()
+                .map_err(|e| format!("failed to get blockstore: {}", e))?;
 
-        let block_bytes = blockstore
-            .get(&parsed_cid.to_bytes())
-            .await
-            .map_err(|e| format!("failed to load block: {}", e))?
-            .ok_or_else(|| format!("block not found: {}", cid_str))?;
+            let block_bytes = blockstore
+                .get(&parsed_cid.to_bytes())
+                .await
+                .map_err(|e| format!("failed to load block: {}", e))?
+                .ok_or_else(|| format!("could not find block {}", cid_str))?;
 
-        let block = defra_core::block::Block::from_dag_cbor(&block_bytes)
-            .map_err(|e| format!("failed to decode block: {}", e))?;
+            let block = defra_core::block::Block::from_dag_cbor(&block_bytes)
+                .map_err(|e| format!("failed to decode block: {}", e))?;
 
-        // Check that the block has a signature
-        let sig_cid = block
-            .signature
-            .ok_or("block has no signature")?;
+            // Check that the block has a signature
+            let sig_cid = block
+                .signature
+                .ok_or("block has no signature")?;
 
-        // Load the signature block from blockstore
-        let sig_bytes = blockstore
-            .get(&sig_cid.to_bytes())
-            .await
-            .map_err(|e| format!("failed to load signature block: {}", e))?
-            .ok_or_else(|| format!("signature block not found: {}", sig_cid))?;
+            // Load the signature block from blockstore
+            let sig_bytes = blockstore
+                .get(&sig_cid.to_bytes())
+                .await
+                .map_err(|e| format!("failed to load signature block: {}", e))?
+                .ok_or_else(|| format!("signature block not found: {}", sig_cid))?;
 
-        let signature = defra_core::block::Signature::from_dag_cbor(&sig_bytes)
-            .map_err(|e| format!("failed to decode signature block: {}", e))?;
+            let signature = defra_core::block::Signature::from_dag_cbor(&sig_bytes)
+                .map_err(|e| format!("failed to decode signature block: {}", e))?;
+
+            (block, signature)
+        };
+        // blockstore borrow is now dropped
+
+        // Discard the read-only transaction
+        txn.discard()
+            .map_err(|e| format!("failed to discard transaction: {}", e))?;
 
         // Verify that the identity matches the signature's identity
         let sig_identity = String::from_utf8_lossy(&signature.header.identity);
         if sig_identity.as_ref() != pub_key_str {
-            return Err(format!(
-                "signature public key mismatch: expected {}, got {}",
-                pub_key_str, sig_identity
-            ));
+            return Err("signature was created by a different key".to_string());
         }
 
         // Get the bytes to verify (block serialized without signature)
@@ -145,10 +152,6 @@ pub unsafe extern "C" fn block_verify_signature(
         if !valid {
             return Err("signature verification failed".to_string());
         }
-
-        // Discard the read-only transaction
-        txn.discard()
-            .map_err(|e| format!("failed to discard transaction: {}", e))?;
 
         Ok::<(), String>(())
     });

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -10,6 +10,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use acp::nac::NodePermission;
+use identity::Identity;
 
 use crate::get_runtime;
 use crate::nac_check::check_nac_for_node;
@@ -110,6 +111,8 @@ pub unsafe extern "C" fn new_node_with_p2p(
         None => return NewNodeResult::error("listen_addr is null"),
     };
 
+    let enable_signing = options.enable_signing != 0;
+
     let result = rt.block_on(async {
         // Create storage backend based on options
         let store: Arc<FfiStore> = if options.in_memory == 0 && !options.db_path.is_null() {
@@ -125,8 +128,79 @@ pub unsafe extern "C" fn new_node_with_p2p(
         // Create event bus for subscriptions
         let event_bus: Arc<dyn events::Bus> = Arc::new(events::ChannelBus::default());
 
-        // Open database and load collections
-        let mut database = db::DB::open_from_arc(store.clone())
+        // Generate or load node identity for signing (matches new_node behavior)
+        let (raw_identity_opt, node_identity_did) = if enable_signing {
+            let raw_identity = if !options.signing_private_key.is_null()
+                && options.signing_private_key_len > 0
+            {
+                let key_bytes = std::slice::from_raw_parts(
+                    options.signing_private_key,
+                    options.signing_private_key_len,
+                );
+                let key_type = crate::types::c_str_to_string(options.signing_key_type)
+                    .unwrap_or_else(|| "secp256k1".to_string());
+
+                match key_type.as_str() {
+                    "secp256k1" => {
+                        let private_key =
+                            crypto::Secp256k1PrivateKey::from_bytes(key_bytes)
+                                .map_err(|e| format!("failed to load secp256k1 key: {}", e))?;
+                        identity::RawIdentity::from_secp256k1(private_key)
+                            .map_err(|e| format!("failed to create node identity: {}", e))?
+                    }
+                    "ed25519" => {
+                        let private_key =
+                            crypto::Ed25519PrivateKey::from_bytes(key_bytes)
+                                .map_err(|e| format!("failed to load ed25519 key: {}", e))?;
+                        identity::RawIdentity::from_ed25519(private_key)
+                            .map_err(|e| format!("failed to create node identity: {}", e))?
+                    }
+                    other => {
+                        return Err(format!("unsupported signing key type: {}", other));
+                    }
+                }
+            } else {
+                let private_key = crypto::generate_secp256k1()
+                    .map_err(|e| format!("failed to generate node signing key: {}", e))?;
+                identity::RawIdentity::from_secp256k1(private_key)
+                    .map_err(|e| format!("failed to create node identity: {}", e))?
+            };
+
+            let did = raw_identity
+                .did()
+                .map_err(|e| format!("failed to derive node DID: {}", e))?;
+            let did_str = did.to_string();
+
+            let key_type = if !options.signing_private_key.is_null() {
+                crate::types::c_str_to_string(options.signing_key_type)
+                    .unwrap_or_else(|| "secp256k1".to_string())
+            } else {
+                "secp256k1".to_string()
+            };
+
+            defra_core::signing::store_identity(
+                &did_str,
+                defra_core::signing::SigningConfig {
+                    key_type,
+                    private_key_bytes: raw_identity.private_key_bytes().to_vec(),
+                    public_key_bytes: raw_identity.public_key_bytes().to_vec(),
+                    public_key_hex: hex::encode(raw_identity.public_key_bytes()),
+                },
+            );
+
+            eprintln!("[SIGN-DEBUG] new_node_with_p2p: node identity DID={}", did_str);
+            (Some(raw_identity), Some(did_str))
+        } else {
+            (None, None)
+        };
+
+        // Open database with node identity (if signing enabled)
+        let mut db_options = db::DbOptions::default();
+        if let Some(raw_id) = raw_identity_opt {
+            db_options = db_options.with_node_identity(raw_id);
+        }
+
+        let mut database = db::DB::open_from_arc_with_options(store.clone(), db_options)
             .await
             .map_err(|e| format!("failed to open database: {}", e))?;
 
@@ -411,7 +485,7 @@ pub unsafe extern "C" fn new_node_with_p2p(
             event_bus,
             policy_store,
             p2p: Some(p2p_state),
-            node_identity_did: None,
+            node_identity_did,
         };
 
         // Register and get handle


### PR DESCRIPTION
## Summary
- Fix `block_verify_signature` transaction reference leak by scoping the blockstore borrow before calling `txn.discard()`
- Match Go error messages for key mismatch (`"signature was created by a different key"`) and block-not-found (`"could not find"`)
- Add signing support to `new_node_with_p2p` which was completely missing identity generation, signing config storage, and DB options with node identity

## Test plan
- [x] All 6 previously failing FFI signature tests now pass (15/15 total)
  - `TestSignatureVerify_WithValidData_ShouldVerify`
  - `TestSignatureVerify_WithDifferentKeyType_ShouldVerify`
  - `TestSignatureVerify_WithWrongIdentity_ShouldError`
  - `TestSignatureVerify_WithWrongCid_ShouldError`
  - `TestDocSignature_WithPeersAnDifferentKeyTypes_ShouldSync`
  - `TestDocSignature_WithPeersAnDifferentKeyTypesUpdatingSameDoc_ShouldSync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)