### PR TITLE
perf: eliminate redundant key clones in ConflictTracker

### DIFF
--- a/crates/storage/src/backends/fjall/transaction.rs
+++ b/crates/storage/src/backends/fjall/transaction.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
-use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -242,10 +241,9 @@ impl Txn for FjallTxn {
 
         if !pending.is_empty() {
             // Check conflicts
-            let write_set: HashSet<Vec<u8>> = pending.keys().cloned().collect();
             if let Err(e) = self
                 .conflict_tracker
-                .check_and_record(self.read_version, write_set)
+                .check_and_record(self.read_version, pending.keys())
             {
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;

--- a/crates/storage/src/backends/memory/transaction.rs
+++ b/crates/storage/src/backends/memory/transaction.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use parking_lot::Mutex;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -192,10 +192,9 @@ impl Txn for MemoryTxn {
 
         // Check for write-write conflicts before applying
         if !pending.is_empty() {
-            let write_set: HashSet<Vec<u8>> = pending.keys().cloned().collect();
             if let Err(e) = self
                 .conflict_tracker
-                .check_and_record(self.read_version, write_set)
+                .check_and_record(self.read_version, pending.keys())
             {
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;

--- a/crates/storage/src/backends/redb/group_commit.rs
+++ b/crates/storage/src/backends/redb/group_commit.rs
@@ -108,8 +108,7 @@ async fn flush_loop(
         let mut failed: Vec<(PendingCommit, Error)> = Vec::new();
 
         for commit in batch {
-            let write_set = commit.changes.keys().cloned().collect();
-            match conflict_tracker.check_and_record(commit.read_version, write_set) {
+            match conflict_tracker.check_and_record(commit.read_version, commit.changes.keys()) {
                 Ok(()) => passed.push(commit),
                 Err(e) => failed.push((commit, e)),
             }

--- a/crates/storage/src/backends/redb/transaction.rs
+++ b/crates/storage/src/backends/redb/transaction.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 use redb::{Database, ReadTransaction};
 use std::collections::BTreeMap;
-use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -320,10 +319,9 @@ impl Txn for RedbTxn {
             }
 
             // Direct commit path: check conflicts eagerly
-            let write_set: HashSet<Vec<u8>> = pending.keys().cloned().collect();
             if let Err(e) = self
                 .conflict_tracker
-                .check_and_record(self.read_version, write_set)
+                .check_and_record(self.read_version, pending.keys())
             {
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;

--- a/crates/storage/src/backends/rocksdb/transaction.rs
+++ b/crates/storage/src/backends/rocksdb/transaction.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
-use std::collections::HashSet;
 use std::ops::Bound;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -361,10 +360,9 @@ impl Txn for RocksDbTxn {
 
         if !pending.is_empty() {
             // Check conflicts
-            let write_set: HashSet<Vec<u8>> = pending.keys().cloned().collect();
             if let Err(e) = self
                 .conflict_tracker
-                .check_and_record(self.read_version, write_set)
+                .check_and_record(self.read_version, pending.keys())
             {
                 CallbackManager::execute_callbacks(self.callbacks.take_error());
                 CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -215,14 +215,15 @@ impl ConflictTracker {
     /// Check for conflicts and record the write set if no conflict.
     /// Returns Err(TxnConflict) if any key in `write_set` was written by a
     /// transaction that committed after `read_version`.
-    pub(crate) fn check_and_record(
+    pub(crate) fn check_and_record<'a>(
         &self,
         read_version: u64,
-        write_set: std::collections::HashSet<Vec<u8>>,
+        write_keys: impl Iterator<Item = &'a Vec<u8>>,
     ) -> std::result::Result<(), crate::corekv::Error> {
         use std::sync::atomic::Ordering;
 
-        if write_set.is_empty() {
+        let write_keys: Vec<&Vec<u8>> = write_keys.collect();
+        if write_keys.is_empty() {
             return Ok(());
         }
 
@@ -232,16 +233,17 @@ impl ConflictTracker {
         // transaction committed after our snapshot
         for (commit_ver, keys) in committed.iter() {
             if *commit_ver > read_version {
-                for key in &write_set {
-                    if keys.contains(key) {
+                for key in &write_keys {
+                    if keys.contains(*key) {
                         return Err(crate::corekv::Error::TxnConflict);
                     }
                 }
             }
         }
 
-        // No conflict - record our write set
+        // No conflict - clone keys into storage (single clone per key)
         let new_version = self.version.fetch_add(1, Ordering::SeqCst) + 1;
+        let write_set = write_keys.into_iter().cloned().collect();
         committed.push((new_version, write_set));
 
         // Prune old entries that can no longer conflict (optional GC).


### PR DESCRIPTION
## Summary

- Change `ConflictTracker::check_and_record` to accept `impl Iterator<Item = &Vec<u8>>` instead of an owned `HashSet<Vec<u8>>`
- Callers now pass `pending.keys()` directly instead of cloning all keys into a HashSet first
- Keys are cloned only once (into committed storage) on the success path, zero times on the conflict path

For write-heavy workloads (Shinzo: 4K-17K keys/block), this eliminates thousands of redundant allocations per commit.

## Test plan

- [x] `cargo test -p storage` — all 7 tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [ ] FFI integration tests exercising transaction commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)