### PR TITLE
fix(index): CRDT counter validation, JSON null filters, and OR filter index support

### DIFF
--- a/crates/cli/src/index_adapter.rs
+++ b/crates/cli/src/index_adapter.rs
@@ -76,6 +76,7 @@ impl<S: Store + 'static> IndexOperations for IndexAdapter<S> {
                     name.unwrap_or("").to_string(),
                     indexed_fields,
                     unique,
+                    &schema.fields,
                 )
                 .await
                 .map_err(|e| format!("{}", e))?;

--- a/crates/db/src/definition_validation.rs
+++ b/crates/db/src/definition_validation.rs
@@ -82,6 +82,7 @@ pub fn validate_new_collections(new_collections: &[CollectionVersion]) -> Result
         validate_embedding_and_kind_compatible,
         validate_embedding_fields_for_generation,
         validate_embedding_provider_and_model,
+        validate_index_fields_not_counter,
     ];
 
     let mut errors = Vec::new();
@@ -804,6 +805,31 @@ fn validate_embedding_provider_and_model(
 
             if embedding.model.is_empty() {
                 errs.push("embedding Model cannot be empty".to_string());
+            }
+        }
+    }
+    errs
+}
+
+/// Validates that no index references a CRDT counter field.
+/// Matches Go's check in NewCollectionIndex: counter fields cannot be indexed.
+fn validate_index_fields_not_counter(
+    new_state: &DefinitionState,
+    _old_state: &DefinitionState,
+) -> Vec<String> {
+    let mut errs = Vec::new();
+    for col in &new_state.collections {
+        for index in &col.indexes {
+            for idx_field in &index.fields {
+                if let Some(field) = col.fields.iter().find(|f| f.name == idx_field.name) {
+                    if field.crdt_type.is_counter() {
+                        errs.push(format!(
+                            "indexing accumulated CRDT fields is not yet supported. Field: {}, CRDTType: {}",
+                            field.name,
+                            format_crdt_type(field.crdt_type)
+                        ));
+                    }
+                }
             }
         }
     }

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -373,6 +373,24 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
                     })?;
                 collect_with_limit(&mut iter, limit, offset, vf).await?
             }
+            IndexScanType::OrScan { branches } => {
+                let mut all_doc_ids = Vec::new();
+                let mut total_raw_fetches = 0u64;
+                for branch in branches {
+                    let branch_params = IndexScanParams {
+                        index_name: params.index_name.clone(),
+                        scan_type: branch.clone(),
+                        limit: None,
+                        offset: 0,
+                        value_filter: None,
+                    };
+                    let branch_result =
+                        self.get_by_index_scan(collection_name, &branch_params).await?;
+                    total_raw_fetches += branch_result.raw_fetches();
+                    all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                }
+                (all_doc_ids, total_raw_fetches)
+            }
         };
 
         // Deduplicate doc_ids while preserving order.

--- a/crates/db/src/index_manager.rs
+++ b/crates/db/src/index_manager.rs
@@ -8,7 +8,7 @@
 use crate::error::{Error, Result};
 use datastore::NamespaceView;
 use document::{Document, NormalValue};
-use schema::{CollectionVersion, IndexDescription, IndexedFieldDescription};
+use schema::{CollectionVersion, FieldDescription, IndexDescription, IndexedFieldDescription};
 use std::collections::HashMap;
 use storage::corekv::Key;
 use storage::index::IndexType;
@@ -136,6 +136,7 @@ impl IndexManager {
         name: String,
         fields: Vec<IndexedFieldDescription>,
         unique: bool,
+        schema_fields: &[FieldDescription],
     ) -> Result<IndexDescription> {
         // Auto-generate name if empty (matches Go behavior)
         let name = if name.is_empty() {
@@ -167,6 +168,18 @@ impl IndexManager {
             return Err(Error::Other(
                 "index must have at least one field".to_string(),
             ));
+        }
+
+        // Reject CRDT counter fields (matches Go's NewCollectionIndex validation)
+        for field in &fields {
+            if let Some(schema_field) = schema_fields.iter().find(|f| f.name == field.name) {
+                if schema_field.crdt_type.is_counter() {
+                    return Err(Error::Other(format!(
+                        "indexing accumulated CRDT fields is not yet supported. Field: {}, CRDTType: {}",
+                        field.name, schema_field.crdt_type.to_string().to_lowercase()
+                    )));
+                }
+            }
         }
 
         // Generate a new index ID

--- a/crates/db/src/lensed_auto_commit_fetcher.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher.rs
@@ -866,6 +866,35 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                     })?;
                 collect_with_limit(&mut iter, limit, offset, vf).await?
             }
+            IndexScanType::OrScan { branches } => {
+                // Discard this txn early; each recursive call creates its own
+                let _ = txn.discard();
+                let mut all_doc_ids = Vec::new();
+                let mut total_raw_fetches = 0u64;
+                for branch in branches {
+                    let branch_params = IndexScanParams {
+                        index_name: params.index_name.clone(),
+                        scan_type: branch.clone(),
+                        limit: None,
+                        offset: 0,
+                        value_filter: None,
+                    };
+                    let branch_result =
+                        self.get_by_index_scan(collection_name, &branch_params).await?;
+                    total_raw_fetches += branch_result.raw_fetches();
+                    all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                }
+                // Skip the txn.discard() below since we already discarded
+                let mut seen = HashSet::new();
+                let doc_ids: Vec<String> = all_doc_ids
+                    .into_iter()
+                    .filter(|id| seen.insert(id.clone()))
+                    .collect();
+                return Ok(query::fetcher::IndexScanResult::with_raw_count(
+                    doc_ids,
+                    total_raw_fetches,
+                ));
+            }
         };
 
         let _ = txn.discard();

--- a/crates/db/tests/index_manager_tests.rs
+++ b/crates/db/tests/index_manager_tests.rs
@@ -39,7 +39,7 @@ async fn test_create_index() {
     }];
 
     let desc = manager
-        .create_index(&datastore, "users", "idx_name".to_string(), fields, false)
+        .create_index(&datastore, "users", "idx_name".to_string(), fields, false, &[])
         .await
         .unwrap();
 
@@ -64,7 +64,7 @@ async fn test_create_unique_index() {
     }];
 
     let desc = manager
-        .create_index(&datastore, "users", "idx_email".to_string(), fields, true)
+        .create_index(&datastore, "users", "idx_email".to_string(), fields, true, &[])
         .await
         .unwrap();
 
@@ -93,12 +93,12 @@ async fn test_create_duplicate_index_fails() {
             "idx_name".to_string(),
             fields.clone(),
             false,
-        )
+        , &[])
         .await
         .unwrap();
 
     let result = manager
-        .create_index(&datastore, "users", "idx_name".to_string(), fields, false)
+        .create_index(&datastore, "users", "idx_name".to_string(), fields, false, &[])
         .await;
 
     assert!(result.is_err());
@@ -115,7 +115,7 @@ async fn test_create_empty_fields_fails() {
     let mut manager = IndexManager::new(1);
 
     let result = manager
-        .create_index(&datastore, "users", "idx_empty".to_string(), vec![], false)
+        .create_index(&datastore, "users", "idx_empty".to_string(), vec![], false, &[])
         .await;
 
     assert!(result.is_err());
@@ -140,7 +140,7 @@ async fn test_drop_index() {
     }];
 
     manager
-        .create_index(&datastore, "users", "idx_name".to_string(), fields, false)
+        .create_index(&datastore, "users", "idx_name".to_string(), fields, false, &[])
         .await
         .unwrap();
 
@@ -183,7 +183,7 @@ async fn test_get_indexes() {
                 descending: false,
             }],
             false,
-        )
+        , &[])
         .await
         .unwrap();
 
@@ -197,7 +197,7 @@ async fn test_get_indexes() {
                 descending: false,
             }],
             true,
-        )
+        , &[])
         .await
         .unwrap();
 
@@ -258,7 +258,7 @@ async fn test_on_document_create() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -297,7 +297,7 @@ async fn test_index_id_sequence() {
                 descending: false,
             }],
             false,
-        )
+        , &[])
         .await
         .unwrap();
 
@@ -311,7 +311,7 @@ async fn test_index_id_sequence() {
                 descending: false,
             }],
             false,
-        )
+        , &[])
         .await
         .unwrap();
 
@@ -325,7 +325,7 @@ async fn test_index_id_sequence() {
                 descending: false,
             }],
             false,
-        )
+        , &[])
         .await
         .unwrap();
 
@@ -357,7 +357,7 @@ async fn test_on_document_update_changes_index_entry() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -440,7 +440,7 @@ async fn test_on_document_update_no_change_when_values_same() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -493,7 +493,7 @@ async fn test_on_document_delete_removes_index_entries() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -560,7 +560,7 @@ async fn test_bulk_index_indexes_all_documents() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -619,7 +619,7 @@ async fn test_bulk_index_skips_documents_without_id() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -690,7 +690,7 @@ async fn test_on_document_create_without_id_fails() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -728,7 +728,7 @@ async fn test_on_document_update_without_id_fails() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -773,7 +773,7 @@ async fn test_on_document_delete_without_id_fails() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -828,7 +828,7 @@ async fn test_multi_index_update() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -842,7 +842,7 @@ async fn test_multi_index_update() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -979,7 +979,7 @@ async fn test_composite_index_through_manager() {
                     },
                 ],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -1071,7 +1071,7 @@ async fn test_missing_field_indexed_as_null() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -1146,7 +1146,7 @@ async fn test_unique_index_allows_multiple_nulls() {
                     descending: false,
                 }],
                 true, // unique
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -1239,7 +1239,7 @@ async fn test_unique_constraint_violation_returns_error() {
                     descending: false,
                 }],
                 true, // unique
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -1309,7 +1309,7 @@ async fn test_index_field_not_in_schema_fails() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -1356,7 +1356,7 @@ async fn test_index_idempotence_create_same_document_twice() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 
@@ -1415,7 +1415,7 @@ async fn test_delete_then_recreate_same_value() {
                     descending: false,
                 }],
                 false,
-            )
+            , &[])
             .await
             .unwrap();
 

--- a/crates/db/tests/property_tests.rs
+++ b/crates/db/tests/property_tests.rs
@@ -58,7 +58,7 @@ proptest! {
                         descending: false,
                     }],
                     false,
-                )
+                , &[])
                 .await
                 .unwrap();
 
@@ -116,7 +116,7 @@ proptest! {
                         descending: false,
                     }],
                     false,
-                )
+                , &[])
                 .await
                 .unwrap();
 
@@ -192,7 +192,7 @@ proptest! {
                         descending: false,
                     }],
                     false,
-                )
+                , &[])
                 .await
                 .unwrap();
 
@@ -270,7 +270,7 @@ proptest! {
                         descending: false,
                     }],
                     false, // NOT unique
-                )
+                , &[])
                 .await
                 .unwrap();
 
@@ -333,7 +333,7 @@ proptest! {
                         descending: false,
                     }],
                     true, // UNIQUE
-                )
+                , &[])
                 .await
                 .unwrap();
 
@@ -396,7 +396,7 @@ proptest! {
                         descending: false,
                     }],
                     false,
-                )
+                , &[])
                 .await
                 .unwrap();
 
@@ -464,7 +464,7 @@ proptest! {
 
             // Attempt to create index with empty fields
             let result = manager
-                .create_index(&datastore, "users", name, vec![], false)
+                .create_index(&datastore, "users", name, vec![], false, &[])
                 .await;
 
             // Property: Empty fields should always be rejected
@@ -500,13 +500,13 @@ proptest! {
 
             // First creation should succeed
             let result1 = manager
-                .create_index(&datastore, "users", name.clone(), fields.clone(), false)
+                .create_index(&datastore, "users", name.clone(), fields.clone(), false, &[])
                 .await;
             assert!(result1.is_ok(), "First creation should succeed");
 
             // Second creation with same name should fail
             let result2 = manager
-                .create_index(&datastore, "users", name, fields, false)
+                .create_index(&datastore, "users", name, fields, false, &[])
                 .await;
             assert!(result2.is_err(), "Duplicate name should be rejected");
         });

--- a/crates/ffi/src/index.rs
+++ b/crates/ffi/src/index.rs
@@ -122,6 +122,7 @@ pub unsafe extern "C" fn create_index(
                     index_input.name,
                     fields,
                     index_input.unique,
+                    &collection.schema().fields,
                 )
                 .await
                 .map_err(|e| format!("{}", e))?;

--- a/crates/query/src/mapper/filter/filter_impl.rs
+++ b/crates/query/src/mapper/filter/filter_impl.rs
@@ -340,6 +340,20 @@ impl Filter {
                 }
             } else {
                 // Operator conditions
+                // When a JSON property is missing (null) and _eq/_ne compares against
+                // a complex value (object/array), exclude the document. Missing JSON
+                // properties can't match complex equality/inequality comparisons.
+                if field_value.is_null() {
+                    for (op_str, expected) in ops {
+                        if matches!(
+                            FilterOp::parse(op_str),
+                            Some(FilterOp::Eq | FilterOp::Ne)
+                        ) && (expected.is_object() || expected.is_array())
+                        {
+                            return Ok(false);
+                        }
+                    }
+                }
                 for (op_str, expected) in ops {
                     let op = FilterOp::parse(op_str).ok_or_else(|| {
                         QueryError::invalid_filter(format!("unknown operator: {}", op_str))

--- a/crates/query/src/planner/builder.rs
+++ b/crates/query/src/planner/builder.rs
@@ -37,8 +37,8 @@ use crate::plan::{
     PermissionFilterNode, ScanNode, SelectNode,
 };
 use crate::planner::index_selection::{
-    can_be_ordered_by_index, filter_to_index_scan, select_best_index, IndexScanParams,
-    IndexScanType,
+    can_be_ordered_by_index, filter_to_index_scan, or_filter_to_index_scan, select_best_index,
+    IndexScanParams, IndexScanType,
 };
 use crate::planner::PlanNode;
 use serde_json::Value as JsonValue;
@@ -1333,6 +1333,17 @@ impl Planner {
                             .unwrap_or(false);
                         return Some((params, provides_ordering));
                     }
+                }
+            }
+        }
+
+        // Try OR filter index selection (e.g., {_or: [{age: {_eq: 55}}, {age: {_eq: 19}}]})
+        if !has_relation_filter {
+            if let Some(filter) = select.filter.as_ref() {
+                if let Some(params) =
+                    or_filter_to_index_scan(filter, &collection.indexes, &collection.fields)
+                {
+                    return Some((params, false));
                 }
             }
         }

--- a/crates/query/src/planner/index_selection.rs
+++ b/crates/query/src/planner/index_selection.rs
@@ -102,6 +102,11 @@ pub enum IndexScanType {
         values: Vec<NormalValue>,
         suffix_values: Vec<NormalValue>,
     },
+    /// Multiple scans combined (for _or filters).
+    /// Each branch is executed separately and results are deduplicated.
+    OrScan {
+        branches: Vec<IndexScanType>,
+    },
 }
 
 /// A parsed filter condition on a single field.
@@ -346,6 +351,47 @@ fn normalize_for_index_field(
     }
 }
 
+/// Determines if a filter condition should force a fallback to full scan instead of using the index.
+/// Matches Go's `shouldFallbackToFullScan` in indexer_iterators.go.
+fn should_fallback_to_full_scan(cond: &FieldCondition, is_json_field: bool) -> bool {
+    let is_null = matches!(&cond.value, ConditionValue::Single(NormalValue::Null));
+    let has_nested_path = cond
+        .json_path
+        .as_ref()
+        .map(|p| !p.is_empty())
+        .unwrap_or(false);
+
+    if is_null {
+        // _gte: null matches everything → fallback
+        if cond.op == FilterOp::Gte {
+            return true;
+        }
+        // _lte: null on nested JSON path → can't find missing fields
+        if cond.op == FilterOp::Lte && has_nested_path {
+            return true;
+        }
+        // _ne: null on root-level JSON → can't find empty objects/arrays
+        if cond.op == FilterOp::Ne && is_json_field && !has_nested_path {
+            return true;
+        }
+    }
+
+    // JSON indexes only store leaf values (scalars), not objects or arrays.
+    // If the filter value is a complex type, fall back to full scan.
+    if is_json_field {
+        // _in/_nin with empty values (all objects were filtered out) → fallback
+        if matches!(cond.op, FilterOp::In | FilterOp::Nin) {
+            if let ConditionValue::Multiple(vs) = &cond.value {
+                if vs.is_empty() {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
 /// Extract field conditions from a filter.
 pub fn extract_field_conditions(filter: &Filter) -> Vec<FieldCondition> {
     let mut conditions = Vec::new();
@@ -580,6 +626,14 @@ pub fn filter_to_index_scan(
 
     if first_field_conditions.is_empty() {
         return None;
+    }
+
+    // Check if any condition requires falling back to full scan (matches Go's shouldFallbackToFullScan).
+    // Returns None to skip index when the index cannot produce correct results.
+    for cond in &first_field_conditions {
+        if should_fallback_to_full_scan(cond, first_field_is_json) {
+            return None;
+        }
     }
 
     // Analyze conditions to determine scan type
@@ -932,6 +986,90 @@ pub fn filter_to_index_scan(
         offset: if index_provides_ordering { offset } else { 0 },
         value_filter: scan_value_filter,
     })
+}
+
+/// Check if a filter with a top-level `_or` can use any of the given indexes.
+///
+/// Returns true if the filter has an `_or` whose branches ALL use the same index.
+pub fn can_or_filter_use_index(filter: &Filter, indexes: &[IndexDescription]) -> bool {
+    let branches = match extract_or_branches(filter) {
+        Some(b) => b,
+        None => return false,
+    };
+    indexes.iter().any(|index| {
+        branches.iter().all(|branch| can_use_index(branch, index))
+    })
+}
+
+/// Extract OR branches from a filter's top-level `_or` condition.
+///
+/// Returns `Some(branches)` if the filter has a single top-level `_or` with
+/// valid sub-filters, `None` otherwise.
+fn extract_or_branches(filter: &Filter) -> Option<Vec<Filter>> {
+    let conditions = filter.conditions();
+    let or_value = conditions.get("_or")?;
+    let arr = or_value.as_array()?;
+    let branches: Vec<Filter> = arr
+        .iter()
+        .filter_map(|item| {
+            item.as_object().map(|obj| {
+                let map: HashMap<String, JsonValue> =
+                    obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                Filter::from_conditions(map)
+            })
+        })
+        .collect();
+    if branches.len() == arr.len() && !branches.is_empty() {
+        Some(branches)
+    } else {
+        None
+    }
+}
+
+/// Try to convert an OR filter to index scan parameters.
+///
+/// Detects top-level `_or` in the filter, extracts each branch, and checks
+/// if ALL branches can use the same index. If so, returns `OrScan` with
+/// one sub-scan per branch.
+///
+/// Matches Go's `newMultiIndexIteratorForOrOp` / `extractOrBranches` pattern.
+pub fn or_filter_to_index_scan(
+    filter: &Filter,
+    indexes: &[IndexDescription],
+    collection_fields: &[schema::FieldDescription],
+) -> Option<IndexScanParams> {
+    let branches = extract_or_branches(filter)?;
+
+    // Try each index to see if all branches can use it
+    for index in indexes {
+        let mut branch_scans = Vec::new();
+        let mut all_work = true;
+
+        for branch in &branches {
+            if let Some(params) =
+                filter_to_index_scan(branch, index, None, collection_fields, None, 0)
+            {
+                branch_scans.push(params.scan_type);
+            } else {
+                all_work = false;
+                break;
+            }
+        }
+
+        if all_work && !branch_scans.is_empty() {
+            return Some(IndexScanParams {
+                index_name: index.name.clone(),
+                scan_type: IndexScanType::OrScan {
+                    branches: branch_scans,
+                },
+                limit: None,
+                offset: 0,
+                value_filter: None,
+            });
+        }
+    }
+
+    None
 }
 
 /// Select the best index for a filter from available indexes.

--- a/crates/query/src/runner/explain/mod.rs
+++ b/crates/query/src/runner/explain/mod.rs
@@ -22,7 +22,9 @@ use crate::document::{documents_to_plan_docs, documents_with_status_to_plan_docs
 use crate::error::{QueryError, Result};
 use crate::mapper::{Requestable, Select};
 use crate::plan::PermissionFilterNode;
-use crate::planner::index_selection::{can_be_ordered_by_index, select_best_index};
+use crate::planner::index_selection::{
+    can_be_ordered_by_index, can_or_filter_use_index, select_best_index,
+};
 use crate::planner::Planner;
 use crate::query_parse::{parse_query_with_variables, ExplainType};
 use crate::txn::TransactionRegistry;
@@ -803,7 +805,18 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 })
                 .unwrap_or(false);
 
-        let can_use_index = can_use_filter_index || can_use_ordering_index;
+        let can_use_or_filter_index = select.doc_ids.is_none()
+            && select.filter.is_some()
+            && !collection.indexes.is_empty()
+            && fetcher.supports_index_queries()
+            && select
+                .filter
+                .as_ref()
+                .map(|f| can_or_filter_use_index(f, &collection.indexes))
+                .unwrap_or(false);
+
+        let can_use_index =
+            can_use_filter_index || can_use_ordering_index || can_use_or_filter_index;
 
         // Check if any aggregates reference relations (e.g., _sum(articles: {field: pages}))
         // Relation aggregates need the Planner to create TypeJoinMany nodes

--- a/crates/query/src/runner/query.rs
+++ b/crates/query/src/runner/query.rs
@@ -12,7 +12,7 @@ use crate::document::{documents_to_plan_docs, documents_with_status_to_plan_docs
 use crate::error::{QueryError, Result};
 use crate::mapper::{Requestable, Select};
 use crate::planner::index_selection::{
-    can_be_ordered_by_index, filter_to_index_scan, select_best_index,
+    can_be_ordered_by_index, can_or_filter_use_index, filter_to_index_scan, select_best_index,
 };
 use crate::planner::Planner;
 use crate::query_parse::parse_query_with_variables;
@@ -288,6 +288,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 })
                 .unwrap_or(false);
 
+        // Check if an OR filter can use an index (planner needed for IndexScanNode with OrScan)
+        let has_or_filter_index = select.filter.is_some()
+            && fetcher.supports_index_queries()
+            && !collection.indexes.is_empty()
+            && select
+                .filter
+                .as_ref()
+                .map(|f| can_or_filter_use_index(f, &collection.indexes))
+                .unwrap_or(false);
+
         // Check if any similarity fields are present (require SimilarityNode in planner)
         let has_similarity = select
             .fields
@@ -375,6 +385,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             || aggregate_filter_has_relations
             || has_secondary_relation_id
             || has_ordering_index
+            || has_or_filter_index
             || has_similarity;
 
         if needs_planner {


### PR DESCRIPTION
## Summary
- Reject CRDT counter fields during index creation (matches Go's `NewCollectionIndex` validation) — fixes 8 tests
- Handle null/object equality in JSON filters and add `should_fallback_to_full_scan` for JSON index edge cases — fixes 10 tests
- Implement `IndexScanType::OrScan` for `_or` filter index support across all three query execution paths (fast path, explain path, planner path) — fixes 3 tests

All 365 FFI index tests pass (was 21 failures after Go develop merge).

## Test plan
- [x] `ffi-test run index` — 365/365 passed
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo build --release -p ffi` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)