### PR TITLE
fix(query): Fix _docID-only query and resolve clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 version = "0.1.0"
 authors = ["Source Network <contact@source.network>"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/sourcenetwork/defradb.rs"
 

--- a/crates/crypto/src/se/artifact.rs
+++ b/crates/crypto/src/se/artifact.rs
@@ -11,17 +11,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// Currently only equality tags are supported, but this enum allows
 /// for future extension to other search types (range, prefix, etc.).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ArtifactType {
     /// Equality search tag - enables exact match queries.
     #[serde(rename = "equality_tag")]
+    #[default]
     EqualityTag,
-}
-
-impl Default for ArtifactType {
-    fn default() -> Self {
-        Self::EqualityTag
-    }
 }
 
 impl std::fmt::Display for ArtifactType {
@@ -36,20 +31,15 @@ impl std::fmt::Display for ArtifactType {
 ///
 /// Used to indicate whether an artifact should be added to or removed
 /// from the remote node's index.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OperationType {
     /// Add the artifact to the index.
     #[serde(rename = "add")]
+    #[default]
     Add,
     /// Remove the artifact from the index.
     #[serde(rename = "delete")]
     Delete,
-}
-
-impl Default for OperationType {
-    fn default() -> Self {
-        Self::Add
-    }
 }
 
 impl std::fmt::Display for OperationType {

--- a/crates/db/src/commits_fetcher.rs
+++ b/crates/db/src/commits_fetcher.rs
@@ -181,7 +181,7 @@ impl<S: Store> CommitsFetcher<S> {
     ///
     /// Go stores field IDs as numeric short IDs in headstore keys, which gives
     /// lexicographic order: "1" < "2" < "C" (composite comes after regular fields).
-    fn sort_commits_go_order(&self, commits: &mut Vec<Document>) {
+    fn sort_commits_go_order(&self, commits: &mut [Document]) {
         commits.sort_by(|a, b| {
             // Primary sort: docID
             let doc_id_a = a.get("docID").and_then(|v| v.as_str()).unwrap_or("");

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -292,7 +292,7 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                         all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
                     } else if is_composite {
                         let mut iter = index
-                            .scan_prefix(&datastore, &[value.clone()], false)
+                            .scan_prefix(&datastore, std::slice::from_ref(value), false)
                             .await
                             .map_err(|e| {
                                 query::error::QueryError::execution(format!("index error: {}", e))
@@ -306,7 +306,7 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                         all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
                     } else {
                         let mut iter =
-                            index.get(&datastore, &[value.clone()]).await.map_err(|e| {
+                            index.get(&datastore, std::slice::from_ref(value)).await.map_err(|e| {
                                 query::error::QueryError::execution(format!("index error: {}", e))
                             })?;
                         let entries = iter.collect_all().await.map_err(|e| {

--- a/crates/db/src/lensed_auto_commit_fetcher.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher.rs
@@ -764,7 +764,7 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                         all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
                     } else if is_composite {
                         let mut iter = index
-                            .scan_prefix(&datastore, &[value.clone()], false)
+                            .scan_prefix(&datastore, std::slice::from_ref(value), false)
                             .await
                             .map_err(|e| {
                                 query::error::QueryError::execution(format!("index error: {}", e))
@@ -778,7 +778,7 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                         all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
                     } else {
                         let mut iter =
-                            index.get(&datastore, &[value.clone()]).await.map_err(|e| {
+                            index.get(&datastore, std::slice::from_ref(value)).await.map_err(|e| {
                                 query::error::QueryError::execution(format!("index error: {}", e))
                             })?;
                         let entries = iter.collect_all().await.map_err(|e| {

--- a/crates/db/src/patch.rs
+++ b/crates/db/src/patch.rs
@@ -144,7 +144,7 @@ impl<S: Store> crate::database::DB<S> {
                 // Extract field name from path before substitution (for name mismatch validation)
                 let field_name_from_path = stripped_path
                     .as_deref()
-                    .and_then(|p| extract_field_name_from_path(p));
+                    .and_then(extract_field_name_from_path);
 
                 // Go compatibility: substitute field names for indices in /Fields/<name> paths
                 let path =
@@ -981,15 +981,12 @@ impl<S: Store> crate::database::DB<S> {
                 .collect();
             let mut depth = 0u64;
             let mut current_id = old_schema.version_id.as_str();
-            loop {
-                match versions_map.get(current_id) {
-                    Some(v) => match &v.previous_version {
-                        Some(prev) => {
-                            depth += 1;
-                            current_id = prev.source_collection_id.as_str();
-                        }
-                        None => break,
-                    },
+            while let Some(v) = versions_map.get(current_id) {
+                match &v.previous_version {
+                    Some(prev) => {
+                        depth += 1;
+                        current_id = prev.source_collection_id.as_str();
+                    }
                     None => break,
                 }
             }
@@ -1378,11 +1375,11 @@ impl<S: Store> crate::database::DB<S> {
         for prefix in prefixes {
             let no_slash_prefix = prefix.trim_start_matches('/');
 
-            if path.starts_with(prefix.as_str()) {
-                return format!("/{}", &path[prefix.len()..]);
+            if let Some(rest) = path.strip_prefix(prefix.as_str()) {
+                return format!("/{}", rest);
             }
-            if path.starts_with(no_slash_prefix) {
-                return format!("/{}", &path[no_slash_prefix.len()..]);
+            if let Some(rest) = path.strip_prefix(no_slash_prefix) {
+                return format!("/{}", rest);
             }
             // Exact match without trailing slash (collection-level operations).
             // E.g., path="/Users" with prefix="/Users/" → "/"

--- a/crates/db/src/se/storage.rs
+++ b/crates/db/src/se/storage.rs
@@ -125,7 +125,7 @@ pub async fn fetch_doc_ids<S: Reader>(
         }
 
         // Early exit if intersection is empty
-        if doc_id_set.as_ref().map_or(false, |s| s.is_empty()) {
+        if doc_id_set.as_ref().is_some_and(|s| s.is_empty()) {
             break;
         }
     }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -271,7 +271,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         // Get the shared transaction from the fetcher
         let shared_txn = ctx.fetcher_shared_txn();
         let txn_guard = shared_txn.lock().await;
-        let txn = txn_guard.as_ref().ok_or_else(|| Error::TxnNotActive)?;
+        let txn = txn_guard.as_ref().ok_or(Error::TxnNotActive)?;
 
         // Call the database's transaction-aware set_migration
         self.db.set_migration_in_txn(txn, config).await

--- a/crates/db/src/versioned_fetcher.rs
+++ b/crates/db/src/versioned_fetcher.rs
@@ -161,7 +161,7 @@ impl<S: Store> VersionedFetcher<S> {
 
         // Reconstruct each document at its specific composite CID
         let mut documents = Vec::new();
-        for (_doc_id, (_priority, composite_cid)) in &doc_composites {
+        for (_priority, composite_cid) in doc_composites.values() {
             let composite_block = match self.load_block(txn, composite_cid).await {
                 Ok(b) => b,
                 Err(_) => continue,

--- a/crates/defra-core/src/encryption.rs
+++ b/crates/defra-core/src/encryption.rs
@@ -44,7 +44,7 @@ impl EncryptionConfig {
 }
 
 thread_local! {
-    static CURRENT_ENCRYPTION_CONFIG: RefCell<Option<EncryptionConfig>> = RefCell::new(None);
+    static CURRENT_ENCRYPTION_CONFIG: RefCell<Option<EncryptionConfig>> = const { RefCell::new(None) };
 }
 
 /// Set the encryption config for the current thread.

--- a/crates/defra-core/src/signing.rs
+++ b/crates/defra-core/src/signing.rs
@@ -22,7 +22,7 @@ pub struct SigningConfig {
 }
 
 thread_local! {
-    static CURRENT_SIGNING_CONFIG: RefCell<Option<SigningConfig>> = RefCell::new(None);
+    static CURRENT_SIGNING_CONFIG: RefCell<Option<SigningConfig>> = const { RefCell::new(None) };
 }
 
 /// Set the signing config for the current thread.

--- a/crates/ffi/src/acp.rs
+++ b/crates/ffi/src/acp.rs
@@ -54,6 +54,10 @@ fn normalize_auth_error(err: String) -> String {
 /// ```
 ///
 /// This function is NAC-gated with the `NacStatus` permission.
+///
+/// # Safety
+///
+/// Caller must ensure all pointer arguments are valid, non-null, and point to valid C strings.
 #[no_mangle]
 pub unsafe extern "C" fn get_nac_status(node_ptr: usize, identity_did: *const c_char) -> FfiResult {
     let rt = get_runtime!(FfiResult);
@@ -520,10 +524,7 @@ pub unsafe extern "C" fn add_dac_policy(
         None => return FfiResult::error("policy is null"),
     };
 
-    let identity_str = match c_str_to_string(_identity_did) {
-        Some(s) => s,
-        None => String::new(),
-    };
+    let identity_str = c_str_to_string(_identity_did).unwrap_or_default();
 
     if identity_str.is_empty() {
         return FfiResult::error("policy creator can not be empty");
@@ -1002,6 +1003,7 @@ pub extern "C" fn get_node_identity(node_ptr: usize) -> FfiResult {
 ///
 /// # Returns
 /// Success with empty JSON object, or error on failure.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn RegisterIdentity(
     did: *const c_char,
@@ -1080,12 +1082,12 @@ pub extern "C" fn create_identity() -> FfiResult {
         // Store identity in global store so block signing can look up the
         // private key from just a DID string during mutations.
         defra_core::signing::store_identity(
-            &did.to_string(),
+            did.as_ref(),
             defra_core::signing::SigningConfig {
                 key_type: "ed25519".to_string(),
                 private_key_bytes: identity.private_key_bytes().to_vec(),
                 public_key_bytes: identity.public_key_bytes().to_vec(),
-                public_key_hex: public_key_hex,
+                public_key_hex,
             },
         );
 

--- a/crates/ffi/src/collection.rs
+++ b/crates/ffi/src/collection.rs
@@ -806,11 +806,7 @@ pub unsafe extern "C" fn refresh_views(node_ptr: usize, options: *const c_char) 
                         .filter_map(|v| v.as_str().map(|s| s.to_string()))
                         .collect::<Vec<_>>()
                 });
-                if let Some(n) = names {
-                    Some(db::RefreshViewsOptions::with_names(n))
-                } else {
-                    None
-                }
+                names.map(db::RefreshViewsOptions::with_names)
             }
             Err(_) => None,
         }

--- a/crates/ffi/src/document.rs
+++ b/crates/ffi/src/document.rs
@@ -246,10 +246,10 @@ fn parse_go_duration(s: &str) -> Result<i64, String> {
         return Ok(0);
     }
 
-    let (negative, s) = if s.starts_with('-') {
-        (true, &s[1..])
-    } else if s.starts_with('+') {
-        (false, &s[1..])
+    let (negative, s) = if let Some(rest) = s.strip_prefix('-') {
+        (true, rest)
+    } else if let Some(rest) = s.strip_prefix('+') {
+        (false, rest)
     } else {
         (false, s)
     };

--- a/crates/ffi/src/encrypted_index.rs
+++ b/crates/ffi/src/encrypted_index.rs
@@ -297,6 +297,10 @@ pub unsafe extern "C" fn list_encrypted_indexes(
 }
 
 /// List all encrypted indexes across all collections.
+///
+/// # Safety
+///
+/// Caller must ensure all pointer arguments are valid, non-null, and point to valid C strings.
 #[no_mangle]
 pub unsafe extern "C" fn list_all_encrypted_indexes(
     node_ptr: usize,

--- a/crates/ffi/src/index.rs
+++ b/crates/ffi/src/index.rs
@@ -405,6 +405,10 @@ pub unsafe extern "C" fn get_indexes(
 ///     "Post": [{ "Name": "idx_title", ... }]
 /// }
 /// ```
+///
+/// # Safety
+///
+/// Caller must ensure all pointer arguments are valid, non-null, and point to valid C strings.
 #[no_mangle]
 pub unsafe extern "C" fn get_all_indexes(
     node_ptr: usize,

--- a/crates/ffi/src/nac_check.rs
+++ b/crates/ffi/src/nac_check.rs
@@ -22,6 +22,7 @@ use crate::ERR_INVALID_NODE_HANDLE;
 /// - NAC enabled + no identity -> Err (not authorized)
 /// - NAC enabled + identity lacks permission -> Err (not authorized)
 /// - NAC enabled + identity has permission -> Ok
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn check_nac_permission(
     rt: &tokio::runtime::Runtime,
     nac_manager: &Arc<FfiNacManager>,

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -106,6 +106,10 @@ pub unsafe extern "C" fn add_schema(
 /// Get all collections from the database.
 ///
 /// Returns a JSON array of collection descriptions.
+///
+/// # Safety
+///
+/// Caller must ensure all pointer arguments are valid, non-null, and point to valid C strings.
 #[no_mangle]
 pub unsafe extern "C" fn get_collections(
     node_ptr: usize,

--- a/crates/ffi/src/subscription.rs
+++ b/crates/ffi/src/subscription.rs
@@ -268,6 +268,7 @@ pub extern "C" fn poll_subscription(subscription_handle: usize) -> PollSubscript
 
 /// Alias for poll_subscription (for Go compatibility)
 /// Accepts a string subscription ID and parses it as a numeric handle.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn poll_graphql_subscription(
     subscription_id: *const c_char,
@@ -316,6 +317,7 @@ pub extern "C" fn close_subscription(subscription_handle: usize) -> CloseSubscri
 
 /// Alias for close_subscription (for Go compatibility)
 /// Accepts a string subscription ID and parses it as a numeric handle.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn close_graphql_subscription(
     subscription_id: *const c_char,

--- a/crates/query/src/mapper/filter/eval/operators.rs
+++ b/crates/query/src/mapper/filter/eval/operators.rs
@@ -335,7 +335,6 @@ fn like_match(
 pub fn like_pattern_match(text: &str, pattern: &str) -> bool {
     let text_bytes = text.as_bytes();
     let pattern_bytes = pattern.as_bytes();
-    let t_len = text_bytes.len();
     let p_len = pattern_bytes.len();
 
     // dp[j] = true means text[0..i] matches pattern[0..j]
@@ -351,7 +350,7 @@ pub fn like_pattern_match(text: &str, pattern: &str) -> bool {
         }
     }
 
-    for i in 0..t_len {
+    for &text_byte in text_bytes {
         let mut prev = dp[0];
         dp[0] = false;
         for j in 0..p_len {
@@ -359,7 +358,7 @@ pub fn like_pattern_match(text: &str, pattern: &str) -> bool {
             if pattern_bytes[j] == b'%' {
                 // '%' matches zero or more chars: either skip '%' (dp[j]) or extend match (dp[j+1])
                 dp[j + 1] = dp[j] || dp[j + 1];
-            } else if text_bytes[i] == pattern_bytes[j] {
+            } else if text_byte == pattern_bytes[j] {
                 dp[j + 1] = prev;
             } else {
                 dp[j + 1] = false;

--- a/crates/query/src/mapper/filter/relation.rs
+++ b/crates/query/src/mapper/filter/relation.rs
@@ -102,34 +102,29 @@ impl Filter {
 
         // Also check inside _and and _or blocks
         for (key, value) in self.conditions() {
-            if let Some(op) = FilterOp::parse(key) {
-                match op {
-                    FilterOp::And | FilterOp::Or => {
-                        if let Some(arr) = value.as_array() {
-                            for item in arr {
-                                if let Some(obj) = item.as_object() {
-                                    if let Some(rel_value) = obj.get(relation_field) {
-                                        if let Some(rel_obj) = rel_value.as_object() {
-                                            let is_nested = rel_obj
-                                                .keys()
-                                                .any(|k| FilterOp::parse(k).is_none());
-                                            if is_nested {
-                                                let nested_conditions: HashMap<String, JsonValue> =
-                                                    rel_obj
-                                                        .iter()
-                                                        .map(|(k, v)| (k.clone(), v.clone()))
-                                                        .collect();
-                                                return Some(Filter::from_conditions(
-                                                    nested_conditions,
-                                                ));
-                                            }
-                                        }
+            if let Some(FilterOp::And | FilterOp::Or) = FilterOp::parse(key) {
+                if let Some(arr) = value.as_array() {
+                    for item in arr {
+                        if let Some(obj) = item.as_object() {
+                            if let Some(rel_value) = obj.get(relation_field) {
+                                if let Some(rel_obj) = rel_value.as_object() {
+                                    let is_nested = rel_obj
+                                        .keys()
+                                        .any(|k| FilterOp::parse(k).is_none());
+                                    if is_nested {
+                                        let nested_conditions: HashMap<String, JsonValue> =
+                                            rel_obj
+                                                .iter()
+                                                .map(|(k, v)| (k.clone(), v.clone()))
+                                                .collect();
+                                        return Some(Filter::from_conditions(
+                                            nested_conditions,
+                                        ));
                                     }
                                 }
                             }
                         }
                     }
-                    _ => {}
                 }
             }
         }
@@ -157,7 +152,7 @@ impl Filter {
     /// - "author" is a relation (its value has non-operator keys)
     /// - "published" is a relation (its value has non-operator keys)
     /// - "rating" is a scalar (its value only has operator keys like "_eq")
-    /// So the path is ["author", "published"].
+    ///   So the path is ["author", "published"].
     fn collect_relation_paths(
         conditions: &HashMap<String, JsonValue>,
         current_path: &mut Vec<String>,
@@ -280,24 +275,19 @@ impl Filter {
 
         // Also check inside _and and _or blocks
         for (key, value) in conditions {
-            if let Some(op) = FilterOp::parse(key) {
-                match op {
-                    FilterOp::And | FilterOp::Or => {
-                        if let Some(arr) = value.as_array() {
-                            for item in arr {
-                                if let Some(obj) = item.as_object() {
-                                    let nested: HashMap<String, JsonValue> =
-                                        obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                                    if let Some(filter) =
-                                        Self::extract_at_path_recursive(&nested, path)
-                                    {
-                                        return Some(filter);
-                                    }
-                                }
+            if let Some(FilterOp::And | FilterOp::Or) = FilterOp::parse(key) {
+                if let Some(arr) = value.as_array() {
+                    for item in arr {
+                        if let Some(obj) = item.as_object() {
+                            let nested: HashMap<String, JsonValue> =
+                                obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                            if let Some(filter) =
+                                Self::extract_at_path_recursive(&nested, path)
+                            {
+                                return Some(filter);
                             }
                         }
                     }
-                    _ => {}
                 }
             }
         }

--- a/crates/query/src/mapper/types.rs
+++ b/crates/query/src/mapper/types.rs
@@ -155,20 +155,15 @@ impl Field {
 }
 
 /// Selection type for polymorphic queries
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum SelectionType {
     /// Normal object selection
+    #[default]
     Object,
     /// Commit/history selection
     Commit,
     /// Encrypted search selection
     EncryptedSearch,
-}
-
-impl Default for SelectionType {
-    fn default() -> Self {
-        Self::Object
-    }
 }
 
 /// A similarity computation (dot product between document vector and query vector)

--- a/crates/query/src/plan/aggregate/average.rs
+++ b/crates/query/src/plan/aggregate/average.rs
@@ -427,11 +427,11 @@ impl PlanNode for AverageNode {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
 
         let source_explain = self.source.explain_execute();
-        let iterations = self.exec_info.iterations as u64;
+        let iterations = self.exec_info.iterations;
         let mut sum_inner = serde_json::Map::new();
         sum_inner.insert("iterations".to_string(), serde_json::json!(iterations));
         if let Some(source_obj) = source_explain.as_object() {

--- a/crates/query/src/plan/aggregate/node.rs
+++ b/crates/query/src/plan/aggregate/node.rs
@@ -339,7 +339,7 @@ impl<Op: AggregateOp> PlanNode for AggregateNode<Op> {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
 
         let child_explain = self.source.explain_execute();

--- a/crates/query/src/plan/groupby.rs
+++ b/crates/query/src/plan/groupby.rs
@@ -878,9 +878,9 @@ impl PlanNode for GroupByNode {
         // groupBy). When _group has a groupBy, Go's child source yields grouped
         // results (fewer items) with different interleaving semantics.
         let group_order = self.group_aliases.first().and_then(|a| a.order.clone());
-        let has_simple_group_order = group_order.as_ref().map_or(false, |o| {
-            !o.is_empty() && self.inner_group_by_fields.is_empty()
-        });
+        let has_simple_group_order = group_order
+            .as_ref()
+            .is_some_and(|o| !o.is_empty() && self.inner_group_by_fields.is_empty());
         let mut ordered_keys: Vec<String> = Vec::new();
         let mut key_set: HashSet<String> = HashSet::new();
 
@@ -1189,7 +1189,7 @@ impl PlanNode for GroupByNode {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
         obj.insert(
             "groups".to_string(),

--- a/crates/query/src/plan/index_scan.rs
+++ b/crates/query/src/plan/index_scan.rs
@@ -287,15 +287,15 @@ impl PlanNode for IndexScanNode {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
         obj.insert(
             "docFetches".to_string(),
-            serde_json::json!(self.exec_info.docs_fetched as u64),
+            serde_json::json!(self.exec_info.docs_fetched),
         );
         obj.insert(
             "fieldFetches".to_string(),
-            serde_json::json!(self.exec_info.fields_fetched as u64),
+            serde_json::json!(self.exec_info.fields_fetched),
         );
         obj.insert(
             "indexFetches".to_string(),

--- a/crates/query/src/plan/limit.rs
+++ b/crates/query/src/plan/limit.rs
@@ -155,7 +155,7 @@ impl PlanNode for LimitNode {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
 
         let child_explain = self.source.explain_execute();

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -65,7 +65,7 @@ fn strip_docid_value(value: &serde_json::Value) -> serde_json::Value {
                     if let serde_json::Value::Array(arr) = val {
                         let filtered: Vec<serde_json::Value> = arr
                             .iter()
-                            .map(|item| strip_docid_value(item))
+                            .map(strip_docid_value)
                             .filter(|item| {
                                 !item.is_null()
                                     && !item.as_object().map(|o| o.is_empty()).unwrap_or(false)

--- a/crates/query/src/plan/orderby.rs
+++ b/crates/query/src/plan/orderby.rs
@@ -338,7 +338,7 @@ impl PlanNode for OrderByNode {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
 
         let child_explain = self.source.explain_execute();

--- a/crates/query/src/plan/scan.rs
+++ b/crates/query/src/plan/scan.rs
@@ -324,19 +324,19 @@ impl PlanNode for ScanNode {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
         obj.insert(
             "docFetches".to_string(),
-            serde_json::json!(self.exec_info.docs_fetched as u64),
+            serde_json::json!(self.exec_info.docs_fetched),
         );
         obj.insert(
             "fieldFetches".to_string(),
-            serde_json::json!(self.exec_info.fields_fetched as u64),
+            serde_json::json!(self.exec_info.fields_fetched),
         );
         obj.insert(
             "indexFetches".to_string(),
-            serde_json::json!(self.exec_info.indexes_fetched as u64),
+            serde_json::json!(self.exec_info.indexes_fetched),
         );
 
         serde_json::Value::Object(obj)

--- a/crates/query/src/plan/select.rs
+++ b/crates/query/src/plan/select.rs
@@ -119,9 +119,7 @@ impl SelectNode {
 
         // Check if root contains another typeIndexJoin (indicating a chain)
         let root_obj = root.as_object()?;
-        if root_obj.get("typeIndexJoin").is_none() {
-            return None; // Single join, no parallelNode needed
-        }
+        root_obj.get("typeIndexJoin")?; // Single join if absent, no parallelNode needed
 
         // Walk the chain collecting all joins and finding the innermost root
         let mut joins_data: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
@@ -178,9 +176,7 @@ impl SelectNode {
         let join_content = obj.get("typeIndexJoin")?.as_object()?;
 
         // Check if this join contains another typeIndexJoin (indicating a chain)
-        if join_content.get("typeIndexJoin").is_none() {
-            return None; // Single join, no parallelNode needed
-        }
+        join_content.get("typeIndexJoin")?; // Single join if absent, no parallelNode needed
 
         // Walk the chain collecting all joins
         let mut joins_data: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
@@ -353,11 +349,11 @@ impl PlanNode for SelectNode {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
         obj.insert(
             "filterMatches".to_string(),
-            serde_json::json!(self.filter_matches as u64),
+            serde_json::json!(self.filter_matches),
         );
 
         // Recursively explain child node with execution info.

--- a/crates/query/src/plan/similarity.rs
+++ b/crates/query/src/plan/similarity.rs
@@ -160,7 +160,7 @@ impl PlanNode for SimilarityNode {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
 
         let child_explain = self.source.explain_execute();

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -1020,7 +1020,7 @@ impl PlanNode for TypeJoinMany {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
 
         let parent_execute = self.parent_plan.explain_execute();

--- a/crates/query/src/plan/type_join/type_join_one.rs
+++ b/crates/query/src/plan/type_join/type_join_one.rs
@@ -574,7 +574,7 @@ impl PlanNode for TypeJoinOne {
 
         obj.insert(
             "iterations".to_string(),
-            serde_json::json!(self.exec_info.iterations as u64),
+            serde_json::json!(self.exec_info.iterations),
         );
 
         let parent_execute = self.parent_plan.explain_execute();

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -255,8 +255,7 @@ impl Planner {
 
                         // If nested_field is not in the selected fields, it's ordering-only
                         if !nested_selection_fields
-                            .iter()
-                            .any(|f| *f == nested_field_name)
+                            .contains(&nested_field_name)
                         {
                             result.push((relation_field_name.clone(), nested_field_name.clone()));
                         }
@@ -387,7 +386,7 @@ impl Planner {
                 let output_name = agg.output_name();
                 // Add a new index if this specific output name isn't already registered
                 if scan_mapping
-                    .try_find_index_from_render_key(&output_name)
+                    .try_find_index_from_render_key(output_name)
                     .is_none()
                 {
                     let scan_index = scan_mapping.next_index();
@@ -462,11 +461,10 @@ impl Planner {
                 if scan_mapping
                     .first_index_of_name(&sim.target_field)
                     .is_none()
+                    && collection.field_by_name(&sim.target_field).is_some()
                 {
-                    if collection.field_by_name(&sim.target_field).is_some() {
-                        let idx = scan_mapping.next_index();
-                        scan_mapping.add(idx, &sim.target_field);
-                    }
+                    let idx = scan_mapping.next_index();
+                    scan_mapping.add(idx, &sim.target_field);
                 }
             }
         }

--- a/crates/query/src/planner/joins.rs
+++ b/crates/query/src/planner/joins.rs
@@ -23,6 +23,13 @@ use crate::planner::PlanNode;
 
 use super::builder::{Planner, MAX_NESTING_DEPTH};
 
+/// Result of applying joins: the updated plan node, document mapping, and aggregate internal keys.
+type JoinResult = Result<(
+    Box<dyn PlanNode>,
+    DocumentMapping,
+    HashMap<String, (String, String)>,
+)>;
+
 impl Planner {
     /// Apply join nodes for nested selects (relation fields)
     ///
@@ -39,11 +46,7 @@ impl Planner {
         mut mapping: DocumentMapping,
         depth: usize,
         parent_filter: Option<&crate::mapper::Filter>,
-    ) -> Result<(
-        Box<dyn PlanNode>,
-        DocumentMapping,
-        HashMap<String, (String, String)>,
-    )> {
+    ) -> JoinResult {
         // Internal keys for aggregate relation data when there's a collision with a relation selection.
         let mut aggregate_internal_keys: HashMap<String, (String, String)> = HashMap::new();
 
@@ -95,7 +98,7 @@ impl Planner {
                         .filter
                         .as_ref()
                         .map(|f| serde_json::to_string(f.conditions()).unwrap_or_default());
-                    let has_limit = s.limit.as_ref().map_or(false, |l| l.limit.is_some());
+                    let has_limit = s.limit.as_ref().is_some_and(|l| l.limit.is_some());
                     (
                         s.field.name.clone(),
                         SelectionJoinInfo {
@@ -255,7 +258,7 @@ impl Planner {
             // If so, add those fields to child_scan_mapping so the filter can be evaluated.
             // For example, Author(filter: {published: {rating: {_gt: 3}}}) needs the 'rating'
             // field to be included even if it's not in the selection set.
-            if let Some(ref pf) = parent_filter {
+            if let Some(pf) = parent_filter {
                 if let Some(nested_filter) = pf.extract_relation_filter(relation_field_name) {
                     for filter_field in nested_filter.referenced_fields() {
                         // Skip special fields
@@ -324,7 +327,7 @@ impl Planner {
                         .into_iter()
                         .filter(|path| {
                             path.first()
-                                .map_or(false, |first| first == relation_field_name)
+                                .is_some_and(|first| first == relation_field_name)
                         })
                         .map(|path| path[1..].to_vec()) // Get remaining path after this relation
                         .filter(|remaining| !remaining.is_empty())
@@ -432,7 +435,7 @@ impl Planner {
                             // Convert nested path to child-relative path
                             Some(OrderCondition {
                                 fields: c.fields[1..].to_vec(),
-                                direction: c.direction.clone(),
+                                direction: c.direction,
                             })
                         } else {
                             None
@@ -1014,7 +1017,7 @@ impl Planner {
                 child_mapping.add_render_key(0, "_docID");
 
                 // Add the FK field (e.g., _authorID) - needed for TypeJoinMany cache indexing
-                let fk_field_name = if let Some(ref target_rel) = target_relation_field {
+                let fk_field_name = if let Some(target_rel) = target_relation_field {
                     schema::CollectionVersion::relation_id_field_name(&target_rel.name)
                 } else {
                     schema::CollectionVersion::relation_id_field_name(&relation_name)
@@ -1304,7 +1307,7 @@ impl Planner {
                         .contains(relation_field_name.as_str())
                         || selection_join_info
                             .get(relation_field_name.as_str())
-                            .map_or(false, |info| {
+                            .is_some_and(|info| {
                                 if info.has_limit {
                                     return false;
                                 }

--- a/crates/query/src/planner/mapping.rs
+++ b/crates/query/src/planner/mapping.rs
@@ -114,11 +114,11 @@ impl Planner {
 
         if let Some(ref filter) = select.filter {
             for field_name in filter.referenced_fields() {
-                if mapping.first_index_of_name(&field_name).is_none() {
-                    if collection.field_by_name(&field_name).is_some() {
-                        let index = mapping.next_index();
-                        mapping.add(index, &field_name);
-                    }
+                if mapping.first_index_of_name(&field_name).is_none()
+                    && collection.field_by_name(&field_name).is_some()
+                {
+                    let index = mapping.next_index();
+                    mapping.add(index, &field_name);
                 }
             }
         }

--- a/crates/query/src/query_parse/aggregates.rs
+++ b/crates/query/src/query_parse/aggregates.rs
@@ -351,7 +351,7 @@ pub(super) fn parse_top_level_aggregate(
         .targets
         .first()
         .map(|t| t.host_name.clone())
-        .unwrap_or_else(|| String::new());
+        .unwrap_or_default();
 
     // Create a Select that wraps this aggregate
     // The field name should be the aggregate name (e.g., "_avg") so the response

--- a/crates/query/src/query_parse/explain.rs
+++ b/crates/query/src/query_parse/explain.rs
@@ -27,7 +27,7 @@ pub(crate) fn parse_explain_directive(
                             ));
                         }
                     };
-                    if let Some(explain_type) = ExplainType::from_str(type_str) {
+                    if let Some(explain_type) = ExplainType::parse_str(type_str) {
                         return Ok(Some(explain_type));
                     }
                     return Err(QueryError::parse(format!(

--- a/crates/query/src/query_parse/parser.rs
+++ b/crates/query/src/query_parse/parser.rs
@@ -33,7 +33,7 @@ pub enum ExplainType {
 
 impl ExplainType {
     /// Parse explain type from string.
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "simple" => Some(Self::Simple),
             "execute" => Some(Self::Execute),
@@ -61,7 +61,7 @@ pub enum ParsedOperation {
     /// Subscription operations (single root field only per GraphQL spec)
     Subscription {
         /// The single select for the subscription.
-        select: Select,
+        select: Box<Select>,
     },
     /// Introspection query (__schema or __type)
     ///
@@ -86,12 +86,12 @@ fn parse_explain_directive(directives: &[Directive<'_, String>]) -> Result<Optio
                         Value::Enum(s) => s.as_str(),
                         Value::String(s) => s.as_str(),
                         _ => {
-                            return Err(QueryError::parse(format!(
-                                "Argument \"type\" has invalid value.\nExpected type \"ExplainType\"."
-                            )));
+                            return Err(QueryError::parse(
+                                "Argument \"type\" has invalid value.\nExpected type \"ExplainType\".",
+                            ));
                         }
                     };
-                    if let Some(explain_type) = ExplainType::from_str(type_str) {
+                    if let Some(explain_type) = ExplainType::parse_str(type_str) {
                         return Ok(Some(explain_type));
                     }
                     return Err(QueryError::parse(format!(
@@ -492,7 +492,7 @@ pub fn parse_request_with_variables(
     if has_subscription {
         // subscription_selects is guaranteed to have exactly one element due to earlier validation
         Ok(ParsedOperation::Subscription {
-            select: subscription_selects.into_iter().next().unwrap(),
+            select: Box::new(subscription_selects.into_iter().next().unwrap()),
         })
     } else if has_mutation {
         Ok(ParsedOperation::Mutation { mutations, explain })

--- a/crates/query/src/query_parse/types.rs
+++ b/crates/query/src/query_parse/types.rs
@@ -16,7 +16,7 @@ pub enum ExplainType {
 
 impl ExplainType {
     /// Parse explain type from string.
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "simple" => Some(Self::Simple),
             "execute" => Some(Self::Execute),
@@ -44,7 +44,7 @@ pub enum ParsedOperation {
     /// Subscription operations (single root field only per GraphQL spec)
     Subscription {
         /// The single select for the subscription.
-        select: Select,
+        select: Box<Select>,
     },
     /// Introspection query (__schema or __type)
     ///

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -379,8 +379,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
     }
 
-    /// Execute a top-level aggregate query (e.g., `{ _avg(Users: {field: Age}) }`).
-
     /// Execute a _commits system collection query.
     ///
     /// This handles queries to the special _commits collection which fetches

--- a/crates/query/src/runner/explain/mod.rs
+++ b/crates/query/src/runner/explain/mod.rs
@@ -991,7 +991,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 if let Some(scan_obj) = scan_node.as_object_mut() {
                     scan_obj.insert(
                         "iterations".to_string(),
-                        serde_json::json!(iterations as u64),
+                        serde_json::json!(iterations),
                     );
                     scan_obj.insert(
                         "docFetches".to_string(),

--- a/crates/query/src/runner/introspection.rs
+++ b/crates/query/src/runner/introspection.rs
@@ -636,13 +636,12 @@ fn build_order_input_type(
 /// Go includes system fields: _deleted, _docID, _group, _version
 fn build_field_enum(collection: &CollectionVersion) -> Enum {
     let type_name = format!("{}Field", collection.name);
-    let mut items: Vec<String> = Vec::new();
-
-    // System fields that Go always includes
-    items.push("_deleted".to_string());
-    items.push("_docID".to_string());
-    items.push("_group".to_string());
-    items.push("_version".to_string());
+    let mut items: Vec<String> = vec![
+        "_deleted".to_string(),
+        "_docID".to_string(),
+        "_group".to_string(),
+        "_version".to_string(),
+    ];
 
     // User-defined fields
     for field in &collection.fields {
@@ -1492,12 +1491,12 @@ fn build_numeric_fields_enum(collection: &CollectionVersion) -> Enum {
     let mut enum_type = Enum::new(&type_name);
 
     for field in &collection.fields {
-        let is_numeric = match &field.kind {
+        let is_numeric = matches!(
+            &field.kind,
             FieldKind::Scalar(ScalarKind::Int)
-            | FieldKind::Scalar(ScalarKind::Float32)
-            | FieldKind::Scalar(ScalarKind::Float64) => true,
-            _ => false,
-        };
+                | FieldKind::Scalar(ScalarKind::Float32)
+                | FieldKind::Scalar(ScalarKind::Float64)
+        );
         if is_numeric {
             enum_type = enum_type.item(EnumItem::new(&field.name));
         }

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -39,7 +39,6 @@ pub(crate) fn validate_select(select: &Select, collection: &CollectionVersion) -
             || name == "_group"
             || name == "__typename"
             || name == "_version"
-            || name == "_deleted"
             || collection.fields.iter().any(|f| f.name == name)
     };
 
@@ -377,8 +376,10 @@ pub(crate) fn build_mapping(
         }
     }
 
-    // If no fields specified (only _docID at index 0), add all from collection
-    if mapping.next_index() == 1 {
+    // If no fields specified (only _docID reserved at index 0, no render keys),
+    // add all collection fields. This handles the "SELECT *" case.
+    // Note: if _docID was explicitly requested, render_keys won't be empty.
+    if mapping.next_index() == 1 && mapping.render_keys.is_empty() {
         for field in &collection.fields {
             let index = mapping.next_index();
             mapping.add(index, &field.name);

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -561,7 +561,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 if !relation_targets.is_empty() {
                     aggregates_info.push((
                         agg.output_name().to_string(),
-                        agg.aggregate_type.clone(),
+                        agg.aggregate_type,
                         relation_targets,
                     ));
                 }
@@ -920,13 +920,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 // `published { name }` but the aggregate filter needed `rating`, we need to remove
                 // `rating` from each item in `published` after aggregate computation.
                 for (relation_name, allowed_fields) in &selected_relation_fields {
-                    if let Some(relation_data) = obj.get_mut(relation_name) {
-                        if let JsonValue::Array(items) = relation_data {
-                            for item in items.iter_mut() {
-                                if let JsonValue::Object(item_obj) = item {
-                                    // Remove fields that weren't in the original selection
-                                    item_obj.retain(|k, _| allowed_fields.contains(k));
-                                }
+                    if let Some(JsonValue::Array(items)) = obj.get_mut(relation_name) {
+                        for item in items.iter_mut() {
+                            if let JsonValue::Object(item_obj) = item {
+                                // Remove fields that weren't in the original selection
+                                item_obj.retain(|k, _| allowed_fields.contains(k));
                             }
                         }
                     }
@@ -1184,20 +1182,18 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         for result in &mut results {
             if let JsonValue::Object(ref mut obj) = result {
                 for (field_name, limit, offset) in &relation_limits {
-                    if let Some(relation_data) = obj.get_mut(field_name) {
-                        if let JsonValue::Array(items) = relation_data {
-                            let offset = *offset as usize;
-                            let total = items.len();
-                            if offset >= total {
-                                *items = Vec::new();
+                    if let Some(JsonValue::Array(items)) = obj.get_mut(field_name) {
+                        let offset = *offset as usize;
+                        let total = items.len();
+                        if offset >= total {
+                            *items = Vec::new();
+                        } else {
+                            let remaining: Vec<JsonValue> = items.drain(offset..).collect();
+                            *items = if *limit > 0 {
+                                remaining.into_iter().take(*limit as usize).collect()
                             } else {
-                                let remaining: Vec<JsonValue> = items.drain(offset..).collect();
-                                *items = if *limit > 0 {
-                                    remaining.into_iter().take(*limit as usize).collect()
-                                } else {
-                                    remaining
-                                };
-                            }
+                                remaining
+                            };
                         }
                     }
                 }
@@ -1337,8 +1333,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         Ok(JsonValue::Array(results))
     }
-
-    /// Execute a CID-based time-travel query with optional _version support.
 
     ///
     /// Top-level aggregates compute a single value over all documents in a collection.

--- a/crates/query/src/sdl_parse/builder.rs
+++ b/crates/query/src/sdl_parse/builder.rs
@@ -54,7 +54,6 @@ impl<'a> SdlParser<'a> {
 
     /// Validate parsed types before building collections.
     /// Checks for NonNull fields, one-one relation primary constraints, and default value constraints.
-
     pub(super) fn build_collections(&self) -> Result<Vec<CollectionVersion>> {
         // Build collection names set for relation detection, including external types
         let mut type_names: std::collections::HashSet<_> = self.type_defs.keys().cloned().collect();
@@ -576,7 +575,7 @@ impl<'a> SdlParser<'a> {
                     };
                     // FK field has same is_primary status as relation object field
                     let mut id_field =
-                        FieldDescription::new(&id_field_id, &id_field_name.clone(), id_field_kind)
+                        FieldDescription::new(&id_field_id, &id_field_name, id_field_kind)
                             .with_crdt_type(id_field_crdt)
                             .with_relation_name(relation_name);
                     if is_primary {

--- a/crates/query/src/sdl_parse/helpers.rs
+++ b/crates/query/src/sdl_parse/helpers.rs
@@ -93,7 +93,7 @@ pub(super) fn graphql_schema_value_to_json(
 /// Go's time.Time drops trailing zeros in fractional seconds, so:
 /// - "2000-07-23T03:00:00.000Z" becomes "2000-07-23T03:00:00Z"
 /// - "2000-07-23T03:00:00.123Z" stays "2000-07-23T03:00:00.123Z"
-/// If parsing fails, returns the original string (e.g., for special values).
+///   If parsing fails, returns the original string (e.g., for special values).
 pub(super) fn normalize_datetime_string(s: &str) -> String {
     // Try to parse as RFC3339 variant (ISO 8601)
     if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
@@ -154,8 +154,8 @@ pub(super) fn parse_policy_directive(directive: &Directive<'_, String>) -> Resul
         _ => None,
     });
 
-    let id_empty = id.as_ref().map_or(true, |s| s.is_empty());
-    let resource_empty = resource.as_ref().map_or(true, |s| s.is_empty());
+    let id_empty = id.as_ref().is_none_or(|s| s.is_empty());
+    let resource_empty = resource.as_ref().is_none_or(|s| s.is_empty());
 
     if id_empty && resource_empty {
         return Err(QueryError::parse(

--- a/crates/storage/src/backends/redb.rs
+++ b/crates/storage/src/backends/redb.rs
@@ -914,7 +914,7 @@ impl Reader for RedbTxn {
 
         // Helper to check prefix
         let matches_prefix =
-            |key: &[u8]| -> bool { opts.prefix().map_or(true, |p| key.starts_with(p)) };
+            |key: &[u8]| -> bool { opts.prefix().is_none_or(|p| key.starts_with(p)) };
 
         // Extract snapshot items into Vec (already sorted by BTreeMap)
         let snapshot_items: Vec<(Vec<u8>, Vec<u8>)> = self

--- a/crates/storage/src/encoding/json.rs
+++ b/crates/storage/src/encoding/json.rs
@@ -267,7 +267,7 @@ pub fn decode_json_descending(buf: &[u8]) -> Result<(&[u8], JsonLeafValue)> {
         // For descending, check if this looks like an inverted uvarint or string
         // Inverted bytes for INT_MIN..INT_MAX would be !INT_MAX..!INT_MIN
         let inverted_byte = !rest[0];
-        if inverted_byte >= INT_MIN && inverted_byte <= INT_MAX {
+        if (INT_MIN..=INT_MAX).contains(&inverted_byte) {
             // Array index - decode descending uvarint
             let (remaining, _idx) = decode_uvarint_descending(rest)?;
             path = path.append_index();

--- a/crates/storage/src/index/matcher.rs
+++ b/crates/storage/src/index/matcher.rs
@@ -197,7 +197,6 @@ impl IndexMatcher for NlikeMatcher {
 fn like_match(text: &str, pattern: &str) -> bool {
     let text_bytes = text.as_bytes();
     let pattern_bytes = pattern.as_bytes();
-    let t_len = text_bytes.len();
     let p_len = pattern_bytes.len();
 
     let mut dp = vec![false; p_len + 1];
@@ -211,14 +210,14 @@ fn like_match(text: &str, pattern: &str) -> bool {
         }
     }
 
-    for i in 0..t_len {
+    for &text_byte in text_bytes {
         let mut prev = dp[0];
         dp[0] = false;
         for j in 0..p_len {
             let temp = dp[j + 1];
             if pattern_bytes[j] == b'%' {
                 dp[j + 1] = prev || dp[j + 1];
-            } else if text_bytes[i] == pattern_bytes[j] {
+            } else if text_byte == pattern_bytes[j] {
                 dp[j + 1] = prev;
             } else {
                 dp[j + 1] = false;

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -20,16 +20,12 @@ pub fn from_js<T: DeserializeOwned>(value: JsValue) -> Result<T> {
 /// Client configuration passed from JavaScript.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
+#[derive(Default)]
 pub struct ClientConfig {
     /// Database name for storage
     pub db_name: Option<String>,
 }
 
-impl Default for ClientConfig {
-    fn default() -> Self {
-        Self { db_name: None }
-    }
-}
 
 /// Collection info returned to JavaScript.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/tools/ffi-test/src/commands/logs.rs
+++ b/tools/ffi-test/src/commands/logs.rs
@@ -63,11 +63,7 @@ pub async fn execute(
             for line in &test.output {
                 // Trim trailing newlines for cleaner output
                 print!("  {}", line.trim_end_matches('\n'));
-                if !line.ends_with('\n') {
-                    println!();
-                } else {
-                    println!();
-                }
+                println!();
             }
             println!("\x1b[90m{}\x1b[0m", "─".repeat(60));
             println!();


### PR DESCRIPTION
## Summary
- Fixed `build_mapping()` incorrectly expanding all collection fields when only `_docID` is requested, causing alias docID test failure
- Resolved all clippy warnings across the workspace (~50 files)
- Bumped MSRV from 1.75 to 1.82 to match actual feature usage (`LazyLock`, `is_some_and`, `is_none_or`)

## FFI Mutation Test Results
- **200 pass** (up from 199)
- **1 fail** — `TestTransactionalCreationAndLinkingOfRelationalDocumentsForward` (known SSI/OCC issue, tracked by #244)
- **21 skip** — embedding tests (Go-only), CRDT counter overflow, mutation-type restrictions

## Test plan
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo test -p query` passes (42/42)
- [x] `ffi-test run mutation` — 200 pass, 1 known fail, 21 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)