### PR TITLE
feat(db): Add embedding generation for create/update mutations

### DIFF
--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -41,6 +41,9 @@ sha2.workspace = true
 # Random number generation (for Counter CRDT nonces)
 rand = "0.8"
 
+# HTTP client (for embedding generation API calls)
+reqwest = { version = "0.12", features = ["json"] }
+
 # Encoding
 base64.workspace = true
 hex.workspace = true

--- a/crates/db/src/auto_commit_mutator.rs
+++ b/crates/db/src/auto_commit_mutator.rs
@@ -64,6 +64,16 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
+        // Generate embeddings before doc ID (embedding values affect content hash)
+        crate::embedding::set_embedding(
+            &collection.schema().vector_embeddings,
+            &mut doc,
+            true,
+            None,
+        )
+        .await
+        .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;
+
         // Generate document ID if not present
         if doc.id().is_none() {
             doc.generate_and_set_doc_id().map_err(|e| {
@@ -289,6 +299,23 @@ impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
             .get_collection(collection_name)
             .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        // Generate embeddings if source fields were modified
+        let mut doc = doc;
+        let mut modified_fields = modified_fields;
+
+        let generated = crate::embedding::set_embedding(
+            &collection.schema().vector_embeddings,
+            &mut doc,
+            false,
+            Some(&modified_fields),
+        )
+        .await
+        .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;
+
+        for field in generated {
+            modified_fields.insert(field);
+        }
 
         // Create a write transaction
         let txn = self.db.new_txn(false).await.map_err(|e| {

--- a/crates/db/src/embedding.rs
+++ b/crates/db/src/embedding.rs
@@ -1,0 +1,179 @@
+use document::{Document, NormalValue};
+use schema::VectorEmbeddingDescription;
+use std::collections::HashSet;
+
+/// Generate and set embedding vectors on a document based on the collection's
+/// vector embedding configuration.
+///
+/// Returns the names of fields that were generated (so the caller can add them
+/// to modified_fields for block creation).
+///
+/// On create: generates embeddings for all configured fields unless the user
+/// already provided the vector value. Runs BEFORE doc ID generation so the
+/// content-addressed ID includes embedding values.
+///
+/// On update: generates embeddings only if a source field was modified.
+/// Skips generation if the user explicitly set the vector field.
+pub async fn set_embedding(
+    embeddings: &[VectorEmbeddingDescription],
+    doc: &mut Document,
+    is_create: bool,
+    modified_fields: Option<&HashSet<String>>,
+) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+    let mut generated = Vec::new();
+
+    for embedding in embeddings {
+        // Skip if user explicitly provided the embedding vector
+        if is_create {
+            if let Some(fv) = doc.get_field_value(&embedding.field_name) {
+                if fv.is_dirty() {
+                    continue;
+                }
+            }
+        } else if let Some(fields) = modified_fields {
+            if fields.contains(&embedding.field_name) {
+                continue;
+            }
+        }
+
+        // On update, check if any source field was modified
+        if !is_create {
+            if let Some(fields) = modified_fields {
+                let any_source_modified = embedding.fields.iter().any(|f| fields.contains(f));
+                if !any_source_modified {
+                    continue;
+                }
+            }
+        }
+
+        // Build text from source field values
+        let mut text = String::new();
+        for field_name in &embedding.fields {
+            if let Some(val) = doc.get(field_name) {
+                let s = normal_value_to_string(val);
+                text.push_str(&s);
+                text.push('\n');
+            }
+        }
+
+        // Call embedding provider
+        let vec =
+            call_embedding_provider(&embedding.provider, &embedding.model, &embedding.url, &text)
+                .await?;
+
+        doc.set(&embedding.field_name, NormalValue::Float32Array(vec));
+        generated.push(embedding.field_name.clone());
+    }
+
+    Ok(generated)
+}
+
+fn normal_value_to_string(val: &NormalValue) -> String {
+    match val {
+        NormalValue::String(s) => s.clone(),
+        NormalValue::Int(i) => i.to_string(),
+        NormalValue::Float64(f) => format!("{}", f),
+        NormalValue::Float32(f) => format!("{}", f),
+        NormalValue::Bool(b) => b.to_string(),
+        other => format!("{:?}", other),
+    }
+}
+
+async fn call_embedding_provider(
+    provider: &str,
+    model: &str,
+    url: &str,
+    text: &str,
+) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+    match provider {
+        "ollama" => call_ollama(model, url, text).await,
+        "openai" => call_openai(model, url, text).await,
+        other => Err(format!("unsupported embedding provider: {}", other).into()),
+    }
+}
+
+async fn call_ollama(
+    model: &str,
+    url: &str,
+    text: &str,
+) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+    let base = if url.is_empty() {
+        "http://localhost:11434/api"
+    } else {
+        url
+    };
+    let endpoint = format!("{}/embeddings", base.trim_end_matches('/'));
+
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "model": model,
+        "prompt": text,
+    });
+
+    let resp = client.post(&endpoint).json(&body).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("ollama returned {}: {}", status, text).into());
+    }
+
+    let result: serde_json::Value = resp.json().await?;
+    let embedding = result
+        .get("embedding")
+        .and_then(|v| v.as_array())
+        .ok_or("ollama response missing 'embedding' array")?;
+
+    let vec: Vec<f32> = embedding
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(0.0) as f32)
+        .collect();
+
+    Ok(vec)
+}
+
+async fn call_openai(
+    model: &str,
+    url: &str,
+    text: &str,
+) -> Result<Vec<f32>, Box<dyn std::error::Error + Send + Sync>> {
+    let base = if url.is_empty() {
+        "https://api.openai.com/v1"
+    } else {
+        url
+    };
+    let endpoint = format!("{}/embeddings", base.trim_end_matches('/'));
+
+    let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "model": model,
+        "input": text,
+    });
+
+    let resp = client
+        .post(&endpoint)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("openai returned {}: {}", status, text).into());
+    }
+
+    let result: serde_json::Value = resp.json().await?;
+    let embedding = result
+        .pointer("/data/0/embedding")
+        .and_then(|v| v.as_array())
+        .ok_or("openai response missing embedding data")?;
+
+    let vec: Vec<f32> = embedding
+        .iter()
+        .map(|v| v.as_f64().unwrap_or(0.0) as f32)
+        .collect();
+
+    Ok(vec)
+}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -62,6 +62,7 @@ pub mod database;
 pub mod definition_validation;
 pub mod doc_fetcher;
 pub mod doc_mutator;
+pub mod embedding;
 pub mod error;
 #[cfg(feature = "p2p")]
 pub mod head_provider;

--- a/crates/query/src/sdl_parse/builder.rs
+++ b/crates/query/src/sdl_parse/builder.rs
@@ -12,7 +12,7 @@ use cid::Cid;
 use crate::error::{QueryError, Result};
 use schema::{
     CType, CollectionVersion, FieldDescription, FieldKind, IndexDescription,
-    IndexedFieldDescription,
+    IndexedFieldDescription, VectorEmbeddingDescription,
 };
 use std::collections::HashMap;
 
@@ -839,10 +839,25 @@ impl<'a> SdlParser<'a> {
             .map(|f| schema::EncryptedIndexDescription::new(&f.name))
             .collect();
 
+        // Build vector embeddings from @embedding directives
+        let vector_embeddings: Vec<VectorEmbeddingDescription> = type_def
+            .fields
+            .iter()
+            .filter_map(|f| {
+                f.directives.embedding.as_ref().map(|emb| {
+                    VectorEmbeddingDescription::new(&f.name, &emb.model, &emb.provider)
+                        .with_fields(emb.fields.clone())
+                        .with_url(&emb.url)
+                        .with_template(&emb.template)
+                })
+            })
+            .collect();
+
         let mut collection =
             CollectionVersion::new(&type_def.name, &version_id, &collection_id, fields);
         collection.indexes = indexes;
         collection.encrypted_indexes = encrypted_indexes;
+        collection.vector_embeddings = vector_embeddings;
         collection.is_materialized = type_def.directives.is_materialized;
         collection.is_branchable = type_def.directives.is_branchable;
         if let Some(ref policy_config) = type_def.directives.policy {

--- a/crates/query/src/sdl_parse/directives.rs
+++ b/crates/query/src/sdl_parse/directives.rs
@@ -104,6 +104,16 @@ pub fn default_type_error(
     ))
 }
 
+/// Parsed embedding configuration from @embedding directive
+#[derive(Debug, Clone)]
+pub struct EmbeddingConfig {
+    pub provider: String,
+    pub model: String,
+    pub url: String,
+    pub fields: Vec<String>,
+    pub template: String,
+}
+
 /// Parsed directive information from a field
 #[derive(Debug, Default, Clone)]
 pub struct ParsedDirectives {
@@ -123,6 +133,8 @@ pub struct ParsedDirectives {
     pub size_constraint: Option<usize>,
     /// Whether this field has an encrypted index for searchable encryption
     pub encrypted_index: bool,
+    /// Embedding configuration from @embedding directive
+    pub embedding: Option<EmbeddingConfig>,
 }
 
 /// Index configuration from @index directive

--- a/crates/query/src/sdl_parse/fields.rs
+++ b/crates/query/src/sdl_parse/fields.rs
@@ -79,7 +79,22 @@ impl<'a> SdlParser<'a> {
                     // Searchable encryption index
                     result.encrypted_index = true;
                 }
-                "embedding" | "policy" => {
+                "embedding" => {
+                    let provider = get_directive_string(directive, "provider").unwrap_or_default();
+                    let model = get_directive_string(directive, "model").unwrap_or_default();
+                    let url = get_directive_string(directive, "url").unwrap_or_default();
+                    let fields = get_directive_string_list(directive, "fields");
+                    let template = get_directive_string(directive, "template").unwrap_or_default();
+
+                    result.embedding = Some(super::directives::EmbeddingConfig {
+                        provider,
+                        model,
+                        url,
+                        fields,
+                        template,
+                    });
+                }
+                "policy" => {
                     // Known but not yet implemented - emit warning so users know
                     self.warnings.push(ParseWarning::UnimplementedDirective {
                         directive_name: directive.name.clone(),

--- a/crates/query/src/sdl_parse/parser.rs
+++ b/crates/query/src/sdl_parse/parser.rs
@@ -276,7 +276,7 @@ pub fn parse_sdl_with_known_types(
 /// - Unknown directives (forward compatibility - ignored but noted)
 /// - Unknown arguments on known directives (possible typos)
 /// - Invalid argument types (e.g., string where bool expected - default used)
-/// - Unimplemented directives (@embedding, @encryptedIndex, field @policy)
+/// - Unimplemented directives (@encryptedIndex, field @policy)
 ///
 /// This is the recommended entry point for production use.
 pub fn parse_sdl_with_warnings(sdl: &str) -> Result<ParseOutput> {

--- a/crates/query/src/sdl_parse/parser_tests.rs
+++ b/crates/query/src/sdl_parse/parser_tests.rs
@@ -1241,29 +1241,25 @@ fn test_policy_directive_unknown_argument_emits_warning() {
 }
 
 #[test]
-fn test_embedding_directive_emits_unimplemented_warning() {
+fn test_embedding_directive_parses_config() {
     let sdl = r#"
         type Document {
-            content: String @embedding(provider: "openai", model: "ada")
+            content: String
+            content_v: [Float32!] @embedding(provider: "openai", model: "ada", url: "http://localhost:8080", fields: ["content"])
         }
     "#;
 
     let output = parse_sdl_with_warnings(sdl).unwrap();
     assert_eq!(output.collections.len(), 1);
-    // @embedding is recognized but not implemented, should emit UnimplementedDirective
-    assert_eq!(output.warnings.len(), 1);
-    match &output.warnings[0] {
-        ParseWarning::UnimplementedDirective {
-            directive_name,
-            type_name,
-            field_name,
-        } => {
-            assert_eq!(directive_name, "embedding");
-            assert_eq!(type_name, "Document");
-            assert_eq!(field_name.as_deref(), Some("content"));
-        }
-        other => panic!("expected UnimplementedDirective, got {:?}", other),
-    }
+    assert_eq!(output.warnings.len(), 0);
+
+    let col = &output.collections[0];
+    assert_eq!(col.vector_embeddings.len(), 1);
+    assert_eq!(col.vector_embeddings[0].field_name, "content_v");
+    assert_eq!(col.vector_embeddings[0].provider, "openai");
+    assert_eq!(col.vector_embeddings[0].model, "ada");
+    assert_eq!(col.vector_embeddings[0].url, "http://localhost:8080");
+    assert_eq!(col.vector_embeddings[0].fields, vec!["content"]);
 }
 
 #[test]
@@ -1276,17 +1272,10 @@ fn test_embedding_directive_unknown_argument_emits_warning() {
 
     let output = parse_sdl_with_warnings(sdl).unwrap();
     assert_eq!(output.collections.len(), 1);
-    // Should have both UnknownDirectiveArgument and UnimplementedDirective
-    assert_eq!(output.warnings.len(), 2);
+    // Should have UnknownDirectiveArgument warning only
+    assert_eq!(output.warnings.len(), 1);
 
-    // Find the UnknownDirectiveArgument warning
-    let unknown_arg = output
-        .warnings
-        .iter()
-        .find(|w| matches!(w, ParseWarning::UnknownDirectiveArgument { .. }))
-        .expect("should have UnknownDirectiveArgument warning");
-
-    match unknown_arg {
+    match &output.warnings[0] {
         ParseWarning::UnknownDirectiveArgument {
             directive_name,
             argument_name,
@@ -1295,7 +1284,7 @@ fn test_embedding_directive_unknown_argument_emits_warning() {
             assert_eq!(directive_name, "embedding");
             assert_eq!(argument_name, "unknownArg");
         }
-        _ => unreachable!(),
+        other => panic!("expected UnknownDirectiveArgument, got {:?}", other),
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `crates/db/src/embedding.rs` implementing `set_embedding()` which calls Ollama/OpenAI APIs to generate vector embeddings during document create/update, matching Go's `setEmbedding()` behavior
- Integrates embedding generation in `auto_commit_mutator.rs`: before doc ID generation on create (so CID includes embedding values), and before `update_with_indexes` on update (only when source fields are modified)
- Implements `@embedding` directive parsing in the SDL parser (`crates/query/src/sdl_parse/`), populating `CollectionVersion.vector_embeddings` with provider, model, url, fields, and template from the directive arguments
- Skips generation when the user explicitly provides the vector field value

## Go companion PR
- Go test changes pushed to `ffi/embeddings` branch on sourcenetwork/defradb — adds `state.RustFFIClientType` to 4 embedding test `SupportedClientTypes` (1 create, 3 update)
- FFI wrapper fix: converts JSON float arrays to `[]float32` to match Go's GraphQL Float32 scalar behavior

## Test plan
- [x] `ollama pull nomic-embed-text` (model used by tests)
- [x] `DEFRA_VECTOR_EMBEDDING=true ffi-test run mutation/create/embeddings` (2/2 pass)
- [x] `DEFRA_VECTOR_EMBEDDING=true ffi-test run mutation/update/embeddings --skip-build` (3/3 pass)
- [x] `cargo clippy --all -- -D warnings` (clean)
- [x] `ffi-test run query/simple --skip-build` (435/435 pass, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)