### PR TITLE
feat(p2p): Wire relay_enabled config to libp2p relay client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,6 +3930,7 @@ dependencies = [
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-quic",
+ "libp2p-relay",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -4145,6 +4146,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",
+ "libp2p-relay",
  "libp2p-swarm",
  "pin-project",
  "prometheus-client 0.22.3",
@@ -4216,6 +4218,31 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-relay"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1c667cfabf3dd675c8e3cea63b7b98434ecf51721b7894cbb01d29983a6a9b"
+dependencies = [
+ "asynchronous-codec 0.7.0",
+ "bytes",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tracing",
+ "void",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ ciborium = "0.2"
 
 # P2P networking
 # Note: Using 0.53 to match iroh-bitswap's dependency
-libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify"] }
+libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "relay"] }
 iroh-bitswap = { git = "https://github.com/sourcenetwork/beetle", branch = "main" }
 libp2p-stream = "0.1.0-alpha.1"
 multiaddr = "0.18"

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -111,17 +111,15 @@ impl Node {
         tokio::sync::mpsc::Receiver<p2p::HostEvent>,
         JoinHandle<()>,
     )> {
-        let enable_relay = config.net.relay_enabled;
+        let p2p_config = p2p::P2PHostConfig {
+            enable_pubsub,
+            enable_relay: config.net.relay_enabled,
+        };
         let (host, handle, events, _replicators) = match keypair {
-            Some(kp) => p2p::P2PHost::with_keypair_and_config(
-                kp,
-                bitswap_store,
-                enable_pubsub,
-                enable_relay,
-            )
-            .await
-            .map_err(Error::P2P)?,
-            None => p2p::P2PHost::with_pubsub(bitswap_store, enable_pubsub, enable_relay)
+            Some(kp) => p2p::P2PHost::with_keypair_and_config(kp, bitswap_store, p2p_config)
+                .await
+                .map_err(Error::P2P)?,
+            None => p2p::P2PHost::with_config(bitswap_store, p2p_config)
                 .await
                 .map_err(Error::P2P)?,
         };
@@ -152,7 +150,7 @@ impl Node {
         }
 
         if config.net.relay_enabled {
-            info!("Relay client enabled");
+            info!("Relay client transport enabled");
         } else {
             info!("Relay client disabled");
         }

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -1,7 +1,7 @@
 //! P2P initialization methods for Node
 
 use tokio::task::JoinHandle;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use super::node::Node;
 use crate::config::Config;
@@ -111,11 +111,17 @@ impl Node {
         tokio::sync::mpsc::Receiver<p2p::HostEvent>,
         JoinHandle<()>,
     )> {
+        let enable_relay = config.net.relay_enabled;
         let (host, handle, events, _replicators) = match keypair {
-            Some(kp) => p2p::P2PHost::with_keypair_and_config(kp, bitswap_store, enable_pubsub)
-                .await
-                .map_err(Error::P2P)?,
-            None => p2p::P2PHost::with_pubsub(bitswap_store, enable_pubsub)
+            Some(kp) => p2p::P2PHost::with_keypair_and_config(
+                kp,
+                bitswap_store,
+                enable_pubsub,
+                enable_relay,
+            )
+            .await
+            .map_err(Error::P2P)?,
+            None => p2p::P2PHost::with_pubsub(bitswap_store, enable_pubsub, enable_relay)
                 .await
                 .map_err(Error::P2P)?,
         };
@@ -146,7 +152,9 @@ impl Node {
         }
 
         if config.net.relay_enabled {
-            warn!("net.relay_enabled=true is not yet supported; relay is not available");
+            info!("Relay client enabled");
+        } else {
+            info!("Relay client disabled");
         }
 
         // Get and display peer ID

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -19,7 +19,7 @@ identity = { path = "../identity" }
 acp = { path = "../acp" }
 
 # P2P
-libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad"] }
+libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad", "relay"] }
 iroh-bitswap = { workspace = true }
 libp2p-stream = { workspace = true }
 multiaddr = { workspace = true }

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -32,6 +32,7 @@ use libp2p::{
     gossipsub::{self, MessageAuthenticity, MessageId, ValidationMode},
     identify,
     kad::{self, store::MemoryStore, Mode},
+    relay,
     request_response::{self, ProtocolSupport},
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
     PeerId, StreamProtocol,
@@ -67,6 +68,9 @@ pub struct DefraBehaviour<S: Store> {
     /// GossipSub for pubsub messaging (optional, controlled by `pubsub_enabled` config).
     pub gossipsub: Toggle<gossipsub::Behaviour>,
 
+    /// Relay client for circuit relay (optional, controlled by `relay_enabled` config).
+    pub relay: Toggle<relay::client::Behaviour>,
+
     /// Raw stream protocol for Go two-stream compatibility.
     /// Go's DefraDB uses separate streams for request and response.
     pub stream: stream::Behaviour,
@@ -89,6 +93,9 @@ pub enum DefraEvent {
 
     /// GossipSub event.
     GossipSub(gossipsub::Event),
+
+    /// Relay client event.
+    Relay(relay::client::Event),
 }
 
 impl From<identify::Event> for DefraEvent {
@@ -118,6 +125,12 @@ impl From<request_response::Event<PushLogRequest, PushLogReply>> for DefraEvent 
 impl From<gossipsub::Event> for DefraEvent {
     fn from(event: gossipsub::Event) -> Self {
         DefraEvent::GossipSub(event)
+    }
+}
+
+impl From<relay::client::Event> for DefraEvent {
+    fn from(event: relay::client::Event) -> Self {
+        DefraEvent::Relay(event)
     }
 }
 
@@ -228,6 +241,7 @@ impl<S: Store> DefraBehaviour<S> {
             bitswap,
             pushlog,
             gossipsub,
+            relay: Toggle::from(None),
             stream,
         })
     }
@@ -313,6 +327,7 @@ impl<S: Store> DefraBehaviour<S> {
             bitswap,
             pushlog,
             gossipsub,
+            relay: Toggle::from(None),
             stream,
         })
     }

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -7,6 +7,7 @@
 //! - Bitswap for block exchange (Go compatibility via iroh-bitswap)
 //! - Request-response for PushLog synchronization
 //! - GossipSub for pubsub messaging
+//! - Circuit relay client for NAT traversal (optional)
 //!
 //! # Wire Compatibility with Go
 //!
@@ -69,6 +70,7 @@ pub struct DefraBehaviour<S: Store> {
     pub gossipsub: Toggle<gossipsub::Behaviour>,
 
     /// Relay client for circuit relay (optional, controlled by `relay_enabled` config).
+    /// Initialized as disabled; the SwarmBuilder injects the client when relay is enabled.
     pub relay: Toggle<relay::client::Behaviour>,
 
     /// Raw stream protocol for Go two-stream compatibility.

--- a/crates/p2p/src/host/mod.rs
+++ b/crates/p2p/src/host/mod.rs
@@ -13,7 +13,7 @@ mod p2p_host;
 pub use command::HostCommand;
 pub use event::HostEvent;
 pub use handle::P2PHostHandle;
-pub use p2p_host::P2PHost;
+pub use p2p_host::{P2PHost, P2PHostConfig};
 
 use libp2p::request_response;
 

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -14,7 +14,8 @@ use std::time::Duration;
 use futures::StreamExt;
 use iroh_bitswap::Store;
 use libp2p::{
-    identity::Keypair, noise, request_response, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder,
+    identity::Keypair, noise, request_response, swarm::behaviour::toggle::Toggle, tcp, yamux,
+    Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -82,10 +83,11 @@ impl<S: Store> P2PHost<S> {
         Self::with_keypair(keypair, bitswap_store).await
     }
 
-    /// Create a new P2P host with pubsub optionally disabled.
+    /// Create a new P2P host with pubsub and relay optionally configured.
     pub async fn with_pubsub(
         bitswap_store: S,
         enable_pubsub: bool,
+        enable_relay: bool,
     ) -> Result<(
         Self,
         P2PHostHandle,
@@ -93,7 +95,7 @@ impl<S: Store> P2PHost<S> {
         Arc<ReplicatorRegistry>,
     )> {
         let keypair = Keypair::generate_ed25519();
-        Self::with_keypair_and_config(keypair, bitswap_store, enable_pubsub).await
+        Self::with_keypair_and_config(keypair, bitswap_store, enable_pubsub, enable_relay).await
     }
 
     /// Create a new P2P host with the given keypair and blockstore.
@@ -121,14 +123,15 @@ impl<S: Store> P2PHost<S> {
         mpsc::Receiver<HostEvent>,
         Arc<ReplicatorRegistry>,
     )> {
-        Self::with_keypair_and_config(keypair, bitswap_store, true).await
+        Self::with_keypair_and_config(keypair, bitswap_store, true, false).await
     }
 
-    /// Create a new P2P host with the given keypair, blockstore, and pubsub config.
+    /// Create a new P2P host with the given keypair, blockstore, and config options.
     pub async fn with_keypair_and_config(
         keypair: Keypair,
         bitswap_store: S,
         enable_pubsub: bool,
+        enable_relay: bool,
     ) -> Result<(
         Self,
         P2PHostHandle,
@@ -144,7 +147,7 @@ impl<S: Store> P2PHost<S> {
         info!("Local peer ID: {}", local_peer_id);
 
         // Pass keypair and blockstore to behaviour for message signing and block exchange
-        let behaviour = DefraBehaviour::new(
+        let mut behaviour = DefraBehaviour::new(
             local_peer_id,
             local_public_key,
             keypair.clone(),
@@ -159,14 +162,33 @@ impl<S: Store> P2PHost<S> {
         // remote side sees the listen address (not an ephemeral port).
         // This is critical for ActivePeers to return correct addresses.
         let tcp_config = tcp::Config::default().port_reuse(true);
-        let swarm = SwarmBuilder::with_existing_identity(keypair.clone())
-            .with_tokio()
-            .with_tcp(tcp_config, noise::Config::new, yamux::Config::default)
-            .map_err(|e| Error::Transport(e.to_string()))?
-            .with_behaviour(|_key| behaviour)
-            .expect("behaviour already constructed")
-            .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(IDLE_CONNECTION_TIMEOUT))
-            .build();
+
+        // Two builder paths required: `.with_relay_client()` changes the
+        // SwarmBuilder's generic types so it cannot be called conditionally.
+        let swarm = if enable_relay {
+            SwarmBuilder::with_existing_identity(keypair.clone())
+                .with_tokio()
+                .with_tcp(tcp_config, noise::Config::new, yamux::Config::default)
+                .map_err(|e| Error::Transport(e.to_string()))?
+                .with_relay_client(noise::Config::new, yamux::Config::default)
+                .map_err(|e| Error::Transport(e.to_string()))?
+                .with_behaviour(|_key, relay_client| {
+                    behaviour.relay = Toggle::from(Some(relay_client));
+                    behaviour
+                })
+                .expect("behaviour already constructed")
+                .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(IDLE_CONNECTION_TIMEOUT))
+                .build()
+        } else {
+            SwarmBuilder::with_existing_identity(keypair.clone())
+                .with_tokio()
+                .with_tcp(tcp_config, noise::Config::new, yamux::Config::default)
+                .map_err(|e| Error::Transport(e.to_string()))?
+                .with_behaviour(|_key| behaviour)
+                .expect("behaviour already constructed")
+                .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(IDLE_CONNECTION_TIMEOUT))
+                .build()
+        };
 
         let (command_tx, command_rx) = mpsc::channel(256);
         let (event_tx, event_rx) = mpsc::channel(256);

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -35,6 +35,22 @@ use super::ResponseChannel;
 /// Default idle connection timeout.
 const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Configuration options for P2P host construction.
+#[derive(Debug, Clone)]
+pub struct P2PHostConfig {
+    pub enable_pubsub: bool,
+    pub enable_relay: bool,
+}
+
+impl Default for P2PHostConfig {
+    fn default() -> Self {
+        Self {
+            enable_pubsub: true,
+            enable_relay: false,
+        }
+    }
+}
+
 /// P2P Host that manages the libp2p swarm.
 pub struct P2PHost<S: Store> {
     pub(super) swarm: Swarm<DefraBehaviour<S>>,
@@ -83,11 +99,10 @@ impl<S: Store> P2PHost<S> {
         Self::with_keypair(keypair, bitswap_store).await
     }
 
-    /// Create a new P2P host with pubsub and relay optionally configured.
-    pub async fn with_pubsub(
+    /// Create a new P2P host with the given config options.
+    pub async fn with_config(
         bitswap_store: S,
-        enable_pubsub: bool,
-        enable_relay: bool,
+        config: P2PHostConfig,
     ) -> Result<(
         Self,
         P2PHostHandle,
@@ -95,10 +110,12 @@ impl<S: Store> P2PHost<S> {
         Arc<ReplicatorRegistry>,
     )> {
         let keypair = Keypair::generate_ed25519();
-        Self::with_keypair_and_config(keypair, bitswap_store, enable_pubsub, enable_relay).await
+        Self::with_keypair_and_config(keypair, bitswap_store, config).await
     }
 
     /// Create a new P2P host with the given keypair and blockstore.
+    ///
+    /// Uses default config: pubsub enabled, relay disabled.
     ///
     /// # Arguments
     ///
@@ -123,15 +140,20 @@ impl<S: Store> P2PHost<S> {
         mpsc::Receiver<HostEvent>,
         Arc<ReplicatorRegistry>,
     )> {
-        Self::with_keypair_and_config(keypair, bitswap_store, true, false).await
+        Self::with_keypair_and_config(keypair, bitswap_store, P2PHostConfig::default()).await
     }
 
     /// Create a new P2P host with the given keypair, blockstore, and config options.
+    ///
+    /// # Arguments
+    ///
+    /// * `keypair` - The identity keypair for this node
+    /// * `bitswap_store` - The blockstore for Bitswap block exchange
+    /// * `config` - P2P host configuration (pubsub, relay toggles)
     pub async fn with_keypair_and_config(
         keypair: Keypair,
         bitswap_store: S,
-        enable_pubsub: bool,
-        enable_relay: bool,
+        config: P2PHostConfig,
     ) -> Result<(
         Self,
         P2PHostHandle,
@@ -152,7 +174,7 @@ impl<S: Store> P2PHost<S> {
             local_public_key,
             keypair.clone(),
             bitswap_store,
-            enable_pubsub,
+            config.enable_pubsub,
         )
         .await
         .map_err(|e| Error::Behaviour(e.to_string()))?;
@@ -163,9 +185,11 @@ impl<S: Store> P2PHost<S> {
         // This is critical for ActivePeers to return correct addresses.
         let tcp_config = tcp::Config::default().port_reuse(true);
 
-        // Two builder paths required: `.with_relay_client()` changes the
-        // SwarmBuilder's generic types so it cannot be called conditionally.
-        let swarm = if enable_relay {
+        // Two builder paths required: libp2p's SwarmBuilder uses a typestate
+        // pattern where `.with_relay_client()` transitions to a different builder
+        // type (different `.with_behaviour()` closure signature), so it cannot be
+        // called conditionally on a single builder chain.
+        let swarm = if config.enable_relay {
             SwarmBuilder::with_existing_identity(keypair.clone())
                 .with_tokio()
                 .with_tcp(tcp_config, noise::Config::new, yamux::Config::default)

--- a/crates/p2p/src/host/p2p_host/swarm.rs
+++ b/crates/p2p/src/host/p2p_host/swarm.rs
@@ -119,6 +119,10 @@ impl<S: Store> P2PHost<S> {
                 self.handle_bitswap_event(bitswap_event).await;
             }
 
+            SwarmEvent::Behaviour(DefraEvent::Relay(relay_event)) => {
+                debug!(event = ?relay_event, "Relay client event");
+            }
+
             SwarmEvent::Behaviour(DefraEvent::Kademlia(kad_event)) => {
                 self.handle_kademlia_event(kad_event).await;
             }

--- a/crates/p2p/src/host/p2p_host/swarm.rs
+++ b/crates/p2p/src/host/p2p_host/swarm.rs
@@ -120,7 +120,38 @@ impl<S: Store> P2PHost<S> {
             }
 
             SwarmEvent::Behaviour(DefraEvent::Relay(relay_event)) => {
-                debug!(event = ?relay_event, "Relay client event");
+                use libp2p::relay;
+                match relay_event {
+                    relay::client::Event::ReservationReqAccepted {
+                        relay_peer_id,
+                        renewal,
+                        limit,
+                    } => {
+                        info!(
+                            relay_peer_id = %relay_peer_id,
+                            renewal = renewal,
+                            limit = ?limit,
+                            "Relay reservation accepted"
+                        );
+                    }
+                    relay::client::Event::OutboundCircuitEstablished {
+                        relay_peer_id,
+                        limit,
+                    } => {
+                        info!(
+                            relay_peer_id = %relay_peer_id,
+                            limit = ?limit,
+                            "Outbound relay circuit established"
+                        );
+                    }
+                    relay::client::Event::InboundCircuitEstablished { src_peer_id, limit } => {
+                        info!(
+                            src_peer_id = %src_peer_id,
+                            limit = ?limit,
+                            "Inbound relay circuit established"
+                        );
+                    }
+                }
             }
 
             SwarmEvent::Behaviour(DefraEvent::Kademlia(kad_event)) => {

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -69,7 +69,7 @@ pub mod two_stream;
 
 // Re-export main types for convenience
 pub use error::{Error, Result};
-pub use host::{HostCommand, HostEvent, P2PHost, P2PHostHandle, ResponseChannel};
+pub use host::{HostCommand, HostEvent, P2PHost, P2PHostConfig, P2PHostHandle, ResponseChannel};
 pub use message::{Message, MetaData, PushLogBroadcast, PushLogReply, PushLogRequest};
 pub use protocol::{
     BASE_PROTOCOL_ID, CODE, MESSAGE_VERSION, NAME, PROTOCOL_BASE, REP_REQUEST_PROTOCOL,


### PR DESCRIPTION
## Summary
- Connects `NetConfig.relay_enabled` to actual libp2p relay client behaviour, replacing the previous "not yet supported" warning
- Uses two SwarmBuilder code paths (with/without `.with_relay_client()`) since the relay method changes the builder's generic types
- Adds `Toggle<relay::client::Behaviour>` field to `DefraBehaviour` and handles relay events at debug level

## Test plan
- [x] `cargo build` compiles with both builder paths
- [x] `cargo test -p p2p` — all 72 unit tests + integration tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all` — formatted
- [ ] `ffi-test run` on a P2P test package — FFI compatibility (relay default=false matches Go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)