### PR TITLE
fix(http): Match Go wire format for collection patch, set-active, and purge

### DIFF
--- a/crates/cli/src/commands/client/collection/document.rs
+++ b/crates/cli/src/commands/client/collection/document.rs
@@ -185,8 +185,7 @@ impl CollectionPatchArgs {
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);
 
-        let result = client.collection_patch(&patch).await?;
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        client.collection_patch(&patch).await?;
         Ok(())
     }
 }
@@ -197,10 +196,9 @@ impl SetActiveArgs {
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);
 
-        let result = client
+        client
             .collection_set_active(self.version_id.as_deref())
             .await?;
-        println!("{}", serde_json::to_string_pretty(&result)?);
         Ok(())
     }
 }

--- a/crates/cli/src/commands/client/http_client/collection.rs
+++ b/crates/cli/src/commands/client/http_client/collection.rs
@@ -32,15 +32,21 @@ impl HttpClient {
         self.request_void("DELETE", &url, None).await
     }
 
-    pub async fn collection_patch(&self, patch: &str) -> Result<JsonValue> {
+    pub async fn collection_patch(&self, patch: &str) -> Result<()> {
         let url = format!("{}/api/v0/collections", self.base_url);
-        self.request_json("PATCH", &url, Some(patch)).await
+        let body = serde_json::json!({ "Patch": patch });
+        let body_str = serde_json::to_string(&body)?;
+        self.request_void("PATCH", &url, Some(&body_str)).await
     }
 
-    pub async fn collection_set_active(&self, version_id: Option<&str>) -> Result<JsonValue> {
-        let url = format!("{}/api/v0/collections/set-active", self.base_url);
-        let body = serde_json::to_string(&serde_json::json!({ "versionID": version_id }))?;
-        self.request_json("POST", &url, Some(&body)).await
+    pub async fn collection_set_active(&self, version_id: Option<&str>) -> Result<()> {
+        let url = format!("{}/api/v0/collections/default", self.base_url);
+        let text = version_id.unwrap_or("");
+        let response = self.post_text(&url, text).await?;
+        if !response.status().is_success() {
+            return Err(Self::extract_error(response).await);
+        }
+        Ok(())
     }
 
     pub async fn collection_truncate(&self, name: &str) -> Result<()> {

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -556,7 +556,8 @@ impl Node {
             // Cast the Arc<QueryRunner> to Arc<dyn QueryExecutor> for the server
             let executor: Arc<dyn query::executor::QueryExecutor> = runner;
             let mut server = defra_http::Server::from_arc_with_config(executor, server_config)
-                .with_rest(rest_ops);
+                .with_rest(rest_ops)
+                .with_dev_mode(config.development);
 
             // Wire node identity DID for signing config fallback in HTTP handlers
             if let Some(did) = node_identity_did {

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -7,6 +7,7 @@
 
 use axum::{
     extract::{Path, State},
+    http::StatusCode,
     Json,
 };
 use serde::Serialize;
@@ -83,23 +84,19 @@ pub async fn get_collection_doc_ids(
     }
 }
 
-/// Request body for patching a collection schema.
+/// Go-compatible request body for patching a collection schema.
 #[derive(Debug, serde::Deserialize)]
 pub struct PatchCollectionRequest {
-    /// Collection name (or version ID) to patch.
-    #[serde(rename = "Name", alias = "name")]
-    pub name: String,
-    /// JSON Patch (RFC 6902) as a JSON string or array.
     #[serde(rename = "Patch", alias = "patch")]
     pub patch: serde_json::Value,
-}
-
-/// Request body for setting the active collection version.
-#[derive(Debug, serde::Deserialize)]
-pub struct SetActiveRequest {
-    /// The version ID to activate.
-    #[serde(rename = "VersionID", alias = "version_id")]
-    pub version_id: String,
+    #[serde(rename = "Migration", default)]
+    pub migration: Option<serde_json::Value>,
+    #[serde(
+        rename = "SetAsDefaultVersion",
+        alias = "set_as_default_version",
+        default
+    )]
+    pub set_as_default_version: Option<bool>,
 }
 
 /// Patch a collection schema.
@@ -114,11 +111,12 @@ pub async fn patch_collection(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     Json(body): Json<PatchCollectionRequest>,
-) -> Result<Json<serde_json::Value>, HttpError> {
+) -> Result<StatusCode, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
 
     let collection_mgmt = state.require_collection_mgmt()?;
 
+    // The Patch field may be a JSON string containing patch ops, or a JSON array directly
     let patch_str = if body.patch.is_string() {
         body.patch.as_str().unwrap().to_string()
     } else {
@@ -126,18 +124,50 @@ pub async fn patch_collection(
             .map_err(|e| HttpError::BadRequest(format!("invalid patch: {}", e)))?
     };
 
-    let result = collection_mgmt
-        .patch_collection(&body.name, &patch_str)
+    // Parse the patch ops to extract the collection name from the first op's path
+    let patch_ops: serde_json::Value = serde_json::from_str(&patch_str)
+        .map_err(|e| HttpError::BadRequest(format!("invalid patch JSON: {}", e)))?;
+
+    let name = extract_collection_name_from_patch(&patch_ops)?;
+
+    collection_mgmt
+        .patch_collection(&name, &patch_str)
         .await
         .map_err(HttpError::BadRequest)?;
 
-    Ok(Json(result))
+    Ok(StatusCode::OK)
+}
+
+/// Extract the collection name from the first patch operation's path.
+/// Go patches use paths like "/Users/Fields/-" where "Users" is the collection name.
+fn extract_collection_name_from_patch(patch_ops: &serde_json::Value) -> Result<String, HttpError> {
+    let ops = patch_ops
+        .as_array()
+        .ok_or_else(|| HttpError::BadRequest("patch must be a JSON array".into()))?;
+
+    let first_op = ops
+        .first()
+        .ok_or_else(|| HttpError::BadRequest("patch array is empty".into()))?;
+
+    let path = first_op
+        .get("path")
+        .and_then(|p| p.as_str())
+        .ok_or_else(|| HttpError::BadRequest("first patch op missing 'path' field".into()))?;
+
+    // Path format: "/<CollectionName>/Fields/-" or "/<CollectionName>/..."
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    let name = segments
+        .first()
+        .ok_or_else(|| HttpError::BadRequest("patch path has no collection name".into()))?;
+
+    Ok(name.to_string())
 }
 
 /// Set the active collection version.
 ///
-/// POST /api/v0/collections/set-active
+/// POST /api/v0/collections/default
 ///
+/// Accepts a plain text body containing the version ID to activate.
 /// Activates the specified version and deactivates other versions
 /// of the same collection.
 ///
@@ -145,18 +175,21 @@ pub async fn patch_collection(
 pub async fn set_active(
     State(state): State<AppState>,
     identity: ExtractIdentity,
-    Json(body): Json<SetActiveRequest>,
-) -> Result<Json<()>, HttpError> {
+    body: axum::body::Bytes,
+) -> Result<StatusCode, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
+
+    let version_id = String::from_utf8(body.to_vec())
+        .map_err(|_| HttpError::BadRequest("invalid UTF-8".into()))?;
 
     let collection_mgmt = state.require_collection_mgmt()?;
 
     collection_mgmt
-        .set_active_version(&body.version_id)
+        .set_active_version(version_id.trim())
         .await
         .map_err(HttpError::BadRequest)?;
 
-    Ok(Json(()))
+    Ok(StatusCode::OK)
 }
 
 /// Truncate all documents in a collection.

--- a/crates/http/src/handlers/utility.rs
+++ b/crates/http/src/handlers/utility.rs
@@ -6,7 +6,9 @@
 //!
 //! These endpoints match Go DefraDB's utility endpoints for compatibility.
 
-use axum::{extract::State, Json};
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
 use serde::Serialize;
 
 use crate::error::HttpError;
@@ -52,8 +54,14 @@ pub async fn get_node_identity(
 pub async fn purge(
     State(state): State<AppState>,
     identity: ExtractIdentity,
-) -> Result<Json<()>, HttpError> {
+) -> Result<StatusCode, HttpError> {
     require_permission(&state, &identity, NodePermission::DocumentUpdate).await?;
+
+    if !state.dev_mode {
+        return Err(HttpError::BadRequest(
+            "cannot purge database when development mode is disabled".into(),
+        ));
+    }
 
     state
         .require_collection_mgmt()?
@@ -61,7 +69,7 @@ pub async fn purge(
         .await
         .map_err(HttpError::Internal)?;
 
-    Ok(Json(()))
+    Ok(StatusCode::OK)
 }
 
 #[cfg(test)]

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -60,7 +60,7 @@ pub fn create_router_with_state(state: AppState) -> Router {
     let collection_routes = Router::new()
         .route("/", get(handlers::list_collections))
         .route("/", patch(handlers::patch_collection))
-        .route("/set-active", post(handlers::set_active))
+        .route("/default", post(handlers::set_active))
         .route(
             "/versions",
             get(handlers::get_all_collections).delete(handlers::delete_collection_versions),

--- a/crates/http/src/router/state.rs
+++ b/crates/http/src/router/state.rs
@@ -31,6 +31,7 @@ pub struct AppState {
     pub txn_ops: Option<Arc<dyn TransactionOperations>>,
     pub event_bus: Option<Arc<dyn events::Bus>>,
     pub node_identity_did: Option<String>,
+    pub dev_mode: bool,
 }
 
 impl std::fmt::Debug for AppState {
@@ -77,6 +78,7 @@ impl std::fmt::Debug for AppState {
             )
             .field("event_bus", &self.event_bus.as_ref().map(|_| "<EventBus>"))
             .field("node_identity_did", &self.node_identity_did)
+            .field("dev_mode", &self.dev_mode)
             .finish()
     }
 }
@@ -223,6 +225,7 @@ pub struct AppStateBuilder {
     txn_ops: Option<Arc<dyn TransactionOperations>>,
     event_bus: Option<Arc<dyn events::Bus>>,
     node_identity_did: Option<String>,
+    dev_mode: bool,
 }
 
 impl AppStateBuilder {
@@ -246,6 +249,7 @@ impl AppStateBuilder {
             txn_ops: None,
             event_bus: None,
             node_identity_did: None,
+            dev_mode: false,
         }
     }
 
@@ -351,6 +355,12 @@ impl AppStateBuilder {
         self
     }
 
+    /// Enable development mode (allows purge and other dev-only operations).
+    pub fn with_dev_mode(mut self, dev_mode: bool) -> Self {
+        self.dev_mode = dev_mode;
+        self
+    }
+
     /// Build the AppState.
     pub fn build(self) -> AppState {
         AppState {
@@ -371,6 +381,7 @@ impl AppStateBuilder {
             txn_ops: self.txn_ops,
             event_bus: self.event_bus,
             node_identity_did: self.node_identity_did,
+            dev_mode: self.dev_mode,
         }
     }
 }

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -60,6 +60,7 @@ pub struct Server {
     txn_ops: Option<Arc<dyn TransactionOperations>>,
     event_bus: Option<Arc<dyn events::Bus>>,
     node_identity_did: Option<String>,
+    dev_mode: bool,
 }
 
 impl Server {
@@ -84,6 +85,7 @@ impl Server {
             txn_ops: None,
             event_bus: None,
             node_identity_did: None,
+            dev_mode: false,
         }
     }
 
@@ -108,6 +110,7 @@ impl Server {
             txn_ops: None,
             event_bus: None,
             node_identity_did: None,
+            dev_mode: false,
         }
     }
 
@@ -132,6 +135,7 @@ impl Server {
             txn_ops: None,
             event_bus: None,
             node_identity_did: None,
+            dev_mode: false,
         }
     }
 
@@ -156,6 +160,7 @@ impl Server {
             txn_ops: None,
             event_bus: None,
             node_identity_did: None,
+            dev_mode: false,
         }
     }
 
@@ -310,6 +315,12 @@ impl Server {
         self
     }
 
+    /// Enable development mode (allows purge and other dev-only operations).
+    pub fn with_dev_mode(mut self, dev_mode: bool) -> Self {
+        self.dev_mode = dev_mode;
+        self
+    }
+
     /// Build the router with all routes and middleware.
     ///
     /// CORS configuration matches Go DefraDB behavior:
@@ -371,6 +382,7 @@ impl Server {
         if let Some(ref did) = self.node_identity_did {
             builder = builder.with_node_identity_did(did.clone());
         }
+        builder = builder.with_dev_mode(self.dev_mode);
         let state = builder.build();
         let router = create_router_with_state(state);
 

--- a/tools/integration-test/src/client/mod.rs
+++ b/tools/integration-test/src/client/mod.rs
@@ -686,4 +686,21 @@ impl DefraClient {
     pub fn lens_reload(&self) -> Result<String> {
         self.exec(&["client", "lens", "reload"])
     }
+
+    // -- Collection management operations --
+
+    /// Patch a collection schema via `client collection patch '<patch>'`.
+    pub fn collection_patch(&self, patch: &str) -> Result<String> {
+        self.exec(&["client", "collection", "patch", patch])
+    }
+
+    /// Set active collection version via `client collection set-active '<version_id>'`.
+    pub fn collection_set_active(&self, version_id: &str) -> Result<String> {
+        self.exec(&["client", "collection", "set-active", version_id])
+    }
+
+    /// Purge the database via `client purge --force`.
+    pub fn purge(&self) -> Result<String> {
+        self.exec(&["client", "purge", "--force"])
+    }
 }

--- a/tools/integration-test/src/client/mod.rs
+++ b/tools/integration-test/src/client/mod.rs
@@ -703,4 +703,30 @@ impl DefraClient {
     pub fn purge(&self) -> Result<String> {
         self.exec(&["client", "purge", "--force"])
     }
+
+    /// Get collection version info including VersionID.
+    ///
+    /// Tries the Rust REST endpoint first (`/collections/{name}/describe`),
+    /// then falls back to the CLI `collection describe` (works for Go nodes).
+    pub fn collection_describe_version(&self, name: &str) -> Result<Value> {
+        // Try Rust REST endpoint first
+        let url = format!("{}/api/v0/collections/{}/describe", self.url, name);
+        let output = Command::new("curl")
+            .arg("-s")
+            .arg("-f")
+            .arg(&url)
+            .output()
+            .with_context(|| format!("failed to curl {}", url))?;
+
+        if output.status.success() {
+            let body = String::from_utf8_lossy(&output.stdout);
+            if let Ok(val) = serde_json::from_str::<Value>(body.trim()) {
+                return Ok(val);
+            }
+        }
+
+        // Fall back to CLI describe (Go CLI returns full CollectionVersion JSON)
+        let out = self.exec(&["client", "collection", "describe", "--name", name])?;
+        serde_json::from_str(&out).context("failed to parse collection describe output")
+    }
 }

--- a/tools/integration-test/src/cluster/builder.rs
+++ b/tools/integration-test/src/cluster/builder.rs
@@ -26,6 +26,7 @@ pub struct TestClusterBuilder {
     signing_enabled: bool,
     nac_enabled: bool,
     source_hub_enabled: bool,
+    development: bool,
 }
 
 impl Default for TestClusterBuilder {
@@ -48,6 +49,7 @@ impl TestClusterBuilder {
             signing_enabled: false,
             nac_enabled: false,
             source_hub_enabled: false,
+            development: false,
         }
     }
 
@@ -104,6 +106,11 @@ impl TestClusterBuilder {
     pub fn with_source_hub(mut self) -> Self {
         self.source_hub_enabled = true;
         self.acp_document_type = Some("source-hub".to_string());
+        self
+    }
+
+    pub fn with_development(mut self) -> Self {
+        self.development = true;
         self
     }
 
@@ -196,6 +203,7 @@ impl TestClusterBuilder {
                 sh_lcd.clone(),
                 sh_comet.clone(),
                 sh_chain_id.clone(),
+                self.development,
             )
             .await
             .with_context(|| format!("failed to start {}", name))?;
@@ -223,6 +231,7 @@ impl TestClusterBuilder {
                 sh_lcd.clone(),
                 sh_comet.clone(),
                 sh_chain_id.clone(),
+                self.development,
             )
             .await
             .with_context(|| format!("failed to start {}", name))?;
@@ -263,6 +272,7 @@ async fn spawn_node(
     source_hub_address: Option<String>,
     source_hub_comet_address: Option<String>,
     source_hub_chain_id: Option<String>,
+    development: bool,
 ) -> Result<RunningNode> {
     let node_dir = run_dir.node_dir(name)?;
     let log_dir = node_dir.join("logs");
@@ -292,6 +302,7 @@ async fn spawn_node(
         source_hub_address,
         source_hub_comet_address,
         source_hub_chain_id,
+        development,
     };
 
     let cmd = node.command(&config);

--- a/tools/integration-test/src/node/go_node.rs
+++ b/tools/integration-test/src/node/go_node.rs
@@ -79,6 +79,10 @@ impl DefraNode for GoNode {
             cmd.arg("--node-acp-enable");
         }
 
+        if config.development {
+            cmd.arg("--development");
+        }
+
         cmd
     }
 

--- a/tools/integration-test/src/node/mod.rs
+++ b/tools/integration-test/src/node/mod.rs
@@ -24,6 +24,7 @@ pub struct NodeConfig {
     pub source_hub_address: Option<String>,
     pub source_hub_comet_address: Option<String>,
     pub source_hub_chain_id: Option<String>,
+    pub development: bool,
 }
 
 /// Trait for building a DefraDB command from config.

--- a/tools/integration-test/src/node/rust_node.rs
+++ b/tools/integration-test/src/node/rust_node.rs
@@ -87,6 +87,10 @@ impl DefraNode for RustNode {
             cmd.arg("--source-hub-chain-id").arg(chain_id);
         }
 
+        if config.development {
+            cmd.arg("--development");
+        }
+
         cmd
     }
 

--- a/tools/integration-test/tests/collection_patch.rs
+++ b/tools/integration-test/tests/collection_patch.rs
@@ -1,0 +1,49 @@
+use integration_test::TestCluster;
+
+async fn collection_patch_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    // 1. Deploy schema with title field
+    client
+        .schema_add("type Book { title: String }")
+        .expect("failed to add schema");
+
+    // 2. Create a document
+    client
+        .query(r#"mutation { create_Book(input: {title: "Rust Programming"}) { _docID } }"#)
+        .expect("create doc failed");
+
+    // 3. Patch schema to add summary field
+    let patch = r#"[{"op": "add", "path": "/Book/Fields/-", "value": {"Name": "summary", "Kind": "String"}}]"#;
+    client
+        .collection_patch(patch)
+        .expect("collection patch failed");
+
+    // 4. Query: verify new field exists (returns null for existing docs)
+    let data = client
+        .query("query { Book { title summary } }")
+        .expect("query after patch failed");
+
+    let books = data["Book"].as_array().expect("expected Book array");
+    assert_eq!(books.len(), 1, "should have 1 book");
+    assert_eq!(books[0]["title"], "Rust Programming");
+    // New field should be null for existing docs
+    assert!(
+        books[0]["summary"].is_null(),
+        "summary should be null for pre-existing doc"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn rust_collection_patch() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    collection_patch_test(cluster).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn go_collection_patch() {
+    let cluster = TestCluster::builder().go_nodes(1).build().await.unwrap();
+    collection_patch_test(cluster).await;
+}

--- a/tools/integration-test/tests/collection_versioning.rs
+++ b/tools/integration-test/tests/collection_versioning.rs
@@ -8,13 +8,23 @@ async fn collection_versioning_test(cluster: TestCluster) {
         .schema_add("type Item { name: String }")
         .expect("failed to add schema");
 
-    // 2. Get version ID from collection describe
-    let desc = client.collection_describe("Item").expect("describe failed");
+    // 2. Get version ID from REST API describe endpoint
+    let desc = client
+        .collection_describe_version("Item")
+        .expect("describe version failed");
 
-    // Extract version ID - Go uses "VersionID", check both
-    let version_id = desc
+    // Extract version ID from describe output.
+    // Go CLI returns an array of collection versions; Rust REST returns a single object.
+    let version_obj = if desc.is_array() {
+        desc.as_array()
+            .and_then(|arr| arr.first())
+            .expect("empty collection describe array")
+    } else {
+        &desc
+    };
+    let version_id = version_obj
         .get("VersionID")
-        .or_else(|| desc.get("version_id"))
+        .or_else(|| version_obj.get("version_id"))
         .and_then(|v| v.as_str())
         .expect("missing VersionID in collection describe");
 

--- a/tools/integration-test/tests/collection_versioning.rs
+++ b/tools/integration-test/tests/collection_versioning.rs
@@ -1,0 +1,52 @@
+use integration_test::TestCluster;
+
+async fn collection_versioning_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    // 1. Deploy schema
+    client
+        .schema_add("type Item { name: String }")
+        .expect("failed to add schema");
+
+    // 2. Get version ID from collection describe
+    let desc = client.collection_describe("Item").expect("describe failed");
+
+    // Extract version ID - Go uses "VersionID", check both
+    let version_id = desc
+        .get("VersionID")
+        .or_else(|| desc.get("version_id"))
+        .and_then(|v| v.as_str())
+        .expect("missing VersionID in collection describe");
+
+    // 3. Set-active with the same version ID (no-op, should succeed)
+    client
+        .collection_set_active(version_id)
+        .expect("set-active failed");
+
+    // 4. Verify collection still works
+    client
+        .query(r#"mutation { create_Item(input: {name: "widget"}) { _docID } }"#)
+        .expect("create after set-active failed");
+
+    let data = client
+        .query("query { Item { name } }")
+        .expect("query after set-active failed");
+
+    let items = data["Item"].as_array().expect("expected Item array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["name"], "widget");
+}
+
+#[tokio::test]
+#[ignore]
+async fn rust_collection_versioning() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    collection_versioning_test(cluster).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn go_collection_versioning() {
+    let cluster = TestCluster::builder().go_nodes(1).build().await.unwrap();
+    collection_versioning_test(cluster).await;
+}

--- a/tools/integration-test/tests/purge.rs
+++ b/tools/integration-test/tests/purge.rs
@@ -1,0 +1,83 @@
+use integration_test::TestCluster;
+
+async fn purge_dev_mode_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    // 1. Deploy schema and create documents
+    client
+        .schema_add("type Note { text: String }")
+        .expect("failed to add schema");
+
+    client
+        .query(r#"mutation { create_Note(input: {text: "hello"}) { _docID } }"#)
+        .expect("create doc failed");
+
+    // 2. Verify document exists
+    let data = client
+        .query("query { Note { text } }")
+        .expect("query failed");
+    let notes = data["Note"].as_array().expect("expected Note array");
+    assert_eq!(notes.len(), 1);
+
+    // 3. Purge in dev mode should succeed
+    client.purge().expect("purge should succeed in dev mode");
+}
+
+async fn purge_non_dev_mode_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    // 1. Deploy schema
+    client
+        .schema_add("type Note { text: String }")
+        .expect("failed to add schema");
+
+    // 2. Purge without dev mode should fail
+    let result = client.purge();
+    assert!(result.is_err(), "purge should fail when not in dev mode");
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("cannot purge database when development mode is disabled")
+            || err_msg.contains("development mode"),
+        "error should mention development mode, got: {}",
+        err_msg
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn rust_purge_dev_mode() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_development()
+        .build()
+        .await
+        .unwrap();
+    purge_dev_mode_test(cluster).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn go_purge_dev_mode() {
+    let cluster = TestCluster::builder()
+        .go_nodes(1)
+        .with_development()
+        .build()
+        .await
+        .unwrap();
+    purge_dev_mode_test(cluster).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn rust_purge_non_dev_mode() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    purge_non_dev_mode_test(cluster).await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn go_purge_non_dev_mode() {
+    let cluster = TestCluster::builder().go_nodes(1).build().await.unwrap();
+    purge_non_dev_mode_test(cluster).await;
+}


### PR DESCRIPTION
## Summary
- **Collection patch**: Replace `{Name, Patch}` request body with Go-compatible `{Patch, Migration, SetAsDefaultVersion}`. Extract collection name from patch op paths. Client wraps patch in `{"Patch": "..."}` envelope.
- **Collection set-active**: Change endpoint from `/set-active` to `/default`. Accept plain text body instead of JSON. Client sends raw version ID.
- **Purge**: Add dev-mode gate matching Go behavior — returns 400 when development mode is disabled. Wire `config.development` through AppState/Server/CLI.
- **Integration tests**: Add `collection_patch`, `collection_versioning`, and `purge` tests with both Rust and Go variants. Add development mode support to test infrastructure.

Closes #410

## Test plan
- [x] `cargo test` — all unit tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [ ] `cargo test -p integration-test rust_collection_patch -- --ignored --nocapture`
- [ ] `cargo test -p integration-test go_collection_patch -- --ignored --nocapture`
- [ ] `cargo test -p integration-test rust_collection_versioning -- --ignored --nocapture`
- [ ] `cargo test -p integration-test go_collection_versioning -- --ignored --nocapture`
- [ ] `cargo test -p integration-test rust_purge -- --ignored --nocapture`
- [ ] `cargo test -p integration-test go_purge -- --ignored --nocapture`

🤖 Generated with [Claude Code](https://claude.com/claude-code)