### PR TITLE
fix(query,db): Fix JSON _ne filter and P2P branchable merge dedup

### DIFF
--- a/crates/db/src/merge_handler.rs
+++ b/crates/db/src/merge_handler.rs
@@ -3,7 +3,7 @@
 //! This module implements the `MergeHandler` trait from the P2P layer,
 //! bridging incoming blocks to the CRDT system for document merging.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -109,12 +109,20 @@ pub struct DbMergeHandler<S: Store, B: blockstore::Blockstore> {
     db: Arc<DB<S>>,
     /// Reference to the blockstore for loading linked blocks.
     blockstore: Arc<B>,
+    /// Tracks composite CIDs that have already been merged, preventing
+    /// duplicate processing from concurrent dual-broadcast paths (doc topic
+    /// + collection topic). Matches Go's `loadComposites` dedup guard.
+    merged_composites: std::sync::Mutex<HashSet<Cid>>,
 }
 
 impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
     /// Create a new database merge handler.
     pub fn new(db: Arc<DB<S>>, blockstore: Arc<B>) -> Self {
-        Self { db, blockstore }
+        Self {
+            db,
+            blockstore,
+            merged_composites: std::sync::Mutex::new(HashSet::new()),
+        }
     }
 
     /// Get reference to blockstore.
@@ -432,8 +440,28 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         // processing this block.  This matches Go's processLog which walks
         // the DAG backwards and merges from oldest to newest, ensuring all
         // prior CRDT deltas are applied before the current one.
+        //
+        // Dedup guard: use merged_composites to skip parents already processed
+        // by another path. Go serializes merge events per-collection and checks
+        // `mt.heads` in loadComposites. In Rust, dual broadcast (doc topic +
+        // collection topic) can trigger concurrent recursive walks that
+        // temporarily re-add stale headstore entries. The guard prevents
+        // re-processing parents that were already merged.
         if let Some(heads) = &block.heads {
             for head_cid in heads {
+                // Skip parents already processed by this or another path.
+                {
+                    let merged = self.merged_composites.lock().unwrap();
+                    if merged.contains(head_cid) {
+                        tracing::debug!(
+                            parent_cid = %head_cid,
+                            child_cid = %cid,
+                            "Parent composite already merged, skipping recursive processing"
+                        );
+                        continue;
+                    }
+                }
+
                 // Load the parent block from blockstore
                 let head_data = match self.blockstore.get(head_cid).await {
                     Ok(Some(data)) => data,
@@ -936,6 +964,14 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             None => {
                 // Commit the entire transaction (all field merges + document storage + headstore)
                 txn.force_commit().await?;
+
+                // Mark this composite as merged so concurrent/recursive paths
+                // skip re-processing it (prevents stale headstore entries).
+                {
+                    let mut merged = self.merged_composites.lock().unwrap();
+                    merged.insert(*cid);
+                }
+
                 tracing::info!(
                     cid = %cid,
                     doc_id = %doc_id_str,

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -98,11 +98,10 @@ pub use index::{create_index, drop_index, get_all_indexes, get_indexes};
 pub use lens::{lens_add, lens_list};
 pub use node::{new_node, node_close};
 pub use p2p::{
-    new_node_with_p2p, p2p_active_peers, p2p_connect, p2p_create_collections,
-    p2p_create_documents, p2p_create_replicator, p2p_delete_collections, p2p_delete_documents,
-    p2p_delete_replicator, p2p_list_collections, p2p_list_documents, p2p_list_replicators,
-    p2p_peer_info, p2p_sync_branchable_collection, p2p_sync_collection_versions,
-    p2p_sync_documents,
+    new_node_with_p2p, p2p_active_peers, p2p_connect, p2p_create_collections, p2p_create_documents,
+    p2p_create_replicator, p2p_delete_collections, p2p_delete_documents, p2p_delete_replicator,
+    p2p_list_collections, p2p_list_documents, p2p_list_replicators, p2p_peer_info,
+    p2p_sync_branchable_collection, p2p_sync_collection_versions, p2p_sync_documents,
 };
 pub use query::exec_request;
 pub use schema::{add_schema, get_collections, get_collections_in_txn};

--- a/crates/query/src/mapper/filter/filter_impl.rs
+++ b/crates/query/src/mapper/filter/filter_impl.rs
@@ -297,7 +297,10 @@ impl Filter {
                 }
             }
 
-            // Field condition - get the field value from the object
+            // Field condition - get the field value from the object.
+            // Track whether the field actually exists vs defaulting to null,
+            // because Go treats missing JSON sub-fields differently from explicit nulls.
+            let field_missing = !obj.contains_key(key);
             let field_value = obj.get(key).cloned().unwrap_or(JsonValue::Null);
 
             let ops = value
@@ -339,11 +342,19 @@ impl Filter {
                     )));
                 }
             } else {
-                // Operator conditions
+                // Operator conditions.
+                // When a field doesn't exist in a JSON object and the operator
+                // compares against a non-null value, the document doesn't match
+                // (Go compatibility: missing JSON sub-field != not-equal).
+                // But when comparing against null (e.g. _gte null), null >= null
+                // is valid and should proceed normally.
                 for (op_str, expected) in ops {
                     let op = FilterOp::parse(op_str).ok_or_else(|| {
                         QueryError::invalid_filter(format!("unknown operator: {}", op_str))
                     })?;
+                    if field_missing && !expected.is_null() {
+                        return Ok(false);
+                    }
                     if !eval_op(&field_value, op, expected)? {
                         return Ok(false);
                     }


### PR DESCRIPTION
## Summary
- **JSON _ne filter**: Missing JSON sub-fields now correctly exclude documents when compared against non-null values. Previously `null _ne {obj}` returned true for missing fields, including documents that Go correctly filters out.
- **P2P branchable merge dedup**: Added `merged_composites` guard to `DbMergeHandler` to prevent concurrent dual-broadcast paths from re-processing parent composites during recursive DAG walks. Without this, stale headstore entries leaked into merge commits, producing 17 commits instead of the expected 15.

## Test plan
- [x] `ffi-test run query/json` — 69/69 pass (was 68/69)
- [x] `ffi-test run query/commits/branchables` — 14/14 pass (was 13/14)
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo test -p db -p query` — pass (pre-existing `test_nilike_null_field_returns_false` failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)