### PR TITLE
feat(cli): Align keyring + identity commands with Go behavior

### DIFF
--- a/crates/cli/src/commands/identity.rs
+++ b/crates/cli/src/commands/identity.rs
@@ -41,8 +41,8 @@ pub struct IdentityNewArgs {
     #[arg(long = "output-key")]
     pub output_key: bool,
 
-    /// Output format: text or json
-    #[arg(long, default_value = "text")]
+    /// Output format: json (default, Go-compatible) or text (Rust extension)
+    #[arg(long, default_value = "json")]
     pub output: String,
 }
 
@@ -155,17 +155,21 @@ impl IdentityNewArgs {
             }
         } else {
             let private_key_hex = hex::encode(&raw_bytes);
+            let public_key_hex = hex::encode(identity.public_key_bytes());
+            let key_type_str = identity.identity_key_type().to_string();
             match self.output.to_lowercase().as_str() {
-                "json" => {
-                    let output = serde_json::json!({
-                        "private_key": private_key_hex,
-                        "did": did.to_string(),
-                    });
-                    println!("{}", serde_json::to_string_pretty(&output)?);
-                }
-                _ => {
+                "text" => {
                     println!("Private key: {}", private_key_hex);
                     println!("DID: {}", did);
+                }
+                _ => {
+                    let output = serde_json::json!({
+                        "PrivateKey": private_key_hex,
+                        "PublicKey": public_key_hex,
+                        "DID": did.to_string(),
+                        "KeyType": key_type_str,
+                    });
+                    println!("{}", serde_json::to_string_pretty(&output)?);
                 }
             }
         }

--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -1,6 +1,6 @@
 //! Keyring command implementation
 
-use std::io::{self, BufRead, IsTerminal, Read, Write};
+use std::io::{self, BufRead, Write};
 
 use clap::{Args, Subcommand};
 
@@ -48,12 +48,24 @@ impl KeyringArgs {
 /// Generate a new cryptographic key
 #[derive(Args, Debug)]
 pub struct GenerateArgs {
-    /// Name of the key to generate
-    pub name: String,
+    /// Name of the key to generate (omit for Go-compatible mode: generates peer-key + encryption-key)
+    pub name: Option<String>,
 
-    /// Key type to generate (ed25519, secp256k1, aes256)
-    #[arg(short = 't', long, default_value = "ed25519")]
+    /// Key type to generate (ed25519, secp256k1, aes256) — only used with a named key
+    #[arg(short = 't', long = "key-type", default_value = "ed25519")]
     pub key_type: String,
+
+    /// Skip generating the encryption key (Go-compatible mode only)
+    #[arg(long = "no-encryption")]
+    pub no_encryption: bool,
+
+    /// Skip generating the peer key (Go-compatible mode only)
+    #[arg(long = "no-peer-key")]
+    pub no_peer_key: bool,
+
+    /// Overwrite existing keys without error
+    #[arg(long)]
+    pub force: bool,
 }
 
 impl GenerateArgs {
@@ -62,39 +74,85 @@ impl GenerateArgs {
 
         let keyring = super::open_keyring(&config)?;
 
-        let (key, description) = match self.key_type.to_lowercase().as_str() {
-            "ed25519" => {
+        if let Some(name) = self.name {
+            // Rust extension mode: generate a single named key
+            if !self.force && key_exists(keyring.as_ref(), &name)? {
+                return Err(Error::Keyring(format!(
+                    "key {} already exists, use --force to overwrite",
+                    name
+                )));
+            }
+
+            let key = generate_key_bytes(&self.key_type)?;
+            keyring
+                .set(&name, &key)
+                .map_err(|e| Error::Keyring(e.to_string()))?;
+        } else {
+            // Go-compatible mode: generate peer-key and/or encryption-key
+            if !self.no_peer_key {
+                if !self.force && key_exists(keyring.as_ref(), "peer-key")? {
+                    return Err(Error::Keyring(
+                        "key peer-key already exists, use --force to overwrite".to_string(),
+                    ));
+                }
                 let private_key = crypto::generate_ed25519().map_err(|e| {
                     Error::Keyring(format!("failed to generate Ed25519 key: {}", e))
                 })?;
-                (private_key.raw().to_vec(), "64-byte Ed25519")
+                keyring
+                    .set("peer-key", &private_key.raw())
+                    .map_err(|e| Error::Keyring(e.to_string()))?;
             }
-            "secp256k1" => {
-                let private_key = crypto::generate_secp256k1().map_err(|e| {
-                    Error::Keyring(format!("failed to generate secp256k1 key: {}", e))
-                })?;
-                (private_key.raw().to_vec(), "32-byte secp256k1")
-            }
-            "aes256" | "aes" => {
+
+            if !self.no_encryption {
+                if !self.force && key_exists(keyring.as_ref(), "encryption-key")? {
+                    return Err(Error::Keyring(
+                        "key encryption-key already exists, use --force to overwrite".to_string(),
+                    ));
+                }
                 let key = crypto::generate_aes256().map_err(|e| {
                     Error::Keyring(format!("failed to generate AES-256 key: {}", e))
                 })?;
-                (key, "32-byte AES-256")
+                keyring
+                    .set("encryption-key", &key)
+                    .map_err(|e| Error::Keyring(e.to_string()))?;
             }
-            _ => {
-                return Err(Error::Keyring(format!(
-                    "unknown key type: '{}'. Valid types: ed25519, secp256k1, aes256",
-                    self.key_type
-                )));
-            }
-        };
+        }
 
-        keyring
-            .set(&self.name, &key)
-            .map_err(|e| Error::Keyring(e.to_string()))?;
-
-        println!("Generated {} key: {}", description, self.name);
         Ok(())
+    }
+}
+
+fn key_exists(keyring: &dyn keyring::Keyring, name: &str) -> Result<bool> {
+    match keyring.get(name) {
+        Ok(_) => Ok(true),
+        Err(keyring::Error::NotFound(_)) => Ok(false),
+        Err(e) => Err(Error::Keyring(e.to_string())),
+    }
+}
+
+fn generate_key_bytes(key_type: &str) -> Result<Vec<u8>> {
+    use crypto::Key;
+
+    match key_type.to_lowercase().as_str() {
+        "ed25519" => {
+            let private_key = crypto::generate_ed25519()
+                .map_err(|e| Error::Keyring(format!("failed to generate Ed25519 key: {}", e)))?;
+            Ok(private_key.raw().to_vec())
+        }
+        "secp256k1" => {
+            let private_key = crypto::generate_secp256k1()
+                .map_err(|e| Error::Keyring(format!("failed to generate secp256k1 key: {}", e)))?;
+            Ok(private_key.raw().to_vec())
+        }
+        "aes256" | "aes" => {
+            let key = crypto::generate_aes256()
+                .map_err(|e| Error::Keyring(format!("failed to generate AES-256 key: {}", e)))?;
+            Ok(key)
+        }
+        _ => Err(Error::Keyring(format!(
+            "unknown key type: '{}'. Valid types: ed25519, secp256k1, aes256",
+            key_type
+        ))),
     }
 }
 
@@ -104,9 +162,9 @@ pub struct ExportArgs {
     /// Name of the key to export
     pub name: String,
 
-    /// Output as hex instead of raw bytes
+    /// Output raw bytes instead of hex (Rust extension)
     #[arg(long)]
-    pub hex: bool,
+    pub raw: bool,
 }
 
 impl ExportArgs {
@@ -117,11 +175,10 @@ impl ExportArgs {
             .get(&self.name)
             .map_err(|e| Error::Keyring(e.to_string()))?;
 
-        if self.hex {
-            println!("{}", hex_encode(&key));
-        } else {
-            // Write raw bytes to stdout
+        if self.raw {
             io::stdout().write_all(&key)?;
+        } else {
+            println!("{}", hex_encode(&key));
         }
 
         Ok(())
@@ -134,38 +191,34 @@ pub struct ImportArgs {
     /// Name for the imported key
     pub name: String,
 
-    /// Input is hex encoded
+    /// Hex-encoded private key (Go-compatible positional argument)
+    pub key_hex: Option<String>,
+
+    /// Read hex-encoded key from stdin (Rust extension)
     #[arg(long)]
-    pub hex: bool,
+    pub stdin: bool,
 }
 
 impl ImportArgs {
     pub fn execute(self, config: Config) -> Result<()> {
         let keyring = super::open_keyring(&config)?;
 
-        // Read from stdin
-        let stdin = io::stdin();
-        let is_terminal = stdin.is_terminal();
-        let key = if self.hex {
+        let key = if let Some(ref hex_str) = self.key_hex {
+            hex_decode(hex_str).map_err(|e| Error::Keyring(format!("invalid hex: {}", e)))?
+        } else if self.stdin {
             let mut line = String::new();
-            stdin.lock().read_line(&mut line)?;
+            io::stdin().lock().read_line(&mut line)?;
             hex_decode(line.trim()).map_err(|e| Error::Keyring(format!("invalid hex: {}", e)))?
         } else {
-            let mut buf = Vec::new();
-            stdin.lock().read_to_end(&mut buf)?;
-            // Only strip trailing newline for terminal input to avoid corrupting binary keys
-            // that legitimately end with 0x0A when piped from files
-            if is_terminal && buf.last() == Some(&b'\n') {
-                buf.pop();
-            }
-            buf
+            return Err(Error::MissingInput(
+                "provide hex key as argument or use --stdin".to_string(),
+            ));
         };
 
         keyring
             .set(&self.name, &key)
             .map_err(|e| Error::Keyring(e.to_string()))?;
 
-        println!("Imported key: {}", self.name);
         Ok(())
     }
 }
@@ -201,10 +254,11 @@ impl ListArgs {
         let keys = keyring.list().map_err(|e| Error::Keyring(e.to_string()))?;
 
         if keys.is_empty() {
-            println!("No keys found");
+            println!("No keys found in the keyring.");
         } else {
+            println!("Keys in the keyring:");
             for key in keys {
-                println!("{}", key);
+                println!("- {}", key);
             }
         }
 

--- a/crates/keyring/src/file.rs
+++ b/crates/keyring/src/file.rs
@@ -14,14 +14,20 @@ use crate::error::{Error, Result};
 use crate::key_name::KeyName;
 use crate::keyring::Keyring;
 
-/// Content encryption algorithm - matches Go jwx default for PBES2_HS512_A256KW
-const CONTENT_ENCRYPTION: &str = "A128CBC-HS256";
+/// Content encryption algorithm — matches Go jwx default (A256GCM).
+const CONTENT_ENCRYPTION: &str = "A256GCM";
+
+/// PBKDF2 iteration count — matches Go jwx default (10000).
+const PBKDF2_ITER_COUNT: usize = 10000;
+
+/// PBKDF2 salt length — matches Go jwx default (32 bytes = AES-256-KW key length).
+const PBKDF2_SALT_LEN: usize = 32;
 
 /// File-based keyring that stores keys in encrypted files using JWE.
 ///
 /// Each key is stored as a separate file in the directory, encrypted using
 /// PBES2-HS512-A256KW (Password-Based Encryption Scheme 2 with HMAC-SHA-512
-/// and AES-256-KW for key wrapping) with A128CBC-HS256 content encryption.
+/// and AES-256-KW for key wrapping) with A256GCM content encryption.
 ///
 /// The file format is compatible with Go DefraDB's file keyring.
 pub struct FileKeyring {
@@ -61,9 +67,11 @@ impl FileKeyring {
         let mut header = JweHeader::new();
         header.set_content_encryption(CONTENT_ENCRYPTION);
 
-        let encrypter = PBES2_HS512_A256KW
+        let mut encrypter = PBES2_HS512_A256KW
             .encrypter_from_bytes(&self.password)
             .map_err(|e| Error::Encryption(format!("failed to create encrypter: {}", e)))?;
+        encrypter.set_iter_count(PBKDF2_ITER_COUNT);
+        encrypter.set_salt_len(PBKDF2_SALT_LEN);
 
         let token = jwe::serialize_compact(data, &header, &encrypter)
             .map_err(|e| Error::Encryption(format!("failed to encrypt: {}", e)))?;

--- a/crates/keyring/tests/file_tests.rs
+++ b/crates/keyring/tests/file_tests.rs
@@ -115,5 +115,13 @@ fn test_jwe_format_go_compatible() {
     let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
 
     assert_eq!(header["alg"], "PBES2-HS512+A256KW");
-    assert_eq!(header["enc"], "A128CBC-HS256");
+    assert_eq!(header["enc"], "A256GCM");
+    assert_eq!(header["p2c"], 10000);
+
+    // Verify salt is 32 bytes (encoded as base64url)
+    let p2s = header["p2s"].as_str().unwrap();
+    let salt_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(p2s)
+        .unwrap();
+    assert_eq!(salt_bytes.len(), 32, "salt should be 32 bytes");
 }

--- a/tools/integration-test/src/identity.rs
+++ b/tools/integration-test/src/identity.rs
@@ -7,6 +7,8 @@ use anyhow::{Context, Result};
 pub struct TestIdentity {
     pub private_key_hex: String,
     pub did: String,
+    pub public_key_hex: Option<String>,
+    pub key_type: Option<String>,
 }
 
 /// Generate a new identity using the given DefraDB binary.
@@ -57,8 +59,9 @@ fn parse_identity_output(output: &str) -> Result<TestIdentity> {
         let val: serde_json::Value =
             serde_json::from_str(trimmed).context("failed to parse identity JSON")?;
 
-        // Rust JSON: {"private_key": ..., "did": ...}
-        // Go JSON:   {"PrivateKey": ..., "DID": ...}
+        // Rust JSON (new): {"PrivateKey": ..., "PublicKey": ..., "DID": ..., "KeyType": ...}
+        // Rust JSON (old): {"private_key": ..., "did": ...}
+        // Go JSON:         {"PrivateKey": ..., "PublicKey": ..., "DID": ..., "KeyType": ...}
         let private_key = val
             .get("private_key")
             .or_else(|| val.get("PrivateKey"))
@@ -71,9 +74,23 @@ fn parse_identity_output(output: &str) -> Result<TestIdentity> {
             .and_then(|v| v.as_str())
             .context("missing did in identity JSON")?;
 
+        let public_key = val
+            .get("PublicKey")
+            .or_else(|| val.get("public_key"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let key_type = val
+            .get("KeyType")
+            .or_else(|| val.get("key_type"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
         return Ok(TestIdentity {
             private_key_hex: private_key.to_string(),
             did: did.to_string(),
+            public_key_hex: public_key,
+            key_type,
         });
     }
 
@@ -92,6 +109,8 @@ fn parse_identity_output(output: &str) -> Result<TestIdentity> {
     Ok(TestIdentity {
         private_key_hex: private_key.context("missing 'Private key:' in identity output")?,
         did: did.context("missing 'DID:' in identity output")?,
+        public_key_hex: None,
+        key_type: None,
     })
 }
 
@@ -105,10 +124,12 @@ mod tests {
         let id = parse_identity_output(output).unwrap();
         assert_eq!(id.private_key_hex, "abcdef0123456789");
         assert_eq!(id.did, "did:key:z6Mk...");
+        assert!(id.public_key_hex.is_none());
+        assert!(id.key_type.is_none());
     }
 
     #[test]
-    fn parse_rust_json_format() {
+    fn parse_rust_json_format_legacy() {
         let output = r#"{"private_key":"abcdef","did":"did:key:z6Mk"}"#;
         let id = parse_identity_output(output).unwrap();
         assert_eq!(id.private_key_hex, "abcdef");
@@ -117,9 +138,11 @@ mod tests {
 
     #[test]
     fn parse_go_json_format() {
-        let output = r#"{"PrivateKey":"abcdef","DID":"did:key:z6Mk"}"#;
+        let output = r#"{"PrivateKey":"abcdef","PublicKey":"012345","DID":"did:key:z6Mk","KeyType":"secp256k1"}"#;
         let id = parse_identity_output(output).unwrap();
         assert_eq!(id.private_key_hex, "abcdef");
         assert_eq!(id.did, "did:key:z6Mk");
+        assert_eq!(id.public_key_hex.as_deref(), Some("012345"));
+        assert_eq!(id.key_type.as_deref(), Some("secp256k1"));
     }
 }

--- a/tools/integration-test/tests/identity_lifecycle.rs
+++ b/tools/integration-test/tests/identity_lifecycle.rs
@@ -66,6 +66,24 @@ fn stderr(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stderr).to_string()
 }
 
+/// Extract DID from either JSON ({"did":"..."}) or text ("DID: ...") output.
+fn extract_did_from_output(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.starts_with('{') {
+        let val: serde_json::Value = serde_json::from_str(trimmed).expect("not valid JSON");
+        val.get("did")
+            .or_else(|| val.get("DID"))
+            .and_then(|v| v.as_str())
+            .expect("missing did field in JSON")
+            .to_string()
+    } else {
+        trimmed
+            .strip_prefix("DID: ")
+            .expect("unexpected output format")
+            .to_string()
+    }
+}
+
 /// Extract the "did" field from a JWK JSON printed on stdout.
 fn did_from_jwk_stdout(output: &std::process::Output) -> String {
     let text = stdout(output);
@@ -139,15 +157,11 @@ fn export_delete_reimport_preserves_did() {
     let tmp = tempfile::tempdir().unwrap();
     let kr = tmp.path();
 
-    // new --name c
+    // new --name c (default output is now JSON)
     let out = defra_identity(kr, &["new", "--name", "c"]);
     assert!(out.status.success(), "new failed: {}", stderr(&out));
     let did1_text = stdout(&out);
-    // DID: did:key:z...
-    let did1 = did1_text
-        .trim()
-        .strip_prefix("DID: ")
-        .expect("unexpected output format");
+    let did1 = extract_did_from_output(&did1_text);
 
     // export --name c
     let out = defra_identity(kr, &["export", "--name", "c"]);
@@ -165,7 +179,7 @@ fn export_delete_reimport_preserves_did() {
     assert!(out.status.success(), "import failed: {}", stderr(&out));
     let did2_text = stdout(&out);
     assert!(
-        did2_text.contains(did1),
+        did2_text.contains(&did1),
         "DID mismatch: got '{}', expected '{}'",
         did2_text.trim(),
         did1
@@ -228,4 +242,84 @@ fn import_rejects_wrong_curve() {
     let out = defra_identity_stdin(kr, &["import", "--name", "x", "--stdin"], jwk);
     assert!(!out.status.success());
     assert!(stderr(&out).contains("unsupported JWK curve"));
+}
+
+#[test]
+#[ignore]
+fn identity_new_json_format_rust() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_identity(kr, &["new"]);
+    assert!(
+        out.status.success(),
+        "identity new failed: {}",
+        stderr(&out)
+    );
+    let text = stdout(&out);
+    let val: serde_json::Value =
+        serde_json::from_str(text.trim()).expect("default output should be JSON");
+    assert!(
+        val.get("PrivateKey").and_then(|v| v.as_str()).is_some(),
+        "missing PrivateKey"
+    );
+    assert!(
+        val.get("PublicKey").and_then(|v| v.as_str()).is_some(),
+        "missing PublicKey"
+    );
+    assert!(
+        val.get("DID")
+            .and_then(|v| v.as_str())
+            .is_some_and(|d| d.starts_with("did:key:z")),
+        "missing or invalid DID"
+    );
+    assert_eq!(
+        val.get("KeyType").and_then(|v| v.as_str()),
+        Some("secp256k1"),
+        "expected KeyType secp256k1"
+    );
+}
+
+#[test]
+#[ignore]
+fn identity_new_ed25519_json_rust() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_identity(kr, &["new", "--type", "ed25519"]);
+    assert!(
+        out.status.success(),
+        "identity new failed: {}",
+        stderr(&out)
+    );
+    let text = stdout(&out);
+    let val: serde_json::Value =
+        serde_json::from_str(text.trim()).expect("default output should be JSON");
+    assert_eq!(
+        val.get("KeyType").and_then(|v| v.as_str()),
+        Some("ed25519"),
+        "expected KeyType ed25519"
+    );
+    assert!(
+        val.get("PublicKey").and_then(|v| v.as_str()).is_some(),
+        "missing PublicKey"
+    );
+}
+
+#[test]
+#[ignore]
+fn identity_new_default_is_json_rust() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    // No --output flag at all — should default to JSON
+    let out = defra_identity(kr, &["new"]);
+    assert!(out.status.success());
+    let text = stdout(&out);
+    let trimmed = text.trim();
+    assert!(
+        trimmed.starts_with('{') && trimmed.ends_with('}'),
+        "expected JSON object, got: '{}'",
+        trimmed
+    );
 }

--- a/tools/integration-test/tests/keyring_lifecycle.rs
+++ b/tools/integration-test/tests/keyring_lifecycle.rs
@@ -1,0 +1,657 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("failed to canonicalize workspace root")
+}
+
+fn defra_binary() -> PathBuf {
+    workspace_root().join("target/debug/defra")
+}
+
+fn go_binary() -> Option<PathBuf> {
+    Command::new("defradb")
+        .arg("--help")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .ok()
+        .filter(|s| s.success())
+        .map(|_| PathBuf::from("defradb"))
+}
+
+fn defra_keyring(binary: &Path, keyring_dir: &Path, args: &[&str]) -> Output {
+    Command::new(binary)
+        .arg("--keyring-backend")
+        .arg("file")
+        .arg("--keyring-path")
+        .arg(keyring_dir)
+        .arg("keyring")
+        .args(args)
+        .env("DEFRA_KEYRING_SECRET", "test-secret")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run defra binary")
+}
+
+fn defra_keyring_stdin(binary: &Path, keyring_dir: &Path, args: &[&str], input: &str) -> Output {
+    use std::io::Write;
+    let mut child = Command::new(binary)
+        .arg("--keyring-backend")
+        .arg("file")
+        .arg("--keyring-path")
+        .arg(keyring_dir)
+        .arg("keyring")
+        .args(args)
+        .env("DEFRA_KEYRING_SECRET", "test-secret")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn defra binary");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+/// Combined stdout + stderr. Go's cobra writes command output to stderr,
+/// while Rust writes to stdout. This helper lets shared tests work with both.
+fn combined_output(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+/// Extract the first hex string from combined output.
+/// Filters out Go's INF log lines and finds the hex-only line.
+fn extract_hex_line(output: &Output) -> String {
+    let combined = combined_output(output);
+    for line in combined.lines() {
+        let trimmed = line.trim();
+        if !trimmed.is_empty()
+            && trimmed.chars().all(|c| c.is_ascii_hexdigit())
+            && trimmed.len() >= 2
+        {
+            return trimmed.to_string();
+        }
+    }
+    String::new()
+}
+
+// ---------------------------------------------------------------------------
+// Go-compatible tests: shared inner + _rust / _go wrappers
+// ---------------------------------------------------------------------------
+
+fn generate_creates_both_keys(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["generate"]);
+    assert!(out.status.success(), "generate failed: {}", stderr(&out));
+
+    let out = defra_keyring(binary, kr, &["list"]);
+    assert!(out.status.success(), "list failed: {}", stderr(&out));
+    let list = combined_output(&out);
+    assert!(list.contains("peer-key"), "missing peer-key in: {}", list);
+    assert!(
+        list.contains("encryption-key"),
+        "missing encryption-key in: {}",
+        list
+    );
+}
+
+#[test]
+#[ignore]
+fn generate_creates_both_keys_rust() {
+    generate_creates_both_keys(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn generate_creates_both_keys_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    generate_creates_both_keys(&go);
+}
+
+fn generate_no_encryption(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["generate", "--no-encryption"]);
+    assert!(out.status.success(), "generate failed: {}", stderr(&out));
+
+    let out = defra_keyring(binary, kr, &["list"]);
+    let list = combined_output(&out);
+    assert!(list.contains("peer-key"), "missing peer-key in: {}", list);
+    assert!(
+        !list.contains("encryption-key"),
+        "unexpected encryption-key in: {}",
+        list
+    );
+}
+
+#[test]
+#[ignore]
+fn generate_no_encryption_rust() {
+    generate_no_encryption(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn generate_no_encryption_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    generate_no_encryption(&go);
+}
+
+fn generate_no_peer_key(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["generate", "--no-peer-key"]);
+    assert!(out.status.success(), "generate failed: {}", stderr(&out));
+
+    let out = defra_keyring(binary, kr, &["list"]);
+    let list = combined_output(&out);
+    assert!(
+        !list.contains("peer-key"),
+        "unexpected peer-key in: {}",
+        list
+    );
+    assert!(
+        list.contains("encryption-key"),
+        "missing encryption-key in: {}",
+        list
+    );
+}
+
+#[test]
+#[ignore]
+fn generate_no_peer_key_rust() {
+    generate_no_peer_key(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn generate_no_peer_key_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    generate_no_peer_key(&go);
+}
+
+fn generate_fails_if_exists(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["generate"]);
+    assert!(
+        out.status.success(),
+        "first generate failed: {}",
+        stderr(&out)
+    );
+
+    let out = defra_keyring(binary, kr, &["generate"]);
+    assert!(
+        !out.status.success(),
+        "second generate should fail but succeeded"
+    );
+    let err = combined_output(&out);
+    assert!(
+        err.contains("already exists"),
+        "expected 'already exists' in error: {}",
+        err
+    );
+}
+
+#[test]
+#[ignore]
+fn generate_fails_if_exists_rust() {
+    generate_fails_if_exists(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn generate_fails_if_exists_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    generate_fails_if_exists(&go);
+}
+
+fn generate_force_overwrites(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["generate"]);
+    assert!(
+        out.status.success(),
+        "first generate failed: {}",
+        stderr(&out)
+    );
+
+    let out = defra_keyring(binary, kr, &["generate", "--force"]);
+    assert!(
+        out.status.success(),
+        "generate --force failed: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+#[ignore]
+fn generate_force_overwrites_rust() {
+    generate_force_overwrites(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn generate_force_overwrites_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    generate_force_overwrites(&go);
+}
+
+fn generate_silent_on_success(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["generate"]);
+    assert!(out.status.success(), "generate failed: {}", stderr(&out));
+    assert!(
+        stdout(&out).trim().is_empty(),
+        "expected empty stdout, got: '{}'",
+        stdout(&out)
+    );
+}
+
+#[test]
+#[ignore]
+fn generate_silent_on_success_rust() {
+    generate_silent_on_success(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn generate_silent_on_success_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    generate_silent_on_success(&go);
+}
+
+fn export_hex_format(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    // Import a known hex key
+    let known_hex = "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233";
+    let out = defra_keyring(binary, kr, &["import", "test-key", known_hex]);
+    assert!(out.status.success(), "import failed: {}", stderr(&out));
+
+    // Export and verify — Go writes hex to stderr, Rust to stdout
+    let out = defra_keyring(binary, kr, &["export", "test-key"]);
+    assert!(out.status.success(), "export failed: {}", stderr(&out));
+    let hex_out = extract_hex_line(&out);
+    assert_eq!(hex_out, known_hex, "exported hex doesn't match imported");
+}
+
+#[test]
+#[ignore]
+fn export_hex_format_rust() {
+    export_hex_format(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn export_hex_format_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    export_hex_format(&go);
+}
+
+fn export_roundtrip(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["generate"]);
+    assert!(out.status.success(), "generate failed: {}", stderr(&out));
+
+    // Export peer-key (Ed25519 = 64 bytes = 128 hex chars)
+    let out = defra_keyring(binary, kr, &["export", "peer-key"]);
+    assert!(out.status.success(), "export failed: {}", stderr(&out));
+    let hex_str = extract_hex_line(&out);
+    assert!(
+        hex_str.len() == 128,
+        "expected 128 hex chars for ed25519, got {} ('{}')",
+        hex_str.len(),
+        hex_str
+    );
+
+    // Export encryption-key (AES-256 = 32 bytes = 64 hex chars)
+    let out = defra_keyring(binary, kr, &["export", "encryption-key"]);
+    assert!(out.status.success(), "export failed: {}", stderr(&out));
+    let hex_str = extract_hex_line(&out);
+    assert!(
+        hex_str.len() == 64,
+        "expected 64 hex chars for aes256, got {} ('{}')",
+        hex_str.len(),
+        hex_str
+    );
+}
+
+#[test]
+#[ignore]
+fn export_roundtrip_rust() {
+    export_roundtrip(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn export_roundtrip_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    export_roundtrip(&go);
+}
+
+fn import_positional_hex(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let hex_key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    let out = defra_keyring(binary, kr, &["import", "my-key", hex_key]);
+    assert!(out.status.success(), "import failed: {}", stderr(&out));
+
+    let out = defra_keyring(binary, kr, &["export", "my-key"]);
+    assert!(out.status.success(), "export failed: {}", stderr(&out));
+    let hex_out = extract_hex_line(&out);
+    assert_eq!(hex_out, hex_key);
+}
+
+#[test]
+#[ignore]
+fn import_positional_hex_rust() {
+    import_positional_hex(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn import_positional_hex_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    import_positional_hex(&go);
+}
+
+fn import_silent_on_success(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let hex_key = "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd";
+    let out = defra_keyring(binary, kr, &["import", "s-key", hex_key]);
+    assert!(out.status.success(), "import failed: {}", stderr(&out));
+    assert!(
+        stdout(&out).trim().is_empty(),
+        "expected empty stdout, got: '{}'",
+        stdout(&out)
+    );
+}
+
+#[test]
+#[ignore]
+fn import_silent_on_success_rust() {
+    import_silent_on_success(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn import_silent_on_success_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    import_silent_on_success(&go);
+}
+
+fn import_invalid_hex_fails(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["import", "bad-key", "ZZZZ"]);
+    assert!(!out.status.success(), "import of invalid hex should fail");
+}
+
+#[test]
+#[ignore]
+fn import_invalid_hex_fails_rust() {
+    import_invalid_hex_fails(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn import_invalid_hex_fails_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    import_invalid_hex_fails(&go);
+}
+
+fn list_empty(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let out = defra_keyring(binary, kr, &["list"]);
+    assert!(out.status.success(), "list failed: {}", stderr(&out));
+    let text = combined_output(&out);
+    assert!(
+        text.contains("No keys found in the keyring."),
+        "expected 'No keys found in the keyring.', got: '{}'",
+        text.trim()
+    );
+}
+
+#[test]
+#[ignore]
+fn list_empty_rust() {
+    list_empty(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn list_empty_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    list_empty(&go);
+}
+
+fn list_format(binary: &Path) {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+
+    let hex_key = "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd";
+    let out = defra_keyring(binary, kr, &["import", "alpha", hex_key]);
+    assert!(out.status.success());
+
+    let out = defra_keyring(binary, kr, &["list"]);
+    assert!(out.status.success());
+    let text = combined_output(&out);
+    assert!(
+        text.contains("Keys in the keyring:"),
+        "expected header, got: '{}'",
+        text.trim()
+    );
+    assert!(
+        text.contains("- alpha"),
+        "expected '- alpha', got: '{}'",
+        text.trim()
+    );
+}
+
+#[test]
+#[ignore]
+fn list_format_rust() {
+    list_format(&defra_binary());
+}
+
+#[test]
+#[ignore]
+fn list_format_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    list_format(&go);
+}
+
+// ---------------------------------------------------------------------------
+// Rust-only tests
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore]
+fn delete_removes_key_rust() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+    let binary = defra_binary();
+
+    let hex_key = "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd";
+    let out = defra_keyring(&binary, kr, &["import", "del-key", hex_key]);
+    assert!(out.status.success());
+
+    let out = defra_keyring(&binary, kr, &["delete", "del-key"]);
+    assert!(out.status.success(), "delete failed: {}", stderr(&out));
+
+    let out = defra_keyring(&binary, kr, &["export", "del-key"]);
+    assert!(!out.status.success(), "export should fail after delete");
+}
+
+#[test]
+#[ignore]
+fn generate_named_key_rust() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+    let binary = defra_binary();
+
+    let out = defra_keyring(&binary, kr, &["generate", "custom-key", "-t", "aes256"]);
+    assert!(
+        out.status.success(),
+        "generate named key failed: {}",
+        stderr(&out)
+    );
+
+    let out = defra_keyring(&binary, kr, &["list"]);
+    let list = stdout(&out);
+    assert!(
+        list.contains("custom-key"),
+        "missing custom-key in: {}",
+        list
+    );
+}
+
+#[test]
+#[ignore]
+fn generate_named_key_force_rust() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+    let binary = defra_binary();
+
+    let out = defra_keyring(&binary, kr, &["generate", "my-key", "-t", "ed25519"]);
+    assert!(out.status.success());
+
+    // Without --force, should fail
+    let out = defra_keyring(&binary, kr, &["generate", "my-key", "-t", "ed25519"]);
+    assert!(!out.status.success());
+    assert!(stderr(&out).contains("already exists"));
+
+    // With --force, should succeed
+    let out = defra_keyring(
+        &binary,
+        kr,
+        &["generate", "my-key", "-t", "ed25519", "--force"],
+    );
+    assert!(
+        out.status.success(),
+        "generate --force failed: {}",
+        stderr(&out)
+    );
+}
+
+#[test]
+#[ignore]
+fn import_stdin_rust() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+    let binary = defra_binary();
+
+    let hex_key = "aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd";
+    let out = defra_keyring_stdin(&binary, kr, &["import", "stdin-key", "--stdin"], hex_key);
+    assert!(
+        out.status.success(),
+        "import --stdin failed: {}",
+        stderr(&out)
+    );
+
+    let out = defra_keyring(&binary, kr, &["export", "stdin-key"]);
+    assert!(out.status.success());
+    assert_eq!(stdout(&out).trim(), hex_key);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-binary tests (Rust <-> Go interop)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore]
+fn import_rust_export_go() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+    let rust = defra_binary();
+
+    let hex_key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    let out = defra_keyring(&rust, kr, &["import", "cross-key", hex_key]);
+    assert!(out.status.success(), "rust import failed: {}", stderr(&out));
+
+    // Go export writes to stderr
+    let out = defra_keyring(&go, kr, &["export", "cross-key"]);
+    assert!(out.status.success(), "go export failed: {}", stderr(&out));
+    let hex_out = extract_hex_line(&out);
+    assert_eq!(hex_out, hex_key, "go export mismatch");
+}
+
+#[test]
+#[ignore]
+fn import_go_export_rust() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+    let rust = defra_binary();
+
+    let hex_key = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe";
+    let out = defra_keyring(&go, kr, &["import", "cross-key2", hex_key]);
+    assert!(out.status.success(), "go import failed: {}", stderr(&out));
+
+    let out = defra_keyring(&rust, kr, &["export", "cross-key2"]);
+    assert!(out.status.success(), "rust export failed: {}", stderr(&out));
+    assert_eq!(stdout(&out).trim(), hex_key, "rust export mismatch");
+}
+
+#[test]
+#[ignore]
+fn generate_go_list_rust() {
+    let go = go_binary().expect("Go defradb not in PATH");
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+    let rust = defra_binary();
+
+    let out = defra_keyring(&go, kr, &["generate"]);
+    assert!(out.status.success(), "go generate failed: {}", stderr(&out));
+
+    let out = defra_keyring(&rust, kr, &["list"]);
+    assert!(out.status.success(), "rust list failed: {}", stderr(&out));
+    let list = stdout(&out);
+    assert!(list.contains("peer-key"), "missing peer-key in: {}", list);
+    assert!(
+        list.contains("encryption-key"),
+        "missing encryption-key in: {}",
+        list
+    );
+}


### PR DESCRIPTION
## Summary
- Aligns all keyring commands (`list`, `export`, `import`, `generate`) with Go DefraDB's exact CLI behavior while keeping Rust extensions
- Changes `identity new` default output to Go-compatible JSON with PascalCase fields (`PrivateKey`, `PublicKey`, `DID`, `KeyType`)
- Adds comprehensive integration test suite: 18 keyring lifecycle tests + 3 identity JSON format tests, with cross-binary (Rust↔Go) interop tests

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] `cargo test -p cli` — 23 passed
- [x] `cargo test -p integration-test --lib` — 4 passed
- [ ] `cargo test -p integration-test --test keyring_lifecycle -- --ignored --nocapture` (Rust integration tests)
- [ ] `cargo test -p integration-test --test identity_lifecycle -- --ignored --nocapture` (identity integration tests)
- [ ] Cross-binary tests with Go `defradb` in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)