### PR TITLE
fix(ffi): P2P migration, txn-aware collections, embedding validation

### DIFF
--- a/crates/db/src/collection_ops.rs
+++ b/crates/db/src/collection_ops.rs
@@ -1112,12 +1112,31 @@ impl<S: Store> crate::database::DB<S> {
                 .await
                 .map_err(Error::Storage)?
                 .ok_or(Error::CollectionVersionNotFound(version_id.to_string()))?;
-            serde_json::from_slice::<CollectionVersion>(&target_bytes).map_err(|e| {
-                Error::Serialization(format!(
-                    "failed to deserialize version '{}': {}",
-                    version_id, e
-                ))
-            })?
+            let mut schema =
+                serde_json::from_slice::<CollectionVersion>(&target_bytes).map_err(|e| {
+                    Error::Serialization(format!(
+                        "failed to deserialize version '{}': {}",
+                        version_id, e
+                    ))
+                })?;
+
+            // Populate root_id from store (skipped during deserialization)
+            if schema.root_id == 0 {
+                let short_id_key = CollectionID::new(&schema.collection_id);
+                if let Some(short_id_bytes) = systemstore
+                    .get(&short_id_key.bytes())
+                    .await
+                    .map_err(Error::Storage)?
+                {
+                    if let Ok(short_id_str) = String::from_utf8(short_id_bytes.to_vec()) {
+                        if let Ok(short_id) = short_id_str.parse::<u32>() {
+                            schema.root_id = short_id;
+                        }
+                    }
+                }
+            }
+
+            schema
         };
         let _ = txn.discard();
 
@@ -1140,7 +1159,7 @@ impl<S: Store> crate::database::DB<S> {
 
         // Validate: no documents exist
         if target_schema.is_active {
-            let has_data = self.collection_has_data(&collection_id).await?;
+            let has_data = self.collection_has_data(&target_schema).await?;
             if has_data {
                 return Err(Error::InvalidPatch(
                     "cannot delete a collection that has documents, first delete the documents and then delete the version".to_string(),
@@ -1289,12 +1308,29 @@ impl<S: Store> crate::database::DB<S> {
     }
 
     /// Check if a collection has any documents in the datastore.
-    pub(crate) async fn collection_has_data(&self, collection_id: &str) -> Result<bool> {
+    pub(crate) async fn collection_has_data(
+        &self,
+        version: &schema::CollectionVersion,
+    ) -> Result<bool> {
+        if !version.is_materialized {
+            return Ok(false);
+        }
+
         let txn = self.new_txn(true).await?;
         let has_data = {
             let datastore = txn.datastore()?;
-            let doc_prefix = format!("/d/{}/", collection_id);
-            let opts = IterOptions::new().with_prefix(doc_prefix.as_bytes().to_vec());
+
+            let prefix = if version.query.is_some() {
+                // View: check view cache prefix using short ID
+                storage::keys::datastore::ViewCacheKey::collection_prefix(version.root_id)
+            } else {
+                // Regular collection: check document prefix
+                format!("/d/{}/", version.collection_id)
+                    .as_bytes()
+                    .to_vec()
+            };
+
+            let opts = IterOptions::new().with_prefix(prefix);
             let mut iter = datastore.iterator(opts).await.map_err(Error::Storage)?;
             let has_any = iter.next().await.map_err(Error::Storage)?.is_some();
             iter.close().await.map_err(Error::Storage)?;

--- a/crates/db/src/definition_validation.rs
+++ b/crates/db/src/definition_validation.rs
@@ -70,6 +70,34 @@ const GLOBAL_VALIDATORS: &[Validator] = &[
     validate_embedding_provider_and_model,
 ];
 
+/// Validates embedding definitions on newly created collections.
+///
+/// Only runs embedding-specific validators (type, fields, provider/model).
+/// Other global validators are not appropriate at create time.
+pub fn validate_new_collections(
+    new_collections: &[CollectionVersion],
+) -> Result<(), String> {
+    let new_state = DefinitionState::new(new_collections);
+    let old_state = DefinitionState::new(&[]);
+
+    let validators: &[Validator] = &[
+        validate_embedding_and_kind_compatible,
+        validate_embedding_fields_for_generation,
+        validate_embedding_provider_and_model,
+    ];
+
+    let mut errors = Vec::new();
+    for validator in validators {
+        errors.extend(validator(&new_state, &old_state));
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n"))
+    }
+}
+
 /// Run all validators comparing old and new collection states.
 ///
 /// Returns Ok(()) if all validators pass, or an error with all validation
@@ -803,9 +831,6 @@ fn is_valid_embedding_kind(kind: &FieldKind) -> bool {
     matches!(
         kind,
         FieldKind::ScalarArray(schema::ScalarArrayKind::Float32Array)
-            | FieldKind::ScalarArray(schema::ScalarArrayKind::Float64Array)
-            | FieldKind::ScalarArray(schema::ScalarArrayKind::NillableFloat32Array)
-            | FieldKind::ScalarArray(schema::ScalarArrayKind::NillableFloat64Array)
     )
 }
 

--- a/crates/db/src/merge_handler.rs
+++ b/crates/db/src/merge_handler.rs
@@ -746,6 +746,11 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                                         }
                                     };
 
+                                    // Set the schema version from the incoming block so the
+                                    // lensed fetcher can detect version mismatches and apply
+                                    // migrations at query time (matches Go's composite merge).
+                                    doc.set_schema_version_id(&payload.schema_version_id);
+
                                     // Overlay new/winning field values on top of existing fields
                                     for (field_name, value) in &field_values {
                                         doc.set(field_name, value.clone());

--- a/crates/db/src/patch.rs
+++ b/crates/db/src/patch.rs
@@ -839,7 +839,7 @@ impl<S: Store> crate::database::DB<S> {
 
             // Validate: can't remove a collection that has documents (only on active→inactive)
             if !new_schema.is_active && old_schema.is_active {
-                let has_data = self.collection_has_data(&collection_id).await?;
+                let has_data = self.collection_has_data(&old_schema).await?;
                 if has_data {
                     return Err(Error::InvalidPatch(
                         "cannot delete a collection that has documents, first delete the documents and then delete the version".to_string(),

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -104,7 +104,7 @@ pub use p2p::{
     p2p_sync_branchable_collection, p2p_sync_documents,
 };
 pub use query::exec_request;
-pub use schema::{add_schema, get_collections};
+pub use schema::{add_schema, get_collections, get_collections_in_txn};
 pub use subscription::{
     close_graphql_subscription, close_subscription, create_merge_complete_subscription,
     create_subscription, poll_graphql_subscription, poll_subscription,

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -72,6 +72,10 @@ pub unsafe extern "C" fn add_schema(
         let collections = query::parse_sdl_with_known_types(&schema_str, known_types)
             .map_err(|e| format!("failed to parse schema: {}", e))?;
 
+        // Run global validators (embedding type checks, etc.)
+        db::definition_validation::validate_new_collections(&collections)
+            .map_err(|e| format!("failed to validate schema: {}", e))?;
+
         // Validate policies on collections before creating them
         for collection in &collections {
             if let Some(ref policy) = collection.policy {

--- a/crates/schema/src/collection.rs
+++ b/crates/schema/src/collection.rs
@@ -116,8 +116,7 @@ pub struct CollectionVersion {
     #[serde(
         rename = "VectorEmbeddings",
         default,
-        deserialize_with = "deserialize_null_as_empty_vec",
-        skip_serializing_if = "Vec::is_empty"
+        deserialize_with = "deserialize_null_as_empty_vec"
     )]
     pub vector_embeddings: Vec<VectorEmbeddingDescription>,
 

--- a/tools/ffi-test/src/runner.rs
+++ b/tools/ffi-test/src/runner.rs
@@ -238,6 +238,9 @@ fn build_env(ctx: &WorktreeContext) -> HashMap<String, String> {
     // Enable Rust FFI client
     env.insert("DEFRA_CLIENT_RUST_FFI".to_string(), "true".to_string());
 
+    // Enable vector embedding tests
+    env.insert("DEFRA_VECTOR_EMBEDDING".to_string(), "true".to_string());
+
     env
 }
 


### PR DESCRIPTION
## Summary
- **P2P migration fix**: Set `schema_version_id` from incoming composite delta during P2P merge so the lensed fetcher detects version mismatches and applies lens transforms
- **Transaction-aware GetCollections**: Export `get_collections_in_txn` FFI function and wire context-based txn delegation in Go wrapper
- **Embedding validation**: Add `validate_new_collections()` for schema creation, fix `is_valid_embedding_kind` to only accept `[Float32!]`, always serialize empty `VectorEmbeddings` as `[]`
- **Enable embedding tests**: Set `DEFRA_VECTOR_EMBEDDING=true` in ffi-test runner

## Test Results
- **collection_version**: 406 pass, 0 fail, 2 skip (100% non-skipped)
- **collection**: 15 pass, 1 fail (pre-existing FK index uniqueness bug)
- 2 remaining skips are materialized view cache tests (infrastructure-gated)

## Test plan
- [x] `ffi-test run collection_version` — 406 pass, 0 fail
- [x] `ffi-test run collection` — no regressions
- [x] P2P migration tests pass (4 previously failing)
- [x] Embedding validation tests pass (11 previously skipped)
- [x] No regressions in other test packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)