### PR TITLE
perf: skip CRDT storage reads for new documents

### DIFF
--- a/crates/crdt/src/composite.rs
+++ b/crates/crdt/src/composite.rs
@@ -207,6 +207,7 @@ impl CompositeDAG {
         rw: &mut dyn ReaderWriter,
         field_name: &str,
         field_delta: &FieldDelta,
+        is_create: bool,
     ) -> Result<MergeResult> {
         let crdt_type = self
             .field_managers
@@ -216,29 +217,32 @@ impl CompositeDAG {
         match (crdt_type, field_delta) {
             (FieldCrdtType::Lww, FieldDelta::Lww { priority, data }) => {
                 let value_key = self.build_value_key(field_name);
-                let current_priority = self.get_field_priority(rw, field_name).await?;
 
-                // LWW conflict resolution: higher priority wins
-                match priority.cmp(&current_priority) {
-                    std::cmp::Ordering::Less => {
-                        return Ok(MergeResult::RejectedLowerPriority {
-                            current: current_priority,
-                            incoming: *priority,
-                        });
-                    }
-                    std::cmp::Ordering::Equal => {
-                        // Same priority - use lexicographic tie-breaking
-                        let current_value = rw
-                            .get(&value_key)
-                            .await
-                            .map_err(|e| Error::Storage(e.to_string()))?
-                            .unwrap_or_default();
-                        if data.as_slice() <= current_value.as_slice() {
-                            return Ok(MergeResult::RejectedTieBreak);
+                if !is_create {
+                    let current_priority = self.get_field_priority(rw, field_name).await?;
+
+                    // LWW conflict resolution: higher priority wins
+                    match priority.cmp(&current_priority) {
+                        std::cmp::Ordering::Less => {
+                            return Ok(MergeResult::RejectedLowerPriority {
+                                current: current_priority,
+                                incoming: *priority,
+                            });
                         }
-                    }
-                    std::cmp::Ordering::Greater => {
-                        // Higher priority - proceed to update
+                        std::cmp::Ordering::Equal => {
+                            // Same priority - use lexicographic tie-breaking
+                            let current_value = rw
+                                .get(&value_key)
+                                .await
+                                .map_err(|e| Error::Storage(e.to_string()))?
+                                .unwrap_or_default();
+                            if data.as_slice() <= current_value.as_slice() {
+                                return Ok(MergeResult::RejectedTieBreak);
+                            }
+                        }
+                        std::cmp::Ordering::Greater => {
+                            // Higher priority - proceed to update
+                        }
                     }
                 }
 
@@ -271,30 +275,35 @@ impl CompositeDAG {
                 nonce_key.extend_from_slice(b"/nonces/");
                 nonce_key.extend_from_slice(&nonce.to_be_bytes());
 
-                if rw
-                    .has(&nonce_key)
-                    .await
-                    .map_err(|e| Error::Storage(e.to_string()))?
+                if !is_create
+                    && rw
+                        .has(&nonce_key)
+                        .await
+                        .map_err(|e| Error::Storage(e.to_string()))?
                 {
                     return Ok(MergeResult::SkippedAlreadyApplied { nonce: *nonce });
                 }
 
                 // Apply increment
-                let current = match rw
-                    .get(&value_key)
-                    .await
-                    .map_err(|e| Error::Storage(e.to_string()))?
-                {
-                    Some(bytes) => {
-                        if bytes.len() != 8 {
-                            return Err(Error::MergeError(format!(
-                                "invalid counter data length for field '{}': expected 8 bytes, got {}",
-                                field_name, bytes.len()
-                            )));
+                let current = if is_create {
+                    0
+                } else {
+                    match rw
+                        .get(&value_key)
+                        .await
+                        .map_err(|e| Error::Storage(e.to_string()))?
+                    {
+                        Some(bytes) => {
+                            if bytes.len() != 8 {
+                                return Err(Error::MergeError(format!(
+                                    "invalid counter data length for field '{}': expected 8 bytes, got {}",
+                                    field_name, bytes.len()
+                                )));
+                            }
+                            i64::from_be_bytes(bytes[..8].try_into().unwrap())
                         }
-                        i64::from_be_bytes(bytes[..8].try_into().unwrap())
+                        None => 0,
                     }
-                    None => 0,
                 };
 
                 if data.len() != 8 {
@@ -318,29 +327,34 @@ impl CompositeDAG {
             }
             (_, FieldDelta::Delete { priority }) => {
                 let value_key = self.build_value_key(field_name);
-                let current_priority = self.get_field_priority(rw, field_name).await?;
 
-                // Delete conflict resolution: higher priority wins
-                // On tie, non-empty value wins over deletion (empty < any value lexicographically)
-                match priority.cmp(&current_priority) {
-                    std::cmp::Ordering::Less => {
-                        return Ok(MergeResult::RejectedLowerPriority {
-                            current: current_priority,
-                            incoming: *priority,
-                        });
-                    }
-                    std::cmp::Ordering::Equal => {
-                        // Same priority - deletion (empty) loses to any existing value
-                        let current_value = rw
-                            .get(&value_key)
-                            .await
-                            .map_err(|e| Error::Storage(e.to_string()))?;
-                        if current_value.is_some() && !current_value.as_ref().unwrap().is_empty() {
-                            return Ok(MergeResult::RejectedTieBreak);
+                if !is_create {
+                    let current_priority = self.get_field_priority(rw, field_name).await?;
+
+                    // Delete conflict resolution: higher priority wins
+                    // On tie, non-empty value wins over deletion (empty < any value lexicographically)
+                    match priority.cmp(&current_priority) {
+                        std::cmp::Ordering::Less => {
+                            return Ok(MergeResult::RejectedLowerPriority {
+                                current: current_priority,
+                                incoming: *priority,
+                            });
                         }
-                    }
-                    std::cmp::Ordering::Greater => {
-                        // Higher priority - proceed to delete
+                        std::cmp::Ordering::Equal => {
+                            // Same priority - deletion (empty) loses to any existing value
+                            let current_value = rw
+                                .get(&value_key)
+                                .await
+                                .map_err(|e| Error::Storage(e.to_string()))?;
+                            if current_value.is_some()
+                                && !current_value.as_ref().unwrap().is_empty()
+                            {
+                                return Ok(MergeResult::RejectedTieBreak);
+                            }
+                        }
+                        std::cmp::Ordering::Greater => {
+                            // Higher priority - proceed to delete
+                        }
                     }
                 }
 
@@ -366,7 +380,7 @@ impl ReplicatedData for CompositeDAG {
     async fn merge(
         &self,
         rw: &mut dyn ReaderWriter,
-        _ctx: &Context,
+        ctx: &Context,
         delta: &dyn Delta,
     ) -> Result<MergeResult> {
         // Downcast to CompositeDelta
@@ -428,7 +442,9 @@ impl ReplicatedData for CompositeDAG {
         // Apply each field delta (now that all fields are pre-validated)
         let mut any_applied = false;
         for (field_name, field_delta) in &composite_delta.field_deltas {
-            let result = self.apply_field_delta(rw, field_name, field_delta).await?;
+            let result = self
+                .apply_field_delta(rw, field_name, field_delta, ctx.is_create)
+                .await?;
             if result.was_applied() {
                 any_applied = true;
             }

--- a/crates/crdt/src/counter.rs
+++ b/crates/crdt/src/counter.rs
@@ -391,6 +391,7 @@ impl Counter {
         &self,
         rw: &mut dyn ReaderWriter,
         delta: &CounterDelta,
+        is_create: bool,
     ) -> Result<MergeResult> {
         // Validate numeric kind matches
         if delta.kind() != self.kind {
@@ -403,7 +404,7 @@ impl Counter {
         }
 
         // Check if nonce already applied (idempotency)
-        if self.has_nonce(rw, delta.nonce).await? {
+        if !is_create && self.has_nonce(rw, delta.nonce).await? {
             return Ok(MergeResult::SkippedAlreadyApplied { nonce: delta.nonce });
         }
 
@@ -414,7 +415,11 @@ impl Counter {
                 if !self.allow_decrement && increment < 0 {
                     return Err(Error::MergeError("decrement not allowed".into()));
                 }
-                let current = self.get_int64(rw).await?;
+                let current = if is_create {
+                    0
+                } else {
+                    self.get_int64(rw).await?
+                };
                 // Int64: Wrap on overflow to match Go DefraDB behavior
                 NewValue::Int64(current.wrapping_add(increment))
             }
@@ -433,7 +438,11 @@ impl Counter {
                     return Err(Error::MergeError("decrement not allowed".into()));
                 }
 
-                let current = self.get_float64(rw).await?;
+                let current = if is_create {
+                    0.0
+                } else {
+                    self.get_float64(rw).await?
+                };
 
                 // Validate current value
                 if !current.is_finite() {
@@ -536,7 +545,7 @@ impl ReplicatedData for Counter {
     async fn merge(
         &self,
         rw: &mut dyn ReaderWriter,
-        _ctx: &Context,
+        ctx: &Context,
         delta: &dyn Delta,
     ) -> Result<MergeResult> {
         // Downcast to CounterDelta
@@ -566,7 +575,7 @@ impl ReplicatedData for Counter {
         }
 
         // Apply delta
-        self.apply_delta(rw, counter_delta).await
+        self.apply_delta(rw, counter_delta, ctx.is_create).await
     }
 
     fn headstore_prefix(&self) -> Vec<u8> {

--- a/crates/crdt/src/lww.rs
+++ b/crates/crdt/src/lww.rs
@@ -190,36 +190,39 @@ impl Lww {
         rw: &mut dyn ReaderWriter,
         data: &[u8],
         incoming_priority: u64,
+        is_create: bool,
     ) -> Result<MergeResult> {
-        // Get current priority
-        let current_priority = self.get_priority_internal(rw).await?;
+        if !is_create {
+            // Get current priority
+            let current_priority = self.get_priority_internal(rw).await?;
 
-        // Compare priorities
-        match incoming_priority.cmp(&current_priority) {
-            std::cmp::Ordering::Less => {
-                // LWW semantics: Reject updates with lower priority
-                return Ok(MergeResult::RejectedLowerPriority {
-                    current: current_priority,
-                    incoming: incoming_priority,
-                });
-            }
-            std::cmp::Ordering::Equal => {
-                // Same priority - use lexicographic tie-breaking for deterministic convergence
-                // Current value wins if incoming data <= current (lexicographically)
-                // This means: incoming data must be strictly greater to win
-                // Note: Store errors propagate via ?, None (uninitialized) treated as empty
-                let current_value: Vec<u8> = rw
-                    .get(&self.value_key)
-                    .await
-                    .map_err(|e| Error::Storage(e.to_string()))?
-                    .unwrap_or_default();
-                if data <= &current_value[..] {
-                    return Ok(MergeResult::RejectedTieBreak);
+            // Compare priorities
+            match incoming_priority.cmp(&current_priority) {
+                std::cmp::Ordering::Less => {
+                    // LWW semantics: Reject updates with lower priority
+                    return Ok(MergeResult::RejectedLowerPriority {
+                        current: current_priority,
+                        incoming: incoming_priority,
+                    });
                 }
-                // Incoming data is lexicographically greater - fall through to update
-            }
-            std::cmp::Ordering::Greater => {
-                // Incoming priority is higher - fall through to update
+                std::cmp::Ordering::Equal => {
+                    // Same priority - use lexicographic tie-breaking for deterministic convergence
+                    // Current value wins if incoming data <= current (lexicographically)
+                    // This means: incoming data must be strictly greater to win
+                    // Note: Store errors propagate via ?, None (uninitialized) treated as empty
+                    let current_value: Vec<u8> = rw
+                        .get(&self.value_key)
+                        .await
+                        .map_err(|e| Error::Storage(e.to_string()))?
+                        .unwrap_or_default();
+                    if data <= &current_value[..] {
+                        return Ok(MergeResult::RejectedTieBreak);
+                    }
+                    // Incoming data is lexicographically greater - fall through to update
+                }
+                std::cmp::Ordering::Greater => {
+                    // Incoming priority is higher - fall through to update
+                }
             }
         }
 
@@ -281,7 +284,7 @@ impl ReplicatedData for Lww {
     async fn merge(
         &self,
         rw: &mut dyn ReaderWriter,
-        _ctx: &Context,
+        ctx: &Context,
         delta: &dyn Delta,
     ) -> Result<MergeResult> {
         // Downcast to LwwDelta
@@ -306,7 +309,7 @@ impl ReplicatedData for Lww {
         }
 
         // Apply merge logic
-        self.set_value(rw, &lww_delta.data, lww_delta.priority)
+        self.set_value(rw, &lww_delta.data, lww_delta.priority, ctx.is_create)
             .await
     }
 

--- a/crates/crdt/src/traits.rs
+++ b/crates/crdt/src/traits.rs
@@ -45,6 +45,8 @@ pub struct Context {
     pub doc_id: DocId,
     /// Schema version
     pub schema_version: String,
+    /// When true, skip storage reads (document doesn't exist yet)
+    pub is_create: bool,
 }
 
 /// Delta trait - represents an incremental change to a CRDT
@@ -141,6 +143,7 @@ mod tests {
         let ctx = Context {
             doc_id: DocId::new("bae-test"),
             schema_version: "v1".to_string(),
+            is_create: false,
         };
         assert_eq!(ctx.doc_id.as_str(), "bae-test");
         assert_eq!(ctx.schema_version, "v1");

--- a/crates/crdt/tests/composite_tests.rs
+++ b/crates/crdt/tests/composite_tests.rs
@@ -24,6 +24,7 @@ async fn test_composite_multiple_fields() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Create composite delta with multiple fields
@@ -77,6 +78,7 @@ async fn test_composite_field_type_mismatch_lww_to_counter() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Try to apply Counter delta to LWW field
@@ -112,6 +114,7 @@ async fn test_composite_field_type_mismatch_counter_to_lww() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Try to apply LWW delta to Counter field
@@ -145,6 +148,7 @@ async fn test_composite_unknown_field() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Try to apply delta to unknown field
@@ -176,6 +180,7 @@ async fn test_composite_schema_evolution_type_change() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Apply LWW delta successfully
@@ -227,6 +232,7 @@ async fn test_composite_doc_id_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Delta with wrong doc ID
@@ -260,6 +266,7 @@ async fn test_composite_schema_version_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Delta with wrong schema version

--- a/crates/crdt/tests/counter_tests.rs
+++ b/crates/crdt/tests/counter_tests.rs
@@ -27,6 +27,7 @@ async fn test_counter_increment() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -78,6 +79,7 @@ async fn test_counter_idempotency() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -119,6 +121,7 @@ async fn test_counter_decrement_not_allowed() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -153,6 +156,7 @@ async fn test_counter_overflow_wrapping() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -205,6 +209,7 @@ async fn test_counter_field_name_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -243,6 +248,7 @@ async fn test_counter_schema_version_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -326,6 +332,7 @@ async fn test_counter_float64_overflow() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -373,6 +380,7 @@ async fn test_counter_float64_basic() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -424,6 +432,7 @@ async fn test_counter_merge_result_applied() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -457,6 +466,7 @@ async fn test_counter_merge_result_skipped_already_applied() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -498,6 +508,7 @@ async fn test_counter_wrong_delta_type() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -535,6 +546,7 @@ async fn test_counter_numeric_kind_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();

--- a/crates/crdt/tests/lww_tests.rs
+++ b/crates/crdt/tests/lww_tests.rs
@@ -19,6 +19,7 @@ async fn test_lww_higher_priority_wins() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // First write with priority 10
@@ -58,6 +59,7 @@ async fn test_lww_lower_priority_ignored() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -96,6 +98,7 @@ async fn test_lww_same_priority_lexicographic() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -135,6 +138,7 @@ async fn test_lww_deletion() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -175,6 +179,7 @@ async fn test_lww_empty_data_tie_breaking() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -231,6 +236,7 @@ async fn test_lww_deletion_resurrection_with_priority() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -364,6 +370,7 @@ async fn test_lww_wrong_delta_type() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Try to merge a CounterDelta into an LWW register
@@ -394,6 +401,7 @@ async fn test_lww_merge_result_applied() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let delta = LwwDelta::new(
@@ -418,6 +426,7 @@ async fn test_lww_merge_result_rejected_lower_priority() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -461,6 +470,7 @@ async fn test_lww_merge_result_rejected_tie_break() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -499,6 +509,7 @@ async fn test_lww_priority_zero() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -539,6 +550,7 @@ async fn test_lww_priority_max() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -578,6 +590,7 @@ async fn test_lww_field_name_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Delta with wrong field name
@@ -607,6 +620,7 @@ async fn test_lww_schema_version_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     // Delta with wrong schema version
@@ -664,6 +678,7 @@ async fn test_lww_large_payload() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();
@@ -720,6 +735,7 @@ async fn test_lww_large_payload_priority_rejected() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let mut txn = store.new_txn(false).await.unwrap();

--- a/crates/crdt/tests/property_tests.rs
+++ b/crates/crdt/tests/property_tests.rs
@@ -45,6 +45,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta1 = LwwDelta::new(
@@ -95,6 +96,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta = LwwDelta::new(
@@ -135,6 +137,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta = LwwDelta::new(
@@ -189,6 +192,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta1 = CounterDelta::new_int64(
@@ -241,6 +245,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta = CounterDelta::new_int64(
@@ -281,6 +286,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta = LwwDelta::new(
@@ -310,6 +316,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta = LwwDelta::new(
@@ -346,6 +353,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let store = MemoryStore::new();
@@ -400,6 +408,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let store = MemoryStore::new();
@@ -444,6 +453,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let store = MemoryStore::new();
@@ -499,6 +509,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta1 = LwwDelta::new(
@@ -568,6 +579,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta1 = CounterDelta::new_int64(
@@ -642,6 +654,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta1 = CounterDelta::new_int64(
@@ -697,6 +710,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta1 = CounterDelta::new_int64(
@@ -772,6 +786,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta1 = CounterDelta::new_float64(
@@ -825,6 +840,7 @@ proptest! {
             let ctx = Context {
                 doc_id: DocId::new("doc1"),
                 schema_version: "v1".to_string(),
+                is_create: false,
             };
 
             let delta = CounterDelta::new_float64(
@@ -862,6 +878,7 @@ async fn test_lww_priority_ordering_exhaustive() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -904,6 +921,7 @@ async fn test_lww_tie_breaking_lexicographic() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -946,6 +964,7 @@ async fn test_counter_multiple_nonces() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -984,6 +1003,7 @@ async fn test_counter_nonce_replay_protection() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -1023,6 +1043,7 @@ async fn test_composite_multi_field_atomicity() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -1061,6 +1082,7 @@ async fn test_lww_empty_value_handling() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -1091,6 +1113,7 @@ async fn test_float64_counter_basic() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -1139,6 +1162,7 @@ async fn test_counter_decrement_not_allowed() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -1172,6 +1196,7 @@ async fn test_composite_doc_id_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -1195,6 +1220,7 @@ async fn test_composite_schema_version_mismatch() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();
@@ -1218,6 +1244,7 @@ async fn test_lww_large_payload() {
     let ctx = Context {
         doc_id: DocId::new("doc1"),
         schema_version: "v1".to_string(),
+        is_create: false,
     };
 
     let store = MemoryStore::new();

--- a/crates/db/src/merge_handler/counter.rs
+++ b/crates/db/src/merge_handler/counter.rs
@@ -71,6 +71,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let ctx = Context {
             doc_id: DocId::new(&doc_id_str),
             schema_version: payload.schema_version_id.clone(),
+            is_create: payload.priority == 1,
         };
 
         // Perform the merge in a scoped block
@@ -203,6 +204,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let ctx = Context {
             doc_id: DocId::new(&doc_id_str),
             schema_version: payload.schema_version_id.clone(),
+            is_create: payload.priority == 1,
         };
 
         // Perform the merge

--- a/crates/db/src/merge_handler/lww.rs
+++ b/crates/db/src/merge_handler/lww.rs
@@ -41,6 +41,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let ctx = Context {
             doc_id: DocId::new(&doc_id_str),
             schema_version: payload.schema_version_id.clone(),
+            is_create: payload.priority == 1,
         };
 
         // Perform the merge in a scoped block to ensure datastore reference is dropped
@@ -148,6 +149,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let ctx = Context {
             doc_id: DocId::new(&doc_id_str),
             schema_version: payload.schema_version_id.clone(),
+            is_create: payload.priority == 1,
         };
 
         // Perform the merge


### PR DESCRIPTION
## Summary
- Thread `is_create: bool` through the CRDT merge path (LWW, Counter, CompositeDAG)
- When `priority == 1` (document creation block), skip all storage reads and go straight to writes
- Eliminates ~8,000+ unnecessary storage reads per block for Shinzo workloads (~800 new docs/block, ~10 fields each)

## Changes
- `Context` struct gains `is_create: bool` field
- `Lww::set_value()` skips `get_priority_internal()` and tie-break value read when `is_create`
- `CompositeDAG::apply_field_delta()` skips field priority reads (LWW/Delete) and nonce+value reads (Counter) when `is_create`
- `Counter::apply_delta()` skips `has_nonce()` check and uses zero for current value when `is_create`
- Merge handlers set `is_create: payload.priority == 1` at both call sites (standalone + in-txn)

## Test plan
- [x] `cargo test -p crdt` — 86 tests pass (all use `is_create: false`, exercising existing paths)
- [x] `cargo test -p db` — 192 tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [ ] FFI integration tests for sync/create paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)