### PR TITLE
fix(ffi): P2P error messages, view sync, and active_peers race

### DIFF
--- a/crates/db/src/merge_handler.rs
+++ b/crates/db/src/merge_handler.rs
@@ -18,7 +18,7 @@ use defra_core::types::DocId;
 use document::{DocID, Document, NormalValue};
 use events::{MergeCompleteData, Message, Update};
 use p2p::sync::{BlockMetadata, MergeHandler, MergeOutcome};
-use schema::{self, CType, CollectionVersion, FieldDescription, FieldKind, ScalarKind};
+use schema::{self, CType, CollectionVersion, FieldDescription, FieldKind, QuerySource, ScalarKind};
 use storage::corekv::{Key, Store};
 use storage::keys::systemstore::{CollectionKey, CollectionVersionKey};
 
@@ -1564,7 +1564,26 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let mut schema =
             CollectionVersion::new(&collection_name, &version_id, &collection_id, fields);
         schema.is_active = false;
-        schema.is_materialized = true;
+
+        // Views (collections with a query_select) are non-materialized and carry query metadata.
+        // Regular collections are materialized.
+        if let Some(ref query_bytes) = payload.query_select {
+            schema.is_materialized = false;
+            if let Ok(query_value) = serde_cbor::from_slice::<serde_json::Value>(query_bytes) {
+                let mut source = QuerySource::new(query_value);
+                if let Some(ref transform_cid) = payload.query_transform {
+                    source.transform = Some(transform_cid.to_string());
+                }
+                schema.query = Some(source);
+            } else {
+                tracing::warn!(
+                    cid = %cid,
+                    "Failed to decode query_select CBOR bytes for view collection"
+                );
+            }
+        } else {
+            schema.is_materialized = true;
+        }
 
         // Store in systemstore
         let txn = self.db.new_txn(false).await.map_err(MergeError::Database)?;

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -619,33 +619,53 @@ pub extern "C" fn p2p_active_peers(node_ptr: usize) -> FfiResult {
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
 
             rt.block_on(async {
-                // Get connected peers with addresses from the P2P host
-                // (populated by ConnectionEstablished events).
-                let host_addrs = p2p
-                    .handle
-                    .peer_addresses()
-                    .await
-                    .map_err(|e| format!("failed to get peer addresses: {}", e))?;
-
-                // Also get the full connected peer list so we can merge in
-                // FFI-stored addresses for peers the host hasn't resolved yet.
+                // Get connected peers from the host first (authoritative list).
                 let connected = p2p
                     .handle
                     .connected_peers()
                     .await
                     .map_err(|e| format!("failed to get connected peers: {}", e))?;
 
+                // Get host-resolved addresses (populated by ConnectionEstablished events).
+                let mut host_addrs = p2p
+                    .handle
+                    .peer_addresses()
+                    .await
+                    .map_err(|e| format!("failed to get peer addresses: {}", e))?;
+
                 // Build a set of peer IDs already covered by host_addrs
                 let mut covered: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
                 for addr_str in &host_addrs {
-                    // Extract peer ID from the /p2p/<id> component
                     if let Some(pid) = addr_str.rsplit("/p2p/").next() {
                         covered.insert(pid.to_string());
+                    }
+                }
+
+                // Check if any connected peers are missing from host_addrs.
+                // This can happen when incoming ConnectionEstablished events
+                // haven't been processed yet by the host event loop.
+                let has_missing = connected.iter().any(|pid| {
+                    let pid_str = pid.to_string();
+                    !covered.contains(&pid_str) && p2p.get_peer_address(&pid_str).is_none()
+                });
+
+                if has_missing {
+                    // Brief yield to let the host process pending events
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    // Retry peer_addresses
+                    if let Ok(retry) = p2p.handle.peer_addresses().await {
+                        covered.clear();
+                        for addr_str in &retry {
+                            if let Some(pid) = addr_str.rsplit("/p2p/").next() {
+                                covered.insert(pid.to_string());
+                            }
+                        }
+                        host_addrs = retry;
                     }
                 }
 
@@ -704,7 +724,7 @@ pub unsafe extern "C" fn p2p_connect(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
 
             rt.block_on(async {
@@ -795,7 +815,7 @@ pub unsafe extern "C" fn p2p_set_replicator(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
             let db = &state.database;
 
@@ -1086,7 +1106,7 @@ pub unsafe extern "C" fn p2p_delete_replicator(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
 
             rt.block_on(async {
@@ -1153,7 +1173,7 @@ pub unsafe extern "C" fn p2p_get_all_replicators(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
 
             rt.block_on(async {
@@ -1236,7 +1256,7 @@ pub unsafe extern "C" fn p2p_add_collections(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
             let db = &state.database;
 
@@ -1313,7 +1333,7 @@ pub unsafe extern "C" fn p2p_remove_collections(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
             let db = &state.database;
 
@@ -1375,7 +1395,7 @@ pub unsafe extern "C" fn p2p_get_all_collections(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
 
             let collections = p2p.get_collections();
@@ -1432,7 +1452,7 @@ pub unsafe extern "C" fn p2p_add_documents(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
 
             rt.block_on(async {
@@ -1505,7 +1525,7 @@ pub unsafe extern "C" fn p2p_remove_documents(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
 
             rt.block_on(async {
@@ -1560,7 +1580,7 @@ pub unsafe extern "C" fn p2p_get_all_documents(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
 
             let mut documents = p2p.get_documents();
@@ -1635,7 +1655,7 @@ pub unsafe extern "C" fn p2p_sync_documents(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
             let db = &state.database;
 
@@ -1751,7 +1771,7 @@ pub unsafe extern "C" fn p2p_sync_branchable_collection(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
             let db = &state.database;
 
@@ -1912,7 +1932,7 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
         .get(node_ptr, |state| {
             let p2p = match &state.p2p {
                 Some(p2p) => p2p,
-                None => return Err("P2P not enabled for this node".to_string()),
+                None => return Err("no p2p system configured".to_string()),
             };
             let db = &state.database;
 

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -415,28 +415,21 @@ pub unsafe extern "C" fn new_node_with_p2p(
             let mut sub = event_bus_for_broadcast.subscribe(&[events::EventName::Update]);
             while let Some(msg) = sub.recv().await {
                 if let Some(update) = msg.as_update() {
-                    // Skip relay updates (already from P2P)
-                    if update.is_relay {
-                        eprintln!(
-                            "[BROADCAST] Skipping relay update cid={} doc_id={}",
-                            update.cid, update.doc_id
-                        );
-                        continue;
-                    }
                     let cid = update.cid;
-                    let block = update.block.clone();
                     let doc_id = update.doc_id.clone();
                     let collection_id = update.collection_id.clone();
 
-                    eprintln!(
-                        "[BROADCAST] Got local update cid={} doc_id={} collection={} block_len={}",
-                        cid,
-                        doc_id,
-                        collection_id,
-                        block.len()
-                    );
+                    // Skip relay updates (already from P2P) - these don't need re-broadcast
+                    // since the originating node already broadcast to GossipSub.
+                    if update.is_relay {
+                        eprintln!("[BROADCAST] Skipping relay update cid={} doc_id={}", cid, doc_id);
+                        continue;
+                    }
 
-                    // Push to replicator peers via direct PushLog.
+                    // Local update: push to replicators + GossipSub broadcast.
+                    let block = update.block.clone();
+                    eprintln!("[BROADCAST] Local update cid={} doc_id={} collection={} block_len={}", cid, doc_id, collection_id, block.len());
+
                     coord_for_broadcast
                         .push_to_replicators(&cid, &block, &doc_id, &collection_id)
                         .await;
@@ -957,6 +950,9 @@ async fn push_existing_docs(
         .datastore()
         .map_err(|e| format!("failed to get datastore: {}", e))?;
 
+    // Collect JoinHandles so we can await all pushes before signaling completion.
+    let mut push_handles = Vec::new();
+
     for col_name in collections {
         let collection = match db
             .get_collection(col_name)
@@ -1041,13 +1037,12 @@ async fn push_existing_docs(
                     continue;
                 }
 
-                // Fire-and-forget: spawn each push so we don't block.
-                // Go's pushHeadsForAllDocs does the same (each push is a goroutine).
-                // The receiver's sync manager handles missing DAG links via Bitswap.
+                // Spawn each push concurrently but track the handle so we can
+                // await completion before emitting ReplicatorCompleted.
                 let push_h = handle.clone();
-                tokio::spawn(async move {
+                push_handles.push(tokio::spawn(async move {
                     let _ = push_h.send_two_stream_request(peer_id, request).await;
-                });
+                }));
             }
 
             iter.close()
@@ -1055,6 +1050,18 @@ async fn push_existing_docs(
                 .map_err(|e| format!("headstore close error: {}", e))?;
         }
     }
+
+    // Await all push tasks so ReplicatorCompleted isn't emitted prematurely.
+    // The Go test framework copies expected heads on ReplicatorCompleted, then
+    // waits for merge events — if pushes haven't landed yet, we get timeouts.
+    eprintln!(
+        "[PUSH-EXISTING] Awaiting {} push tasks to complete",
+        push_handles.len()
+    );
+    for handle in push_handles {
+        let _ = handle.await;
+    }
+    eprintln!("[PUSH-EXISTING] All push tasks completed");
 
     Ok(())
 }

--- a/crates/p2p/src/sync/coordinator.rs
+++ b/crates/p2p/src/sync/coordinator.rs
@@ -374,6 +374,10 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
                 topic,
                 ..
             } => {
+                eprintln!(
+                    "[COORD] GossipMessage from={} doc_id={} collection={} topic={}",
+                    propagation_source, message.doc_id, message.collection_id, topic
+                );
                 tracing::debug!(
                     doc_id = %message.doc_id,
                     collection_id = %message.collection_id,
@@ -419,6 +423,10 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
                 request,
                 channel,
             } => {
+                eprintln!(
+                    "[COORD] PushLogRequest from={} doc_id={} collection={}",
+                    peer_id, request.doc_id, request.collection_id
+                );
                 tracing::debug!(
                     peer_id = %peer_id,
                     doc_id = %request.doc_id,
@@ -510,6 +518,10 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
             }
             HostEvent::TwoStreamRequest { peer_id, request } => {
                 // Handle request via Go's two-stream protocol
+                eprintln!(
+                    "[COORD] TwoStreamRequest from={} doc_id={} collection={}",
+                    peer_id, request.doc_id, request.collection_id
+                );
                 tracing::debug!(
                     peer_id = %peer_id,
                     doc_id = %request.doc_id,

--- a/crates/p2p/src/sync/manager.rs
+++ b/crates/p2p/src/sync/manager.rs
@@ -294,6 +294,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         // Check if already merged
         match self.blockstore.is_merged(cid).await {
             Ok(true) => {
+                eprintln!("[SYNC-MGR] Block already merged cid={} doc_id={}", cid, msg.doc_id);
                 tracing::debug!(?cid, "Block already merged, skipping");
                 if self
                     .event_tx
@@ -376,6 +377,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
 
         if missing.is_empty() {
             // DAG is complete - emit BlockReceived for merge
+            eprintln!("[SYNC-MGR] DAG complete cid={} doc_id={} — emitting BlockReceived", cid, msg.doc_id);
             tracing::info!(
                 ?cid,
                 doc_id = %msg.doc_id,
@@ -403,6 +405,10 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             }
         } else {
             // DAG has missing blocks - track as pending and request Bitswap fetch
+            eprintln!(
+                "[SYNC-MGR] DAG incomplete cid={} doc_id={} missing={} — requesting Bitswap",
+                cid, msg.doc_id, missing.len()
+            );
             tracing::info!(
                 ?cid,
                 missing_count = missing.len(),


### PR DESCRIPTION
## Summary
- Fix P2P error message strings to match Go implementation ("no p2p system configured")
- Fix IsMaterialized handling for synced view collections — views now correctly non-materialized with QuerySource metadata
- Add retry mechanism in active_peers for ConnectionEstablished race condition
- **NEW:** Await push tasks in `push_existing_docs` before emitting `ReplicatorCompleted` — fixes 30s timeout issues in replicator tests

## FFI Test Results
- Branchable collection sync: **6/6 PASS**
- Full net suite: **106/124 (85.5%)** — up from 102/124 (82%)

### Remaining Failures (18)
- Collection version sync (views, patches) — not yet implemented
- Some CRDT counter update tests
- Node chain propagation tests  
- Schema version update tests

## What Was Fixed
The `push_existing_docs` function now awaits all spawned push JoinHandles before emitting `ReplicatorCompleted`. Previously, push tasks were fire-and-forget, causing the Go test framework to copy expected DAG heads before pushes actually landed — resulting in 30s timeout failures.

## Regression Avoided
Attempted relay re-broadcast (pushing relay updates to replicators for multi-hop), but this interfered with Bitswap block fetching and caused MORE timeouts. Reverted to original design where relay updates are skipped — multi-hop relies on GossipSub broadcast from the originating node.

## Test plan
- [x] `cargo build --release -p ffi` — builds cleanly
- [x] `make test:ffi RUST_LIB=<path> FFI_PKG="net/sync/branchable_collection"` — 6/6 pass
- [x] `make test:ffi RUST_LIB=<path> FFI_PKG=net` — 106/124 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)