### PR TITLE
feat(p2p): batch merge processing for P2P sync

### DIFF
--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -362,6 +362,24 @@ impl<S: Store + 'static> Blockstore for DefraBlockstore<S> {
         Ok(())
     }
 
+    async fn mark_batch_as_merged(&self, cids: &[Cid]) -> Result<()> {
+        if cids.is_empty() {
+            return Ok(());
+        }
+        let mut txn = self.store.new_txn(false).await?;
+        {
+            let bs_txn = txn
+                .as_any_mut()
+                .downcast_mut::<BlockstoreTxn>()
+                .ok_or_else(|| Error::Internal("Failed to downcast transaction".to_string()))?;
+            for cid in cids {
+                bs_txn.mark_as_merged(cid).await?;
+            }
+        }
+        txn.commit().await?;
+        Ok(())
+    }
+
     async fn get_unmerged(&self) -> Result<Vec<Cid>> {
         let txn = self.store.new_txn(true).await?;
         let bs_txn = txn

--- a/crates/blockstore/src/traits.rs
+++ b/crates/blockstore/src/traits.rs
@@ -117,6 +117,17 @@ pub trait Blockstore: MaybeSendSync {
     /// will no longer appear in `get_unmerged` results.
     async fn mark_as_merged(&self, cid: &Cid) -> Result<()>;
 
+    /// Mark multiple blocks as merged in a single transaction.
+    ///
+    /// Default implementation calls `mark_as_merged` per CID. Implementations
+    /// can override to batch into a single transaction for better performance.
+    async fn mark_batch_as_merged(&self, cids: &[Cid]) -> Result<()> {
+        for cid in cids {
+            self.mark_as_merged(cid).await?;
+        }
+        Ok(())
+    }
+
     /// Get all unmerged block CIDs
     ///
     /// Returns CIDs of blocks that have been received via P2P but not yet

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -201,6 +201,7 @@ impl Node {
                 let replication_config = p2p::sync::ReplicationConfig {
                     continue_on_error: true,
                     rebroadcast_on_merge: false, // Don't re-broadcast during initial sync
+                    batch_size: 50,
                 };
                 let replication_task = tokio::spawn(async move {
                     info!("Starting replication loop for P2P sync");

--- a/crates/db/src/merge_handler/batch.rs
+++ b/crates/db/src/merge_handler/batch.rs
@@ -1,0 +1,231 @@
+use super::*;
+
+use p2p::sync::MergeBlock;
+
+/// Event collected during batch processing, emitted after commit.
+pub(crate) struct PendingMergeEvent {
+    pub message: Message,
+}
+
+impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMergeHandler<S, B> {
+    /// Process blocks individually, each with its own transaction.
+    pub(crate) async fn merge_blocks_individually(
+        &self,
+        blocks: &[MergeBlock],
+    ) -> Vec<Result<MergeOutcome, MergeError>> {
+        let mut results = Vec::with_capacity(blocks.len());
+        for block in blocks {
+            let metadata =
+                BlockMetadata::normal(&block.doc_id, &block.collection_id, &block.creator);
+            results.push(
+                self.handle_block(&block.cid, &block.block_data, metadata)
+                    .await,
+            );
+        }
+        results
+    }
+
+    /// Attempt to merge all blocks within a single shared transaction.
+    ///
+    /// If any block fails, the entire transaction is rolled back and the caller
+    /// should fall back to per-block processing.
+    pub(crate) async fn try_batch_merge(
+        &self,
+        blocks: &[MergeBlock],
+    ) -> Result<Vec<Result<MergeOutcome, MergeError>>, MergeError> {
+        let txn = self.db.new_txn(false).await?;
+        let batch_merged: std::sync::Mutex<HashSet<Cid>> = std::sync::Mutex::new(HashSet::new());
+        let pending_events: std::sync::Mutex<Vec<PendingMergeEvent>> =
+            std::sync::Mutex::new(Vec::new());
+
+        let mut results = Vec::with_capacity(blocks.len());
+        let mut batch_error: Option<MergeError> = None;
+
+        // Create NamespaceViews from the shared transaction. These use
+        // Arc<SharedTxn> internally and are Send+Sync, avoiding the
+        // "future cannot be sent between threads safely" error that
+        // would occur if we passed &DbTxn<S> across await points.
+        {
+            let datastore = txn.datastore()?;
+            let headstore = txn.headstore()?;
+
+            for block in blocks {
+                let metadata =
+                    BlockMetadata::normal(&block.doc_id, &block.collection_id, &block.creator);
+                match self
+                    .process_block_in_txn(
+                        &datastore,
+                        &headstore,
+                        &block.cid,
+                        &block.block_data,
+                        &metadata,
+                        &batch_merged,
+                        &pending_events,
+                    )
+                    .await
+                {
+                    Ok(outcome) => results.push(Ok(outcome)),
+                    Err(e) => {
+                        batch_error = Some(e);
+                        break;
+                    }
+                }
+            }
+        } // NamespaceViews dropped here so txn can be committed
+
+        if let Some(e) = batch_error {
+            if let Err(de) = txn.force_discard() {
+                tracing::error!(error = %de, "Failed to discard batch txn");
+            }
+            return Err(e);
+        }
+
+        txn.force_commit().await?;
+
+        // Move batch-merged CIDs into the permanent dedup set
+        {
+            let batch = batch_merged.lock().unwrap();
+            let mut merged = self.merged_composites.lock().unwrap();
+            merged.extend(batch.iter());
+        }
+
+        // Emit all collected events
+        if let Some(bus) = self.db.event_bus() {
+            let events = pending_events.into_inner().unwrap();
+            for event in events {
+                bus.publish(event.message);
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Decode a block and dispatch to the appropriate _in_txn handler.
+    ///
+    /// Does NOT commit/discard — caller manages the transaction lifecycle.
+    #[allow(clippy::too_many_arguments)]
+    async fn process_block_in_txn(
+        &self,
+        datastore: &NamespaceView,
+        headstore: &NamespaceView,
+        cid: &Cid,
+        block_data: &[u8],
+        metadata: &BlockMetadata<'_>,
+        batch_merged: &std::sync::Mutex<HashSet<Cid>>,
+        pending_events: &std::sync::Mutex<Vec<PendingMergeEvent>>,
+    ) -> Result<MergeOutcome, MergeError> {
+        // Decode the block from DAG-CBOR
+        let block =
+            Block::from_dag_cbor(block_data).map_err(|e| MergeError::BlockDecode(e.to_string()))?;
+
+        // Decrypt delta data if the block has encryption
+        let decrypted_block;
+        let effective_block = if block.encryption.is_some() {
+            match &block.delta {
+                CrdtDelta::Lww(payload) => {
+                    match self
+                        .decrypt_block_data(&payload.data, block.encryption.as_ref())
+                        .await
+                    {
+                        Ok(decrypted_data) => {
+                            let mut new_payload = payload.clone();
+                            new_payload.data = decrypted_data;
+                            decrypted_block = Block {
+                                delta: CrdtDelta::Lww(new_payload),
+                                heads: block.heads.clone(),
+                                links: block.links.clone(),
+                                encryption: block.encryption,
+                                signature: block.signature,
+                            };
+                            &decrypted_block
+                        }
+                        Err(_) => &block,
+                    }
+                }
+                CrdtDelta::Counter(payload) => {
+                    match self
+                        .decrypt_block_data(&payload.data, block.encryption.as_ref())
+                        .await
+                    {
+                        Ok(decrypted_data) => {
+                            let mut new_payload = payload.clone();
+                            new_payload.data = decrypted_data;
+                            decrypted_block = Block {
+                                delta: CrdtDelta::Counter(new_payload),
+                                heads: block.heads.clone(),
+                                links: block.links.clone(),
+                                encryption: block.encryption,
+                                signature: block.signature,
+                            };
+                            &decrypted_block
+                        }
+                        Err(_) => &block,
+                    }
+                }
+                _ => &block,
+            }
+        } else {
+            &block
+        };
+
+        // Dispatch based on delta type
+        match &effective_block.delta {
+            CrdtDelta::Composite(payload) => {
+                self.process_composite_delta_in_txn(
+                    datastore,
+                    headstore,
+                    cid,
+                    &block,
+                    payload,
+                    metadata,
+                    false,
+                    batch_merged,
+                    pending_events,
+                )
+                .await
+            }
+            CrdtDelta::Collection(payload) => {
+                self.process_collection_delta_in_txn(
+                    datastore,
+                    headstore,
+                    cid,
+                    &block,
+                    payload,
+                    metadata,
+                    batch_merged,
+                    pending_events,
+                )
+                .await
+            }
+            CrdtDelta::Lww(payload) => {
+                let mut ds = datastore.clone();
+                let result = self.process_lww_delta_in_txn(&mut ds, cid, payload).await;
+                match result {
+                    Ok(r) if r.applied => Ok(MergeOutcome::Merged),
+                    Ok(_) => Ok(MergeOutcome::skipped("rejected by CRDT")),
+                    Err(e) => Err(e),
+                }
+            }
+            CrdtDelta::Counter(payload) => {
+                let mut ds = datastore.clone();
+                let result = self
+                    .process_counter_delta_in_txn(&mut ds, cid, payload, metadata.collection_id)
+                    .await;
+                match result {
+                    Ok(r) if r.applied => Ok(MergeOutcome::Merged),
+                    Ok(_) => Ok(MergeOutcome::skipped("rejected by CRDT")),
+                    Err(e) => Err(e),
+                }
+            }
+            CrdtDelta::FieldDefinition(_) => Ok(MergeOutcome::skipped(
+                "field definition processed with collection",
+            )),
+            CrdtDelta::CollectionDefinition(payload) => {
+                // CollectionDefinition uses its own txn (rare, not worth batching)
+                self.process_collection_definition_delta(cid, &block, payload, metadata)
+                    .await
+            }
+            CrdtDelta::CollectionSet(_) => Ok(MergeOutcome::skipped("collection set delta")),
+        }
+    }
+}

--- a/crates/db/src/merge_handler/collection.rs
+++ b/crates/db/src/merge_handler/collection.rs
@@ -1,3 +1,4 @@
+use super::batch::PendingMergeEvent;
 use super::*;
 
 impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
@@ -234,6 +235,153 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             any_merged = any_merged,
             "Collection delta processed"
         );
+
+        if any_merged {
+            Ok(MergeOutcome::Merged)
+        } else {
+            Ok(MergeOutcome::skipped("no linked composites needed merging"))
+        }
+    }
+
+    /// Process a Collection delta within a shared transaction (batch mode).
+    ///
+    /// Same logic as `process_collection_delta` but uses a shared transaction
+    /// and delegates to `process_composite_delta_in_txn` for linked composites.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn process_collection_delta_in_txn(
+        &self,
+        datastore: &NamespaceView,
+        headstore: &NamespaceView,
+        cid: &Cid,
+        block: &Block,
+        payload: &defra_core::block::CollectionDeltaPayload,
+        metadata: &BlockMetadata<'_>,
+        batch_merged: &std::sync::Mutex<HashSet<Cid>>,
+        pending_events: &std::sync::Mutex<Vec<PendingMergeEvent>>,
+    ) -> std::result::Result<MergeOutcome, MergeError> {
+        tracing::debug!(
+            cid = %cid,
+            schema_version = %payload.schema_version_id,
+            "Processing Collection delta in batch txn"
+        );
+
+        // Recursively process parent collection blocks
+        if let Some(heads) = &block.heads {
+            for head_cid in heads {
+                let head_data = match self.blockstore.get(head_cid).await {
+                    Ok(Some(data)) => data,
+                    _ => continue,
+                };
+
+                let head_block = match Block::from_dag_cbor(&head_data) {
+                    Ok(b) => b,
+                    Err(_) => continue,
+                };
+
+                if let CrdtDelta::Collection(head_payload) = &head_block.delta {
+                    let _ = Box::pin(self.process_collection_delta_in_txn(
+                        datastore,
+                        headstore,
+                        head_cid,
+                        &head_block,
+                        head_payload,
+                        metadata,
+                        batch_merged,
+                        pending_events,
+                    ))
+                    .await;
+                }
+            }
+        }
+
+        // Process linked document composites
+        let mut any_merged = false;
+        if let Some(links) = &block.links {
+            for dag_link in links {
+                let link_cid = &dag_link.link;
+
+                let linked_data = match self.blockstore.get(link_cid).await {
+                    Ok(Some(data)) => data,
+                    _ => continue,
+                };
+
+                let linked_block = match Block::from_dag_cbor(&linked_data) {
+                    Ok(b) => b,
+                    Err(_) => continue,
+                };
+
+                if let CrdtDelta::Composite(composite_payload) = &linked_block.delta {
+                    let doc_id_str = String::from_utf8_lossy(&composite_payload.doc_id).to_string();
+                    match self
+                        .process_composite_delta_in_txn(
+                            datastore,
+                            headstore,
+                            link_cid,
+                            &linked_block,
+                            composite_payload,
+                            metadata,
+                            true,
+                            batch_merged,
+                            pending_events,
+                        )
+                        .await
+                    {
+                        Ok(MergeOutcome::Merged) => {
+                            any_merged = true;
+                            // Collect per-document MergeComplete event
+                            let col_id = metadata
+                                .collection_id
+                                .unwrap_or(&payload.schema_version_id)
+                                .to_string();
+                            let mut pe = pending_events.lock().unwrap();
+                            pe.push(PendingMergeEvent {
+                                message: Message::merge_complete(MergeCompleteData {
+                                    doc_id: doc_id_str,
+                                    cid: *link_cid,
+                                    collection_id: col_id,
+                                    by_peer: String::new(),
+                                }),
+                            });
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::debug!(link_cid = %link_cid, error = %e, "Composite merge failed in batch");
+                        }
+                    }
+                }
+            }
+        }
+
+        // Update collection headstore using the shared headstore view
+        let collection_id = metadata.collection_id.unwrap_or(&payload.schema_version_id);
+        let short_id = collection_short_id(collection_id);
+
+        {
+            if let Some(heads) = &block.heads {
+                for parent_cid in heads {
+                    let parent_key =
+                        storage::keys::headstore::HeadstoreColKey::new(short_id, *parent_cid);
+                    let _ = headstore
+                        .delete(
+                            &<storage::keys::headstore::HeadstoreColKey as storage::corekv::Key>::bytes(
+                                &parent_key,
+                            ),
+                        )
+                        .await;
+                }
+            }
+
+            let col_key = storage::keys::headstore::HeadstoreColKey::new(short_id, *cid);
+            let priority_bytes = encode_priority_varint(payload.priority);
+            let _ = headstore
+                .set(
+                    &<storage::keys::headstore::HeadstoreColKey as storage::corekv::Key>::bytes(
+                        &col_key,
+                    ),
+                    &priority_bytes,
+                )
+                .await;
+        }
 
         if any_merged {
             Ok(MergeOutcome::Merged)

--- a/crates/db/src/merge_handler/composite.rs
+++ b/crates/db/src/merge_handler/composite.rs
@@ -1,3 +1,4 @@
+use super::batch::PendingMergeEvent;
 use super::*;
 
 /// Check whether the merge handler should skip decryption for an encrypted block.
@@ -714,6 +715,483 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 }
                 Err(e)
             }
+        }
+    }
+
+    /// Process a Composite delta within a shared transaction (batch mode).
+    ///
+    /// Same logic as `process_composite_delta` but:
+    /// - Uses a shared transaction (no create/commit/discard)
+    /// - Checks both `self.merged_composites` and `batch_merged` for dedup
+    /// - Inserts into `batch_merged` on success
+    /// - Collects events into `pending_events` instead of publishing
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn process_composite_delta_in_txn(
+        &self,
+        datastore: &NamespaceView,
+        headstore: &NamespaceView,
+        cid: &Cid,
+        block: &Block,
+        payload: &defra_core::block::CompositeDeltaPayload,
+        metadata: &BlockMetadata<'_>,
+        from_collection: bool,
+        batch_merged: &std::sync::Mutex<HashSet<Cid>>,
+        pending_events: &std::sync::Mutex<Vec<PendingMergeEvent>>,
+    ) -> std::result::Result<MergeOutcome, MergeError> {
+        let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
+
+        tracing::info!(
+            cid = %cid,
+            doc_id = %doc_id_str,
+            priority = payload.priority,
+            "Processing Composite delta in batch txn"
+        );
+
+        // Recursively merge parent composites (using batch dedup)
+        if let Some(heads) = &block.heads {
+            for head_cid in heads {
+                // Check both permanent and batch-local dedup sets
+                {
+                    let merged = self.merged_composites.lock().unwrap();
+                    if merged.contains(head_cid) {
+                        continue;
+                    }
+                }
+                {
+                    let bm = batch_merged.lock().unwrap();
+                    if bm.contains(head_cid) {
+                        continue;
+                    }
+                }
+
+                let head_data = match self.blockstore.get(head_cid).await {
+                    Ok(Some(data)) => data,
+                    _ => continue,
+                };
+
+                let head_block = match Block::from_dag_cbor(&head_data) {
+                    Ok(b) => b,
+                    Err(_) => continue,
+                };
+
+                if let CrdtDelta::Composite(head_payload) = &head_block.delta {
+                    let _ = Box::pin(self.process_composite_delta_in_txn(
+                        datastore,
+                        headstore,
+                        head_cid,
+                        &head_block,
+                        head_payload,
+                        metadata,
+                        from_collection,
+                        batch_merged,
+                        pending_events,
+                    ))
+                    .await;
+                }
+            }
+        }
+
+        // ACP pre-lookup
+        let collection_for_acp = self
+            .db
+            .find_collection_by_id(&payload.schema_version_id)
+            .ok()
+            .flatten()
+            .or_else(|| {
+                metadata
+                    .collection_id
+                    .and_then(|cid| self.db.find_collection_by_id(cid).ok().flatten())
+            });
+
+        let skip_encrypted = should_skip_encrypted_merge(
+            self.document_acp.get(),
+            collection_for_acp.as_ref().map(|c| c.schema()),
+            &doc_id_str,
+        )
+        .await;
+
+        // Process field links within the shared transaction
+        let mut field_values: HashMap<String, NormalValue> = HashMap::new();
+        let mut _any_field_applied = false;
+        let mut process_error: Option<MergeError> = None;
+        let mut is_branchable = false;
+        let mut field_block_heads: HashMap<String, Vec<Cid>> = HashMap::new();
+
+        {
+            let mut datastore = datastore.clone();
+
+            if let Some(links) = &block.links {
+                for dag_link in links {
+                    let link_name = &dag_link.name;
+                    let link_cid = &dag_link.link;
+
+                    let linked_block_data = match self.blockstore.get(link_cid).await {
+                        Ok(Some(data)) => data,
+                        Ok(None) => {
+                            process_error = Some(MergeError::Storage(format!(
+                                "Linked block {} not found in blockstore",
+                                link_cid
+                            )));
+                            break;
+                        }
+                        Err(e) => {
+                            process_error = Some(MergeError::Storage(e.to_string()));
+                            break;
+                        }
+                    };
+
+                    let linked_block = match Block::from_dag_cbor(&linked_block_data) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            process_error = Some(MergeError::BlockDecode(e.to_string()));
+                            break;
+                        }
+                    };
+
+                    if let Some(heads) = &linked_block.heads {
+                        field_block_heads.insert(link_name.clone(), heads.clone());
+                    }
+
+                    if skip_encrypted && linked_block.encryption.is_some() {
+                        continue;
+                    }
+
+                    // Decrypt linked block data if encrypted
+                    let effective_linked_delta = match &linked_block.delta {
+                        CrdtDelta::Lww(p) if linked_block.encryption.is_some() => {
+                            match self
+                                .decrypt_block_data(&p.data, linked_block.encryption.as_ref())
+                                .await
+                            {
+                                Ok(decrypted) => {
+                                    let mut dp = p.clone();
+                                    dp.data = decrypted;
+                                    CrdtDelta::Lww(dp)
+                                }
+                                Err(_) => linked_block.delta.clone(),
+                            }
+                        }
+                        CrdtDelta::Counter(p) if linked_block.encryption.is_some() => {
+                            match self
+                                .decrypt_block_data(&p.data, linked_block.encryption.as_ref())
+                                .await
+                            {
+                                Ok(decrypted) => {
+                                    let mut dp = p.clone();
+                                    dp.data = decrypted;
+                                    CrdtDelta::Counter(dp)
+                                }
+                                Err(_) => linked_block.delta.clone(),
+                            }
+                        }
+                        other => other.clone(),
+                    };
+
+                    match &effective_linked_delta {
+                        CrdtDelta::Lww(lww_payload) => {
+                            match self
+                                .process_lww_delta_in_txn(&mut datastore, link_cid, lww_payload)
+                                .await
+                            {
+                                Ok(result) => {
+                                    if result.applied {
+                                        _any_field_applied = true;
+                                    }
+                                    if let Some(value) = result.value {
+                                        field_values.insert(lww_payload.field_name.clone(), value);
+                                    }
+                                }
+                                Err(e) => {
+                                    process_error = Some(e);
+                                    break;
+                                }
+                            }
+                        }
+                        CrdtDelta::Counter(counter_payload) => {
+                            match self
+                                .process_counter_delta_in_txn(
+                                    &mut datastore,
+                                    link_cid,
+                                    counter_payload,
+                                    metadata.collection_id,
+                                )
+                                .await
+                            {
+                                Ok(result) => {
+                                    if result.applied {
+                                        _any_field_applied = true;
+                                    }
+                                    if let Some(value) = result.value {
+                                        field_values
+                                            .insert(counter_payload.field_name.clone(), value);
+                                    }
+                                }
+                                Err(e) => {
+                                    process_error = Some(e);
+                                    break;
+                                }
+                            }
+                        }
+                        other => {
+                            process_error = Some(MergeError::UnsupportedDelta(format!(
+                                "Unexpected delta type in linked block: {:?}",
+                                std::mem::discriminant(other)
+                            )));
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Store document if no errors
+            if process_error.is_none() {
+                let collection_lookup = self
+                    .db
+                    .find_collection_by_id(&payload.schema_version_id)
+                    .ok()
+                    .flatten()
+                    .or_else(|| {
+                        metadata
+                            .collection_id
+                            .and_then(|cid| self.db.find_collection_by_id(cid).ok().flatten())
+                    });
+
+                let is_delete = payload.status == 2;
+
+                match collection_lookup {
+                    Some(collection) => {
+                        is_branchable = collection.schema().is_branchable;
+                        if is_delete {
+                            if let Ok(doc_id) = DocID::from_string(&doc_id_str) {
+                                if let Ok(Some(old_doc)) =
+                                    collection.get_with_datastore(&datastore, &doc_id).await
+                                {
+                                    let short_id = collection_short_id(collection.collection_id());
+                                    if let Ok(index_manager) =
+                                        IndexManager::from_collection(short_id, collection.schema())
+                                    {
+                                        let _ = index_manager
+                                            .on_document_delete(
+                                                &datastore,
+                                                &old_doc,
+                                                collection.schema(),
+                                            )
+                                            .await;
+                                    }
+                                }
+                            }
+
+                            let deleted_key =
+                                build_deleted_key(collection.collection_id(), &doc_id_str);
+                            if let Err(e) = datastore.set(&deleted_key, &[DELETED_MARKER]).await {
+                                process_error =
+                                    Some(MergeError::Database(crate::error::Error::Storage(e)));
+                            }
+                        } else if !field_values.is_empty() {
+                            match DocID::from_string(&doc_id_str) {
+                                Ok(doc_id) => {
+                                    let (mut doc, old_doc) = match collection
+                                        .get_with_datastore(&datastore, &doc_id)
+                                        .await
+                                    {
+                                        Ok(Some(existing)) => {
+                                            let old = existing.clone();
+                                            (existing, Some(old))
+                                        }
+                                        _ => {
+                                            let mut new_doc = Document::new();
+                                            new_doc.set_id(doc_id.clone());
+                                            (new_doc, None)
+                                        }
+                                    };
+
+                                    doc.set_schema_version_id(&payload.schema_version_id);
+                                    for (field_name, value) in &field_values {
+                                        doc.set(field_name, value.clone());
+                                    }
+
+                                    let known_fields: std::collections::HashSet<&str> = collection
+                                        .schema()
+                                        .fields
+                                        .iter()
+                                        .map(|f| f.name.as_str())
+                                        .collect();
+                                    let all_field_names: Vec<String> =
+                                        doc.field_names().map(|s| s.to_string()).collect();
+                                    for fname in &all_field_names {
+                                        if !known_fields.contains(fname.as_str()) {
+                                            doc.remove(fname);
+                                        }
+                                    }
+
+                                    if let Err(e) =
+                                        collection.save_with_datastore(&datastore, &doc).await
+                                    {
+                                        process_error = Some(MergeError::Database(e));
+                                    } else {
+                                        let short_id =
+                                            collection_short_id(collection.collection_id());
+                                        if let Ok(index_manager) = IndexManager::from_collection(
+                                            short_id,
+                                            collection.schema(),
+                                        ) {
+                                            let index_result = match &old_doc {
+                                                Some(old) => {
+                                                    index_manager
+                                                        .on_document_update(
+                                                            &datastore,
+                                                            old,
+                                                            &doc,
+                                                            collection.schema(),
+                                                        )
+                                                        .await
+                                                }
+                                                None => {
+                                                    index_manager
+                                                        .on_document_create(
+                                                            &datastore,
+                                                            &doc,
+                                                            collection.schema(),
+                                                        )
+                                                        .await
+                                                }
+                                            };
+                                            if let Err(e) = index_result {
+                                                tracing::warn!(
+                                                    doc_id = %doc_id_str,
+                                                    error = %e,
+                                                    "Failed to update indexes after batch merge"
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    process_error = Some(MergeError::MergeFailed(format!(
+                                        "Invalid doc_id: {}",
+                                        e
+                                    )));
+                                }
+                            }
+                        }
+                    }
+                    None => {
+                        process_error = Some(MergeError::MissingMetadata(format!(
+                            "Collection not found for schema_version_id: {}",
+                            payload.schema_version_id
+                        )));
+                    }
+                }
+            }
+        } // datastore dropped here
+
+        // Write headstore entries using the shared headstore view
+        if process_error.is_none() && !skip_encrypted {
+            {
+                let priority_bytes = encode_priority_varint(payload.priority);
+
+                if let Some(heads) = &block.heads {
+                    for parent_cid in heads {
+                        let parent_key = storage::keys::headstore::HeadstoreDocKey::new(
+                            &doc_id_str,
+                            "C",
+                            *parent_cid,
+                        );
+                        let _ = headstore
+                            .delete(
+                                &<storage::keys::headstore::HeadstoreDocKey as storage::corekv::Key>::bytes(&parent_key),
+                            )
+                            .await;
+                    }
+                }
+
+                let composite_head_key =
+                    storage::keys::headstore::HeadstoreDocKey::new(&doc_id_str, "C", *cid);
+                let _ = headstore
+                    .set(
+                        &<storage::keys::headstore::HeadstoreDocKey as storage::corekv::Key>::bytes(
+                            &composite_head_key,
+                        ),
+                        &priority_bytes,
+                    )
+                    .await;
+
+                if let Some(links) = &block.links {
+                    for dag_link in links {
+                        if let Some(parent_cids) = field_block_heads.get(&dag_link.name) {
+                            for parent_cid in parent_cids {
+                                let parent_key = storage::keys::headstore::HeadstoreDocKey::new(
+                                    &doc_id_str,
+                                    &dag_link.name,
+                                    *parent_cid,
+                                );
+                                let _ = headstore
+                                    .delete(
+                                        &<storage::keys::headstore::HeadstoreDocKey as storage::corekv::Key>::bytes(&parent_key),
+                                    )
+                                    .await;
+                            }
+                        }
+                        let field_head_key = storage::keys::headstore::HeadstoreDocKey::new(
+                            &doc_id_str,
+                            &dag_link.name,
+                            dag_link.link,
+                        );
+                        let _ = headstore
+                            .set(
+                                &<storage::keys::headstore::HeadstoreDocKey as storage::corekv::Key>::bytes(&field_head_key),
+                                &priority_bytes,
+                            )
+                            .await;
+                    }
+                }
+            }
+        }
+
+        // Handle result (NO commit/discard — caller manages transaction)
+        match process_error {
+            None => {
+                // Mark as merged in batch-local set
+                {
+                    let mut bm = batch_merged.lock().unwrap();
+                    bm.insert(*cid);
+                }
+
+                // Collect events for deferred publishing
+                {
+                    let mut pe = pending_events.lock().unwrap();
+                    let update = Update::new(
+                        doc_id_str.clone(),
+                        *cid,
+                        payload.schema_version_id.clone(),
+                        vec![],
+                        false,
+                        true,
+                    );
+                    pe.push(PendingMergeEvent {
+                        message: Message::update(update),
+                    });
+
+                    if is_branchable {
+                        let by_peer = metadata.creator.unwrap_or("").to_string();
+                        let mc = MergeCompleteData {
+                            doc_id: String::new(),
+                            cid: *cid,
+                            collection_id: metadata
+                                .collection_id
+                                .unwrap_or(&payload.schema_version_id)
+                                .to_string(),
+                            by_peer,
+                        };
+                        pe.push(PendingMergeEvent {
+                            message: Message::merge_complete(mc),
+                        });
+                    }
+                }
+
+                Ok(MergeOutcome::Merged)
+            }
+            Some(e) => Err(e),
         }
     }
 }

--- a/crates/db/src/merge_handler/mod.rs
+++ b/crates/db/src/merge_handler/mod.rs
@@ -3,6 +3,7 @@
 //! This module implements the `MergeHandler` trait from the P2P layer,
 //! bridging incoming blocks to the CRDT system for document merging.
 
+mod batch;
 mod collection;
 mod composite;
 mod counter;
@@ -23,7 +24,7 @@ use defra_core::block::{
 use defra_core::types::DocId;
 use document::{DocID, Document, NormalValue};
 use events::{MergeCompleteData, Message, Update};
-use p2p::sync::{BlockMetadata, MergeHandler, MergeOutcome};
+use p2p::sync::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
 use schema::{
     self, CType, CollectionSource, CollectionVersion, FieldDescription, FieldKind, QuerySource,
     ScalarKind,
@@ -429,6 +430,27 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> Merg
             CrdtDelta::CollectionSet(_) => {
                 tracing::debug!(cid = %cid, "CollectionSet delta - skipping");
                 Ok(MergeOutcome::skipped("collection set delta"))
+            }
+        }
+    }
+
+    async fn handle_block_batch(
+        &self,
+        blocks: &[MergeBlock],
+    ) -> Vec<Result<MergeOutcome, Self::Error>> {
+        if blocks.len() <= 1 {
+            return self.merge_blocks_individually(blocks).await;
+        }
+
+        match self.try_batch_merge(blocks).await {
+            Ok(results) => results,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    batch_size = blocks.len(),
+                    "Batch merge failed, falling back to per-block processing"
+                );
+                self.merge_blocks_individually(blocks).await
             }
         }
     }

--- a/crates/ffi/src/p2p/node.rs
+++ b/crates/ffi/src/p2p/node.rs
@@ -262,57 +262,65 @@ pub unsafe extern "C" fn new_node_with_p2p(
             let config = ReplicationConfig::default();
             let mut events = sync_events_rx;
             loop {
-                let result = ReplicationLoop::process_next(
+                let results = ReplicationLoop::process_next_batch(
                     &coord_for_repl,
                     &mut events,
                     handler_for_repl.as_ref(),
                     &config,
                 )
                 .await;
-                match &result {
-                    ReplicationResult::Merged { cid, doc_id, collection_id } => {
-                        let mc = events::MergeCompleteData {
-                            doc_id: doc_id.clone(),
-                            cid: *cid,
-                            collection_id: collection_id.clone(),
-                            by_peer: coord_for_repl.local_peer_id().to_string(),
-                        };
-                        event_bus_for_repl.publish(events::Message::merge_complete(mc));
-                        if !doc_id.is_empty() {
-                            event_bus_for_repl.publish(events::Message::se_artifact_received(
-                                events::SEArtifactReceivedData { doc_id: doc_id.clone() },
-                            ));
+
+                let mut should_break = false;
+                for result in &results {
+                    match result {
+                        ReplicationResult::Merged { cid, doc_id, collection_id } => {
+                            let mc = events::MergeCompleteData {
+                                doc_id: doc_id.clone(),
+                                cid: *cid,
+                                collection_id: collection_id.clone(),
+                                by_peer: coord_for_repl.local_peer_id().to_string(),
+                            };
+                            event_bus_for_repl.publish(events::Message::merge_complete(mc));
+                            if !doc_id.is_empty() {
+                                event_bus_for_repl.publish(events::Message::se_artifact_received(
+                                    events::SEArtifactReceivedData { doc_id: doc_id.clone() },
+                                ));
+                            }
                         }
-                    }
-                    ReplicationResult::MergedButBroadcastFailed { cid, doc_id, collection_id, .. } => {
-                        tracing::info!(cid = %cid, doc_id = %doc_id, "Block merged (broadcast failed) - publishing MergeComplete event");
-                        let mc = events::MergeCompleteData {
-                            doc_id: doc_id.clone(),
-                            cid: *cid,
-                            collection_id: collection_id.clone(),
-                            by_peer: coord_for_repl.local_peer_id().to_string(),
-                        };
-                        event_bus_for_repl.publish(events::Message::merge_complete(mc));
-                        if !doc_id.is_empty() {
-                            event_bus_for_repl.publish(events::Message::se_artifact_received(
-                                events::SEArtifactReceivedData { doc_id: doc_id.clone() },
-                            ));
+                        ReplicationResult::MergedButBroadcastFailed { cid, doc_id, collection_id, .. } => {
+                            tracing::info!(cid = %cid, doc_id = %doc_id, "Block merged (broadcast failed) - publishing MergeComplete event");
+                            let mc = events::MergeCompleteData {
+                                doc_id: doc_id.clone(),
+                                cid: *cid,
+                                collection_id: collection_id.clone(),
+                                by_peer: coord_for_repl.local_peer_id().to_string(),
+                            };
+                            event_bus_for_repl.publish(events::Message::merge_complete(mc));
+                            if !doc_id.is_empty() {
+                                event_bus_for_repl.publish(events::Message::se_artifact_received(
+                                    events::SEArtifactReceivedData { doc_id: doc_id.clone() },
+                                ));
+                            }
                         }
+                        ReplicationResult::ChannelClosed => {
+                            tracing::info!("Sync event channel closed, stopping replication loop");
+                            should_break = true;
+                            break;
+                        }
+                        ReplicationResult::Failed { cid, error } => {
+                            tracing::error!(cid = %cid, error = %error, "Block merge failed");
+                        }
+                        ReplicationResult::Skipped { cid, reason } => {
+                            tracing::debug!(cid = %cid, reason = %reason, "replication loop: skipped");
+                        }
+                        ReplicationResult::BitswapFetchStarted { root_cid, .. } => {
+                            tracing::debug!(root_cid = %root_cid, "replication loop: bitswap fetch started");
+                        }
+                        _ => {}
                     }
-                    ReplicationResult::ChannelClosed => {
-                        tracing::info!("Sync event channel closed, stopping replication loop");
-                        break;
-                    }
-                    ReplicationResult::Failed { cid, error } => {
-                        tracing::error!(cid = %cid, error = %error, "Block merge failed");
-                    }
-                    ReplicationResult::Skipped { cid, reason } => {
-                        tracing::debug!(cid = %cid, reason = %reason, "replication loop: skipped");
-                    }
-                    ReplicationResult::BitswapFetchStarted { root_cid, .. } => {
-                        tracing::debug!(root_cid = %root_cid, "replication loop: bitswap fetch started");
-                    }
-                    _ => {}
+                }
+                if should_break {
+                    break;
                 }
             }
             tracing::info!("FFI replication loop stopped");

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -169,6 +169,11 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
         self.manager.mark_as_merged(cid).await
     }
 
+    /// Mark multiple blocks as merged in a single transaction.
+    pub async fn mark_batch_as_merged(&self, cids: &[Cid]) -> Result<()> {
+        self.manager.mark_batch_as_merged(cids).await
+    }
+
     /// Check if a block is merged.
     pub async fn is_merged(&self, cid: &Cid) -> Result<bool> {
         self.manager.is_merged(cid).await

--- a/crates/p2p/src/sync/manager/process/mod.rs
+++ b/crates/p2p/src/sync/manager/process/mod.rs
@@ -127,6 +127,14 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             .map_err(|e| crate::error::Error::BlockstoreError(e.to_string()))
     }
 
+    /// Mark multiple blocks as merged in a single transaction.
+    pub async fn mark_batch_as_merged(&self, cids: &[Cid]) -> crate::error::Result<()> {
+        self.blockstore
+            .mark_batch_as_merged(cids)
+            .await
+            .map_err(|e| crate::error::Error::BlockstoreError(e.to_string()))
+    }
+
     /// Get all unmerged block CIDs.
     pub async fn get_unmerged(&self) -> crate::error::Result<Vec<Cid>> {
         self.blockstore

--- a/crates/p2p/src/sync/merge.rs
+++ b/crates/p2p/src/sync/merge.rs
@@ -6,6 +6,19 @@
 use async_trait::async_trait;
 use cid::Cid;
 
+/// Owned block data for batch processing.
+///
+/// Unlike `BlockMetadata` which borrows strings, this struct owns all data
+/// so it can be collected into a batch and processed together.
+#[derive(Debug, Clone)]
+pub struct MergeBlock {
+    pub cid: Cid,
+    pub block_data: Vec<u8>,
+    pub doc_id: String,
+    pub collection_id: String,
+    pub creator: String,
+}
+
 /// Outcome of a merge operation.
 ///
 /// Used by `MergeHandler::handle_block` to communicate the result.
@@ -132,6 +145,26 @@ pub trait MergeHandler: Send + Sync {
         block_data: &[u8],
         metadata: BlockMetadata<'_>,
     ) -> Result<MergeOutcome, Self::Error>;
+
+    /// Process a batch of blocks. Default impl calls handle_block() per block.
+    ///
+    /// Implementations can override this to process all blocks within a single
+    /// shared transaction, reducing fsync overhead during P2P catch-up.
+    async fn handle_block_batch(
+        &self,
+        blocks: &[MergeBlock],
+    ) -> Vec<Result<MergeOutcome, Self::Error>> {
+        let mut results = Vec::with_capacity(blocks.len());
+        for block in blocks {
+            let metadata =
+                BlockMetadata::normal(&block.doc_id, &block.collection_id, &block.creator);
+            results.push(
+                self.handle_block(&block.cid, &block.block_data, metadata)
+                    .await,
+            );
+        }
+        results
+    }
 }
 
 #[cfg(test)]

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -50,7 +50,7 @@ pub use coordinator::{LoadReplicatorsResult, PushFailure, SetReplicatorResult, S
 pub use dag_sync::{DagSync, DagSyncConfig, DagSyncState, NeedsFetchData, SyncPlan};
 pub use head_provider::{DocumentHeadProvider, NoOpHeadProvider};
 pub use manager::{SyncConfig, SyncEvent, SyncManager};
-pub use merge::{BlockMetadata, MergeHandler, MergeOutcome};
+pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
 pub use peer_state::{PeerStateTracker, PeerStats};
 pub use queue::ProcessQueue;
 pub use replication::{recover_unmerged, ReplicationConfig, ReplicationLoop, ReplicationResult};

--- a/crates/p2p/src/sync/replication/config.rs
+++ b/crates/p2p/src/sync/replication/config.rs
@@ -7,6 +7,8 @@ pub struct ReplicationConfig {
     pub continue_on_error: bool,
     /// Whether to re-broadcast successfully merged blocks
     pub rebroadcast_on_merge: bool,
+    /// Max blocks per batch (matches Go's MergeBatchWithTxn batch size)
+    pub batch_size: usize,
 }
 
 impl Default for ReplicationConfig {
@@ -14,6 +16,7 @@ impl Default for ReplicationConfig {
         Self {
             continue_on_error: true,
             rebroadcast_on_merge: false,
+            batch_size: 50,
         }
     }
 }

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -8,7 +8,7 @@ use super::config::ReplicationConfig;
 use super::result::ReplicationResult;
 use crate::sync::coordinator::SyncCoordinator;
 use crate::sync::manager::SyncEvent;
-use crate::sync::merge::{BlockMetadata, MergeHandler, MergeOutcome};
+use crate::sync::merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
 
 /// Handle a DagNeedsFetch event by initiating a Bitswap sync.
 pub(super) async fn handle_dag_needs_fetch<B>(
@@ -173,6 +173,144 @@ where
             error: e.to_string(),
         },
     }
+}
+
+/// Returns true if this event type can be batch-merged.
+pub(super) fn is_mergeable_event(event: &SyncEvent) -> bool {
+    matches!(
+        event,
+        SyncEvent::BlockReceived { .. } | SyncEvent::DagReady { .. }
+    )
+}
+
+/// Extract merge block metadata from a SyncEvent.
+fn event_to_merge_metadata(event: &SyncEvent) -> (Cid, String, String, String) {
+    match event {
+        SyncEvent::BlockReceived {
+            cid,
+            doc_id,
+            collection_id,
+            creator,
+        } => (*cid, doc_id.clone(), collection_id.clone(), creator.clone()),
+        SyncEvent::DagReady {
+            root_cid,
+            doc_id,
+            collection_id,
+            schema_version_id,
+        } => (
+            *root_cid,
+            doc_id.clone(),
+            collection_id.clone(),
+            schema_version_id.clone(),
+        ),
+        _ => unreachable!("is_mergeable_event should have filtered this"),
+    }
+}
+
+/// Process a batch of merge-eligible events using handle_block_batch().
+///
+/// Loads block data from the blockstore, delegates batch merge to the handler,
+/// then batch-marks successful merges in a single transaction.
+pub(super) async fn process_merge_batch<B, H>(
+    coordinator: &SyncCoordinator<B>,
+    events: Vec<SyncEvent>,
+    handler: &H,
+    _config: &ReplicationConfig,
+) -> Vec<ReplicationResult>
+where
+    B: Blockstore + 'static,
+    H: MergeHandler + ?Sized + 'static,
+{
+    let mut merge_blocks = Vec::with_capacity(events.len());
+    let mut results = Vec::new();
+
+    // Load block data for each event from blockstore
+    for event in &events {
+        let (cid, doc_id, collection_id, creator) = event_to_merge_metadata(event);
+
+        match coordinator.blockstore().get(&cid).await {
+            Ok(Some(data)) => {
+                merge_blocks.push(MergeBlock {
+                    cid,
+                    block_data: data,
+                    doc_id,
+                    collection_id,
+                    creator,
+                });
+            }
+            Ok(None) => {
+                results.push(ReplicationResult::Failed {
+                    cid,
+                    error: "Block not found in blockstore".to_string(),
+                });
+            }
+            Err(e) => {
+                results.push(ReplicationResult::Failed {
+                    cid,
+                    error: format!("Failed to load block: {}", e),
+                });
+            }
+        }
+    }
+
+    if merge_blocks.is_empty() {
+        return results;
+    }
+
+    // Call handler.handle_block_batch()
+    let batch_results = handler.handle_block_batch(&merge_blocks).await;
+
+    // Collect CIDs to mark as merged
+    let mut merged_cids = Vec::new();
+    for (block, result) in merge_blocks.iter().zip(batch_results.into_iter()) {
+        match result {
+            Ok(MergeOutcome::Merged) => {
+                merged_cids.push(block.cid);
+                results.push(ReplicationResult::Merged {
+                    cid: block.cid,
+                    doc_id: block.doc_id.clone(),
+                    collection_id: block.collection_id.clone(),
+                });
+            }
+            Ok(MergeOutcome::Skipped { reason }) => {
+                merged_cids.push(block.cid); // Still mark skipped blocks
+                results.push(ReplicationResult::Skipped {
+                    cid: block.cid,
+                    reason,
+                });
+            }
+            Err(e) => {
+                results.push(ReplicationResult::Failed {
+                    cid: block.cid,
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    // Batch mark_as_merged in one txn
+    if !merged_cids.is_empty() {
+        if let Err(e) = coordinator.mark_batch_as_merged(&merged_cids).await {
+            tracing::error!(
+                error = %e,
+                count = merged_cids.len(),
+                "Failed to batch mark_as_merged"
+            );
+            // Downgrade affected Merged results to MergedButNotMarked
+            for result in &mut results {
+                if let ReplicationResult::Merged { cid, .. } = result {
+                    if merged_cids.contains(cid) {
+                        *result = ReplicationResult::MergedButNotMarked {
+                            cid: *cid,
+                            error: e.to_string(),
+                        };
+                    }
+                }
+            }
+        }
+    }
+
+    results
 }
 
 /// Process a sync event and return the result.

--- a/crates/p2p/src/sync/replication/loop_runner.rs
+++ b/crates/p2p/src/sync/replication/loop_runner.rs
@@ -24,7 +24,7 @@ use blockstore::Blockstore;
 use tokio::sync::mpsc;
 
 use super::config::ReplicationConfig;
-use super::handlers::process_event;
+use super::handlers::{is_mergeable_event, process_event, process_merge_batch};
 use super::result::ReplicationResult;
 use crate::sync::coordinator::SyncCoordinator;
 use crate::sync::manager::SyncEvent;
@@ -48,11 +48,11 @@ use crate::sync::merge::MergeHandler;
 pub struct ReplicationLoop;
 
 impl ReplicationLoop {
-    /// Run the replication loop.
+    /// Run the replication loop with batch processing.
     ///
     /// This method runs until the event channel is closed or a fatal error occurs.
-    /// It processes SyncEvents, delegates merges to the handler, and marks blocks
-    /// as merged.
+    /// It batches merge-eligible events together for efficient processing with
+    /// shared transactions, reducing fsync overhead during P2P catch-up.
     pub async fn run<B, H>(
         coordinator: Arc<SyncCoordinator<B>>,
         mut events: mpsc::Receiver<SyncEvent>,
@@ -62,59 +62,66 @@ impl ReplicationLoop {
         B: Blockstore + 'static,
         H: MergeHandler + 'static,
     {
-        tracing::info!("Starting replication loop");
+        tracing::info!(batch_size = config.batch_size, "Starting replication loop");
 
         loop {
-            let result =
-                Self::process_next(&coordinator, &mut events, handler.as_ref(), &config).await;
+            let results =
+                Self::process_next_batch(&coordinator, &mut events, handler.as_ref(), &config)
+                    .await;
 
-            match &result {
-                ReplicationResult::Merged { cid, doc_id, .. } => {
-                    tracing::info!(cid = %cid, doc_id = %doc_id, "Block merged successfully");
-                }
-                ReplicationResult::MergedButBroadcastFailed {
-                    cid,
-                    doc_id,
-                    broadcast_error,
-                    ..
-                } => {
-                    tracing::error!(
-                        cid = %cid,
-                        doc_id = %doc_id,
-                        error = %broadcast_error,
-                        "Block merged but re-broadcast failed - other nodes may not receive this update"
-                    );
-                    // Continue processing - the local merge succeeded
-                }
-                ReplicationResult::Skipped { cid, reason } => {
-                    tracing::debug!(cid = %cid, reason = %reason, "Block skipped");
-                }
-                ReplicationResult::Failed { cid, error } => {
-                    tracing::error!(cid = %cid, error = %error, "Block merge failed");
-                    if !config.continue_on_error {
-                        tracing::error!("Stopping replication loop due to error");
+            let mut should_break = false;
+            for result in &results {
+                match result {
+                    ReplicationResult::Merged { cid, doc_id, .. } => {
+                        tracing::info!(cid = %cid, doc_id = %doc_id, "Block merged successfully");
+                    }
+                    ReplicationResult::MergedButBroadcastFailed {
+                        cid,
+                        doc_id,
+                        broadcast_error,
+                        ..
+                    } => {
+                        tracing::error!(
+                            cid = %cid,
+                            doc_id = %doc_id,
+                            error = %broadcast_error,
+                            "Block merged but re-broadcast failed"
+                        );
+                    }
+                    ReplicationResult::Skipped { cid, reason } => {
+                        tracing::debug!(cid = %cid, reason = %reason, "Block skipped");
+                    }
+                    ReplicationResult::Failed { cid, error } => {
+                        tracing::error!(cid = %cid, error = %error, "Block merge failed");
+                        if !config.continue_on_error {
+                            tracing::error!("Stopping replication loop due to error");
+                            should_break = true;
+                            break;
+                        }
+                    }
+                    ReplicationResult::MergedButNotMarked { cid, error } => {
+                        tracing::error!(
+                            cid = %cid,
+                            error = %error,
+                            "Block merged but failed to mark - will be reprocessed on restart"
+                        );
+                    }
+                    ReplicationResult::ChannelClosed => {
+                        tracing::info!("Event channel closed, stopping replication loop");
+                        should_break = true;
                         break;
                     }
+                    ReplicationResult::BitswapFetchStarted { root_cid, query_id } => {
+                        tracing::debug!(
+                            cid = %root_cid,
+                            query_id = ?query_id,
+                            "Bitswap fetch started for missing blocks"
+                        );
+                    }
                 }
-                ReplicationResult::MergedButNotMarked { cid, error } => {
-                    tracing::error!(
-                        cid = %cid,
-                        error = %error,
-                        "Block merged but failed to mark - will be reprocessed on restart"
-                    );
-                    // Continue processing - the merge succeeded, just the bookkeeping failed
-                }
-                ReplicationResult::ChannelClosed => {
-                    tracing::info!("Event channel closed, stopping replication loop");
-                    break;
-                }
-                ReplicationResult::BitswapFetchStarted { root_cid, query_id } => {
-                    tracing::debug!(
-                        cid = %root_cid,
-                        query_id = ?query_id,
-                        "Bitswap fetch started for missing blocks"
-                    );
-                }
+            }
+            if should_break {
+                break;
             }
         }
 
@@ -142,6 +149,66 @@ impl ReplicationLoop {
         };
 
         process_event(coordinator, event, handler, config).await
+    }
+
+    /// Process the next batch of sync events.
+    ///
+    /// Waits for at least one event (blocking), then drains up to
+    /// `config.batch_size - 1` more events using `try_recv()`.
+    /// Merge-eligible events are batched together for efficient processing;
+    /// other events (errors, already-merged, Bitswap) are processed individually.
+    pub async fn process_next_batch<B, H>(
+        coordinator: &SyncCoordinator<B>,
+        events: &mut mpsc::Receiver<SyncEvent>,
+        handler: &H,
+        config: &ReplicationConfig,
+    ) -> Vec<ReplicationResult>
+    where
+        B: Blockstore + 'static,
+        H: MergeHandler + ?Sized + 'static,
+    {
+        // Wait for first event (blocking)
+        let first = match events.recv().await {
+            Some(e) => e,
+            None => return vec![ReplicationResult::ChannelClosed],
+        };
+
+        // Drain more events non-blocking
+        let mut batch = vec![first];
+        while batch.len() < config.batch_size {
+            match events.try_recv() {
+                Ok(e) => batch.push(e),
+                Err(_) => break,
+            }
+        }
+
+        // Separate merge-worthy events from immediate-action events
+        let mut immediate = Vec::new();
+        let mut merge_events = Vec::new();
+        for event in batch {
+            if is_mergeable_event(&event) {
+                merge_events.push(event);
+            } else {
+                immediate.push(event);
+            }
+        }
+
+        let mut results = Vec::new();
+
+        // Process immediate events normally
+        for event in immediate {
+            results.push(process_event(coordinator, event, handler, config).await);
+        }
+
+        // Batch-process merge events
+        if !merge_events.is_empty() {
+            tracing::debug!(batch_size = merge_events.len(), "Processing merge batch");
+            let batch_results =
+                process_merge_batch(coordinator, merge_events, handler, config).await;
+            results.extend(batch_results);
+        }
+
+        results
     }
 
     /// Process all pending events without blocking.

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -33,7 +33,7 @@ pub use result::ReplicationResult;
 mod tests {
     use super::*;
     use crate::sync::manager::SyncEvent;
-    use crate::sync::merge::{BlockMetadata, MergeHandler, MergeOutcome};
+    use crate::sync::merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
     use async_trait::async_trait;
     use blockstore::{Blockstore, DefraBlockstore};
     use cid::Cid;
@@ -45,6 +45,13 @@ mod tests {
 
     fn test_cid() -> Cid {
         Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap()
+    }
+
+    /// Generate distinct test CIDs by hashing different data.
+    fn make_cid(data: &[u8]) -> Cid {
+        use cid::multihash::{Code, MultihashDigest};
+        let hash = Code::Sha2_256.digest(data);
+        Cid::new_v1(0x55, hash) // 0x55 = raw codec
     }
 
     /// Test merge handler that tracks calls
@@ -100,6 +107,82 @@ mod tests {
             } else {
                 Ok(MergeOutcome::Merged)
             }
+        }
+    }
+
+    /// Batch-aware merge handler that tracks per-block and batch calls separately.
+    struct BatchTestHandler {
+        per_block_calls: AtomicUsize,
+        batch_calls: AtomicUsize,
+        batch_block_count: AtomicUsize,
+        fail_at_index: Option<usize>,
+    }
+
+    impl BatchTestHandler {
+        fn new() -> Self {
+            Self {
+                per_block_calls: AtomicUsize::new(0),
+                batch_calls: AtomicUsize::new(0),
+                batch_block_count: AtomicUsize::new(0),
+                fail_at_index: None,
+            }
+        }
+
+        fn with_failure_at(index: usize) -> Self {
+            Self {
+                per_block_calls: AtomicUsize::new(0),
+                batch_calls: AtomicUsize::new(0),
+                batch_block_count: AtomicUsize::new(0),
+                fail_at_index: Some(index),
+            }
+        }
+
+        fn per_block_calls(&self) -> usize {
+            self.per_block_calls.load(Ordering::SeqCst)
+        }
+
+        fn batch_calls(&self) -> usize {
+            self.batch_calls.load(Ordering::SeqCst)
+        }
+
+        fn batch_block_count(&self) -> usize {
+            self.batch_block_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl MergeHandler for BatchTestHandler {
+        type Error = TestError;
+
+        async fn handle_block(
+            &self,
+            _cid: &Cid,
+            _block_data: &[u8],
+            _metadata: BlockMetadata<'_>,
+        ) -> Result<MergeOutcome, Self::Error> {
+            self.per_block_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(MergeOutcome::Merged)
+        }
+
+        async fn handle_block_batch(
+            &self,
+            blocks: &[MergeBlock],
+        ) -> Vec<Result<MergeOutcome, Self::Error>> {
+            self.batch_calls.fetch_add(1, Ordering::SeqCst);
+            self.batch_block_count
+                .fetch_add(blocks.len(), Ordering::SeqCst);
+
+            blocks
+                .iter()
+                .enumerate()
+                .map(|(i, _block)| {
+                    if self.fail_at_index == Some(i) {
+                        Err(TestError("batch block failed".to_string()))
+                    } else {
+                        Ok(MergeOutcome::Merged)
+                    }
+                })
+                .collect()
         }
     }
 
@@ -229,6 +312,206 @@ mod tests {
                 assert!(broadcast_error.contains("no peers"));
             }
             _ => panic!("Expected MergedButBroadcastFailed"),
+        }
+    }
+
+    // =========================================================================
+    // Batch merge tests
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_default_handle_block_batch_calls_per_block() {
+        // The default handle_block_batch delegates to handle_block per block.
+        let handler = TestMergeHandler::new(true, false);
+        let blocks: Vec<MergeBlock> = (0..5)
+            .map(|i| {
+                let data = format!("block{}", i);
+                MergeBlock {
+                    cid: make_cid(data.as_bytes()),
+                    block_data: data.into_bytes(),
+                    doc_id: format!("doc{}", i),
+                    collection_id: "col1".to_string(),
+                    creator: "peer1".to_string(),
+                }
+            })
+            .collect();
+
+        let results = handler.handle_block_batch(&blocks).await;
+
+        assert_eq!(results.len(), 5);
+        assert!(results.iter().all(|r| r.as_ref().unwrap().is_merged()));
+        assert_eq!(
+            handler.calls(),
+            5,
+            "default impl should call handle_block per block"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_handler_receives_all_blocks_at_once() {
+        // A custom handle_block_batch override gets all blocks in one call.
+        let handler = BatchTestHandler::new();
+        let blocks: Vec<MergeBlock> = (0..10)
+            .map(|i| {
+                let data = format!("block{}", i);
+                MergeBlock {
+                    cid: make_cid(data.as_bytes()),
+                    block_data: data.into_bytes(),
+                    doc_id: format!("doc{}", i),
+                    collection_id: "col1".to_string(),
+                    creator: "peer1".to_string(),
+                }
+            })
+            .collect();
+
+        let results = handler.handle_block_batch(&blocks).await;
+
+        assert_eq!(results.len(), 10);
+        assert!(results.iter().all(|r| r.as_ref().unwrap().is_merged()));
+        assert_eq!(handler.batch_calls(), 1, "batch should be called once");
+        assert_eq!(
+            handler.batch_block_count(),
+            10,
+            "batch should receive all 10 blocks"
+        );
+        assert_eq!(
+            handler.per_block_calls(),
+            0,
+            "handle_block should NOT be called"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_handler_partial_failure() {
+        // When one block in a batch fails, the rest still get results.
+        let handler = BatchTestHandler::with_failure_at(2);
+        let blocks: Vec<MergeBlock> = (0..5)
+            .map(|i| {
+                let data = format!("block{}", i);
+                MergeBlock {
+                    cid: make_cid(data.as_bytes()),
+                    block_data: data.into_bytes(),
+                    doc_id: format!("doc{}", i),
+                    collection_id: "col1".to_string(),
+                    creator: "peer1".to_string(),
+                }
+            })
+            .collect();
+
+        let results = handler.handle_block_batch(&blocks).await;
+
+        assert_eq!(results.len(), 5);
+        assert!(results[0].is_ok());
+        assert!(results[1].is_ok());
+        assert!(results[2].is_err());
+        assert!(results[3].is_ok());
+        assert!(results[4].is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_batch_handler_empty_batch() {
+        let handler = BatchTestHandler::new();
+        let results = handler.handle_block_batch(&[]).await;
+
+        assert!(results.is_empty());
+        assert_eq!(handler.batch_calls(), 1, "batch called even when empty");
+        assert_eq!(handler.batch_block_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_batch_handler_single_block() {
+        // Single-block batch should still go through handle_block_batch.
+        let handler = BatchTestHandler::new();
+        let blocks = vec![MergeBlock {
+            cid: make_cid(b"single"),
+            block_data: b"single".to_vec(),
+            doc_id: "doc0".to_string(),
+            collection_id: "col1".to_string(),
+            creator: "peer1".to_string(),
+        }];
+
+        let results = handler.handle_block_batch(&blocks).await;
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].as_ref().unwrap().is_merged());
+        assert_eq!(handler.batch_calls(), 1);
+        assert_eq!(handler.batch_block_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_merge_block_metadata_preserved() {
+        // Verify that MergeBlock fields are accessible to the batch handler.
+        let handler = TestMergeHandler::new(true, false);
+        let cid = make_cid(b"metadata-test");
+        let blocks = vec![MergeBlock {
+            cid,
+            block_data: b"test data".to_vec(),
+            doc_id: "my-doc".to_string(),
+            collection_id: "my-collection".to_string(),
+            creator: "my-peer".to_string(),
+        }];
+
+        // The default impl passes metadata through to handle_block.
+        // We can't inspect the metadata inside TestMergeHandler, but we can
+        // verify the call succeeds and the block round-trips correctly.
+        let results = handler.handle_block_batch(&blocks).await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].as_ref().unwrap().is_merged());
+        assert_eq!(blocks[0].doc_id, "my-doc");
+        assert_eq!(blocks[0].collection_id, "my-collection");
+        assert_eq!(blocks[0].creator, "my-peer");
+    }
+
+    #[tokio::test]
+    async fn test_default_batch_propagates_errors() {
+        // The default handle_block_batch should propagate per-block errors.
+        let handler = TestMergeHandler::new(false, false); // all blocks fail
+        let blocks: Vec<MergeBlock> = (0..3)
+            .map(|i| {
+                let data = format!("block{}", i);
+                MergeBlock {
+                    cid: make_cid(data.as_bytes()),
+                    block_data: data.into_bytes(),
+                    doc_id: format!("doc{}", i),
+                    collection_id: "col1".to_string(),
+                    creator: "peer1".to_string(),
+                }
+            })
+            .collect();
+
+        let results = handler.handle_block_batch(&blocks).await;
+
+        assert_eq!(results.len(), 3);
+        assert!(results.iter().all(|r| r.is_err()));
+        assert_eq!(
+            handler.calls(),
+            3,
+            "default impl calls handle_block for each"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_batch_mixed_skip_and_merge() {
+        // Test that skip outcomes are preserved through the batch.
+        let handler = TestMergeHandler::new(true, true); // all blocks skip
+        let blocks: Vec<MergeBlock> = (0..3)
+            .map(|i| {
+                let data = format!("block{}", i);
+                MergeBlock {
+                    cid: make_cid(data.as_bytes()),
+                    block_data: data.into_bytes(),
+                    doc_id: format!("doc{}", i),
+                    collection_id: "col1".to_string(),
+                    creator: "peer1".to_string(),
+                }
+            })
+            .collect();
+
+        let results = handler.handle_block_batch(&blocks).await;
+
+        assert_eq!(results.len(), 3);
+        for result in &results {
+            assert!(result.as_ref().unwrap().is_skipped());
         }
     }
 }

--- a/crates/p2p/src/sync/replication/recovery.rs
+++ b/crates/p2p/src/sync/replication/recovery.rs
@@ -45,6 +45,7 @@ where
     let config = ReplicationConfig {
         continue_on_error: true,
         rebroadcast_on_merge: false,
+        batch_size: 50,
     };
 
     let unmerged = coordinator.get_unmerged().await?;

--- a/tools/integration-test/tests/replication_advanced.rs
+++ b/tools/integration-test/tests/replication_advanced.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use integration_test::{for_each_p2p_topology, poll_until, TestCluster};
@@ -39,123 +40,190 @@ async fn replication_crud_test(cluster: TestCluster) {
     node1.p2p_collection_add(&["User"]).unwrap();
     node0.p2p_replicator_set(&["User"], addr1).unwrap();
 
-    // Step 1: Create 3 documents on node 0
-    let alice = node0
-        .query(r#"mutation { create_User(input: {name: "Alice", age: 30}) { _docID name age } }"#)
-        .unwrap();
-    let alice_id = alice["create_User"][0]["_docID"]
-        .as_str()
-        .expect("missing Alice _docID")
-        .to_string();
+    // --- Step 1: Create 10 documents rapidly on node0 ---
+    // Creating many documents at once increases the chance that multiple
+    // sync events land in the same batch window (try_recv draining).
+    let users = [
+        ("Alice", 30),
+        ("Bob", 25),
+        ("Carol", 35),
+        ("Dave", 28),
+        ("Eve", 22),
+        ("Frank", 40),
+        ("Grace", 33),
+        ("Hank", 27),
+        ("Iris", 31),
+        ("Jack", 29),
+    ];
 
-    let bob = node0
-        .query(r#"mutation { create_User(input: {name: "Bob", age: 25}) { _docID name age } }"#)
-        .unwrap();
-    let bob_id = bob["create_User"][0]["_docID"]
-        .as_str()
-        .expect("missing Bob _docID")
-        .to_string();
+    let mut doc_ids: HashMap<String, String> = HashMap::new();
+    for (name, age) in &users {
+        let result = node0
+            .query(&format!(
+                r#"mutation {{ create_User(input: {{name: "{}", age: {}}}) {{ _docID name age }} }}"#,
+                name, age
+            ))
+            .unwrap();
+        let doc_id = result["create_User"][0]["_docID"]
+            .as_str()
+            .unwrap_or_else(|| panic!("missing _docID for {}", name))
+            .to_string();
+        doc_ids.insert(name.to_string(), doc_id);
+    }
 
-    node0
-        .query(r#"mutation { create_User(input: {name: "Carol", age: 35}) { _docID name age } }"#)
-        .unwrap();
-
-    // Step 2: Wait for all 3 to replicate to node 1
+    // --- Step 2: Wait for all 10 to replicate, verify exact field values ---
     let node1_ref = &node1;
     poll_until(
         || {
             let result = node1_ref
                 .query("query { User { _docID name age } }")
                 .unwrap();
-            result["User"]
-                .as_array()
-                .map(|arr| arr.len() == 3)
-                .unwrap_or(false)
+            let arr = match result["User"].as_array() {
+                Some(a) => a,
+                None => return false,
+            };
+            if arr.len() != 10 {
+                return false;
+            }
+            // Verify every user has correct name and age
+            let mut found: HashMap<String, i64> = HashMap::new();
+            for u in arr {
+                if let (Some(name), Some(age)) = (u["name"].as_str(), u["age"].as_i64()) {
+                    found.insert(name.to_string(), age);
+                }
+            }
+            users
+                .iter()
+                .all(|(name, age)| found.get(*name) == Some(&(*age as i64)))
         },
-        Duration::from_secs(15),
+        Duration::from_secs(30),
         Duration::from_millis(200),
-        "3 docs did not replicate",
+        "10 docs with correct field values did not replicate",
     )
     .await;
 
-    // Step 3: Update Alice's age on node 0
-    node0
-        .query(&format!(
-            r#"mutation {{ update_User(docID: "{}", input: {{age: 31}}) {{ _docID name age }} }}"#,
-            alice_id
-        ))
-        .unwrap();
+    // --- Step 3: Batch update — change ages for Alice, Dave, and Grace ---
+    // Multiple rapid updates also exercise the batch merge path.
+    let updates = [("Alice", 31), ("Dave", 29), ("Grace", 34)];
+    for (name, new_age) in &updates {
+        let doc_id = &doc_ids[*name];
+        node0
+            .query(&format!(
+                r#"mutation {{ update_User(docID: "{}", input: {{age: {}}}) {{ _docID name age }} }}"#,
+                doc_id, new_age
+            ))
+            .unwrap();
+    }
 
-    // Step 4: Wait for update to replicate, verify on node 1
-    let alice_id_ref = &alice_id;
+    // --- Step 4: Wait for all 3 updates to replicate with exact values ---
     poll_until(
         || {
             let result = node1_ref
                 .query("query { User { _docID name age } }")
                 .unwrap();
-            if let Some(users) = result["User"].as_array() {
-                users
-                    .iter()
-                    .any(|u| u["_docID"].as_str() == Some(alice_id_ref.as_str()) && u["age"] == 31)
-            } else {
-                false
+            let arr = match result["User"].as_array() {
+                Some(a) => a,
+                None => return false,
+            };
+            let mut found: HashMap<String, i64> = HashMap::new();
+            for u in arr {
+                if let (Some(name), Some(age)) = (u["name"].as_str(), u["age"].as_i64()) {
+                    found.insert(name.to_string(), age);
+                }
             }
+            // Check updated values
+            found.get("Alice") == Some(&31)
+                && found.get("Dave") == Some(&29)
+                && found.get("Grace") == Some(&34)
+                // Check unchanged values are still correct
+                && found.get("Bob") == Some(&25)
+                && found.get("Carol") == Some(&35)
         },
         Duration::from_secs(15),
         Duration::from_millis(200),
-        "Alice update did not replicate",
+        "batch updates did not replicate with correct values",
     )
     .await;
 
-    // Step 5: Query with filter on node 1
+    // --- Step 5: Query with filter on node1 (ages > 30) ---
     let filtered = node1
-        .query(r#"query { User(filter: {age: {_gt: 25}}) { _docID name age } }"#)
+        .query(r#"query { User(filter: {age: {_gt: 30}}) { name age } }"#)
         .unwrap();
     let filtered_users = filtered["User"]
         .as_array()
         .expect("filtered result not array");
+    // Alice=31, Carol=35, Grace=34, Frank=40, Iris=31 → 5 users
     assert_eq!(
         filtered_users.len(),
-        2,
-        "expected Alice and Carol, got {:?}",
+        5,
+        "expected 5 users with age > 30, got {:?}",
         filtered_users
     );
     let names: Vec<&str> = filtered_users
         .iter()
         .filter_map(|u| u["name"].as_str())
         .collect();
-    assert!(names.contains(&"Alice"), "Alice missing from filter result");
-    assert!(names.contains(&"Carol"), "Carol missing from filter result");
+    for expected in &["Alice", "Carol", "Grace", "Frank", "Iris"] {
+        assert!(
+            names.contains(expected),
+            "{} missing from age>30 filter, got {:?}",
+            expected,
+            names
+        );
+    }
 
-    // Step 6: Delete Bob on node 0
-    node0.collection_delete("User", &bob_id).unwrap();
+    // --- Step 6: Delete Bob and Eve on node0 ---
+    node0.collection_delete("User", &doc_ids["Bob"]).unwrap();
+    node0.collection_delete("User", &doc_ids["Eve"]).unwrap();
 
-    // Step 7: Wait for deletion to replicate
+    // --- Step 7: Wait for deletions to replicate, verify remaining 8 ---
     poll_until(
         || {
-            let result = node1_ref.query("query { User { _docID name } }").unwrap();
-            result["User"]
-                .as_array()
-                .map(|arr| arr.len() == 2)
-                .unwrap_or(false)
+            let result = node1_ref.query("query { User { name age } }").unwrap();
+            let arr = match result["User"].as_array() {
+                Some(a) => a,
+                None => return false,
+            };
+            if arr.len() != 8 {
+                return false;
+            }
+            let names: Vec<&str> = arr.iter().filter_map(|u| u["name"].as_str()).collect();
+            !names.contains(&"Bob")
+                && !names.contains(&"Eve")
+                && names.contains(&"Alice")
+                && names.contains(&"Carol")
+                && names.contains(&"Dave")
+                && names.contains(&"Frank")
+                && names.contains(&"Grace")
+                && names.contains(&"Hank")
+                && names.contains(&"Iris")
+                && names.contains(&"Jack")
         },
         Duration::from_secs(15),
         Duration::from_millis(200),
-        "Bob deletion did not replicate",
+        "deletions did not replicate correctly",
     )
     .await;
 
-    // Verify remaining docs are Alice and Carol
-    let remaining = node1.query("query { User { name } }").unwrap();
-    let remaining_names: Vec<&str> = remaining["User"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .filter_map(|u| u["name"].as_str())
-        .collect();
-    assert!(remaining_names.contains(&"Alice"));
-    assert!(remaining_names.contains(&"Carol"));
-    assert!(!remaining_names.contains(&"Bob"));
+    // Final verification: all remaining field values are correct
+    let final_result = node1.query("query { User { name age } }").unwrap();
+    let final_users = final_result["User"].as_array().unwrap();
+    let mut final_map: HashMap<String, i64> = HashMap::new();
+    for u in final_users {
+        if let (Some(name), Some(age)) = (u["name"].as_str(), u["age"].as_i64()) {
+            final_map.insert(name.to_string(), age);
+        }
+    }
+    // Updated values
+    assert_eq!(final_map["Alice"], 31);
+    assert_eq!(final_map["Dave"], 29);
+    assert_eq!(final_map["Grace"], 34);
+    // Unchanged values
+    assert_eq!(final_map["Carol"], 35);
+    assert_eq!(final_map["Frank"], 40);
+    assert_eq!(final_map["Hank"], 27);
+    assert_eq!(final_map["Iris"], 31);
+    assert_eq!(final_map["Jack"], 29);
 }
 
 for_each_p2p_topology!(replication_crud, replication_crud_test, .with_p2p());


### PR DESCRIPTION
## Summary
- Batches up to 50 P2P sync blocks into a single shared transaction, reducing ~100 txn commits per 50 blocks down to 2 (matching Go's `MergeBatchWithTxn()`)
- Adds `MergeBlock` struct, `handle_block_batch()` trait method, and `ReplicationLoop::process_next_batch()` that drains events via `try_recv()`
- Implements `DbMergeHandler::try_batch_merge()` with shared-txn `_in_txn` variants for composite/collection processing, plus `Blockstore::mark_batch_as_merged()` for single-txn batch marking
- Falls back to per-block processing if batch merge fails (rolls back entire batch on any error)

Closes #428

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] `cargo build --release` succeeds
- [ ] FFI integration tests for P2P sync scenarios
- [ ] Verify batch behavior with multi-block sync test

🤖 Generated with [Claude Code](https://claude.com/claude-code)