### PR TITLE
feat(keyring): Add systemd-creds backend for headless Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,6 +3737,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
+ "tracing",
  "zeroize",
 ]
 

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -249,7 +249,7 @@ fn generate_auth_token_from_keyring(config: &Config, name: &str, audience: &str)
         KeyringBackend::System => {
             #[cfg(target_os = "linux")]
             {
-                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
+                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
                     Box::new(keyring::SystemKeyring::open(&config.keyring.namespace))
                 } else if keyring::systemd_creds_available() {
                     let p = PathBuf::from(&config.keyring.path);

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -252,6 +252,9 @@ fn generate_auth_token_from_keyring(config: &Config, name: &str, audience: &str)
                 if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
                     Box::new(keyring::SystemKeyring::open(&config.keyring.namespace))
                 } else if keyring::systemd_creds_available() {
+                    tracing::warn!(
+                        "no D-Bus session available; falling back to systemd-creds keyring"
+                    );
                     let p = PathBuf::from(&config.keyring.path);
                     let path = if p.is_absolute() {
                         p

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -247,8 +247,52 @@ fn generate_auth_token_from_keyring(config: &Config, name: &str, audience: &str)
             Box::new(kr)
         }
         KeyringBackend::System => {
-            let kr = keyring::SystemKeyring::open(&config.keyring.namespace);
-            Box::new(kr)
+            #[cfg(target_os = "linux")]
+            {
+                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
+                    Box::new(keyring::SystemKeyring::open(&config.keyring.namespace))
+                } else if keyring::systemd_creds_available() {
+                    let p = PathBuf::from(&config.keyring.path);
+                    let path = if p.is_absolute() {
+                        p
+                    } else {
+                        config.rootdir.join(p)
+                    };
+                    let kr = keyring::SystemdCredsKeyring::open(&path)
+                        .map_err(|e| Error::Keyring(e.to_string()))?;
+                    Box::new(kr)
+                } else {
+                    return Err(Error::Keyring(
+                        "no system keyring available: no D-Bus session for secret-service \
+                         and systemd-creds not found; use --keyring-backend file"
+                            .to_string(),
+                    ));
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Box::new(keyring::SystemKeyring::open(&config.keyring.namespace))
+            }
+        }
+        KeyringBackend::SystemdCreds => {
+            #[cfg(target_os = "linux")]
+            {
+                let p = PathBuf::from(&config.keyring.path);
+                let path = if p.is_absolute() {
+                    p
+                } else {
+                    config.rootdir.join(p)
+                };
+                let kr = keyring::SystemdCredsKeyring::open(&path)
+                    .map_err(|e| Error::Keyring(e.to_string()))?;
+                Box::new(kr)
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                return Err(Error::Keyring(
+                    "systemd-creds backend is only available on Linux".to_string(),
+                ));
+            }
         }
     };
 

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -221,83 +221,10 @@ pub fn generate_auth_token(identity_hex: &str, audience: &str) -> Result<String>
 
 /// Generate a JWT auth token from a named key in the keyring.
 fn generate_auth_token_from_keyring(config: &Config, name: &str, audience: &str) -> Result<String> {
-    use crate::config::KeyringBackend;
     use crypto::KeyType;
     use identity::{new_token, RawIdentity};
-    use std::path::PathBuf;
 
-    if config.keyring.disabled {
-        return Err(Error::Keyring("keyring is disabled".to_string()));
-    }
-
-    let keyring: Box<dyn keyring::Keyring> = match config.keyring.backend {
-        KeyringBackend::File => {
-            let path = {
-                let p = PathBuf::from(&config.keyring.path);
-                if p.is_absolute() {
-                    p
-                } else {
-                    config.rootdir.join(p)
-                }
-            };
-            let secret =
-                keyring::load_secret_from_env().map_err(|e| Error::Keyring(e.to_string()))?;
-            let kr = keyring::FileKeyring::open(&path, secret)
-                .map_err(|e| Error::Keyring(e.to_string()))?;
-            Box::new(kr)
-        }
-        KeyringBackend::System => {
-            #[cfg(target_os = "linux")]
-            {
-                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
-                    Box::new(keyring::SystemKeyring::open(&config.keyring.namespace))
-                } else if keyring::systemd_creds_available() {
-                    tracing::warn!(
-                        "no D-Bus session available; falling back to systemd-creds keyring"
-                    );
-                    let p = PathBuf::from(&config.keyring.path);
-                    let path = if p.is_absolute() {
-                        p
-                    } else {
-                        config.rootdir.join(p)
-                    };
-                    let kr = keyring::SystemdCredsKeyring::open(&path)
-                        .map_err(|e| Error::Keyring(e.to_string()))?;
-                    Box::new(kr)
-                } else {
-                    return Err(Error::Keyring(
-                        "no system keyring available: no D-Bus session for secret-service \
-                         and systemd-creds not found; use --keyring-backend file"
-                            .to_string(),
-                    ));
-                }
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                Box::new(keyring::SystemKeyring::open(&config.keyring.namespace))
-            }
-        }
-        KeyringBackend::SystemdCreds => {
-            #[cfg(target_os = "linux")]
-            {
-                let p = PathBuf::from(&config.keyring.path);
-                let path = if p.is_absolute() {
-                    p
-                } else {
-                    config.rootdir.join(p)
-                };
-                let kr = keyring::SystemdCredsKeyring::open(&path)
-                    .map_err(|e| Error::Keyring(e.to_string()))?;
-                Box::new(kr)
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                return Err(Error::Keyring(
-                    "systemd-creds backend is only available on Linux".to_string(),
-                ));
-            }
-        }
-    };
+    let keyring = super::open_keyring(config)?;
 
     let key_bytes = keyring
         .get(name)

--- a/crates/cli/src/commands/identity.rs
+++ b/crates/cli/src/commands/identity.rs
@@ -72,7 +72,7 @@ impl IdentityNewArgs {
         let private_key_hex = hex::encode(identity.private_key_bytes());
 
         if let Some(ref name) = self.name {
-            let keyring = open_keyring(&config)?;
+            let keyring = super::open_keyring(&config)?;
             keyring
                 .set(name, &identity.private_key_bytes())
                 .map_err(|e| Error::Keyring(e.to_string()))?;
@@ -106,87 +106,5 @@ impl IdentityNewArgs {
         }
 
         Ok(())
-    }
-}
-
-fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
-    use crate::config::KeyringBackend;
-    use std::path::PathBuf;
-
-    if config.keyring.disabled {
-        return Err(Error::Keyring("keyring is disabled".to_string()));
-    }
-
-    match config.keyring.backend {
-        KeyringBackend::File => {
-            let path = {
-                let p = PathBuf::from(&config.keyring.path);
-                if p.is_absolute() {
-                    p
-                } else {
-                    config.rootdir.join(p)
-                }
-            };
-            let secret =
-                keyring::load_secret_from_env().map_err(|e| Error::Keyring(e.to_string()))?;
-            let kr = keyring::FileKeyring::open(&path, secret)
-                .map_err(|e| Error::Keyring(e.to_string()))?;
-            Ok(Box::new(kr))
-        }
-        KeyringBackend::System => {
-            #[cfg(target_os = "linux")]
-            {
-                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
-                    Ok(Box::new(keyring::SystemKeyring::open(
-                        &config.keyring.namespace,
-                    )))
-                } else if keyring::systemd_creds_available() {
-                    tracing::warn!(
-                        "no D-Bus session available; falling back to systemd-creds keyring"
-                    );
-                    let p = PathBuf::from(&config.keyring.path);
-                    let path = if p.is_absolute() {
-                        p
-                    } else {
-                        config.rootdir.join(p)
-                    };
-                    let kr = keyring::SystemdCredsKeyring::open(&path)
-                        .map_err(|e| Error::Keyring(e.to_string()))?;
-                    Ok(Box::new(kr))
-                } else {
-                    Err(Error::Keyring(
-                        "no system keyring available: no D-Bus session for secret-service \
-                         and systemd-creds not found; use --keyring-backend file"
-                            .to_string(),
-                    ))
-                }
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                Ok(Box::new(keyring::SystemKeyring::open(
-                    &config.keyring.namespace,
-                )))
-            }
-        }
-        KeyringBackend::SystemdCreds => {
-            #[cfg(target_os = "linux")]
-            {
-                let p = PathBuf::from(&config.keyring.path);
-                let path = if p.is_absolute() {
-                    p
-                } else {
-                    config.rootdir.join(p)
-                };
-                let kr = keyring::SystemdCredsKeyring::open(&path)
-                    .map_err(|e| Error::Keyring(e.to_string()))?;
-                Ok(Box::new(kr))
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                Err(Error::Keyring(
-                    "systemd-creds backend is only available on Linux".to_string(),
-                ))
-            }
-        }
     }
 }

--- a/crates/cli/src/commands/identity.rs
+++ b/crates/cli/src/commands/identity.rs
@@ -136,7 +136,7 @@ fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
         KeyringBackend::System => {
             #[cfg(target_os = "linux")]
             {
-                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
+                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
                     Ok(Box::new(keyring::SystemKeyring::open(
                         &config.keyring.namespace,
                     )))

--- a/crates/cli/src/commands/identity.rs
+++ b/crates/cli/src/commands/identity.rs
@@ -141,6 +141,9 @@ fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
                         &config.keyring.namespace,
                     )))
                 } else if keyring::systemd_creds_available() {
+                    tracing::warn!(
+                        "no D-Bus session available; falling back to systemd-creds keyring"
+                    );
                     let p = PathBuf::from(&config.keyring.path);
                     let path = if p.is_absolute() {
                         p

--- a/crates/cli/src/commands/identity.rs
+++ b/crates/cli/src/commands/identity.rs
@@ -134,8 +134,56 @@ fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
             Ok(Box::new(kr))
         }
         KeyringBackend::System => {
-            let kr = keyring::SystemKeyring::open(&config.keyring.namespace);
-            Ok(Box::new(kr))
+            #[cfg(target_os = "linux")]
+            {
+                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
+                    Ok(Box::new(keyring::SystemKeyring::open(
+                        &config.keyring.namespace,
+                    )))
+                } else if keyring::systemd_creds_available() {
+                    let p = PathBuf::from(&config.keyring.path);
+                    let path = if p.is_absolute() {
+                        p
+                    } else {
+                        config.rootdir.join(p)
+                    };
+                    let kr = keyring::SystemdCredsKeyring::open(&path)
+                        .map_err(|e| Error::Keyring(e.to_string()))?;
+                    Ok(Box::new(kr))
+                } else {
+                    Err(Error::Keyring(
+                        "no system keyring available: no D-Bus session for secret-service \
+                         and systemd-creds not found; use --keyring-backend file"
+                            .to_string(),
+                    ))
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Ok(Box::new(keyring::SystemKeyring::open(
+                    &config.keyring.namespace,
+                )))
+            }
+        }
+        KeyringBackend::SystemdCreds => {
+            #[cfg(target_os = "linux")]
+            {
+                let p = PathBuf::from(&config.keyring.path);
+                let path = if p.is_absolute() {
+                    p
+                } else {
+                    config.rootdir.join(p)
+                };
+                let kr = keyring::SystemdCredsKeyring::open(&path)
+                    .map_err(|e| Error::Keyring(e.to_string()))?;
+                Ok(Box::new(kr))
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Err(Error::Keyring(
+                    "systemd-creds backend is only available on Linux".to_string(),
+                ))
+            }
         }
     }
 }

--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -231,8 +231,46 @@ fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
             Ok(Box::new(kr))
         }
         KeyringBackend::System => {
-            let kr = keyring::SystemKeyring::open(&config.keyring.namespace);
-            Ok(Box::new(kr))
+            #[cfg(target_os = "linux")]
+            {
+                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
+                    Ok(Box::new(keyring::SystemKeyring::open(
+                        &config.keyring.namespace,
+                    )))
+                } else if keyring::systemd_creds_available() {
+                    let path = resolve_keyring_path(config)?;
+                    let kr = keyring::SystemdCredsKeyring::open(&path)
+                        .map_err(|e| Error::Keyring(e.to_string()))?;
+                    Ok(Box::new(kr))
+                } else {
+                    Err(Error::Keyring(
+                        "no system keyring available: no D-Bus session for secret-service \
+                         and systemd-creds not found; use --keyring-backend file"
+                            .to_string(),
+                    ))
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Ok(Box::new(keyring::SystemKeyring::open(
+                    &config.keyring.namespace,
+                )))
+            }
+        }
+        KeyringBackend::SystemdCreds => {
+            #[cfg(target_os = "linux")]
+            {
+                let path = resolve_keyring_path(config)?;
+                let kr = keyring::SystemdCredsKeyring::open(&path)
+                    .map_err(|e| Error::Keyring(e.to_string()))?;
+                Ok(Box::new(kr))
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Err(Error::Keyring(
+                    "systemd-creds backend is only available on Linux".to_string(),
+                ))
+            }
         }
     }
 }

--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -238,6 +238,9 @@ fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
                         &config.keyring.namespace,
                     )))
                 } else if keyring::systemd_creds_available() {
+                    tracing::warn!(
+                        "no D-Bus session available; falling back to systemd-creds keyring"
+                    );
                     let path = resolve_keyring_path(config)?;
                     let kr = keyring::SystemdCredsKeyring::open(&path)
                         .map_err(|e| Error::Keyring(e.to_string()))?;

--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -1,7 +1,6 @@
 //! Keyring command implementation
 
 use std::io::{self, BufRead, IsTerminal, Read, Write};
-use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 
@@ -61,7 +60,7 @@ impl GenerateArgs {
     pub fn execute(self, config: Config) -> Result<()> {
         use crypto::Key;
 
-        let keyring = open_keyring(&config)?;
+        let keyring = super::open_keyring(&config)?;
 
         let (key, description) = match self.key_type.to_lowercase().as_str() {
             "ed25519" => {
@@ -112,7 +111,7 @@ pub struct ExportArgs {
 
 impl ExportArgs {
     pub fn execute(self, config: Config) -> Result<()> {
-        let keyring = open_keyring(&config)?;
+        let keyring = super::open_keyring(&config)?;
 
         let key = keyring
             .get(&self.name)
@@ -142,7 +141,7 @@ pub struct ImportArgs {
 
 impl ImportArgs {
     pub fn execute(self, config: Config) -> Result<()> {
-        let keyring = open_keyring(&config)?;
+        let keyring = super::open_keyring(&config)?;
 
         // Read from stdin
         let stdin = io::stdin();
@@ -180,7 +179,7 @@ pub struct DeleteArgs {
 
 impl DeleteArgs {
     pub fn execute(self, config: Config) -> Result<()> {
-        let keyring = open_keyring(&config)?;
+        let keyring = super::open_keyring(&config)?;
 
         keyring
             .delete(&self.name)
@@ -197,7 +196,7 @@ pub struct ListArgs {}
 
 impl ListArgs {
     pub fn execute(self, config: Config) -> Result<()> {
-        let keyring = open_keyring(&config)?;
+        let keyring = super::open_keyring(&config)?;
 
         let keys = keyring.list().map_err(|e| Error::Keyring(e.to_string()))?;
 
@@ -210,81 +209,6 @@ impl ListArgs {
         }
 
         Ok(())
-    }
-}
-
-/// Open the appropriate keyring based on config
-fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
-    use crate::config::KeyringBackend;
-
-    if config.keyring.disabled {
-        return Err(Error::Keyring("keyring is disabled".to_string()));
-    }
-
-    match config.keyring.backend {
-        KeyringBackend::File => {
-            let path = resolve_keyring_path(config)?;
-            let secret =
-                keyring::load_secret_from_env().map_err(|e| Error::Keyring(e.to_string()))?;
-            let kr = keyring::FileKeyring::open(&path, secret)
-                .map_err(|e| Error::Keyring(e.to_string()))?;
-            Ok(Box::new(kr))
-        }
-        KeyringBackend::System => {
-            #[cfg(target_os = "linux")]
-            {
-                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
-                    Ok(Box::new(keyring::SystemKeyring::open(
-                        &config.keyring.namespace,
-                    )))
-                } else if keyring::systemd_creds_available() {
-                    tracing::warn!(
-                        "no D-Bus session available; falling back to systemd-creds keyring"
-                    );
-                    let path = resolve_keyring_path(config)?;
-                    let kr = keyring::SystemdCredsKeyring::open(&path)
-                        .map_err(|e| Error::Keyring(e.to_string()))?;
-                    Ok(Box::new(kr))
-                } else {
-                    Err(Error::Keyring(
-                        "no system keyring available: no D-Bus session for secret-service \
-                         and systemd-creds not found; use --keyring-backend file"
-                            .to_string(),
-                    ))
-                }
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                Ok(Box::new(keyring::SystemKeyring::open(
-                    &config.keyring.namespace,
-                )))
-            }
-        }
-        KeyringBackend::SystemdCreds => {
-            #[cfg(target_os = "linux")]
-            {
-                let path = resolve_keyring_path(config)?;
-                let kr = keyring::SystemdCredsKeyring::open(&path)
-                    .map_err(|e| Error::Keyring(e.to_string()))?;
-                Ok(Box::new(kr))
-            }
-            #[cfg(not(target_os = "linux"))]
-            {
-                Err(Error::Keyring(
-                    "systemd-creds backend is only available on Linux".to_string(),
-                ))
-            }
-        }
-    }
-}
-
-/// Resolve the keyring path, using rootdir if path is relative
-fn resolve_keyring_path(config: &Config) -> Result<PathBuf> {
-    let path = PathBuf::from(&config.keyring.path);
-    if path.is_absolute() {
-        Ok(path)
-    } else {
-        Ok(config.rootdir.join(path))
     }
 }
 

--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -233,7 +233,7 @@ fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
         KeyringBackend::System => {
             #[cfg(target_os = "linux")]
             {
-                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
+                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
                     Ok(Box::new(keyring::SystemKeyring::open(
                         &config.keyring.namespace,
                     )))

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -23,8 +23,8 @@ use crate::error::{Error, Result};
 
 /// Open the appropriate keyring based on config.
 ///
-/// Handles all backend types including auto-detection of systemd-creds
-/// fallback on Linux when no D-Bus session is available.
+/// On Linux, the System backend falls back to systemd-creds
+/// when no D-Bus session is available.
 pub(crate) fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
     use crate::config::KeyringBackend;
 
@@ -49,13 +49,15 @@ pub(crate) fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>>
                         &config.keyring.namespace,
                     )))
                 } else if keyring::systemd_creds_available() {
+                    eprintln!(
+                        "WARNING: no D-Bus session available; using systemd-creds keyring \
+                         instead of secret-service. Keys are stored as .cred files in {:?}.",
+                        resolve_keyring_path(config).unwrap_or_default()
+                    );
                     tracing::warn!(
                         "no D-Bus session available; falling back to systemd-creds keyring"
                     );
-                    let path = resolve_keyring_path(config)?;
-                    let kr = keyring::SystemdCredsKeyring::open(&path)
-                        .map_err(|e| Error::Keyring(e.to_string()))?;
-                    Ok(Box::new(kr))
+                    open_systemd_creds(config)
                 } else {
                     Err(Error::Keyring(
                         "no system keyring available: no D-Bus session for secret-service \
@@ -74,10 +76,7 @@ pub(crate) fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>>
         KeyringBackend::SystemdCreds => {
             #[cfg(target_os = "linux")]
             {
-                let path = resolve_keyring_path(config)?;
-                let kr = keyring::SystemdCredsKeyring::open(&path)
-                    .map_err(|e| Error::Keyring(e.to_string()))?;
-                Ok(Box::new(kr))
+                open_systemd_creds(config)
             }
             #[cfg(not(target_os = "linux"))]
             {
@@ -89,8 +88,15 @@ pub(crate) fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>>
     }
 }
 
-/// Resolve the keyring path, using rootdir if path is relative.
-pub(crate) fn resolve_keyring_path(config: &Config) -> Result<PathBuf> {
+#[cfg(target_os = "linux")]
+fn open_systemd_creds(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
+    let path = resolve_keyring_path(config)?;
+    let kr =
+        keyring::SystemdCredsKeyring::open(&path).map_err(|e| Error::Keyring(e.to_string()))?;
+    Ok(Box::new(kr))
+}
+
+fn resolve_keyring_path(config: &Config) -> Result<PathBuf> {
     let path = PathBuf::from(&config.keyring.path);
     if path.is_absolute() {
         Ok(path)

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,5 +1,7 @@
 //! CLI subcommands
 
+use std::path::PathBuf;
+
 pub mod client;
 mod identity;
 mod keyring_cmd;
@@ -15,3 +17,84 @@ pub use sdl::SdlArgs;
 pub use server_dump::ServerDumpArgs;
 pub use start::{Node, StartArgs};
 pub use version::VersionArgs;
+
+use crate::config::Config;
+use crate::error::{Error, Result};
+
+/// Open the appropriate keyring based on config.
+///
+/// Handles all backend types including auto-detection of systemd-creds
+/// fallback on Linux when no D-Bus session is available.
+pub(crate) fn open_keyring(config: &Config) -> Result<Box<dyn keyring::Keyring>> {
+    use crate::config::KeyringBackend;
+
+    if config.keyring.disabled {
+        return Err(Error::Keyring("keyring is disabled".to_string()));
+    }
+
+    match config.keyring.backend {
+        KeyringBackend::File => {
+            let path = resolve_keyring_path(config)?;
+            let secret =
+                keyring::load_secret_from_env().map_err(|e| Error::Keyring(e.to_string()))?;
+            let kr = keyring::FileKeyring::open(&path, secret)
+                .map_err(|e| Error::Keyring(e.to_string()))?;
+            Ok(Box::new(kr))
+        }
+        KeyringBackend::System => {
+            #[cfg(target_os = "linux")]
+            {
+                if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
+                    Ok(Box::new(keyring::SystemKeyring::open(
+                        &config.keyring.namespace,
+                    )))
+                } else if keyring::systemd_creds_available() {
+                    tracing::warn!(
+                        "no D-Bus session available; falling back to systemd-creds keyring"
+                    );
+                    let path = resolve_keyring_path(config)?;
+                    let kr = keyring::SystemdCredsKeyring::open(&path)
+                        .map_err(|e| Error::Keyring(e.to_string()))?;
+                    Ok(Box::new(kr))
+                } else {
+                    Err(Error::Keyring(
+                        "no system keyring available: no D-Bus session for secret-service \
+                         and systemd-creds not found; use --keyring-backend file"
+                            .to_string(),
+                    ))
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Ok(Box::new(keyring::SystemKeyring::open(
+                    &config.keyring.namespace,
+                )))
+            }
+        }
+        KeyringBackend::SystemdCreds => {
+            #[cfg(target_os = "linux")]
+            {
+                let path = resolve_keyring_path(config)?;
+                let kr = keyring::SystemdCredsKeyring::open(&path)
+                    .map_err(|e| Error::Keyring(e.to_string()))?;
+                Ok(Box::new(kr))
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Err(Error::Keyring(
+                    "systemd-creds backend is only available on Linux".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+/// Resolve the keyring path, using rootdir if path is relative.
+pub(crate) fn resolve_keyring_path(config: &Config) -> Result<PathBuf> {
+    let path = PathBuf::from(&config.keyring.path);
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(config.rootdir.join(path))
+    }
+}

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -29,7 +29,52 @@ impl Node {
                     FileKeyring::open(&path, secret).map_err(|e| Error::Keyring(e.to_string()))?,
                 )
             }
-            KeyringBackend::System => Box::new(SystemKeyring::open(&config.keyring.namespace)),
+            KeyringBackend::System => {
+                #[cfg(target_os = "linux")]
+                {
+                    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
+                        Box::new(SystemKeyring::open(&config.keyring.namespace))
+                    } else if keyring::systemd_creds_available() {
+                        let path = if config.keyring.path.starts_with('/') {
+                            std::path::PathBuf::from(&config.keyring.path)
+                        } else {
+                            config.rootdir.join(&config.keyring.path)
+                        };
+                        let kr = keyring::SystemdCredsKeyring::open(&path)
+                            .map_err(|e| Error::Keyring(e.to_string()))?;
+                        Box::new(kr)
+                    } else {
+                        return Err(Error::Keyring(
+                            "no system keyring available: no D-Bus session for secret-service \
+                             and systemd-creds not found; use --keyring-backend file"
+                                .to_string(),
+                        ));
+                    }
+                }
+                #[cfg(not(target_os = "linux"))]
+                {
+                    Box::new(SystemKeyring::open(&config.keyring.namespace))
+                }
+            }
+            KeyringBackend::SystemdCreds => {
+                #[cfg(target_os = "linux")]
+                {
+                    let path = if config.keyring.path.starts_with('/') {
+                        std::path::PathBuf::from(&config.keyring.path)
+                    } else {
+                        config.rootdir.join(&config.keyring.path)
+                    };
+                    let kr = keyring::SystemdCredsKeyring::open(&path)
+                        .map_err(|e| Error::Keyring(e.to_string()))?;
+                    Box::new(kr)
+                }
+                #[cfg(not(target_os = "linux"))]
+                {
+                    return Err(Error::Keyring(
+                        "systemd-creds backend is only available on Linux".to_string(),
+                    ));
+                }
+            }
         };
 
         // Try to load existing peer key

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -32,7 +32,7 @@ impl Node {
             KeyringBackend::System => {
                 #[cfg(target_os = "linux")]
                 {
-                    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok() {
+                    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
                         Box::new(SystemKeyring::open(&config.keyring.namespace))
                     } else if keyring::systemd_creds_available() {
                         let path = if config.keyring.path.starts_with('/') {

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -35,6 +35,9 @@ impl Node {
                     if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
                         Box::new(SystemKeyring::open(&config.keyring.namespace))
                     } else if keyring::systemd_creds_available() {
+                        tracing::warn!(
+                            "no D-Bus session available; falling back to systemd-creds keyring"
+                        );
                         let path = if config.keyring.path.starts_with('/') {
                             std::path::PathBuf::from(&config.keyring.path)
                         } else {

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -13,72 +13,9 @@ impl Node {
     /// If a peer key exists in the keyring, it is loaded and converted to a libp2p Keypair.
     /// If no peer key exists, a new Ed25519 key is generated and stored in the keyring.
     pub(super) fn init_peer_key(config: &Config) -> Result<(p2p::Keypair, String)> {
-        use crate::config::KeyringBackend;
-        use keyring::{FileKeyring, Keyring, SystemKeyring, PEER_KEY};
+        use keyring::PEER_KEY;
 
-        let kr: Box<dyn Keyring> = match config.keyring.backend {
-            KeyringBackend::File => {
-                let path = if config.keyring.path.starts_with('/') {
-                    std::path::PathBuf::from(&config.keyring.path)
-                } else {
-                    config.rootdir.join(&config.keyring.path)
-                };
-                let secret =
-                    keyring::load_secret_from_env().map_err(|e| Error::Keyring(e.to_string()))?;
-                Box::new(
-                    FileKeyring::open(&path, secret).map_err(|e| Error::Keyring(e.to_string()))?,
-                )
-            }
-            KeyringBackend::System => {
-                #[cfg(target_os = "linux")]
-                {
-                    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_ok_and(|v| !v.is_empty()) {
-                        Box::new(SystemKeyring::open(&config.keyring.namespace))
-                    } else if keyring::systemd_creds_available() {
-                        tracing::warn!(
-                            "no D-Bus session available; falling back to systemd-creds keyring"
-                        );
-                        let path = if config.keyring.path.starts_with('/') {
-                            std::path::PathBuf::from(&config.keyring.path)
-                        } else {
-                            config.rootdir.join(&config.keyring.path)
-                        };
-                        let kr = keyring::SystemdCredsKeyring::open(&path)
-                            .map_err(|e| Error::Keyring(e.to_string()))?;
-                        Box::new(kr)
-                    } else {
-                        return Err(Error::Keyring(
-                            "no system keyring available: no D-Bus session for secret-service \
-                             and systemd-creds not found; use --keyring-backend file"
-                                .to_string(),
-                        ));
-                    }
-                }
-                #[cfg(not(target_os = "linux"))]
-                {
-                    Box::new(SystemKeyring::open(&config.keyring.namespace))
-                }
-            }
-            KeyringBackend::SystemdCreds => {
-                #[cfg(target_os = "linux")]
-                {
-                    let path = if config.keyring.path.starts_with('/') {
-                        std::path::PathBuf::from(&config.keyring.path)
-                    } else {
-                        config.rootdir.join(&config.keyring.path)
-                    };
-                    let kr = keyring::SystemdCredsKeyring::open(&path)
-                        .map_err(|e| Error::Keyring(e.to_string()))?;
-                    Box::new(kr)
-                }
-                #[cfg(not(target_os = "linux"))]
-                {
-                    return Err(Error::Keyring(
-                        "systemd-creds backend is only available on Linux".to_string(),
-                    ));
-                }
-            }
-        };
+        let kr = crate::commands::open_keyring(config)?;
 
         // Try to load existing peer key
         match kr.get(PEER_KEY) {

--- a/crates/cli/src/config/types.rs
+++ b/crates/cli/src/config/types.rs
@@ -102,11 +102,12 @@ impl std::str::FromStr for LogOutput {
 
 /// Keyring backend options
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum KeyringBackend {
     #[default]
     File,
     System,
+    SystemdCreds,
 }
 
 impl std::fmt::Display for KeyringBackend {
@@ -114,6 +115,7 @@ impl std::fmt::Display for KeyringBackend {
         match self {
             KeyringBackend::File => write!(f, "file"),
             KeyringBackend::System => write!(f, "system"),
+            KeyringBackend::SystemdCreds => write!(f, "systemd-creds"),
         }
     }
 }
@@ -125,6 +127,7 @@ impl std::str::FromStr for KeyringBackend {
         match s.to_lowercase().as_str() {
             "file" => Ok(KeyringBackend::File),
             "system" => Ok(KeyringBackend::System),
+            "systemd-creds" => Ok(KeyringBackend::SystemdCreds),
             _ => Err(Error::InvalidKeyringBackend(s.to_string())),
         }
     }

--- a/crates/cli/tests/config_types_tests.rs
+++ b/crates/cli/tests/config_types_tests.rs
@@ -156,8 +156,16 @@ fn test_keyring_backend_from_str_valid() {
         KeyringBackend::System
     );
     assert_eq!(
+        "systemd-creds".parse::<KeyringBackend>().unwrap(),
+        KeyringBackend::SystemdCreds
+    );
+    assert_eq!(
         "FILE".parse::<KeyringBackend>().unwrap(),
         KeyringBackend::File
+    );
+    assert_eq!(
+        "SYSTEMD-CREDS".parse::<KeyringBackend>().unwrap(),
+        KeyringBackend::SystemdCreds
     );
 }
 
@@ -172,9 +180,27 @@ fn test_keyring_backend_from_str_invalid() {
 
 #[test]
 fn test_keyring_backend_display_roundtrip() {
-    for backend in [KeyringBackend::File, KeyringBackend::System] {
+    for backend in [
+        KeyringBackend::File,
+        KeyringBackend::System,
+        KeyringBackend::SystemdCreds,
+    ] {
         let display = backend.to_string();
         let parsed: KeyringBackend = display.parse().unwrap();
         assert_eq!(backend, parsed);
+    }
+}
+
+#[test]
+fn test_keyring_backend_serde_roundtrip() {
+    for (variant, expected_str) in [
+        (KeyringBackend::File, "\"file\""),
+        (KeyringBackend::System, "\"system\""),
+        (KeyringBackend::SystemdCreds, "\"systemd-creds\""),
+    ] {
+        let serialized = serde_json::to_string(&variant).unwrap();
+        assert_eq!(serialized, expected_str);
+        let deserialized: KeyringBackend = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, variant);
     }
 }

--- a/crates/keyring/Cargo.toml
+++ b/crates/keyring/Cargo.toml
@@ -10,6 +10,7 @@ description = "Keyring and key management for DefraDB"
 
 [dependencies]
 thiserror.workspace = true
+tracing.workspace = true
 base64 = "0.22"
 zeroize = "1.8"
 

--- a/crates/keyring/src/error.rs
+++ b/crates/keyring/src/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     #[error("system keyring error: {0}")]
     SystemKeyring(String),
 
+    #[error("systemd-creds error: {0}")]
+    SystemdCreds(String),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }

--- a/crates/keyring/src/keyring.rs
+++ b/crates/keyring/src/keyring.rs
@@ -5,7 +5,7 @@ use crate::error::Result;
 /// Keyring provides a simple set/get interface for a keyring service.
 ///
 /// Keys are stored as raw bytes and can be used for cryptographic operations.
-/// Different backends (file-based, OS keyring) implement this trait.
+/// Different backends (file-based, OS keyring, systemd-creds) implement this trait.
 pub trait Keyring: Send + Sync {
     /// Stores the given key in the keystore under the given name.
     ///

--- a/crates/keyring/src/lib.rs
+++ b/crates/keyring/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides secure storage for cryptographic keys with support for multiple backends:
 //! - File-based storage with JWE encryption (PBES2-HS512-A256KW)
 //! - System keyring (OS-provided key management)
+//! - systemd-creds encryption (Linux, requires systemd 250+)
 
 mod error;
 mod file;

--- a/crates/keyring/src/lib.rs
+++ b/crates/keyring/src/lib.rs
@@ -10,6 +10,8 @@ mod key_name;
 mod keyring;
 mod signer;
 mod system;
+#[cfg(target_os = "linux")]
+mod systemd_creds;
 
 pub use error::{Error, Result};
 pub use file::FileKeyring;
@@ -19,6 +21,8 @@ pub use keyring::Keyring;
 pub use signer::KeyringSigner;
 pub use signer::{KeyHandle, KeyType};
 pub use system::SystemKeyring;
+#[cfg(target_os = "linux")]
+pub use systemd_creds::{systemd_creds_available, SystemdCredsKeyring};
 
 /// Environment variable name for the keyring secret
 pub const KEYRING_SECRET_ENV: &str = "DEFRA_KEYRING_SECRET";

--- a/crates/keyring/src/systemd_creds.rs
+++ b/crates/keyring/src/systemd_creds.rs
@@ -1,0 +1,183 @@
+//! systemd-creds keyring backend for headless Linux servers
+//!
+//! Encrypts credentials using TPM2 or host key via the `systemd-creds` binary.
+//! Each key is stored as a separate `.cred` file in a directory with 0700 permissions.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::error::{Error, Result};
+use crate::key_name::KeyName;
+use crate::keyring::Keyring;
+
+const CRED_EXTENSION: &str = "cred";
+
+/// Keyring backend that uses `systemd-creds` for encryption.
+///
+/// Stores each key as a `.cred` file encrypted with TPM2 or a host key.
+/// Requires the `systemd-creds` binary to be available on the system.
+pub struct SystemdCredsKeyring {
+    dir: PathBuf,
+}
+
+impl SystemdCredsKeyring {
+    /// Opens or creates a systemd-creds keyring in the given directory.
+    ///
+    /// Returns an error if `systemd-creds` is not available on the system.
+    /// The directory is created with 0700 permissions if it does not exist.
+    pub fn open(dir: impl AsRef<Path>) -> Result<Self> {
+        if !systemd_creds_available() {
+            return Err(Error::SystemdCreds(
+                "systemd-creds not found; install systemd 250+ or use a different backend"
+                    .to_string(),
+            ));
+        }
+
+        let dir = dir.as_ref().to_path_buf();
+        fs::create_dir_all(&dir)?;
+
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))?;
+
+        Ok(Self { dir })
+    }
+
+    fn key_path(&self, name: &str) -> Result<PathBuf> {
+        KeyName::validate(name)?;
+        Ok(self.dir.join(format!("{}.{}", name, CRED_EXTENSION)))
+    }
+
+    fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>> {
+        let mut child = Command::new("systemd-creds")
+            .args(["encrypt", "--with-key=auto", "--name=", "-", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| Error::SystemdCreds(format!("failed to run systemd-creds: {}", e)))?;
+
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin was piped")
+            .write_all(data)
+            .map_err(|e| Error::Encryption(format!("failed to write to systemd-creds: {}", e)))?;
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| Error::Encryption(format!("systemd-creds encrypt failed: {}", e)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::Encryption(format!(
+                "systemd-creds encrypt failed: {}",
+                stderr.trim()
+            )));
+        }
+
+        Ok(output.stdout)
+    }
+
+    fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>> {
+        let mut child = Command::new("systemd-creds")
+            .args(["decrypt", "--name=", "-", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| Error::SystemdCreds(format!("failed to run systemd-creds: {}", e)))?;
+
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin was piped")
+            .write_all(data)
+            .map_err(|e| Error::Decryption(format!("failed to write to systemd-creds: {}", e)))?;
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| Error::Decryption(format!("systemd-creds decrypt failed: {}", e)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::Decryption(format!(
+                "systemd-creds decrypt failed: {}",
+                stderr.trim()
+            )));
+        }
+
+        Ok(output.stdout)
+    }
+}
+
+impl Keyring for SystemdCredsKeyring {
+    fn set(&self, name: &str, key: &[u8]) -> Result<()> {
+        let path = self.key_path(name)?;
+        let encrypted = self.encrypt(key)?;
+
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        file.write_all(&encrypted)?;
+
+        Ok(())
+    }
+
+    fn get(&self, name: &str) -> Result<Vec<u8>> {
+        let path = self.key_path(name)?;
+        let encrypted = fs::read(&path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Error::NotFound(name.to_string())
+            } else {
+                Error::Io(e)
+            }
+        })?;
+        self.decrypt(&encrypted)
+    }
+
+    fn delete(&self, name: &str) -> Result<()> {
+        let path = self.key_path(name)?;
+        fs::remove_file(&path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Error::NotFound(name.to_string())
+            } else {
+                Error::Io(e)
+            }
+        })
+    }
+
+    fn list(&self) -> Result<Vec<String>> {
+        let entries = fs::read_dir(&self.dir)?;
+        let mut keys = Vec::new();
+        for entry in entries {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                let file_name = entry.file_name();
+                let file_name = file_name.to_string_lossy();
+                if let Some(name) = file_name.strip_suffix(&format!(".{}", CRED_EXTENSION)) {
+                    if KeyName::validate(name).is_ok() {
+                        keys.push(name.to_string());
+                    }
+                }
+            }
+        }
+        Ok(keys)
+    }
+}
+
+/// Returns true if the `systemd-creds` binary is available on this system.
+pub fn systemd_creds_available() -> bool {
+    Command::new("systemd-creds")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}

--- a/crates/keyring/src/systemd_creds.rs
+++ b/crates/keyring/src/systemd_creds.rs
@@ -1,6 +1,6 @@
-//! systemd-creds keyring backend for headless Linux servers
+//! systemd-creds keyring backend
 //!
-//! Encrypts credentials using TPM2 or host key via the `systemd-creds` binary.
+//! Encrypts credentials via the `systemd-creds` binary with automatic key selection.
 //! Each key is stored as a separate `.cred` file in a directory with 0700 permissions.
 
 use std::fs;
@@ -12,12 +12,7 @@ use crate::error::{Error, Result};
 use crate::key_name::KeyName;
 use crate::keyring::Keyring;
 
-const CRED_EXTENSION: &str = "cred";
-
-/// Keyring backend that uses `systemd-creds` for encryption.
-///
-/// Stores each key as a `.cred` file encrypted with TPM2 or a host key.
-/// Requires the `systemd-creds` binary to be available on the system.
+/// Keyring backend using `systemd-creds` for encryption.
 pub struct SystemdCredsKeyring {
     dir: PathBuf,
 }
@@ -26,7 +21,7 @@ impl SystemdCredsKeyring {
     /// Opens or creates a systemd-creds keyring in the given directory.
     ///
     /// Returns an error if `systemd-creds` is not available on the system.
-    /// The directory is created with 0700 permissions if it does not exist.
+    /// The directory is created if it does not exist. Permissions are set to 0700.
     pub fn open(dir: impl AsRef<Path>) -> Result<Self> {
         if !systemd_creds_available() {
             return Err(Error::SystemdCreds(
@@ -46,12 +41,21 @@ impl SystemdCredsKeyring {
 
     fn key_path(&self, name: &str) -> Result<PathBuf> {
         KeyName::validate(name)?;
-        Ok(self.dir.join(format!("{}.{}", name, CRED_EXTENSION)))
+        Ok(self.dir.join(format!("{}.cred", name)))
     }
 
-    fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>> {
+    /// Run a systemd-creds subcommand, piping `input` to stdin and returning stdout.
+    fn run(&self, args: &[&str], operation: &str, input: &[u8]) -> Result<Vec<u8>> {
+        let make_err = |msg: String| -> Error {
+            if operation == "encrypt" {
+                Error::Encryption(msg)
+            } else {
+                Error::Decryption(msg)
+            }
+        };
+
         let mut child = Command::new("systemd-creds")
-            .args(["encrypt", "--with-key=auto", "--name=", "-", "-"])
+            .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -59,78 +63,57 @@ impl SystemdCredsKeyring {
             .map_err(|e| Error::SystemdCreds(format!("failed to run systemd-creds: {}", e)))?;
 
         let write_result = {
-            let mut stdin = child.stdin.take().expect("stdin was piped");
-            stdin.write_all(data)
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| Error::SystemdCreds("failed to open stdin pipe".to_string()))?;
+            stdin.write_all(input)
         };
 
         let output = child
             .wait_with_output()
-            .map_err(|e| Error::Encryption(format!("systemd-creds encrypt failed: {}", e)))?;
+            .map_err(|e| make_err(format!("systemd-creds {} failed: {}", operation, e)))?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(Error::Encryption(format!(
-                "systemd-creds encrypt failed: {}",
-                stderr.trim()
-            )));
-        }
-
+        // Check write result first — a write failure is the root cause
+        // if the process also failed.
         if let Err(e) = write_result {
-            return Err(Error::Encryption(format!(
-                "failed to write to systemd-creds: {}",
+            return Err(make_err(format!(
+                "failed to write to systemd-creds stdin: {}",
                 e
             )));
         }
 
-        if output.stdout.is_empty() {
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(make_err(format!(
+                "systemd-creds {} failed: {}",
+                operation,
+                stderr.trim()
+            )));
+        }
+
+        Ok(output.stdout)
+    }
+
+    fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>> {
+        let output = self.run(
+            &["encrypt", "--with-key=auto", "--name=", "-", "-"],
+            "encrypt",
+            data,
+        )?;
+
+        // Encrypted ciphertext is never empty.
+        if output.is_empty() {
             return Err(Error::Encryption(
                 "systemd-creds encrypt produced empty output".to_string(),
             ));
         }
 
-        Ok(output.stdout)
+        Ok(output)
     }
 
     fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>> {
-        let mut child = Command::new("systemd-creds")
-            .args(["decrypt", "--name=", "-", "-"])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| Error::SystemdCreds(format!("failed to run systemd-creds: {}", e)))?;
-
-        let write_result = {
-            let mut stdin = child.stdin.take().expect("stdin was piped");
-            stdin.write_all(data)
-        };
-
-        let output = child
-            .wait_with_output()
-            .map_err(|e| Error::Decryption(format!("systemd-creds decrypt failed: {}", e)))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(Error::Decryption(format!(
-                "systemd-creds decrypt failed: {}",
-                stderr.trim()
-            )));
-        }
-
-        if let Err(e) = write_result {
-            return Err(Error::Decryption(format!(
-                "failed to write to systemd-creds: {}",
-                e
-            )));
-        }
-
-        if output.stdout.is_empty() {
-            return Err(Error::Decryption(
-                "systemd-creds decrypt produced empty output".to_string(),
-            ));
-        }
-
-        Ok(output.stdout)
+        self.run(&["decrypt", "--name=", "-", "-"], "decrypt", data)
     }
 }
 
@@ -182,10 +165,21 @@ impl Keyring for SystemdCredsKeyring {
             let entry = entry?;
             if entry.file_type()?.is_file() {
                 let file_name = entry.file_name();
-                let file_name = file_name.to_string_lossy();
-                if let Some(name) = file_name.strip_suffix(&format!(".{}", CRED_EXTENSION)) {
+                let Some(file_name) = file_name.to_str() else {
+                    tracing::warn!(
+                        "skipping credential file with non-UTF-8 filename in {}",
+                        self.dir.display()
+                    );
+                    continue;
+                };
+                if let Some(name) = file_name.strip_suffix(".cred") {
                     if KeyName::validate(name).is_ok() {
                         keys.push(name.to_string());
+                    } else {
+                        tracing::warn!(
+                            file = file_name,
+                            "skipping .cred file with invalid key name"
+                        );
                     }
                 }
             }
@@ -196,11 +190,17 @@ impl Keyring for SystemdCredsKeyring {
 
 /// Returns true if the `systemd-creds` binary is available on this system.
 pub fn systemd_creds_available() -> bool {
-    Command::new("systemd-creds")
+    match Command::new("systemd-creds")
         .arg("--version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    {
+        Ok(status) => status.success(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(e) => {
+            tracing::warn!("systemd-creds availability check failed: {}", e);
+            false
+        }
+    }
 }

--- a/crates/keyring/src/systemd_creds.rs
+++ b/crates/keyring/src/systemd_creds.rs
@@ -58,12 +58,10 @@ impl SystemdCredsKeyring {
             .spawn()
             .map_err(|e| Error::SystemdCreds(format!("failed to run systemd-creds: {}", e)))?;
 
-        child
-            .stdin
-            .as_mut()
-            .expect("stdin was piped")
-            .write_all(data)
-            .map_err(|e| Error::Encryption(format!("failed to write to systemd-creds: {}", e)))?;
+        let write_result = {
+            let mut stdin = child.stdin.take().expect("stdin was piped");
+            stdin.write_all(data)
+        };
 
         let output = child
             .wait_with_output()
@@ -75,6 +73,19 @@ impl SystemdCredsKeyring {
                 "systemd-creds encrypt failed: {}",
                 stderr.trim()
             )));
+        }
+
+        if let Err(e) = write_result {
+            return Err(Error::Encryption(format!(
+                "failed to write to systemd-creds: {}",
+                e
+            )));
+        }
+
+        if output.stdout.is_empty() {
+            return Err(Error::Encryption(
+                "systemd-creds encrypt produced empty output".to_string(),
+            ));
         }
 
         Ok(output.stdout)
@@ -89,12 +100,10 @@ impl SystemdCredsKeyring {
             .spawn()
             .map_err(|e| Error::SystemdCreds(format!("failed to run systemd-creds: {}", e)))?;
 
-        child
-            .stdin
-            .as_mut()
-            .expect("stdin was piped")
-            .write_all(data)
-            .map_err(|e| Error::Decryption(format!("failed to write to systemd-creds: {}", e)))?;
+        let write_result = {
+            let mut stdin = child.stdin.take().expect("stdin was piped");
+            stdin.write_all(data)
+        };
 
         let output = child
             .wait_with_output()
@@ -106,6 +115,19 @@ impl SystemdCredsKeyring {
                 "systemd-creds decrypt failed: {}",
                 stderr.trim()
             )));
+        }
+
+        if let Err(e) = write_result {
+            return Err(Error::Decryption(format!(
+                "failed to write to systemd-creds: {}",
+                e
+            )));
+        }
+
+        if output.stdout.is_empty() {
+            return Err(Error::Decryption(
+                "systemd-creds decrypt produced empty output".to_string(),
+            ));
         }
 
         Ok(output.stdout)
@@ -125,6 +147,7 @@ impl Keyring for SystemdCredsKeyring {
             .mode(0o600)
             .open(&path)?;
         file.write_all(&encrypted)?;
+        file.sync_all()?;
 
         Ok(())
     }

--- a/crates/keyring/tests/systemd_creds_tests.rs
+++ b/crates/keyring/tests/systemd_creds_tests.rs
@@ -1,7 +1,4 @@
 //! Tests for systemd-creds keyring backend
-//!
-//! These tests require the `systemd-creds` binary (systemd 250+) on Linux.
-//! Run with: cargo test -p keyring -- --ignored systemd_creds
 
 #![cfg(target_os = "linux")]
 
@@ -45,6 +42,16 @@ fn test_systemd_creds_delete() {
 
 #[test]
 #[ignore]
+fn test_systemd_creds_delete_not_found() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    let result = kr.delete("nonexistent");
+    assert!(matches!(result, Err(Error::NotFound(_))));
+}
+
+#[test]
+#[ignore]
 fn test_systemd_creds_list() {
     let temp_dir = tempfile::tempdir().unwrap();
     let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
@@ -56,6 +63,32 @@ fn test_systemd_creds_list() {
     let mut keys = kr.list().unwrap();
     keys.sort();
     assert_eq!(keys, vec!["key-a", "key-b", "key-c"]);
+}
+
+#[test]
+#[ignore]
+fn test_systemd_creds_list_empty() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    let keys = kr.list().unwrap();
+    assert!(keys.is_empty());
+}
+
+#[test]
+#[ignore]
+fn test_systemd_creds_list_ignores_non_cred_files() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    kr.set("real-key", b"data").unwrap();
+
+    // Create non-.cred files in the directory
+    std::fs::write(temp_dir.path().join("stray.txt"), b"not a cred").unwrap();
+    std::fs::write(temp_dir.path().join(".hidden"), b"hidden").unwrap();
+
+    let keys = kr.list().unwrap();
+    assert_eq!(keys, vec!["real-key"]);
 }
 
 #[test]

--- a/crates/keyring/tests/systemd_creds_tests.rs
+++ b/crates/keyring/tests/systemd_creds_tests.rs
@@ -1,0 +1,85 @@
+//! Tests for systemd-creds keyring backend
+//!
+//! These tests require the `systemd-creds` binary (systemd 250+) on Linux.
+//! Run with: cargo test -p keyring -- --ignored systemd_creds
+
+#![cfg(target_os = "linux")]
+
+use keyring::{Error, Keyring, SystemdCredsKeyring};
+
+#[test]
+#[ignore]
+fn test_systemd_creds_set_get_roundtrip() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    let data = b"my-secret-key-data";
+    kr.set("test-key", data).unwrap();
+
+    let retrieved = kr.get("test-key").unwrap();
+    assert_eq!(retrieved, data);
+}
+
+#[test]
+#[ignore]
+fn test_systemd_creds_get_not_found() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    let result = kr.get("nonexistent");
+    assert!(matches!(result, Err(Error::NotFound(_))));
+}
+
+#[test]
+#[ignore]
+fn test_systemd_creds_delete() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    kr.set("to-delete", b"some-data").unwrap();
+    assert!(kr.get("to-delete").is_ok());
+
+    kr.delete("to-delete").unwrap();
+    assert!(matches!(kr.get("to-delete"), Err(Error::NotFound(_))));
+}
+
+#[test]
+#[ignore]
+fn test_systemd_creds_list() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    kr.set("key-a", b"data-a").unwrap();
+    kr.set("key-b", b"data-b").unwrap();
+    kr.set("key-c", b"data-c").unwrap();
+
+    let mut keys = kr.list().unwrap();
+    keys.sort();
+    assert_eq!(keys, vec!["key-a", "key-b", "key-c"]);
+}
+
+#[test]
+#[ignore]
+fn test_systemd_creds_overwrite() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    kr.set("key", b"original").unwrap();
+    kr.set("key", b"updated").unwrap();
+
+    let retrieved = kr.get("key").unwrap();
+    assert_eq!(retrieved, b"updated");
+}
+
+#[test]
+#[ignore]
+fn test_systemd_creds_binary_data() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kr = SystemdCredsKeyring::open(temp_dir.path()).unwrap();
+
+    let binary_data: Vec<u8> = (0u8..=255).collect();
+    kr.set("binary-key", &binary_data).unwrap();
+
+    let retrieved = kr.get("binary-key").unwrap();
+    assert_eq!(retrieved, binary_data);
+}


### PR DESCRIPTION
## Summary

- Adds `--keyring-backend systemd-creds` option that encrypts credentials via TPM2/host key using the `systemd-creds` binary (Linux-only)
- When `--keyring-backend system` is used on Linux without a D-Bus session, auto-detects and falls back to `systemd-creds`
- File-per-key storage with `.cred` extension, 0700 dir / 0600 file permissions
- All systemd-creds code cfg-gated behind `target_os = "linux"`

Closes #377

## Test plan

- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] `cargo test -p keyring@0.1.0` — all existing tests pass
- [x] macOS build succeeds (Linux modules compiled out)
- [ ] Linux VPS: `cargo test -p keyring@0.1.0 -- --ignored systemd_creds` (requires systemd 250+)
- [ ] Linux VPS: CLI end-to-end with `--keyring-backend systemd-creds`
- [ ] Linux VPS: Auto-detect fallback with `--keyring-backend system` (no D-Bus session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)