### PR TITLE
feat(ffi): GraphQL subscription support via FFI

### DIFF
--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -270,16 +270,24 @@ pub extern "C" fn new_node(options: NodeInitOptions) -> NewNodeResult {
 /// All subscriptions associated with this node will be closed.
 #[no_mangle]
 pub extern "C" fn node_close(node_ptr: usize) -> FfiResult {
-    use crate::state::SUBSCRIPTIONS;
+    use crate::state::{GRAPHQL_SUBSCRIPTIONS, SUBSCRIPTIONS};
 
     let rt = get_runtime!(FfiResult);
 
-    // Remove all subscriptions for this node
+    // Remove all raw subscriptions for this node
     let removed_subs = SUBSCRIPTIONS.remove_for_node(node_ptr);
     for sub_state in removed_subs {
-        // Unsubscribe from the event bus
         NODES.get(node_ptr, |state| {
             state.event_bus.unsubscribe(sub_state.subscription.id());
+        });
+    }
+
+    // Remove all GraphQL subscriptions for this node
+    let removed_gql_subs = GRAPHQL_SUBSCRIPTIONS.remove_for_node(node_ptr);
+    for sub_state in removed_gql_subs {
+        sub_state.task_abort.abort();
+        NODES.get(node_ptr, |state| {
+            state.event_bus.unsubscribe(sub_state.event_sub_id);
         });
     }
 

--- a/crates/ffi/src/query.rs
+++ b/crates/ffi/src/query.rs
@@ -9,7 +9,7 @@ use acp::nac::NodePermission;
 
 use crate::get_runtime;
 use crate::nac_check::check_nac_for_node;
-use crate::state::NODES;
+use crate::state::{GraphQLSubscriptionState, GRAPHQL_SUBSCRIPTIONS, NODES};
 use crate::types::{c_str_to_string, FfiResult};
 use crate::ERR_INVALID_NODE_HANDLE;
 
@@ -187,6 +187,91 @@ pub unsafe extern "C" fn exec_request(
     // Check if identity has DAC bypass (NAC admin/owner can read all documents)
     check_and_set_dac_bypass(rt, node_ptr, identity_did);
 
+    // Check if this is a subscription query - handle it separately from regular queries/mutations.
+    // Subscriptions return status=2 with a handle that the Go side polls via poll_graphql_subscription.
+    let trimmed_query = query_str.trim_start();
+    if trimmed_query.starts_with("subscription") {
+        // Create an event bus subscription to receive update events
+        let mut subscription = match NODES.get(node_ptr, |state| {
+            state.event_bus.subscribe(&[events::EventName::Update])
+        }) {
+            Some(sub) => sub,
+            None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
+        };
+        let sub_id = subscription.id();
+
+        let query_runner = match NODES.get(node_ptr, |state| state.query_runner.clone()) {
+            Some(r) => r,
+            None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
+        };
+
+        // Extract any pre-existing docID filter from the subscription query
+        let subscription_doc_id = extract_doc_id_from_query(&query_str);
+        let sub_query = query_str.clone();
+        let sub_identity = did.clone();
+
+        // Create result channel for buffering processed subscription results
+        let (result_tx, result_rx) = tokio::sync::mpsc::channel::<String>(256);
+
+        // Detect if this is a _commits subscription (uses CID-based queries)
+        let is_commits = is_commits_subscription(&query_str);
+
+        // Spawn background task that processes events and executes queries at event time.
+        // This ensures the DB state at query execution matches the event's state.
+        let task = rt.spawn(async move {
+            while let Some(message) = subscription.recv().await {
+                if let Some(update) = message.as_update() {
+                    let event_doc_id = update.doc_id.clone();
+
+                    // Check subscription docID filter
+                    if let Some(ref sub_doc) = subscription_doc_id {
+                        if event_doc_id != *sub_doc {
+                            continue;
+                        }
+                    }
+
+                    // Convert subscription to a query scoped to the changed document.
+                    // For _commits subscriptions, use the event's CID to get just the
+                    // composite commit. For regular subscriptions, use docID.
+                    let query_text = if is_commits {
+                        let cid_str = update.cid.to_string();
+                        subscription_to_commits_query_with_cid(&sub_query, &cid_str)
+                    } else {
+                        subscription_to_query_with_doc_id(&sub_query, &event_doc_id)
+                    };
+
+                    // Execute the query
+                    let mut request = query::QueryRequest::new(query_text);
+                    if sub_identity.is_some() {
+                        request = request.with_identity(sub_identity.clone());
+                    }
+                    let response = query_runner.execute(request).await;
+
+                    // Skip empty results (filter excluded the document)
+                    if !crate::subscription::response_has_data(&response) {
+                        continue;
+                    }
+
+                    if let Ok(json) = serde_json::to_string(&response) {
+                        if result_tx.send(json).await.is_err() {
+                            break; // Receiver dropped
+                        }
+                    }
+                }
+            }
+        });
+
+        let state = GraphQLSubscriptionState {
+            result_receiver: result_rx,
+            node_handle: node_ptr,
+            event_sub_id: sub_id,
+            task_abort: task.abort_handle(),
+        };
+
+        let handle = GRAPHQL_SUBSCRIPTIONS.insert(state);
+        return FfiResult::subscription(handle.to_string());
+    }
+
     // Check if this is an encrypted query (encrypted_<Collection>) and validate P2P is enabled
     // Go only generates the encrypted_<Collection> GraphQL field when P2P is enabled,
     // so we need to return a schema validation error if P2P is disabled
@@ -247,6 +332,182 @@ pub unsafe extern "C" fn exec_request(
     match result {
         Ok(json) => FfiResult::success(json),
         Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Extract a docID value from a GraphQL query string.
+///
+/// Looks for patterns like `docID: "bae-xxx"` or `docID: "bae-xxx"` in the query.
+/// Returns None if no docID is found.
+pub(crate) fn extract_doc_id_from_query(query: &str) -> Option<String> {
+    // Look for docID: "..." or docID:"..."
+    let doc_id_marker = "docID:";
+    let pos = query.find(doc_id_marker)?;
+    let after = &query[pos + doc_id_marker.len()..];
+    let after = after.trim_start();
+
+    // Find the quoted value
+    if after.starts_with('"') {
+        let value_start = 1;
+        let value_end = after[value_start..].find('"')?;
+        Some(after[value_start..value_start + value_end].to_string())
+    } else {
+        None
+    }
+}
+
+/// Convert a subscription query to a regular query scoped to a specific docID.
+///
+/// Transforms: `subscription { User(filter: ...) { fields } }`
+/// Into: `{ User(docID: "bae-xxx", filter: ...) { fields } }`
+pub(crate) fn subscription_to_query_with_doc_id(subscription_query: &str, doc_id: &str) -> String {
+    // Step 1: Remove "subscription" keyword
+    let trimmed = subscription_query.trim_start();
+    let query = if let Some(after) = trimmed.strip_prefix("subscription") {
+        let after = after.trim_start();
+        if after.starts_with('{') {
+            after.to_string()
+        } else if let Some(brace_pos) = after.find('{') {
+            after[brace_pos..].to_string()
+        } else {
+            after.to_string()
+        }
+    } else {
+        trimmed.to_string()
+    };
+
+    // Step 2: Find the root field name and inject docID
+    let brace_pos = match query.find('{') {
+        Some(p) => p,
+        None => return query,
+    };
+
+    let after_brace = &query[brace_pos + 1..];
+    let ws_len = after_brace.len() - after_brace.trim_start().len();
+    let field_start_in_q = brace_pos + 1 + ws_len;
+
+    let rest = &query[field_start_in_q..];
+    let field_end = rest
+        .find(|c: char| !c.is_alphanumeric() && c != '_')
+        .unwrap_or(rest.len());
+    let after_field = field_start_in_q + field_end;
+
+    // Check what follows the field name
+    let post_field = query[after_field..].trim_start();
+    if post_field.starts_with('(') {
+        // Already has arguments
+        let paren_offset = query[after_field..].find('(').unwrap();
+        let paren_idx = after_field + paren_offset;
+
+        // Check if there's already a docID argument
+        if extract_doc_id_from_query(&query).is_some() {
+            // Keep the existing docID filter - just convert subscription to query
+            query
+        } else {
+            // Inject docID at start of existing args
+            format!(
+                "{}docID: \"{}\", {}",
+                &query[..paren_idx + 1],
+                doc_id,
+                &query[paren_idx + 1..]
+            )
+        }
+    } else {
+        // No arguments - inject (docID: "...")
+        format!(
+            "{}(docID: \"{}\"){}",
+            &query[..after_field],
+            doc_id,
+            &query[after_field..]
+        )
+    }
+}
+
+/// Check if a subscription query targets the `_commits` root field.
+pub(crate) fn is_commits_subscription(query: &str) -> bool {
+    let trimmed = query.trim_start();
+    let after_sub = trimmed.strip_prefix("subscription").unwrap_or(trimmed);
+    let brace_pos = match after_sub.find('{') {
+        Some(p) => p,
+        None => return false,
+    };
+    let after_brace = after_sub[brace_pos + 1..].trim_start();
+    after_brace.starts_with("_commits")
+}
+
+/// Convert a _commits subscription to a query scoped to a specific CID.
+///
+/// Transforms: `subscription { _commits(docID: "...") { fields } }`
+/// Into: `{ _commits(cid: "bafyrei-xxx") { fields } }`
+pub(crate) fn subscription_to_commits_query_with_cid(
+    subscription_query: &str,
+    cid: &str,
+) -> String {
+    // Step 1: Remove "subscription" keyword
+    let trimmed = subscription_query.trim_start();
+    let query = if let Some(after) = trimmed.strip_prefix("subscription") {
+        let after = after.trim_start();
+        if after.starts_with('{') {
+            after.to_string()
+        } else if let Some(brace_pos) = after.find('{') {
+            after[brace_pos..].to_string()
+        } else {
+            after.to_string()
+        }
+    } else {
+        trimmed.to_string()
+    };
+
+    // Step 2: Find the root field name (_commits)
+    let brace_pos = match query.find('{') {
+        Some(p) => p,
+        None => return query,
+    };
+
+    let after_brace = &query[brace_pos + 1..];
+    let ws_len = after_brace.len() - after_brace.trim_start().len();
+    let field_start_in_q = brace_pos + 1 + ws_len;
+
+    let rest = &query[field_start_in_q..];
+    let field_end = rest
+        .find(|c: char| !c.is_alphanumeric() && c != '_')
+        .unwrap_or(rest.len());
+    let after_field = field_start_in_q + field_end;
+
+    // Step 3: Replace or inject cid argument
+    let post_field = query[after_field..].trim_start();
+    if post_field.starts_with('(') {
+        // Has existing arguments - find the closing paren and replace all args with cid
+        let paren_start = query[after_field..].find('(').unwrap();
+        let paren_start_abs = after_field + paren_start;
+        let mut depth = 0;
+        let mut close_paren_abs = paren_start_abs;
+        for (i, c) in query[paren_start_abs..].char_indices() {
+            if c == '(' {
+                depth += 1;
+            }
+            if c == ')' {
+                depth -= 1;
+                if depth == 0 {
+                    close_paren_abs = paren_start_abs + i;
+                    break;
+                }
+            }
+        }
+        format!(
+            "{}(cid: \"{}\"){}",
+            &query[..paren_start_abs],
+            cid,
+            &query[close_paren_abs + 1..]
+        )
+    } else {
+        // No arguments - inject (cid: "...")
+        format!(
+            "{}(cid: \"{}\"){}",
+            &query[..after_field],
+            cid,
+            &query[after_field..]
+        )
     }
 }
 

--- a/crates/ffi/src/state.rs
+++ b/crates/ffi/src/state.rs
@@ -319,6 +319,23 @@ pub struct SubscriptionState {
     pub collection_filter: Option<String>,
 }
 
+/// State held for each GraphQL subscription (used by poll_graphql_subscription).
+///
+/// Subscription queries are re-executed at **event time** (not poll time) to ensure
+/// the DB state matches the event. A background tokio task processes events as they
+/// arrive, executes the subscription query scoped to the changed document, and
+/// buffers the full GraphQL JSON results for polling.
+pub struct GraphQLSubscriptionState {
+    /// Receiver for fully-processed GraphQL result JSON strings.
+    pub result_receiver: tokio::sync::mpsc::Receiver<String>,
+    /// The node handle this subscription belongs to.
+    pub node_handle: NodeHandle,
+    /// The event bus subscription ID (for cleanup/unsubscribe).
+    pub event_sub_id: u64,
+    /// Abort handle for the background event processing task.
+    pub task_abort: tokio::task::AbortHandle,
+}
+
 /// Global registry of active nodes.
 ///
 /// Uses RwLock for safe concurrent access from multiple threads.
@@ -450,6 +467,67 @@ pub fn subscriptions() -> &'static SubscriptionRegistry {
     SUBSCRIPTION_REGISTRY.get_or_init(SubscriptionRegistry::new)
 }
 
+/// Global registry of active GraphQL subscriptions.
+pub struct GraphQLSubscriptionRegistry {
+    subscriptions: RwLock<HashMap<SubscriptionHandle, GraphQLSubscriptionState>>,
+    next_handle: AtomicUsize,
+}
+
+impl GraphQLSubscriptionRegistry {
+    fn new() -> Self {
+        Self {
+            subscriptions: RwLock::new(HashMap::new()),
+            next_handle: AtomicUsize::new(1),
+        }
+    }
+
+    /// Insert a new GraphQL subscription state and return its handle.
+    pub fn insert(&self, state: GraphQLSubscriptionState) -> SubscriptionHandle {
+        let handle = self.next_handle.fetch_add(1, Ordering::SeqCst);
+        let mut subs = self.subscriptions.write();
+        subs.insert(handle, state);
+        handle
+    }
+
+    /// Get mutable access to a GraphQL subscription state.
+    pub fn get_mut<F, R>(&self, handle: SubscriptionHandle, f: F) -> Option<R>
+    where
+        F: FnOnce(&mut GraphQLSubscriptionState) -> R,
+    {
+        let mut subs = self.subscriptions.write();
+        subs.get_mut(&handle).map(f)
+    }
+
+    /// Remove and return a GraphQL subscription state.
+    pub fn remove(&self, handle: SubscriptionHandle) -> Option<GraphQLSubscriptionState> {
+        let mut subs = self.subscriptions.write();
+        subs.remove(&handle)
+    }
+
+    /// Remove all GraphQL subscriptions for a given node handle.
+    pub fn remove_for_node(&self, node_handle: NodeHandle) -> Vec<GraphQLSubscriptionState> {
+        let mut subs = self.subscriptions.write();
+        let handles_to_remove: Vec<SubscriptionHandle> = subs
+            .iter()
+            .filter(|(_, state)| state.node_handle == node_handle)
+            .map(|(handle, _)| *handle)
+            .collect();
+
+        handles_to_remove
+            .into_iter()
+            .filter_map(|handle| subs.remove(&handle))
+            .collect()
+    }
+}
+
+/// Global GraphQL subscription registry singleton.
+static GRAPHQL_SUBSCRIPTION_REGISTRY: OnceLock<GraphQLSubscriptionRegistry> = OnceLock::new();
+
+/// Access the global GraphQL subscription registry.
+pub fn graphql_subscriptions() -> &'static GraphQLSubscriptionRegistry {
+    GRAPHQL_SUBSCRIPTION_REGISTRY.get_or_init(GraphQLSubscriptionRegistry::new)
+}
+
 /// Convenience wrapper for subscription registry access.
 pub struct SubscriptionsAccess;
 
@@ -499,6 +577,33 @@ impl NodesAccess {
 
 /// Global NODES accessor for backwards compatibility.
 pub static NODES: NodesAccess = NodesAccess;
+
+/// Convenience wrapper for GraphQL subscription registry access.
+pub struct GraphQLSubscriptionsAccess;
+
+impl GraphQLSubscriptionsAccess {
+    pub fn insert(&self, state: GraphQLSubscriptionState) -> SubscriptionHandle {
+        graphql_subscriptions().insert(state)
+    }
+
+    pub fn get_mut<F, R>(&self, handle: SubscriptionHandle, f: F) -> Option<R>
+    where
+        F: FnOnce(&mut GraphQLSubscriptionState) -> R,
+    {
+        graphql_subscriptions().get_mut(handle, f)
+    }
+
+    pub fn remove(&self, handle: SubscriptionHandle) -> Option<GraphQLSubscriptionState> {
+        graphql_subscriptions().remove(handle)
+    }
+
+    pub fn remove_for_node(&self, node_handle: NodeHandle) -> Vec<GraphQLSubscriptionState> {
+        graphql_subscriptions().remove_for_node(node_handle)
+    }
+}
+
+/// Global GRAPHQL_SUBSCRIPTIONS accessor.
+pub static GRAPHQL_SUBSCRIPTIONS: GraphQLSubscriptionsAccess = GraphQLSubscriptionsAccess;
 
 #[cfg(test)]
 mod tests {

--- a/crates/ffi/src/subscription.rs
+++ b/crates/ffi/src/subscription.rs
@@ -10,7 +10,7 @@
 use std::ffi::{c_char, c_int};
 use std::ptr;
 
-use crate::state::{SubscriptionState, NODES, SUBSCRIPTIONS};
+use crate::state::{SubscriptionState, GRAPHQL_SUBSCRIPTIONS, NODES, SUBSCRIPTIONS};
 use crate::types::{c_str_to_string, sanitize_to_cstring};
 use crate::ERR_INVALID_NODE_HANDLE;
 
@@ -266,8 +266,10 @@ pub extern "C" fn poll_subscription(subscription_handle: usize) -> PollSubscript
     result.unwrap_or_else(|| PollSubscriptionResult::error("invalid subscription handle"))
 }
 
-/// Alias for poll_subscription (for Go compatibility)
-/// Accepts a string subscription ID and parses it as a numeric handle.
+/// Poll a GraphQL subscription for new results.
+///
+/// Results have already been processed by the background task at event time,
+/// so this function simply checks the result buffer.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn poll_graphql_subscription(
@@ -283,7 +285,36 @@ pub extern "C" fn poll_graphql_subscription(
         Ok(h) => h,
         Err(_) => return PollSubscriptionResult::error("invalid subscription id: not a number"),
     };
-    poll_subscription(handle)
+
+    let result =
+        GRAPHQL_SUBSCRIPTIONS.get_mut(handle, |state| match state.result_receiver.try_recv() {
+            Ok(json) => PollSubscriptionResult::event(json, 0),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                PollSubscriptionResult::no_event(0)
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                PollSubscriptionResult::closed()
+            }
+        });
+
+    result.unwrap_or_else(|| PollSubscriptionResult::error("invalid subscription handle"))
+}
+
+/// Check if a query response has any non-empty data.
+///
+/// Returns false if data is null/empty or all top-level collection arrays are empty
+/// (indicating the subscription's filter excluded the document).
+pub(crate) fn response_has_data(response: &query::QueryResponse) -> bool {
+    if let Some(serde_json::Value::Object(map)) = response.data.as_ref() {
+        for value in map.values() {
+            if let serde_json::Value::Array(arr) = value {
+                if !arr.is_empty() {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Close a subscription and release resources.
@@ -315,7 +346,8 @@ pub extern "C" fn close_subscription(subscription_handle: usize) -> CloseSubscri
     CloseSubscriptionResult::success()
 }
 
-/// Alias for close_subscription (for Go compatibility)
+/// Close a GraphQL subscription and release resources.
+///
 /// Accepts a string subscription ID and parses it as a numeric handle.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
@@ -332,7 +364,22 @@ pub extern "C" fn close_graphql_subscription(
         Ok(h) => h,
         Err(_) => return CloseSubscriptionResult::error("invalid subscription id: not a number"),
     };
-    close_subscription(handle)
+
+    // Remove from GraphQL subscription registry
+    let state = match GRAPHQL_SUBSCRIPTIONS.remove(handle) {
+        Some(state) => state,
+        None => return CloseSubscriptionResult::error("invalid subscription handle"),
+    };
+
+    // Abort the background event processing task
+    state.task_abort.abort();
+
+    // Unsubscribe from the event bus
+    NODES.get(state.node_handle, |node_state| {
+        node_state.event_bus.unsubscribe(state.event_sub_id);
+    });
+
+    CloseSubscriptionResult::success()
 }
 
 /// Convert an event message to JSON.

--- a/crates/ffi/src/types.rs
+++ b/crates/ffi/src/types.rs
@@ -52,6 +52,15 @@ impl FfiResult {
             value: ptr::null_mut(),
         }
     }
+
+    /// Create a subscription result (status=2) with the subscription ID in value.
+    pub fn subscription(id: impl Into<String>) -> Self {
+        Self {
+            status: 2,
+            error: ptr::null_mut(),
+            value: sanitize_to_cstring(id, "0").into_raw(),
+        }
+    }
 }
 
 /// FFI result for node creation, containing a node handle.

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -64,14 +64,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     ) -> Result<JsonValue> {
         use crate::fetcher::CommitsQueryOptions;
 
-        // Fetch commits for this document
-        // When we have a target CID, we need to traverse all commits back to genesis
-        // by setting a large depth. Without a target CID (regular query), depth=None
-        // traverses all heads to genesis anyway.
+        // Fetch commits for this document.
+        // When we have a target CID, traverse all commits back to genesis.
+        // Without a target CID, only return the current heads (depth=1).
         let depth = if target_cid.is_some() {
-            Some(1000) // Reasonable max depth for version history traversal
+            Some(1000)
         } else {
-            None
+            Some(1)
         };
 
         let options = CommitsQueryOptions {


### PR DESCRIPTION
## Summary
- Implement GraphQL subscription support in the Rust FFI layer (13/13 tests pass, up from 0)
- Subscription queries detected in `exec_request`, return status=2 with polling handle
- Background tokio tasks execute queries at **event time** (not poll time) for correct DB state
- For `_commits` subscriptions, use event CID to return only the composite commit
- Fix `_version` field to return only head commits (depth=1) instead of full DAG history
- Proper cleanup of GraphQL subscriptions on `node_close`

## Files changed
- `crates/ffi/src/types.rs` - `FfiResult::subscription()` for status=2 responses
- `crates/ffi/src/state.rs` - `GraphQLSubscriptionState` and registry
- `crates/ffi/src/query.rs` - Subscription detection, background task, query helpers
- `crates/ffi/src/subscription.rs` - Rewritten poll/close for GraphQL subscriptions
- `crates/ffi/src/node.rs` - GraphQL subscription cleanup on node close
- `crates/query/src/runner/commits.rs` - `_version` depth fix (head-only)

## Test plan
- [x] All 13 subscription FFI tests pass (`ffi-test run subscription`)
- [x] `cargo clippy -p ffi -p query` clean (pre-existing `acp` issue excluded)
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)