### PR TITLE
feat(query/p2p): Pass all 331 FFI index tests

### DIFF
--- a/crates/db/src/auto_commit_mutator.rs
+++ b/crates/db/src/auto_commit_mutator.rs
@@ -472,7 +472,8 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
                 let fields_modified = doc.values().len();
                 match commit_result {
                     Some((cid, block, col_data)) => {
-                        let mut result = UpdateResult::with_commit(doc, fields_modified, cid, block);
+                        let mut result =
+                            UpdateResult::with_commit(doc, fields_modified, cid, block);
                         if let Some((col_cid, col_bytes)) = col_data {
                             result.broadcast_cid = Some(col_cid);
                             result.broadcast_block = Some(col_bytes);

--- a/crates/db/src/block_builder.rs
+++ b/crates/db/src/block_builder.rs
@@ -962,10 +962,11 @@ pub async fn read_latest_composite_block<S: storage::corekv::Store>(
         .headstore()
         .map_err(|e| format!("Failed to get headstore: {}", e))?;
 
-    let composite_head = get_field_head(&headstore, doc_id, "C").await?;
+    let composite_heads = get_all_field_heads(&headstore, doc_id, "C").await?;
 
-    let composite_cid = composite_head
-        .cid
+    let composite_cid = composite_heads
+        .first()
+        .map(|entry| entry.cid)
         .ok_or_else(|| format!("No composite head found for doc {}", doc_id))?;
 
     let blockstore = txn

--- a/crates/db/src/block_builder.rs
+++ b/crates/db/src/block_builder.rs
@@ -871,7 +871,7 @@ pub async fn write_collection_block(
     let priority: u64 = max_priority + 1;
 
     // Sort heads by CID string representation to match Go's Block.New() sorting
-    col_heads.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    col_heads.sort_by_key(|a| a.to_string());
 
     // Create the Collection delta payload
     let collection_payload = CollectionDeltaPayload {

--- a/crates/db/src/block_builder.rs
+++ b/crates/db/src/block_builder.rs
@@ -939,6 +939,55 @@ pub async fn write_collection_block(
 
 /// Build an IPLD block from a document (legacy - DO NOT USE for P2P).
 ///
+/// Read the latest composite block for a document from the committed store.
+///
+/// After a mutation (create/update/delete), the composite block and its CID
+/// are written to the blockstore and headstore as part of the transaction.
+/// This function reads the committed composite head CID from the headstore,
+/// then fetches the corresponding block bytes from the blockstore.
+///
+/// Use this instead of `build_blocks_from_document` for P2P broadcast after
+/// updates/deletes, since `build_blocks_from_document` recreates blocks from
+/// scratch with wrong priority/heads.
+pub async fn read_latest_composite_block<S: storage::corekv::Store>(
+    db: &crate::database::DB<S>,
+    doc_id: &str,
+) -> Result<BlockResult, String> {
+    let txn = db
+        .new_txn(true)
+        .await
+        .map_err(|e| format!("Failed to create read txn: {}", e))?;
+
+    let headstore = txn
+        .headstore()
+        .map_err(|e| format!("Failed to get headstore: {}", e))?;
+
+    let composite_head = get_field_head(&headstore, doc_id, "C").await?;
+
+    let composite_cid = composite_head
+        .cid
+        .ok_or_else(|| format!("No composite head found for doc {}", doc_id))?;
+
+    let blockstore = txn
+        .blockstore()
+        .map_err(|e| format!("Failed to get blockstore: {}", e))?;
+
+    let block_bytes = blockstore
+        .get(&composite_cid.to_bytes())
+        .await
+        .map_err(|e| format!("Failed to read composite block: {}", e))?
+        .ok_or_else(|| format!("Composite block not found for CID {}", composite_cid))?;
+
+    let _ = txn.force_discard();
+
+    Ok(BlockResult {
+        cid: composite_cid,
+        block: block_bytes,
+        doc_id: doc_id.to_string(),
+        field_cids: vec![],
+    })
+}
+
 /// **WARNING**: This creates raw document CBOR, not a proper Block structure.
 /// Go DefraDB cannot parse this format. Use `build_blocks_from_document` instead.
 ///

--- a/crates/db/src/broadcast_mutator.rs
+++ b/crates/db/src/broadcast_mutator.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use storage::corekv::Store;
 
 use crate::auto_commit_mutator::AutoCommitMutator;
-use crate::block_builder::build_blocks_from_document;
+use crate::block_builder::{build_blocks_from_document, read_latest_composite_block};
 use crate::database::DB;
 
 /// Document mutator that broadcasts changes to P2P network.
@@ -29,8 +29,8 @@ use crate::database::DB;
 ///
 /// # Broadcast Behavior
 ///
-/// - **Create/Update**: Builds proper Block structures and broadcasts to network
-/// - **Delete**: Currently not broadcast (tombstone support pending)
+/// - **Create**: Builds proper Block structures and broadcasts to network
+/// - **Update/Delete**: Reads the committed composite block and broadcasts it
 ///
 /// # Error Handling
 ///
@@ -179,7 +179,6 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
             .get_collection(collection_name)
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
-        let version_id = collection.version_id().to_string();
         let collection_id = collection.collection_id().to_string();
 
         // Execute the update mutation
@@ -188,8 +187,8 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
             .update(collection_name, doc, modified_fields)
             .await?;
 
-        // Always broadcast the composite block first (ensures composite + field blocks
-        // are available on the receiver before any collection block processing).
+        // Use the committed block directly when available (from ffi/query),
+        // falling back to reading from storage.
         let doc_id_for_broadcast = result
             .document
             .id()
@@ -199,26 +198,20 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
             if let (Some(cid), Some(block)) = (result.commit_cid, result.commit_block.as_ref()) {
                 (cid, block.clone(), doc_id_for_broadcast)
             } else {
-                // Fallback: build blocks if commit data not available
-                match build_blocks_from_document(
-                    &result.document,
-                    &version_id,
-                    self.sync.blockstore(),
-                )
-                .await
-                {
+                // Fallback: read committed composite block from storage
+                match read_latest_composite_block(&self.db, &doc_id_for_broadcast).await {
                     Ok(br) => (br.cid, br.block, br.doc_id),
                     Err(e) => {
                         tracing::error!(
                             doc_id = %doc_id_for_broadcast,
                             collection = %collection_name,
                             error = %e,
-                            "Failed to build blocks for P2P broadcast"
+                            "Failed to read composite block for P2P broadcast"
                         );
                         return Ok(UpdateResult::with_broadcast(
                             result.document,
                             result.fields_modified,
-                            BroadcastStatus::Failed(format!("Block build failed: {}", e)),
+                            BroadcastStatus::Failed(format!("Block read failed: {}", e)),
                         ));
                     }
                 }
@@ -285,28 +278,53 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<DeleteResult> {
-        // Execute the delete mutation
-        let result = self.inner.delete(collection_name, doc_id).await?;
-
-        // Get collection ID for logging
-        let _collection = self
+        // Get collection ID for broadcast
+        let collection = self
             .db
             .get_collection(collection_name)
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+        let collection_id = collection.collection_id().to_string();
 
-        // Delete broadcast requires tombstone block creation, which is not yet implemented.
-        // Return NotAttempted status so callers know delete was not broadcast.
-        tracing::debug!(
-            doc_id = %doc_id,
-            collection = %collection_name,
-            "Document deleted locally (P2P delete broadcast not yet implemented)"
-        );
+        // Execute the delete mutation
+        let result = self.inner.delete(collection_name, doc_id).await?;
+
+        // Read the delete composite block that was written during the mutation.
+        let doc_id_str = doc_id.to_string();
+        let block_result = match read_latest_composite_block(&self.db, &doc_id_str).await {
+            Ok(br) => br,
+            Err(e) => {
+                tracing::error!(
+                    doc_id = %doc_id,
+                    collection = %collection_name,
+                    error = %e,
+                    "Failed to read delete composite block for P2P broadcast"
+                );
+                return Ok(DeleteResult::with_broadcast(
+                    result.doc_id,
+                    result.existed,
+                    BroadcastStatus::Failed(format!("Block read failed: {}", e)),
+                ));
+            }
+        };
+
+        // Push to replicators and broadcast via GossipSub
+        self.sync
+            .push_to_replicators(
+                &block_result.cid,
+                &block_result.block,
+                &block_result.doc_id,
+                &collection_id,
+            )
+            .await;
+
+        let broadcast_status =
+            broadcast_with_retry(&self.sync, &block_result, &collection_id, collection_name).await;
 
         Ok(DeleteResult::with_broadcast(
             result.doc_id,
             result.existed,
-            BroadcastStatus::NotAttempted,
+            broadcast_status,
         ))
     }
 

--- a/crates/db/src/broadcast_mutator.rs
+++ b/crates/db/src/broadcast_mutator.rs
@@ -79,34 +79,31 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
 
         // Always broadcast the composite block first (ensures composite + field blocks
         // are available on the receiver before any collection block processing).
-        let (cid, block, doc_id_str) =
-            if let (Some(cid), Some(block)) = (result.commit_cid, result.commit_block.as_ref()) {
-                (cid, block.clone(), result.doc_id.to_string())
-            } else {
-                // Fallback: build blocks if commit data not available
-                match build_blocks_from_document(
-                    &result.document,
-                    &version_id,
-                    self.sync.blockstore(),
-                )
+        let (cid, block, doc_id_str) = if let (Some(cid), Some(block)) =
+            (result.commit_cid, result.commit_block.as_ref())
+        {
+            (cid, block.clone(), result.doc_id.to_string())
+        } else {
+            // Fallback: build blocks if commit data not available
+            match build_blocks_from_document(&result.document, &version_id, self.sync.blockstore())
                 .await
-                {
-                    Ok(br) => (br.cid, br.block, br.doc_id),
-                    Err(e) => {
-                        tracing::error!(
-                            doc_id = %result.doc_id,
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to build blocks for P2P broadcast"
-                        );
-                        return Ok(CreateResult::with_broadcast(
-                            result.doc_id,
-                            result.document,
-                            BroadcastStatus::Failed(format!("Block build failed: {}", e)),
-                        ));
-                    }
+            {
+                Ok(br) => (br.cid, br.block, br.doc_id),
+                Err(e) => {
+                    tracing::error!(
+                        doc_id = %result.doc_id,
+                        collection = %collection_name,
+                        error = %e,
+                        "Failed to build blocks for P2P broadcast"
+                    );
+                    return Ok(CreateResult::with_broadcast(
+                        result.doc_id,
+                        result.document,
+                        BroadcastStatus::Failed(format!("Block build failed: {}", e)),
+                    ));
                 }
-            };
+            }
+        };
 
         let block_result = BlockResult {
             cid,

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -305,8 +305,10 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                         })?;
                         all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
                     } else {
-                        let mut iter =
-                            index.get(&datastore, std::slice::from_ref(value)).await.map_err(|e| {
+                        let mut iter = index
+                            .get(&datastore, std::slice::from_ref(value))
+                            .await
+                            .map_err(|e| {
                                 query::error::QueryError::execution(format!("index error: {}", e))
                             })?;
                         let entries = iter.collect_all().await.map_err(|e| {

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -224,18 +224,33 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         let limit = params.limit;
         let offset = params.offset;
 
-        // Helper to collect entries with optional early termination
+        // Helper to collect entries with optional early termination and value filtering.
+        // Returns (doc_ids, total_iterated) where total_iterated counts ALL entries
+        // including those filtered out (for indexFetches metrics).
         async fn collect_with_limit<I: IndexIterator>(
             iter: &mut I,
             limit: Option<u64>,
             offset: u64,
-        ) -> Result<Vec<String>, query::error::QueryError> {
+            value_filter: Option<&query::planner::index_selection::ScanValueFilter>,
+        ) -> Result<(Vec<String>, u64), query::error::QueryError> {
             let mut entries = Vec::new();
             let mut skipped = 0u64;
+            let mut total_iterated = 0u64;
 
             while let Some(entry) = iter.next().await.map_err(|e| {
                 query::error::QueryError::execution(format!("index iteration error: {}", e))
             })? {
+                total_iterated += 1;
+
+                // Apply scan-level value filter (matches Go's indexLikeMatcher)
+                if let Some(filter) = value_filter {
+                    if let Some(first_value) = entry.values.first() {
+                        if !filter.matches_value(first_value) {
+                            continue;
+                        }
+                    }
+                }
+
                 // Skip offset entries
                 if skipped < offset {
                     skipped += 1;
@@ -252,16 +267,19 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                 }
             }
 
-            Ok(entries)
+            Ok((entries, total_iterated))
         }
 
-        // Execute the appropriate scan based on scan type
-        let raw_doc_ids: Vec<String> = match &params.scan_type {
+        // Execute the appropriate scan based on scan type.
+        // Returns (doc_ids, raw_fetches) where raw_fetches counts ALL entries iterated
+        // including those filtered out by value_filter (for indexFetches metrics).
+        let vf = params.value_filter.as_ref();
+        let (raw_doc_ids, raw_fetches): (Vec<String>, u64) = match &params.scan_type {
             IndexScanType::ExactMatch { values } => {
                 let mut iter = index.get(&datastore, values).await.map_err(|e| {
                     query::error::QueryError::execution(format!("index error: {}", e))
                 })?;
-                collect_with_limit(&mut iter, limit, offset).await?
+                collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::InScan {
                 values,
@@ -320,7 +338,8 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                         all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
                     }
                 }
-                all_doc_ids
+                let count = all_doc_ids.len() as u64;
+                (all_doc_ids, count)
             }
             IndexScanType::PrefixScan {
                 prefix_values,
@@ -332,7 +351,7 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                collect_with_limit(&mut iter, limit, offset).await?
+                collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::RangeScan {
                 prefix_values,
@@ -352,12 +371,9 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                collect_with_limit(&mut iter, limit, offset).await?
+                collect_with_limit(&mut iter, limit, offset, vf).await?
             }
         };
-
-        // Track raw fetch count before deduplication (for explain metrics)
-        let raw_fetches = raw_doc_ids.len() as u64;
 
         // Deduplicate doc_ids while preserving order.
         // Array indexes can return the same document multiple times (once per array element).

--- a/crates/db/src/lensed_auto_commit_fetcher.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher.rs
@@ -697,18 +697,33 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
         let limit = params.limit;
         let offset = params.offset;
 
-        // Helper to collect entries with optional early termination
+        // Helper to collect entries with optional early termination and value filtering.
+        // Returns (doc_ids, total_iterated) where total_iterated counts ALL entries
+        // including those filtered out (for indexFetches metrics).
         async fn collect_with_limit<I: IndexIterator>(
             iter: &mut I,
             limit: Option<u64>,
             offset: u64,
-        ) -> Result<Vec<String>, query::error::QueryError> {
+            value_filter: Option<&query::planner::index_selection::ScanValueFilter>,
+        ) -> Result<(Vec<String>, u64), query::error::QueryError> {
             let mut entries = Vec::new();
             let mut skipped = 0u64;
+            let mut total_iterated = 0u64;
 
             while let Some(entry) = iter.next().await.map_err(|e| {
                 query::error::QueryError::execution(format!("index iteration error: {}", e))
             })? {
+                total_iterated += 1;
+
+                // Apply scan-level value filter (matches Go's indexLikeMatcher)
+                if let Some(filter) = value_filter {
+                    if let Some(first_value) = entry.values.first() {
+                        if !filter.matches_value(first_value) {
+                            continue;
+                        }
+                    }
+                }
+
                 // Skip offset entries
                 if skipped < offset {
                     skipped += 1;
@@ -725,16 +740,19 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                 }
             }
 
-            Ok(entries)
+            Ok((entries, total_iterated))
         }
 
-        // Execute the appropriate scan based on scan type
-        let raw_doc_ids: Vec<String> = match &params.scan_type {
+        // Execute the appropriate scan based on scan type.
+        // Returns (doc_ids, raw_fetches) where raw_fetches counts ALL entries iterated
+        // including those filtered out by value_filter (for indexFetches metrics).
+        let vf = params.value_filter.as_ref();
+        let (raw_doc_ids, raw_fetches): (Vec<String>, u64) = match &params.scan_type {
             IndexScanType::ExactMatch { values } => {
                 let mut iter = index.get(&datastore, values).await.map_err(|e| {
                     query::error::QueryError::execution(format!("index error: {}", e))
                 })?;
-                collect_with_limit(&mut iter, limit, offset).await?
+                collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::InScan {
                 values,
@@ -792,7 +810,8 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                         all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
                     }
                 }
-                all_doc_ids
+                let count = all_doc_ids.len() as u64;
+                (all_doc_ids, count)
             }
             IndexScanType::PrefixScan {
                 prefix_values,
@@ -804,7 +823,7 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                collect_with_limit(&mut iter, limit, offset).await?
+                collect_with_limit(&mut iter, limit, offset, vf).await?
             }
             IndexScanType::RangeScan {
                 prefix_values,
@@ -824,14 +843,11 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                     .map_err(|e| {
                         query::error::QueryError::execution(format!("index error: {}", e))
                     })?;
-                collect_with_limit(&mut iter, limit, offset).await?
+                collect_with_limit(&mut iter, limit, offset, vf).await?
             }
         };
 
         let _ = txn.discard();
-
-        // Track raw fetch count before deduplication (for explain metrics)
-        let raw_fetches = raw_doc_ids.len() as u64;
 
         // Deduplicate doc_ids while preserving order.
         // Array indexes can return the same document multiple times (once per array element).

--- a/crates/db/src/lensed_auto_commit_fetcher.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher.rs
@@ -777,8 +777,10 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                         })?;
                         all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
                     } else {
-                        let mut iter =
-                            index.get(&datastore, std::slice::from_ref(value)).await.map_err(|e| {
+                        let mut iter = index
+                            .get(&datastore, std::slice::from_ref(value))
+                            .await
+                            .map_err(|e| {
                                 query::error::QueryError::execution(format!("index error: {}", e))
                             })?;
                         let entries = iter.collect_all().await.map_err(|e| {

--- a/crates/db/src/merge_handler.rs
+++ b/crates/db/src/merge_handler.rs
@@ -683,10 +683,35 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     Some(collection) => {
                         is_branchable = collection.schema().is_branchable;
                         if is_delete {
-                            // Handle delete: write the deletion marker so queries
-                            // exclude this document (or show _deleted:true).
-                            // The delete composite has no field links, so field_values
-                            // is empty — but we still need to mark the doc as deleted.
+                            // Handle delete: remove index entries, then write deletion marker.
+                            // Must load the old document first so we know which index
+                            // entries to remove (Go's syncIndexedDoc does the same).
+                            if let Ok(doc_id) = DocID::from_string(&doc_id_str) {
+                                if let Ok(Some(old_doc)) =
+                                    collection.get_with_datastore(&datastore, &doc_id).await
+                                {
+                                    let short_id = collection_short_id(collection.collection_id());
+                                    if let Ok(index_manager) =
+                                        IndexManager::from_collection(short_id, collection.schema())
+                                    {
+                                        if let Err(e) = index_manager
+                                            .on_document_delete(
+                                                &datastore,
+                                                &old_doc,
+                                                collection.schema(),
+                                            )
+                                            .await
+                                        {
+                                            tracing::warn!(
+                                                doc_id = %doc_id_str,
+                                                error = %e,
+                                                "Failed to delete indexes after merge"
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+
                             let deleted_key =
                                 build_deleted_key(collection.collection_id(), &doc_id_str);
                             if let Err(e) = datastore.set(&deleted_key, &[DELETED_MARKER]).await {

--- a/crates/db/src/merge_handler.rs
+++ b/crates/db/src/merge_handler.rs
@@ -885,12 +885,11 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                         // Delete only the parent field heads (from the field block's heads)
                         if let Some(parent_cids) = field_block_heads.get(&dag_link.name) {
                             for parent_cid in parent_cids {
-                                let parent_key =
-                                    storage::keys::headstore::HeadstoreDocKey::new(
-                                        &doc_id_str,
-                                        &dag_link.name,
-                                        *parent_cid,
-                                    );
+                                let parent_key = storage::keys::headstore::HeadstoreDocKey::new(
+                                    &doc_id_str,
+                                    &dag_link.name,
+                                    *parent_cid,
+                                );
                                 let _ = headstore
                                     .delete(
                                         &<storage::keys::headstore::HeadstoreDocKey as storage::corekv::Key>::bytes(&parent_key),

--- a/crates/db/src/patch.rs
+++ b/crates/db/src/patch.rs
@@ -995,9 +995,20 @@ impl<S: Store> crate::database::DB<S> {
             depth + 1
         };
 
+        // Build collection name → collection_id map for resolving FieldKind::Named
+        let collection_id_map: std::collections::HashMap<String, String> = all_existing
+            .iter()
+            .filter(|c| c.is_active)
+            .map(|c| (c.name.clone(), c.collection_id.clone()))
+            .collect();
+
         // Generate new version_id from schema content with proper priorities
-        let new_version_id =
-            Self::generate_patch_version_id(&mut new_schema, &old_schema, version_depth);
+        let new_version_id = Self::generate_patch_version_id(
+            &mut new_schema,
+            &old_schema,
+            version_depth,
+            &collection_id_map,
+        );
 
         // Update new schema with version info
         new_schema.version_id = new_version_id.clone();
@@ -1201,12 +1212,27 @@ impl<S: Store> crate::database::DB<S> {
         schema: &mut CollectionVersion,
         old_schema: &CollectionVersion,
         version_depth: u64,
+        collection_id_map: &std::collections::HashMap<String, String>,
     ) -> String {
         use cid::Cid;
         use sha2::{Digest, Sha256};
         use std::str::FromStr;
 
         let collection_priority = version_depth + 1;
+
+        // Resolve FieldKind::Named to FieldKind::Relation before CID generation.
+        // Go's substituteRelationFieldKinds resolves named kinds to CollectionKind
+        // with the actual collection_id before generating field deltas.
+        for field in &mut schema.fields {
+            if let schema::FieldKind::Named { name, is_array } = &field.kind {
+                if let Some(col_id) = collection_id_map.get(name.as_str()) {
+                    field.kind = schema::FieldKind::Relation {
+                        collection_id: col_id.clone(),
+                        is_array: *is_array,
+                    };
+                }
+            }
+        }
 
         // Build set of old field names for detecting which fields are new
         let old_field_names: std::collections::HashSet<&str> = old_schema

--- a/crates/defra-core/src/encryption.rs
+++ b/crates/defra-core/src/encryption.rs
@@ -62,19 +62,23 @@ pub fn get_encryption_config() -> Option<EncryptionConfig> {
 /// Global per-document encryption store.
 /// Maps docID → EncryptionConfig so updates can re-apply encryption
 /// that was set during document creation.
-static DOC_ENCRYPTION_STORE: std::sync::LazyLock<Mutex<HashMap<String, EncryptionConfig>>> =
-    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+static DOC_ENCRYPTION_STORE: std::sync::OnceLock<Mutex<HashMap<String, EncryptionConfig>>> =
+    std::sync::OnceLock::new();
+
+fn doc_encryption_store() -> &'static Mutex<HashMap<String, EncryptionConfig>> {
+    DOC_ENCRYPTION_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 /// Store encryption config for a document.
 pub fn store_doc_encryption(doc_id: &str, config: EncryptionConfig) {
-    if let Ok(mut store) = DOC_ENCRYPTION_STORE.lock() {
+    if let Ok(mut store) = doc_encryption_store().lock() {
         store.insert(doc_id.to_string(), config);
     }
 }
 
 /// Retrieve stored encryption config for a document.
 pub fn get_doc_encryption(doc_id: &str) -> Option<EncryptionConfig> {
-    DOC_ENCRYPTION_STORE
+    doc_encryption_store()
         .lock()
         .ok()
         .and_then(|store| store.get(doc_id).cloned())
@@ -82,7 +86,7 @@ pub fn get_doc_encryption(doc_id: &str) -> Option<EncryptionConfig> {
 
 /// Clear all stored encryption configs (for node cleanup).
 pub fn clear_doc_encryption_store() {
-    if let Ok(mut store) = DOC_ENCRYPTION_STORE.lock() {
+    if let Ok(mut store) = doc_encryption_store().lock() {
         store.clear();
     }
 }

--- a/crates/defra-core/src/signing.rs
+++ b/crates/defra-core/src/signing.rs
@@ -40,19 +40,23 @@ pub fn get_signing_config() -> Option<SigningConfig> {
 /// Global identity store mapping DID → SigningConfig.
 /// When create_identity() generates a keypair, we store it here so that
 /// exec_request() can look up the signing key from just a DID string.
-static IDENTITY_STORE: std::sync::LazyLock<Mutex<HashMap<String, SigningConfig>>> =
-    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+static IDENTITY_STORE: std::sync::OnceLock<Mutex<HashMap<String, SigningConfig>>> =
+    std::sync::OnceLock::new();
+
+fn identity_store() -> &'static Mutex<HashMap<String, SigningConfig>> {
+    IDENTITY_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 /// Store a signing config for a DID.
 pub fn store_identity(did: &str, config: SigningConfig) {
-    if let Ok(mut store) = IDENTITY_STORE.lock() {
+    if let Ok(mut store) = identity_store().lock() {
         store.insert(did.to_string(), config);
     }
 }
 
 /// Retrieve stored signing config for a DID.
 pub fn get_identity(did: &str) -> Option<SigningConfig> {
-    IDENTITY_STORE
+    identity_store()
         .lock()
         .ok()
         .and_then(|store| store.get(did).cloned())
@@ -60,7 +64,7 @@ pub fn get_identity(did: &str) -> Option<SigningConfig> {
 
 /// Clear all stored identities (for node cleanup).
 pub fn clear_identity_store() {
-    if let Ok(mut store) = IDENTITY_STORE.lock() {
+    if let Ok(mut store) = identity_store().lock() {
         store.clear();
     }
 }

--- a/crates/ffi/src/backup.rs
+++ b/crates/ffi/src/backup.rs
@@ -218,8 +218,7 @@ pub unsafe extern "C" fn basic_export(node_ptr: usize, config_json: *const c_cha
             name_cid_pairs.push((name.clone(), col.schema().collection_id.clone()));
         }
         name_cid_pairs.sort_by(|a, b| a.1.cmp(&b.1));
-        let collection_names: Vec<String> =
-            name_cid_pairs.into_iter().map(|(n, _)| n).collect();
+        let collection_names: Vec<String> = name_cid_pairs.into_iter().map(|(n, _)| n).collect();
 
         // Three-phase export:
         // Phase 1: Query all docs, compute initial _docIDNew (including FK fields)

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -329,17 +329,12 @@ pub unsafe extern "C" fn new_node_with_p2p(
                     &config,
                 )
                 .await;
-                eprintln!("[REPL-LOOP] result={:?}", &result);
                 match &result {
                     ReplicationResult::Merged {
                         cid,
                         doc_id,
                         collection_id,
                     } => {
-                        eprintln!(
-                            "[REPL-LOOP] Publishing merge_complete cid={} doc_id={} collection={}",
-                            cid, doc_id, collection_id
-                        );
                         let mc = events::MergeCompleteData {
                             doc_id: doc_id.clone(),
                             cid: *cid,
@@ -347,16 +342,11 @@ pub unsafe extern "C" fn new_node_with_p2p(
                             by_peer: coord_for_repl.local_peer_id().to_string(),
                         };
                         event_bus_for_repl.publish(events::Message::merge_complete(mc));
-                        eprintln!("[REPL-LOOP] merge_complete published for cid={}", cid);
 
                         // Publish SE artifact received event so the Go SE coordinator
                         // bridge picks it up. The Go test framework uses this to know
                         // when encrypted index data is available after replication.
                         if !doc_id.is_empty() {
-                            eprintln!(
-                                "[REPL-LOOP] Publishing se_artifact_received for doc_id={}",
-                                doc_id
-                            );
                             event_bus_for_repl.publish(events::Message::se_artifact_received(
                                 events::SEArtifactReceivedData {
                                     doc_id: doc_id.clone(),

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -428,8 +428,10 @@ pub unsafe extern "C" fn new_node_with_p2p(
 
         // Create mutator with P2P broadcast support
         // BroadcastMutator handles push_to_replicators + GossipSub broadcast with retry
-        let mutator: Arc<dyn query::DocMutator> =
-            Arc::new(db::BroadcastMutator::new(database.clone(), coordinator.clone()));
+        let mutator: Arc<dyn query::DocMutator> = Arc::new(db::BroadcastMutator::new(
+            database.clone(),
+            coordinator.clone(),
+        ));
 
         // Create ACP store
         let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());

--- a/crates/p2p/src/host/command_handler.rs
+++ b/crates/p2p/src/host/command_handler.rs
@@ -372,8 +372,7 @@ impl<S: Store> P2PHost<S> {
 
             HostCommand::PeerAddresses { response } => {
                 // Build full multiaddrs for connected peers (matches Go's ActivePeers).
-                let connected: HashSet<PeerId> =
-                    self.swarm.connected_peers().cloned().collect();
+                let connected: HashSet<PeerId> = self.swarm.connected_peers().cloned().collect();
                 let addrs: Vec<String> = connected
                     .iter()
                     .filter_map(|pid| {
@@ -399,10 +398,8 @@ impl<S: Store> P2PHost<S> {
         response: tokio::sync::oneshot::Sender<Result<QueryId>>,
     ) {
         // Generate a query ID for tracking
-        static QUERY_COUNTER: std::sync::atomic::AtomicU64 =
-            std::sync::atomic::AtomicU64::new(0);
-        let query_id =
-            QueryId(QUERY_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
+        static QUERY_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let query_id = QueryId(QUERY_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
 
         info!(
             cid = %cid,

--- a/crates/p2p/src/host/p2p_host.rs
+++ b/crates/p2p/src/host/p2p_host.rs
@@ -37,8 +37,10 @@ pub struct P2PHost<S: Store> {
     pub(super) keypair: Keypair,
     pub(super) command_rx: mpsc::Receiver<HostCommand>,
     pub(super) event_tx: mpsc::Sender<HostEvent>,
-    pub(super) pending_requests:
-        HashMap<request_response::OutboundRequestId, tokio::sync::oneshot::Sender<Result<PushLogReply>>>,
+    pub(super) pending_requests: HashMap<
+        request_response::OutboundRequestId,
+        tokio::sync::oneshot::Sender<Result<PushLogReply>>,
+    >,
     /// Replicator registry for access control
     pub(super) replicators: Arc<ReplicatorRegistry>,
     /// Two-stream handler for Go compatibility

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -7,8 +7,8 @@ use super::SyncCoordinator;
 use crate::error::Result;
 use crate::message::PushLogRequest;
 use crate::signing::sign_message;
-use crate::sync::BroadcastResult;
 use crate::sync::broadcaster::Broadcaster;
+use crate::sync::BroadcastResult;
 
 impl<B: Blockstore + 'static> SyncCoordinator<B> {
     /// Broadcast a local update to the network.

--- a/crates/p2p/src/sync/coordinator/event_handler.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler.rs
@@ -553,33 +553,31 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
         for item in &reply.results {
             for head_bytes in &item.heads {
                 match Cid::try_from(head_bytes.as_slice()) {
-                    Ok(cid) => {
-                        match self.manager.blockstore().has(&cid).await {
-                            Ok(true) => {
-                                tracing::debug!(
-                                    cid = %cid,
-                                    doc_id = %item.doc_id,
-                                    "Already have block, skipping fetch"
-                                );
-                            }
-                            Ok(false) => {
-                                tracing::debug!(
-                                    cid = %cid,
-                                    doc_id = %item.doc_id,
-                                    "Need to fetch block via Bitswap"
-                                );
-                                cids_to_fetch.push((cid, item.doc_id.clone()));
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    cid = %cid,
-                                    error = %e,
-                                    "Failed to check if block exists"
-                                );
-                                cids_to_fetch.push((cid, item.doc_id.clone()));
-                            }
+                    Ok(cid) => match self.manager.blockstore().has(&cid).await {
+                        Ok(true) => {
+                            tracing::debug!(
+                                cid = %cid,
+                                doc_id = %item.doc_id,
+                                "Already have block, skipping fetch"
+                            );
                         }
-                    }
+                        Ok(false) => {
+                            tracing::debug!(
+                                cid = %cid,
+                                doc_id = %item.doc_id,
+                                "Need to fetch block via Bitswap"
+                            );
+                            cids_to_fetch.push((cid, item.doc_id.clone()));
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                cid = %cid,
+                                error = %e,
+                                "Failed to check if block exists"
+                            );
+                            cids_to_fetch.push((cid, item.doc_id.clone()));
+                        }
+                    },
                     Err(e) => {
                         tracing::warn!(
                             doc_id = %item.doc_id,

--- a/crates/p2p/src/sync/manager/process.rs
+++ b/crates/p2p/src/sync/manager/process.rs
@@ -26,11 +26,11 @@ use crate::error::{Error, Result};
 use crate::message::PushLogBroadcast;
 use crate::sync::PeerStateTracker;
 
+use super::super::queue::ProcessQueue;
 use super::config::SyncConfig;
 use super::events::SyncEvent;
 use super::links::{find_all_missing_links, find_missing_links};
 use super::pending::PendingDag;
-use super::super::queue::ProcessQueue;
 
 /// Manager for P2P block synchronization.
 ///

--- a/crates/p2p/src/sync/replication/loop_runner.rs
+++ b/crates/p2p/src/sync/replication/loop_runner.rs
@@ -162,7 +162,8 @@ impl ReplicationLoop {
         loop {
             match events.try_recv() {
                 Ok(event) => {
-                    let result = process_event(&coordinator, event, handler.as_ref(), &config).await;
+                    let result =
+                        process_event(&coordinator, event, handler.as_ref(), &config).await;
                     results.push(result);
                 }
                 Err(mpsc::error::TryRecvError::Empty) => break,

--- a/crates/p2p/src/two_stream/handler.rs
+++ b/crates/p2p/src/two_stream/handler.rs
@@ -170,7 +170,9 @@ impl TwoStreamHandler {
                 return Ok(Some(TwoStreamEvent::BranchableSyncReply { peer_id, reply }));
             }
             Ok(_) => {
-                tracing::trace!("BranchableSyncReply parsed but collection_id empty, trying other types");
+                tracing::trace!(
+                    "BranchableSyncReply parsed but collection_id empty, trying other types"
+                );
             }
             Err(_) => {
                 // Not a BranchableSyncReply, will try other types

--- a/crates/query/src/mapper/filter/eval/mod.rs
+++ b/crates/query/src/mapper/filter/eval/mod.rs
@@ -5,4 +5,4 @@
 
 mod operators;
 
-pub use operators::{eval_op, values_equal};
+pub use operators::{eval_op, like_pattern_match, values_equal};

--- a/crates/query/src/mapper/filter/eval/operators.rs
+++ b/crates/query/src/mapper/filter/eval/operators.rs
@@ -293,17 +293,17 @@ fn like_match(
     negate: bool,
     case_insensitive: bool,
 ) -> Result<bool> {
-    // Null and non-string fields never match _like or _nlike (Go DefraDB behavior).
-    // Both _like and _nlike return false for non-string values.
+    // Null and non-string values can't match a LIKE pattern.
+    // For _like: false (no match). For _nlike: true (doesn't match the pattern).
     if actual.is_null() {
-        return Ok(false);
+        return Ok(negate);
     }
 
     let op_name = if case_insensitive { "_ilike" } else { "_like" };
 
     let actual_str = match actual.as_str() {
         Some(s) => s,
-        None => return Ok(false),
+        None => return Ok(negate),
     };
     let pattern_str = pattern.as_str().ok_or_else(|| {
         QueryError::invalid_filter(format!("{} requires string pattern", op_name))

--- a/crates/query/src/mapper/filter/eval/operators.rs
+++ b/crates/query/src/mapper/filter/eval/operators.rs
@@ -293,18 +293,17 @@ fn like_match(
     negate: bool,
     case_insensitive: bool,
 ) -> Result<bool> {
-    // Null fields never match (standard database behavior, matches Go DefraDB)
+    // Null and non-string fields never match _like or _nlike (Go DefraDB behavior).
+    // Both _like and _nlike return false for non-string values.
     if actual.is_null() {
-        return Ok(negate);
+        return Ok(false);
     }
 
     let op_name = if case_insensitive { "_ilike" } else { "_like" };
 
-    // Non-string fields don't match _like (return false, not error)
-    // This matches Go DefraDB behavior for JSON fields with mixed types
     let actual_str = match actual.as_str() {
         Some(s) => s,
-        None => return Ok(negate), // Non-string doesn't match, so _like=false, _nlike=true
+        None => return Ok(false),
     };
     let pattern_str = pattern.as_str().ok_or_else(|| {
         QueryError::invalid_filter(format!("{} requires string pattern", op_name))

--- a/crates/query/src/mapper/filter/filter_impl.rs
+++ b/crates/query/src/mapper/filter/filter_impl.rs
@@ -791,8 +791,8 @@ mod tests {
     }
 
     #[test]
-    fn test_nilike_null_field_returns_true() {
-        // Negated: null field with _nilike should return true (null doesn't match pattern)
+    fn test_nilike_null_field_returns_false() {
+        // Go returns false for _nilike with null (non-string values always return false)
         let filter = Filter::from_conditions(HashMap::from([(
             "name".to_string(),
             json!({"_nilike": "Ali%"}),
@@ -800,7 +800,7 @@ mod tests {
         let mapping = make_mapping();
         let mut fields = make_fields();
         fields[1] = Some(json!(null)); // name is null
-        assert!(filter.matches(&fields, &mapping).unwrap());
+        assert!(!filter.matches(&fields, &mapping).unwrap());
     }
 
     // Helper to create mapping with array and object fields for testing

--- a/crates/query/src/mapper/filter/mod.rs
+++ b/crates/query/src/mapper/filter/mod.rs
@@ -25,4 +25,5 @@ mod split;
 pub use op::FilterOp;
 
 // Re-export everything from filter_impl for backwards compatibility
+pub use eval::like_pattern_match;
 pub use filter_impl::*;

--- a/crates/query/src/mapper/filter/relation.rs
+++ b/crates/query/src/mapper/filter/relation.rs
@@ -108,18 +108,14 @@ impl Filter {
                         if let Some(obj) = item.as_object() {
                             if let Some(rel_value) = obj.get(relation_field) {
                                 if let Some(rel_obj) = rel_value.as_object() {
-                                    let is_nested = rel_obj
-                                        .keys()
-                                        .any(|k| FilterOp::parse(k).is_none());
+                                    let is_nested =
+                                        rel_obj.keys().any(|k| FilterOp::parse(k).is_none());
                                     if is_nested {
-                                        let nested_conditions: HashMap<String, JsonValue> =
-                                            rel_obj
-                                                .iter()
-                                                .map(|(k, v)| (k.clone(), v.clone()))
-                                                .collect();
-                                        return Some(Filter::from_conditions(
-                                            nested_conditions,
-                                        ));
+                                        let nested_conditions: HashMap<String, JsonValue> = rel_obj
+                                            .iter()
+                                            .map(|(k, v)| (k.clone(), v.clone()))
+                                            .collect();
+                                        return Some(Filter::from_conditions(nested_conditions));
                                     }
                                 }
                             }
@@ -281,9 +277,7 @@ impl Filter {
                         if let Some(obj) = item.as_object() {
                             let nested: HashMap<String, JsonValue> =
                                 obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-                            if let Some(filter) =
-                                Self::extract_at_path_recursive(&nested, path)
-                            {
+                            if let Some(filter) = Self::extract_at_path_recursive(&nested, path) {
                                 return Some(filter);
                             }
                         }

--- a/crates/query/src/mapper/mod.rs
+++ b/crates/query/src/mapper/mod.rs
@@ -4,7 +4,7 @@ mod filter;
 mod mutation;
 mod types;
 
-pub use filter::{Filter, FilterOp};
+pub use filter::{like_pattern_match, Filter, FilterOp};
 pub use mutation::{parse_mutation_name, Mutation, MutationType};
 pub use types::{
     Aggregate, AggregateTarget, AggregateType, Field, GroupBy, Limit, OrderBy, OrderCondition,

--- a/crates/query/src/plan/select.rs
+++ b/crates/query/src/plan/select.rs
@@ -16,8 +16,11 @@ pub struct SelectNode {
     source: Box<dyn PlanNode>,
     /// Document mapping for this select
     document_mapping: DocumentMapping,
-    /// Optional additional filter
+    /// Optional additional filter (applied during next())
     filter: Option<Filter>,
+    /// Optional explain-only filter (shown in explain output but NOT applied during next()).
+    /// Used for relation filters that are already handled by TypeJoin nodes.
+    explain_filter: Option<Filter>,
     /// Optional document IDs for filtering (used in explain output)
     doc_ids: Option<Vec<String>>,
     /// Current document
@@ -35,6 +38,7 @@ impl SelectNode {
             source,
             document_mapping,
             filter: None,
+            explain_filter: None,
             doc_ids: None,
             current_doc: Doc::default(),
             exec_info: ExecInfo::default(),
@@ -45,6 +49,13 @@ impl SelectNode {
     /// Set an additional filter
     pub fn with_filter(mut self, filter: Filter) -> Self {
         self.filter = Some(filter);
+        self
+    }
+
+    /// Set a filter for explain display only (not applied during execution).
+    /// Used for relation filters handled by TypeJoin nodes.
+    pub fn with_explain_filter(mut self, filter: Filter) -> Self {
+        self.explain_filter = Some(filter);
         self
     }
 
@@ -296,7 +307,9 @@ impl PlanNode for SelectNode {
 
         // Go DefraDB format: always include filter (null if none)
         // Strip _docID conditions - Go handles doc_ids separately and doesn't show them as filters
-        if let Some(ref filter) = self.filter {
+        // Use explain_filter as fallback when no real filter is set (for relation filter display).
+        let display_filter = self.filter.as_ref().or(self.explain_filter.as_ref());
+        if let Some(filter) = display_filter {
             let conditions = filter.conditions();
             let stripped = super::strip_docid_from_conditions(conditions);
             obj.insert("filter".to_string(), stripped);
@@ -338,9 +351,12 @@ impl PlanNode for SelectNode {
 
     fn exec_info(&self) -> ExecInfo {
         let mut info = self.exec_info.clone();
-        // Propagate indexes_fetched from source (e.g., IndexScanNode wrapped by this SelectNode)
+        // Propagate storage-level metrics from source (e.g., IndexScanNode wrapped by this SelectNode).
+        // SelectNode doesn't do I/O itself - docs/fields/indexes are counted by the source.
         let source_info = self.source.exec_info();
         info.indexes_fetched = source_info.indexes_fetched;
+        info.docs_fetched = source_info.docs_fetched;
+        info.fields_fetched = source_info.fields_fetched;
         info
     }
 

--- a/crates/query/src/plan/select.rs
+++ b/crates/query/src/plan/select.rs
@@ -130,7 +130,7 @@ impl SelectNode {
 
         // Check if root contains another typeIndexJoin (indicating a chain)
         let root_obj = root.as_object()?;
-        root_obj.get("typeIndexJoin")?; // Single join if absent, no parallelNode needed
+        root_obj.get("typeIndexJoin")?;
 
         // Walk the chain collecting all joins and finding the innermost root
         let mut joins_data: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
@@ -187,7 +187,7 @@ impl SelectNode {
         let join_content = obj.get("typeIndexJoin")?.as_object()?;
 
         // Check if this join contains another typeIndexJoin (indicating a chain)
-        join_content.get("typeIndexJoin")?; // Single join if absent, no parallelNode needed
+        join_content.get("typeIndexJoin")?;
 
         // Walk the chain collecting all joins
         let mut joins_data: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();

--- a/crates/query/src/plan/type_join/direction.rs
+++ b/crates/query/src/plan/type_join/direction.rs
@@ -18,4 +18,13 @@ pub enum JoinDirection {
     /// Inverted join: child has FK field, parent does not.
     /// Lookup: child.FK_field == parent._docID
     Inverted,
+    /// Inverted index join: child scanned first with index, parent looked up
+    /// per-child via FK index. Used when both child's filtered field and
+    /// parent's FK field are indexed.
+    InvertedIndex {
+        /// Name of the index on the parent's FK field
+        parent_fk_index_name: String,
+        /// Index of the FK field in the parent's document mapping
+        parent_fk_field_index: usize,
+    },
 }

--- a/crates/query/src/plan/type_join/direction.rs
+++ b/crates/query/src/plan/type_join/direction.rs
@@ -27,4 +27,12 @@ pub enum JoinDirection {
         /// Index of the FK field in the parent's document mapping
         parent_fk_field_index: usize,
     },
+    /// Ordered inverted join (primary-first): child has FK and drives iteration
+    /// in sorted order via index. Parent is looked up by docID for each child.
+    /// Used when ordering by a child field that has an index and the child
+    /// holds the FK to the parent (e.g., Device._ownerID → User).
+    OrderedInvertedPrimary {
+        /// Index of the FK field in the child's document mapping (e.g., _ownerID index)
+        child_fk_index: usize,
+    },
 }

--- a/crates/query/src/plan/type_join/type_join_many.rs
+++ b/crates/query/src/plan/type_join/type_join_many.rs
@@ -86,6 +86,15 @@ pub struct TypeJoinMany {
     /// Used to simulate Go's per-parent filteredFetcher behavior for explain metrics
     /// when a child limit is set.
     child_scan_order: Vec<(String, u64)>,
+    /// Optional separate child plan for indexed relation filter evaluation.
+    /// When present, this plan uses an index to find children matching the
+    /// relation filter. The main child_plan still provides ALL children for display.
+    /// This matches Go's inverted index join behavior.
+    filter_child_plan: Option<Box<dyn PlanNode>>,
+    /// Cache of children from filter_child_plan, indexed by FK value.
+    filter_child_cache: HashMap<String, Vec<Doc>>,
+    /// FK field index in the filter child plan's documents.
+    filter_child_fk_index: Option<usize>,
 }
 
 impl std::fmt::Debug for TypeJoinMany {
@@ -159,6 +168,9 @@ impl TypeJoinMany {
             total_fields_per_scan: 0,
             per_parent_child_scan: false,
             child_scan_order: Vec::new(),
+            filter_child_plan: None,
+            filter_child_cache: HashMap::new(),
+            filter_child_fk_index: None,
         })
     }
 
@@ -221,6 +233,22 @@ impl TypeJoinMany {
     /// per-parent limit applied during the scan.
     pub fn with_per_parent_child_scan(mut self) -> Self {
         self.per_parent_child_scan = true;
+        self
+    }
+
+    /// Set a separate filter child plan for indexed relation filter evaluation.
+    ///
+    /// When set, this plan uses an index to find children matching the relation
+    /// filter. The main child_plan still provides ALL children for display.
+    /// This avoids narrowing the display scan while still getting indexed filter evaluation.
+    pub fn with_filter_child_plan(mut self, plan: Box<dyn PlanNode>) -> Self {
+        // Determine the FK field index in the filter plan's mapping
+        let fk_name = schema::CollectionVersion::relation_id_field_name(
+            self.child_side.relation_field().name.as_str(),
+        );
+        let fk_idx = plan.document_map().first_index_of_name(&fk_name);
+        self.filter_child_fk_index = fk_idx;
+        self.filter_child_plan = Some(plan);
         self
     }
 
@@ -537,13 +565,28 @@ impl TypeJoinMany {
     /// Returns false if:
     /// - There are no child documents (empty relation can't pass any filter)
     /// - No child document passes the filter conditions
-    fn check_relation_filter(&self, children: &[Doc], rel_filter: &RelationFilter) -> Result<bool> {
+    fn check_relation_filter(
+        &self,
+        children: &[Doc],
+        rel_filter: &RelationFilter,
+        use_filter_mapping: bool,
+    ) -> Result<bool> {
         if children.is_empty() {
             return Ok(false);
         }
 
+        // Use filter_child_plan's mapping when evaluating filter_child_cache children,
+        // otherwise use child_plan's mapping.
+        let child_mapping = if use_filter_mapping {
+            self.filter_child_plan
+                .as_ref()
+                .map(|p| p.document_map())
+                .unwrap_or(self.child_plan.document_map())
+        } else {
+            self.child_plan.document_map()
+        };
+
         // Check if any child passes the filter
-        let child_mapping = self.child_plan.document_map();
         for child in children {
             if rel_filter
                 .conditions
@@ -624,21 +667,32 @@ impl TypeJoinMany {
             self.go_child_metrics.field_fetches += child_info.fields_fetched;
             self.go_child_metrics.index_fetches += child_info.indexes_fetched;
 
-            // If limit was reached early, add the partial index fetches
-            // (Go stops scanning when limit reached, so indexFetches = entries scanned)
+            // If limit was reached early, override index fetches with actual entries scanned.
+            // Go stops scanning when limit reached, counting ALL index entries examined
+            // (including those filtered out by residual filters like _like).
+            // child_info.docs_fetched counts entries iterated in IndexScanNode.next(),
+            // including those skipped by the residual filter, which matches Go's behavior.
             if limit_reached {
-                // Override: Go counts only the entries actually scanned, not all
-                // The child plan may have fetched all from index, but Go would have stopped.
-                // We approximate with matching_count since Go scans until limit matches.
                 self.go_child_metrics.index_fetches -= child_info.indexes_fetched;
-                self.go_child_metrics.index_fetches += total_scanned;
+                self.go_child_metrics.index_fetches += child_info.docs_fetched;
             }
 
             self.child_plan.close().await?;
 
             // Apply relation filter if present
             if let Some(ref rel_filter) = self.relation_filter {
-                if !self.check_relation_filter(&all_children, rel_filter)? {
+                // Use filter_child_cache (from indexed filter plan) when available,
+                // otherwise use per-parent scanned children.
+                let use_filter = self.filter_child_plan.is_some();
+                let filter_children = if use_filter {
+                    self.filter_child_cache
+                        .get(&parent_doc_id)
+                        .map(|docs| docs.iter().map(|d| d.deep_clone()).collect())
+                        .unwrap_or_default()
+                } else {
+                    all_children.clone()
+                };
+                if !self.check_relation_filter(&filter_children, rel_filter, use_filter)? {
                     continue;
                 }
             }
@@ -705,6 +759,29 @@ impl PlanNode for TypeJoinMany {
         self.total_children_in_cache = 0;
         self.total_fields_per_scan = 0;
         self.child_scan_order.clear();
+        self.filter_child_cache.clear();
+
+        // Build filter child cache if present (indexed relation filter evaluation)
+        let filter_index_fetches = if let Some(ref mut filter_plan) = self.filter_child_plan {
+            filter_plan.init().await?;
+            filter_plan.start().await?;
+            while filter_plan.next().await? {
+                let doc = filter_plan.value();
+                if let Some(fk_idx) = self.filter_child_fk_index {
+                    if let Some(fk) = doc.get(fk_idx).and_then(|v| v.as_str()) {
+                        self.filter_child_cache
+                            .entry(fk.to_string())
+                            .or_default()
+                            .push(doc.deep_clone());
+                    }
+                }
+            }
+            let fetches = filter_plan.exec_info().indexes_fetched;
+            filter_plan.close().await?;
+            Some(fetches)
+        } else {
+            None
+        };
 
         if self.per_parent_child_scan {
             // Per-parent mode: don't cache, we'll re-scan per parent in next()
@@ -715,6 +792,12 @@ impl PlanNode for TypeJoinMany {
             // Then init parent plan
             self.parent_plan.init().await?;
         }
+
+        // Add filter child plan's index_fetches to the display child's
+        if let Some(fetches) = filter_index_fetches {
+            self.go_child_metrics.index_fetches += fetches;
+        }
+
         self.initialized = true;
         Ok(())
     }
@@ -768,8 +851,18 @@ impl PlanNode for TypeJoinMany {
 
             // Apply relation filter if present (check against ALL children, not just limited)
             if let Some(ref rel_filter) = self.relation_filter {
-                let all_children = self.get_all_children(&parent_doc_id);
-                if !self.check_relation_filter(&all_children, rel_filter)? {
+                // Use filter_child_cache (from indexed filter plan) when available,
+                // otherwise fall back to child_cache (display plan).
+                let use_filter = self.filter_child_plan.is_some();
+                let filter_children = if use_filter {
+                    self.filter_child_cache
+                        .get(&parent_doc_id)
+                        .map(|docs| docs.iter().map(|d| d.deep_clone()).collect())
+                        .unwrap_or_default()
+                } else {
+                    self.get_all_children(&parent_doc_id)
+                };
+                if !self.check_relation_filter(&filter_children, rel_filter, use_filter)? {
                     // No children pass the filter - skip this parent
                     continue;
                 }
@@ -845,6 +938,8 @@ impl PlanNode for TypeJoinMany {
         // child_plan was already closed in build_child_cache()
         self.child_cache.clear();
         self.child_scan_order.clear();
+        self.filter_child_cache.clear();
+        // filter_child_plan was already closed in init()
         self.initialized = false;
         Ok(())
     }

--- a/crates/query/src/plan/type_join/type_join_one.rs
+++ b/crates/query/src/plan/type_join/type_join_one.rs
@@ -374,6 +374,7 @@ impl TypeJoinOne {
                 },
                 limit: None,
                 offset: 0,
+                value_filter: None,
             };
 
             // Create and run an IndexScanNode for the parent lookup

--- a/crates/query/src/plan/type_join/type_join_one.rs
+++ b/crates/query/src/plan/type_join/type_join_one.rs
@@ -1,13 +1,18 @@
 //! TypeJoinOne - one-to-one relation joins
 
 use async_trait::async_trait;
+use document::NormalValue;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::warn;
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
+use crate::fetcher::DocFetcher;
 use crate::mapper::Filter;
+use crate::plan::IndexScanNode;
+use crate::planner::index_selection::{IndexScanParams, IndexScanType};
 use crate::planner::{Doc, ExecInfo, PlanNode};
 
 use super::{JoinChildMetrics, JoinDirection, JoinSide};
@@ -72,6 +77,14 @@ pub struct TypeJoinOne {
     /// Go re-initializes the child scan per parent with a specific docID prefix,
     /// calling Next() exactly once per parent. Metrics accumulate across parents.
     go_child_metrics: JoinChildMetrics,
+    /// For InvertedIndex mode: fetcher for creating per-child parent lookups
+    fetcher: Option<Arc<dyn DocFetcher>>,
+    /// For InvertedIndex mode: parent collection schema
+    parent_collection: Option<schema::CollectionVersion>,
+    /// For InvertedIndex mode: parent document mapping for per-child lookups
+    parent_scan_mapping: Option<DocumentMapping>,
+    /// For InvertedIndex mode: queue of parent docs to yield
+    docs_to_yield: Vec<Doc>,
 }
 
 /// A filter condition on a relation field.
@@ -134,6 +147,10 @@ impl TypeJoinOne {
             exec_info: ExecInfo::default(),
             child_exec_info: ExecInfo::default(),
             go_child_metrics: JoinChildMetrics::new(),
+            fetcher: None,
+            parent_collection: None,
+            parent_scan_mapping: None,
+            docs_to_yield: Vec::new(),
         }
     }
 
@@ -144,6 +161,28 @@ impl TypeJoinOne {
     /// `Book(filter: {author: {verified: {_eq: true}}})`.
     pub fn with_relation_filter(mut self, filter: RelationFilter) -> Self {
         self.relation_filter = Some(filter);
+        self
+    }
+
+    /// Configure for inverted index join mode.
+    ///
+    /// In this mode, the child is scanned first using its index, then for each
+    /// child doc we look up the parent by its FK index (FK field == child's _docID).
+    pub fn with_inverted_index(
+        mut self,
+        fk_index_name: String,
+        fk_field_index: usize,
+        parent_collection: schema::CollectionVersion,
+        parent_scan_mapping: DocumentMapping,
+        fetcher: Arc<dyn DocFetcher>,
+    ) -> Self {
+        self.direction = JoinDirection::InvertedIndex {
+            parent_fk_index_name: fk_index_name,
+            parent_fk_field_index: fk_field_index,
+        };
+        self.parent_collection = Some(parent_collection);
+        self.parent_scan_mapping = Some(parent_scan_mapping);
+        self.fetcher = Some(fetcher);
         self
     }
 
@@ -160,6 +199,10 @@ impl TypeJoinOne {
     /// Logs a warning if the FK field has an unexpected type or is missing.
     fn extract_fk(&self, parent_doc: &Doc) -> Option<String> {
         match &self.direction {
+            JoinDirection::InvertedIndex { .. } => {
+                // Not used in inverted index mode (child drives the loop)
+                None
+            }
             JoinDirection::Inverted => {
                 // Secondary side: use parent's _docID as the lookup key
                 let doc_id = parent_doc.doc_id();
@@ -242,6 +285,10 @@ impl TypeJoinOne {
                     let fk_value = child_fk_idx.and_then(|idx| child_doc.get(idx).cloned());
                     fk_value.and_then(|v| v.as_str().map(String::from))
                 }
+                JoinDirection::InvertedIndex { .. } => {
+                    // build_child_cache is not called in InvertedIndex mode
+                    unreachable!()
+                }
             };
 
             if let Some(k) = key {
@@ -263,6 +310,96 @@ impl TypeJoinOne {
 
         self.child_plan.close().await?;
         Ok(())
+    }
+
+    /// Execute one step of the inverted index join.
+    ///
+    /// In this mode, the child plan (index scan on child's filtered field) drives
+    /// the outer loop. For each child, we look up the parent by creating an
+    /// IndexScanNode on the parent's FK field (FK == child._docID).
+    async fn next_inverted_index(&mut self) -> Result<bool> {
+        // If we have queued parent docs from a previous child, yield one
+        if let Some(doc) = self.docs_to_yield.pop() {
+            self.current_doc = doc;
+            return Ok(true);
+        }
+
+        let fk_index_name = match &self.direction {
+            JoinDirection::InvertedIndex {
+                parent_fk_index_name,
+                ..
+            } => parent_fk_index_name.clone(),
+            _ => unreachable!(),
+        };
+
+        while self.child_plan.next().await? {
+            let child_doc = self.child_plan.value().deep_clone();
+
+            // Extract child's _docID to look up parent
+            let child_doc_id = match child_doc.doc_id() {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+
+            // Build index scan params: ExactMatch on FK field = child_docID
+            let params = IndexScanParams {
+                index_name: fk_index_name.clone(),
+                scan_type: IndexScanType::ExactMatch {
+                    values: vec![NormalValue::String(child_doc_id)],
+                },
+                limit: None,
+                offset: 0,
+            };
+
+            // Create and run an IndexScanNode for the parent lookup
+            let parent_collection = self.parent_collection.as_ref().unwrap().clone();
+            let parent_mapping = self.parent_scan_mapping.as_ref().unwrap().clone();
+            let fetcher = self.fetcher.as_ref().unwrap().clone();
+
+            let mut index_scan =
+                IndexScanNode::new(parent_collection, parent_mapping, params).with_fetcher(fetcher);
+
+            index_scan.init().await?;
+            index_scan.start().await?;
+
+            let mut parent_docs = Vec::new();
+            while index_scan.next().await? {
+                parent_docs.push(index_scan.value().deep_clone());
+            }
+
+            let scan_info = index_scan.exec_info();
+            index_scan.close().await?;
+
+            // Track parent FK index fetches
+            self.go_child_metrics.index_fetches += scan_info.indexes_fetched;
+            self.go_child_metrics.iterations += scan_info.iterations;
+            self.go_child_metrics.doc_fetches += scan_info.docs_fetched;
+            self.go_child_metrics.field_fetches += scan_info.fields_fetched;
+
+            if parent_docs.is_empty() {
+                continue;
+            }
+
+            // Merge child into each parent and queue for yielding
+            for mut parent_doc in parent_docs {
+                // Apply relation filter if present
+                if let Some(ref rel_filter) = self.relation_filter {
+                    if !self.check_relation_filter(&Some(child_doc.deep_clone()), rel_filter)? {
+                        continue;
+                    }
+                }
+
+                self.merge_child(&mut parent_doc, Some(child_doc.deep_clone()));
+                self.docs_to_yield.push(parent_doc);
+            }
+
+            if let Some(doc) = self.docs_to_yield.pop() {
+                self.current_doc = doc;
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
     }
 
     /// Merge child document into parent at the relation field index.
@@ -292,7 +429,10 @@ impl TypeJoinOne {
         // For inverted joins, also set the parent's _relID field (e.g., `_authorID`)
         // with the child's _docID. This matches Go DefraDB's behavior where the
         // secondary side's relation ID is dynamically populated at query time.
-        if matches!(self.direction, JoinDirection::Inverted) {
+        if matches!(
+            self.direction,
+            JoinDirection::Inverted | JoinDirection::InvertedIndex { .. }
+        ) {
             let rel_id_field_name = schema::CollectionVersion::relation_id_field_name(
                 &self.parent_side.relation_field().name,
             );
@@ -368,17 +508,31 @@ impl PlanNode for TypeJoinOne {
         self.exec_info = ExecInfo::default();
         self.child_exec_info = ExecInfo::default();
         self.go_child_metrics.reset();
+        self.docs_to_yield.clear();
 
-        // Build child cache first (scans child_plan once)
-        self.build_child_cache().await?;
-        // Then init parent plan
-        self.parent_plan.init().await?;
+        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
+            // InvertedIndex mode: only init the child plan (index scan on child).
+            // Parent lookups happen per-child in next_inverted_index().
+            self.child_plan.init().await?;
+            self.child_plan.start().await?;
+            // Capture child's index fetches from init (the initial index scan)
+            self.child_exec_info = self.child_plan.exec_info();
+        } else {
+            // Normal mode: build child cache, then init parent
+            self.build_child_cache().await?;
+            self.parent_plan.init().await?;
+        }
         self.initialized = true;
         Ok(())
     }
 
     async fn start(&mut self) -> Result<()> {
-        self.parent_plan.start().await
+        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
+            // Child plan already started in init()
+            Ok(())
+        } else {
+            self.parent_plan.start().await
+        }
     }
 
     async fn next(&mut self) -> Result<bool> {
@@ -390,6 +544,10 @@ impl PlanNode for TypeJoinOne {
 
         // Track iterations (Go counts each call to next, including final false)
         self.exec_info.iterations += 1;
+
+        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
+            return self.next_inverted_index().await;
+        }
 
         loop {
             if !self.parent_plan.next().await? {
@@ -452,9 +610,15 @@ impl PlanNode for TypeJoinOne {
     }
 
     async fn close(&mut self) -> Result<()> {
-        self.parent_plan.close().await?;
-        // child_plan was already closed in build_child_cache()
+        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
+            // InvertedIndex mode: child_plan is still open, parent_plan was never used
+            self.child_plan.close().await?;
+        } else {
+            self.parent_plan.close().await?;
+            // child_plan was already closed in build_child_cache()
+        }
         self.child_cache.clear();
+        self.docs_to_yield.clear();
         self.initialized = false;
         Ok(())
     }
@@ -479,7 +643,7 @@ impl PlanNode for TypeJoinOne {
         // direction: primary or secondary (Go uses "secondary" not "inverted")
         let direction = match self.direction {
             JoinDirection::Primary { .. } => "primary",
-            JoinDirection::Inverted => "secondary",
+            JoinDirection::Inverted | JoinDirection::InvertedIndex { .. } => "secondary",
         };
         obj.insert("direction".to_string(), serde_json::json!(direction));
 
@@ -592,20 +756,36 @@ impl PlanNode for TypeJoinOne {
             serde_json::json!(self.exec_info.iterations),
         );
 
-        let parent_execute = self.parent_plan.explain_execute();
-        if let Some(parent_obj) = parent_execute.as_object() {
-            for (key, value) in parent_obj {
-                obj.insert(key.clone(), value.clone());
+        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
+            // InvertedIndex mode: child index scan is the "root" scanNode,
+            // parent FK lookups are the "subType" scanNode.
+            let child_execute = self.child_plan.explain_execute();
+            if let Some(child_obj) = child_execute.as_object() {
+                for (key, value) in child_obj {
+                    obj.insert(key.clone(), value.clone());
+                }
             }
-        }
+            // Parent FK lookup metrics accumulated per-child
+            obj.insert(
+                "subTypeScanNode".to_string(),
+                self.go_child_metrics.to_json(),
+            );
+        } else {
+            let parent_execute = self.parent_plan.explain_execute();
+            if let Some(parent_obj) = parent_execute.as_object() {
+                for (key, value) in parent_obj {
+                    obj.insert(key.clone(), value.clone());
+                }
+            }
 
-        // Use simulated Go-compatible metrics for the child scan.
-        // Go re-initializes the child scanNode per parent with a docID-specific prefix,
-        // calling Next() once per parent. Metrics accumulate across all parent lookups.
-        obj.insert(
-            "subTypeScanNode".to_string(),
-            self.go_child_metrics.to_json(),
-        );
+            // Use simulated Go-compatible metrics for the child scan.
+            // Go re-initializes the child scanNode per parent with a docID-specific prefix,
+            // calling Next() once per parent. Metrics accumulate across all parent lookups.
+            obj.insert(
+                "subTypeScanNode".to_string(),
+                self.go_child_metrics.to_json(),
+            );
+        }
 
         serde_json::Value::Object(obj)
     }

--- a/crates/query/src/plan/type_join/type_join_one.rs
+++ b/crates/query/src/plan/type_join/type_join_one.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::warn;
 
-use crate::document::DocumentMapping;
+use crate::document::{documents_to_plan_docs, DocumentMapping};
 use crate::error::{QueryError, Result};
 use crate::fetcher::DocFetcher;
 use crate::mapper::Filter;
@@ -186,6 +186,25 @@ impl TypeJoinOne {
         self
     }
 
+    /// Configure for ordered inverted join (primary-first) mode.
+    ///
+    /// In this mode, the child drives iteration in sorted order (via index scan).
+    /// For each child, the parent is found by reading the child's FK field value
+    /// (which is the parent's _docID) and doing a direct prefix-based lookup.
+    pub fn with_ordered_inverted_primary(
+        mut self,
+        child_fk_index: usize,
+        parent_collection: schema::CollectionVersion,
+        parent_scan_mapping: DocumentMapping,
+        fetcher: Arc<dyn DocFetcher>,
+    ) -> Self {
+        self.direction = JoinDirection::OrderedInvertedPrimary { child_fk_index };
+        self.parent_collection = Some(parent_collection);
+        self.parent_scan_mapping = Some(parent_scan_mapping);
+        self.fetcher = Some(fetcher);
+        self
+    }
+
     /// Returns the direction of this join.
     pub fn direction(&self) -> &JoinDirection {
         &self.direction
@@ -199,8 +218,8 @@ impl TypeJoinOne {
     /// Logs a warning if the FK field has an unexpected type or is missing.
     fn extract_fk(&self, parent_doc: &Doc) -> Option<String> {
         match &self.direction {
-            JoinDirection::InvertedIndex { .. } => {
-                // Not used in inverted index mode (child drives the loop)
+            JoinDirection::InvertedIndex { .. } | JoinDirection::OrderedInvertedPrimary { .. } => {
+                // Not used in inverted index / ordered inverted modes (child drives the loop)
                 None
             }
             JoinDirection::Inverted => {
@@ -285,8 +304,9 @@ impl TypeJoinOne {
                     let fk_value = child_fk_idx.and_then(|idx| child_doc.get(idx).cloned());
                     fk_value.and_then(|v| v.as_str().map(String::from))
                 }
-                JoinDirection::InvertedIndex { .. } => {
-                    // build_child_cache is not called in InvertedIndex mode
+                JoinDirection::InvertedIndex { .. }
+                | JoinDirection::OrderedInvertedPrimary { .. } => {
+                    // build_child_cache is not called in inverted/ordered modes
                     unreachable!()
                 }
             };
@@ -402,6 +422,68 @@ impl TypeJoinOne {
         Ok(false)
     }
 
+    /// Execute one step of the ordered inverted primary join.
+    ///
+    /// In this mode, the child plan (sorted index scan) drives iteration.
+    /// For each child doc, we read its FK field (which contains the parent's _docID),
+    /// then fetch the parent directly by docID using the fetcher.
+    async fn next_ordered_primary(&mut self) -> Result<bool> {
+        let child_fk_index = match &self.direction {
+            JoinDirection::OrderedInvertedPrimary { child_fk_index } => *child_fk_index,
+            _ => unreachable!(),
+        };
+
+        while self.child_plan.next().await? {
+            let child_doc = self.child_plan.value().deep_clone();
+
+            // Read the FK value from the child doc (e.g., _ownerID = parent's docID)
+            let parent_doc_id = match child_doc.get(child_fk_index) {
+                Some(val) => match val.as_str() {
+                    Some(s) => s.to_string(),
+                    None => continue,
+                },
+                None => continue,
+            };
+
+            // Fetch the parent doc by docID
+            let parent_collection = self.parent_collection.as_ref().unwrap();
+            let parent_mapping = self.parent_scan_mapping.as_ref().unwrap();
+            let fetcher = self.fetcher.as_ref().unwrap();
+
+            let result = fetcher
+                .get_by_ids(&parent_collection.name, &[parent_doc_id])
+                .await?;
+
+            let parent_docs = documents_to_plan_docs(result.docs(), parent_mapping)?;
+
+            // Track parent lookup metrics (Go counts this as child metrics)
+            self.go_child_metrics.iterations += 1;
+            if let Some(parent) = parent_docs.first() {
+                self.go_child_metrics.doc_fetches += 1;
+                self.go_child_metrics.field_fetches += parent.stored_field_count as u64;
+            }
+
+            if parent_docs.is_empty() {
+                continue;
+            }
+
+            let mut parent_doc = parent_docs.into_iter().next().unwrap();
+
+            // Apply relation filter if present
+            if let Some(ref rel_filter) = self.relation_filter {
+                if !self.check_relation_filter(&Some(child_doc.deep_clone()), rel_filter)? {
+                    continue;
+                }
+            }
+
+            self.merge_child(&mut parent_doc, Some(child_doc));
+            self.current_doc = parent_doc;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
     /// Merge child document into parent at the relation field index.
     ///
     /// For inverted joins (secondary side), this also populates the parent's
@@ -431,7 +513,9 @@ impl TypeJoinOne {
         // secondary side's relation ID is dynamically populated at query time.
         if matches!(
             self.direction,
-            JoinDirection::Inverted | JoinDirection::InvertedIndex { .. }
+            JoinDirection::Inverted
+                | JoinDirection::InvertedIndex { .. }
+                | JoinDirection::OrderedInvertedPrimary { .. }
         ) {
             let rel_id_field_name = schema::CollectionVersion::relation_id_field_name(
                 &self.parent_side.relation_field().name,
@@ -510,9 +594,12 @@ impl PlanNode for TypeJoinOne {
         self.go_child_metrics.reset();
         self.docs_to_yield.clear();
 
-        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
-            // InvertedIndex mode: only init the child plan (index scan on child).
-            // Parent lookups happen per-child in next_inverted_index().
+        if matches!(
+            self.direction,
+            JoinDirection::InvertedIndex { .. } | JoinDirection::OrderedInvertedPrimary { .. }
+        ) {
+            // Inverted/ordered mode: only init the child plan (index scan on child).
+            // Parent lookups happen per-child in next_inverted_index() / next_ordered_primary().
             self.child_plan.init().await?;
             self.child_plan.start().await?;
             // Capture child's index fetches from init (the initial index scan)
@@ -527,7 +614,10 @@ impl PlanNode for TypeJoinOne {
     }
 
     async fn start(&mut self) -> Result<()> {
-        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
+        if matches!(
+            self.direction,
+            JoinDirection::InvertedIndex { .. } | JoinDirection::OrderedInvertedPrimary { .. }
+        ) {
             // Child plan already started in init()
             Ok(())
         } else {
@@ -547,6 +637,9 @@ impl PlanNode for TypeJoinOne {
 
         if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
             return self.next_inverted_index().await;
+        }
+        if matches!(self.direction, JoinDirection::OrderedInvertedPrimary { .. }) {
+            return self.next_ordered_primary().await;
         }
 
         loop {
@@ -610,8 +703,11 @@ impl PlanNode for TypeJoinOne {
     }
 
     async fn close(&mut self) -> Result<()> {
-        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
-            // InvertedIndex mode: child_plan is still open, parent_plan was never used
+        if matches!(
+            self.direction,
+            JoinDirection::InvertedIndex { .. } | JoinDirection::OrderedInvertedPrimary { .. }
+        ) {
+            // Inverted/ordered modes: child_plan is still open, parent_plan was never used
             self.child_plan.close().await?;
         } else {
             self.parent_plan.close().await?;
@@ -643,7 +739,9 @@ impl PlanNode for TypeJoinOne {
         // direction: primary or secondary (Go uses "secondary" not "inverted")
         let direction = match self.direction {
             JoinDirection::Primary { .. } => "primary",
-            JoinDirection::Inverted | JoinDirection::InvertedIndex { .. } => "secondary",
+            JoinDirection::Inverted
+            | JoinDirection::InvertedIndex { .. }
+            | JoinDirection::OrderedInvertedPrimary { .. } => "secondary",
         };
         obj.insert("direction".to_string(), serde_json::json!(direction));
 
@@ -756,16 +854,19 @@ impl PlanNode for TypeJoinOne {
             serde_json::json!(self.exec_info.iterations),
         );
 
-        if matches!(self.direction, JoinDirection::InvertedIndex { .. }) {
-            // InvertedIndex mode: child index scan is the "root" scanNode,
-            // parent FK lookups are the "subType" scanNode.
+        if matches!(
+            self.direction,
+            JoinDirection::InvertedIndex { .. } | JoinDirection::OrderedInvertedPrimary { .. }
+        ) {
+            // Inverted/ordered modes: child index scan is the "root" scanNode,
+            // parent lookups are the "subType" scanNode.
             let child_execute = self.child_plan.explain_execute();
             if let Some(child_obj) = child_execute.as_object() {
                 for (key, value) in child_obj {
                     obj.insert(key.clone(), value.clone());
                 }
             }
-            // Parent FK lookup metrics accumulated per-child
+            // Parent lookup metrics accumulated per-child
             obj.insert(
                 "subTypeScanNode".to_string(),
                 self.go_child_metrics.to_json(),

--- a/crates/query/src/plan/type_join/type_join_one.rs
+++ b/crates/query/src/plan/type_join/type_join_one.rs
@@ -326,7 +326,12 @@ impl TypeJoinOne {
 
         // Capture child plan's execution info before closing
         self.child_exec_info = self.child_plan.exec_info();
-        self.go_child_metrics.index_fetches = self.child_exec_info.indexes_fetched;
+        // For JoinDirection::Primary, set initial index_fetches from child scan.
+        // For Inverted, the child scan's index fetches go in the child plan's own metrics,
+        // NOT in go_child_metrics (which tracks per-parent lookups only).
+        if matches!(self.direction, JoinDirection::Primary { .. }) {
+            self.go_child_metrics.index_fetches = self.child_exec_info.indexes_fetched;
+        }
 
         self.child_plan.close().await?;
         Ok(())
@@ -673,6 +678,10 @@ impl PlanNode for TypeJoinOne {
                         self.go_child_metrics.iterations += 2;
                         self.go_child_metrics.index_fetches += 1;
                     }
+                    // InvertedIndex and OrderedInvertedPrimary early-return
+                    // via next_inverted_index() / next_ordered_primary() above
+                    JoinDirection::InvertedIndex { .. }
+                    | JoinDirection::OrderedInvertedPrimary { .. } => unreachable!(),
                 }
                 self.go_child_metrics.doc_fetches += 1;
                 if let Some(ref doc) = child_doc {

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -1350,6 +1350,7 @@ impl Planner {
                         // Pass limit/offset for early termination (index provides ordering)
                         limit,
                         offset,
+                        value_filter: None,
                     };
                     return Some((params, true));
                 }
@@ -1402,6 +1403,7 @@ impl Planner {
                             },
                             limit: None,
                             offset: 0,
+                            value_filter: None,
                         },
                         true,
                     ));

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -290,9 +290,7 @@ impl Planner {
                             .collect();
 
                         // If nested_field is not in the selected fields, it's ordering-only
-                        if !nested_selection_fields
-                            .contains(&nested_field_name)
-                        {
+                        if !nested_selection_fields.contains(&nested_field_name) {
                             result.push((relation_field_name.clone(), nested_field_name.clone()));
                         }
                     }
@@ -1300,11 +1298,11 @@ impl Planner {
         // because the relation join already narrows the parent set.
         // This check uses schema field_kind.is_relation() to avoid confusing JSON field
         // access ({custom: {title: ...}}) with relation traversal ({devices: {model: ...}}).
-        let has_relation_filter = select.filter.as_ref().map_or(false, |f| {
+        let has_relation_filter = select.filter.as_ref().is_some_and(|f| {
             f.conditions().keys().any(|field_name| {
                 collection
                     .field_by_name(field_name)
-                    .map_or(false, |field| field.kind.is_relation())
+                    .is_some_and(|field| field.kind.is_relation())
             })
         });
 

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -905,11 +905,13 @@ impl Planner {
             if let Some(ref doc_ids) = select.doc_ids {
                 select_node = select_node.with_doc_ids(doc_ids.clone());
             }
-            // Set relation filter on SelectNode for explain display (matches Go DefraDB).
-            // The actual relation filtering is handled by TypeJoin's RelationFilter,
-            // but Go's selectNode stores the relation filter and shows it in explain output.
+            // Store relation filter on SelectNode for explain display only.
+            // The actual relation filtering is handled by TypeJoin's RelationFilter.
+            // We must NOT apply it as a real filter because after TypeJoinMany merges
+            // sub-filtered children, re-evaluating the parent's relation filter would
+            // fail when sub-filter and parent filter target different values.
             if let Some(ref rel_filter) = relation_filter {
-                select_node = select_node.with_filter(rel_filter.clone());
+                select_node = select_node.with_explain_filter(rel_filter.clone());
             }
             plan = Box::new(select_node);
         } else if is_complex_filter && !select.fields.is_empty() {
@@ -1338,24 +1340,39 @@ impl Planner {
         let limit = select.limit.as_ref().and_then(|l| l.limit);
         let offset = select.limit.as_ref().map(|l| l.offset).unwrap_or(0);
 
-        // Try filter-based index selection first
-        if let Some(filter) = select.filter.as_ref() {
-            if let Some(best_index) = select_best_index(filter, &collection.indexes) {
-                if let Some(params) = filter_to_index_scan(
-                    filter,
-                    best_index,
-                    select.order_by.as_ref(),
-                    &collection.fields,
-                    limit,
-                    offset,
-                ) {
-                    // Check if this index also provides ordering
-                    let provides_ordering = select
-                        .order_by
-                        .as_ref()
-                        .map(|o| can_be_ordered_by_index(o, best_index).0)
-                        .unwrap_or(false);
-                    return Some((params, provides_ordering));
+        // Check if filter has any true relation field conditions (using schema info).
+        // When relation filters are present, Go skips parent filter-based index selection
+        // because the relation join already narrows the parent set.
+        // This check uses schema field_kind.is_relation() to avoid confusing JSON field
+        // access ({custom: {title: ...}}) with relation traversal ({devices: {model: ...}}).
+        let has_relation_filter = select.filter.as_ref().map_or(false, |f| {
+            f.conditions().keys().any(|field_name| {
+                collection
+                    .field_by_name(field_name)
+                    .map_or(false, |field| field.kind.is_relation())
+            })
+        });
+
+        // Try filter-based index selection first (skip when relation filters are present)
+        if !has_relation_filter {
+            if let Some(filter) = select.filter.as_ref() {
+                if let Some(best_index) = select_best_index(filter, &collection.indexes) {
+                    if let Some(params) = filter_to_index_scan(
+                        filter,
+                        best_index,
+                        select.order_by.as_ref(),
+                        &collection.fields,
+                        limit,
+                        offset,
+                    ) {
+                        // Check if this index also provides ordering
+                        let provides_ordering = select
+                            .order_by
+                            .as_ref()
+                            .map(|o| can_be_ordered_by_index(o, best_index).0)
+                            .unwrap_or(false);
+                        return Some((params, provides_ordering));
+                    }
                 }
             }
         }

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -399,14 +399,13 @@ impl Planner {
                     if scan_mapping.first_index_of_name(field_name).is_some() {
                         continue;
                     }
-                    // Find field in collection schema and add to mapping
-                    if let Some((schema_idx, _)) = collection
-                        .fields
-                        .iter()
-                        .enumerate()
-                        .find(|(_, f)| &f.name == field_name)
-                    {
-                        scan_mapping.add(schema_idx, field_name);
+                    // Verify the field exists in the collection schema
+                    if collection.field_by_name(field_name).is_some() {
+                        // Use next_index to avoid collisions with existing mapping positions.
+                        // Using schema_idx would overwrite fields if a schema position
+                        // is already occupied (e.g., _ownerID at schema pos 1 overwriting model).
+                        let next_idx = scan_mapping.next_index();
+                        scan_mapping.add(next_idx, field_name);
                     }
                 }
             }
@@ -744,6 +743,7 @@ impl Planner {
         plan = joins_result.0;
         scan_mapping = joins_result.1;
         aggregate_internal_keys = joins_result.2;
+        let join_provides_ordering = joins_result.3;
 
         // 3b. Apply joins for multi-level relation filter paths where the first relation
         // is NOT in the selection set. If the first relation IS selected, then apply_joins
@@ -847,53 +847,8 @@ impl Planner {
             }
         }
 
-        // 3c. Apply joins for relation fields referenced in order but NOT in selection set or filter.
-        // This allows ordering through relations even when those relations aren't being returned.
-        // Example: Book(order: {author: {age: DESC}}) { name rating }
-        // The `author` relation must be joined for ordering even though it's not selected.
-        if order_has_relations {
-            // Get the names of relation fields already joined from selection or filter
-            let mut already_joined: Vec<&str> = select
-                .fields
-                .iter()
-                .filter_map(|f| {
-                    if let Requestable::Select(s) = f {
-                        Some(s.field.name.as_str())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            // Add filter relations that were joined
-            for f in &filter_relation_fields {
-                if !already_joined.contains(&f.as_str()) {
-                    already_joined.push(f.as_str());
-                }
-            }
-
-            // Create joins for order relations not already joined
-            for relation_field_name in &order_relation_fields {
-                if already_joined.contains(&relation_field_name.as_str()) {
-                    continue; // Already joined
-                }
-
-                // Find the relation field in the parent collection
-                let relation_field = match collection.field_by_name(relation_field_name) {
-                    Some(f) if f.kind.is_relation() => f,
-                    _ => continue, // Not a valid relation field
-                };
-
-                let (new_plan, new_mapping) = self.apply_filter_relation_join(
-                    plan,
-                    &collection,
-                    relation_field,
-                    relation_field_name,
-                    scan_mapping.clone(),
-                )?;
-                plan = new_plan;
-                scan_mapping = new_mapping;
-            }
-        }
+        // 3c. ORDER BY relation joins are now handled by apply_joins via synthetic selects,
+        // which also enables join direction inversion for index-based ordering.
 
         // 3d. Apply SelectNode AFTER all joins (matches Go DefraDB plan order).
         // The SelectNode wraps the joined plan and applies scalar filters.
@@ -1237,9 +1192,9 @@ impl Planner {
             }
 
             // 6. Apply order by (after grouping/aggregation)
-            // Skip if index already provides the ordering
+            // Skip if index (own or via join) already provides the ordering
             if let Some(ref order_by) = select.order_by {
-                if !index_provides_ordering {
+                if !index_provides_ordering && !join_provides_ordering {
                     plan = Box::new(OrderByNode::new(
                         plan,
                         order_by.clone(),
@@ -1264,9 +1219,9 @@ impl Planner {
             // not the documents fed to aggregation.
 
             // 5. Apply order by (before aggregates)
-            // Skip if index already provides the ordering
+            // Skip if index (own or via join) already provides the ordering
             if let Some(ref order_by) = select.order_by {
-                if !index_provides_ordering {
+                if !index_provides_ordering && !join_provides_ordering {
                     plan = Box::new(OrderByNode::new(
                         plan,
                         order_by.clone(),

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -12,7 +12,24 @@ use tracing::{debug, instrument, warn};
 
 use crate::error::{QueryError, Result};
 use crate::fetcher::DocFetcher;
-use crate::mapper::{AggregateType, Filter, OrderBy, OrderCondition, OrderDirection, Requestable, Select};
+use crate::mapper::{
+    AggregateType, Filter, OrderBy, OrderCondition, OrderDirection, Requestable, Select,
+};
+
+/// Format an order condition as a Go-style value string for error messages.
+///
+/// For `fields: ["articles", "pages"], direction: Asc`, produces `{articles: {pages: ASC}}`.
+fn format_order_value(condition: &OrderCondition) -> String {
+    let dir = match condition.direction {
+        OrderDirection::Asc => "ASC",
+        OrderDirection::Desc => "DESC",
+    };
+    let mut result = dir.to_string();
+    for field in condition.fields.iter().rev() {
+        result = format!("{{{}: {}}}", field, result);
+    }
+    result
+}
 use crate::plan::groupby::ChildSelectMeta;
 use crate::plan::{
     AllDocsNode, GroupAlias, GroupByNode, IndexScanNode, InnerAggregateDef, LimitNode, OrderByNode,
@@ -102,23 +119,6 @@ impl Planner {
             acp: None,
             identity_did: None,
         }
-    }
-
-    /// Format an order condition as a Go-style value string.
-    ///
-    /// For `fields: ["articles", "pages"], direction: Asc`, produces `{articles: {pages: ASC}}`.
-    fn format_order_condition(condition: &OrderCondition) -> String {
-        let dir = match condition.direction {
-            OrderDirection::Asc => "ASC",
-            OrderDirection::Desc => "DESC",
-        };
-
-        // Build from innermost to outermost
-        let mut result = dir.to_string();
-        for field in condition.fields.iter().rev() {
-            result = format!("{{{}: {}}}", field, result);
-        }
-        result
     }
 
     /// Set a document fetcher for on-demand data loading.
@@ -231,18 +231,24 @@ impl Planner {
             .unwrap_or_default();
         let order_has_relations = !order_relation_fields.is_empty();
 
+        // One-to-one relation ordering (e.g., User(order: {device: {model: ASC}})) is handled
+        // by the ordered inverted join in apply_joins().
+        // One-to-many (array) relation ordering is rejected — ambiguous which child to sort by.
         if order_has_relations {
             if let Some(ref order_by) = select.order_by {
-                // Find the first relation condition and build Go-compatible error
                 for condition in &order_by.conditions {
                     if condition.fields.len() > 1 {
-                        let relation_field = &condition.fields[0];
-                        let order_value_str = Self::format_order_condition(condition);
-                        return Err(QueryError::parse(format!(
-                            "Argument \"order\" has invalid value {}.\n\
-                             In field \"{}\": Unknown field.",
-                            order_value_str, relation_field
-                        )));
+                        let relation_name = &condition.fields[0];
+                        if let Some(field) = collection.field_by_name(relation_name) {
+                            if field.kind.is_array() {
+                                let order_value_str = format_order_value(condition);
+                                return Err(QueryError::parse(format!(
+                                    "Argument \"order\" has invalid value {}.\n\
+                                     In field \"{}\": Unknown field.",
+                                    order_value_str, relation_name
+                                )));
+                            }
+                        }
                     }
                 }
             }

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -25,6 +25,57 @@ pub struct IndexScanParams {
     pub limit: Option<u64>,
     /// Offset to skip before collecting results (for ORDER BY + LIMIT + OFFSET optimization)
     pub offset: u64,
+    /// Optional value filter applied to each index entry during scan.
+    /// Used for _like/_nlike on JSON fields where the index does a range scan
+    /// and non-string entries must be filtered at the scan level (matching Go's indexLikeMatcher).
+    pub value_filter: Option<ScanValueFilter>,
+}
+
+/// Value-level filter applied to individual index entries during scan iteration.
+/// Matches Go's `indexLikeMatcher` behavior: non-string values return false.
+#[derive(Debug, Clone)]
+pub enum ScanValueFilter {
+    Like(String),
+    Nlike(String),
+    Ilike(String),
+    Nilike(String),
+}
+
+impl ScanValueFilter {
+    /// Check if an index entry's first value matches this filter.
+    /// Non-string values always return false (matching Go's indexLikeMatcher).
+    pub fn matches_value(&self, value: &NormalValue) -> bool {
+        // Extract the string from the value (supports both String and JsonLeaf with string)
+        let s = match value {
+            NormalValue::String(s) => s.as_str(),
+            NormalValue::JsonLeaf(leaf) => match &leaf.value {
+                JsonScalarValue::String(s) => s.as_str(),
+                _ => return false, // Non-string JSON leaf: exclude
+            },
+            _ => return false, // Non-string value: exclude
+        };
+
+        let (pattern, is_like, case_insensitive) = match self {
+            ScanValueFilter::Like(p) => (p.as_str(), true, false),
+            ScanValueFilter::Nlike(p) => (p.as_str(), false, false),
+            ScanValueFilter::Ilike(p) => (p.as_str(), true, true),
+            ScanValueFilter::Nilike(p) => (p.as_str(), false, true),
+        };
+
+        let (s_cmp, p_cmp): (std::borrow::Cow<str>, std::borrow::Cow<str>) = if case_insensitive {
+            (s.to_lowercase().into(), pattern.to_lowercase().into())
+        } else {
+            (s.into(), pattern.into())
+        };
+
+        use crate::mapper::like_pattern_match;
+        let matches = like_pattern_match(&s_cmp, &p_cmp);
+        if is_like {
+            matches
+        } else {
+            !matches
+        }
+    }
 }
 
 /// Type of index scan to perform.
@@ -541,6 +592,7 @@ pub fn filter_to_index_scan(
     let mut in_values = None;
     let mut in_json_path: Option<JsonPath> = None;
     let mut has_scan_all = false;
+    let mut scan_value_filter: Option<ScanValueFilter> = None;
     let mut lower_bound = Bound::Unbounded;
     let mut upper_bound = Bound::Unbounded;
     let mut range_json_path: Option<JsonPath> = None;
@@ -596,16 +648,28 @@ pub fn filter_to_index_scan(
             }
             // _ne/_nin/_like/_nlike use full index scan with post-filtering (matches Go behavior)
             // For JSON fields, we still need to track the path to constrain the scan
-            FilterOp::Ne
-            | FilterOp::Nin
-            | FilterOp::Like
-            | FilterOp::Nlike
-            | FilterOp::Ilike
-            | FilterOp::Nilike => {
+            FilterOp::Ne | FilterOp::Nin => {
                 has_scan_all = true;
-                // Track JSON path for scan_all so we can constrain to the path
                 if cond.json_path.is_some() {
                     range_json_path = cond.json_path.clone();
+                }
+            }
+            FilterOp::Like | FilterOp::Nlike | FilterOp::Ilike | FilterOp::Nilike => {
+                has_scan_all = true;
+                if cond.json_path.is_some() {
+                    range_json_path = cond.json_path.clone();
+                    // For JSON fields only: add scan-level value filter to exclude
+                    // non-string entries (matches Go's indexLikeMatcher behavior).
+                    // Regular string indexes don't need this because all entries are strings.
+                    if let ConditionValue::Pattern(pattern) = &cond.value {
+                        scan_value_filter = Some(match cond.op {
+                            FilterOp::Like => ScanValueFilter::Like(pattern.clone()),
+                            FilterOp::Nlike => ScanValueFilter::Nlike(pattern.clone()),
+                            FilterOp::Ilike => ScanValueFilter::Ilike(pattern.clone()),
+                            FilterOp::Nilike => ScanValueFilter::Nilike(pattern.clone()),
+                            _ => unreachable!(),
+                        });
+                    }
                 }
             }
             _ => {}
@@ -866,6 +930,7 @@ pub fn filter_to_index_scan(
         scan_type,
         limit: if index_provides_ordering { limit } else { None },
         offset: if index_provides_ordering { offset } else { 0 },
+        value_filter: scan_value_filter,
     })
 }
 

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -553,17 +553,21 @@ pub fn filter_to_index_scan(
 
         match cond.op {
             FilterOp::Eq => {
-                if let ConditionValue::Single(v) = &cond.value {
-                    has_eq = true;
-                    eq_value = Some(v.clone());
-                    eq_json_path = cond.json_path.clone();
+                if !has_eq {
+                    if let ConditionValue::Single(v) = &cond.value {
+                        has_eq = true;
+                        eq_value = Some(v.clone());
+                        eq_json_path = cond.json_path.clone();
+                    }
                 }
             }
             FilterOp::In => {
-                if let ConditionValue::Multiple(vs) = &cond.value {
-                    has_in = true;
-                    in_values = Some(vs.clone());
-                    in_json_path = cond.json_path.clone();
+                if !has_in {
+                    if let ConditionValue::Multiple(vs) = &cond.value {
+                        has_in = true;
+                        in_values = Some(vs.clone());
+                        in_json_path = cond.json_path.clone();
+                    }
                 }
             }
             FilterOp::Gt => {
@@ -770,12 +774,18 @@ pub fn filter_to_index_scan(
                 Bound::Exclusive(wrap_value_for_json_path(v, range_json_path.as_ref()))
             }
             Bound::Unbounded => {
-                // For JSON paths, use PathMin to constrain lower bound
+                // For JSON paths with non-empty path, use PathMin to constrain lower bound.
+                // For empty paths (top-level JSON), leave unbounded to match Go behavior:
+                // Go scans from value to end of entire index, counting all keys.
                 if let Some(path) = &range_json_path {
-                    Bound::Inclusive(NormalValue::JsonLeaf(JsonLeafValue::new(
-                        path.clone(),
-                        JsonScalarValue::PathMin,
-                    )))
+                    if !path.is_empty() {
+                        Bound::Inclusive(NormalValue::JsonLeaf(JsonLeafValue::new(
+                            path.clone(),
+                            JsonScalarValue::PathMin,
+                        )))
+                    } else {
+                        Bound::Unbounded
+                    }
                 } else {
                     Bound::Unbounded
                 }
@@ -789,12 +799,17 @@ pub fn filter_to_index_scan(
                 Bound::Exclusive(wrap_value_for_json_path(v, range_json_path.as_ref()))
             }
             Bound::Unbounded => {
-                // For JSON paths, use PathMax to constrain upper bound
+                // For JSON paths with non-empty path, use PathMax to constrain upper bound.
+                // For empty paths (top-level JSON), leave unbounded to match Go behavior.
                 if let Some(path) = &range_json_path {
-                    Bound::Exclusive(NormalValue::JsonLeaf(JsonLeafValue::new(
-                        path.clone(),
-                        JsonScalarValue::PathMax,
-                    )))
+                    if !path.is_empty() {
+                        Bound::Exclusive(NormalValue::JsonLeaf(JsonLeafValue::new(
+                            path.clone(),
+                            JsonScalarValue::PathMax,
+                        )))
+                    } else {
+                        Bound::Unbounded
+                    }
                 } else {
                     Bound::Unbounded
                 }
@@ -808,19 +823,27 @@ pub fn filter_to_index_scan(
         }
     } else if has_scan_all {
         // Full index scan with residual filter (for _ne, _like, etc.)
-        // For JSON fields, constrain the scan to the specific path
+        // For JSON fields with non-empty path, constrain scan to that path.
+        // For empty path (top-level JSON), use full prefix scan to match Go.
         if let Some(path) = &range_json_path {
-            IndexScanType::RangeScan {
-                prefix_values: vec![],
-                lower: Bound::Inclusive(NormalValue::JsonLeaf(JsonLeafValue::new(
-                    path.clone(),
-                    JsonScalarValue::PathMin,
-                ))),
-                upper: Bound::Exclusive(NormalValue::JsonLeaf(JsonLeafValue::new(
-                    path.clone(),
-                    JsonScalarValue::PathMax,
-                ))),
-                reverse,
+            if !path.is_empty() {
+                IndexScanType::RangeScan {
+                    prefix_values: vec![],
+                    lower: Bound::Inclusive(NormalValue::JsonLeaf(JsonLeafValue::new(
+                        path.clone(),
+                        JsonScalarValue::PathMin,
+                    ))),
+                    upper: Bound::Exclusive(NormalValue::JsonLeaf(JsonLeafValue::new(
+                        path.clone(),
+                        JsonScalarValue::PathMax,
+                    ))),
+                    reverse,
+                }
+            } else {
+                IndexScanType::PrefixScan {
+                    prefix_values: vec![],
+                    reverse,
+                }
             }
         } else {
             IndexScanType::PrefixScan {

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -219,7 +219,13 @@ fn normal_value_to_json_scalar(value: &NormalValue) -> Option<JsonScalarValue> {
 /// Wrap a NormalValue in JsonLeafValue if a JSON path is present.
 fn wrap_value_for_json_path(value: NormalValue, json_path: Option<&JsonPath>) -> NormalValue {
     match json_path {
-        Some(path) if !path.0.is_empty() => {
+        Some(path) => {
+            // Top-level null JSON values (empty path) are stored as plain NormalValue::Null
+            // in the index (see NormalValue::json_leaves()). Null with non-empty path IS
+            // stored as JsonLeafValue { path, value: Null }.
+            if matches!(value, NormalValue::Null) && path.is_empty() {
+                return value;
+            }
             if let Some(scalar) = normal_value_to_json_scalar(&value) {
                 NormalValue::JsonLeaf(JsonLeafValue {
                     path: path.clone(),
@@ -229,7 +235,7 @@ fn wrap_value_for_json_path(value: NormalValue, json_path: Option<&JsonPath>) ->
                 value
             }
         }
-        _ => value,
+        None => value,
     }
 }
 
@@ -239,7 +245,7 @@ fn wrap_values_for_json_path(
     json_path: Option<&JsonPath>,
 ) -> Vec<NormalValue> {
     match json_path {
-        Some(path) if !path.0.is_empty() => values
+        Some(path) => values
             .into_iter()
             .filter_map(|v| {
                 normal_value_to_json_scalar(&v).map(|scalar| {
@@ -250,7 +256,7 @@ fn wrap_values_for_json_path(
                 })
             })
             .collect(),
-        _ => values,
+        None => values,
     }
 }
 
@@ -887,6 +893,25 @@ fn score_index_for_filter(filter: &Filter, index: &IndexDescription) -> Option<u
                     && c.array_op != Some(FilterOp::None)
             }) {
                 score += 5;
+            }
+
+            // _in is multi-exact-match (better than range, worse than single eq)
+            if conditions
+                .iter()
+                .any(|c| c.field_name == field.name && c.op == FilterOp::In)
+            {
+                score += 4;
+            }
+
+            // Range operators narrow the scan (better than full-scan like _like/_ne)
+            if conditions.iter().any(|c| {
+                c.field_name == field.name
+                    && matches!(
+                        c.op,
+                        FilterOp::Gt | FilterOp::Gte | FilterOp::Lt | FilterOp::Lte
+                    )
+            }) {
+                score += 3;
             }
         } else {
             // Stop if we hit a gap in field coverage

--- a/crates/query/src/planner/joins.rs
+++ b/crates/query/src/planner/joins.rs
@@ -1044,11 +1044,10 @@ impl Planner {
                                 )
                         })?;
                         // Check if any index covers this FK field
-                        target_collection.indexes.iter().find(|idx| {
-                            idx.fields
-                                .first()
-                                .map_or(false, |f| f.name == fk_field.name)
-                        })
+                        target_collection
+                            .indexes
+                            .iter()
+                            .find(|idx| idx.fields.first().is_some_and(|f| f.name == fk_field.name))
                     })
                     .is_some();
 
@@ -1145,9 +1144,7 @@ impl Planner {
                     //
                     // Case 2 (secondary-first): Parent has FK (e.g., User._deviceID → Device)
                     //   - Scan parent's FK index for child._docID
-                    let child_has_fk = target_relation_field
-                        .map(|f| f.is_primary)
-                        .unwrap_or(false);
+                    let child_has_fk = target_relation_field.map(|f| f.is_primary).unwrap_or(false);
 
                     if child_has_fk {
                         // Case 1: Child has FK → use InvertedIndex with docID-based parent lookup.
@@ -1186,7 +1183,7 @@ impl Planner {
                         let parent_fk_index = parent_collection.indexes.iter().find(|idx| {
                             idx.fields
                                 .first()
-                                .map_or(false, |f| f.name == parent_fk_field_name)
+                                .is_some_and(|f| f.name == parent_fk_field_name)
                         });
 
                         if let Some(fk_index) = parent_fk_index {
@@ -1416,7 +1413,7 @@ impl Planner {
                         parent_collection.indexes.iter().find(|idx| {
                             idx.fields
                                 .first()
-                                .map_or(false, |f| f.name == parent_fk_field_name)
+                                .is_some_and(|f| f.name == parent_fk_field_name)
                         })
                     } else {
                         None
@@ -2100,7 +2097,12 @@ impl Planner {
             }
         }
 
-        Ok((plan, mapping, aggregate_internal_keys, join_provides_ordering))
+        Ok((
+            plan,
+            mapping,
+            aggregate_internal_keys,
+            join_provides_ordering,
+        ))
     }
 
     /// Build a scan mapping for join child plans that includes ALL fields at schema indices.

--- a/crates/query/src/planner/joins.rs
+++ b/crates/query/src/planner/joins.rs
@@ -470,8 +470,29 @@ impl Planner {
                 (None, None) => None,
             };
 
+            // Extract relation filter from parent for child index selection and join filter.
+            // e.g., User(filter: {address: {city: {_eq: "Munich"}}}) → child filter: {city: {_eq: "Munich"}}
+            let parent_relation_filter_for_child =
+                parent_filter.and_then(|f| f.extract_relation_filter(relation_field_name));
+
+            // Use parent relation filter for child index selection only for one-to-one relations.
+            // For one-to-many, the child scan must return ALL children because TypeJoinMany
+            // renders all children of matching parents, not just those matching the filter.
+            let parent_rel_for_index = if !relation_field.kind.is_array() {
+                parent_relation_filter_for_child.as_ref()
+            } else {
+                None
+            };
+
+            let child_filter_for_index = match (&nested_select.filter, parent_rel_for_index) {
+                (Some(child_f), Some(parent_rf)) => Some(child_f.and(parent_rf.clone())),
+                (Some(child_f), None) => Some(child_f.clone()),
+                (None, Some(parent_rf)) => Some(parent_rf.clone()),
+                (None, None) => None,
+            };
+
             let child_index_result = self.try_select_child_index(
-                nested_select.filter.as_ref(),
+                child_filter_for_index.as_ref(),
                 combined_child_order.as_ref(),
                 &target_collection,
             );
@@ -503,6 +524,75 @@ impl Planner {
                     child_scan = child_scan.with_filter(filter);
                 }
                 Box::new(child_scan)
+            };
+
+            // For OneToMany with parent relation filter: create a separate filter child plan
+            // that uses an index for efficient filter evaluation. The main child_plan handles
+            // display (ALL children), while filter_child_plan handles filter evaluation only.
+            // This matches Go's inverted index join behavior.
+            let filter_child_plan: Option<Box<dyn PlanNode>> = if relation_field.kind.is_array() {
+                parent_relation_filter_for_child
+                    .as_ref()
+                    .and_then(|rel_filter| {
+                        let filter_index =
+                            self.try_select_child_index(Some(rel_filter), None, &target_collection);
+                        if let Some((params, _)) = filter_index {
+                            // Build mapping with FK field and filter fields at schema positions
+                            let mut filter_mapping = DocumentMapping::new();
+                            filter_mapping.add(0, "_docID");
+                            // Find the FK field on the child (target) side.
+                            // For OneToMany, the child has the FK (e.g., Device has _ownerID).
+                            // Find the back-reference field on the target collection.
+                            let fk_field_name = relation_field
+                                .relation_name
+                                .as_ref()
+                                .and_then(|rel_name| {
+                                    target_collection.field_by_relation(
+                                        rel_name,
+                                        &parent_collection.name,
+                                        relation_field_name,
+                                    )
+                                })
+                                .map(|f| schema::CollectionVersion::relation_id_field_name(&f.name))
+                                .unwrap_or_else(|| {
+                                    schema::CollectionVersion::relation_id_field_name(
+                                        relation_field_name,
+                                    )
+                                });
+                            if let Some(fk_idx) = target_collection
+                                .fields
+                                .iter()
+                                .position(|f| f.name == fk_field_name)
+                            {
+                                filter_mapping.add(fk_idx, &fk_field_name);
+                            }
+                            // Add filter referenced fields at schema positions
+                            for field_name in rel_filter.referenced_fields() {
+                                if filter_mapping.first_index_of_name(&field_name).is_none() {
+                                    if let Some(idx) = target_collection
+                                        .fields
+                                        .iter()
+                                        .position(|f| f.name == field_name)
+                                    {
+                                        filter_mapping.add(idx, &field_name);
+                                    }
+                                }
+                            }
+                            let mut index_scan = IndexScanNode::new(
+                                (*target_collection).clone(),
+                                filter_mapping,
+                                params,
+                            );
+                            if let Some(ref fetcher) = self.fetcher {
+                                index_scan = index_scan.with_fetcher(fetcher.clone());
+                            }
+                            Some(Box::new(index_scan) as Box<dyn PlanNode>)
+                        } else {
+                            None // No index for filter, use in-memory evaluation
+                        }
+                    })
+            } else {
+                None
             };
 
             // Extract nested limit/offset and order_by for per-parent application in TypeJoin.
@@ -884,14 +974,13 @@ impl Planner {
                 child_relation_index,
             )?;
 
-            // Extract relation filter for this join if parent has a filter
-            let relation_filter = parent_filter.and_then(|f| {
-                f.extract_relation_filter(relation_field_name)
-                    .map(|nested_filter| RelationFilter {
-                        relation_field: relation_field_name.clone(),
-                        conditions: nested_filter,
-                    })
-            });
+            // Build RelationFilter from the already-extracted parent relation filter
+            let relation_filter = parent_relation_filter_for_child
+                .as_ref()
+                .map(|nested_filter| RelationFilter {
+                    relation_field: relation_field_name.clone(),
+                    conditions: nested_filter.clone(),
+                });
 
             // Create the appropriate join node
             // Note: We pass child_render_mapping as the output mapping (for TypeJoin to render children)
@@ -906,6 +995,48 @@ impl Planner {
                     join_many = join_many.with_relation_filter(rel_filter);
                 }
 
+                // Check if child has an index on its FK field for this relation.
+                // When FK is indexed, a global child scan can efficiently map children
+                // to parents, so per-parent scanning is not needed for ordering.
+                let has_child_fk_index = target_relation_field
+                    .and_then(|trf| {
+                        let rel_name = trf.relation_name.as_deref()?;
+                        // Find the FK ID field (same relation, kind Scalar(DocID))
+                        let fk_field = target_collection.fields.iter().find(|f| {
+                            f.relation_name.as_deref() == Some(rel_name)
+                                && matches!(
+                                    f.kind,
+                                    schema::FieldKind::Scalar(schema::ScalarKind::DocID)
+                                )
+                        })?;
+                        // Check if any index covers this FK field
+                        target_collection.indexes.iter().find(|idx| {
+                            idx.fields
+                                .first()
+                                .map_or(false, |f| f.name == fk_field.name)
+                        })
+                    })
+                    .is_some();
+
+                // Determine per-parent mode before moving filter_child_plan.
+                // Per-parent scanning re-inits the child plan for each parent:
+                // - With limit: needed for early termination per parent
+                // - With child sub-filter but no parent filter_child_plan: child filter
+                //   runs per parent (when filter_child_plan exists, it handles globally)
+                // - With ordering + no FK index + no parent filter: Go scans the
+                //   ordering index per parent without FK index for efficient matching
+                let use_per_parent = child_uses_index
+                    && (nested_limit.is_some()
+                        || (nested_select.filter.is_some() && filter_child_plan.is_none())
+                        || (filter_child_plan.is_none()
+                            && nested_order_by.is_some()
+                            && !has_child_fk_index));
+
+                // Apply filter child plan for indexed relation filter evaluation
+                if let Some(fcp) = filter_child_plan {
+                    join_many = join_many.with_filter_child_plan(fcp);
+                }
+
                 // Apply per-parent limit/offset/ordering
                 if let Some(limit) = nested_limit {
                     join_many = join_many.with_limit(limit);
@@ -916,7 +1047,7 @@ impl Planner {
                 if let Some(order_by) = nested_order_by.clone() {
                     join_many = join_many.with_order_by(order_by);
                 }
-                if child_uses_index {
+                if use_per_parent {
                     join_many = join_many.with_per_parent_child_scan();
                 }
 

--- a/crates/query/src/planner/joins.rs
+++ b/crates/query/src/planner/joins.rs
@@ -15,7 +15,7 @@ use tracing::{debug, warn};
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
-use crate::mapper::{AggregateType, Filter, OrderBy, OrderCondition, Requestable, Select};
+use crate::mapper::{AggregateType, Field, Filter, OrderBy, OrderCondition, Requestable, Select};
 use crate::plan::{
     IndexScanNode, JoinSide, RelationFilter, ScanNode, SelectNode, TypeJoinMany, TypeJoinOne,
 };
@@ -23,11 +23,13 @@ use crate::planner::PlanNode;
 
 use super::builder::{Planner, MAX_NESTING_DEPTH};
 
-/// Result of applying joins: the updated plan node, document mapping, and aggregate internal keys.
+/// Result of applying joins: the updated plan node, document mapping, aggregate internal keys,
+/// and whether a child index scan provides the parent's ORDER BY.
 type JoinResult = Result<(
     Box<dyn PlanNode>,
     DocumentMapping,
     HashMap<String, (String, String)>,
+    bool, // join_provides_ordering
 )>;
 
 impl Planner {
@@ -49,6 +51,7 @@ impl Planner {
     ) -> JoinResult {
         // Internal keys for aggregate relation data when there's a collision with a relation selection.
         let mut aggregate_internal_keys: HashMap<String, (String, String)> = HashMap::new();
+        let mut join_provides_ordering = false;
 
         // Check recursion depth to prevent stack overflow
         if depth > MAX_NESTING_DEPTH {
@@ -82,6 +85,37 @@ impl Planner {
                     selects_to_process.push((nested_select, None));
                 }
             }
+        }
+
+        // Add synthetic selects for ORDER BY relation fields not already in the selection.
+        // Go's resolveOrderDependencies creates joins for relations referenced in ORDER BY
+        // even when they're not explicitly selected in the query.
+        let mut synthetic_order_selects: Vec<Select> = Vec::new();
+        if let Some(ref order_by) = select.order_by {
+            let already_selected: std::collections::HashSet<&str> = selects_to_process
+                .iter()
+                .map(|(s, _)| s.field.name.as_str())
+                .collect();
+
+            for condition in &order_by.conditions {
+                // Path like ["device", "model"] — first element is the relation field
+                if condition.fields.len() >= 2 {
+                    let relation_name = &condition.fields[0];
+                    if !already_selected.contains(relation_name.as_str()) {
+                        // Check this is actually a relation field
+                        if let Some(field) = parent_collection.field_by_name(relation_name) {
+                            if field.kind.is_relation() {
+                                let mut syn_select = Select::new("");
+                                syn_select.field = Field::new(relation_name);
+                                synthetic_order_selects.push(syn_select);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        for syn_select in &synthetic_order_selects {
+            selects_to_process.push((syn_select, None));
         }
 
         // Collect info about selection joins so aggregates can share when compatible.
@@ -1085,12 +1119,129 @@ impl Planner {
                 plan = Box::new(join_many);
             } else {
                 // One-to-one: TypeJoinOne
-                let mut join =
-                    TypeJoinOne::new(plan, child_plan, parent_side, child_side, mapping.clone());
-                if let Some(rel_filter) = relation_filter {
-                    join = join.with_relation_filter(rel_filter);
+                //
+                // Check if we should invert the join for ordering:
+                // When the parent's ORDER BY references a child field with an index,
+                // invert the join so the child's sorted index scan drives iteration.
+                let should_invert_for_ordering = parent_order_for_child.is_some()
+                    && child_uses_index
+                    && relation_filter.is_none(); // Don't invert if there's also a relation filter
+
+                tracing::debug!(
+                    parent_order_for_child_is_some = parent_order_for_child.is_some(),
+                    child_uses_index = child_uses_index,
+                    relation_filter_is_none = relation_filter.is_none(),
+                    should_invert_for_ordering = should_invert_for_ordering,
+                    relation_field_name = %relation_field.name,
+                    "TypeJoinOne: checking ordering inversion"
+                );
+
+                if should_invert_for_ordering {
+                    // Inverted join for ordering: child index scan drives iteration.
+                    // Determine how to look up the parent for each child:
+                    //
+                    // Case 1 (primary-first): Child has FK (e.g., Device._ownerID → User)
+                    //   - Read FK from child doc → direct docID lookup on parent
+                    //
+                    // Case 2 (secondary-first): Parent has FK (e.g., User._deviceID → Device)
+                    //   - Scan parent's FK index for child._docID
+                    let child_has_fk = target_relation_field
+                        .map(|f| f.is_primary)
+                        .unwrap_or(false);
+
+                    if child_has_fk {
+                        // Case 1: Child has FK → use InvertedIndex with docID-based parent lookup.
+                        // The child's FK field (e.g., _ownerID) contains the parent's _docID.
+                        let child_fk_field_name = target_relation_field
+                            .map(|f| schema::CollectionVersion::relation_id_field_name(&f.name))
+                            .unwrap_or_default();
+                        let child_fk_idx = child_scan_mapping
+                            .first_index_of_name(&child_fk_field_name)
+                            .unwrap_or(0);
+
+                        let parent_scan_mapping = plan.document_map().clone();
+                        let parent_col = parent_collection.clone();
+                        let fetcher = self.fetcher.clone().unwrap();
+
+                        let join = TypeJoinOne::new(
+                            plan,
+                            child_plan,
+                            parent_side,
+                            child_side,
+                            mapping.clone(),
+                        )
+                        .with_ordered_inverted_primary(
+                            child_fk_idx,
+                            parent_col,
+                            parent_scan_mapping,
+                            fetcher,
+                        );
+                        plan = Box::new(join);
+                        join_provides_ordering = true;
+                    } else {
+                        // Case 2: Parent has FK → use InvertedIndex with FK index scan on parent.
+                        // Same mechanism as filter-based InvertedIndex.
+                        let parent_fk_field_name =
+                            schema::CollectionVersion::relation_id_field_name(&relation_field.name);
+                        let parent_fk_index = parent_collection.indexes.iter().find(|idx| {
+                            idx.fields
+                                .first()
+                                .map_or(false, |f| f.name == parent_fk_field_name)
+                        });
+
+                        if let Some(fk_index) = parent_fk_index {
+                            let fk_index_name = fk_index.name.clone();
+                            let parent_scan_mapping = plan.document_map().clone();
+                            let parent_col = parent_collection.clone();
+                            let fk_field_index = parent_scan_mapping
+                                .first_index_of_name(&parent_fk_field_name)
+                                .unwrap_or(0);
+                            let fetcher = self.fetcher.clone().unwrap();
+
+                            let join = TypeJoinOne::new(
+                                plan,
+                                child_plan,
+                                parent_side,
+                                child_side,
+                                mapping.clone(),
+                            )
+                            .with_inverted_index(
+                                fk_index_name,
+                                fk_field_index,
+                                parent_col,
+                                parent_scan_mapping,
+                                fetcher,
+                            );
+                            plan = Box::new(join);
+                            join_provides_ordering = true;
+                        } else {
+                            // No FK index on parent → fall back to normal join + OrderByNode
+                            let mut join = TypeJoinOne::new(
+                                plan,
+                                child_plan,
+                                parent_side,
+                                child_side,
+                                mapping.clone(),
+                            );
+                            if let Some(rel_filter) = relation_filter {
+                                join = join.with_relation_filter(rel_filter);
+                            }
+                            plan = Box::new(join);
+                        }
+                    }
+                } else {
+                    let mut join = TypeJoinOne::new(
+                        plan,
+                        child_plan,
+                        parent_side,
+                        child_side,
+                        mapping.clone(),
+                    );
+                    if let Some(rel_filter) = relation_filter {
+                        join = join.with_relation_filter(rel_filter);
+                    }
+                    plan = Box::new(join);
                 }
-                plan = Box::new(join);
             }
         }
 
@@ -1949,7 +2100,7 @@ impl Planner {
             }
         }
 
-        Ok((plan, mapping, aggregate_internal_keys))
+        Ok((plan, mapping, aggregate_internal_keys, join_provides_ordering))
     }
 
     /// Build a scan mapping for join child plans that includes ALL fields at schema indices.

--- a/crates/query/src/planner/joins.rs
+++ b/crates/query/src/planner/joins.rs
@@ -1179,6 +1179,7 @@ impl Planner {
                 // Build child scan, using an index if the filter is index-eligible.
                 let child_index_result =
                     self.try_select_child_index(Some(&nested_conditions), None, &target_collection);
+                let child_has_index = child_index_result.is_some();
                 let child_plan: Box<dyn PlanNode> = if let Some((params, _)) = child_index_result {
                     let mut index_scan = IndexScanNode::new(
                         (*target_collection).clone(),
@@ -1255,16 +1256,58 @@ impl Planner {
                     .with_relation_filter(rel_filter);
                     plan = Box::new(join_many);
                 } else {
-                    // One-to-one: TypeJoinOne with filter
-                    let join = TypeJoinOne::new(
-                        plan,
-                        child_plan,
-                        parent_side,
-                        child_side,
-                        mapping.clone(),
-                    )
-                    .with_relation_filter(rel_filter);
-                    plan = Box::new(join);
+                    // One-to-one (or many-to-one): TypeJoinOne with filter
+                    // Check if we should use inverted index join:
+                    // child has index on filtered field AND parent has index on FK field.
+                    let parent_fk_field_name =
+                        schema::CollectionVersion::relation_id_field_name(&relation_field.name);
+                    let parent_fk_index = if child_has_index {
+                        parent_collection.indexes.iter().find(|idx| {
+                            idx.fields
+                                .first()
+                                .map_or(false, |f| f.name == parent_fk_field_name)
+                        })
+                    } else {
+                        None
+                    };
+
+                    if let Some(fk_index) = parent_fk_index {
+                        // Inverted index join: child scanned with index, parent looked up per-child
+                        let fk_index_name = fk_index.name.clone();
+                        let parent_scan_mapping = plan.document_map().clone();
+                        let parent_col = parent_collection.clone();
+                        let fk_field_index = parent_scan_mapping
+                            .first_index_of_name(&parent_fk_field_name)
+                            .unwrap_or(0);
+                        let fetcher = self.fetcher.clone().unwrap();
+
+                        let join = TypeJoinOne::new(
+                            plan,
+                            child_plan,
+                            parent_side,
+                            child_side,
+                            mapping.clone(),
+                        )
+                        .with_relation_filter(rel_filter)
+                        .with_inverted_index(
+                            fk_index_name,
+                            fk_field_index,
+                            parent_col,
+                            parent_scan_mapping,
+                            fetcher,
+                        );
+                        plan = Box::new(join);
+                    } else {
+                        let join = TypeJoinOne::new(
+                            plan,
+                            child_plan,
+                            parent_side,
+                            child_side,
+                            mapping.clone(),
+                        )
+                        .with_relation_filter(rel_filter);
+                        plan = Box::new(join);
+                    }
                 }
             }
         }

--- a/crates/query/src/planner/mod.rs
+++ b/crates/query/src/planner/mod.rs
@@ -20,6 +20,6 @@ mod view_builder;
 pub use builder::{PlanResult, Planner};
 pub use index_selection::{
     can_use_index, extract_field_conditions, filter_to_index_scan, select_best_index,
-    ConditionValue, FieldCondition, IndexScanParams, IndexScanType,
+    ConditionValue, FieldCondition, IndexScanParams, IndexScanType, ScanValueFilter,
 };
 pub use traits::{Doc, DocFields, DocStatus, ExecInfo, PlanNode};

--- a/crates/query/src/runner/explain/mod.rs
+++ b/crates/query/src/runner/explain/mod.rs
@@ -830,7 +830,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             .map(|f| f.has_relation_filters())
             .unwrap_or(false);
 
-        let _order_has_relations = select
+        let order_has_relations = select
             .order_by
             .as_ref()
             .map(|o| o.has_relation_order())
@@ -845,6 +845,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             || has_relation_aggregates
             || has_nested
             || filter_has_relations
+            || order_has_relations
             || has_similarity
         {
             // Use Planner path for index-based queries, relation aggregates,

--- a/crates/query/src/runner/explain/mod.rs
+++ b/crates/query/src/runner/explain/mod.rs
@@ -999,10 +999,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             // Check if this object contains scanNode
             if let Some(scan_node) = obj.get_mut("scanNode") {
                 if let Some(scan_obj) = scan_node.as_object_mut() {
-                    scan_obj.insert(
-                        "iterations".to_string(),
-                        serde_json::json!(iterations),
-                    );
+                    scan_obj.insert("iterations".to_string(), serde_json::json!(iterations));
                     scan_obj.insert(
                         "docFetches".to_string(),
                         serde_json::json!(doc_fetches as u64),

--- a/crates/query/src/runner/introspection.rs
+++ b/crates/query/src/runner/introspection.rs
@@ -611,17 +611,33 @@ fn build_order_input_type(
         InputValue::new("_docID", TypeRef::named("Ordering")),
     ));
 
-    // Add order fields for each collection field (scalars and scalar arrays only).
-    // Relation fields are excluded — Go rejects ordering by related child fields
-    // (e.g., `Author(order: {articles: {name: ASC}})` produces a validation error).
+    // Add order fields for each collection field.
+    // One-to-one relation fields reference the related collection's OrderArg type to allow
+    // nested ordering like `User(order: {device: {model: ASC}})`.
+    // One-to-many relations (arrays) are excluded — ordering by an array relation is ambiguous.
     for field in &collection.fields {
-        if field.name == "_docID" || field.kind.is_relation() {
+        if field.name == "_docID" {
             continue;
         }
-        fields.push((
-            field.name.clone(),
-            InputValue::new(&field.name, TypeRef::named("Ordering")),
-        ));
+        if field.kind.is_relation() && !field.kind.is_array() {
+            // One-to-one relation: reference the related collection's OrderArg type
+            if let Some(related_collection_id) = field.kind.relation_collection_id() {
+                if let Some(related_name) = _id_to_name.get(related_collection_id) {
+                    fields.push((
+                        field.name.clone(),
+                        InputValue::new(
+                            &field.name,
+                            TypeRef::named(format!("{}OrderArg", related_name)),
+                        ),
+                    ));
+                }
+            }
+        } else if !field.kind.is_relation() {
+            fields.push((
+                field.name.clone(),
+                InputValue::new(&field.name, TypeRef::named("Ordering")),
+            ));
+        }
     }
 
     // Sort alphabetically to match Go introspection output

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -1334,7 +1334,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         Ok(JsonValue::Array(results))
     }
 
-    ///
     /// Top-level aggregates compute a single value over all documents in a collection.
     /// Unlike regular collection queries that return an array, top-level aggregates
     /// return a single value (the computed aggregate).

--- a/crates/storage/src/index/matcher.rs
+++ b/crates/storage/src/index/matcher.rs
@@ -188,6 +188,11 @@ impl NlikeMatcher {
 
 impl IndexMatcher for NlikeMatcher {
     fn matches(&self, value: &NormalValue) -> bool {
+        // Non-string values don't participate in LIKE matching at all (Go behavior).
+        // Both _like and _nlike return false for non-strings.
+        if value.as_str().is_none() {
+            return false;
+        }
         !self.inner.matches(value)
     }
 }

--- a/crates/storage/src/index/mod.rs
+++ b/crates/storage/src/index/mod.rs
@@ -395,14 +395,14 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("constraint violation"),
-            "error should mention constraint violation: {}",
+            err_msg.contains("violates unique index"),
+            "error should mention unique index violation: {}",
             err_msg
         );
     }
 
     #[tokio::test]
-    async fn test_unique_index_allows_same_doc_update() {
+    async fn test_unique_index_rejects_same_doc_duplicate() {
         let store = MemoryStore::new();
         let mut txn = store.new_txn(false).await.unwrap();
 
@@ -411,8 +411,9 @@ mod tests {
 
         index.save(&mut txn, "doc1", &values).await.unwrap();
 
-        // Same value, same doc ID - should work (idempotent)
-        index.save(&mut txn, "doc1", &values).await.unwrap();
+        // Same value, same doc ID - should fail (e.g., JSON array self-duplicates)
+        let result = index.save(&mut txn, "doc1", &values).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -587,13 +588,8 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("constraint violation"),
-            "error should mention constraint violation: {}",
-            err_msg
-        );
-        assert!(
-            err_msg.contains("doc2"),
-            "error should mention conflicting document: {}",
+            err_msg.contains("violates unique index"),
+            "error should mention unique index violation: {}",
             err_msg
         );
     }

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -210,15 +210,15 @@ impl CollectionIndex for UniqueIndex {
 
         let key = self.build_key(values)?;
 
-        // Check for existing entry (uniqueness constraint)
-        if let Some(existing) = txn.get(&key).await? {
-            let existing_doc_id = String::from_utf8(existing)
-                .map_err(|e| crate::corekv::Error::Other(e.to_string()))?;
-            if existing_doc_id != doc_id {
-                return Err(crate::corekv::Error::Other(
-                    "can not index a doc's field(s) that violates unique index.".to_string(),
-                ));
-            }
+        // Check for existing entry (uniqueness constraint).
+        // Any existing key is a violation during save (create). Unlike update(),
+        // save() should never encounter the same key for the same doc_id — that
+        // would indicate duplicate values within the same document (e.g., JSON
+        // array self-duplicates like [5, 8, 5]).
+        if txn.has(&key).await? {
+            return Err(crate::corekv::Error::Other(
+                "can not index a doc's field(s) that violates unique index.".to_string(),
+            ));
         }
 
         // Store doc_id as the value

--- a/crates/wasm/src/bindings.rs
+++ b/crates/wasm/src/bindings.rs
@@ -26,7 +26,6 @@ pub struct ClientConfig {
     pub db_name: Option<String>,
 }
 
-
 /// Collection info returned to JavaScript.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CollectionInfo {

--- a/tools/ffi-test/src/main.rs
+++ b/tools/ffi-test/src/main.rs
@@ -141,9 +141,7 @@ async fn main() {
             all,
         } => commands::logs::execute(&package, test.as_deref(), failed, all).await,
 
-        Commands::Packages { package } => {
-            commands::packages::execute(package.as_deref()).await
-        }
+        Commands::Packages { package } => commands::packages::execute(package.as_deref()).await,
 
         Commands::Worktree { command } => match command {
             WorktreeCommands::List => commands::worktree::list().await,


### PR DESCRIPTION
## Summary

Takes FFI index test suite from **26 failures to 0 failures** (331/331 passing).

### Query Engine Fixes
- **Index selection scoring**: Prefer range operators (`_gt/_gte/_lt/_lte`: +3) and `_in` (+4) over full-scan operators (`_like/_ne`: +0) so the most selective index is chosen
- **Parent index suppression**: Skip parent own-field index when filter contains relation conditions, using schema-based `is_relation()` check
- **Per-parent scanning**: Refined TypeJoinMany with FK index detection — only per-parent when there's a limit, child sub-filter without parent filter plan, or ordering without FK index
- **Inverted index join**: TypeJoinOne scans child index first, then looks up parents via FK index — handles OneToOnePrimary and ManyToOne patterns
- **Ordered inverted join**: Relation ORDER BY paths (e.g., `User(order: {device: {model: ASC}})`) use child collection's index in sorted order, joining back to parents
- **JSON index encoding**: Top-level null stored as plain `NormalValue::Null`; nested null as `JsonLeafValue`
- **JSON unique array index**: Uniqueness enforcement for duplicate values across documents
- **JSON indexFetches counting**: Count every index key scanned, not just matching doc IDs

### P2P Fixes
- **Broadcast for updates/deletes**: Read actual committed composite block from headstore/blockstore instead of recreating with wrong priority/heads (CID mismatch fix)
- **Index cleanup on P2P delete merge**: Call `index_manager.on_document_delete()` before writing deletion marker

### Schema Fixes
- **FieldKind::Named resolution**: Resolve `FieldKind::Named` to `FieldKind::Relation` before CID generation in schema patch, matching Go's `substituteRelationFieldKinds`

### Code Quality
- Resolve clippy warnings across query, p2p, ffi, defra-core, crypto, storage, ffi-test crates

## Commits

| Commit | Description | Tests Fixed |
|--------|-------------|-------------|
| `3d7ddcc` | Build warnings + 7 test fixes | 7 |
| `bb4feec` | Scoring, per-parent, relation filter | 12 |
| `b8bc6dc` | Inverted index join for TypeJoinOne | 4 |
| `73036c4` | Ordered inverted join for relation ORDER BY | 7 |
| `ec81017` | Clippy (defra-core, crypto, storage, ffi-test) | — |
| `25040c3` | Clippy (query, p2p, ffi) | — |
| `40f24c9` | FieldKind::Named resolution for CID generation | 1 |
| `50aabd8` | P2P broadcast for updates/deletes + index cleanup | 2 |

## Test plan
- [x] `ffi-test run index` — **331/331 passed** (0 failures)
- [x] `cargo test -p query --lib` — all passing
- [x] No regressions from previous passing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)