### PR TITLE
perf: parallelize block computation in create_many

### DIFF
--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::block_builder::{compute_document_blocks, insert_computed_blocks, ComputedBlocks};
+
 #[allow(clippy::type_complexity)]
 impl<S: Store + 'static> AutoCommitMutator<S> {
     pub(super) async fn create_many_impl(
@@ -22,14 +24,10 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
         let collection = self.get_collection_or_err(collection_name)?;
 
-        // Create ONE write transaction for the entire batch
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
-
         let short_id = collection_short_id(collection.collection_id());
-        let schema_version_id = collection.version_id();
+        let schema_version_id = collection.version_id().to_string();
         let sign_config = get_signing_config();
+        let enc_config = get_encryption_config();
 
         // Build IndexManager once for the entire batch (schema is identical for all docs)
         let index_manager =
@@ -40,15 +38,9 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 ))
             })?;
 
-        let mut results: Vec<(
-            DocID,
-            Document,
-            Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)>,
-        )> = Vec::with_capacity(docs.len());
-
-        // Process each document within the SAME transaction
+        // === Phase 1: Prepare documents (sequential — embeddings are async/external) ===
+        let mut prepared_docs: Vec<(Document, bool)> = Vec::with_capacity(docs.len());
         for mut doc in docs {
-            // Generate embeddings
             crate::embedding::set_embedding(
                 &collection.schema().vector_embeddings,
                 &mut doc,
@@ -58,8 +50,6 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;
 
-            // Generate document ID.
-            // Track whether ID was just generated for blind create optimization.
             let id_was_generated = doc.id().is_none();
             if id_was_generated {
                 doc.generate_and_set_doc_id().map_err(|e| {
@@ -67,11 +57,60 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 })?;
             }
 
+            prepared_docs.push((doc, id_was_generated));
+        }
+
+        // === Phase 2: Compute blocks in parallel (pure CPU, no storage access) ===
+        let block_futures: Vec<_> = prepared_docs
+            .iter()
+            .map(|(doc, _)| {
+                let doc_clone = doc.clone();
+                let schema = schema_version_id.clone();
+                let enc = enc_config.clone();
+                let sign = sign_config.clone();
+                tokio::task::spawn_blocking(move || {
+                    compute_document_blocks(&doc_clone, &schema, enc.as_ref(), sign.as_ref())
+                })
+            })
+            .collect();
+
+        let computed_results = futures::future::join_all(block_futures).await;
+
+        // Unpack JoinHandle results — a JoinError means the task panicked
+        let computed_blocks: Vec<Option<ComputedBlocks>> = computed_results
+            .into_iter()
+            .map(|join_result| match join_result {
+                Ok(Ok(blocks)) => Some(blocks),
+                Ok(Err(e)) => {
+                    warn!(error = %e, "Failed to compute document blocks");
+                    None
+                }
+                Err(e) => {
+                    warn!(error = %e, "Block computation task panicked");
+                    None
+                }
+            })
+            .collect();
+
+        // === Phase 3: Transaction — sequential writes ===
+        let txn = self.db.new_txn(false).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        let mut results: Vec<(
+            DocID,
+            Document,
+            Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)>,
+        )> = Vec::with_capacity(prepared_docs.len());
+
+        for ((doc, id_was_generated), blocks) in
+            prepared_docs.into_iter().zip(computed_blocks.into_iter())
+        {
             let doc_id = doc.id().cloned().ok_or_else(|| {
                 query::error::QueryError::execution("document should have ID after generation")
             })?;
 
-            // Create with indexes (scoped borrow of datastore)
+            // Datastore + index writes
             {
                 let datastore = txn.datastore().map_err(|e| {
                     query::error::QueryError::execution(format!(
@@ -97,70 +136,71 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     })?;
             } // datastore dropped
 
-            // Write blocks (scoped borrow of blockstore + headstore)
-            let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = {
-                let blockstore = txn.blockstore().map_err(|e| {
-                    query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
-                })?;
-                let headstore = txn.headstore().map_err(|e| {
-                    query::error::QueryError::execution(format!("failed to get headstore: {}", e))
-                })?;
+            // Insert pre-computed blocks + collection blocks
+            let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = match blocks {
+                Some(computed) => {
+                    let blockstore = txn.blockstore().map_err(|e| {
+                        query::error::QueryError::execution(format!(
+                            "failed to get blockstore: {}",
+                            e
+                        ))
+                    })?;
+                    let headstore = txn.headstore().map_err(|e| {
+                        query::error::QueryError::execution(format!(
+                            "failed to get headstore: {}",
+                            e
+                        ))
+                    })?;
 
-                let enc_config = get_encryption_config();
+                    match insert_computed_blocks(&blockstore, &headstore, &computed).await {
+                        Ok(()) => {
+                            if let Some(ref config) = enc_config {
+                                store_doc_encryption(&doc_id.to_string(), config.clone());
+                            }
 
-                match write_document_blocks(
-                    &blockstore,
-                    &headstore,
-                    &doc,
-                    schema_version_id,
-                    None,
-                    enc_config.as_ref(),
-                    sign_config.as_ref(),
-                )
-                .await
-                {
-                    Ok(block_result) => {
-                        if let Some(ref config) = enc_config {
-                            store_doc_encryption(&doc_id.to_string(), config.clone());
-                        }
-
-                        let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                        if collection.schema().is_branchable {
-                            match write_collection_block(
-                                &blockstore,
-                                &headstore,
-                                short_id,
-                                schema_version_id,
-                                block_result.cid,
-                                sign_config.as_ref(),
-                            )
-                            .await
-                            {
-                                Ok((col_cid, col_bytes)) => {
-                                    col_block_data = Some((col_cid, col_bytes));
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        collection = %collection_name,
-                                        error = %e,
-                                        "Failed to write collection block for branchable create"
-                                    );
+                            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+                            if collection.schema().is_branchable {
+                                match write_collection_block(
+                                    &blockstore,
+                                    &headstore,
+                                    short_id,
+                                    &schema_version_id,
+                                    computed.block_result.cid,
+                                    sign_config.as_ref(),
+                                )
+                                .await
+                                {
+                                    Ok((col_cid, col_bytes)) => {
+                                        col_block_data = Some((col_cid, col_bytes));
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            collection = %collection_name,
+                                            error = %e,
+                                            "Failed to write collection block for branchable create"
+                                        );
+                                    }
                                 }
                             }
-                        }
 
-                        Some((block_result.cid, block_result.block, col_block_data))
-                    }
-                    Err(e) => {
-                        warn!(
-                            collection = %collection_name,
-                            error = %e,
-                            "Failed to write document blocks - commits queries may not work"
-                        );
-                        None
+                            Some((
+                                computed.block_result.cid,
+                                computed.block_result.block,
+                                col_block_data,
+                            ))
+                        }
+                        Err(e) => {
+                            warn!(
+                                collection = %collection_name,
+                                error = %e,
+                                "Failed to insert pre-computed blocks"
+                            );
+                            None
+                        }
                     }
                 }
-            }; // blockstore and headstore dropped
+                None => None,
+            };
 
             results.push((doc_id, doc, commit_result));
         }

--- a/crates/db/src/block_builder/compute.rs
+++ b/crates/db/src/block_builder/compute.rs
@@ -1,0 +1,231 @@
+use super::*;
+
+/// Pre-computed blocks ready for batch insertion into storage.
+///
+/// All (key, value) pairs are accumulated during pure computation (no storage
+/// access). The caller inserts them into blockstore/headstore inside a transaction.
+#[derive(Debug, Clone)]
+pub struct ComputedBlocks {
+    pub blockstore_entries: Vec<(Vec<u8>, Vec<u8>)>,
+    pub headstore_entries: Vec<(Vec<u8>, Vec<u8>)>,
+    pub block_result: BlockResult,
+}
+
+/// Compute all document blocks without any storage access.
+///
+/// This is the CREATE-only path extracted from `write_document_blocks()`.
+/// For creates: priority is always 1, no headstore reads, no prev heads.
+/// The entire computation is a pure function of the inputs.
+///
+/// For each field: CBOR encode → optional encrypt → build Block → optional sign →
+/// serialize → CID. Then builds composite block the same way.
+/// Accumulates all (key, value) pairs instead of writing to storage.
+pub fn compute_document_blocks(
+    doc: &Document,
+    schema_version_id: &str,
+    encryption_config: Option<&EncryptionConfig>,
+    signing_config: Option<&SigningConfig>,
+) -> Result<ComputedBlocks, String> {
+    let doc_id = doc
+        .id()
+        .ok_or_else(|| "Document must have an ID".to_string())?;
+    let doc_id_str = doc_id.to_string();
+    let doc_id_bytes = doc_id_str.as_bytes().to_vec();
+
+    let mut blockstore_entries: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut headstore_entries: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    let mut field_links: Vec<DAGLink> = Vec::new();
+    let mut field_cids: Vec<Cid> = Vec::new();
+
+    let priority: u64 = 1; // Always 1 for creates
+
+    for (field_name, field_value) in doc.values() {
+        if field_name == "_docID" {
+            continue;
+        }
+
+        // For counter fields during creates, use the raw delta if set
+        let cbor_value = if let Some(delta) = doc.get_counter_delta(field_name) {
+            delta
+        } else {
+            field_value.value()
+        };
+
+        let value_bytes = encode_value_as_cbor(cbor_value)?;
+
+        // Encrypt delta and create Encryption metadata block if configured
+        let (value_bytes, encryption_cid) = if let Some(enc) = encryption_config {
+            if enc.should_encrypt_field(field_name) {
+                let key = enc.derive_key(field_name, &doc_id_str);
+                let encrypted = encrypt_delta(&value_bytes, &key)?;
+
+                let is_field_level = enc.encrypt_fields.iter().any(|f| f == field_name);
+                let enc_block = Encryption {
+                    doc_id: doc_id_bytes.clone(),
+                    field_name: if is_field_level {
+                        Some(field_name.clone())
+                    } else {
+                        None
+                    },
+                    key: key.to_vec(),
+                };
+                let enc_bytes = enc_block
+                    .to_dag_cbor()
+                    .map_err(|e| format!("Failed to encode encryption block: {}", e))?;
+                let enc_cid = generate_cid_from_bytes(&enc_bytes)
+                    .map_err(|e| format!("Failed to generate encryption CID: {}", e))?;
+                blockstore_entries.push((enc_cid.to_bytes(), enc_bytes));
+
+                (encrypted, Some(enc_cid))
+            } else {
+                (value_bytes, None)
+            }
+        } else {
+            (value_bytes, None)
+        };
+
+        let is_counter = doc
+            .fields()
+            .get(field_name)
+            .map(|f| f.crdt_type().is_counter())
+            .unwrap_or(false)
+            || doc.get_counter_delta(field_name).is_some();
+
+        // For creates, heads are always empty → nonce is always 0
+        let nonce: i64 = 0;
+
+        let delta = if is_counter {
+            CrdtDelta::Counter(CounterDeltaPayload {
+                doc_id: doc_id_bytes.clone(),
+                field_name: field_name.clone(),
+                priority,
+                nonce,
+                schema_version_id: schema_version_id.to_string(),
+                data: value_bytes,
+            })
+        } else {
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: doc_id_bytes.clone(),
+                field_name: field_name.clone(),
+                priority,
+                schema_version_id: schema_version_id.to_string(),
+                data: value_bytes,
+            })
+        };
+
+        // No prev heads for creates
+        let mut field_block = Block::new_with_options(delta, vec![], vec![], encryption_cid, None);
+
+        if let Some(signer) = signing_config {
+            if let Some((sig_cid, sig_cbor)) = compute_signature(&field_block, signer)? {
+                blockstore_entries.push((sig_cid.to_bytes(), sig_cbor));
+                field_block.signature = Some(sig_cid);
+            }
+        }
+
+        let field_block_bytes = field_block
+            .to_dag_cbor()
+            .map_err(|e| format!("Failed to encode field block: {}", e))?;
+        let field_cid = generate_cid_from_bytes(&field_block_bytes)
+            .map_err(|e| format!("Failed to generate field CID: {}", e))?;
+
+        blockstore_entries.push((field_cid.to_bytes(), field_block_bytes));
+
+        // Head entry: /d/{doc_id}/{field_name}/{cid} → priority
+        let head_key = HeadstoreDocKey::new(&doc_id_str, field_name, field_cid);
+        let priority_bytes = encode_priority_varint(priority);
+        headstore_entries.push((head_key.bytes(), priority_bytes));
+
+        field_links.push(DAGLink::new(field_name.clone(), field_cid));
+        field_cids.push(field_cid);
+    }
+
+    // Composite encryption CID for doc-level encryption
+    let composite_encryption_cid = if let Some(enc) = encryption_config {
+        if enc.encrypt_doc {
+            let key = enc.derive_key("", &doc_id_str);
+            let enc_block = Encryption {
+                doc_id: doc_id_str.as_bytes().to_vec(),
+                field_name: None,
+                key: key.to_vec(),
+            };
+            let enc_bytes = enc_block
+                .to_dag_cbor()
+                .map_err(|e| format!("Failed to encode composite encryption block: {}", e))?;
+            let enc_cid = generate_cid_from_bytes(&enc_bytes)
+                .map_err(|e| format!("Failed to generate composite encryption CID: {}", e))?;
+            blockstore_entries.push((enc_cid.to_bytes(), enc_bytes));
+            Some(enc_cid)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let composite_payload = CompositeDeltaPayload {
+        doc_id: doc_id_bytes,
+        schema_version_id: schema_version_id.to_string(),
+        priority,
+        status: 1, // Active document
+    };
+
+    let mut composite_block = Block::new_with_options(
+        CrdtDelta::Composite(composite_payload),
+        vec![], // No prev heads for creates
+        field_links,
+        composite_encryption_cid,
+        None,
+    );
+
+    if let Some(signer) = signing_config {
+        if let Some((sig_cid, sig_cbor)) = compute_signature(&composite_block, signer)? {
+            blockstore_entries.push((sig_cid.to_bytes(), sig_cbor));
+            composite_block.signature = Some(sig_cid);
+        }
+    }
+
+    let composite_bytes = composite_block
+        .to_dag_cbor()
+        .map_err(|e| format!("Failed to encode composite block: {}", e))?;
+    let composite_cid = generate_cid_from_bytes(&composite_bytes)
+        .map_err(|e| format!("Failed to generate composite CID: {}", e))?;
+
+    blockstore_entries.push((composite_cid.to_bytes(), composite_bytes.clone()));
+
+    let composite_head_key = HeadstoreDocKey::new(&doc_id_str, "C", composite_cid);
+    let priority_bytes = encode_priority_varint(priority);
+    headstore_entries.push((composite_head_key.bytes(), priority_bytes));
+
+    Ok(ComputedBlocks {
+        blockstore_entries,
+        headstore_entries,
+        block_result: BlockResult {
+            cid: composite_cid,
+            block: composite_bytes,
+            doc_id: doc_id_str,
+            field_cids,
+        },
+    })
+}
+
+/// Batch-insert pre-computed blocks into blockstore and headstore.
+pub async fn insert_computed_blocks(
+    blockstore: &NamespaceView,
+    headstore: &NamespaceView,
+    blocks: &ComputedBlocks,
+) -> Result<(), String> {
+    for (key, value) in &blocks.blockstore_entries {
+        blockstore
+            .set(key, value)
+            .await
+            .map_err(|e| format!("Failed to store block: {}", e))?;
+    }
+    for (key, value) in &blocks.headstore_entries {
+        headstore
+            .set(key, value)
+            .await
+            .map_err(|e| format!("Failed to write head: {}", e))?;
+    }
+    Ok(())
+}

--- a/crates/db/src/block_builder/mod.rs
+++ b/crates/db/src/block_builder/mod.rs
@@ -9,6 +9,7 @@
 
 mod build;
 mod collection;
+mod compute;
 mod read;
 #[cfg(test)]
 mod tests;
@@ -18,6 +19,7 @@ mod write;
 pub use build::build_block_from_document;
 pub use build::build_blocks_from_document;
 pub use collection::write_collection_block;
+pub use compute::{compute_document_blocks, insert_computed_blocks, ComputedBlocks};
 pub use read::read_latest_composite_block;
 pub use write::{write_delete_block, write_document_blocks};
 
@@ -43,22 +45,14 @@ pub(super) fn encrypt_delta(plaintext: &[u8], key: &[u8; 32]) -> Result<Vec<u8>,
     Ok(ciphertext)
 }
 
-/// Sign a block and store the signature as a separate IPLD block.
+/// Compute a signature block without writing to storage.
 ///
-/// Matches Go's `signBlock()` in `internal/core/block/signing.go`:
-/// 1. Only signs first field blocks (priority <= 1) and composite blocks
-/// 2. Marshals block WITHOUT signature to get bytes to sign
-/// 3. Signs the bytes with the private key
-/// 4. Creates a Signature block with header (type + public key) and value
-/// 5. Stores the signature block in blockstore
-/// 6. Returns the signature block's CID
-///
-/// The caller must then set `block.signature = Some(sig_cid)` and re-serialize.
-pub(super) async fn sign_block(
+/// Pure function: returns `(sig_cid, sig_cbor_bytes)` for the caller to store.
+/// Returns `None` for field blocks with priority > 1 (not signed per Go behavior).
+pub(super) fn compute_signature(
     block: &Block,
     signer: &SigningConfig,
-    blockstore: &NamespaceView,
-) -> Result<Option<Cid>, String> {
+) -> Result<Option<(Cid, Vec<u8>)>, String> {
     // Only sign first field blocks (priority <= 1) and composite blocks.
     // Higher-priority field blocks are not signed — their integrity is
     // guaranteed by the signature on the parent composite block.
@@ -101,12 +95,28 @@ pub(super) async fn sign_block(
         sig_bytes,
     );
 
-    // Store signature block in blockstore and return its CID
     let sig_cbor = signature
         .to_dag_cbor()
         .map_err(|e| format!("Failed to encode signature block: {}", e))?;
     let sig_cid = generate_cid_from_bytes(&sig_cbor)
         .map_err(|e| format!("Failed to generate signature CID: {}", e))?;
+
+    Ok(Some((sig_cid, sig_cbor)))
+}
+
+/// Sign a block and store the signature as a separate IPLD block.
+///
+/// Delegates to `compute_signature()` for the pure computation, then writes
+/// the signature block to blockstore. The caller must then set
+/// `block.signature = Some(sig_cid)` and re-serialize.
+pub(super) async fn sign_block(
+    block: &Block,
+    signer: &SigningConfig,
+    blockstore: &NamespaceView,
+) -> Result<Option<Cid>, String> {
+    let Some((sig_cid, sig_cbor)) = compute_signature(block, signer)? else {
+        return Ok(None);
+    };
 
     blockstore
         .set(&sig_cid.to_bytes(), &sig_cbor)


### PR DESCRIPTION
## Summary
- Extract pure block computation (`compute_document_blocks()`) from the storage-coupled `write_document_blocks()` for CREATE operations
- Run block computation in parallel across documents via `tokio::task::spawn_blocking` + `futures::future::join_all` before opening the transaction
- Restructure `create_many_impl()` into 3 phases: prepare docs, parallel compute, sequential transaction writes

For Shinzo workloads (852 docs/block), this moves all CPU-bound work (CBOR encoding, SHA-256 CID generation, AES encryption, Ed25519/secp256k1 signing) out of the serial per-document loop and onto the tokio blocking thread pool.

## Key insight
For CREATEs: priority is always 1, no headstore reads, no storage reads at all. The entire block computation is a pure function of `(document, schema_version_id, encryption_config, signing_config)`.

## Changes
- `crates/db/src/block_builder/compute.rs` — new `ComputedBlocks`, `compute_document_blocks()`, `insert_computed_blocks()`
- `crates/db/src/block_builder/mod.rs` — new `compute_signature()` pure function, `sign_block()` refactored to use it
- `crates/db/src/auto_commit_mutator/create_many.rs` — 3-phase parallel pipeline

## What didn't change
- `write_document_blocks()` — intact for UPDATE path
- `write_collection_block()` — stays sequential (inter-doc headstore dependency)
- Single-doc create path — still delegates to `create_impl()`
- Error handling — block failures remain soft-failures

## Test plan
- [x] `cargo test -p db` — 192 tests pass
- [x] `cargo clippy -p db -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [ ] FFI integration tests for mutation/create paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)