### PR TITLE
feat(tools): Add ffi-test CLI for FFI compatibility testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -434,6 +434,30 @@ git branch
 git worktree remove ../defradb.rs-crdt
 ```
 
+### FFI Testing
+
+The `ffi-test` tool runs Go integration tests against the Rust FFI implementation.
+
+```bash
+# Install the tool (once)
+cargo install --path tools/ffi-test
+
+# Run tests from any worktree
+cd /path/to/defradb.rs-index
+ffi-test run query/simple                    # All tests in package
+ffi-test run query/simple -t TestFilter      # Specific test
+ffi-test run query/simple --verbose          # Full output
+
+# View status
+ffi-test status                              # Current worktree
+ffi-test status --all                        # All worktrees
+
+# Manage worktrees
+ffi-test worktree create foo                 # Create paired worktrees
+ffi-test worktree list                       # List all pairs
+ffi-test worktree remove foo                 # Remove both
+```
+
 ## Goal
 
 **New contributor feels "cozy and right inside their workshop, ready to do very productive work."**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/ffi",
     "crates/lens",
     "crates/wasm",
+    "tools/ffi-test",
 ]
 
 [workspace.package]

--- a/tools/ffi-test/Cargo.toml
+++ b/tools/ffi-test/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ffi-test"
+version = "0.1.0"
+edition = "2021"
+description = "FFI compatibility testing tool for defradb.rs"
+
+[[bin]]
+name = "ffi-test"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+tokio = { version = "1.35", features = ["process", "fs", "rt-multi-thread", "macros", "io-util"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+colored = "2.0"
+dirs = "5.0"

--- a/tools/ffi-test/src/builder.rs
+++ b/tools/ffi-test/src/builder.rs
@@ -1,0 +1,95 @@
+use std::path::Path;
+use tokio::process::Command;
+
+use crate::config::{CBINDGEN_CONFIG, FFI_LIB_NAME, HEADER_DESTINATION};
+use crate::error::{FfiTestError, Result};
+use crate::worktree::WorktreeContext;
+
+/// Build the FFI library and generate the C header
+pub async fn build_ffi(ctx: &WorktreeContext, verbose: bool) -> Result<()> {
+    // Build the FFI crate
+    build_ffi_crate(&ctx.rust_path, verbose).await?;
+
+    // Generate and copy the header
+    generate_header(ctx, verbose).await?;
+
+    Ok(())
+}
+
+/// Build the FFI crate in release mode
+async fn build_ffi_crate(rust_path: &Path, verbose: bool) -> Result<()> {
+    if verbose {
+        println!("Building FFI crate...");
+    }
+
+    let mut cmd = Command::new("cargo");
+    cmd.args(["build", "--release", "-p", FFI_LIB_NAME])
+        .current_dir(rust_path);
+
+    let output = cmd.output().await?;
+
+    if !output.status.success() {
+        return Err(FfiTestError::FfiBuild(
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
+
+    if verbose {
+        println!("FFI crate built successfully");
+    }
+
+    Ok(())
+}
+
+/// Generate the C header using cbindgen and copy to Go worktree
+async fn generate_header(ctx: &WorktreeContext, verbose: bool) -> Result<()> {
+    // Check if cbindgen is available
+    check_cbindgen().await?;
+
+    if verbose {
+        println!("Generating C header...");
+    }
+
+    let config_path = ctx.rust_path.join(CBINDGEN_CONFIG);
+    let header_dest = ctx.go_path.join(HEADER_DESTINATION);
+
+    // Ensure destination directory exists
+    if let Some(parent) = header_dest.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let output = Command::new("cbindgen")
+        .args([
+            "--config",
+            config_path.to_str().unwrap(),
+            "--crate",
+            FFI_LIB_NAME,
+            "--output",
+            header_dest.to_str().unwrap(),
+        ])
+        .current_dir(&ctx.rust_path)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(FfiTestError::HeaderGeneration(
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
+
+    if verbose {
+        println!("Header generated at: {}", header_dest.display());
+    }
+
+    Ok(())
+}
+
+/// Check if cbindgen is installed
+async fn check_cbindgen() -> Result<()> {
+    let output = Command::new("cbindgen").arg("--version").output().await;
+
+    match output {
+        Ok(o) if o.status.success() => Ok(()),
+        _ => Err(FfiTestError::CbindgenNotFound),
+    }
+}

--- a/tools/ffi-test/src/commands/diff.rs
+++ b/tools/ffi-test/src/commands/diff.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+
+use colored::Colorize;
+
+use crate::error::Result;
+use crate::report::load_for_diff;
+use crate::runner::TestStatus;
+use crate::worktree::WorktreeContext;
+
+/// Show diff between two test runs
+pub async fn execute(package: &str) -> Result<()> {
+    let ctx = WorktreeContext::detect().await?;
+
+    println!(
+        "{} {} - {}",
+        "FFI Test Diff:".bold(),
+        ctx.branch.cyan(),
+        package.cyan()
+    );
+    println!();
+
+    // Load the two most recent reports
+    let reports = load_for_diff(&ctx.branch, package, 2).await?;
+
+    if reports.len() < 2 {
+        println!(
+            "{}",
+            "Need at least 2 reports to diff. Run more tests first.".yellow()
+        );
+        return Ok(());
+    }
+
+    let newer = &reports[0];
+    let older = &reports[1];
+
+    println!(
+        "Comparing: {} ({}) vs {} ({})",
+        newer.commit.green(),
+        newer.timestamp.format("%Y-%m-%d %H:%M"),
+        older.commit.red(),
+        older.timestamp.format("%Y-%m-%d %H:%M")
+    );
+    println!();
+
+    // Build maps for comparison
+    let older_tests: HashMap<&str, &TestStatus> = older
+        .tests
+        .iter()
+        .map(|t| (t.name.as_str(), &t.status))
+        .collect();
+
+    let newer_tests: HashMap<&str, &TestStatus> = newer
+        .tests
+        .iter()
+        .map(|t| (t.name.as_str(), &t.status))
+        .collect();
+
+    // Find changes
+    let mut fixed = Vec::new();
+    let mut broken = Vec::new();
+    let mut new_tests = Vec::new();
+    let mut removed_tests = Vec::new();
+
+    for test in &newer.tests {
+        match older_tests.get(test.name.as_str()) {
+            Some(old_status) => {
+                if **old_status == TestStatus::Fail && test.status == TestStatus::Pass {
+                    fixed.push(&test.name);
+                } else if **old_status == TestStatus::Pass && test.status == TestStatus::Fail {
+                    broken.push(&test.name);
+                }
+            }
+            None => {
+                new_tests.push(&test.name);
+            }
+        }
+    }
+
+    for test in &older.tests {
+        if !newer_tests.contains_key(test.name.as_str()) {
+            removed_tests.push(&test.name);
+        }
+    }
+
+    // Print results
+    if !fixed.is_empty() {
+        println!("{} ({}):", "Fixed".green().bold(), fixed.len());
+        for name in &fixed {
+            println!("  {} {}", "✓".green(), name);
+        }
+        println!();
+    }
+
+    if !broken.is_empty() {
+        println!("{} ({}):", "Broken".red().bold(), broken.len());
+        for name in &broken {
+            println!("  {} {}", "✗".red(), name);
+        }
+        println!();
+    }
+
+    if !new_tests.is_empty() {
+        println!("{} ({}):", "New".cyan().bold(), new_tests.len());
+        for name in &new_tests {
+            println!("  {} {}", "+".cyan(), name);
+        }
+        println!();
+    }
+
+    if !removed_tests.is_empty() {
+        println!("{} ({}):", "Removed".yellow().bold(), removed_tests.len());
+        for name in &removed_tests {
+            println!("  {} {}", "-".yellow(), name);
+        }
+        println!();
+    }
+
+    if fixed.is_empty() && broken.is_empty() && new_tests.is_empty() && removed_tests.is_empty() {
+        println!("{}", "No changes detected".dimmed());
+    }
+
+    // Summary comparison
+    println!("{}", "─".repeat(50));
+    println!(
+        "Summary: {} → {}",
+        format!(
+            "{}/{}/{}",
+            older.summary.passed, older.summary.failed, older.summary.skipped
+        )
+        .red(),
+        format!(
+            "{}/{}/{}",
+            newer.summary.passed, newer.summary.failed, newer.summary.skipped
+        )
+        .green()
+    );
+
+    let pass_delta = newer.summary.passed as i32 - older.summary.passed as i32;
+    let fail_delta = newer.summary.failed as i32 - older.summary.failed as i32;
+
+    if pass_delta != 0 || fail_delta != 0 {
+        print!("Delta: ");
+        if pass_delta > 0 {
+            print!("{} ", format!("+{} pass", pass_delta).green());
+        } else if pass_delta < 0 {
+            print!("{} ", format!("{} pass", pass_delta).red());
+        }
+        if fail_delta > 0 {
+            print!("{}", format!("+{} fail", fail_delta).red());
+        } else if fail_delta < 0 {
+            print!("{}", format!("{} fail", fail_delta).green());
+        }
+        println!();
+    }
+
+    Ok(())
+}

--- a/tools/ffi-test/src/commands/mod.rs
+++ b/tools/ffi-test/src/commands/mod.rs
@@ -1,0 +1,4 @@
+pub mod diff;
+pub mod run;
+pub mod status;
+pub mod worktree;

--- a/tools/ffi-test/src/commands/run.rs
+++ b/tools/ffi-test/src/commands/run.rs
@@ -1,0 +1,98 @@
+use colored::Colorize;
+
+use crate::builder::build_ffi;
+use crate::error::Result;
+use crate::report::Report;
+use crate::runner::{run_tests, TestStatus};
+use crate::worktree::WorktreeContext;
+
+/// Run FFI tests for a package
+pub async fn execute(
+    package: &str,
+    test_filter: Option<&str>,
+    verbose: bool,
+    skip_build: bool,
+) -> Result<()> {
+    // Detect worktree context
+    let ctx = WorktreeContext::detect().await?;
+
+    println!(
+        "{} {} @ {}{}",
+        "FFI Test:".bold(),
+        ctx.branch.cyan(),
+        ctx.commit.yellow(),
+        if ctx.dirty {
+            " (dirty)".red().to_string()
+        } else {
+            String::new()
+        }
+    );
+    println!("  Rust: {}", ctx.rust_path.display());
+    println!("  Go:   {}", ctx.go_path.display());
+    println!();
+
+    // Build FFI library (unless skipped)
+    if !skip_build {
+        println!("{}", "Building FFI...".bold());
+        build_ffi(&ctx, verbose).await?;
+        println!();
+    }
+
+    // Run tests
+    println!("{} {}", "Running tests:".bold(), package.cyan());
+    if let Some(filter) = test_filter {
+        println!("  Filter: {}", filter);
+    }
+    println!();
+
+    let result = run_tests(&ctx, package, test_filter, verbose).await?;
+
+    // Print summary
+    println!();
+    println!("{}", "─".repeat(60));
+    println!(
+        "{}: {} total, {} passed, {} failed, {} skipped",
+        "Summary".bold(),
+        result.summary.total,
+        result.summary.passed.to_string().green(),
+        if result.summary.failed > 0 {
+            result.summary.failed.to_string().red()
+        } else {
+            result.summary.failed.to_string().normal()
+        },
+        result.summary.skipped.to_string().yellow()
+    );
+    println!("Duration: {:.2}s", result.duration_secs);
+
+    // Print failed tests
+    let failed: Vec<_> = result
+        .tests
+        .iter()
+        .filter(|t| t.status == TestStatus::Fail)
+        .collect();
+    if !failed.is_empty() {
+        println!();
+        println!("{}", "Failed tests:".red().bold());
+        for test in &failed {
+            println!("  {} {}", "✗".red(), test.name);
+            if verbose && !test.output.is_empty() {
+                for line in &test.output {
+                    println!("    {}", line.trim_end());
+                }
+            }
+        }
+    }
+
+    // Save report
+    let report = Report::new(&ctx, package, result);
+    let report_path = report.save().await?;
+    println!();
+    println!("Report saved: {}", report_path.display());
+
+    // Exit with error if tests failed
+    if report.summary.failed > 0 {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}

--- a/tools/ffi-test/src/commands/status.rs
+++ b/tools/ffi-test/src/commands/status.rs
@@ -1,0 +1,163 @@
+use std::collections::HashMap;
+
+use colored::Colorize;
+
+use crate::error::Result;
+use crate::report::{load_all_for_branch, Report};
+use crate::runner::list_packages;
+use crate::worktree::{list_rust_worktrees, WorktreeContext};
+
+/// Show status of FFI tests
+pub async fn execute(all: bool) -> Result<()> {
+    if all {
+        show_all_worktrees().await
+    } else {
+        show_current_worktree().await
+    }
+}
+
+async fn show_current_worktree() -> Result<()> {
+    let ctx = WorktreeContext::detect().await?;
+
+    println!(
+        "{} {} @ {}{}",
+        "FFI Test Status:".bold(),
+        ctx.branch.cyan(),
+        ctx.commit.yellow(),
+        if ctx.dirty {
+            " (dirty)".red().to_string()
+        } else {
+            String::new()
+        }
+    );
+    println!();
+
+    // Get available packages
+    let packages = list_packages(&ctx.go_path).await?;
+
+    // Load reports for this branch
+    let reports = load_all_for_branch(&ctx.branch).await?;
+
+    // Group reports by package (keep only latest per package)
+    let mut latest_by_package: HashMap<String, Report> = HashMap::new();
+    for report in reports {
+        latest_by_package
+            .entry(report.package.clone())
+            .or_insert(report);
+    }
+
+    // Print table header
+    println!(
+        "{:<25} {:<20} {:>6} {:>6} {:>6} {:>6}",
+        "Package".bold(),
+        "Last Run".bold(),
+        "Pass".bold(),
+        "Fail".bold(),
+        "Skip".bold(),
+        "Total".bold()
+    );
+    println!("{}", "─".repeat(75));
+
+    // Print each package
+    for package in &packages {
+        if let Some(report) = latest_by_package.get(package) {
+            let timestamp = report.timestamp.format("%Y-%m-%d %H:%M");
+            let pass = report.summary.passed.to_string().green();
+            let fail = if report.summary.failed > 0 {
+                report.summary.failed.to_string().red()
+            } else {
+                report.summary.failed.to_string().normal()
+            };
+            let skip = report.summary.skipped.to_string().yellow();
+
+            println!(
+                "{:<25} {:<20} {:>6} {:>6} {:>6} {:>6}",
+                package, timestamp, pass, fail, skip, report.summary.total
+            );
+        } else {
+            println!(
+                "{:<25} {:<20} {:>6} {:>6} {:>6} {:>6}",
+                package,
+                "-".dimmed(),
+                "-".dimmed(),
+                "-".dimmed(),
+                "-".dimmed(),
+                "-".dimmed()
+            );
+        }
+    }
+
+    if packages.is_empty() {
+        println!("{}", "No test packages found".dimmed());
+    }
+
+    Ok(())
+}
+
+async fn show_all_worktrees() -> Result<()> {
+    println!("{}", "FFI Test Status (All Worktrees)".bold());
+    println!();
+
+    let worktrees = list_rust_worktrees().await?;
+
+    if worktrees.is_empty() {
+        println!("{}", "No defradb.rs worktrees found".dimmed());
+        return Ok(());
+    }
+
+    for (rust_path, branch) in worktrees {
+        // Try to get context for this worktree
+        let ctx = match WorktreeContext::from_path(&rust_path).await {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        println!("{} @ {}", branch.cyan().bold(), ctx.commit.yellow());
+        println!("  Rust: {}", ctx.rust_path.display());
+        println!("  Go:   {}", ctx.go_path.display());
+
+        // Load reports for this branch
+        let reports = load_all_for_branch(&branch).await?;
+
+        if reports.is_empty() {
+            println!("  {}", "No test reports".dimmed());
+        } else {
+            // Group by package
+            let mut latest_by_package: HashMap<String, &Report> = HashMap::new();
+            for report in &reports {
+                latest_by_package
+                    .entry(report.package.clone())
+                    .or_insert(report);
+            }
+
+            // Calculate totals
+            let mut total_pass = 0;
+            let mut total_fail = 0;
+            let mut total_skip = 0;
+
+            for report in latest_by_package.values() {
+                total_pass += report.summary.passed;
+                total_fail += report.summary.failed;
+                total_skip += report.summary.skipped;
+            }
+
+            let total = total_pass + total_fail + total_skip;
+
+            println!(
+                "  Tests: {} passed, {} failed, {} skipped ({} total)",
+                total_pass.to_string().green(),
+                if total_fail > 0 {
+                    total_fail.to_string().red()
+                } else {
+                    total_fail.to_string().normal()
+                },
+                total_skip.to_string().yellow(),
+                total
+            );
+        }
+
+        println!();
+    }
+
+    Ok(())
+}

--- a/tools/ffi-test/src/commands/worktree.rs
+++ b/tools/ffi-test/src/commands/worktree.rs
@@ -1,0 +1,145 @@
+use colored::Colorize;
+
+use crate::config::{GO_REPO_BASE, GO_WORKTREE_PREFIX, RUST_WORKTREE_PREFIX};
+use crate::error::Result;
+use crate::worktree::{
+    check_uncommitted_changes, check_unpushed_commits, create_worktree_pair, list_rust_worktrees,
+    remove_worktree_pair, WorktreeContext,
+};
+
+/// List all paired worktrees
+pub async fn list() -> Result<()> {
+    println!("{}", "Paired Worktrees".bold());
+    println!();
+
+    let worktrees = list_rust_worktrees().await?;
+
+    if worktrees.is_empty() {
+        println!("{}", "No defradb.rs worktrees found".dimmed());
+        return Ok(());
+    }
+
+    for (rust_path, branch) in worktrees {
+        let ctx = match WorktreeContext::from_path(&rust_path).await {
+            Ok(c) => c,
+            Err(e) => {
+                println!(
+                    "{} {} - {}",
+                    "✗".red(),
+                    rust_path.display(),
+                    e.to_string().red()
+                );
+                continue;
+            }
+        };
+
+        let status = if ctx.dirty {
+            " (dirty)".red().to_string()
+        } else {
+            String::new()
+        };
+
+        println!(
+            "{} {} @ {}{}",
+            "✓".green(),
+            branch.cyan(),
+            ctx.commit.yellow(),
+            status
+        );
+        println!("  Rust: {}", ctx.rust_path.display());
+        println!("  Go:   {}", ctx.go_path.display());
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Create a new paired worktree
+pub async fn create(suffix: &str) -> Result<()> {
+    println!("{} {}", "Creating worktree pair:".bold(), suffix.cyan());
+
+    let rust_path =
+        std::path::PathBuf::from(GO_REPO_BASE).join(format!("{}-{}", RUST_WORKTREE_PREFIX, suffix));
+    let go_path =
+        std::path::PathBuf::from(GO_REPO_BASE).join(format!("{}-{}", GO_WORKTREE_PREFIX, suffix));
+
+    // Check if either already exists
+    if rust_path.exists() {
+        println!(
+            "{} Rust worktree already exists: {}",
+            "Error:".red(),
+            rust_path.display()
+        );
+        return Ok(());
+    }
+    if go_path.exists() {
+        println!(
+            "{} Go worktree already exists: {}",
+            "Error:".red(),
+            go_path.display()
+        );
+        return Ok(());
+    }
+
+    let (rust, go) = create_worktree_pair(suffix).await?;
+
+    println!();
+    println!("{}", "Created:".green());
+    println!("  Rust: {}", rust.display());
+    println!("  Go:   {}", go.display());
+    println!();
+    println!("Branch: {}", format!("ffi/{}", suffix).cyan());
+
+    Ok(())
+}
+
+/// Remove a paired worktree
+pub async fn remove(suffix: &str, force: bool, delete_branch: bool) -> Result<()> {
+    println!("{} {}", "Removing worktree pair:".bold(), suffix.cyan());
+
+    let rust_path =
+        std::path::PathBuf::from(GO_REPO_BASE).join(format!("{}-{}", RUST_WORKTREE_PREFIX, suffix));
+    let go_path =
+        std::path::PathBuf::from(GO_REPO_BASE).join(format!("{}-{}", GO_WORKTREE_PREFIX, suffix));
+
+    // Check for uncommitted changes
+    if !force {
+        if rust_path.exists() {
+            if check_uncommitted_changes(&rust_path).await? {
+                println!(
+                    "{} Rust worktree has uncommitted changes. Use --force to override.",
+                    "Error:".red()
+                );
+                return Ok(());
+            }
+            if check_unpushed_commits(&rust_path).await? {
+                println!(
+                    "{} Rust worktree has unpushed commits. Use --force to override.",
+                    "Warning:".yellow()
+                );
+                return Ok(());
+            }
+        }
+
+        if go_path.exists() && check_uncommitted_changes(&go_path).await? {
+            println!(
+                "{} Go worktree has uncommitted changes. Use --force to override.",
+                "Error:".red()
+            );
+            return Ok(());
+        }
+    }
+
+    remove_worktree_pair(suffix, force, delete_branch).await?;
+
+    println!();
+    println!("{}", "Removed:".green());
+    println!("  Rust: {}", rust_path.display());
+    println!("  Go:   {}", go_path.display());
+
+    if delete_branch {
+        println!("  Branch: {}", format!("ffi/{}", suffix).cyan());
+    }
+
+    Ok(())
+}

--- a/tools/ffi-test/src/config.rs
+++ b/tools/ffi-test/src/config.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+/// Base path for Go defradb repository
+pub const GO_REPO_BASE: &str = "/Users/johnzampolin/go/src/github.com/sourcenetwork";
+
+/// Rust worktree prefix
+pub const RUST_WORKTREE_PREFIX: &str = "defradb.rs";
+
+/// Go worktree prefix
+pub const GO_WORKTREE_PREFIX: &str = "defradb";
+
+/// Report retention count per branch+package
+pub const REPORT_RETENTION_COUNT: usize = 10;
+
+/// Get the reports directory
+pub fn reports_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("Could not determine home directory")
+        .join(".defra-ffi-reports")
+        .join("runs")
+}
+
+/// FFI crate path relative to Rust worktree root
+pub const FFI_CRATE_PATH: &str = "crates/ffi";
+
+/// cbindgen config path relative to Rust worktree root
+pub const CBINDGEN_CONFIG: &str = "crates/ffi/cbindgen.toml";
+
+/// Header destination relative to Go worktree root
+pub const HEADER_DESTINATION: &str = "tests/clients/rustffi/defra.h";
+
+/// FFI library name (without lib prefix or extension)
+pub const FFI_LIB_NAME: &str = "ffi";

--- a/tools/ffi-test/src/error.rs
+++ b/tools/ffi-test/src/error.rs
@@ -1,0 +1,41 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum FfiTestError {
+    #[error("Worktree detection failed: {0}")]
+    WorktreeDetection(String),
+
+    #[error(
+        "Go worktree not found at {path}. Create it with: git worktree add {path} -b {branch}"
+    )]
+    GoWorktreeNotFound { path: String, branch: String },
+
+    #[error("FFI build failed: {0}")]
+    FfiBuild(String),
+
+    #[error("Header generation failed: {0}")]
+    HeaderGeneration(String),
+
+    #[error("Test execution failed: {0}")]
+    TestExecution(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Worktree has uncommitted changes: {path}")]
+    UncommittedChanges { path: String },
+
+    #[error("Worktree has unpushed commits: {path}")]
+    UnpushedCommits { path: String },
+
+    #[error("cbindgen not found. Install with: cargo install cbindgen")]
+    CbindgenNotFound,
+
+    #[error("Not in a defradb.rs worktree")]
+    NotInWorktree,
+}
+
+pub type Result<T> = std::result::Result<T, FfiTestError>;

--- a/tools/ffi-test/src/main.rs
+++ b/tools/ffi-test/src/main.rs
@@ -1,0 +1,117 @@
+use clap::{Parser, Subcommand};
+
+mod builder;
+mod commands;
+mod config;
+mod error;
+mod report;
+mod runner;
+mod worktree;
+
+#[derive(Parser)]
+#[command(name = "ffi-test")]
+#[command(about = "FFI compatibility testing tool for defradb.rs")]
+#[command(version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run FFI tests for a package
+    Run {
+        /// Test package path (e.g., "query/simple", "mutation/create")
+        package: String,
+
+        /// Filter tests by name pattern
+        #[arg(short = 't', long)]
+        test: Option<String>,
+
+        /// Show verbose output
+        #[arg(short, long)]
+        verbose: bool,
+
+        /// Skip FFI build step
+        #[arg(long)]
+        skip_build: bool,
+    },
+
+    /// Show status of FFI tests
+    Status {
+        /// Show status for all worktrees
+        #[arg(long)]
+        all: bool,
+    },
+
+    /// Show diff between test runs
+    Diff {
+        /// Test package path to compare
+        package: String,
+    },
+
+    /// Manage paired worktrees
+    Worktree {
+        #[command(subcommand)]
+        command: WorktreeCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum WorktreeCommands {
+    /// List all paired worktrees
+    List,
+
+    /// Create a new paired worktree
+    Create {
+        /// Worktree suffix (e.g., "index" creates defradb.rs-index and defradb-index)
+        suffix: String,
+    },
+
+    /// Remove a paired worktree
+    Remove {
+        /// Worktree suffix to remove
+        suffix: String,
+
+        /// Force removal even with uncommitted changes
+        #[arg(long)]
+        force: bool,
+
+        /// Also delete the branch
+        #[arg(long)]
+        delete_branch: bool,
+    },
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Commands::Run {
+            package,
+            test,
+            verbose,
+            skip_build,
+        } => commands::run::execute(&package, test.as_deref(), verbose, skip_build).await,
+
+        Commands::Status { all } => commands::status::execute(all).await,
+
+        Commands::Diff { package } => commands::diff::execute(&package).await,
+
+        Commands::Worktree { command } => match command {
+            WorktreeCommands::List => commands::worktree::list().await,
+            WorktreeCommands::Create { suffix } => commands::worktree::create(&suffix).await,
+            WorktreeCommands::Remove {
+                suffix,
+                force,
+                delete_branch,
+            } => commands::worktree::remove(&suffix, force, delete_branch).await,
+        },
+    };
+
+    if let Err(e) = result {
+        eprintln!("\x1b[31mError:\x1b[0m {}", e);
+        std::process::exit(1);
+    }
+}

--- a/tools/ffi-test/src/report.rs
+++ b/tools/ffi-test/src/report.rs
@@ -1,0 +1,204 @@
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::config::{reports_dir, REPORT_RETENTION_COUNT};
+use crate::error::Result;
+use crate::runner::{RunResult, TestResult, TestSummary};
+use crate::worktree::WorktreeContext;
+
+/// A saved test report
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Report {
+    pub timestamp: DateTime<Utc>,
+    pub branch: String,
+    pub commit: String,
+    pub dirty: bool,
+    pub package: String,
+    pub rust_worktree: String,
+    pub go_worktree: String,
+    pub duration_secs: f64,
+    pub summary: TestSummary,
+    pub tests: Vec<TestResult>,
+}
+
+impl Report {
+    /// Create a new report from a test run
+    pub fn new(ctx: &WorktreeContext, package: &str, result: RunResult) -> Self {
+        Report {
+            timestamp: Utc::now(),
+            branch: ctx.branch.clone(),
+            commit: ctx.commit.clone(),
+            dirty: ctx.dirty,
+            package: package.to_string(),
+            rust_worktree: ctx.rust_path.display().to_string(),
+            go_worktree: ctx.go_path.display().to_string(),
+            duration_secs: result.duration_secs,
+            summary: result.summary,
+            tests: result.tests,
+        }
+    }
+
+    /// Generate filename for this report
+    fn filename(&self) -> String {
+        let branch_safe = self.branch.replace('/', "_");
+        let package_safe = self.package.replace('/', "_");
+        let timestamp = self.timestamp.format("%Y%m%d_%H%M%S");
+        format!(
+            "{}_{}_{}_{}.json",
+            branch_safe, package_safe, timestamp, self.commit
+        )
+    }
+
+    /// Save the report to disk
+    pub async fn save(&self) -> Result<PathBuf> {
+        let dir = reports_dir();
+        tokio::fs::create_dir_all(&dir).await?;
+
+        let path = dir.join(self.filename());
+        let json = serde_json::to_string_pretty(self)?;
+        tokio::fs::write(&path, json).await?;
+
+        // Enforce retention
+        enforce_retention(&self.branch, &self.package).await?;
+
+        Ok(path)
+    }
+}
+
+/// Enforce retention policy for reports
+async fn enforce_retention(branch: &str, package: &str) -> Result<()> {
+    let dir = reports_dir();
+    if !dir.exists() {
+        return Ok(());
+    }
+
+    let branch_safe = branch.replace('/', "_");
+    let package_safe = package.replace('/', "_");
+    let prefix = format!("{}_{}_", branch_safe, package_safe);
+
+    // Collect matching reports
+    let mut reports: Vec<(PathBuf, DateTime<Utc>)> = Vec::new();
+    let mut entries = tokio::fs::read_dir(&dir).await?;
+
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        if name_str.starts_with(&prefix) && name_str.ends_with(".json") {
+            // Parse timestamp from filename
+            if let Some(ts) = parse_timestamp_from_filename(&name_str) {
+                reports.push((entry.path(), ts));
+            }
+        }
+    }
+
+    // Sort by timestamp, newest first
+    reports.sort_by(|a, b| b.1.cmp(&a.1));
+
+    // Delete oldest reports beyond retention count
+    for (path, _) in reports.into_iter().skip(REPORT_RETENTION_COUNT) {
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    Ok(())
+}
+
+/// Parse timestamp from report filename
+fn parse_timestamp_from_filename(filename: &str) -> Option<DateTime<Utc>> {
+    // Format: branch_package_YYYYMMDD_HHMMSS_commit.json
+    let parts: Vec<&str> = filename.trim_end_matches(".json").split('_').collect();
+    if parts.len() < 4 {
+        return None;
+    }
+
+    // Find the date part (YYYYMMDD format, 8 digits)
+    for (i, part) in parts.iter().enumerate() {
+        if part.len() == 8
+            && part.chars().all(|c| c.is_ascii_digit())
+            && i + 1 < parts.len()
+            && parts[i + 1].len() == 6
+        {
+            let date_str = format!("{}_{}", part, parts[i + 1]);
+            if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(&date_str, "%Y%m%d_%H%M%S") {
+                return Some(DateTime::from_naive_utc_and_offset(naive, Utc));
+            }
+        }
+    }
+
+    None
+}
+
+/// Load all reports for a branch
+pub async fn load_all_for_branch(branch: &str) -> Result<Vec<Report>> {
+    let dir = reports_dir();
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let branch_safe = branch.replace('/', "_");
+    let prefix = format!("{}_", branch_safe);
+
+    let mut reports = Vec::new();
+    let mut entries = tokio::fs::read_dir(&dir).await?;
+
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        if name_str.starts_with(&prefix) && name_str.ends_with(".json") {
+            let content = tokio::fs::read_to_string(entry.path()).await?;
+            if let Ok(report) = serde_json::from_str::<Report>(&content) {
+                reports.push(report);
+            }
+        }
+    }
+
+    // Sort by package then timestamp
+    reports.sort_by(|a, b| {
+        a.package
+            .cmp(&b.package)
+            .then_with(|| b.timestamp.cmp(&a.timestamp))
+    });
+
+    Ok(reports)
+}
+
+/// Load two reports for comparison
+pub async fn load_for_diff(branch: &str, package: &str, count: usize) -> Result<Vec<Report>> {
+    let dir = reports_dir();
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let branch_safe = branch.replace('/', "_");
+    let package_safe = package.replace('/', "_");
+    let prefix = format!("{}_{}_", branch_safe, package_safe);
+
+    let mut reports_with_ts: Vec<(Report, DateTime<Utc>)> = Vec::new();
+    let mut entries = tokio::fs::read_dir(&dir).await?;
+
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        if name_str.starts_with(&prefix) && name_str.ends_with(".json") {
+            if let Some(ts) = parse_timestamp_from_filename(&name_str) {
+                let content = tokio::fs::read_to_string(entry.path()).await?;
+                if let Ok(report) = serde_json::from_str::<Report>(&content) {
+                    reports_with_ts.push((report, ts));
+                }
+            }
+        }
+    }
+
+    // Sort by timestamp, newest first
+    reports_with_ts.sort_by(|a, b| b.1.cmp(&a.1));
+
+    Ok(reports_with_ts
+        .into_iter()
+        .take(count)
+        .map(|(r, _)| r)
+        .collect())
+}

--- a/tools/ffi-test/src/runner.rs
+++ b/tools/ffi-test/src/runner.rs
@@ -1,0 +1,290 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+
+use crate::config::FFI_CRATE_PATH;
+use crate::error::{FfiTestError, Result};
+use crate::worktree::WorktreeContext;
+
+/// A single Go test event from JSON output
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct GoTestEvent {
+    #[allow(dead_code)]
+    time: Option<String>,
+    action: String,
+    #[allow(dead_code)]
+    package: Option<String>,
+    test: Option<String>,
+    output: Option<String>,
+    elapsed: Option<f64>,
+}
+
+/// Status of a test
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum TestStatus {
+    Pass,
+    Fail,
+    Skip,
+}
+
+/// Result of a single test
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestResult {
+    pub name: String,
+    pub status: TestStatus,
+    pub elapsed_secs: f64,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub output: Vec<String>,
+}
+
+/// Summary of test run
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TestSummary {
+    pub total: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub skipped: usize,
+}
+
+/// Result of running tests
+#[derive(Debug)]
+pub struct RunResult {
+    pub summary: TestSummary,
+    pub tests: Vec<TestResult>,
+    pub duration_secs: f64,
+}
+
+/// Run Go tests for a package
+pub async fn run_tests(
+    ctx: &WorktreeContext,
+    package: &str,
+    test_filter: Option<&str>,
+    verbose: bool,
+) -> Result<RunResult> {
+    let start = Instant::now();
+
+    // Build environment variables
+    let env = build_env(ctx);
+
+    // Build the go test command
+    let mut cmd = Command::new("go");
+    cmd.arg("test").arg("-json").arg("-count=1");
+
+    if let Some(filter) = test_filter {
+        cmd.arg("-run").arg(filter);
+    }
+
+    cmd.arg(format!("./tests/integration/{}/...", package))
+        .current_dir(&ctx.go_path)
+        .envs(env);
+
+    if verbose {
+        println!(
+            "Running: go test -json -count=1 ./tests/integration/{}/...",
+            package
+        );
+    }
+
+    let mut child = cmd
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+
+    let stdout = child.stdout.take().expect("Failed to capture stdout");
+    let reader = BufReader::new(stdout);
+    let mut lines = reader.lines();
+
+    // Accumulate test results
+    let mut test_outputs: HashMap<String, Vec<String>> = HashMap::new();
+    let mut test_results: HashMap<String, TestResult> = HashMap::new();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.is_empty() {
+            continue;
+        }
+
+        let event: GoTestEvent = match serde_json::from_str(&line) {
+            Ok(e) => e,
+            Err(_) => continue, // Skip non-JSON lines
+        };
+
+        // Only process events with test names (skip package-level events)
+        let test_name = match &event.test {
+            Some(name) => name.clone(),
+            None => continue,
+        };
+
+        match event.action.as_str() {
+            "run" => {
+                test_outputs.insert(test_name.clone(), Vec::new());
+            }
+            "output" => {
+                if let Some(output) = event.output {
+                    if verbose {
+                        print!("{}", output.trim_end_matches('\n'));
+                        if !output.ends_with('\n') {
+                            println!();
+                        }
+                    }
+                    if let Some(outputs) = test_outputs.get_mut(&test_name) {
+                        outputs.push(output);
+                    }
+                }
+            }
+            "pass" => {
+                let output = test_outputs.remove(&test_name).unwrap_or_default();
+                test_results.insert(
+                    test_name.clone(),
+                    TestResult {
+                        name: test_name,
+                        status: TestStatus::Pass,
+                        elapsed_secs: event.elapsed.unwrap_or(0.0),
+                        output: if output
+                            .iter()
+                            .any(|o| o.contains("FAIL") || o.contains("Error"))
+                        {
+                            output
+                        } else {
+                            Vec::new()
+                        },
+                    },
+                );
+            }
+            "fail" => {
+                let output = test_outputs.remove(&test_name).unwrap_or_default();
+                test_results.insert(
+                    test_name.clone(),
+                    TestResult {
+                        name: test_name,
+                        status: TestStatus::Fail,
+                        elapsed_secs: event.elapsed.unwrap_or(0.0),
+                        output,
+                    },
+                );
+            }
+            "skip" => {
+                let output = test_outputs.remove(&test_name).unwrap_or_default();
+                test_results.insert(
+                    test_name.clone(),
+                    TestResult {
+                        name: test_name,
+                        status: TestStatus::Skip,
+                        elapsed_secs: event.elapsed.unwrap_or(0.0),
+                        output,
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+
+    // Wait for the command to complete
+    let status = child.wait().await?;
+    let duration_secs = start.elapsed().as_secs_f64();
+
+    // If no tests ran and command failed, report error
+    if test_results.is_empty() && !status.success() {
+        return Err(FfiTestError::TestExecution(
+            "No tests found or test execution failed".to_string(),
+        ));
+    }
+
+    // Build summary
+    let mut summary = TestSummary::default();
+    let mut tests: Vec<TestResult> = test_results.into_values().collect();
+    tests.sort_by(|a, b| a.name.cmp(&b.name));
+
+    for test in &tests {
+        summary.total += 1;
+        match test.status {
+            TestStatus::Pass => summary.passed += 1,
+            TestStatus::Fail => summary.failed += 1,
+            TestStatus::Skip => summary.skipped += 1,
+        }
+    }
+
+    Ok(RunResult {
+        summary,
+        tests,
+        duration_secs,
+    })
+}
+
+/// Build environment variables for Go test
+fn build_env(ctx: &WorktreeContext) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+
+    // CGO flags
+    let ffi_include = ctx.rust_path.join(FFI_CRATE_PATH);
+    let lib_dir = ctx.rust_path.join("target").join("release");
+
+    env.insert(
+        "CGO_CFLAGS".to_string(),
+        format!("-I{}", ffi_include.display()),
+    );
+    env.insert(
+        "CGO_LDFLAGS".to_string(),
+        format!("-L{}", lib_dir.display()),
+    );
+    env.insert("CGO_ENABLED".to_string(), "1".to_string());
+
+    // Enable Rust FFI client
+    env.insert("DEFRA_CLIENT_RUST_FFI".to_string(), "true".to_string());
+
+    env
+}
+
+/// List available test packages in the Go integration tests
+pub async fn list_packages(go_path: &Path) -> Result<Vec<String>> {
+    let tests_dir = go_path.join("tests").join("integration");
+
+    if !tests_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut packages = Vec::new();
+    collect_packages(&tests_dir, &tests_dir, &mut packages).await?;
+
+    packages.sort();
+    Ok(packages)
+}
+
+/// Recursively collect test packages
+async fn collect_packages(base: &Path, current: &Path, packages: &mut Vec<String>) -> Result<()> {
+    let mut entries = tokio::fs::read_dir(current).await?;
+
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+
+        if entry.file_type().await?.is_dir() {
+            // Check if this directory contains Go test files
+            let mut has_tests = false;
+            let mut dir_entries = tokio::fs::read_dir(&path).await?;
+
+            while let Some(file) = dir_entries.next_entry().await? {
+                let name = file.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str.ends_with("_test.go") {
+                    has_tests = true;
+                    break;
+                }
+            }
+
+            if has_tests {
+                let relative = path.strip_prefix(base).unwrap();
+                packages.push(relative.to_string_lossy().to_string());
+            }
+
+            // Recurse into subdirectory
+            Box::pin(collect_packages(base, &path, packages)).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/tools/ffi-test/src/worktree.rs
+++ b/tools/ffi-test/src/worktree.rs
@@ -1,0 +1,352 @@
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+use crate::config::{GO_REPO_BASE, GO_WORKTREE_PREFIX, RUST_WORKTREE_PREFIX};
+use crate::error::{FfiTestError, Result};
+
+/// Information about the current worktree context
+#[derive(Debug, Clone)]
+pub struct WorktreeContext {
+    /// Path to the Rust worktree root
+    pub rust_path: PathBuf,
+    /// Path to the paired Go worktree root
+    pub go_path: PathBuf,
+    /// Worktree suffix (empty for main worktree)
+    #[allow(dead_code)]
+    pub suffix: String,
+    /// Current git branch
+    pub branch: String,
+    /// Current git commit SHA (short)
+    pub commit: String,
+    /// Whether the worktree has uncommitted changes
+    pub dirty: bool,
+}
+
+impl WorktreeContext {
+    /// Detect the current worktree context from the current directory
+    pub async fn detect() -> Result<Self> {
+        let cwd = std::env::current_dir()?;
+        Self::from_path(&cwd).await
+    }
+
+    /// Detect worktree context from a given path
+    pub async fn from_path(path: &Path) -> Result<Self> {
+        // Find the git root
+        let rust_path = find_git_root(path).await?;
+
+        // Extract suffix from path
+        let suffix = extract_suffix(&rust_path)?;
+
+        // Derive Go worktree path
+        let go_path = derive_go_path(&suffix);
+
+        // Validate Go worktree exists
+        if !go_path.exists() {
+            let branch = if suffix.is_empty() {
+                "jack/ffi-rust-compat".to_string()
+            } else {
+                format!("ffi/{}", suffix)
+            };
+            return Err(FfiTestError::GoWorktreeNotFound {
+                path: go_path.display().to_string(),
+                branch,
+            });
+        }
+
+        // Get git info
+        let branch = get_git_branch(&rust_path).await?;
+        let commit = get_git_commit(&rust_path).await?;
+        let dirty = is_git_dirty(&rust_path).await?;
+
+        Ok(WorktreeContext {
+            rust_path,
+            go_path,
+            suffix,
+            branch,
+            commit,
+            dirty,
+        })
+    }
+}
+
+/// Find the git root from a given path
+async fn find_git_root(path: &Path) -> Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(path)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(FfiTestError::NotInWorktree);
+    }
+
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(PathBuf::from(root))
+}
+
+/// Extract suffix from Rust worktree path
+fn extract_suffix(rust_path: &Path) -> Result<String> {
+    let dir_name = rust_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| FfiTestError::WorktreeDetection("Invalid path".to_string()))?;
+
+    // Check if this is a defradb.rs worktree
+    if !dir_name.starts_with(RUST_WORKTREE_PREFIX) {
+        return Err(FfiTestError::NotInWorktree);
+    }
+
+    // Extract suffix: "defradb.rs-index" -> "index", "defradb.rs" -> ""
+    let suffix = if dir_name == RUST_WORKTREE_PREFIX {
+        String::new()
+    } else if let Some(stripped) = dir_name.strip_prefix(&format!("{}-", RUST_WORKTREE_PREFIX)) {
+        stripped.to_string()
+    } else {
+        return Err(FfiTestError::WorktreeDetection(format!(
+            "Unexpected directory name format: {}",
+            dir_name
+        )));
+    };
+
+    Ok(suffix)
+}
+
+/// Derive Go worktree path from suffix
+fn derive_go_path(suffix: &str) -> PathBuf {
+    let go_dir = if suffix.is_empty() {
+        GO_WORKTREE_PREFIX.to_string()
+    } else {
+        format!("{}-{}", GO_WORKTREE_PREFIX, suffix)
+    };
+    PathBuf::from(GO_REPO_BASE).join(go_dir)
+}
+
+/// Get the current git branch
+async fn get_git_branch(path: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(path)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(FfiTestError::WorktreeDetection(
+            "Failed to get git branch".to_string(),
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Get the current git commit (short SHA)
+async fn get_git_commit(path: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(path)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(FfiTestError::WorktreeDetection(
+            "Failed to get git commit".to_string(),
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Check if the worktree has uncommitted changes
+async fn is_git_dirty(path: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(path)
+        .output()
+        .await?;
+
+    Ok(!output.stdout.is_empty())
+}
+
+/// Check for uncommitted changes in a worktree
+pub async fn check_uncommitted_changes(path: &Path) -> Result<bool> {
+    is_git_dirty(path).await
+}
+
+/// Check for unpushed commits
+pub async fn check_unpushed_commits(path: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["log", "@{u}..", "--oneline"])
+        .current_dir(path)
+        .output()
+        .await?;
+
+    // If the command fails (e.g., no upstream), treat as having unpushed commits
+    if !output.status.success() {
+        return Ok(true);
+    }
+
+    Ok(!output.stdout.is_empty())
+}
+
+/// List all defradb.rs worktrees
+pub async fn list_rust_worktrees() -> Result<Vec<(PathBuf, String)>> {
+    let base = PathBuf::from(GO_REPO_BASE);
+    let mut worktrees = Vec::new();
+
+    let mut entries = tokio::fs::read_dir(&base).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        if name_str.starts_with(RUST_WORKTREE_PREFIX) && entry.file_type().await?.is_dir() {
+            let path = entry.path();
+
+            // Get branch for this worktree
+            if let Ok(branch) = get_git_branch(&path).await {
+                worktrees.push((path, branch));
+            }
+        }
+    }
+
+    worktrees.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(worktrees)
+}
+
+/// Create paired worktrees for Rust and Go
+pub async fn create_worktree_pair(suffix: &str) -> Result<(PathBuf, PathBuf)> {
+    let branch = format!("ffi/{}", suffix);
+    let rust_path =
+        PathBuf::from(GO_REPO_BASE).join(format!("{}-{}", RUST_WORKTREE_PREFIX, suffix));
+    let go_path = PathBuf::from(GO_REPO_BASE).join(format!("{}-{}", GO_WORKTREE_PREFIX, suffix));
+
+    // Create Rust worktree
+    let main_rust = PathBuf::from(GO_REPO_BASE).join(RUST_WORKTREE_PREFIX);
+    let output = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            rust_path.to_str().unwrap(),
+            "-b",
+            &branch,
+        ])
+        .current_dir(&main_rust)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(FfiTestError::WorktreeDetection(format!(
+            "Failed to create Rust worktree: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    // Create Go worktree
+    let main_go = PathBuf::from(GO_REPO_BASE).join(GO_WORKTREE_PREFIX);
+    let output = Command::new("git")
+        .args(["worktree", "add", go_path.to_str().unwrap(), "-b", &branch])
+        .current_dir(&main_go)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        // Clean up Rust worktree on failure
+        let _ = Command::new("git")
+            .args(["worktree", "remove", rust_path.to_str().unwrap()])
+            .current_dir(&main_rust)
+            .output()
+            .await;
+
+        return Err(FfiTestError::WorktreeDetection(format!(
+            "Failed to create Go worktree: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    Ok((rust_path, go_path))
+}
+
+/// Remove paired worktrees
+pub async fn remove_worktree_pair(suffix: &str, force: bool, delete_branch: bool) -> Result<()> {
+    let rust_path =
+        PathBuf::from(GO_REPO_BASE).join(format!("{}-{}", RUST_WORKTREE_PREFIX, suffix));
+    let go_path = PathBuf::from(GO_REPO_BASE).join(format!("{}-{}", GO_WORKTREE_PREFIX, suffix));
+    let branch = format!("ffi/{}", suffix);
+
+    // Check for uncommitted changes if not forcing
+    if !force {
+        if check_uncommitted_changes(&rust_path).await? {
+            return Err(FfiTestError::UncommittedChanges {
+                path: rust_path.display().to_string(),
+            });
+        }
+        if check_uncommitted_changes(&go_path).await? {
+            return Err(FfiTestError::UncommittedChanges {
+                path: go_path.display().to_string(),
+            });
+        }
+        if check_unpushed_commits(&rust_path).await? {
+            return Err(FfiTestError::UnpushedCommits {
+                path: rust_path.display().to_string(),
+            });
+        }
+    }
+
+    let main_rust = PathBuf::from(GO_REPO_BASE).join(RUST_WORKTREE_PREFIX);
+    let main_go = PathBuf::from(GO_REPO_BASE).join(GO_WORKTREE_PREFIX);
+
+    // Remove Rust worktree
+    let mut args = vec!["worktree", "remove"];
+    if force {
+        args.push("--force");
+    }
+    args.push(rust_path.to_str().unwrap());
+
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(&main_rust)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(FfiTestError::WorktreeDetection(format!(
+            "Failed to remove Rust worktree: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    // Remove Go worktree
+    let mut go_args = vec!["worktree", "remove"];
+    if force {
+        go_args.push("--force");
+    }
+    go_args.push(go_path.to_str().unwrap());
+    let output = Command::new("git")
+        .args(&go_args)
+        .current_dir(&main_go)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(FfiTestError::WorktreeDetection(format!(
+            "Failed to remove Go worktree: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    // Delete branches if requested
+    if delete_branch {
+        let _ = Command::new("git")
+            .args(["branch", "-d", &branch])
+            .current_dir(&main_rust)
+            .output()
+            .await;
+
+        let _ = Command::new("git")
+            .args(["branch", "-d", &branch])
+            .current_dir(&main_go)
+            .output()
+            .await;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `ffi-test` CLI tool that orchestrates FFI compatibility testing between defradb.rs and Go defradb
- Automatically detects worktree pairing (Rust `defradb.rs-foo` ↔ Go `defradb-foo`)
- Builds FFI library and generates C headers via cbindgen
- Runs Go integration tests with JSON output parsing
- Stores test reports in `~/.defra-ffi-reports/runs/` with 10-report retention per branch+package
- Provides status, diff, and worktree management commands

## Test plan

- [x] Build succeeds: `cargo build -p ffi-test`
- [x] Clippy passes: `cargo clippy -p ffi-test -- -D warnings`
- [x] Help works: `./target/release/ffi-test --help`
- [x] Status detects worktree: `./target/release/ffi-test status`
- [x] Worktree list works: `./target/release/ffi-test worktree list`
- [ ] Run tests end-to-end (requires Go worktree setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)