### PR TITLE
fix(query): Go-compatible group ordering and query fixes

### DIFF
--- a/crates/query/src/plan/groupby.rs
+++ b/crates/query/src/plan/groupby.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use serde_json::Value as JsonValue;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
@@ -859,19 +859,104 @@ impl PlanNode for GroupByNode {
         self.source.start().await?;
         self.started = true;
 
-        // Buffer all documents and group them
-        let mut group_map: HashMap<String, usize> = HashMap::new();
-
+        // Buffer all documents from scan (storage order)
+        let mut all_docs: Vec<Doc> = Vec::new();
         while self.source.next().await? {
-            let doc = self.source.value().deep_clone();
-            let key = self.generate_key(&doc)?;
+            all_docs.push(self.source.value().deep_clone());
+        }
 
+        // Determine group key ordering.
+        //
+        // Go DefraDB's GroupNode uses an interleaved join of parent (scan order) and
+        // child (sorted by _group order) documents. Both mergeParent and appendChild
+        // can create new groups, so the group ordering depends on which source
+        // encounters a new group key first. We replicate this interleaving here.
+        //
+        // The interleaving only applies when _group has a simple order (no inner
+        // groupBy). When _group has a groupBy, Go's child source yields grouped
+        // results (fewer items) with different interleaving semantics.
+        let group_order = self.group_aliases.first().and_then(|a| a.order.clone());
+        let has_simple_group_order = group_order
+            .as_ref()
+            .map_or(false, |o| !o.is_empty() && self.inner_group_by_fields.is_empty());
+        let mut ordered_keys: Vec<String> = Vec::new();
+        let mut key_set: HashSet<String> = HashSet::new();
+
+        if has_simple_group_order {
+            let order = group_order.as_ref().unwrap();
+            if !all_docs.is_empty() {
+                // Sort indices by _group order (child order)
+                let mut sorted_indices: Vec<usize> = (0..all_docs.len()).collect();
+                sorted_indices.sort_by(|&ai, &bi| {
+                    for cond in &order.conditions {
+                        if let Some(field_name) = cond.fields.first() {
+                            if let Some(idx) =
+                                self.document_mapping.first_index_of_name(field_name)
+                            {
+                                let val_a = all_docs[ai].get(idx);
+                                let val_b = all_docs[bi].get(idx);
+                                let cmp = Self::compare_field_values(val_a, val_b);
+                                let cmp = match cond.direction {
+                                    OrderDirection::Asc => cmp,
+                                    OrderDirection::Desc => cmp.reverse(),
+                                };
+                                if cmp != std::cmp::Ordering::Equal {
+                                    return cmp;
+                                }
+                            }
+                        }
+                    }
+                    std::cmp::Ordering::Equal
+                });
+
+                // Interleave parent (scan order) and child (sorted order)
+                for i in 0..all_docs.len() {
+                    let parent_key = self.generate_key(&all_docs[i])?;
+                    if key_set.insert(parent_key.clone()) {
+                        ordered_keys.push(parent_key);
+                    }
+
+                    let child_key = self.generate_key(&all_docs[sorted_indices[i]])?;
+                    if key_set.insert(child_key.clone()) {
+                        ordered_keys.push(child_key);
+                    }
+                }
+            }
+        }
+
+        // Fallback: if no interleaving was done, use scan order
+        if ordered_keys.is_empty() {
+            for doc in &all_docs {
+                let key = self.generate_key(doc)?;
+                if key_set.insert(key.clone()) {
+                    ordered_keys.push(key);
+                }
+            }
+        }
+
+        // Pre-create groups in the determined order
+        let mut group_map: HashMap<String, usize> = HashMap::new();
+        for key in &ordered_keys {
+            let idx = self.groups.len();
+            group_map.insert(key.clone(), idx);
+            self.groups.push((
+                key.clone(),
+                DocumentGroup {
+                    docs: vec![],
+                    representative: Doc::default(),
+                },
+            ));
+        }
+
+        // Populate groups with docs in scan order
+        for doc in all_docs {
+            let key = self.generate_key(&doc)?;
             if let Some(&idx) = group_map.get(&key) {
-                self.groups[idx].1.add(doc);
-            } else {
-                let idx = self.groups.len();
-                group_map.insert(key.clone(), idx);
-                self.groups.push((key, DocumentGroup::new(doc)));
+                let group = &mut self.groups[idx].1;
+                if group.docs.is_empty() {
+                    group.representative = doc.deep_clone();
+                }
+                group.docs.push(doc);
             }
         }
 

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -652,8 +652,16 @@ impl Planner {
             // Apply scalar filter as residual filter on IndexScanNode.
             // The index may only cover part of the filter (e.g., first field of composite index),
             // so remaining conditions are applied as post-filtering on the fetched documents.
+            // Strip _alias for complex filters (same reason as ScanNode below).
             if let Some(ref filter) = scalar_filter {
-                index_scan_node = index_scan_node.with_residual_filter(filter.clone());
+                if is_complex_filter && filter.has_alias_filter() {
+                    let (non_alias, _alias) = filter.split_alias();
+                    if let Some(f) = non_alias {
+                        index_scan_node = index_scan_node.with_residual_filter(f);
+                    }
+                } else {
+                    index_scan_node = index_scan_node.with_residual_filter(filter.clone());
+                }
             }
             Box::new(index_scan_node)
         } else {
@@ -667,9 +675,20 @@ impl Planner {
             if let Some(ref doc_ids) = select.doc_ids {
                 scan = scan.with_doc_ids(doc_ids.clone());
             }
-            // Push scalar filter to ScanNode (matches Go DefraDB plan construction)
+            // Push scalar filter to ScanNode (matches Go DefraDB plan construction).
+            // For complex filters, strip _alias conditions: they reference aliased
+            // relation fields whose data is only available after TypeJoin populates
+            // the relation index. The full filter (including _alias) is applied after
+            // joins at the complex filter SelectNode.
             if let Some(ref filter) = scalar_filter {
-                scan = scan.with_filter(filter.clone());
+                if is_complex_filter && filter.has_alias_filter() {
+                    let (non_alias, _alias) = filter.split_alias();
+                    if let Some(f) = non_alias {
+                        scan = scan.with_filter(f);
+                    }
+                } else {
+                    scan = scan.with_filter(filter.clone());
+                }
             }
             Box::new(scan)
         };

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -87,7 +87,7 @@ pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -
         }
     }
 
-    // Validate GROUP BY fields exist in schema
+    // Validate GROUP BY fields exist in schema and are groupable
     if let Some(ref group_by) = select.group_by {
         for field_name in &group_by.fields {
             if !field_exists(field_name) {
@@ -95,6 +95,15 @@ pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -
                     "GROUP BY field '{}' not found in collection '{}'",
                     field_name, select.collection_name
                 )));
+            }
+            // Reject array relation fields (one-to-many) - can't group by a list value
+            if let Some(field) = collection.field_by_name(field_name) {
+                if field.kind.is_object() && field.kind.is_array() {
+                    return Err(QueryError::parse(format!(
+                        "invalid field value to groupBy. Field: {}",
+                        field_name
+                    )));
+                }
             }
         }
 

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -2966,7 +2966,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             for nested_select in &nested_selects {
                 let relation_name = &nested_select.field.name;
                 let output_name = nested_select.field.output_name();
-                let related_collection = &nested_select.collection_name;
+
+                // Resolve the actual collection name from the relation field.
+                // nested_select.collection_name is the field name (e.g., "author"),
+                // but we need the collection type name (e.g., "Author").
+                let related_collection =
+                    self.resolve_relation_target_name(&collection, relation_name).await
+                        .unwrap_or_else(|| nested_select.collection_name.clone());
 
                 // Many-to-one: parent has FK field (e.g., Book._authorID → Author)
                 let fk_field_name = CollectionVersion::relation_id_field_name(relation_name);
@@ -2977,7 +2983,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         .unwrap_or_default();
 
                     if !fk_doc_id.is_empty() {
-                        let result = fetcher.get_by_ids(related_collection, &[fk_doc_id]).await?;
+                        let result = fetcher.get_by_ids(&related_collection, &[fk_doc_id]).await?;
 
                         if let Some(related_doc) = result.docs().first() {
                             let related_obj =
@@ -3149,6 +3155,38 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         Ok(JsonValue::Array(enriched_results))
+    }
+
+    /// Resolve the actual collection name for a relation field on a parent collection.
+    ///
+    /// Nested selects have collection_name set to the field name (e.g., "author"),
+    /// but fetcher operations need the collection type name (e.g., "Author").
+    /// This method resolves the target collection name by looking at the parent
+    /// collection's relation field metadata.
+    async fn resolve_relation_target_name(
+        &self,
+        parent_collection: &CollectionVersion,
+        relation_field_name: &str,
+    ) -> Option<String> {
+        let field = parent_collection.field_by_name(relation_field_name)?;
+        let target_id = field.kind.relation_collection_id()?;
+
+        // For Named fields, target_id is the collection name directly
+        if let Ok(Some(coll)) = self.collection_provider.get_collection(target_id).await {
+            return Some(coll.name.clone());
+        }
+
+        // For Relation fields, target_id is a collection_id/version_id — search by ID
+        if let Ok(names) = self.collection_provider.list_collections().await {
+            for name in names {
+                if let Ok(Some(coll)) = self.collection_provider.get_collection(&name).await {
+                    if coll.collection_id == target_id || coll.version_id == target_id {
+                        return Some(coll.name.clone());
+                    }
+                }
+            }
+        }
+        None
     }
 
     /// Render a Document's fields as a JSON object using only the fields requested by a Select.


### PR DESCRIPTION
## Summary
- Implement Go-compatible group ordering in GroupByNode via parent/child interleaving
- Strip _alias suffix from ScanNode/IndexScanNode filter fields
- Add groupBy validation for array relation fields  
- Add resolve_relation_target_name helper for relation lookups

## Test Results
- query/simple: 434 pass, 1 fail (pre-existing deleted docs issue)
- query/one_to_many: 87 pass, 0 fail
- query/many_to_many: 2 pass, 0 fail

## Technical Details
Go DefraDB's GroupNode uses an interleaved join of parent (scan order) and child (sorted by _group order) documents. Both mergeParent and appendChild can create new groups, so group ordering depends on which source encounters a new group key first. This commit replicates that interleaving behavior in Rust.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)