### PR TITLE
fix(cli): P2P document wire format + integration test coverage

### DIFF
--- a/crates/cli/src/commands/client/http_client/p2p.rs
+++ b/crates/cli/src/commands/client/http_client/p2p.rs
@@ -144,25 +144,19 @@ impl HttpClient {
         self.request_void("POST", &url, Some(&body)).await
     }
 
-    pub async fn p2p_document_add(&self, doc_ids: &[String], schema_ids: &[String]) -> Result<()> {
+    pub async fn p2p_document_add(&self, doc_ids: &[String], _schema_ids: &[String]) -> Result<()> {
         let url = format!("{}/api/v0/p2p/documents", self.base_url);
-        let body = serde_json::to_string(&P2pDocumentRequest {
-            doc_ids: doc_ids.to_vec(),
-            schema_ids: schema_ids.to_vec(),
-        })?;
+        let body = serde_json::to_string(&doc_ids)?;
         self.request_void("POST", &url, Some(&body)).await
     }
 
     pub async fn p2p_document_remove(
         &self,
         doc_ids: &[String],
-        schema_ids: &[String],
+        _schema_ids: &[String],
     ) -> Result<()> {
         let url = format!("{}/api/v0/p2p/documents", self.base_url);
-        let body = serde_json::to_string(&P2pDocumentRequest {
-            doc_ids: doc_ids.to_vec(),
-            schema_ids: schema_ids.to_vec(),
-        })?;
+        let body = serde_json::to_string(&doc_ids)?;
         self.request_void("DELETE", &url, Some(&body)).await
     }
 

--- a/tools/integration-test/src/client/mod.rs
+++ b/tools/integration-test/src/client/mod.rs
@@ -456,6 +456,28 @@ impl DefraClient {
         self.exec(&args)
     }
 
+    // -- P2P Document operations --
+
+    /// Add documents to P2P subscription via `client p2p document create <id1> <id2>`.
+    pub fn p2p_document_create(&self, doc_ids: &[&str]) -> Result<String> {
+        let mut args = vec!["client", "p2p", "document", "create"];
+        args.extend(doc_ids);
+        self.exec(&args)
+    }
+
+    /// Remove documents from P2P subscription via `client p2p document delete <id1> <id2>`.
+    pub fn p2p_document_delete(&self, doc_ids: &[&str]) -> Result<String> {
+        let mut args = vec!["client", "p2p", "document", "delete"];
+        args.extend(doc_ids);
+        self.exec(&args)
+    }
+
+    /// List P2P document subscriptions via `client p2p document list`.
+    pub fn p2p_document_list(&self) -> Result<Value> {
+        let out = self.exec(&["client", "p2p", "document", "list"])?;
+        serde_json::from_str(&out).context("failed to parse p2p_document_list output")
+    }
+
     // -- ACP Document extensions --
 
     /// Delete an ACP document relationship.

--- a/tools/integration-test/tests/index_management.rs
+++ b/tools/integration-test/tests/index_management.rs
@@ -1,0 +1,119 @@
+use integration_test::{TestCluster, PRODUCT_SCHEMA};
+use serde_json::Value;
+
+/// Extract indexes from list output, handling both flat array `[...]`
+/// and Go's map format `{"CollectionName": [...]}`.
+fn extract_indexes(val: &Value) -> Vec<&Value> {
+    if let Some(arr) = val.as_array() {
+        return arr.iter().collect();
+    }
+    if let Some(obj) = val.as_object() {
+        for v in obj.values() {
+            if let Some(arr) = v.as_array() {
+                return arr.iter().collect();
+            }
+        }
+    }
+    vec![]
+}
+
+/// Check if any index in the list has the given name (handles both `name` and `Name` keys).
+fn has_index_name(indexes: &[&Value], name: &str) -> bool {
+    indexes.iter().any(|idx| {
+        idx.get("name")
+            .or_else(|| idx.get("Name"))
+            .and_then(|v| v.as_str())
+            .map(|n| n == name)
+            .unwrap_or(false)
+    })
+}
+
+async fn index_management_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+
+    // Deploy Product schema
+    node.schema_add(PRODUCT_SCHEMA).expect("add Product schema");
+
+    // Insert sample data so queries have something to exercise
+    node.query(
+        r#"mutation { create_Product(input: {name: "Widget", sku: "W001", price: 100}) { _docID } }"#,
+    )
+    .expect("create product");
+
+    // 1. Create a named single-field index
+    node.index_create("Product", &["name"], Some("idx_name"), false)
+        .expect("create index idx_name");
+
+    // 2. Create a unique index
+    node.index_create("Product", &["sku"], Some("idx_sku_unique"), true)
+        .expect("create unique index idx_sku_unique");
+
+    // 3. Create a composite (multi-field) index
+    node.index_create("Product", &["name", "price"], Some("idx_name_price"), false)
+        .expect("create composite index idx_name_price");
+
+    // 4. List all indexes for the collection — should have 3
+    let list = node
+        .index_list(Some("Product"))
+        .expect("index_list Product");
+    let indexes = extract_indexes(&list);
+    assert_eq!(
+        indexes.len(),
+        3,
+        "expected 3 indexes, got {}: {}",
+        indexes.len(),
+        serde_json::to_string_pretty(&list).unwrap()
+    );
+    assert!(
+        has_index_name(&indexes, "idx_name"),
+        "idx_name not found in list"
+    );
+    assert!(
+        has_index_name(&indexes, "idx_sku_unique"),
+        "idx_sku_unique not found in list"
+    );
+    assert!(
+        has_index_name(&indexes, "idx_name_price"),
+        "idx_name_price not found in list"
+    );
+
+    // 5. Drop one index and verify removal
+    node.index_drop("Product", "idx_name")
+        .expect("drop idx_name");
+
+    let list_after = node
+        .index_list(Some("Product"))
+        .expect("index_list after drop");
+    let indexes_after = extract_indexes(&list_after);
+    assert_eq!(
+        indexes_after.len(),
+        2,
+        "expected 2 indexes after drop, got {}",
+        indexes_after.len()
+    );
+    assert!(
+        !has_index_name(&indexes_after, "idx_name"),
+        "idx_name should be gone after drop"
+    );
+
+    // 6. Verify queries still work with remaining indexes
+    let products = node
+        .query("query { Product { name sku price } }")
+        .expect("query products with indexes");
+    let arr = products["Product"].as_array().expect("products array");
+    assert_eq!(arr.len(), 1, "should still have 1 product");
+}
+
+#[tokio::test]
+#[ignore]
+async fn rust_index_management() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    index_management_test(cluster).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn go_index_management() {
+    let cluster = TestCluster::builder().go_nodes(1).build().await.unwrap();
+    index_management_test(cluster).await;
+}

--- a/tools/integration-test/tests/lens_migration.rs
+++ b/tools/integration-test/tests/lens_migration.rs
@@ -20,17 +20,25 @@ async fn lens_migration_test(cluster: TestCluster) {
         "schema describe should mention Article"
     );
 
-    // List lens migrations (may be empty initially)
-    let list_result = node.lens_list();
-    if let Err(e) = &list_result {
-        eprintln!("lens list not supported: {}", e);
-    }
+    // lens_list should succeed on fresh node (empty result)
+    let list_result = node.lens_list().expect("lens_list should succeed");
+    let is_empty = list_result.is_null()
+        || list_result
+            .as_object()
+            .map(|o| o.is_empty())
+            .unwrap_or(false)
+        || list_result
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(false);
+    assert!(
+        is_empty,
+        "lens_list on fresh node should be empty, got: {}",
+        list_result
+    );
 
-    // Try lens reload
-    let reload_result = node.lens_reload();
-    if let Err(e) = &reload_result {
-        eprintln!("lens reload not supported: {}", e);
-    }
+    // lens_reload should succeed
+    node.lens_reload().expect("lens_reload should succeed");
 
     // Verify articles still queryable
     let articles = node

--- a/tools/integration-test/tests/p2p_document.rs
+++ b/tools/integration-test/tests/p2p_document.rs
@@ -1,0 +1,119 @@
+use integration_test::TestCluster;
+use serde_json::Value;
+use std::time::Duration;
+
+/// Extract document IDs from list output, handling both flat array `["id1", ...]`
+/// and wrapped object formats.
+fn extract_doc_ids(val: &Value) -> Vec<String> {
+    if let Some(arr) = val.as_array() {
+        return arr
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect();
+    }
+    if let Some(obj) = val.as_object() {
+        for v in obj.values() {
+            if let Some(arr) = v.as_array() {
+                return arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+            }
+        }
+    }
+    vec![]
+}
+
+async fn p2p_document_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+
+    // Wait for P2P listener to be ready
+    cluster
+        .wait_for_log(0, "p2p_listening", Duration::from_secs(15))
+        .await
+        .expect("P2P listener did not start");
+
+    // Deploy schema
+    node.schema_add("type Note { text: String }")
+        .expect("add Note schema");
+
+    // 1. List documents on fresh node — should be empty
+    let list_empty = node.p2p_document_list().expect("p2p_document_list empty");
+    let ids_empty = extract_doc_ids(&list_empty);
+    assert!(
+        ids_empty.is_empty(),
+        "expected 0 P2P documents initially, got {:?}",
+        ids_empty
+    );
+
+    // 2. Create a real document to get a valid doc ID
+    let result = node
+        .query(r#"mutation { create_Note(input: {text: "hello world"}) { _docID } }"#)
+        .expect("create note");
+    let doc_id = result["create_Note"]
+        .as_array()
+        .and_then(|arr| arr.first())
+        .or_else(|| {
+            result["create_Note"]
+                .as_object()
+                .map(|_| &result["create_Note"])
+        })
+        .and_then(|v| v.get("_docID"))
+        .and_then(|v| v.as_str())
+        .expect("could not extract _docID from mutation result");
+
+    // 3. Add document to P2P subscription
+    node.p2p_document_create(&[doc_id])
+        .expect("p2p_document_create");
+
+    // 4. Verify document appears in list
+    let list_after_add = node
+        .p2p_document_list()
+        .expect("p2p_document_list after add");
+    let ids_after_add = extract_doc_ids(&list_after_add);
+    assert!(
+        ids_after_add.iter().any(|id| id == doc_id),
+        "expected doc {} in P2P document list, got {:?}",
+        doc_id,
+        ids_after_add
+    );
+
+    // 5. Remove document from P2P subscription
+    node.p2p_document_delete(&[doc_id])
+        .expect("p2p_document_delete");
+
+    // 6. List after delete — should be empty
+    let list_after_del = node
+        .p2p_document_list()
+        .expect("p2p_document_list after delete");
+    let ids_after_del = extract_doc_ids(&list_after_del);
+    assert!(
+        ids_after_del.is_empty(),
+        "expected 0 P2P documents after delete, got {:?}",
+        ids_after_del
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn rust_p2p_document() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    p2p_document_test(cluster).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn go_p2p_document() {
+    let cluster = TestCluster::builder()
+        .go_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    p2p_document_test(cluster).await;
+}


### PR DESCRIPTION
## Summary

- **Fix P2P document CLI-to-HTTP wire format bug**: `p2p_document_add` and `p2p_document_remove` were sending a `P2pDocumentRequest` struct (`{"docIDs": [...], "schemaIDs": [...]}`) but the HTTP handler expects `Json<Vec<String>>` (flat array `["docID1"]`). Now sends flat array, matching the `p2p_collection_add` pattern.
- **Add index management integration tests**: Tests for `index_create`, `index_list`, `index_drop` covering single-field, unique, and composite indexes with verification of list counts and post-drop behavior.
- **Add P2P document integration tests**: Tests for `p2p document create/delete/list` using real document IDs from mutations, with `.with_p2p()` enabled.
- **Harden lens migration test**: Replace soft-fail `eprintln!` with hard `assert!`/`expect` for `lens_list` and `lens_reload`.

## Test plan

- [ ] `cargo build -p cli -p integration-test` — compiles clean
- [ ] `cargo clippy --all -- -D warnings` — no warnings
- [ ] `cargo test rust_index_management -- --ignored --nocapture`
- [ ] `cargo test rust_p2p_document -- --ignored --nocapture`
- [ ] `cargo test rust_lens_migration -- --ignored --nocapture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)