### PR TITLE
fix(explain): Pass all 249 explain FFI tests

### DIFF
--- a/crates/query/src/plan/groupby.rs
+++ b/crates/query/src/plan/groupby.rs
@@ -256,6 +256,30 @@ impl GroupByNode {
         }
     }
 
+    /// Increment scanNode.iterations by 1 in the explain JSON output.
+    ///
+    /// In Go's pipeNode architecture, when `_group` child selections exist,
+    /// the childSource also iterates through the shared scanNode, causing
+    /// one additional iteration beyond what the parent source consumes.
+    fn increment_scan_iterations(mut value: serde_json::Value) -> serde_json::Value {
+        if let Some(obj) = value.as_object_mut() {
+            if let Some(select_node) = obj.get_mut("selectNode") {
+                if let Some(select_obj) = select_node.as_object_mut() {
+                    if let Some(scan_node) = select_obj.get_mut("scanNode") {
+                        if let Some(scan_obj) = scan_node.as_object_mut() {
+                            if let Some(iterations) = scan_obj.get_mut("iterations") {
+                                if let Some(n) = iterations.as_u64() {
+                                    *iterations = serde_json::json!(n + 1);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        value
+    }
+
     /// Compare two field values for ordering.
     fn compare_field_values(a: Option<&JsonValue>, b: Option<&JsonValue>) -> std::cmp::Ordering {
         match (a, b) {
@@ -1203,8 +1227,16 @@ impl PlanNode for GroupByNode {
         obj.insert("hiddenAfterLimit".to_string(), serde_json::json!(0u64));
         obj.insert("hiddenChildSelections".to_string(), serde_json::json!(0u64));
 
-        // Recursively explain child node with execution info
+        // Recursively explain child node with execution info.
+        // When _group child selections exist, Go's pipeNode architecture causes
+        // the scanNode to be iterated one additional time by the childSource
+        // exhausting the shared scan. Adjust the JSON output to match.
         let child_explain = self.source.explain_execute();
+        let child_explain = if !self.child_selects.is_empty() {
+            Self::increment_scan_iterations(child_explain)
+        } else {
+            child_explain
+        };
         if let Some(child_obj) = child_explain.as_object() {
             for (key, value) in child_obj {
                 obj.insert(key.clone(), value.clone());

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -82,6 +82,10 @@ pub struct TypeJoinMany {
     /// Used when the child plan uses an index for ordering, matching Go's per-parent
     /// scan behavior for correct metrics and limit support.
     per_parent_child_scan: bool,
+    /// Child documents in storage scan order: (fk_value, stored_field_count).
+    /// Used to simulate Go's per-parent filteredFetcher behavior for explain metrics
+    /// when a child limit is set.
+    child_scan_order: Vec<(String, u64)>,
 }
 
 impl std::fmt::Debug for TypeJoinMany {
@@ -154,6 +158,7 @@ impl TypeJoinMany {
             total_children_in_cache: 0,
             total_fields_per_scan: 0,
             per_parent_child_scan: false,
+            child_scan_order: Vec::new(),
         })
     }
 
@@ -284,12 +289,21 @@ impl TypeJoinMany {
     /// Indexes children by their FK field value.
     async fn build_child_cache(&mut self) -> Result<()> {
         self.child_cache.clear();
+        self.child_scan_order.clear();
         self.child_plan.init().await?;
         self.child_plan.start().await?;
 
         while self.child_plan.next().await? {
             let child_doc = self.child_plan.value();
             let child_fk_value = child_doc.get(self.child_fk_index);
+
+            // Record scan order for per-parent metric simulation (used when child_limit is set)
+            let fk_str = child_fk_value
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            self.child_scan_order
+                .push((fk_str, child_doc.stored_field_count as u64));
 
             // Log type mismatch for non-null, non-string FK values
             if let Some(v) = child_fk_value {
@@ -690,6 +704,7 @@ impl PlanNode for TypeJoinMany {
         self.go_child_metrics.reset();
         self.total_children_in_cache = 0;
         self.total_fields_per_scan = 0;
+        self.child_scan_order.clear();
 
         if self.per_parent_child_scan {
             // Per-parent mode: don't cache, we'll re-scan per parent in next()
@@ -766,16 +781,52 @@ impl PlanNode for TypeJoinMany {
             // Simulate Go's per-parent child scan metrics.
             // In Go, fetchPrimaryDocsReferencingSecondaryDoc re-initializes the child
             // scan for each parent, reading ALL children from the collection. The scanNode
-            // filters by FK, counting iterations for each outer Next() call (matching + 1 false).
-            // docFetches/fieldFetches count ALL docs read from storage per scan.
-            let matching_count = self
-                .child_cache
-                .get(&parent_doc_id)
-                .map(|v| v.len() as u64)
-                .unwrap_or(0);
-            self.go_child_metrics.iterations += matching_count + 1; // matching children + 1 false
-            self.go_child_metrics.doc_fetches += self.total_children_in_cache;
-            self.go_child_metrics.field_fetches += self.total_fields_per_scan;
+            // uses a filteredFetcher that skips non-matching docs inside FetchNext().
+            if let Some(limit) = self.child_limit {
+                // With a child limit, Go's collectDocs(limit) stops after finding
+                // enough matches. The filteredFetcher reads docs from storage in CID
+                // order, skipping non-matching docs internally. We simulate this by
+                // walking the recorded scan order.
+                let effective_limit = self.child_offset + limit;
+                let mut matches_found = 0u64;
+                let mut docs_read = 0u64;
+                let mut fields_read = 0u64;
+                let mut iterations = 0u64;
+
+                for (fk, field_count) in &self.child_scan_order {
+                    docs_read += 1;
+                    fields_read += field_count;
+                    if fk == &parent_doc_id {
+                        matches_found += 1;
+                        iterations += 1; // Each match ends a FetchNext call → Next() returns true
+                        if matches_found >= effective_limit {
+                            break; // collectDocs stops when limit reached
+                        }
+                    }
+                }
+
+                // If collection exhausted without hitting limit, add 1 for the final
+                // false Next() call (FetchNext returns nil → Next returns false).
+                if matches_found < effective_limit {
+                    iterations += 1;
+                }
+
+                self.go_child_metrics.iterations += iterations;
+                self.go_child_metrics.doc_fetches += docs_read;
+                self.go_child_metrics.field_fetches += fields_read;
+            } else {
+                // Without a child limit, Go scans ALL children per parent.
+                // Each FetchNext reads until finding a match (or end), so iterations
+                // = matching children + 1 (for the final false Next()).
+                let matching_count = self
+                    .child_cache
+                    .get(&parent_doc_id)
+                    .map(|v| v.len() as u64)
+                    .unwrap_or(0);
+                self.go_child_metrics.iterations += matching_count + 1;
+                self.go_child_metrics.doc_fetches += self.total_children_in_cache;
+                self.go_child_metrics.field_fetches += self.total_fields_per_scan;
+            }
 
             // Merge children array into parent
             self.merge_children(&mut parent_doc, children);
@@ -793,6 +844,7 @@ impl PlanNode for TypeJoinMany {
         self.parent_plan.close().await?;
         // child_plan was already closed in build_child_cache()
         self.child_cache.clear();
+        self.child_scan_order.clear();
         self.initialized = false;
         Ok(())
     }

--- a/crates/query/src/plan/type_join/type_join_one.rs
+++ b/crates/query/src/plan/type_join/type_join_one.rs
@@ -403,11 +403,26 @@ impl PlanNode for TypeJoinOne {
             let child_doc = fk.and_then(|fk| self.find_child_doc(&fk));
 
             // Simulate Go's per-parent child scan metrics.
-            // In Go, fetchDocWithIDAndItsSubDocs calls Init() + Next() once per parent
-            // with a docID-specific prefix. Next() is called exactly once.
+            // The behavior differs by join direction:
+            //
+            // Primary: fetchDocWithIDAndItsSubDocs calls Init() + Next() once per parent
+            // with a docID-specific prefix. Next() is called exactly once (no false call).
+            //
+            // Inverted: fetchPrimaryDocsReferencingSecondaryDoc sets a filter + unique index
+            // on the child scanNode, then calls collectDocs(0). This calls Next() twice
+            // per parent (true + false), and uses the index (1 indexFetch per match).
             if child_doc.is_some() {
-                // Found a child: 1 iteration (Next()=true), 1 doc fetched
-                self.go_child_metrics.iterations += 1;
+                match &self.direction {
+                    JoinDirection::Primary { .. } => {
+                        // 1 iteration (Next()=true only), no index
+                        self.go_child_metrics.iterations += 1;
+                    }
+                    JoinDirection::Inverted => {
+                        // 2 iterations (Next()=true, Next()=false), 1 indexFetch
+                        self.go_child_metrics.iterations += 2;
+                        self.go_child_metrics.index_fetches += 1;
+                    }
+                }
                 self.go_child_metrics.doc_fetches += 1;
                 if let Some(ref doc) = child_doc {
                     self.go_child_metrics.field_fetches += doc.stored_field_count as u64;

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -12,7 +12,7 @@ use tracing::{debug, instrument, warn};
 
 use crate::error::{QueryError, Result};
 use crate::fetcher::DocFetcher;
-use crate::mapper::{AggregateType, Filter, OrderBy, Requestable, Select};
+use crate::mapper::{AggregateType, Filter, OrderBy, OrderCondition, OrderDirection, Requestable, Select};
 use crate::plan::groupby::ChildSelectMeta;
 use crate::plan::{
     AllDocsNode, GroupAlias, GroupByNode, IndexScanNode, InnerAggregateDef, LimitNode, OrderByNode,
@@ -102,6 +102,23 @@ impl Planner {
             acp: None,
             identity_did: None,
         }
+    }
+
+    /// Format an order condition as a Go-style value string.
+    ///
+    /// For `fields: ["articles", "pages"], direction: Asc`, produces `{articles: {pages: ASC}}`.
+    fn format_order_condition(condition: &OrderCondition) -> String {
+        let dir = match condition.direction {
+            OrderDirection::Asc => "ASC",
+            OrderDirection::Desc => "DESC",
+        };
+
+        // Build from innermost to outermost
+        let mut result = dir.to_string();
+        for field in condition.fields.iter().rev() {
+            result = format!("{{{}: {}}}", field, result);
+        }
+        result
     }
 
     /// Set a document fetcher for on-demand data loading.
@@ -204,13 +221,32 @@ impl Planner {
             .unwrap_or_default();
         let filter_has_relations = !filter_relation_fields.is_empty();
 
-        // Check if order references relation fields (needs joins even if not selected)
+        // Check if order references relation fields.
+        // Go rejects ordering by relation fields at the GraphQL validation level
+        // (the relation field doesn't exist in the OrderArg input type).
         let order_relation_fields: Vec<String> = select
             .order_by
             .as_ref()
             .map(|o| o.relation_field_names())
             .unwrap_or_default();
         let order_has_relations = !order_relation_fields.is_empty();
+
+        if order_has_relations {
+            if let Some(ref order_by) = select.order_by {
+                // Find the first relation condition and build Go-compatible error
+                for condition in &order_by.conditions {
+                    if condition.fields.len() > 1 {
+                        let relation_field = &condition.fields[0];
+                        let order_value_str = Self::format_order_condition(condition);
+                        return Err(QueryError::parse(format!(
+                            "Argument \"order\" has invalid value {}.\n\
+                             In field \"{}\": Unknown field.",
+                            order_value_str, relation_field
+                        )));
+                    }
+                }
+            }
+        }
 
         // Compute ordering-only fields: nested relation fields used in ORDER BY but not in selection.
         // These will be stripped from the final output.

--- a/crates/query/src/runner/explain/mod.rs
+++ b/crates/query/src/runner/explain/mod.rs
@@ -179,6 +179,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     operation_children.push(mutation_explain);
                 }
                 Err(e) => {
+                    if matches!(&e, QueryError::Parse(_)) {
+                        return Err(e);
+                    }
                     execution_success = false;
                     execution_errors.push(e.to_string());
                 }
@@ -678,6 +681,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     }
                 }
                 Err(e) => {
+                    // Parse errors should propagate directly — in Go, GraphQL schema
+                    // validation errors happen before the explain handler runs, so they
+                    // are returned as top-level GQL errors, not wrapped in executionErrors.
+                    if matches!(&e, QueryError::Parse(_)) {
+                        return Err(e);
+                    }
                     execution_success = false;
                     execution_errors.push(e.to_string());
                 }

--- a/crates/query/src/runner/introspection.rs
+++ b/crates/query/src/runner/introspection.rs
@@ -611,9 +611,11 @@ fn build_order_input_type(
         InputValue::new("_docID", TypeRef::named("Ordering")),
     ));
 
-    // Add order fields for each collection field
+    // Add order fields for each collection field (scalars and scalar arrays only).
+    // Relation fields are excluded — Go rejects ordering by related child fields
+    // (e.g., `Author(order: {articles: {name: ASC}})` produces a validation error).
     for field in &collection.fields {
-        if field.name == "_docID" {
+        if field.name == "_docID" || field.kind.is_relation() {
             continue;
         }
         fields.push((


### PR DESCRIPTION
## Summary
- Fix all 7 failing explain FFI tests to reach 249/249 (100%) pass rate
- Reject ordering by relation fields with Go-compatible validation errors
- Fix execute explain metrics for GroupBy, TypeJoinOne inverted, and TypeJoinMany with child limits

## Changes

**Order-by-relation validation (3 tests)**
- `builder.rs`: Reject `Author(order: {articles: {pages: ASC}})` with Go-compatible error message
- `explain/mod.rs`: Propagate parse errors instead of wrapping in `executionErrors`
- `introspection.rs`: Filter relation fields from order input type

**Execute explain metric fixes (3 tests)**
- `groupby.rs`: +1 scanNode iteration when `_group` selected (Go pipeNode behavior)
- `type_join_one.rs`: Inverted joins produce iterations=2, index_fetches=1 per parent
- `type_join_many.rs`: Track child scan order to simulate Go's filteredFetcher with limits

## Test plan
- [x] `ffi-test run explain` — 249 pass, 0 fail, 0 skip
- [x] `cargo build --release -p ffi` compiles clean

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)