### PR TITLE
feat(cli): Identity management and keyring-based client auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +306,18 @@ dependencies = [
  "concurrent-queue",
  "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -400,6 +424,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.3",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.3",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +491,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -763,12 +840,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -823,6 +922,15 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cbindgen"
@@ -1158,6 +1266,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1727,6 +1845,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "futures-util",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "deadqueue"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,12 +2277,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -2424,7 +2598,10 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
+ "fastrand",
  "futures-core",
+ "futures-io",
+ "parking",
  "pin-project-lite",
 ]
 
@@ -3192,7 +3369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
  "async-io",
- "core-foundation",
+ "core-foundation 0.9.4",
  "fnv",
  "futures",
  "if-addrs",
@@ -3261,6 +3438,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -3325,8 +3503,8 @@ source = "git+https://github.com/sourcenetwork/beetle?branch=main#48e70b0345ea84
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
- "async-broadcast",
- "async-channel",
+ "async-broadcast 0.4.1",
+ "async-channel 1.9.0",
  "async-stream",
  "async-trait",
  "asynchronous-codec 0.6.2",
@@ -3560,7 +3738,13 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "dbus-secret-service",
  "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.5.1",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -3607,6 +3791,15 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libipld"
@@ -4279,6 +4472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,7 +4656,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4536,6 +4738,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -4581,12 +4796,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -4606,6 +4844,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-modular"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4618,6 +4867,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
 dependencies = [
  "num-modular",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4871,6 +5131,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5116,6 +5386,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkcs8"
@@ -6072,7 +6353,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -6262,13 +6543,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6866,7 +7179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -6877,7 +7190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -7602,6 +7915,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
 
 [[package]]
 name = "uint"
@@ -8726,6 +9050,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8816,6 +9150,62 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "synstructure 0.13.2",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast 0.7.2",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -8944,4 +9334,41 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -125,7 +125,7 @@ impl Cli {
             Command::Version(args) => args.execute(),
             Command::Keyring(args) => args.execute(config),
             Command::Client(args) => args.execute(config, self.url).await,
-            Command::Identity(args) => args.execute(),
+            Command::Identity(args) => args.execute(config),
             Command::Sdl(args) => args.execute(),
             Command::ServerDump(args) => args.execute(),
         }

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -283,16 +283,11 @@ fn generate_auth_token_from_keyring(config: &Config, name: &str, audience: &str)
 ///
 /// Uses HTTPS if TLS is configured (both pubkey_path and privkey_path are set).
 pub fn get_url(config: &Config, url_override: Option<String>) -> String {
-    if let Some(url) = url_override {
-        return url;
-    }
-
-    // Use HTTPS if TLS is configured
+    let address = url_override.unwrap_or_else(|| config.api.address.clone());
     let scheme = if config.api.tls_enabled() {
         "https"
     } else {
         "http"
     };
-
-    format!("{}://{}", scheme, config.api.address)
+    format!("{}://{}", scheme, address)
 }

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -81,6 +81,10 @@ pub struct ClientArgs {
     #[arg(long, short = 'i', global = true)]
     pub identity: Option<String>,
 
+    /// Load identity from keyring by name (alternative to --identity)
+    #[arg(long, global = true)]
+    pub identity_name: Option<String>,
+
     /// Transaction ID to execute commands within
     #[arg(long, global = true)]
     pub tx: Option<u64>,
@@ -133,9 +137,11 @@ impl ClientArgs {
     pub async fn execute(&self, config: Config, url_override: Option<String>) -> Result<()> {
         let url = get_url(&config, url_override);
 
-        // Generate auth token from identity if provided
+        // Generate auth token from identity (hex key or keyring name)
         let auth_token = if let Some(ref identity_hex) = self.identity {
             Some(generate_auth_token(identity_hex, &url)?)
+        } else if let Some(ref name) = self.identity_name {
+            Some(generate_auth_token_from_keyring(&config, name, &url)?)
         } else {
             None
         };
@@ -206,6 +212,67 @@ pub fn generate_auth_token(identity_hex: &str, audience: &str) -> Result<String>
     .map_err(|e| Error::InvalidIdentity(format!("failed to generate token: {}", e)))?;
 
     // Convert bytes to string
+    String::from_utf8(token_bytes)
+        .map_err(|e| Error::InvalidIdentity(format!("token is not valid UTF-8: {}", e)))
+}
+
+/// Generate a JWT auth token from a named key in the keyring.
+fn generate_auth_token_from_keyring(config: &Config, name: &str, audience: &str) -> Result<String> {
+    use crate::config::KeyringBackend;
+    use crypto::KeyType;
+    use identity::{new_token, RawIdentity};
+    use std::path::PathBuf;
+
+    if config.keyring.disabled {
+        return Err(Error::Keyring("keyring is disabled".to_string()));
+    }
+
+    let keyring: Box<dyn keyring::Keyring> = match config.keyring.backend {
+        KeyringBackend::File => {
+            let path = {
+                let p = PathBuf::from(&config.keyring.path);
+                if p.is_absolute() {
+                    p
+                } else {
+                    config.rootdir.join(p)
+                }
+            };
+            let secret =
+                keyring::load_secret_from_env().map_err(|e| Error::Keyring(e.to_string()))?;
+            let kr = keyring::FileKeyring::open(&path, secret)
+                .map_err(|e| Error::Keyring(e.to_string()))?;
+            Box::new(kr)
+        }
+        KeyringBackend::System => {
+            let kr = keyring::SystemKeyring::open(&config.keyring.namespace);
+            Box::new(kr)
+        }
+    };
+
+    let key_bytes = keyring
+        .get(name)
+        .map_err(|e| Error::Keyring(e.to_string()))?;
+
+    let key_type = match key_bytes.len() {
+        32 => KeyType::Secp256k1,
+        64 => KeyType::Ed25519,
+        len => return Err(Error::InvalidIdentity(format!(
+            "key '{}' has invalid length: {} bytes (expected 32 for secp256k1 or 64 for ed25519)",
+            name, len
+        ))),
+    };
+
+    let identity = RawIdentity::from_bytes(key_type, &key_bytes)
+        .map_err(|e| Error::InvalidIdentity(format!("invalid key '{}': {}", name, e)))?;
+
+    let token_bytes = new_token(
+        &identity,
+        std::time::Duration::from_secs(15 * 60),
+        Some(audience.to_string()),
+        None,
+    )
+    .map_err(|e| Error::InvalidIdentity(format!("failed to generate token: {}", e)))?;
+
     String::from_utf8(token_bytes)
         .map_err(|e| Error::InvalidIdentity(format!("token is not valid UTF-8: {}", e)))
 }

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -256,10 +256,12 @@ fn generate_auth_token_from_keyring(config: &Config, name: &str, audience: &str)
     let key_type = match key_bytes.len() {
         32 => KeyType::Secp256k1,
         64 => KeyType::Ed25519,
-        len => return Err(Error::InvalidIdentity(format!(
+        len => {
+            return Err(Error::InvalidIdentity(format!(
             "key '{}' has invalid length: {} bytes (expected 32 for secp256k1 or 64 for ed25519)",
             name, len
-        ))),
+        )))
+        }
     };
 
     let identity = RawIdentity::from_bytes(key_type, &key_bytes)

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -202,11 +202,14 @@ pub fn generate_auth_token(identity_hex: &str, audience: &str) -> Result<String>
     let identity = RawIdentity::from_bytes(key_type, &key_bytes)
         .map_err(|e| Error::InvalidIdentity(format!("invalid private key: {}", e)))?;
 
+    // The audience must be bare host:port (matches Go's req.Host behavior)
+    let audience_host = strip_url_scheme(audience);
+
     // Generate JWT token with 15-minute expiration (matches Go CLI)
     let token_bytes = new_token(
         &identity,
         std::time::Duration::from_secs(15 * 60),
-        Some(audience.to_string()),
+        Some(audience_host.to_string()),
         None,
     )
     .map_err(|e| Error::InvalidIdentity(format!("failed to generate token: {}", e)))?;
@@ -267,16 +270,28 @@ fn generate_auth_token_from_keyring(config: &Config, name: &str, audience: &str)
     let identity = RawIdentity::from_bytes(key_type, &key_bytes)
         .map_err(|e| Error::InvalidIdentity(format!("invalid key '{}': {}", name, e)))?;
 
+    let audience_host = strip_url_scheme(audience);
+
     let token_bytes = new_token(
         &identity,
         std::time::Duration::from_secs(15 * 60),
-        Some(audience.to_string()),
+        Some(audience_host.to_string()),
         None,
     )
     .map_err(|e| Error::InvalidIdentity(format!("failed to generate token: {}", e)))?;
 
     String::from_utf8(token_bytes)
         .map_err(|e| Error::InvalidIdentity(format!("token is not valid UTF-8: {}", e)))
+}
+
+/// Strip the URL scheme to get bare host:port for JWT audience.
+///
+/// The server uses `req.Host` (bare host:port) as the expected audience,
+/// matching Go DefraDB behavior.
+fn strip_url_scheme(url: &str) -> &str {
+    url.strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url)
 }
 
 /// Get the URL to connect to, prioritizing command-line override.

--- a/crates/cli/src/commands/identity.rs
+++ b/crates/cli/src/commands/identity.rs
@@ -2,7 +2,8 @@
 
 use clap::{Args, Subcommand};
 
-use crate::error::Result;
+use crate::config::Config;
+use crate::error::{Error, Result};
 
 /// Manage identities
 #[derive(Args, Debug)]
@@ -24,19 +25,117 @@ pub struct IdentityNewArgs {
     /// Key type to generate (secp256k1 or ed25519)
     #[arg(long = "type", default_value = "secp256k1")]
     pub key_type: String,
+
+    /// Store the key in the keyring under this name (outputs only DID)
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Output format: text or json
+    #[arg(long, default_value = "text")]
+    pub output: String,
 }
 
 impl IdentityArgs {
-    pub fn execute(&self) -> Result<()> {
+    pub fn execute(&self, config: Config) -> Result<()> {
         match &self.command {
-            IdentityCommand::New(args) => args.execute(),
+            IdentityCommand::New(args) => args.execute(config),
         }
     }
 }
 
 impl IdentityNewArgs {
-    pub fn execute(&self) -> Result<()> {
-        eprintln!("not yet implemented");
+    pub fn execute(&self, config: Config) -> Result<()> {
+        use identity::{Identity, RawIdentity};
+
+        let identity = match self.key_type.to_lowercase().as_str() {
+            "secp256k1" => {
+                let private_key = crypto::generate_secp256k1().map_err(|e| {
+                    Error::Keyring(format!("failed to generate secp256k1 key: {}", e))
+                })?;
+                RawIdentity::from_secp256k1(private_key)?
+            }
+            "ed25519" => {
+                let private_key = crypto::generate_ed25519().map_err(|e| {
+                    Error::Keyring(format!("failed to generate ed25519 key: {}", e))
+                })?;
+                RawIdentity::from_ed25519(private_key)?
+            }
+            _ => {
+                return Err(Error::InvalidIdentity(format!(
+                    "unknown key type: '{}'. Valid types: secp256k1, ed25519",
+                    self.key_type
+                )));
+            }
+        };
+
+        let did = identity.did()?;
+        let private_key_hex = hex::encode(identity.private_key_bytes());
+
+        if let Some(ref name) = self.name {
+            let keyring = open_keyring(&config)?;
+            keyring
+                .set(name, &identity.private_key_bytes())
+                .map_err(|e| Error::Keyring(e.to_string()))?;
+
+            match self.output.to_lowercase().as_str() {
+                "json" => {
+                    let output = serde_json::json!({
+                        "did": did.to_string(),
+                        "name": name,
+                    });
+                    println!("{}", serde_json::to_string_pretty(&output)?);
+                }
+                _ => {
+                    println!("DID: {}", did);
+                }
+            }
+        } else {
+            match self.output.to_lowercase().as_str() {
+                "json" => {
+                    let output = serde_json::json!({
+                        "private_key": private_key_hex,
+                        "did": did.to_string(),
+                    });
+                    println!("{}", serde_json::to_string_pretty(&output)?);
+                }
+                _ => {
+                    println!("Private key: {}", private_key_hex);
+                    println!("DID: {}", did);
+                }
+            }
+        }
+
         Ok(())
+    }
+}
+
+fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
+    use crate::config::KeyringBackend;
+    use std::path::PathBuf;
+
+    if config.keyring.disabled {
+        return Err(Error::Keyring("keyring is disabled".to_string()));
+    }
+
+    match config.keyring.backend {
+        KeyringBackend::File => {
+            let path = {
+                let p = PathBuf::from(&config.keyring.path);
+                if p.is_absolute() {
+                    p
+                } else {
+                    config.rootdir.join(p)
+                }
+            };
+            let secret =
+                keyring::load_secret_from_env().map_err(|e| Error::Keyring(e.to_string()))?;
+            let kr = keyring::FileKeyring::open(&path, secret)
+                .map_err(|e| Error::Keyring(e.to_string()))?;
+            Ok(Box::new(kr))
+        }
+        KeyringBackend::System => {
+            let kr = keyring::SystemKeyring::open(&config.keyring.namespace);
+            Ok(Box::new(kr))
+        }
     }
 }

--- a/crates/cli/tests/client_tests.rs
+++ b/crates/cli/tests/client_tests.rs
@@ -11,7 +11,7 @@ use cli::config::{ApiConfig, Config};
 #[test]
 fn test_get_url_with_override() {
     let config = Config::default();
-    let url = get_url(&config, Some("http://custom:8080".to_string()));
+    let url = get_url(&config, Some("custom:8080".to_string()));
     assert_eq!(url, "http://custom:8080");
 }
 

--- a/crates/keyring/Cargo.toml
+++ b/crates/keyring/Cargo.toml
@@ -17,7 +17,18 @@ zeroize = "1.8"
 josekit = "0.8"
 
 # OS keyring (macOS Keychain, Linux Secret Service, Windows Credential Manager)
-# Renamed to avoid conflict with our crate name
+# Renamed to avoid conflict with our crate name.
+# Platform features required: without them keyring v3 uses a no-op mock store.
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring_crate = { package = "keyring", version = "3", features = ["apple-native"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring_crate = { package = "keyring", version = "3", features = ["sync-secret-service", "crypto-rust"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring_crate = { package = "keyring", version = "3", features = ["windows-native"] }
+
+[target.'cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))'.dependencies]
 keyring_crate = { package = "keyring", version = "3" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- **`defra identity new`** (#378): Generates secp256k1/ed25519 keys, derives `did:key` DIDs, outputs private key + DID. `--name` stores in keyring (outputs only DID). `--output json` for scripting.
- **`--identity-name`** (#379): New global flag on all client commands that loads a named key from the configured keyring, signs a JWT, and sets the `Authorization: Bearer` header — keeping private keys out of shell history and logs.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy -p cli -- -D warnings` — clean  
- [x] `cargo fmt --all` — applied
- [x] `cargo test -p cli` — 23/23 passing
- [ ] Manual: `defra identity new` outputs private key + DID
- [ ] Manual: `defra identity new --type ed25519` generates ed25519 key
- [ ] Manual: `defra identity new --name jack --keyring-backend file` stores key, outputs DID only
- [ ] Manual: `defra client query --identity-name jack '{ ... }'` authenticates via keyring

Closes #378, closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)