### PR TITLE
fix(cli): Accept bare boolean flags like Go CLI

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -33,11 +33,11 @@ pub struct Cli {
     pub log_format: Option<String>,
 
     /// Include stacktrace in error and fatal logs
-    #[arg(long, global = true, env = "DEFRA_LOG_STACKTRACE")]
+    #[arg(long, global = true, env = "DEFRA_LOG_STACKTRACE", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub log_stacktrace: Option<bool>,
 
     /// Include source location in logs
-    #[arg(long, global = true, env = "DEFRA_LOG_SOURCE")]
+    #[arg(long, global = true, env = "DEFRA_LOG_SOURCE", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub log_source: Option<bool>,
 
     /// Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
@@ -45,7 +45,7 @@ pub struct Cli {
     pub log_overrides: Option<String>,
 
     /// Disable colored log output
-    #[arg(long, global = true, env = "DEFRA_NO_LOG_COLOR")]
+    #[arg(long, global = true, env = "DEFRA_NO_LOG_COLOR", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_log_color: Option<bool>,
 
     /// URL of HTTP endpoint to listen on or connect to
@@ -65,7 +65,7 @@ pub struct Cli {
     pub keyring_path: Option<String>,
 
     /// Disable the keyring and generate ephemeral keys
-    #[arg(long, global = true, env = "DEFRA_NO_KEYRING")]
+    #[arg(long, global = true, env = "DEFRA_NO_KEYRING", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_keyring: Option<bool>,
 
     /// The SourceHub address authorized by the client to make SourceHub transactions
@@ -88,7 +88,7 @@ pub struct Cli {
     ///
     /// When enabled, node operations require authentication and authorization
     /// based on the node's identity from the keyring.
-    #[arg(long, global = true, env = "DEFRA_ACP_NODE_ENABLE")]
+    #[arg(long, global = true, env = "DEFRA_ACP_NODE_ENABLE", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub acp_node_enable: Option<bool>,
 
     /// Document ACP type. Options are none, local, or source-hub

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -48,7 +48,7 @@ pub struct StartArgs {
     pub p2paddr: Option<Vec<String>>,
 
     /// Disable the peer-to-peer network synchronization system
-    #[arg(long)]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_p2p: Option<bool>,
 
     /// List of origins to allow for CORS requests
@@ -64,19 +64,19 @@ pub struct StartArgs {
     pub privkeypath: Option<String>,
 
     /// Enables development mode features
-    #[arg(long)]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub development: Option<bool>,
 
     /// Skip generating an encryption key. Encryption at rest will be disabled.
-    #[arg(long)]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_encryption: Option<bool>,
 
     /// Disable telemetry reporting
-    #[arg(long)]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_telemetry: Option<bool>,
 
     /// Disable signing of commits
-    #[arg(long)]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_signing: Option<bool>,
 
     /// Default key type to generate new node identity
@@ -84,7 +84,7 @@ pub struct StartArgs {
     pub default_key_type: Option<String>,
 
     /// Skip generating a searchable encryption key
-    #[arg(long)]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_searchable_encryption: Option<bool>,
 
     /// Hex formatted private key used to authenticate with ACP.

--- a/tools/integration-test/src/client/mod.rs
+++ b/tools/integration-test/src/client/mod.rs
@@ -271,9 +271,13 @@ impl DefraClient {
 
     // -- Schema extensions --
 
-    /// Describe the full schema via `client schema describe`.
+    /// List schema type names via GraphQL introspection.
+    ///
+    /// Works on both Go and Rust binaries (Go lacks `client schema describe`,
+    /// Rust's `client collection describe` requires `--name`).
     pub fn schema_describe(&self) -> Result<String> {
-        self.exec(&["client", "schema", "describe"])
+        let result = self.query(r#"{ __schema { types { name } } }"#)?;
+        Ok(result.to_string())
     }
 
     // -- Index operations --

--- a/tools/integration-test/src/node/rust_node.rs
+++ b/tools/integration-test/src/node/rust_node.rs
@@ -38,20 +38,20 @@ impl DefraNode for RustNode {
 
         cmd.arg("--rootdir").arg(&config.rootdir);
         cmd.arg("--url").arg(&config.http_addr);
-        cmd.arg("--no-log-color").arg("true");
+        cmd.arg("--no-log-color");
         cmd.arg("--log-output").arg("stdout");
-        cmd.arg("--no-keyring").arg("true");
+        cmd.arg("--no-keyring");
 
         cmd.arg("start");
         cmd.arg("--store").arg("memory");
-        cmd.arg("--no-telemetry").arg("true");
+        cmd.arg("--no-telemetry");
 
         if !config.encryption_enabled {
-            cmd.arg("--no-encryption").arg("true");
-            cmd.arg("--no-searchable-encryption").arg("true");
+            cmd.arg("--no-encryption");
+            cmd.arg("--no-searchable-encryption");
         }
         if !config.signing_enabled {
-            cmd.arg("--no-signing").arg("true");
+            cmd.arg("--no-signing");
         }
 
         if config.p2p_enabled {
@@ -62,7 +62,7 @@ impl DefraNode for RustNode {
                 cmd.arg("--peers").arg(peer);
             }
         } else {
-            cmd.arg("--no-p2p").arg("true");
+            cmd.arg("--no-p2p");
         }
 
         if let Some(ref identity) = config.identity {
@@ -74,7 +74,7 @@ impl DefraNode for RustNode {
         }
 
         if config.nac_enabled {
-            cmd.arg("--acp-node-enable").arg("true");
+            cmd.arg("--acp-node-enable");
         }
 
         if let Some(ref addr) = config.source_hub_address {


### PR DESCRIPTION
## Summary
- Adds `num_args = 0..=1, require_equals = true, default_missing_value = "true"` to all 11 `Option<bool>` CLI flags across `cli.rs` (5 global flags) and `start/mod.rs` (6 start flags)
- Removes `.arg("true")` workarounds from `rust_node.rs` integration test harness, matching `go_node.rs` behavior
- Fixes `schema_describe()` in integration test client to use GraphQL introspection (`__schema { types { name } }`) instead of `client schema describe` (Go lacks this command) or `client collection describe` (Rust requires `--name`)
- Bare `--no-p2p`, `--no-p2p=true`, and `--no-p2p=false` all work correctly, matching Go cobra semantics

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo test -p cli` — all 129 tests pass
- [x] `cargo test -p integration-test -- --ignored` — all 68 integration tests pass (Go + Rust)
- [x] Manual verification: `./target/debug/defra --no-log-color --no-keyring start --no-p2p --help` works

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)