### PR TITLE
fix(p2p): Fix peer discovery and address handling for Go compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,7 @@ dependencies = [
  "query",
  "schema",
  "serde",
+ "serde_ipld_dagcbor",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,7 @@ dependencies = [
  "query",
  "schema",
  "serde",
+ "serde_bytes",
  "serde_ipld_dagcbor",
  "serde_json",
  "serde_yaml",

--- a/crates/db/src/broadcast_mutator.rs
+++ b/crates/db/src/broadcast_mutator.rs
@@ -112,9 +112,11 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
             field_cids: vec![],
         };
 
-        // Push directly to registered replicators first (fast, fire-and-forget per peer)
+        // Push the full DAG (field blocks + composite) to replicators.
+        // Field blocks are sent first so the receiver has them when the composite arrives,
+        // avoiding Bitswap fetches (which can fail after node restarts).
         self.sync
-            .push_to_replicators(
+            .push_dag_to_replicators(
                 &block_result.cid,
                 &block_result.block,
                 &block_result.doc_id,
@@ -328,9 +330,9 @@ impl<S: Store + 'static, B: Blockstore + 'static> DocMutator for BroadcastMutato
             field_cids: vec![],
         };
 
-        // Push directly to registered replicators first (fast, fire-and-forget per peer)
+        // Push the full DAG (field blocks + composite) to replicators.
         self.sync
-            .push_to_replicators(
+            .push_dag_to_replicators(
                 &block_result.cid,
                 &block_result.block,
                 &block_result.doc_id,
@@ -472,6 +474,10 @@ async fn broadcast_with_retry<B: Blockstore + 'static>(
             .await
         {
             Ok(BroadcastResult::Success) => {
+                eprintln!(
+                    "[BROADCAST-RETRY] SUCCESS doc_id={} cid={} attempts={}",
+                    block_result.doc_id, block_result.cid, attempt
+                );
                 tracing::debug!(
                     doc_id = %block_result.doc_id,
                     cid = %block_result.cid,
@@ -511,6 +517,10 @@ async fn broadcast_with_retry<B: Blockstore + 'static>(
                 if err_str.contains("InsufficientPeers") && attempt <= MAX_RETRIES {
                     // Exponential backoff: 100ms, 200ms, 400ms, ... capped at 3.2s
                     let delay_ms = 100 * (1u64 << attempt.min(5));
+                    eprintln!(
+                        "[BROADCAST-RETRY] InsufficientPeers doc_id={} attempt={}/{} delay={}ms",
+                        block_result.doc_id, attempt, MAX_RETRIES, delay_ms
+                    );
                     tracing::trace!(
                         doc_id = %block_result.doc_id,
                         attempt = attempt,
@@ -520,6 +530,10 @@ async fn broadcast_with_retry<B: Blockstore + 'static>(
                     tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                     continue;
                 }
+                eprintln!(
+                    "[BROADCAST-RETRY] FAILED doc_id={} collection={} err={} attempts={}",
+                    block_result.doc_id, collection_name, e, attempt
+                );
                 tracing::warn!(
                     doc_id = %block_result.doc_id,
                     collection = %collection_name,

--- a/crates/db/src/collection_ops/create.rs
+++ b/crates/db/src/collection_ops/create.rs
@@ -54,6 +54,58 @@ impl<S: Store> crate::database::DB<S> {
         // Validate schema (includes policy validation for path traversal prevention)
         schema.validate()?;
         let name = collection_name.as_str().to_string();
+
+        // For views, regenerate version_id to include query_select in the CID
+        // (matching Go's saveBlocks which includes querySelect in the delta).
+        // This must happen before any systemstore writes that use version_id.
+        if schema.query.is_some() {
+            let (qs_bytes, qt_cid) = if let Some(ref qs) = schema.query {
+                let select_cbor = serde_cbor::to_vec(&qs.query).unwrap_or_default();
+                let transform_cid = qs
+                    .transform
+                    .as_ref()
+                    .and_then(|t| cid::Cid::try_from(t.as_str()).ok());
+                (Some(select_cbor), transform_cid)
+            } else {
+                (None, None)
+            };
+
+            // Regenerate field CIDs to compute the correct version_id
+            let mut sorted: Vec<&schema::FieldDescription> =
+                schema.fields.iter().filter(|f| !f.id.is_empty()).collect();
+            sorted.sort_by(|a, b| {
+                if a.name == "_docID" {
+                    std::cmp::Ordering::Less
+                } else if b.name == "_docID" {
+                    std::cmp::Ordering::Greater
+                } else {
+                    a.name.cmp(&b.name)
+                }
+            });
+            let mut fld_cids = Vec::new();
+            for field in &sorted {
+                if let Ok(cid) = schema::generate_field_cid_with_priority(field, 1) {
+                    fld_cids.push(cid);
+                }
+            }
+
+            if let Ok(new_cid) = schema::generate_collection_cid_full_with_query(
+                Some(&schema.name),
+                &fld_cids,
+                1,
+                &[],
+                qs_bytes.as_deref(),
+                qt_cid.as_ref(),
+            ) {
+                let new_version_id = new_cid.to_string();
+                let old_version_id = schema.version_id.clone();
+                schema.version_id = new_version_id.clone();
+                if schema.collection_id == old_version_id {
+                    schema.collection_id = new_version_id;
+                }
+            }
+        }
+
         let version_id = &schema.version_id.clone();
         let collection_id = &schema.collection_id.clone();
 
@@ -161,6 +213,7 @@ impl<S: Store> crate::database::DB<S> {
 
         // Store the collection definition block
         // This includes the collection name, field CIDs, priority, and head CIDs.
+        // For views, also includes query_select and query_transform in the delta.
         // For new collections (not patches), there are no heads, so we pass an empty slice.
         match schema::generate_collection_block_full(
             Some(&schema.name),

--- a/crates/db/src/merge_handler/definition.rs
+++ b/crates/db/src/merge_handler/definition.rs
@@ -13,16 +13,35 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         payload: &CollectionDefinitionDeltaPayload,
         _metadata: &BlockMetadata<'_>,
     ) -> Result<MergeOutcome, MergeError> {
-        let collection_name = match &payload.name {
-            Some(name) => name.clone(),
-            None => {
-                tracing::debug!(cid = %cid, "CollectionDefinition has no name - skipping");
-                return Ok(MergeOutcome::skipped("collection definition has no name"));
-            }
-        };
-
         // The version_id is the CID of this collection definition block
         let version_id = cid.to_string();
+
+        // For patched versions, payload.name is None (name didn't change).
+        // Resolve name and collection_id from the previous version via block.heads.
+        let (collection_name, collection_id, prev_fields) = match &payload.name {
+            Some(name) => {
+                // Initial version: name is explicit, collection_id = version_id
+                (name.clone(), version_id.clone(), Vec::new())
+            }
+            None => {
+                // Patched version: look up previous version from heads
+                let prev_version = self.resolve_previous_collection_version(block).await?;
+                match prev_version {
+                    Some(prev) => {
+                        let name = prev.name.clone();
+                        let col_id = prev.collection_id.clone();
+                        let fields = prev.fields.clone();
+                        (name, col_id, fields)
+                    }
+                    None => {
+                        tracing::debug!(cid = %cid, "CollectionDefinition has no name and no resolvable previous version - skipping");
+                        return Ok(MergeOutcome::skipped(
+                            "collection definition has no name and no previous version",
+                        ));
+                    }
+                }
+            }
+        };
 
         tracing::info!(
             cid = %cid,
@@ -31,10 +50,8 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             "Processing collection definition delta"
         );
 
-        // Load and decode all linked field definition blocks
-        // Note: _docID is already included in the linked blocks from the source node,
-        // so we don't need to add it implicitly.
-        let mut fields = Vec::new();
+        // Load and decode linked field definition blocks (new fields for this version)
+        let mut new_fields = Vec::new();
         if let Some(links) = &block.links {
             for link in links.iter() {
                 let field_cid = &link.link;
@@ -52,16 +69,26 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 })?;
 
                 if let CrdtDelta::FieldDefinition(field_payload) = &field_block.delta {
-                    // Use the field block CID as the field ID (matches Go's behavior)
                     let field_desc = self
                         .field_definition_to_description(field_payload, &field_cid.to_string())?;
-                    fields.push(field_desc);
+                    new_fields.push(field_desc);
                 } else {
                     tracing::warn!(
                         field_cid = %field_cid,
                         "Linked block is not a FieldDefinition - skipping"
                     );
                 }
+            }
+        }
+
+        // Merge previous version's fields with new fields from this delta.
+        // For initial versions, prev_fields is empty so fields = new_fields.
+        // For patched versions, combine existing fields + newly added fields.
+        let mut fields = prev_fields;
+        let existing_names: HashSet<String> = fields.iter().map(|f| f.name.clone()).collect();
+        for field in new_fields {
+            if !existing_names.contains(&field.name) {
+                fields.push(field);
             }
         }
 
@@ -73,16 +100,19 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             }
         }
 
-        // For initial collection creation, collection_id equals version_id (the CID)
-        // For patched versions, we'd need to look up the existing collection
-        let collection_id = version_id.clone();
-
         // Build the CollectionVersion
         // Synced collections come in as inactive (user must activate manually via SetActiveCollectionVersion)
         // and materialized (matching Go's behavior)
         let mut schema =
             CollectionVersion::new(&collection_name, &version_id, &collection_id, fields);
         schema.is_active = false;
+
+        // For patched versions, set previous_version to point to the head (previous version CID)
+        if let Some(heads) = &block.heads {
+            if let Some(head_cid) = heads.first() {
+                schema.previous_version = Some(CollectionSource::new(head_cid.to_string()));
+            }
+        }
 
         // Views (collections with a query_select) are non-materialized and carry query metadata.
         // Regular collections are materialized.
@@ -156,7 +186,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
     }
 
     /// Convert a FieldDefinitionDeltaPayload to a FieldDescription.
-    fn field_definition_to_description(
+    pub(crate) fn field_definition_to_description(
         &self,
         payload: &FieldDefinitionDeltaPayload,
         field_id: &str,

--- a/crates/db/src/merge_handler/mod.rs
+++ b/crates/db/src/merge_handler/mod.rs
@@ -25,7 +25,8 @@ use document::{DocID, Document, NormalValue};
 use events::{MergeCompleteData, Message, Update};
 use p2p::sync::{BlockMetadata, MergeHandler, MergeOutcome};
 use schema::{
-    self, CType, CollectionVersion, FieldDescription, FieldKind, QuerySource, ScalarKind,
+    self, CType, CollectionSource, CollectionVersion, FieldDescription, FieldKind, QuerySource,
+    ScalarKind,
 };
 use storage::corekv::{Key, Store};
 use storage::keys::systemstore::{CollectionKey, CollectionVersionKey};
@@ -187,6 +188,134 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 Err(MergeError::MergeFailed(format!("Decryption failed: {}", e)))
             }
         }
+    }
+
+    /// Look up a previous CollectionVersion from block heads.
+    ///
+    /// For patched collection versions, the block's heads point to previous version CIDs.
+    /// First checks systemstore, then falls back to decoding the head block directly
+    /// from blockstore (for the UnknownCollection case where the initial version
+    /// hasn't been processed yet).
+    async fn resolve_previous_collection_version(
+        &self,
+        block: &Block,
+    ) -> Result<Option<CollectionVersion>, MergeError> {
+        let heads = match &block.heads {
+            Some(heads) if !heads.is_empty() => heads,
+            _ => return Ok(None),
+        };
+
+        for head_cid in heads {
+            // Fast path: check systemstore (KnownCollection case)
+            let head_key = CollectionKey::new(head_cid.to_string());
+            let txn = self.db.new_txn(true).await.map_err(MergeError::Database)?;
+            let systemstore = txn.systemstore().map_err(MergeError::Database)?;
+
+            if let Ok(Some(data)) = systemstore.get(&head_key.bytes()).await {
+                if let Ok(prev) = serde_json::from_slice::<CollectionVersion>(&data) {
+                    tracing::debug!(
+                        head_cid = %head_cid,
+                        name = %prev.name,
+                        collection_id = %prev.collection_id,
+                        "Resolved previous collection version from systemstore"
+                    );
+                    return Ok(Some(prev));
+                }
+            }
+
+            // Slow path: decode head block directly from blockstore.
+            // Build a CollectionVersion from the raw block data without going
+            // through the full merge handler (avoids async recursion).
+            if let Ok(Some(head_block_data)) = self.blockstore.get(head_cid).await {
+                let head_block = Block::from_dag_cbor(&head_block_data).map_err(|e| {
+                    MergeError::BlockDecode(format!("Failed to decode head block: {}", e))
+                })?;
+
+                if let CrdtDelta::CollectionDefinition(head_payload) = &head_block.delta {
+                    if let Some(name) = &head_payload.name {
+                        tracing::debug!(
+                            head_cid = %head_cid,
+                            name = %name,
+                            "Resolved previous collection version from blockstore"
+                        );
+
+                        // Decode field blocks from the head block's links
+                        let mut prev_fields = Vec::new();
+                        if let Some(links) = &head_block.links {
+                            for link in links.iter() {
+                                let field_cid = &link.link;
+                                if let Ok(Some(field_bytes)) = self.blockstore.get(field_cid).await
+                                {
+                                    if let Ok(field_block) = Block::from_dag_cbor(&field_bytes) {
+                                        if let CrdtDelta::FieldDefinition(fp) = &field_block.delta {
+                                            if let Ok(fd) = self.field_definition_to_description(
+                                                fp,
+                                                &field_cid.to_string(),
+                                            ) {
+                                                prev_fields.push(fd);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        let head_version_id = head_cid.to_string();
+                        let mut prev = CollectionVersion::new(
+                            name,
+                            &head_version_id,
+                            &head_version_id,
+                            prev_fields,
+                        );
+                        prev.is_active = false;
+                        prev.is_materialized = true;
+
+                        // Ensure _docID is first in fields
+                        if let Some(pos) = prev.fields.iter().position(|f| f.name == "_docID") {
+                            if pos > 0 {
+                                let f = prev.fields.remove(pos);
+                                prev.fields.insert(0, f);
+                            }
+                        }
+
+                        // Store in systemstore so GetCollections can find it
+                        let txn2 = self.db.new_txn(false).await.map_err(MergeError::Database)?;
+                        {
+                            let ss = txn2.systemstore().map_err(MergeError::Database)?;
+                            let key = CollectionKey::new(&head_version_id);
+                            let data = serde_json::to_vec(&prev).map_err(|e| {
+                                MergeError::Storage(format!(
+                                    "Failed to serialize prev collection: {}",
+                                    e
+                                ))
+                            })?;
+                            ss.set(&key.bytes(), &data).await.map_err(|e| {
+                                MergeError::Storage(format!(
+                                    "Failed to store prev collection: {}",
+                                    e
+                                ))
+                            })?;
+                            let vkey =
+                                CollectionVersionKey::new(&head_version_id, &head_version_id);
+                            ss.set(&vkey.bytes(), b"1").await.map_err(|e| {
+                                MergeError::Storage(format!(
+                                    "Failed to store prev version index: {}",
+                                    e
+                                ))
+                            })?;
+                        }
+                        txn2.commit().await.map_err(MergeError::Database)?;
+                        self.db
+                            .add_collection_to_cache(prev.clone())
+                            .map_err(MergeError::Database)?;
+
+                        return Ok(Some(prev));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
     }
 }
 

--- a/crates/db/src/patch/store.rs
+++ b/crates/db/src/patch/store.rs
@@ -326,6 +326,94 @@ impl<S: Store> crate::database::DB<S> {
                 .map_err(Error::Storage)?;
         } // systemstore reference dropped here
 
+        // Store field and collection definition blocks in blockstore for Bitswap sync.
+        // This mirrors create_collection_with_txn's block storage but only for NEW fields
+        // and uses the patch-specific heads/priority.
+        {
+            let blockstore = txn.blockstore()?;
+
+            // Identify new fields (same logic as generate_patch_version_id_with_heads)
+            let old_field_names: std::collections::HashSet<&str> = old_schema
+                .fields
+                .iter()
+                .filter(|f| !f.id.is_empty())
+                .map(|f| f.name.as_str())
+                .collect();
+
+            let mut new_field_indices: Vec<usize> = new_schema
+                .fields
+                .iter()
+                .enumerate()
+                .filter(|(_, f)| {
+                    let is_new = !old_field_names.contains(f.name.as_str());
+                    let is_secondary_relation = f.relation_name.is_some() && !f.is_primary;
+                    is_new && !is_secondary_relation
+                })
+                .map(|(i, _)| i)
+                .collect();
+            new_field_indices.sort_by(|&a, &b| {
+                let fa = &new_schema.fields[a];
+                let fb = &new_schema.fields[b];
+                if fa.name == "_docID" {
+                    std::cmp::Ordering::Less
+                } else if fb.name == "_docID" {
+                    std::cmp::Ordering::Greater
+                } else {
+                    fa.name.cmp(&fb.name)
+                }
+            });
+
+            // Generate and store field blocks for new fields
+            let mut field_cids = Vec::new();
+            for &idx in &new_field_indices {
+                let field = &new_schema.fields[idx];
+                match schema::generate_field_block_with_priority_and_heads(field, 1, &[]) {
+                    Ok(block_with_cid) => {
+                        blockstore
+                            .set(&block_with_cid.cid.to_bytes(), &block_with_cid.bytes)
+                            .await
+                            .map_err(Error::Storage)?;
+                        field_cids.push(block_with_cid.cid);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            field_name = %field.name,
+                            error = %e,
+                            "Failed to generate field block for patch"
+                        );
+                    }
+                }
+            }
+
+            // Generate and store the collection definition block
+            let name_changed = new_schema.name != old_schema.name;
+            let col_name = if name_changed {
+                Some(new_schema.name.as_str())
+            } else {
+                None
+            };
+            match schema::generate_collection_block_full(
+                col_name,
+                &field_cids,
+                collection_priority,
+                &collection_heads,
+            ) {
+                Ok(block_with_cid) => {
+                    blockstore
+                        .set(&block_with_cid.cid.to_bytes(), &block_with_cid.bytes)
+                        .await
+                        .map_err(Error::Storage)?;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        collection_name = %actual_name,
+                        error = %e,
+                        "Failed to generate collection block for patch"
+                    );
+                }
+            }
+        }
+
         txn.commit().await?;
 
         // Clean up any pending migration that was linked to this version

--- a/crates/defra-core/src/lens_block.rs
+++ b/crates/defra-core/src/lens_block.rs
@@ -1,0 +1,61 @@
+//! Lens IPLD block types for P2P sync.
+//!
+//! These types match Go's `lens/host-go/store/block.go` IPLD schema.
+//! Used to deserialize lens blocks fetched via Bitswap during P2P sync.
+
+use cid::Cid;
+use serde::Deserialize;
+
+/// Top-level lens config block containing links to module blocks.
+#[derive(Debug, Deserialize)]
+pub struct LensConfigBlock {
+    pub modules: Vec<Cid>,
+}
+
+/// Lens module block with configuration for a single WASM module.
+#[derive(Debug, Deserialize)]
+pub struct LensModuleBlock {
+    pub inverse: bool,
+    pub arguments: Vec<LensKeyValue>,
+    pub lens: Cid,
+}
+
+/// Key-value pair for lens module arguments.
+#[derive(Debug, Deserialize)]
+pub struct LensKeyValue {
+    pub key: String,
+    pub value: String,
+}
+
+/// Lens WASM block containing WASM bytes or links to chunks.
+///
+/// Go uses a keyed union: `{"wasmBytes": <bytes>}` or `{"chunks": [<CID>...]}`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum LensWasmBlock {
+    Direct {
+        #[serde(rename = "wasmBytes")]
+        wasm_bytes: Vec<u8>,
+    },
+    Chunked {
+        chunks: Vec<Cid>,
+    },
+}
+
+impl LensWasmBlock {
+    /// Extract WASM bytes, returning None if chunked (caller must resolve chunks).
+    pub fn wasm_bytes(&self) -> Option<&[u8]> {
+        match self {
+            LensWasmBlock::Direct { wasm_bytes } => Some(wasm_bytes),
+            LensWasmBlock::Chunked { .. } => None,
+        }
+    }
+
+    /// Get chunk CIDs if this is a chunked block.
+    pub fn chunks(&self) -> Option<&[Cid]> {
+        match self {
+            LensWasmBlock::Direct { .. } => None,
+            LensWasmBlock::Chunked { chunks } => Some(chunks),
+        }
+    }
+}

--- a/crates/defra-core/src/lens_block.rs
+++ b/crates/defra-core/src/lens_block.rs
@@ -1,19 +1,19 @@
 //! Lens IPLD block types for P2P sync.
 //!
 //! These types match Go's `lens/host-go/store/block.go` IPLD schema.
-//! Used to deserialize lens blocks fetched via Bitswap during P2P sync.
+//! Used to serialize/deserialize lens blocks for Bitswap during P2P sync.
 
 use cid::Cid;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Top-level lens config block containing links to module blocks.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LensConfigBlock {
     pub modules: Vec<Cid>,
 }
 
 /// Lens module block with configuration for a single WASM module.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LensModuleBlock {
     pub inverse: bool,
     pub arguments: Vec<LensKeyValue>,
@@ -21,7 +21,7 @@ pub struct LensModuleBlock {
 }
 
 /// Key-value pair for lens module arguments.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LensKeyValue {
     pub key: String,
     pub value: String,
@@ -30,11 +30,11 @@ pub struct LensKeyValue {
 /// Lens WASM block containing WASM bytes or links to chunks.
 ///
 /// Go uses a keyed union: `{"wasmBytes": <bytes>}` or `{"chunks": [<CID>...]}`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LensWasmBlock {
     Direct {
-        #[serde(rename = "wasmBytes")]
+        #[serde(rename = "wasmBytes", with = "serde_bytes")]
         wasm_bytes: Vec<u8>,
     },
     Chunked {
@@ -58,4 +58,100 @@ impl LensWasmBlock {
             LensWasmBlock::Chunked { chunks } => Some(chunks),
         }
     }
+}
+
+/// A CID paired with its serialized bytes.
+pub type CidBlock = (Cid, Vec<u8>);
+
+/// Maximum size for a single WASM block before chunking.
+/// Must be well below iroh-bitswap's MAX_BUF_SIZE (2 MB) to account for
+/// CBOR encoding overhead and Bitswap message framing.
+const MAX_BLOCK_SIZE: usize = 256 * 1024; // 256 KB
+
+/// Build the 3-level IPLD block hierarchy for a lens module.
+///
+/// For WASM files larger than MAX_BLOCK_SIZE, the bytes are chunked into
+/// multiple blocks and the `LensWasmBlock::Chunked` variant is used.
+///
+/// Returns (config_block_cid, vec of CidBlock pairs for all blocks to store).
+pub fn build_lens_ipld_blocks(
+    wasm_bytes: &[u8],
+    inverse: bool,
+    arguments: &[(String, String)],
+) -> Result<(Cid, Vec<CidBlock>), String> {
+    use multihash::MultihashGeneric;
+    use sha2::{Digest, Sha256};
+
+    const DAG_CBOR_CODEC: u64 = 0x71;
+    const SHA2_256_CODE: u64 = 0x12;
+
+    let compute_cid = |bytes: &[u8]| -> Result<Cid, String> {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let digest = hasher.finalize();
+        let mh = MultihashGeneric::<64>::wrap(SHA2_256_CODE, &digest)
+            .map_err(|e| format!("multihash: {}", e))?;
+        Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
+    };
+
+    let mut blocks = Vec::new();
+
+    // Level 3: LensBlock (WASM bytes, possibly chunked)
+    let lens_cid = if wasm_bytes.len() <= MAX_BLOCK_SIZE {
+        // Small enough for a single block
+        let lens_block = LensWasmBlock::Direct {
+            wasm_bytes: wasm_bytes.to_vec(),
+        };
+        let lens_bytes = serde_ipld_dagcbor::to_vec(&lens_block)
+            .map_err(|e| format!("encode lens block: {}", e))?;
+        let cid = compute_cid(&lens_bytes)?;
+        blocks.push((cid, lens_bytes));
+        cid
+    } else {
+        // Chunk the WASM bytes into smaller blocks
+        let mut chunk_cids = Vec::new();
+        for chunk in wasm_bytes.chunks(MAX_BLOCK_SIZE) {
+            // Each chunk is stored as a DAG-CBOR encoded byte string
+            let chunk_bytes = serde_ipld_dagcbor::to_vec(&serde_bytes::ByteBuf::from(chunk))
+                .map_err(|e| format!("encode chunk: {}", e))?;
+            let chunk_cid = compute_cid(&chunk_bytes)?;
+            blocks.push((chunk_cid, chunk_bytes));
+            chunk_cids.push(chunk_cid);
+        }
+        // Create the chunked lens block referencing all chunks
+        let lens_block = LensWasmBlock::Chunked { chunks: chunk_cids };
+        let lens_bytes = serde_ipld_dagcbor::to_vec(&lens_block)
+            .map_err(|e| format!("encode chunked lens block: {}", e))?;
+        let cid = compute_cid(&lens_bytes)?;
+        blocks.push((cid, lens_bytes));
+        cid
+    };
+
+    // Level 2: ModuleBlock
+    let module_block = LensModuleBlock {
+        inverse,
+        arguments: arguments
+            .iter()
+            .map(|(k, v)| LensKeyValue {
+                key: k.clone(),
+                value: v.clone(),
+            })
+            .collect(),
+        lens: lens_cid,
+    };
+    let module_bytes = serde_ipld_dagcbor::to_vec(&module_block)
+        .map_err(|e| format!("encode module block: {}", e))?;
+    let module_cid = compute_cid(&module_bytes)?;
+    blocks.push((module_cid, module_bytes));
+
+    // Level 1: ConfigBlock
+    let config_block = LensConfigBlock {
+        modules: vec![module_cid],
+    };
+    let config_bytes = serde_ipld_dagcbor::to_vec(&config_block)
+        .map_err(|e| format!("encode config block: {}", e))?;
+    let config_cid = compute_cid(&config_bytes)?;
+    blocks.push((config_cid, config_bytes));
+
+    Ok((config_cid, blocks))
 }

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -25,7 +25,9 @@ pub use block::{
 };
 pub use error::{Error, Result};
 pub use ipld::{collect_block_links, extract_links, walk_ipld, IpldVisitor};
-pub use lens_block::{LensConfigBlock, LensKeyValue, LensModuleBlock, LensWasmBlock};
+pub use lens_block::{
+    build_lens_ipld_blocks, CidBlock, LensConfigBlock, LensKeyValue, LensModuleBlock, LensWasmBlock,
+};
 
 /// Version information for DefraDB
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod document;
 pub mod encryption;
 pub mod error;
 pub mod ipld;
+pub mod lens_block;
 pub mod signing;
 pub mod store;
 pub mod thread_bounds;
@@ -24,6 +25,7 @@ pub use block::{
 };
 pub use error::{Error, Result};
 pub use ipld::{collect_block_links, extract_links, walk_ipld, IpldVisitor};
+pub use lens_block::{LensConfigBlock, LensKeyValue, LensModuleBlock, LensWasmBlock};
 
 /// Version information for DefraDB
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -24,6 +24,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
 serde_ipld_dagcbor.workspace = true
+serde_bytes.workspace = true
 
 # Error handling
 thiserror.workspace = true

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -23,6 +23,7 @@ async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
+serde_ipld_dagcbor.workspace = true
 
 # Error handling
 thiserror.workspace = true

--- a/crates/ffi/src/lens.rs
+++ b/crates/ffi/src/lens.rs
@@ -5,6 +5,9 @@
 //! - Listing lens transforms
 
 use std::ffi::c_char;
+use std::sync::Arc;
+
+use blockstore::{Blockstore, DefraBlockstore};
 
 use acp::nac::NodePermission;
 
@@ -14,24 +17,53 @@ use crate::state::NODES;
 use crate::types::{c_str_to_string, FfiResult};
 use crate::ERR_INVALID_NODE_HANDLE;
 
-use lens::{LensConfig, LensModule};
+use lens::{LensConfig, LensModule, TransformId};
+
+/// Read WASM bytes from a LensModule (from path or embedded bytes).
+fn read_wasm_bytes(module: &LensModule) -> Result<Vec<u8>, String> {
+    if let Some(ref bytes) = module.module {
+        return Ok(bytes.clone());
+    }
+    if let Some(ref path_str) = module.path {
+        let clean_path = path_str.strip_prefix("file://").unwrap_or(path_str);
+        std::fs::read(clean_path)
+            .map_err(|e| format!("failed to read WASM file {}: {}", clean_path, e))
+    } else {
+        Err("lens module has neither path nor module bytes".to_string())
+    }
+}
+
+/// Extract arguments from a LensModule as key-value pairs for IPLD blocks.
+fn extract_arguments(module: &LensModule) -> Vec<(String, String)> {
+    match &module.arguments {
+        Some(serde_json::Value::Object(map)) => map
+            .iter()
+            .map(|(k, v)| {
+                let val = match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                };
+                (k.clone(), val)
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
 
 /// Add a lens transform to the database.
 ///
-/// This registers a lens transform without linking it to schema versions.
-/// Use `set_migration` to link a transform between specific versions.
+/// Builds Go-compatible IPLD blocks (ConfigBlock -> ModuleBlock -> LensBlock),
+/// stores them in the blockstore for P2P Bitswap, and registers the transform
+/// under the ConfigBlock CID.
 ///
 /// # Arguments
 ///
 /// * `node_ptr` - Handle to the node
-/// * `lens_json` - JSON string containing the lens configuration:
-///   - `Path`: Optional path to WASM module file
-///   - `Module`: Optional base64-encoded WASM bytes
-///   - `Arguments`: Optional JSON arguments for the module
+/// * `lens_json` - JSON string containing the lens configuration
 ///
 /// # Returns
 ///
-/// - Status 0: Success (value contains the lens ID)
+/// - Status 0: Success (value contains the lens CID)
 /// - Status 1: Error (error field contains message)
 ///
 /// # Safety
@@ -72,9 +104,15 @@ pub unsafe extern "C" fn lens_add(node_ptr: usize, lens_json: *const c_char) -> 
         }
     }
 
-    // No version IDs — register as standalone lens module(s)
-    let lens_store = match NODES.get(node_ptr, |state| state.database.lens_store().clone()) {
-        Some(store) => store,
+    // No version IDs — register as standalone lens module(s).
+    // Get both the lens store and the database store for blockstore access.
+    let (lens_store, db_store) = match NODES.get(node_ptr, |state| {
+        (
+            state.database.lens_store().clone(),
+            state.database.store().clone(),
+        )
+    }) {
+        Some(pair) => pair,
         None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
     };
 
@@ -100,14 +138,47 @@ pub unsafe extern "C" fn lens_add(node_ptr: usize, lens_json: *const c_char) -> 
                     .map_err(|e| format!("failed to parse lens config: {}", e))?]
             };
 
+        // Create a blockstore for storing IPLD blocks (non-P2P mode, no merge tracking)
+        let blockstore = Arc::new(DefraBlockstore::new(db_store, false));
+
         let mut all_ids = Vec::new();
-        for lens_module in modules {
-            let config = LensConfig::new("", "", lens_module);
-            let lens_id = lens_store
-                .add(config)
+        for lens_module in &modules {
+            // Read WASM bytes from file or embedded bytes
+            let wasm_bytes = read_wasm_bytes(lens_module)?;
+            let arguments = extract_arguments(lens_module);
+
+            // Build the 3-level IPLD block hierarchy matching Go's format
+            let (config_cid, blocks) =
+                defra_core::build_lens_ipld_blocks(&wasm_bytes, lens_module.inverse, &arguments)?;
+
+            // Store all blocks in the blockstore for Bitswap availability
+            for (cid, data) in &blocks {
+                eprintln!(
+                    "[FFI-LENS-ADD] Storing block cid={} ({} bytes)",
+                    cid,
+                    data.len()
+                );
+                blockstore
+                    .put(cid, data)
+                    .await
+                    .map_err(|e| format!("failed to store lens block: {}", e))?;
+                // Verify the block was stored
+                let has = blockstore
+                    .has(cid)
+                    .await
+                    .map_err(|e| format!("failed to check block: {}", e))?;
+                eprintln!("[FFI-LENS-ADD] Block {} stored: {}", cid, has);
+            }
+
+            // Register the transform under the real IPLD CID
+            let config = LensConfig::new("", "", lens_module.clone());
+            let transform_id = TransformId::new(config_cid.to_string());
+            lens_store
+                .add_with_id(transform_id, config)
                 .await
                 .map_err(|e| format!("failed to add lens: {}", e))?;
-            all_ids.push(lens_id.to_string());
+
+            all_ids.push(config_cid.to_string());
         }
 
         // Return comma-joined IDs so chained transforms are preserved
@@ -123,24 +194,6 @@ pub unsafe extern "C" fn lens_add(node_ptr: usize, lens_json: *const c_char) -> 
 /// List all lens transforms.
 ///
 /// Returns a JSON object mapping lens IDs to their configurations.
-///
-/// # Arguments
-///
-/// * `node_ptr` - Handle to the node
-///
-/// # Returns
-///
-/// - Status 0: Success (value contains JSON object of lenses)
-/// - Status 1: Error (error field contains message)
-///
-/// # Example Response
-///
-/// ```json
-/// {
-///   "lens_0": {"Path": "/path/to/transform.wasm"},
-///   "lens_1": {"Module": "base64...", "Arguments": {...}}
-/// }
-/// ```
 ///
 /// # Safety
 ///

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -23,7 +23,7 @@ use defra_core::Block;
 use p2p::bitswap::BitswapStoreAdapter;
 use p2p::message::PushLogRequest;
 use p2p::sync::{
-    ReplicationConfig, ReplicationLoop, ReplicationResult, SyncConfig, SyncCoordinator,
+    PushFailure, ReplicationConfig, ReplicationLoop, ReplicationResult, SyncConfig, SyncCoordinator,
 };
 use p2p::topics::DefraTopic;
 use p2p::P2PHost;
@@ -297,7 +297,7 @@ pub unsafe extern "C" fn new_node_with_p2p(
             Arc::new(db::DbHeadProvider::new(database.clone()));
 
         // Create SyncCoordinator for processing incoming P2P sync messages
-        let (coordinator, sync_events_rx) = SyncCoordinator::with_head_provider(
+        let (mut coordinator, sync_events_rx) = SyncCoordinator::with_head_provider(
             handle.clone(),
             blockstore.clone(),
             SyncConfig::default(),
@@ -308,6 +308,10 @@ pub unsafe extern "C" fn new_node_with_p2p(
         )
         .await
         .map_err(|e| format!("failed to create sync coordinator: {}", e))?;
+
+        // Create push failure channel and set it on the coordinator before wrapping in Arc.
+        let (failure_tx, failure_rx) = tokio::sync::mpsc::unbounded_channel::<PushFailure>();
+        coordinator.set_failure_channel(failure_tx);
         let coordinator = Arc::new(coordinator);
 
         // Create DbMergeHandler for merging CRDT blocks into the database
@@ -442,13 +446,167 @@ pub unsafe extern "C" fn new_node_with_p2p(
         // Create P2P state with sync pipeline components and abort handles
         // Note: Local update broadcast is now handled by BroadcastMutator directly
         // when mutations are executed, so no separate broadcast task is needed.
-        let p2p_state = Arc::new(P2PState::new(
+        let mut p2p_state = P2PState::new(
             handle.clone(),
             blockstore.clone(),
             merge_handler.clone(),
             host_event_task.abort_handle(),
             replication_task.abort_handle(),
-        ));
+        );
+
+        // Task 3: Failure Recorder — reads push failures from the channel and
+        // persists them to the Peerstore for later retry.
+        let recorder_store = store.clone();
+        let failure_recorder_task = tokio::spawn(async move {
+            let mut rx = failure_rx;
+            while let Some(failure) = rx.recv().await {
+                eprintln!(
+                    "[RETRY-RECORDER] Push failure: peer={} doc={} col={}",
+                    failure.peer_id, failure.doc_id, failure.collection_id
+                );
+                let peerstore = Peerstore::new(recorder_store.clone());
+                let retry_info = storage::stores::RetryInfo::new_initial();
+                let info_bytes = match retry_info.to_bytes() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Failed to serialize RetryInfo");
+                        continue;
+                    }
+                };
+                if let Err(e) = peerstore
+                    .record_push_failure(
+                        &failure.peer_id.to_string(),
+                        &failure.doc_id,
+                        &failure.collection_id,
+                        &info_bytes,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        peer_id = %failure.peer_id,
+                        doc_id = %failure.doc_id,
+                        error = %e,
+                        "Failed to record push failure"
+                    );
+                } else {
+                    eprintln!(
+                        "[RETRY-RECORDER] Recorded failure for peer={} doc={}",
+                        failure.peer_id, failure.doc_id
+                    );
+                }
+            }
+        });
+        p2p_state.failure_recorder_handle = Some(failure_recorder_task.abort_handle());
+
+        // Task 4: Retry Loop — every 2 seconds, check for due retries and
+        // re-push failed documents to their replicator peers.
+        let retry_store = store.clone();
+        let retry_handle = handle.clone();
+        let retry_loop_task = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+                let peerstore = Peerstore::new(retry_store.clone());
+                let peers = match peerstore.get_all_retry_peers().await {
+                    Ok(p) => p,
+                    Err(_) => continue,
+                };
+
+                if !peers.is_empty() {
+                    eprintln!("[RETRY-LOOP] Found {} retry peers", peers.len());
+                }
+
+                for (peer_id_str, info_bytes) in peers {
+                    let mut retry_info = match storage::stores::RetryInfo::from_bytes(&info_bytes) {
+                        Ok(i) => i,
+                        Err(e) => {
+                            eprintln!("[RETRY-LOOP] Failed to parse RetryInfo for peer={}: {}", peer_id_str, e);
+                            continue;
+                        }
+                    };
+
+                    if !retry_info.is_due() {
+                        continue;
+                    }
+
+                    let peer_id = match libp2p::PeerId::from_str(&peer_id_str) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            eprintln!("[RETRY-LOOP] Invalid peer ID {}: {}", peer_id_str, e);
+                            continue;
+                        }
+                    };
+
+                    // Only attempt retry when the peer is connected. If the peer
+                    // restarted on a new port, we can't reach it at the old address.
+                    // The test framework (or mDNS/DHT) will re-connect the peers,
+                    // at which point we retry immediately.
+                    let connected = retry_handle
+                        .connected_peers()
+                        .await
+                        .unwrap_or_default();
+                    if !connected.contains(&peer_id) {
+                        continue;
+                    }
+
+                    let docs = match peerstore.get_retry_doc_ids(&peer_id_str).await {
+                        Ok(d) => d,
+                        Err(_) => continue,
+                    };
+
+                    if docs.is_empty() {
+                        let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                        continue;
+                    }
+
+                    eprintln!(
+                        "[RETRY-LOOP] Retrying {} docs for peer={}",
+                        docs.len(), peer_id_str
+                    );
+
+                    let mut all_succeeded = true;
+                    for (doc_id, collection_id) in &docs {
+                        match retry_doc(
+                            &retry_handle,
+                            &retry_store,
+                            peer_id,
+                            doc_id,
+                            collection_id,
+                        )
+                        .await
+                        {
+                            Ok(()) => {
+                                eprintln!(
+                                    "[RETRY-LOOP] SUCCESS doc={} peer={}",
+                                    doc_id, peer_id_str
+                                );
+                                let _ = peerstore.remove_retry_doc(&peer_id_str, doc_id).await;
+                            }
+                            Err(e) => {
+                                eprintln!(
+                                    "[RETRY-LOOP] FAILED doc={} peer={}: {}",
+                                    doc_id, peer_id_str, e
+                                );
+                                all_succeeded = false;
+                            }
+                        }
+                    }
+
+                    if all_succeeded {
+                        eprintln!("[RETRY-LOOP] All docs succeeded for peer={}", peer_id_str);
+                        let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                    } else {
+                        retry_info.bump();
+                        if let Ok(bytes) = retry_info.to_bytes() {
+                            let _ = peerstore.update_retry_info(&peer_id_str, &bytes).await;
+                        }
+                    }
+                }
+            }
+        });
+        p2p_state.retry_loop_handle = Some(retry_loop_task.abort_handle());
+
+        let p2p_state = Arc::new(p2p_state);
 
         // Load persisted replicators from the Peerstore (Go's loadAndPublishReplicators).
         // On restart, this restores the in-memory replicator registry and GossipSub
@@ -1434,6 +1592,155 @@ pub unsafe extern "C" fn p2p_retry_replicators(node_ptr: usize) -> FfiResult {
     match result {
         Ok(()) => FfiResult::ok(),
         Err(e) => FfiResult::error(e),
+    }
+}
+
+/// Retry pushing a single document's composite heads to a replicator peer.
+///
+/// Reads composite head CIDs from the headstore, loads block data from the
+/// blockstore, builds signed PushLogRequests, and sends them.
+async fn retry_doc(
+    handle: &p2p::P2PHostHandle,
+    store: &Arc<crate::state::FfiStore>,
+    peer_id: libp2p::PeerId,
+    doc_id: &str,
+    collection_id: &str,
+) -> Result<(), String> {
+    use storage::corekv::{Reader, Store};
+
+    let local_peer_id = handle
+        .local_peer_id()
+        .await
+        .map_err(|e| format!("failed to get local peer ID: {}", e))?;
+
+    let headstore = storage::stores::Headstore::new(store.clone());
+    let head_txn = headstore
+        .new_txn(true)
+        .await
+        .map_err(|e| format!("headstore txn: {}", e))?;
+
+    let blockstore_view = storage::stores::Blockstore::new(store.clone(), true);
+    let block_txn = blockstore_view
+        .new_txn(true)
+        .await
+        .map_err(|e| format!("blockstore txn: {}", e))?;
+
+    let prefix = storage::keys::headstore::HeadstoreDocKey::field_prefix(doc_id, "C");
+    eprintln!(
+        "[RETRY-DOC] Looking for heads with prefix={} for doc={}",
+        String::from_utf8_lossy(&prefix),
+        doc_id
+    );
+    let opts = IterOptions::new().with_prefix(prefix);
+    let mut iter = head_txn
+        .iterator(opts)
+        .await
+        .map_err(|e| format!("headstore iterator: {}", e))?;
+
+    let mut any_failed = false;
+    let mut head_count = 0u32;
+    while let Some(pair) = iter
+        .next()
+        .await
+        .map_err(|e| format!("headstore iteration: {}", e))?
+    {
+        // Parse CID from key: /d/{doc_id}/C/{cid}
+        let key_str = String::from_utf8_lossy(&pair.key);
+        let parts: Vec<&str> = key_str.split('/').collect();
+        if parts.len() < 5 {
+            eprintln!("[RETRY-DOC] Skipping key with <5 parts: {}", key_str);
+            continue;
+        }
+        let head_cid = match cid::Cid::from_str(parts[4]) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[RETRY-DOC] Failed to parse CID from {}: {}", parts[4], e);
+                continue;
+            }
+        };
+        head_count += 1;
+
+        // Read composite block data from blockstore
+        let block_data = match block_txn.get(&head_cid.to_bytes()).await {
+            Ok(Some(data)) => data,
+            Ok(None) => {
+                eprintln!("[RETRY-DOC] Block not found for CID={}", head_cid);
+                continue;
+            }
+            Err(e) => {
+                eprintln!("[RETRY-DOC] Block read error for CID={}: {}", head_cid, e);
+                continue;
+            }
+        };
+
+        // Send the full DAG: field blocks first, then composite last.
+        // This matches push_dag_to_replicators() so the receiver has all
+        // blocks when the composite arrives and doesn't need Bitswap.
+        if let Ok(parsed) = Block::from_dag_cbor(&block_data) {
+            if let Some(ref links) = parsed.links {
+                for link in links {
+                    if let Ok(Some(field_data)) = block_txn.get(&link.link.to_bytes()).await {
+                        let mut field_req = PushLogRequest::new(
+                            doc_id.to_string(),
+                            link.link.to_bytes(),
+                            collection_id.to_string(),
+                            local_peer_id.to_string(),
+                            field_data,
+                        );
+                        if p2p::signing::sign_message(handle.keypair(), &mut field_req).is_ok() {
+                            if let Err(e) =
+                                handle.send_two_stream_request(peer_id, field_req).await
+                            {
+                                eprintln!(
+                                    "[RETRY-DOC] Field block send failed: cid={} error={}",
+                                    link.link, e
+                                );
+                                any_failed = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Send composite block last
+        let mut request = PushLogRequest::new(
+            doc_id.to_string(),
+            head_cid.to_bytes(),
+            collection_id.to_string(),
+            local_peer_id.to_string(),
+            block_data,
+        );
+
+        if let Err(e) = p2p::signing::sign_message(handle.keypair(), &mut request) {
+            tracing::warn!(error = %e, "Failed to sign retry PushLog request");
+            any_failed = true;
+            continue;
+        }
+
+        if let Err(e) = handle.send_two_stream_request(peer_id, request).await {
+            eprintln!(
+                "[RETRY-DOC] PushLog send failed: peer={} doc={} cid={} error={}",
+                peer_id, doc_id, head_cid, e
+            );
+            any_failed = true;
+        } else {
+            eprintln!(
+                "[RETRY-DOC] PushLog sent OK: peer={} doc={} cid={}",
+                peer_id, doc_id, head_cid
+            );
+        }
+    }
+
+    eprintln!(
+        "[RETRY-DOC] Done: doc={} heads_found={} any_failed={}",
+        doc_id, head_count, any_failed
+    );
+
+    if any_failed {
+        Err("some pushes failed".to_string())
+    } else {
+        Ok(())
     }
 }
 

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -27,8 +27,9 @@ use p2p::sync::{
 };
 use p2p::topics::DefraTopic;
 use p2p::P2PHost;
+use p2p::ReplicatorInfo;
 use storage::corekv::IterOptions;
-use storage::Store as _;
+use storage::stores::Peerstore;
 
 /// Parsed multiaddr containing peer ID and transport address.
 struct ParsedMultiaddr {
@@ -225,61 +226,39 @@ pub unsafe extern "C" fn new_node_with_p2p(
         let blockstore = Arc::new(DefraBlockstore::new(store.clone(), true));
         let bitswap_store = BitswapStoreAdapter::new(blockstore.clone());
 
-        // Try to load persisted P2P keypair from the store.
-        // Key uses systemstore prefix 's' + '/p2p/host_key'.
-        const P2P_HOST_KEY: &[u8] = b"s/p2p/host_key";
-
-        let stored_keypair = {
-            let txn = store
-                .new_txn(true)
-                .await
-                .map_err(|e| format!("failed to create txn for P2P key load: {}", e))?;
-            match txn.get(P2P_HOST_KEY).await {
+        // Load or generate P2P identity key. Go persists the libp2p identity so
+        // PeerIds are stable across restarts; we do the same using the Peerstore.
+        let p2p_keypair = {
+            let ps = Peerstore::new(store.clone());
+            let key_id = "__local_p2p_identity__";
+            match ps.get_replicator(key_id).await {
                 Ok(Some(bytes)) => {
+                    // Restore persisted keypair
                     match libp2p::identity::Keypair::from_protobuf_encoding(&bytes) {
-                        Ok(kp) => Some(kp),
-                        Err(e) => {
-                            eprintln!(
-                                "[P2P] Warning: failed to decode stored keypair: {}, generating new one",
-                                e
-                            );
-                            None
+                        Ok(kp) => kp,
+                        Err(_) => {
+                            let kp = libp2p::identity::Keypair::generate_ed25519();
+                            let _ = ps.set_replicator(key_id, &kp.to_protobuf_encoding().unwrap_or_default()).await;
+                            kp
                         }
                     }
                 }
-                _ => None,
+                _ => {
+                    // First run: generate and persist
+                    let kp = libp2p::identity::Keypair::generate_ed25519();
+                    if let Ok(encoded) = kp.to_protobuf_encoding() {
+                        let _ = ps.set_replicator(key_id, &encoded).await;
+                    }
+                    kp
+                }
             }
         };
 
+        // Create P2P host with the persisted identity
         let (host, handle, event_rx, _replicator_registry) =
-            if let Some(kp) = stored_keypair {
-                P2PHost::with_keypair(kp, bitswap_store.clone())
-                    .await
-                    .map_err(|e| format!("failed to create P2P host with stored keypair: {}", e))?
-            } else {
-                let result = P2PHost::new(bitswap_store.clone())
-                    .await
-                    .map_err(|e| format!("failed to create P2P host: {}", e))?;
-
-                // Persist the newly generated keypair
-                let key_bytes = result
-                    .1
-                    .keypair()
-                    .to_protobuf_encoding()
-                    .map_err(|e| format!("failed to encode P2P keypair: {}", e))?;
-                let mut txn = store
-                    .new_txn(false)
-                    .await
-                    .map_err(|e| format!("failed to create txn for P2P key store: {}", e))?;
-                txn.set(P2P_HOST_KEY, &key_bytes)
-                    .await
-                    .map_err(|e| format!("failed to store P2P keypair: {}", e))?;
-                txn.commit()
-                    .await
-                    .map_err(|e| format!("failed to commit P2P keypair: {}", e))?;
-
-                result
-            };
+            P2PHost::with_keypair(p2p_keypair, bitswap_store.clone())
+                .await
+                .map_err(|e| format!("failed to create P2P host: {}", e))?;
 
         // Spawn the P2P host event loop BEFORE sending any commands.
         // The host must be running to process commands like Listen/Dial.
@@ -293,6 +272,9 @@ pub unsafe extern "C" fn new_node_with_p2p(
         let addr: libp2p::Multiaddr = listen_addr_str
             .parse()
             .map_err(|e| format!("invalid multiaddr '{}': {}", listen_addr_str, e))?;
+
+        let rust_peer_id = handle.local_peer_id().await.map_err(|e| format!("peer id: {}", e))?;
+        eprintln!("[RUST-P2P] Created Rust P2P host PeerId={} ListenAddr={}", rust_peer_id, listen_addr_str);
 
         handle
             .listen(addr)
@@ -467,6 +449,79 @@ pub unsafe extern "C" fn new_node_with_p2p(
             host_event_task.abort_handle(),
             replication_task.abort_handle(),
         ));
+
+        // Load persisted replicators from the Peerstore (Go's loadAndPublishReplicators).
+        // On restart, this restores the in-memory replicator registry and GossipSub
+        // subscriptions so that syncing resumes without the caller re-creating replicators.
+        let peerstore = Peerstore::new(store.clone());
+        match peerstore.get_all_replicators().await {
+            Ok(entries) => {
+                eprintln!("[LOAD-REPLICATORS] Found {} stored replicators", entries.len());
+                for (peer_id_str, data) in entries {
+                    match ReplicatorInfo::from_bytes(&data) {
+                        Ok(info) => {
+                            if let Some(peer_id) = info.peer_id() {
+                                eprintln!("[LOAD-REPLICATORS] Restoring replicator peer={} collections={:?}", peer_id, info.collections);
+                                if let Err(e) = handle
+                                    .set_replicator(peer_id, info.collections.clone())
+                                    .await
+                                {
+                                    eprintln!("[LOAD-REPLICATORS] Failed to set_replicator: {}", e);
+                                    continue;
+                                }
+                                for collection_id in &info.collections {
+                                    let topic = DefraTopic::collection(collection_id);
+                                    if let Err(e) = handle.subscribe(topic).await {
+                                        eprintln!("[LOAD-REPLICATORS] Failed to subscribe topic {}: {}", collection_id, e);
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("[LOAD-REPLICATORS] Failed to deserialize peer={}: {}", peer_id_str, e);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("[LOAD-REPLICATORS] Failed to load from storage: {}", e);
+            }
+        }
+
+        // Load persisted P2P collection subscriptions (Go's loadAndPublishP2PCollections).
+        {
+            let peerstore = Peerstore::new(store.clone());
+            if let Ok(Some(data)) = peerstore.get_p2p_collections().await {
+                if let Ok(collections) = serde_json::from_slice::<Vec<String>>(&data) {
+                    eprintln!("[LOAD-P2P-SUBS] Restoring {} collection subscriptions", collections.len());
+                    for name in &collections {
+                        if let Ok(Some(col)) = database.get_collection(name) {
+                            let collection_id = col.collection_id().to_string();
+                            let topic = DefraTopic::collection(&collection_id);
+                            if let Err(e) = handle.subscribe(topic).await {
+                                eprintln!("[LOAD-P2P-SUBS] Failed to subscribe collection {}: {}", name, e);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Load persisted P2P document subscriptions (Go's loadAndPublishPeerDocuments).
+        {
+            let peerstore = Peerstore::new(store.clone());
+            if let Ok(Some(data)) = peerstore.get_p2p_documents().await {
+                if let Ok(doc_ids) = serde_json::from_slice::<Vec<String>>(&data) {
+                    eprintln!("[LOAD-P2P-SUBS] Restoring {} document subscriptions", doc_ids.len());
+                    for doc_id in &doc_ids {
+                        let topic = DefraTopic::document(doc_id);
+                        if let Err(e) = handle.subscribe(topic).await {
+                            eprintln!("[LOAD-P2P-SUBS] Failed to subscribe document {}: {}", doc_id, e);
+                        }
+                    }
+                }
+            }
+        }
 
         // Create lensed auto-committing fetcher
         let fetcher = db::LensedAutoCommitFetcher::new(database.clone());
@@ -923,9 +978,26 @@ pub unsafe extern "C" fn p2p_create_replicator(
 
                 // Set the replicator with collection CIDs (not names)
                 p2p.handle
-                    .set_replicator(parsed.peer_id, collection_cids)
+                    .set_replicator(parsed.peer_id, collection_cids.clone())
                     .await
                     .map_err(|e| format!("failed to set replicator: {}", e))?;
+
+                // Persist to Peerstore so the replicator survives node restarts.
+                let info = ReplicatorInfo::new(parsed.peer_id, collection_cids);
+                if let Ok(bytes) = info.to_bytes() {
+                    let peerstore = Peerstore::new(db.store().clone());
+                    match peerstore
+                        .set_replicator(&parsed.peer_id.to_string(), &bytes)
+                        .await
+                    {
+                        Ok(()) => {
+                            eprintln!("[PERSIST-REPLICATOR] Saved replicator peer={} ({} bytes)", parsed.peer_id, bytes.len());
+                        }
+                        Err(e) => {
+                            eprintln!("[PERSIST-REPLICATOR] Failed: {}", e);
+                        }
+                    }
+                }
 
                 // Auto-subscribe to collection topics using schema root CIDs
                 // (Go does this implicitly via SetReplicator → subscribe_collection)
@@ -1414,16 +1486,58 @@ pub unsafe extern "C" fn p2p_delete_replicator(
                 Some(p2p) => p2p,
                 None => return Err("no p2p system configured".to_string()),
             };
+            let db = &state.database;
 
             rt.block_on(async {
                 let peer_id: libp2p::PeerId = peer_str
                     .parse()
                     .map_err(|e| format!("invalid peer ID '{}': {}", peer_str, e))?;
 
-                p2p.handle
-                    .remove_replicator_collections(peer_id, collections)
+                // Get the replicator's collections BEFORE deleting so we can
+                // unsubscribe from orphaned collection topics afterward.
+                let removed_collections = p2p
+                    .handle
+                    .get_replicator(peer_id)
                     .await
-                    .map_err(|e| format!("failed to delete replicator: {}", e))?;
+                    .ok()
+                    .flatten()
+                    .map(|info| info.collections)
+                    .unwrap_or_default();
+
+                // Empty collections = delete entire replicator (Go behavior).
+                // Must use delete_replicator (which calls remove_peer) rather
+                // than remove_replicator_collections (which loops over empty vec).
+                if collections.is_empty() {
+                    p2p.handle
+                        .delete_replicator(peer_id)
+                        .await
+                        .map_err(|e| format!("failed to delete replicator: {}", e))?;
+                } else {
+                    p2p.handle
+                        .remove_replicator_collections(peer_id, collections)
+                        .await
+                        .map_err(|e| format!("failed to delete replicator: {}", e))?;
+                }
+
+                // Remove from Peerstore so deleted replicators don't reload on restart.
+                let peerstore = Peerstore::new(db.store().clone());
+                if let Err(e) = peerstore.delete_replicator(&peer_id.to_string()).await {
+                    tracing::warn!(peer_id = %peer_id, error = %e, "Failed to delete replicator from storage");
+                }
+
+                // Unsubscribe from collection topics that no longer have replicators.
+                // This prevents GossipSub from delivering updates after deletion.
+                let remaining_replicators =
+                    p2p.handle.get_all_replicators().await.unwrap_or_default();
+                for collection_id in &removed_collections {
+                    let still_needed = remaining_replicators
+                        .iter()
+                        .any(|r| r.collections.contains(collection_id));
+                    if !still_needed {
+                        let topic = DefraTopic::collection(collection_id);
+                        let _ = p2p.handle.unsubscribe(topic).await;
+                    }
+                }
 
                 // Signal that the replicator deletion is complete.
                 // The Go test framework waits for this event before proceeding.
@@ -1586,6 +1700,11 @@ pub unsafe extern "C" fn p2p_create_collections(
                     }
                     p2p.add_collection(name);
                 }
+
+                // Persist collection subscriptions so they survive restarts.
+                let all_cols = p2p.get_collections();
+                persist_p2p_collections(db, &all_cols).await;
+
                 Ok(())
             })
         })
@@ -1760,6 +1879,7 @@ pub unsafe extern "C" fn p2p_create_documents(
                 Some(p2p) => p2p,
                 None => return Err("no p2p system configured".to_string()),
             };
+            let db = &state.database;
 
             rt.block_on(async {
                 // Validate all document IDs have valid format (atomic: all or nothing)
@@ -1778,6 +1898,11 @@ pub unsafe extern "C" fn p2p_create_documents(
                     }
                     p2p.add_document(doc_id);
                 }
+
+                // Persist document subscriptions so they survive restarts.
+                let all_docs = p2p.get_documents();
+                persist_p2p_documents(db, &all_docs).await;
+
                 Ok(())
             })
         })
@@ -2750,4 +2875,34 @@ async fn sync_lens(
         transform_cid
     );
     Ok(())
+}
+
+/// Persist the current P2P collection subscription list to the Peerstore.
+async fn persist_p2p_collections(db: &crate::state::FfiDatabase, collections: &[String]) {
+    let data = match serde_json::to_vec(collections) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("[PERSIST-P2P] Failed to serialize collections: {}", e);
+            return;
+        }
+    };
+    let peerstore = Peerstore::new(db.store().clone());
+    if let Err(e) = peerstore.set_p2p_collections(&data).await {
+        eprintln!("[PERSIST-P2P] Failed to persist collections: {}", e);
+    }
+}
+
+/// Persist the current P2P document subscription list to the Peerstore.
+async fn persist_p2p_documents(db: &crate::state::FfiDatabase, documents: &[String]) {
+    let data = match serde_json::to_vec(documents) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("[PERSIST-P2P] Failed to serialize documents: {}", e);
+            return;
+        }
+    };
+    let peerstore = Peerstore::new(db.store().clone());
+    if let Err(e) = peerstore.set_p2p_documents(&data).await {
+        eprintln!("[PERSIST-P2P] Failed to persist documents: {}", e);
+    }
 }

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -670,18 +670,28 @@ pub extern "C" fn p2p_active_peers(node_ptr: usize) -> FfiResult {
             };
 
             rt.block_on(async {
+                let local_pid = p2p
+                    .handle
+                    .local_peer_id()
+                    .await
+                    .map(|p| p.to_string())
+                    .unwrap_or_else(|_| "unknown".to_string());
                 // Get connected peers from the host first (authoritative list).
                 let connected = p2p
                     .handle
                     .connected_peers()
                     .await
                     .map_err(|e| format!("failed to get connected peers: {}", e))?;
+                eprintln!(
+                    "[FFI-ACTIVE-PEERS] node={} node_ptr={} connected={}",
+                    &local_pid[local_pid.len().saturating_sub(8)..],
+                    node_ptr,
+                    connected.len()
+                );
 
-                // Wait for identify protocol to resolve addresses for all connected
-                // peers. Incoming connections initially have no address in peer_addrs
-                // (we skip storing the ephemeral send_back_addr). The identify protocol
-                // updates peer_addrs with the correct listen address, typically within
-                // a few milliseconds on localhost.
+                // Wait for all connected peers to have resolved addresses.
+                // With TCP port reuse + biased select, addresses are typically
+                // available immediately, but we retry for robustness.
                 let mut host_addrs = Vec::new();
                 let mut covered: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
@@ -720,6 +730,16 @@ pub extern "C" fn p2p_active_peers(node_ptr: usize) -> FfiResult {
                             all_addrs.push(ffi_addr.to_string());
                         }
                     }
+                }
+
+                eprintln!(
+                    "[FFI-ACTIVE-PEERS] connected={} host_addrs={} all_addrs={}",
+                    connected.len(),
+                    covered.len(),
+                    all_addrs.len()
+                );
+                for a in &all_addrs {
+                    eprintln!("[FFI-ACTIVE-PEERS]   addr={}", a);
                 }
 
                 serde_json::to_string(&all_addrs)

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -1958,6 +1958,8 @@ pub unsafe extern "C" fn p2p_sync_documents(
             };
             let db = &state.database;
 
+            let event_bus = &state.event_bus;
+
             rt.block_on(async {
                 // Verify the collection exists
                 let _collection = db
@@ -1993,30 +1995,72 @@ pub unsafe extern "C" fn p2p_sync_documents(
                     return Err(format!("failed to sign DocSync request: {}", e));
                 }
 
-                // Send DocSync request to each connected peer
-                // The response handling happens asynchronously via the coordinator:
-                // 1. Request is sent via two-stream protocol
-                // 2. Peer responds with DocSyncReply containing head CIDs
-                // 3. Coordinator receives DocSyncReply and initiates Bitswap fetch
-                // 4. Blocks are stored and merged via the replication loop
+                // Subscribe to merge_complete events BEFORE sending requests
+                // so we don't miss events that arrive quickly
+                let mut sub = event_bus.subscribe(&[events::EventName::MergeComplete]);
+
+                // Send DocSync request to each connected peer synchronously
                 for peer_id in &connected_peers {
                     eprintln!("[DOCSYNC] Sending DocSync request to peer={}", peer_id);
-                    let request_clone = request.clone();
-                    let handle = p2p.handle.clone();
-                    let peer_id = *peer_id;
-
-                    tokio::spawn(async move {
-                        eprintln!("[DOCSYNC] Spawned task sending to peer={}", peer_id);
-                        match handle.send_doc_sync_request(peer_id, request_clone).await {
-                            Ok(()) => {
-                                eprintln!("[DOCSYNC] Sent DocSync request to peer={}", peer_id)
-                            }
-                            Err(e) => eprintln!(
-                                "[DOCSYNC] Failed to send DocSync request to peer={}: {}",
-                                peer_id, e
-                            ),
+                    match p2p
+                        .handle
+                        .send_doc_sync_request(*peer_id, request.clone())
+                        .await
+                    {
+                        Ok(()) => {
+                            eprintln!("[DOCSYNC] Sent DocSync request to peer={}", peer_id)
                         }
-                    });
+                        Err(e) => eprintln!(
+                            "[DOCSYNC] Failed to send DocSync request to peer={}: {}",
+                            peer_id, e
+                        ),
+                    }
+                }
+
+                // Wait for all documents to be merged
+                let timeout = std::time::Duration::from_secs(30);
+                let start = std::time::Instant::now();
+                let mut remaining_docs: std::collections::HashSet<String> =
+                    doc_ids.iter().cloned().collect();
+
+                eprintln!(
+                    "[DOCSYNC] Waiting for {} documents to be merged",
+                    remaining_docs.len()
+                );
+
+                while !remaining_docs.is_empty() && start.elapsed() < timeout {
+                    match tokio::time::timeout(std::time::Duration::from_millis(100), sub.recv())
+                        .await
+                    {
+                        Ok(Some(msg)) => {
+                            if let Some(data) = msg.as_merge_complete() {
+                                if remaining_docs.remove(&data.doc_id) {
+                                    eprintln!(
+                                        "[DOCSYNC] Doc merged: doc_id={} remaining={}",
+                                        data.doc_id,
+                                        remaining_docs.len()
+                                    );
+                                }
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(_) => {}
+                    }
+                }
+
+                event_bus.unsubscribe(sub.id());
+
+                if remaining_docs.is_empty() {
+                    eprintln!(
+                        "[DOCSYNC] All {} documents synced successfully",
+                        doc_ids.len()
+                    );
+                } else {
+                    eprintln!(
+                        "[DOCSYNC] Timeout waiting for {} documents: {:?}",
+                        remaining_docs.len(),
+                        remaining_docs
+                    );
                 }
 
                 Ok(())
@@ -2393,20 +2437,23 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
                         }
                     };
 
-                    // Fetch all linked field blocks
-                    for link_cid in &linked_cids {
+                    // Fetch all linked blocks recursively.
+                    // For patched versions, heads point to previous version CIDs which
+                    // themselves have linked field blocks that also need fetching.
+                    let mut fetch_queue: std::collections::VecDeque<cid::Cid> = linked_cids.into_iter().collect();
+                    let mut fetched: std::collections::HashSet<String> = std::collections::HashSet::new();
+                    fetched.insert(version_cid.to_string());
+
+                    while let Some(link_cid) = fetch_queue.pop_front() {
+                        if fetched.contains(&link_cid.to_string()) {
+                            continue;
+                        }
+                        fetched.insert(link_cid.to_string());
+
                         // Check if we already have this block
-                        match p2p.blockstore.get(link_cid).await {
-                            Ok(Some(_)) => {
-                                eprintln!(
-                                    "[FFI-COLLECTION-VERSION] Link {} already present",
-                                    link_cid
-                                );
-                                continue;
-                            }
-                            Ok(None) => {
-                                // Need to fetch
-                            }
+                        let already_present = match p2p.blockstore.get(&link_cid).await {
+                            Ok(Some(_)) => true,
+                            Ok(None) => false,
                             Err(e) => {
                                 eprintln!(
                                     "[FFI-COLLECTION-VERSION] Error checking link {}: {}",
@@ -2414,58 +2461,79 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
                                 );
                                 continue;
                             }
-                        }
+                        };
 
-                        eprintln!(
-                            "[FFI-COLLECTION-VERSION] Fetching linked block {}",
-                            link_cid
-                        );
-
-                        // Start Bitswap sync for linked block
-                        if let Err(e) = p2p.handle
-                            .bitswap_sync(*link_cid, connected_peers.clone(), vec![*link_cid])
-                            .await
-                        {
+                        if !already_present {
                             eprintln!(
-                                "[FFI-COLLECTION-VERSION] Bitswap sync failed for link {}: {}",
-                                link_cid, e
+                                "[FFI-COLLECTION-VERSION] Fetching linked block {}",
+                                link_cid
                             );
-                            continue;
-                        }
 
-                        // Wait for linked block
-                        let link_timeout = std::time::Duration::from_secs(10);
-                        let link_start = std::time::Instant::now();
-                        let mut link_found = false;
+                            if let Err(e) = p2p.handle
+                                .bitswap_sync(link_cid, connected_peers.clone(), vec![link_cid])
+                                .await
+                            {
+                                eprintln!(
+                                    "[FFI-COLLECTION-VERSION] Bitswap sync failed for link {}: {}",
+                                    link_cid, e
+                                );
+                                continue;
+                            }
 
-                        while link_start.elapsed() < link_timeout {
-                            match p2p.blockstore.get(link_cid).await {
-                                Ok(Some(_)) => {
-                                    link_found = true;
-                                    eprintln!(
-                                        "[FFI-COLLECTION-VERSION] Linked block {} fetched",
-                                        link_cid
-                                    );
-                                    break;
+                            let link_timeout = std::time::Duration::from_secs(10);
+                            let link_start = std::time::Instant::now();
+                            let mut link_found = false;
+
+                            while link_start.elapsed() < link_timeout {
+                                match p2p.blockstore.get(&link_cid).await {
+                                    Ok(Some(_)) => {
+                                        link_found = true;
+                                        break;
+                                    }
+                                    Ok(None) => {
+                                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                                    }
+                                    Err(e) => {
+                                        eprintln!(
+                                            "[FFI-COLLECTION-VERSION] Error waiting for link {}: {}",
+                                            link_cid, e
+                                        );
+                                        break;
+                                    }
                                 }
-                                Ok(None) => {
-                                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                                }
-                                Err(e) => {
-                                    eprintln!(
-                                        "[FFI-COLLECTION-VERSION] Error waiting for link {}: {}",
-                                        link_cid, e
-                                    );
-                                    break;
-                                }
+                            }
+
+                            if !link_found {
+                                eprintln!(
+                                    "[FFI-COLLECTION-VERSION] Timeout waiting for linked block {}",
+                                    link_cid
+                                );
+                                continue;
                             }
                         }
 
-                        if !link_found {
-                            eprintln!(
-                                "[FFI-COLLECTION-VERSION] Timeout waiting for linked block {}",
-                                link_cid
-                            );
+                        eprintln!(
+                            "[FFI-COLLECTION-VERSION] Linked block {} available",
+                            link_cid
+                        );
+
+                        // If this linked block is a CollectionDefinition (previous version),
+                        // also fetch its linked blocks (field definitions)
+                        if let Ok(Some(link_data)) = p2p.blockstore.get(&link_cid).await {
+                            if let Ok(link_block) = Block::from_dag_cbor(&link_data) {
+                                if matches!(&link_block.delta, defra_core::block::CrdtDelta::CollectionDefinition(_)) {
+                                    let sub_links = link_block.all_links();
+                                    eprintln!(
+                                        "[FFI-COLLECTION-VERSION] Previous version {} has {} sub-links",
+                                        link_cid, sub_links.len()
+                                    );
+                                    for sub_cid in sub_links {
+                                        if !fetched.contains(&sub_cid.to_string()) {
+                                            fetch_queue.push_back(sub_cid);
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
 

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -442,7 +442,14 @@ pub unsafe extern "C" fn new_node_with_p2p(
                         break;
                     }
                     ReplicationResult::Failed { cid, error } => {
+                        eprintln!("[REPL-LOOP] FAILED cid={} error={}", cid, error);
                         tracing::error!(cid = %cid, error = %error, "Block merge failed");
+                    }
+                    ReplicationResult::Skipped { cid, reason } => {
+                        eprintln!("[REPL-LOOP] SKIPPED cid={} reason={}", cid, reason);
+                    }
+                    ReplicationResult::BitswapFetchStarted { root_cid, .. } => {
+                        eprintln!("[REPL-LOOP] BITSWAP_FETCH root={}", root_cid);
                     }
                     _ => {}
                 }
@@ -1987,81 +1994,92 @@ pub unsafe extern "C" fn p2p_sync_documents(
                     connected_peers.len()
                 );
 
-                // Create DocSync request
-                let mut request = p2p::message::DocSyncRequest::new(doc_ids.clone());
-
-                // Sign the request
-                if let Err(e) = p2p::signing::sign_message(p2p.handle.keypair(), &mut request) {
-                    return Err(format!("failed to sign DocSync request: {}", e));
-                }
-
                 // Subscribe to merge_complete events BEFORE sending requests
                 // so we don't miss events that arrive quickly
                 let mut sub = event_bus.subscribe(&[events::EventName::MergeComplete]);
 
-                // Send DocSync request to each connected peer synchronously
-                for peer_id in &connected_peers {
-                    eprintln!("[DOCSYNC] Sending DocSync request to peer={}", peer_id);
-                    match p2p
-                        .handle
-                        .send_doc_sync_request(*peer_id, request.clone())
-                        .await
-                    {
-                        Ok(()) => {
-                            eprintln!("[DOCSYNC] Sent DocSync request to peer={}", peer_id)
-                        }
-                        Err(e) => eprintln!(
-                            "[DOCSYNC] Failed to send DocSync request to peer={}: {}",
-                            peer_id, e
-                        ),
-                    }
-                }
-
-                // Wait for all documents to be merged
-                let timeout = std::time::Duration::from_secs(30);
+                let total_expected = connected_peers.len() * doc_ids.len();
+                let mut total_received = 0;
+                let overall_timeout = std::time::Duration::from_secs(30);
+                let idle_timeout = std::time::Duration::from_secs(3);
                 let start = std::time::Instant::now();
-                let mut remaining_docs: std::collections::HashSet<String> =
-                    doc_ids.iter().cloned().collect();
+                let doc_set: std::collections::HashSet<String> = doc_ids.iter().cloned().collect();
 
-                eprintln!(
-                    "[DOCSYNC] Waiting for {} documents to be merged",
-                    remaining_docs.len()
-                );
+                // Retry DocSync up to 3 times to handle "connection is closed" errors
+                // where a peer fails to send the response back.
+                for attempt in 0..3 {
+                    if total_received >= total_expected || start.elapsed() >= overall_timeout {
+                        break;
+                    }
 
-                while !remaining_docs.is_empty() && start.elapsed() < timeout {
-                    match tokio::time::timeout(std::time::Duration::from_millis(100), sub.recv())
+                    // Create a fresh request per attempt (unique message_id)
+                    let mut request = p2p::message::DocSyncRequest::new(doc_ids.clone());
+                    if let Err(e) = p2p::signing::sign_message(p2p.handle.keypair(), &mut request) {
+                        return Err(format!("failed to sign DocSync request: {}", e));
+                    }
+
+                    eprintln!(
+                        "[DOCSYNC] Attempt {} - sending to {} peers, have {}/{} merges",
+                        attempt + 1,
+                        connected_peers.len(),
+                        total_received,
+                        total_expected
+                    );
+
+                    for peer_id in &connected_peers {
+                        eprintln!("[DOCSYNC] Sending DocSync request to peer={}", peer_id);
+                        match p2p
+                            .handle
+                            .send_doc_sync_request(*peer_id, request.clone())
+                            .await
+                        {
+                            Ok(()) => {
+                                eprintln!("[DOCSYNC] Sent DocSync request to peer={}", peer_id)
+                            }
+                            Err(e) => eprintln!(
+                                "[DOCSYNC] Failed to send DocSync request to peer={}: {}",
+                                peer_id, e
+                            ),
+                        }
+                    }
+
+                    // Wait for merges with idle timeout
+                    let mut last_merge = std::time::Instant::now();
+                    while total_received < total_expected && start.elapsed() < overall_timeout {
+                        if total_received >= doc_ids.len() && last_merge.elapsed() > idle_timeout {
+                            break;
+                        }
+
+                        match tokio::time::timeout(
+                            std::time::Duration::from_millis(100),
+                            sub.recv(),
+                        )
                         .await
-                    {
-                        Ok(Some(msg)) => {
-                            if let Some(data) = msg.as_merge_complete() {
-                                if remaining_docs.remove(&data.doc_id) {
-                                    eprintln!(
-                                        "[DOCSYNC] Doc merged: doc_id={} remaining={}",
-                                        data.doc_id,
-                                        remaining_docs.len()
-                                    );
+                        {
+                            Ok(Some(msg)) => {
+                                if let Some(data) = msg.as_merge_complete() {
+                                    if doc_set.contains(&data.doc_id) {
+                                        total_received += 1;
+                                        last_merge = std::time::Instant::now();
+                                        eprintln!(
+                                            "[DOCSYNC] Doc merged: doc_id={} ({}/{})",
+                                            data.doc_id, total_received, total_expected
+                                        );
+                                    }
                                 }
                             }
+                            Ok(None) => break,
+                            Err(_) => {}
                         }
-                        Ok(None) => break,
-                        Err(_) => {}
                     }
                 }
 
                 event_bus.unsubscribe(sub.id());
 
-                if remaining_docs.is_empty() {
-                    eprintln!(
-                        "[DOCSYNC] All {} documents synced successfully",
-                        doc_ids.len()
-                    );
-                } else {
-                    eprintln!(
-                        "[DOCSYNC] Timeout waiting for {} documents: {:?}",
-                        remaining_docs.len(),
-                        remaining_docs
-                    );
-                }
+                eprintln!(
+                    "[DOCSYNC] Done: {}/{} merges received",
+                    total_received, total_expected
+                );
 
                 Ok(())
             })
@@ -2566,7 +2584,7 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
                         version_id_str
                     );
 
-                    // After merge, check if this is a view with a lens transform to sync
+                    // After merge, check if this is a view with a lens transform to sync.
                     if let Ok(block) = Block::from_dag_cbor(&block_data) {
                         if let defra_core::CrdtDelta::CollectionDefinition(ref payload) = block.delta {
                             if let Some(ref transform_cid) = payload.query_transform {
@@ -2657,6 +2675,7 @@ async fn sync_lens(
 
     for module_cid in &config_block.modules {
         // 2. Fetch ModuleBlock
+        eprintln!("[FFI-LENS-SYNC] Fetching module block cid={}", module_cid);
         let module_data =
             fetch_lens_block(*module_cid, &p2p.blockstore, &p2p.handle, connected_peers).await?;
         let module_block: LensModuleBlock = serde_ipld_dagcbor::from_slice(&module_data)
@@ -2676,12 +2695,16 @@ async fn sync_lens(
         let wasm_bytes = match &wasm_block {
             LensWasmBlock::Direct { wasm_bytes } => wasm_bytes.clone(),
             LensWasmBlock::Chunked { chunks } => {
+                eprintln!("[FFI-LENS-SYNC] Fetching {} WASM chunks", chunks.len());
                 let mut all_bytes = Vec::new();
                 for chunk_cid in chunks {
                     let chunk_data =
                         fetch_lens_block(*chunk_cid, &p2p.blockstore, &p2p.handle, connected_peers)
                             .await?;
-                    all_bytes.extend_from_slice(&chunk_data);
+                    // Chunks are CBOR-encoded byte strings, decode to get raw bytes
+                    let decoded: serde_bytes::ByteBuf = serde_ipld_dagcbor::from_slice(&chunk_data)
+                        .map_err(|e| format!("decode WASM chunk {}: {}", chunk_cid, e))?;
+                    all_bytes.extend_from_slice(&decoded);
                 }
                 all_bytes
             }

--- a/crates/ffi/src/p2p.rs
+++ b/crates/ffi/src/p2p.rs
@@ -2565,6 +2565,24 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
                         "[FFI-COLLECTION-VERSION] Successfully synced version {}",
                         version_id_str
                     );
+
+                    // After merge, check if this is a view with a lens transform to sync
+                    if let Ok(block) = Block::from_dag_cbor(&block_data) {
+                        if let defra_core::CrdtDelta::CollectionDefinition(ref payload) = block.delta {
+                            if let Some(ref transform_cid) = payload.query_transform {
+                                eprintln!(
+                                    "[FFI-COLLECTION-VERSION] View has transform CID={}, syncing lens...",
+                                    transform_cid
+                                );
+                                if let Err(e) = sync_lens(transform_cid, p2p, db, &connected_peers).await {
+                                    eprintln!(
+                                        "[FFI-COLLECTION-VERSION] Lens sync failed: {}",
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                    }
                 }
 
                 Ok(())
@@ -2577,4 +2595,136 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
         Ok(()) => FfiResult::ok(),
         Err(e) => FfiResult::error(e),
     }
+}
+
+/// Fetch a single block via Bitswap, polling until available.
+async fn fetch_lens_block(
+    target_cid: cid::Cid,
+    blockstore: &Arc<DefraBlockstore<crate::state::FfiStore>>,
+    handle: &p2p::P2PHostHandle,
+    peers: &[libp2p::PeerId],
+) -> Result<Vec<u8>, String> {
+    // Check local blockstore first
+    if let Ok(Some(data)) = blockstore.get(&target_cid).await {
+        return Ok(data);
+    }
+    // Fetch via Bitswap
+    handle
+        .bitswap_sync(target_cid, peers.to_vec(), vec![target_cid])
+        .await
+        .map_err(|e| format!("bitswap sync for {}: {}", target_cid, e))?;
+
+    // Poll until available
+    let timeout = std::time::Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(Some(data)) = blockstore.get(&target_cid).await {
+            return Ok(data);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    Err(format!("timeout fetching block {}", target_cid))
+}
+
+/// Fetch lens IPLD blocks via Bitswap and register the WASM module.
+///
+/// Follows Go's 3-level block hierarchy: ConfigBlock -> ModuleBlock -> LensBlock.
+async fn sync_lens(
+    transform_cid: &cid::Cid,
+    p2p: &P2PState,
+    db: &Arc<crate::state::FfiDatabase>,
+    connected_peers: &[libp2p::PeerId],
+) -> Result<(), String> {
+    use defra_core::{LensConfigBlock, LensModuleBlock, LensWasmBlock};
+
+    // 1. Fetch ConfigBlock
+    let config_data = fetch_lens_block(
+        *transform_cid,
+        &p2p.blockstore,
+        &p2p.handle,
+        connected_peers,
+    )
+    .await?;
+    let config_block: LensConfigBlock = serde_ipld_dagcbor::from_slice(&config_data)
+        .map_err(|e| format!("decode config block: {}", e))?;
+
+    eprintln!(
+        "[FFI-LENS-SYNC] Config block has {} module(s)",
+        config_block.modules.len()
+    );
+
+    let mut lens_modules = Vec::new();
+
+    for module_cid in &config_block.modules {
+        // 2. Fetch ModuleBlock
+        let module_data =
+            fetch_lens_block(*module_cid, &p2p.blockstore, &p2p.handle, connected_peers).await?;
+        let module_block: LensModuleBlock = serde_ipld_dagcbor::from_slice(&module_data)
+            .map_err(|e| format!("decode module block {}: {}", module_cid, e))?;
+
+        // 3. Fetch LensBlock (WASM bytes)
+        let lens_data = fetch_lens_block(
+            module_block.lens,
+            &p2p.blockstore,
+            &p2p.handle,
+            connected_peers,
+        )
+        .await?;
+        let wasm_block: LensWasmBlock = serde_ipld_dagcbor::from_slice(&lens_data)
+            .map_err(|e| format!("decode lens block {}: {}", module_block.lens, e))?;
+
+        let wasm_bytes = match &wasm_block {
+            LensWasmBlock::Direct { wasm_bytes } => wasm_bytes.clone(),
+            LensWasmBlock::Chunked { chunks } => {
+                let mut all_bytes = Vec::new();
+                for chunk_cid in chunks {
+                    let chunk_data =
+                        fetch_lens_block(*chunk_cid, &p2p.blockstore, &p2p.handle, connected_peers)
+                            .await?;
+                    all_bytes.extend_from_slice(&chunk_data);
+                }
+                all_bytes
+            }
+        };
+
+        eprintln!(
+            "[FFI-LENS-SYNC] Got WASM module ({} bytes), inverse={}",
+            wasm_bytes.len(),
+            module_block.inverse
+        );
+
+        let mut lens_mod = lens::LensModule::from_bytes(wasm_bytes);
+        lens_mod.inverse = module_block.inverse;
+
+        // Convert arguments from key-value pairs to JSON object
+        if !module_block.arguments.is_empty() {
+            let args_map: serde_json::Map<String, serde_json::Value> = module_block
+                .arguments
+                .iter()
+                .map(|kv| (kv.key.clone(), serde_json::Value::String(kv.value.clone())))
+                .collect();
+            lens_mod.arguments = Some(serde_json::Value::Object(args_map));
+        }
+
+        lens_modules.push(lens_mod);
+    }
+
+    // Build LensConfig and register under the Go CID
+    let config = lens::LensConfig {
+        source_schema_version_id: String::new(),
+        destination_schema_version_id: String::new(),
+        lenses: lens_modules,
+    };
+
+    let transform_id = lens::TransformId::new(transform_cid.to_string());
+    db.lens_store()
+        .add_with_id(transform_id, config)
+        .await
+        .map_err(|e| format!("register lens: {}", e))?;
+
+    eprintln!(
+        "[FFI-LENS-SYNC] Lens registered under CID {}",
+        transform_cid
+    );
+    Ok(())
 }

--- a/crates/ffi/src/state.rs
+++ b/crates/ffi/src/state.rs
@@ -151,6 +151,10 @@ pub struct P2PState {
     pub host_event_handle: Option<tokio::task::AbortHandle>,
     /// Abort handle for the replication loop task.
     pub replication_handle: Option<tokio::task::AbortHandle>,
+    /// Abort handle for the failure recorder task.
+    pub failure_recorder_handle: Option<tokio::task::AbortHandle>,
+    /// Abort handle for the retry loop task.
+    pub retry_loop_handle: Option<tokio::task::AbortHandle>,
 }
 
 impl P2PState {
@@ -171,6 +175,8 @@ impl P2PState {
             peer_addresses: RwLock::new(HashMap::new()),
             host_event_handle: Some(host_event_handle),
             replication_handle: Some(replication_handle),
+            failure_recorder_handle: None,
+            retry_loop_handle: None,
         }
     }
 
@@ -180,6 +186,12 @@ impl P2PState {
             h.abort();
         }
         if let Some(ref h) = self.replication_handle {
+            h.abort();
+        }
+        if let Some(ref h) = self.failure_recorder_handle {
+            h.abort();
+        }
+        if let Some(ref h) = self.retry_loop_handle {
             h.abort();
         }
     }

--- a/crates/lens/src/store.rs
+++ b/crates/lens/src/store.rs
@@ -54,6 +54,11 @@ pub trait TransformStore: Send + Sync {
     /// Returns the unique ID for the registered transform.
     async fn add(&self, config: LensConfig) -> Result<TransformId>;
 
+    /// Register a lens transform under a specific ID.
+    ///
+    /// Used for P2P sync where the transform ID is the Go-generated IPLD CID.
+    async fn add_with_id(&self, id: TransformId, config: LensConfig) -> Result<()>;
+
     /// List all registered transforms.
     ///
     /// Returns a map of transform IDs to their lens modules.
@@ -118,6 +123,15 @@ impl TransformStore for MemoryTransformStore {
         transforms.insert(id.clone(), config);
 
         Ok(id)
+    }
+
+    async fn add_with_id(&self, id: TransformId, config: LensConfig) -> Result<()> {
+        let mut transforms = self
+            .transforms
+            .write()
+            .map_err(|e| Error::Pipeline(format!("failed to acquire write lock: {}", e)))?;
+        transforms.insert(id, config);
+        Ok(())
     }
 
     async fn list(&self) -> Result<std::collections::HashMap<String, crate::LensModule>> {

--- a/crates/lens/src/wasm.rs
+++ b/crates/lens/src/wasm.rs
@@ -166,6 +166,36 @@ impl TransformStore for WasmTransformStore {
         Ok(id)
     }
 
+    async fn add_with_id(&self, id: TransformId, config: LensConfig) -> Result<()> {
+        info!(
+            transform_id = %id,
+            "Adding transform to WASM store with explicit ID"
+        );
+
+        // Check if this transform already exists
+        {
+            let modules = self.modules.read();
+            if modules.contains_key(&id) {
+                info!(transform_id = %id, "Transform already exists");
+                return Ok(());
+            }
+        }
+
+        let first_lens = config.lens().cloned().unwrap_or_default();
+        let module = self.load_module(&first_lens)?;
+
+        let compiled = CompiledModule {
+            module,
+            arguments: first_lens.arguments.clone(),
+        };
+
+        self.modules.write().insert(id.clone(), compiled);
+        self.configs.write().insert(id.clone(), config);
+
+        info!(transform_id = %id, "Transform added with explicit ID");
+        Ok(())
+    }
+
     async fn list(&self) -> Result<std::collections::HashMap<String, crate::LensModule>> {
         let configs = self.configs.read();
         let result = configs

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -177,6 +177,11 @@ impl<S: Store> DefraBehaviour<S> {
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(1))
                 .validation_mode(ValidationMode::Strict)
+                // Enable peer exchange (PX) in PRUNE messages — matches Go's
+                // pubsub.WithPeerExchange(true). Allows peers sharing a topic
+                // to discover each other through mesh management.
+                .do_px()
+                .flood_publish(true)
                 .message_id_fn(|message: &gossipsub::Message| {
                     let hash = crypto::sha256(&message.data);
                     MessageId::from(hash.to_vec())

--- a/crates/p2p/src/bitswap/store.rs
+++ b/crates/p2p/src/bitswap/store.rs
@@ -73,7 +73,6 @@ impl<B: Blockstore + Debug + 'static> Store for BitswapStoreAdapter<B> {
             .await
             .map_err(|e| anyhow!("blockstore error: {}", e))?
             .ok_or_else(|| anyhow!("block not found: {}", cid))?;
-
         Ok(Block::new(Bytes::from(data), *cid))
     }
 

--- a/crates/p2p/src/host/command_handler.rs
+++ b/crates/p2p/src/host/command_handler.rs
@@ -421,6 +421,15 @@ impl<S: Store> P2PHost<S> {
             HostCommand::PeerAddresses { response } => {
                 // Build full multiaddrs for connected peers (matches Go's ActivePeers).
                 let connected: HashSet<PeerId> = self.swarm.connected_peers().cloned().collect();
+                eprintln!(
+                    "[PEER-ADDRS] connected_peers={} peer_addrs={}",
+                    connected.len(),
+                    self.peer_addrs.len()
+                );
+                for pid in &connected {
+                    let has_addr = self.peer_addrs.contains_key(pid);
+                    eprintln!("[PEER-ADDRS]   peer={} has_addr={}", pid, has_addr);
+                }
                 let addrs: Vec<String> = connected
                     .iter()
                     .filter_map(|pid| {

--- a/crates/p2p/src/host/command_handler.rs
+++ b/crates/p2p/src/host/command_handler.rs
@@ -456,6 +456,12 @@ impl<S: Store> P2PHost<S> {
             query_id = query_id.0,
             "Starting Bitswap block fetch via Client API"
         );
+        eprintln!(
+            "[BITSWAP-SYNC] Starting fetch cid={} providers={:?} missing={}",
+            cid,
+            providers,
+            missing.len()
+        );
 
         // Clone the client for use in the spawned task
         let client = self.swarm.behaviour().bitswap.client().clone();
@@ -475,8 +481,13 @@ impl<S: Store> P2PHost<S> {
                 }
             }
 
+            eprintln!(
+                "[BITSWAP-SYNC] Session created, providers added, calling get_blocks for {} CIDs",
+                missing_cids.len()
+            );
             match session.get_blocks(&missing_cids).await {
                 Ok(receiver) => {
+                    eprintln!("[BITSWAP-SYNC] get_blocks returned receiver, waiting for blocks...");
                     // Use into_parts() to get the underlying channel
                     // BlockReceiver only implements Deref (not DerefMut), so we can't call recv() through it
                     let (chan, _guard) = receiver.into_parts();
@@ -516,10 +527,16 @@ impl<S: Store> P2PHost<S> {
                             }
                             Ok(Err(_)) => {
                                 // Channel closed — no more blocks coming
+                                eprintln!("[BITSWAP-SYNC] Channel closed, no more blocks");
                                 break;
                             }
                             Err(_) => {
                                 // Timeout — no block arrived within the window
+                                eprintln!(
+                                    "[BITSWAP-SYNC] TIMEOUT waiting for block ({} fetched of {})",
+                                    fetched,
+                                    missing_cids.len()
+                                );
                                 break;
                             }
                         }

--- a/crates/p2p/src/host/command_handler.rs
+++ b/crates/p2p/src/host/command_handler.rs
@@ -421,15 +421,6 @@ impl<S: Store> P2PHost<S> {
             HostCommand::PeerAddresses { response } => {
                 // Build full multiaddrs for connected peers (matches Go's ActivePeers).
                 let connected: HashSet<PeerId> = self.swarm.connected_peers().cloned().collect();
-                eprintln!(
-                    "[PEER-ADDRS] connected_peers={} peer_addrs={}",
-                    connected.len(),
-                    self.peer_addrs.len()
-                );
-                for pid in &connected {
-                    let has_addr = self.peer_addrs.contains_key(pid);
-                    eprintln!("[PEER-ADDRS]   peer={} has_addr={}", pid, has_addr);
-                }
                 let addrs: Vec<String> = connected
                     .iter()
                     .filter_map(|pid| {
@@ -474,25 +465,12 @@ impl<S: Store> P2PHost<S> {
 
         // Spawn async task to fetch blocks (with cancellation support)
         let task_handle = tokio::spawn(async move {
-            info!(
-                query_id = query_id.0,
-                missing_count = missing_cids.len(),
-                providers = ?providers_list,
-                "Bitswap fetch task started"
-            );
-
             // Create a session and add providers for each CID
             let session = client.new_session().await;
 
             // Add each provider for each missing CID
             for cid in &missing_cids {
                 for provider in &providers_list {
-                    info!(
-                        query_id = query_id.0,
-                        cid = %cid,
-                        provider = %provider,
-                        "Adding Bitswap provider for CID"
-                    );
                     session.add_provider(cid, *provider).await;
                 }
             }
@@ -504,35 +482,46 @@ impl<S: Store> P2PHost<S> {
                     let (chan, _guard) = receiver.into_parts();
                     let mut fetched = 0;
 
-                    while let Ok(block) = chan.recv().await {
-                        fetched += 1;
-                        let block_cid = *block.cid();
-                        let block_data = block.data().to_vec();
+                    // Timeout per block: 10 seconds. If no block arrives within this
+                    // window, we give up and report partial success so the retry
+                    // mechanism can try again with fresh provider info.
+                    let per_block_timeout = std::time::Duration::from_secs(10);
 
-                        info!(
-                            query_id = query_id.0,
-                            cid = %block_cid,
-                            fetched = fetched,
-                            total = missing_cids.len(),
-                            data_len = block_data.len(),
-                            "Bitswap fetched block"
-                        );
+                    loop {
+                        match tokio::time::timeout(per_block_timeout, chan.recv()).await {
+                            Ok(Ok(block)) => {
+                                fetched += 1;
+                                let block_cid = *block.cid();
+                                let block_data = block.data().to_vec();
 
-                        // Send block to coordinator for storage
-                        if let Err(e) = event_tx
-                            .send(HostEvent::BitswapBlockReceived {
-                                query_id,
-                                cid: block_cid,
-                                data: block_data,
-                            })
-                            .await
-                        {
-                            warn!(
-                                query_id = query_id.0,
-                                cid = %block_cid,
-                                error = %e,
-                                "Failed to send BitswapBlockReceived event"
-                            );
+                                // Send block to coordinator for storage
+                                if let Err(e) = event_tx
+                                    .send(HostEvent::BitswapBlockReceived {
+                                        query_id,
+                                        cid: block_cid,
+                                        data: block_data,
+                                    })
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        query_id = query_id.0,
+                                        error = %e,
+                                        "Failed to send BitswapBlockReceived event"
+                                    );
+                                }
+
+                                if fetched == missing_cids.len() {
+                                    break;
+                                }
+                            }
+                            Ok(Err(_)) => {
+                                // Channel closed — no more blocks coming
+                                break;
+                            }
+                            Err(_) => {
+                                // Timeout — no block arrived within the window
+                                break;
+                            }
                         }
                     }
 
@@ -563,7 +552,11 @@ impl<S: Store> P2PHost<S> {
                         .await;
                 }
                 Err(e) => {
-                    warn!(query_id = query_id.0, error = %e, "Bitswap fetch failed");
+                    tracing::error!(
+                        query_id = query_id.0,
+                        error = %e,
+                        "Bitswap get_blocks failed"
+                    );
                     let _ = event_tx
                         .send(HostEvent::BitswapComplete {
                             query_id,

--- a/crates/p2p/src/host/p2p_host.rs
+++ b/crates/p2p/src/host/p2p_host.rs
@@ -193,12 +193,14 @@ impl<S: Store> P2PHost<S> {
             .accept(TwoStreamHandler::se_response_protocol())
             .map_err(|_| Error::Behaviour("Failed to register SE response protocol".into()))?;
 
-        let two_stream_handler = Arc::new(tokio::sync::Mutex::new(TwoStreamHandler::new(control)));
+        let handler = TwoStreamHandler::new(control);
+        let pending = handler.pending_responses();
+        let two_stream_handler = Arc::new(tokio::sync::Mutex::new(handler));
         let (two_stream_event_tx, two_stream_event_rx) = mpsc::channel(256);
 
         // Spawn the two-stream runner as a background task
         let runner = TwoStreamRunner::new(
-            Arc::clone(&two_stream_handler),
+            pending,
             request_streams,
             response_streams,
             se_request_streams,

--- a/crates/p2p/src/host/p2p_host.rs
+++ b/crates/p2p/src/host/p2p_host.rs
@@ -445,6 +445,28 @@ impl<S: Store> P2PHost<S> {
                     .kademlia
                     .add_address(&peer_id, peer_addr);
 
+                // Pre-announce bitswap protocols so the peer immediately transitions
+                // from Connected → Responsive in iroh-bitswap. Without this, there's
+                // a race between the Identify protocol completing and the first
+                // Bitswap fetch: after a node restart, GossipSub notifications can
+                // trigger Bitswap fetches before Identify finishes, leaving the peer
+                // in Connected state where peer_connected() is never called and the
+                // peer has no MessageQueue, so want messages are never sent.
+                // The actual protocol version is negotiated per-substream regardless.
+                eprintln!(
+                    "[BITSWAP-PREANNOUNCE] Pre-announcing bitswap protocols for peer={}",
+                    peer_id
+                );
+                self.swarm.behaviour().on_identify(
+                    &peer_id,
+                    &[
+                        "/ipfs/bitswap/1.2.0".to_string(),
+                        "/ipfs/bitswap/1.1.0".to_string(),
+                        "/ipfs/bitswap/1.0.0".to_string(),
+                    ],
+                );
+                eprintln!("[BITSWAP-PREANNOUNCE] Done for peer={}", peer_id);
+
                 // Trigger Kademlia bootstrap to discover peers through the DHT.
                 // When node2 connects to node0 (who already knows node1),
                 // this causes node2 to query node0, discover node1, and dial it.
@@ -791,9 +813,18 @@ impl<S: Store> P2PHost<S> {
                 limit,
             } => {
                 debug!(cid = %key, limit = limit, "Bitswap requests to find providers");
-                // Could query Kademlia DHT to find providers
-                // For now, send empty set (peer discovery via manual dial)
-                let _ = response.send(Ok(std::collections::HashSet::new())).await;
+                // Return all connected peers as potential providers. In a small
+                // DefraDB network, any connected peer may have the requested block.
+                // This complements session.add_provider() which may not take effect
+                // if processed before get_blocks() adds CIDs to the want list.
+                let providers: std::collections::HashSet<PeerId> =
+                    self.peer_addrs.keys().copied().collect();
+                eprintln!(
+                    "[BITSWAP-FIND-PROVIDERS] cid={} returning {} connected peers",
+                    key,
+                    providers.len()
+                );
+                let _ = response.send(Ok(providers)).await;
             }
             BitswapEvent::Ping { peer, response } => {
                 debug!(peer_id = %peer, "Bitswap ping request");

--- a/crates/p2p/src/host/p2p_host.rs
+++ b/crates/p2p/src/host/p2p_host.rs
@@ -151,13 +151,14 @@ impl<S: Store> P2PHost<S> {
         .await
         .map_err(|e| Error::Behaviour(e.to_string()))?;
 
+        // Enable TCP port reuse to match Go-libp2p behavior.
+        // Go-libp2p reuses the listen port for outgoing connections, so the
+        // remote side sees the listen address (not an ephemeral port).
+        // This is critical for ActivePeers to return correct addresses.
+        let tcp_config = tcp::Config::default().port_reuse(true);
         let swarm = SwarmBuilder::with_existing_identity(keypair.clone())
             .with_tokio()
-            .with_tcp(
-                tcp::Config::default(),
-                noise::Config::new,
-                yamux::Config::default,
-            )
+            .with_tcp(tcp_config, noise::Config::new, yamux::Config::default)
             .map_err(|e| Error::Transport(e.to_string()))?
             .with_behaviour(|_key| behaviour)
             .expect("behaviour already constructed")
@@ -238,7 +239,19 @@ impl<S: Store> P2PHost<S> {
     /// This method runs until shutdown is requested.
     pub async fn run(mut self) {
         loop {
+            // Biased select: process swarm events before commands.
+            // This ensures ConnectionEstablished events (which update peer_addrs)
+            // are processed before PeerAddresses commands read them.
             tokio::select! {
+                biased;
+
+                event = self.swarm.select_next_some() => {
+                    self.handle_swarm_event(event).await;
+                }
+                // Handle two-stream protocol events (Go compatibility)
+                Some(two_stream_event) = self.two_stream_event_rx.recv() => {
+                    self.handle_two_stream_event(two_stream_event).await;
+                }
                 command = self.command_rx.recv() => {
                     match command {
                         Some(cmd) => {
@@ -251,13 +264,6 @@ impl<S: Store> P2PHost<S> {
                             break;
                         }
                     }
-                }
-                event = self.swarm.select_next_some() => {
-                    self.handle_swarm_event(event).await;
-                }
-                // Handle two-stream protocol events (Go compatibility)
-                Some(two_stream_event) = self.two_stream_event_rx.recv() => {
-                    self.handle_two_stream_event(two_stream_event).await;
                 }
             }
         }
@@ -416,12 +422,31 @@ impl<S: Store> P2PHost<S> {
                 peer_id, endpoint, ..
             } => {
                 info!("Connected to peer: {}", peer_id);
-                // For dialer: store the address we dialed (which is the peer's listen addr).
-                // For listener: do NOT store send_back_addr (it has an ephemeral port).
-                // The identify protocol will provide the correct listen address shortly.
-                if let libp2p::core::ConnectedPoint::Dialer { address, .. } = &endpoint {
-                    self.peer_addrs.insert(peer_id, address.clone());
-                }
+                // Store the remote peer's address from the connection endpoint.
+                // For dialer: the address we dialed (peer's listen addr).
+                // For listener: the send_back_addr. With TCP port reuse enabled,
+                // this IS the peer's listen address (Go-compatible behavior).
+                let peer_addr = match &endpoint {
+                    libp2p::core::ConnectedPoint::Dialer { address, .. } => address.clone(),
+                    libp2p::core::ConnectedPoint::Listener { send_back_addr, .. } => {
+                        send_back_addr.clone()
+                    }
+                };
+                self.peer_addrs.insert(peer_id, peer_addr.clone());
+
+                // Add peer to Kademlia BEFORE bootstrap. Kademlia's own
+                // ConnectionEstablished handler doesn't add peers to the
+                // routing table until protocol negotiation completes (async).
+                // We add the address now so bootstrap() has a peer to query.
+                self.swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .add_address(&peer_id, peer_addr);
+
+                // Trigger Kademlia bootstrap to discover peers through the DHT.
+                // When node2 connects to node0 (who already knows node1),
+                // this causes node2 to query node0, discover node1, and dial it.
+                let _ = self.swarm.behaviour_mut().kademlia.bootstrap();
 
                 if self
                     .event_tx
@@ -571,11 +596,16 @@ impl<S: Store> P2PHost<S> {
                 );
                 self.swarm.behaviour().on_identify(&peer_id, &protocols);
 
+                // Store the peer's listen addresses in Kademlia for routing.
+                // Do NOT call add_external_address — those are the REMOTE peer's
+                // addresses, not ours. Adding them as local external addresses
+                // causes address cross-contamination between peers.
                 for addr in &info.listen_addrs {
-                    debug!(peer_id = %peer_id, address = %addr, "Adding external address from identify");
-                }
-                for addr in info.listen_addrs {
-                    self.swarm.add_external_address(addr);
+                    debug!(peer_id = %peer_id, address = %addr, "Adding peer address to Kademlia");
+                    self.swarm
+                        .behaviour_mut()
+                        .kademlia
+                        .add_address(&peer_id, addr.clone());
                 }
             }
             libp2p::identify::Event::Sent { peer_id, .. } => {

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -121,8 +121,20 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
 
             // Fire-and-forget: spawn a task per peer that sends blocks in order.
             let host = self.host.clone();
+            let failure_tx = self.failure_tx.clone();
+            let doc_id_owned = doc_id.to_string();
+            let collection_id_owned = collection_id.to_string();
             tokio::spawn(async move {
-                Self::send_ordered_pushlogs(host, peer_id, requests).await;
+                let any_failed = Self::send_ordered_pushlogs(host, peer_id, requests).await;
+                if any_failed {
+                    if let Some(tx) = failure_tx {
+                        let _ = tx.send(super::PushFailure {
+                            peer_id,
+                            doc_id: doc_id_owned,
+                            collection_id: collection_id_owned,
+                        });
+                    }
+                }
             });
         }
     }
@@ -172,6 +184,9 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
 
             let host = self.host.clone();
             let cid_clone = *cid;
+            let failure_tx = self.failure_tx.clone();
+            let doc_id_owned = doc_id.to_string();
+            let collection_id_owned = collection_id.to_string();
             tokio::spawn(async move {
                 if let Err(e) = host.send_two_stream_request(peer_id, request).await {
                     tracing::debug!(
@@ -180,6 +195,13 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
                         error = %e,
                         "PushLog to replicator failed"
                     );
+                    if let Some(tx) = failure_tx {
+                        let _ = tx.send(super::PushFailure {
+                            peer_id,
+                            doc_id: doc_id_owned,
+                            collection_id: collection_id_owned,
+                        });
+                    }
                 }
             });
         }
@@ -213,11 +235,14 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
     }
 
     /// Send PushLog requests to a peer in order, waiting for each to complete.
+    ///
+    /// Returns `true` if any request failed.
     async fn send_ordered_pushlogs(
         host: crate::host::P2PHostHandle,
         peer_id: PeerId,
         requests: Vec<(Cid, PushLogRequest)>,
-    ) {
+    ) -> bool {
+        let mut any_failed = false;
         for (cid, request) in requests {
             if let Err(e) = host.send_two_stream_request(peer_id, request).await {
                 tracing::debug!(
@@ -226,7 +251,9 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
                     error = %e,
                     "PushLog to replicator failed"
                 );
+                any_failed = true;
             }
         }
+        any_failed
     }
 }

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -2,6 +2,7 @@
 
 use blockstore::Blockstore;
 use cid::Cid;
+use libp2p::PeerId;
 
 use super::SyncCoordinator;
 use crate::error::Result;
@@ -39,10 +40,97 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
         self.broadcaster.broadcast_update(&broadcast).await
     }
 
-    /// Push a local update to all registered replicator peers via direct PushLog.
+    /// Push a composite block and all its linked field blocks to replicator peers.
     ///
-    /// This complements `broadcast_local_update` (GossipSub) by sending the update
-    /// directly to each replicator peer that is registered for the given collection.
+    /// This decodes the composite block to find field block CIDs, loads them from
+    /// the blockstore, and sends field blocks BEFORE the composite to each replicator.
+    /// This ensures the receiver has all DAG blocks when it processes the composite,
+    /// avoiding Bitswap fetches (which can fail after node restarts).
+    pub async fn push_dag_to_replicators(
+        &self,
+        cid: &Cid,
+        block: &[u8],
+        doc_id: &str,
+        collection_id: &str,
+    ) {
+        let replicators = match self.host.get_all_replicators().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to get replicators for push");
+                return;
+            }
+        };
+
+        if replicators.is_empty() {
+            return;
+        }
+
+        // Decode composite block to find linked field block CIDs.
+        let field_blocks = self.load_linked_blocks(block).await;
+
+        tracing::debug!(
+            cid = %cid,
+            doc_id = %doc_id,
+            collection_id = %collection_id,
+            replicator_count = replicators.len(),
+            field_block_count = field_blocks.len(),
+            "Pushing DAG to replicators"
+        );
+
+        for rep in &replicators {
+            if !rep.collections.is_empty() && !rep.collections.contains(&collection_id.to_string())
+            {
+                continue;
+            }
+
+            let peer_id = match rep.peer_id() {
+                Some(id) => id,
+                None => continue,
+            };
+
+            // Build signed requests for field blocks and composite.
+            let mut requests: Vec<(Cid, PushLogRequest)> = Vec::new();
+
+            // Field blocks first so receiver has them when composite arrives.
+            for (field_cid, field_data) in &field_blocks {
+                let mut req = PushLogRequest::new(
+                    doc_id.to_string(),
+                    field_cid.to_bytes(),
+                    collection_id.to_string(),
+                    self.local_peer_id.clone(),
+                    field_data.clone(),
+                );
+                if sign_message(self.host.keypair(), &mut req).is_ok() {
+                    requests.push((*field_cid, req));
+                }
+            }
+
+            // Composite block last.
+            let mut composite_req = PushLogRequest::new(
+                doc_id.to_string(),
+                cid.to_bytes(),
+                collection_id.to_string(),
+                self.local_peer_id.clone(),
+                block.to_vec(),
+            );
+            if let Err(e) = sign_message(self.host.keypair(), &mut composite_req) {
+                tracing::debug!(error = %e, "Failed to sign composite PushLog request");
+                continue;
+            }
+            requests.push((*cid, composite_req));
+
+            // Fire-and-forget: spawn a task per peer that sends blocks in order.
+            let host = self.host.clone();
+            tokio::spawn(async move {
+                Self::send_ordered_pushlogs(host, peer_id, requests).await;
+            });
+        }
+    }
+
+    /// Push a single block to replicator peers (no DAG expansion).
+    ///
+    /// Used for collection blocks and other non-composite blocks that
+    /// don't have linked field blocks.
     pub async fn push_to_replicators(
         &self,
         cid: &Cid,
@@ -58,24 +146,9 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
             }
         };
 
-        tracing::debug!(
-            cid = %cid,
-            doc_id = %doc_id,
-            collection_id = %collection_id,
-            replicator_count = replicators.len(),
-            "Pushing update to replicators"
-        );
-
         for rep in &replicators {
-            // Check if this replicator is registered for the collection
-            // Empty collections means "all collections" in Go semantics
             if !rep.collections.is_empty() && !rep.collections.contains(&collection_id.to_string())
             {
-                tracing::trace!(
-                    replicator_collections = ?rep.collections,
-                    collection_id = %collection_id,
-                    "Skipping replicator (collection mismatch)"
-                );
                 continue;
             }
 
@@ -83,7 +156,6 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
                 Some(id) => id,
                 None => continue,
             };
-            tracing::debug!(peer_id = %peer_id, cid = %cid, "Sending to replicator peer");
 
             let mut request = PushLogRequest::new(
                 doc_id.to_string(),
@@ -98,11 +170,63 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
                 continue;
             }
 
-            // Fire-and-forget: spawn each push so we don't block the broadcast loop.
             let host = self.host.clone();
+            let cid_clone = *cid;
             tokio::spawn(async move {
-                let _ = host.send_two_stream_request(peer_id, request).await;
+                if let Err(e) = host.send_two_stream_request(peer_id, request).await {
+                    tracing::debug!(
+                        peer_id = %peer_id,
+                        cid = %cid_clone,
+                        error = %e,
+                        "PushLog to replicator failed"
+                    );
+                }
             });
+        }
+    }
+
+    /// Load all blocks linked from a composite block's DAG links.
+    async fn load_linked_blocks(&self, composite_bytes: &[u8]) -> Vec<(Cid, Vec<u8>)> {
+        let parsed = match defra_core::Block::from_dag_cbor(composite_bytes) {
+            Ok(b) => b,
+            Err(_) => return vec![],
+        };
+
+        let links = match parsed.links {
+            Some(ref links) => links,
+            None => return vec![],
+        };
+
+        let mut blocks = Vec::with_capacity(links.len());
+        for link in links {
+            match self.blockstore().get(&link.link).await {
+                Ok(Some(data)) => blocks.push((link.link, data)),
+                Ok(None) => {
+                    tracing::debug!(cid = %link.link, "Linked block not found in blockstore");
+                }
+                Err(e) => {
+                    tracing::debug!(cid = %link.link, error = %e, "Failed to load linked block");
+                }
+            }
+        }
+        blocks
+    }
+
+    /// Send PushLog requests to a peer in order, waiting for each to complete.
+    async fn send_ordered_pushlogs(
+        host: crate::host::P2PHostHandle,
+        peer_id: PeerId,
+        requests: Vec<(Cid, PushLogRequest)>,
+    ) {
+        for (cid, request) in requests {
+            if let Err(e) = host.send_two_stream_request(peer_id, request).await {
+                tracing::debug!(
+                    peer_id = %peer_id,
+                    cid = %cid,
+                    error = %e,
+                    "PushLog to replicator failed"
+                );
+            }
         }
     }
 }

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -146,8 +146,17 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
                 )),
                 collection_store,
                 head_provider,
+                failure_tx: None,
             },
             events,
         ))
+    }
+
+    /// Set the failure channel for reporting push failures to the FFI layer.
+    pub fn set_failure_channel(
+        &mut self,
+        tx: tokio::sync::mpsc::UnboundedSender<super::PushFailure>,
+    ) {
+        self.failure_tx = Some(tx);
     }
 }

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -1,0 +1,146 @@
+//! Poll-based DAG fetcher for DocSync and BranchableSync.
+//!
+//! Uses bitswap_sync + blockstore polling instead of the event-driven
+//! pending DAG + BitswapComplete + retry mechanism. The poll-based approach
+//! is more reliable for multi-level DAG fetching.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use blockstore::Blockstore;
+use cid::Cid;
+use libp2p::PeerId;
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use crate::host::P2PHostHandle;
+use crate::sync::manager::links::find_all_missing_links;
+use crate::sync::manager::SyncEvent;
+
+/// Fetch an entire DAG rooted at `root_cid` using poll-based Bitswap.
+///
+/// Walks the DAG level by level, fetching missing blocks via Bitswap
+/// and polling the blockstore until they appear. Emits DagReady when complete.
+#[allow(clippy::too_many_arguments)]
+pub async fn poll_fetch_dag<B: Blockstore + 'static>(
+    host: P2PHostHandle,
+    blockstore: Arc<B>,
+    event_tx: mpsc::Sender<SyncEvent>,
+    root_cid: Cid,
+    doc_id: String,
+    collection_id: String,
+    schema_version_id: String,
+    source_peer: PeerId,
+) {
+    debug!(
+        root_cid = %root_cid,
+        doc_id = %doc_id,
+        source_peer = %source_peer,
+        "Starting poll-based DAG fetch"
+    );
+
+    // Fetch root block
+    if !poll_fetch_block(&root_cid, &host, &blockstore, source_peer).await {
+        warn!(root_cid = %root_cid, "Failed to fetch root block");
+        return;
+    }
+
+    // Walk DAG, fetching missing blocks level by level
+    for iteration in 0..20 {
+        let root_data = match blockstore.get(&root_cid).await {
+            Ok(Some(data)) => data,
+            _ => {
+                warn!(root_cid = %root_cid, "Root block disappeared from blockstore");
+                return;
+            }
+        };
+
+        let missing = match find_all_missing_links(blockstore.as_ref(), &root_data).await {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(root_cid = %root_cid, error = %e, "find_all_missing_links failed");
+                return;
+            }
+        };
+
+        if missing.is_empty() {
+            break;
+        }
+
+        debug!(
+            root_cid = %root_cid,
+            iteration = iteration,
+            missing_count = missing.len(),
+            "Fetching missing DAG blocks"
+        );
+
+        for cid in &missing {
+            if !poll_fetch_block(cid, &host, &blockstore, source_peer).await {
+                warn!(
+                    cid = %cid,
+                    root_cid = %root_cid,
+                    "Timeout fetching child block (30s)"
+                );
+            }
+        }
+    }
+
+    // Verify DAG is complete
+    let root_data = match blockstore.get(&root_cid).await {
+        Ok(Some(data)) => data,
+        _ => return,
+    };
+    let remaining = find_all_missing_links(blockstore.as_ref(), &root_data)
+        .await
+        .unwrap_or_default();
+
+    if remaining.is_empty() {
+        info!(root_cid = %root_cid, doc_id = %doc_id, "DAG fetch complete");
+        let _ = event_tx
+            .send(SyncEvent::DagReady {
+                root_cid,
+                doc_id,
+                collection_id,
+                schema_version_id,
+            })
+            .await;
+    } else {
+        warn!(
+            root_cid = %root_cid,
+            doc_id = %doc_id,
+            remaining_count = remaining.len(),
+            "DAG fetch incomplete"
+        );
+    }
+}
+
+/// Fetch a single block via Bitswap + blockstore polling.
+async fn poll_fetch_block<B: Blockstore>(
+    cid: &Cid,
+    host: &P2PHostHandle,
+    blockstore: &Arc<B>,
+    source_peer: PeerId,
+) -> bool {
+    // Already have it?
+    if let Ok(true) = blockstore.has(cid).await {
+        return true;
+    }
+
+    // Start Bitswap fetch
+    if let Err(e) = host.bitswap_sync(*cid, vec![source_peer], vec![*cid]).await {
+        warn!(cid = %cid, error = %e, "bitswap_sync failed");
+        return false;
+    }
+
+    // Poll blockstore for up to 30 seconds
+    let timeout = Duration::from_secs(30);
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(true) = blockstore.has(cid).await {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    false
+}

--- a/crates/p2p/src/sync/coordinator/event_handler.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler.rs
@@ -395,73 +395,61 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
             "Bitswap fetch completed"
         );
 
-        if success {
-            let pending_dags: Vec<Cid> = self.manager.pending_dag_cids();
-            tracing::debug!(
-                pending_dag_count = pending_dags.len(),
-                "Processing pending DAGs after Bitswap completion"
-            );
+        if !success {
+            if let Some(ref err) = error {
+                tracing::warn!(
+                    query_id = query_id.0,
+                    error = %err,
+                    "Bitswap fetch failed, retrying pending DAGs"
+                );
+            }
+        }
 
-            for root_cid in pending_dags {
-                tracing::debug!(root_cid = %root_cid, "Retrying pending DAG");
-                match self.manager.retry_pending_dag(&root_cid).await {
-                    Ok(true) => {
-                        tracing::info!(
-                            query_id = query_id.0,
-                            root_cid = %root_cid,
-                            "Pending DAG completed after Bitswap fetch"
-                        );
-                    }
-                    Ok(false) => {
-                        let missing = self.manager.pending_dag_missing(&root_cid);
-                        if !missing.is_empty() {
-                            tracing::debug!(
-                                root_cid = %root_cid,
-                                missing_count = missing.len(),
-                                "Pending DAG has missing child blocks, fetching via Bitswap"
-                            );
-                            let providers = self
-                                .peer_state
-                                .connected_peers()
-                                .into_iter()
-                                .collect::<Vec<_>>();
-                            if let Err(e) =
-                                self.host.bitswap_sync(root_cid, providers, missing).await
-                            {
-                                tracing::warn!(
-                                    root_cid = %root_cid,
-                                    error = %e,
-                                    "Failed to start Bitswap fetch for child blocks"
-                                );
+        // Retry ALL pending DAGs on both success AND failure.
+        // On success: newly fetched blocks may complete other DAGs.
+        // On failure: the timeout ensures we re-issue bitswap_sync with
+        //   a fresh session so the retry loop doesn't stall.
+        let pending_dags: Vec<Cid> = self.manager.pending_dag_cids();
+        for root_cid in pending_dags {
+            match self.manager.retry_pending_dag(&root_cid).await {
+                Ok(true) => {
+                    tracing::info!(
+                        query_id = query_id.0,
+                        root_cid = %root_cid,
+                        "Pending DAG completed after Bitswap fetch"
+                    );
+                }
+                Ok(false) => {
+                    let missing = self.manager.pending_dag_missing(&root_cid);
+                    if !missing.is_empty() {
+                        // Build provider list: connected peers + the original source peer.
+                        // The source peer is the one that sent the DocSync/Branchable reply
+                        // and definitely has the blocks.
+                        let mut providers: Vec<libp2p::PeerId> =
+                            self.peer_state.connected_peers().into_iter().collect();
+                        if let Some(source) = self.manager.pending_dag_source_peer(&root_cid) {
+                            if !providers.contains(&source) {
+                                providers.push(source);
                             }
-                        } else {
-                            tracing::debug!(
+                        }
+                        if let Err(e) = self.host.bitswap_sync(root_cid, providers, missing).await {
+                            tracing::warn!(
                                 root_cid = %root_cid,
-                                "Pending DAG still has missing links but no missing CIDs reported"
+                                error = %e,
+                                "Failed to start Bitswap fetch for child blocks"
                             );
                         }
-                        tracing::debug!(
-                            query_id = query_id.0,
-                            root_cid = %root_cid,
-                            "Pending DAG still has missing links, initiated additional fetch"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            query_id = query_id.0,
-                            root_cid = %root_cid,
-                            error = %e,
-                            "Failed to retry pending DAG"
-                        );
                     }
                 }
+                Err(e) => {
+                    tracing::warn!(
+                        query_id = query_id.0,
+                        root_cid = %root_cid,
+                        error = %e,
+                        "Failed to retry pending DAG"
+                    );
+                }
             }
-        } else if let Some(ref err) = error {
-            tracing::warn!(
-                query_id = query_id.0,
-                error = %err,
-                "Bitswap fetch failed"
-            );
         }
         Ok(())
     }
@@ -548,7 +536,6 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
             results_count = reply.results.len(),
             "Processing DocSync reply"
         );
-
         let mut cids_to_fetch: Vec<(Cid, String)> = Vec::new();
         for item in &reply.results {
             for head_bytes in &item.heads {
@@ -592,30 +579,34 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
         if !cids_to_fetch.is_empty() {
             tracing::info!(
                 cid_count = cids_to_fetch.len(),
-                "Initiating Bitswap fetch for DocSync blocks"
+                "Spawning poll-based DAG fetchers for DocSync blocks"
             );
 
-            for (root_cid, doc_id) in &cids_to_fetch {
+            let host = self.host.clone();
+            let blockstore = self.manager.blockstore().clone();
+            let event_tx = self.manager.event_sender();
+
+            for (root_cid, doc_id) in cids_to_fetch {
                 tracing::debug!(
                     cid = %root_cid,
                     doc_id = %doc_id,
-                    "Registering pending DAG for DocSync"
+                    "Spawning poll-based DAG fetcher for DocSync"
                 );
-                self.manager.register_docsync_dag(*root_cid, doc_id.clone());
 
-                tracing::debug!(cid = %root_cid, "Starting Bitswap sync");
-                if let Err(e) = self
-                    .host
-                    .bitswap_sync(*root_cid, vec![peer_id], vec![*root_cid])
-                    .await
-                {
-                    tracing::warn!(
-                        error = %e,
-                        cid = %root_cid,
-                        doc_id = %doc_id,
-                        "Failed to initiate Bitswap sync for DocSync CID"
-                    );
-                }
+                let host = host.clone();
+                let blockstore = blockstore.clone();
+                let event_tx = event_tx.clone();
+
+                tokio::spawn(super::dag_fetcher::poll_fetch_dag(
+                    host,
+                    blockstore,
+                    event_tx,
+                    root_cid,
+                    doc_id,
+                    String::new(),
+                    String::new(),
+                    peer_id,
+                ));
             }
         } else {
             tracing::debug!("No blocks to fetch from DocSync reply (all local)");
@@ -735,24 +726,29 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
             tracing::info!(
                 collection_id = %reply.collection_id,
                 cid_count = cids_to_fetch.len(),
-                "Initiating Bitswap fetch for collection blocks"
+                "Spawning poll-based DAG fetchers for collection blocks"
             );
 
-            for root_cid in &cids_to_fetch {
-                self.manager
-                    .register_branchable_dag(*root_cid, reply.collection_id.clone());
+            let host = self.host.clone();
+            let blockstore = self.manager.blockstore().clone();
+            let event_tx = self.manager.event_sender();
 
-                if let Err(e) = self
-                    .host
-                    .bitswap_sync(*root_cid, vec![peer_id], vec![*root_cid])
-                    .await
-                {
-                    tracing::warn!(
-                        cid = %root_cid,
-                        error = %e,
-                        "Failed to start Bitswap for collection block"
-                    );
-                }
+            for root_cid in cids_to_fetch {
+                let host = host.clone();
+                let blockstore = blockstore.clone();
+                let event_tx = event_tx.clone();
+                let collection_id = reply.collection_id.clone();
+
+                tokio::spawn(super::dag_fetcher::poll_fetch_dag(
+                    host,
+                    blockstore,
+                    event_tx,
+                    root_cid,
+                    String::new(),
+                    collection_id,
+                    String::new(),
+                    peer_id,
+                ));
             }
         } else {
             tracing::debug!(

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -56,6 +56,16 @@ pub use result_types::{LoadReplicatorsResult, SetReplicatorResult};
 
 use std::sync::Arc;
 
+/// A push failure notification sent when a PushLog to a replicator peer fails.
+///
+/// The FFI layer consumes these to record failures in the Peerstore for retry.
+#[derive(Debug, Clone)]
+pub struct PushFailure {
+    pub peer_id: libp2p::PeerId,
+    pub doc_id: String,
+    pub collection_id: String,
+}
+
 use blockstore::Blockstore;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
@@ -100,6 +110,9 @@ pub struct SyncCoordinator<B: Blockstore> {
 
     /// Document head provider for DocSync responses
     pub(super) head_provider: Arc<dyn DocumentHeadProvider>,
+
+    /// Channel for reporting push failures to the FFI layer for retry tracking.
+    pub(super) failure_tx: Option<tokio::sync::mpsc::UnboundedSender<PushFailure>>,
 }
 
 #[cfg(test)]

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -46,6 +46,7 @@ mod access;
 mod accessors;
 mod broadcast;
 mod constructor;
+pub(crate) mod dag_fetcher;
 mod event_handler;
 mod replicators;
 mod result_types;

--- a/crates/p2p/src/sync/coordinator/replicators.rs
+++ b/crates/p2p/src/sync/coordinator/replicators.rs
@@ -81,11 +81,22 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
 
     /// Delete a replicator.
     ///
-    /// Removes the peer from the replicator registry.
-    /// Does not unsubscribe from collections (other peers may still be replicating).
+    /// Removes the peer from the replicator registry and unsubscribes from
+    /// collection topics that no longer have any replicators.
     pub async fn delete_replicator(&self, peer_id: PeerId) -> Result<()> {
+        // Get collections BEFORE deleting so we know what to potentially unsubscribe
+        let removed_collections = match self.host.get_replicator(peer_id).await? {
+            Some(info) => info.collections,
+            None => Vec::new(),
+        };
+
         self.host.delete_replicator(peer_id).await?;
         tracing::info!(peer_id = %peer_id, "Deleted replicator");
+
+        // Unsubscribe from collections that no longer have any replicators
+        self.unsubscribe_orphaned_collections(&removed_collections)
+            .await;
+
         Ok(())
     }
 
@@ -104,8 +115,18 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
     ) -> Result<bool> {
         // Go behavior: empty collections = delete all
         if collections.is_empty() {
+            // Get collections BEFORE deleting
+            let removed_collections = match self.host.get_replicator(peer_id).await? {
+                Some(info) => info.collections,
+                None => Vec::new(),
+            };
+
             self.host.delete_replicator(peer_id).await?;
             tracing::info!(peer_id = %peer_id, "Deleted replicator (empty collections = delete all)");
+
+            self.unsubscribe_orphaned_collections(&removed_collections)
+                .await;
+
             return Ok(true);
         }
 
@@ -129,7 +150,31 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
             );
         }
 
+        // Unsubscribe from removed collections that no longer have replicators
+        self.unsubscribe_orphaned_collections(&collections).await;
+
         Ok(fully_deleted)
+    }
+
+    /// Unsubscribe from collection topics that no longer have any replicators.
+    async fn unsubscribe_orphaned_collections(&self, collections: &[String]) {
+        for collection_id in collections {
+            // Check if any remaining replicators use this collection
+            let remaining = match self.host.get_all_replicators().await {
+                Ok(reps) => reps.iter().any(|r| r.collections.contains(collection_id)),
+                Err(_) => true, // conservative: don't unsubscribe if we can't check
+            };
+
+            if !remaining {
+                if let Err(e) = self.unsubscribe_collection(collection_id).await {
+                    tracing::warn!(
+                        collection_id = %collection_id,
+                        error = %e,
+                        "Failed to unsubscribe from orphaned collection"
+                    );
+                }
+            }
+        }
     }
 
     /// Get all registered replicators.

--- a/crates/p2p/src/sync/manager/mod.rs
+++ b/crates/p2p/src/sync/manager/mod.rs
@@ -14,7 +14,7 @@
 
 mod config;
 mod events;
-mod links;
+pub(crate) mod links;
 mod pending;
 mod process;
 

--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use cid::Cid;
+use libp2p::PeerId;
 
 /// Metadata for a pending DAG sync waiting for Bitswap to complete.
 #[derive(Debug, Clone)]
@@ -16,4 +17,8 @@ pub struct PendingDag {
     /// CIDs still missing (gets smaller as blocks arrive via Bitswap)
     #[allow(dead_code)] // Used for tracking Bitswap progress
     pub missing: HashSet<Cid>,
+    /// The peer that originally provided this DAG (e.g. DocSync reply sender).
+    /// Always included in the Bitswap provider list during retries so the
+    /// blocks can be fetched even if the peer isn't in connected_peers().
+    pub source_peer: Option<PeerId>,
 }

--- a/crates/p2p/src/sync/manager/process.rs
+++ b/crates/p2p/src/sync/manager/process.rs
@@ -332,6 +332,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         collection_id: msg.collection_id.clone(),
                         creator: msg.creator.clone(),
                         missing: missing.iter().cloned().collect(),
+                        source_peer: None,
                     },
                 );
             }
@@ -505,6 +506,14 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             .unwrap_or_default()
     }
 
+    /// Get the source peer for a pending DAG (the peer that originally provided it).
+    pub fn pending_dag_source_peer(&self, root_cid: &Cid) -> Option<libp2p::PeerId> {
+        self.pending_dags
+            .read()
+            .get(root_cid)
+            .and_then(|dag| dag.source_peer)
+    }
+
     /// Register a pending DAG for DocSync.
     ///
     /// This is called when a DocSyncReply contains head CIDs that need to be
@@ -516,10 +525,11 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     ///
     /// * `root_cid` - The head CID to fetch
     /// * `doc_id` - Document ID from the DocSyncItem
-    pub fn register_docsync_dag(&self, root_cid: Cid, doc_id: String) {
+    pub fn register_docsync_dag(&self, root_cid: Cid, doc_id: String, source_peer: libp2p::PeerId) {
         tracing::debug!(
             cid = %root_cid,
             doc_id = %doc_id,
+            source_peer = %source_peer,
             "Registering DocSync pending DAG"
         );
 
@@ -533,6 +543,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 collection_id: String::new(),
                 creator: String::new(),
                 missing: std::iter::once(root_cid).collect(),
+                source_peer: Some(source_peer),
             },
         );
     }
@@ -542,7 +553,12 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// Unlike `register_docsync_dag` which stores the document ID,
     /// this stores the collection ID so the merge handler can look up
     /// the local collection for cross-schema-version merges.
-    pub fn register_branchable_dag(&self, root_cid: Cid, collection_id: String) {
+    pub fn register_branchable_dag(
+        &self,
+        root_cid: Cid,
+        collection_id: String,
+        source_peer: libp2p::PeerId,
+    ) {
         tracing::debug!(
             cid = %root_cid,
             collection_id = %collection_id,
@@ -557,6 +573,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 collection_id,
                 creator: String::new(),
                 missing: std::iter::once(root_cid).collect(),
+                source_peer: Some(source_peer),
             },
         );
     }
@@ -588,6 +605,11 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// Get the blockstore reference.
     pub fn blockstore(&self) -> &Arc<B> {
         &self.blockstore
+    }
+
+    /// Get a clone of the sync event sender for spawning background tasks.
+    pub fn event_sender(&self) -> mpsc::Sender<SyncEvent> {
+        self.event_tx.clone()
     }
 
     /// Store a block received via Bitswap and check if pending DAGs can now proceed.

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -46,7 +46,7 @@ mod replication;
 
 pub use broadcaster::{BroadcastResult, Broadcaster};
 pub use collection_store::{NoOpCollectionStorage, P2PCollectionStorage, P2PCollectionStore};
-pub use coordinator::{LoadReplicatorsResult, SetReplicatorResult, SyncCoordinator};
+pub use coordinator::{LoadReplicatorsResult, PushFailure, SetReplicatorResult, SyncCoordinator};
 pub use dag_sync::{DagSync, DagSyncConfig, DagSyncState, NeedsFetchData, SyncPlan};
 pub use head_provider::{DocumentHeadProvider, NoOpHeadProvider};
 pub use manager::{SyncConfig, SyncEvent, SyncManager};

--- a/crates/p2p/src/two_stream/handler.rs
+++ b/crates/p2p/src/two_stream/handler.rs
@@ -34,9 +34,9 @@ const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// State for tracking pending responses.
 #[derive(Default)]
-struct PendingResponses {
+pub(crate) struct PendingResponses {
     /// Map of MessageID to response channel.
-    channels: HashMap<String, oneshot::Sender<PushLogReply>>,
+    pub(crate) channels: HashMap<String, oneshot::Sender<PushLogReply>>,
 }
 
 /// Two-stream protocol handler.
@@ -59,6 +59,11 @@ impl TwoStreamHandler {
             control,
             pending: Arc::new(Mutex::new(PendingResponses::default())),
         }
+    }
+
+    /// Get a clone of the pending responses Arc for lock-free response processing.
+    pub(crate) fn pending_responses(&self) -> Arc<Mutex<PendingResponses>> {
+        self.pending.clone()
     }
 
     /// Get the request protocol.
@@ -138,8 +143,11 @@ impl TwoStreamHandler {
     /// DocSyncReply is a superset of PushLogReply (same fields plus Results),
     /// so we deserialize as DocSyncReply first. We then check if there's a
     /// pending PushLog channel for the message_id to determine the routing.
-    pub async fn handle_response_stream(
-        &self,
+    ///
+    /// This is an associated function (no `&self`) so it can be called without
+    /// holding the handler lock. Only needs the pending responses Arc.
+    pub(crate) async fn handle_response_stream(
+        pending: &Arc<Mutex<PendingResponses>>,
         peer_id: PeerId,
         mut stream: Stream,
     ) -> Result<Option<TwoStreamEvent>> {
@@ -191,7 +199,7 @@ impl TwoStreamHandler {
             // Check if there's a pending PushLog channel for this message_id.
             // If yes, this is actually a PushLogReply being routed.
             let pending_sender = {
-                let mut pending = self.pending.lock();
+                let mut pending = pending.lock();
                 pending.channels.remove(&message_id)
             };
 
@@ -235,7 +243,7 @@ impl TwoStreamHandler {
             );
 
             let sender = {
-                let mut pending = self.pending.lock();
+                let mut pending = pending.lock();
                 pending.channels.remove(&message_id)
             };
 

--- a/crates/p2p/src/two_stream/runner.rs
+++ b/crates/p2p/src/two_stream/runner.rs
@@ -7,17 +7,20 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use libp2p_stream as stream;
+use parking_lot::Mutex;
 use tokio::sync::mpsc;
 
 use super::event::TwoStreamEvent;
-use super::handler::TwoStreamHandler;
+use super::handler::{PendingResponses, TwoStreamHandler};
 
 /// Runner that accepts incoming streams and emits events.
 ///
 /// This should be spawned as a separate task.
 pub struct TwoStreamRunner {
-    /// Handler for processing streams.
-    handler: Arc<tokio::sync::Mutex<TwoStreamHandler>>,
+    /// Pending responses for lock-free response processing.
+    /// Stored separately from the handler to avoid holding the handler's
+    /// tokio::sync::Mutex during network I/O in response stream reads.
+    pending: Arc<Mutex<PendingResponses>>,
     /// Incoming request streams.
     request_streams: stream::IncomingStreams,
     /// Incoming response streams.
@@ -32,8 +35,8 @@ pub struct TwoStreamRunner {
 
 impl TwoStreamRunner {
     /// Create a new runner.
-    pub fn new(
-        handler: Arc<tokio::sync::Mutex<TwoStreamHandler>>,
+    pub(crate) fn new(
+        pending: Arc<Mutex<PendingResponses>>,
         request_streams: stream::IncomingStreams,
         response_streams: stream::IncomingStreams,
         se_request_streams: stream::IncomingStreams,
@@ -41,7 +44,7 @@ impl TwoStreamRunner {
         event_tx: mpsc::Sender<TwoStreamEvent>,
     ) -> Self {
         Self {
-            handler,
+            pending,
             request_streams,
             response_streams,
             se_request_streams,
@@ -100,11 +103,10 @@ impl TwoStreamRunner {
                         peer_id = %peer_id,
                         "Received incoming stream on response protocol"
                     );
-                    let handler = self.handler.clone();
+                    let pending = self.pending.clone();
                     let event_tx = self.event_tx.clone();
                     tokio::spawn(async move {
-                        let h = handler.lock().await;
-                        match h.handle_response_stream(peer_id, stream).await {
+                        match TwoStreamHandler::handle_response_stream(&pending, peer_id, stream).await {
                             Ok(Some(event)) => {
                                 // DocSyncReply events should be forwarded to the coordinator
                                 tracing::debug!(peer_id = %peer_id, "Sending DocSyncReply event to host channel");

--- a/crates/schema/src/cid.rs
+++ b/crates/schema/src/cid.rs
@@ -111,12 +111,23 @@ pub fn generate_collection_cid_full(
     priority: u64,
     heads: &[Cid],
 ) -> crate::Result<Cid> {
-    let mut delta = CollectionDefinitionDeltaPayload::new(priority);
-    if let Some(n) = name {
-        delta = delta.with_name(n);
-    }
+    generate_collection_cid_full_with_query(name, field_cids, priority, heads, None, None)
+}
 
-    // Convert field CIDs to DAGLinks (Go uses empty string as the link name for field definitions)
+/// Generate a collection CID with optional name, priority, head CIDs, and query data.
+///
+/// For view collections, `query_select` contains the CBOR-encoded query definition
+/// and `query_transform` contains the lens transform CID.
+pub fn generate_collection_cid_full_with_query(
+    name: Option<&str>,
+    field_cids: &[Cid],
+    priority: u64,
+    heads: &[Cid],
+    query_select: Option<&[u8]>,
+    query_transform: Option<&Cid>,
+) -> crate::Result<Cid> {
+    let delta = build_collection_delta(name, priority, query_select, query_transform);
+
     let links: Vec<DAGLink> = field_cids
         .iter()
         .map(|cid| DAGLink::new("", *cid))
@@ -128,6 +139,26 @@ pub fn generate_collection_cid_full(
         links,
     );
     generate_block_cid(&block)
+}
+
+/// Helper to build a CollectionDefinitionDeltaPayload with optional fields.
+fn build_collection_delta(
+    name: Option<&str>,
+    priority: u64,
+    query_select: Option<&[u8]>,
+    query_transform: Option<&Cid>,
+) -> CollectionDefinitionDeltaPayload {
+    let mut delta = CollectionDefinitionDeltaPayload::new(priority);
+    if let Some(n) = name {
+        delta = delta.with_name(n);
+    }
+    if let Some(qs) = query_select {
+        delta = delta.with_query_select(qs.to_vec());
+    }
+    if let Some(qt) = query_transform {
+        delta = delta.with_query_transform(*qt);
+    }
+    delta
 }
 
 /// Generates a CID from a Block using DAG-CBOR encoding.
@@ -187,12 +218,23 @@ pub fn generate_collection_block_full(
     priority: u64,
     heads: &[Cid],
 ) -> crate::Result<BlockWithCid> {
-    let mut delta = CollectionDefinitionDeltaPayload::new(priority);
-    if let Some(n) = name {
-        delta = delta.with_name(n);
-    }
+    generate_collection_block_full_with_query(name, field_cids, priority, heads, None, None)
+}
 
-    // Convert field CIDs to DAGLinks (Go uses empty string as the link name for field definitions)
+/// Generate a collection definition block (CID + bytes) with optional query data.
+///
+/// For view collections, includes `query_select` and `query_transform` in the delta
+/// so peers can identify the collection as a view after Bitswap sync.
+pub fn generate_collection_block_full_with_query(
+    name: Option<&str>,
+    field_cids: &[Cid],
+    priority: u64,
+    heads: &[Cid],
+    query_select: Option<&[u8]>,
+    query_transform: Option<&Cid>,
+) -> crate::Result<BlockWithCid> {
+    let delta = build_collection_delta(name, priority, query_select, query_transform);
+
     let links: Vec<DAGLink> = field_cids
         .iter()
         .map(|cid| DAGLink::new("", *cid))

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -20,7 +20,8 @@ mod source;
 mod validation;
 
 pub use cid::{
-    generate_collection_block_full, generate_collection_cid, generate_collection_cid_full,
+    generate_collection_block_full, generate_collection_block_full_with_query,
+    generate_collection_cid, generate_collection_cid_full, generate_collection_cid_full_with_query,
     generate_collection_cid_with_priority, generate_collection_cid_with_priority_and_heads,
     generate_collection_set_cid, generate_field_block_with_priority_and_heads, generate_field_cid,
     generate_field_cid_with_priority, generate_field_cid_with_priority_and_heads, BlockWithCid,

--- a/crates/storage/src/stores/mod.rs
+++ b/crates/storage/src/stores/mod.rs
@@ -15,6 +15,7 @@ pub mod datastore;
 pub mod headstore;
 pub mod multistore;
 pub mod peerstore;
+pub mod retry_info;
 pub mod rootstore;
 pub mod systemstore;
 
@@ -24,6 +25,7 @@ pub use datastore::{Datastore, CHUNK_SIZE};
 pub use headstore::Headstore;
 pub use multistore::Multistore;
 pub use peerstore::Peerstore;
+pub use retry_info::RetryInfo;
 pub use rootstore::RootStore;
 pub use systemstore::Systemstore;
 

--- a/crates/storage/src/stores/peerstore.rs
+++ b/crates/storage/src/stores/peerstore.rs
@@ -83,6 +83,32 @@ impl<S: Store> Peerstore<S> {
         let txn = self.store.new_txn(true).await?;
         txn.has(&key.bytes()).await
     }
+
+    /// Store P2P collection subscriptions (persists across restarts).
+    pub async fn set_p2p_collections(&self, data: &[u8]) -> Result<()> {
+        let mut txn = self.store.new_txn(false).await?;
+        txn.set(b"/p2p/collections", data).await?;
+        txn.commit().await
+    }
+
+    /// Load stored P2P collection subscriptions.
+    pub async fn get_p2p_collections(&self) -> Result<Option<Vec<u8>>> {
+        let txn = self.store.new_txn(true).await?;
+        txn.get(b"/p2p/collections").await
+    }
+
+    /// Store P2P document subscriptions (persists across restarts).
+    pub async fn set_p2p_documents(&self, data: &[u8]) -> Result<()> {
+        let mut txn = self.store.new_txn(false).await?;
+        txn.set(b"/p2p/documents", data).await?;
+        txn.commit().await
+    }
+
+    /// Load stored P2P document subscriptions.
+    pub async fn get_p2p_documents(&self) -> Result<Option<Vec<u8>>> {
+        let txn = self.store.new_txn(true).await?;
+        txn.get(b"/p2p/documents").await
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/crates/storage/src/stores/peerstore.rs
+++ b/crates/storage/src/stores/peerstore.rs
@@ -3,7 +3,7 @@
 /// The Peerstore handles storage of replicator configuration, replication
 /// retry tracking, and search engine retry tracking for P2P operations.
 use crate::corekv::{IterOptions, Key, Reader, Result, Store, Txn, Writer};
-use crate::keys::peerstore::ReplicatorKey;
+use crate::keys::peerstore::{ReplicatorKey, ReplicatorRetryDocIDKey, ReplicatorRetryIDKey};
 use crate::namespace::{Namespace, NamespacedStore};
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -108,6 +108,103 @@ impl<S: Store> Peerstore<S> {
     pub async fn get_p2p_documents(&self) -> Result<Option<Vec<u8>>> {
         let txn = self.store.new_txn(true).await?;
         txn.get(b"/p2p/documents").await
+    }
+
+    /// Record a push failure for a specific peer/doc pair.
+    ///
+    /// Writes the retry info at `/rep/retry/id/{peer}` and the collection_id
+    /// at `/rep/retry/doc/{peer}/{doc}`.
+    pub async fn record_push_failure(
+        &self,
+        peer_id: &str,
+        doc_id: &str,
+        collection_id: &str,
+        retry_info_bytes: &[u8],
+    ) -> Result<()> {
+        let mut txn = self.store.new_txn(false).await?;
+        let id_key = ReplicatorRetryIDKey::new(peer_id);
+        // Only write retry info if not already present (preserve existing backoff state).
+        if !txn.has(&id_key.bytes()).await? {
+            txn.set(&id_key.bytes(), retry_info_bytes).await?;
+        }
+        let doc_key = ReplicatorRetryDocIDKey::new(peer_id, doc_id);
+        txn.set(&doc_key.bytes(), collection_id.as_bytes()).await?;
+        txn.commit().await
+    }
+
+    /// Get retry info bytes for a peer.
+    pub async fn get_retry_info(&self, peer_id: &str) -> Result<Option<Vec<u8>>> {
+        let txn = self.store.new_txn(true).await?;
+        let key = ReplicatorRetryIDKey::new(peer_id);
+        txn.get(&key.bytes()).await
+    }
+
+    /// Get all peers that have pending retries.
+    ///
+    /// Returns `(peer_id, retry_info_bytes)` pairs.
+    pub async fn get_all_retry_peers(&self) -> Result<Vec<(String, Vec<u8>)>> {
+        let prefix = ReplicatorRetryIDKey::retry_prefix();
+        let txn = self.store.new_txn(true).await?;
+        let opts = IterOptions::new().with_prefix(prefix);
+        let mut iter = txn.iterator(opts).await?;
+
+        let mut results = Vec::new();
+        while let Some(pair) = iter.next().await? {
+            let key_str = String::from_utf8_lossy(&pair.key);
+            if let Some(peer_id) = key_str.strip_prefix("/rep/retry/id/") {
+                if !peer_id.is_empty() {
+                    results.push((peer_id.to_string(), pair.value));
+                }
+            }
+        }
+        Ok(results)
+    }
+
+    /// Get all doc IDs pending retry for a specific peer.
+    ///
+    /// Returns `(doc_id, collection_id)` pairs.
+    pub async fn get_retry_doc_ids(&self, peer_id: &str) -> Result<Vec<(String, String)>> {
+        let prefix = ReplicatorRetryDocIDKey::peer_prefix(peer_id);
+        let txn = self.store.new_txn(true).await?;
+        let opts = IterOptions::new().with_prefix(prefix);
+        let mut iter = txn.iterator(opts).await?;
+
+        let expected_prefix = format!("/rep/retry/doc/{}/", peer_id);
+        let mut results = Vec::new();
+        while let Some(pair) = iter.next().await? {
+            let key_str = String::from_utf8_lossy(&pair.key);
+            if let Some(doc_id) = key_str.strip_prefix(&expected_prefix) {
+                if !doc_id.is_empty() {
+                    let collection_id = String::from_utf8_lossy(&pair.value).to_string();
+                    results.push((doc_id.to_string(), collection_id));
+                }
+            }
+        }
+        Ok(results)
+    }
+
+    /// Remove a single doc retry entry for a peer.
+    pub async fn remove_retry_doc(&self, peer_id: &str, doc_id: &str) -> Result<()> {
+        let key = ReplicatorRetryDocIDKey::new(peer_id, doc_id);
+        let mut txn = self.store.new_txn(false).await?;
+        txn.delete(&key.bytes()).await?;
+        txn.commit().await
+    }
+
+    /// Clear retry info for a peer (called when all docs succeed).
+    pub async fn clear_retry_peer(&self, peer_id: &str) -> Result<()> {
+        let key = ReplicatorRetryIDKey::new(peer_id);
+        let mut txn = self.store.new_txn(false).await?;
+        txn.delete(&key.bytes()).await?;
+        txn.commit().await
+    }
+
+    /// Update the retry info for a peer (after a failed retry attempt).
+    pub async fn update_retry_info(&self, peer_id: &str, bytes: &[u8]) -> Result<()> {
+        let key = ReplicatorRetryIDKey::new(peer_id);
+        let mut txn = self.store.new_txn(false).await?;
+        txn.set(&key.bytes(), bytes).await?;
+        txn.commit().await
     }
 }
 

--- a/crates/storage/src/stores/retry_info.rs
+++ b/crates/storage/src/stores/retry_info.rs
@@ -1,0 +1,84 @@
+/// Retry information for failed replicator pushes.
+///
+/// Tracks the number of retries and the next retry time using exponential
+/// backoff intervals matching Go DefraDB's replicator retry behavior.
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Exponential backoff intervals in seconds: 30s, 1m, 2m, 4m, 8m, 16m, 32m.
+pub const RETRY_INTERVALS_SECS: &[u64] = &[30, 60, 120, 240, 480, 960, 1920];
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RetryInfo {
+    pub num_retries: u32,
+    pub next_retry_unix: u64,
+}
+
+impl RetryInfo {
+    /// Create a new RetryInfo with the first retry scheduled immediately.
+    ///
+    /// The first retry fires on the next 2-second tick rather than waiting
+    /// the full 30s, so temporarily-offline peers recover quickly.
+    pub fn new_initial() -> Self {
+        Self {
+            num_retries: 0,
+            next_retry_unix: 0,
+        }
+    }
+
+    /// Returns true if a retry is due (current time >= next_retry_unix).
+    pub fn is_due(&self) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        now >= self.next_retry_unix
+    }
+
+    /// Bump the retry counter and schedule the next retry with exponential backoff.
+    pub fn bump(&mut self) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let idx = (self.num_retries as usize).min(RETRY_INTERVALS_SECS.len() - 1);
+        self.next_retry_unix = now + RETRY_INTERVALS_SECS[idx];
+        self.num_retries += 1;
+    }
+
+    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        serde_cbor::to_vec(self).map_err(|e| format!("failed to serialize RetryInfo: {}", e))
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        serde_cbor::from_slice(bytes).map_err(|e| format!("failed to deserialize RetryInfo: {}", e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_initial_is_due() {
+        let info = RetryInfo::new_initial();
+        assert!(info.is_due());
+        assert_eq!(info.num_retries, 0);
+    }
+
+    #[test]
+    fn test_bump_advances_retry() {
+        let mut info = RetryInfo::new_initial();
+        info.bump();
+        assert_eq!(info.num_retries, 1);
+        assert!(!info.is_due());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let info = RetryInfo::new_initial();
+        let bytes = info.to_bytes().unwrap();
+        let restored = RetryInfo::from_bytes(&bytes).unwrap();
+        assert_eq!(restored.num_retries, info.num_retries);
+        assert_eq!(restored.next_retry_unix, info.next_retry_unix);
+    }
+}


### PR DESCRIPTION
## Summary

- **Disable MDNS** — Go doesn't use mDNS; leaving it enabled caused cross-test contamination and unwanted connections from other processes
- **Fix `add_external_address` bug** — identify handler was adding REMOTE peer addresses as LOCAL external addresses, causing address cross-contamination between peers. Now uses `kademlia.add_address()` instead
- **Enable TCP port reuse** — matches Go-libp2p's SO_REUSEPORT behavior so incoming connections show the peer's listen port (not ephemeral)
- **Store incoming connection addresses** — Listener `send_back_addr` is now stored in `peer_addrs` (previously only Dialer connections were stored)
- **Biased select** — prioritize swarm events before commands to prevent race conditions
- **Kademlia bootstrap on connect** — add peer to Kademlia + trigger bootstrap in `ConnectionEstablished`, enabling automatic peer discovery through the DHT
- **GossipSub PX + flood publish** — match Go's `pubsub.WithPeerExchange(true)` and `WithFloodPublish(true)`

Fixes 4 previously-failing FFI net tests:
- `TestNetInfoConnectPeers`
- `TestNetInfoConnectMultiplePeers`
- `TestNetInfoGetPeerInfo`  
- `TestP2POneToManyReplicatorWithPermissionedCollection_Error`

## Test plan

- [x] `ffi-test run net/info` — 4/4 pass (was 2/4)
- [x] `ffi-test run net/one_to_many/peer` — 1/1 pass (was 0/1)
- [x] `ffi-test run net/simple/replicator` — 18 pass, 1 fail, 1 skip (same as main)
- [x] `ffi-test run net/sync` — 4 pass, 1 fail (same as main)
- [x] `ffi-test run net/sync/collection_version` — 1 pass, 5 fail (same as main)
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)