### PR TITLE
feat: CAR file support for P2P DAG transmission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5486,6 +5486,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "unsigned-varint 0.8.0",
  "uuid",
 ]
 

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -49,6 +49,9 @@ tracing = { workspace = true }
 # Bytes
 bytes = { workspace = true }
 
+# Varint encoding for CARv1 format
+unsigned-varint = "0.8"
+
 # Synchronization (non-poisoning locks)
 parking_lot = { workspace = true }
 

--- a/crates/p2p/src/host/command.rs
+++ b/crates/p2p/src/host/command.rs
@@ -184,6 +184,20 @@ pub enum HostCommand {
         response: oneshot::Sender<Result<()>>,
     },
 
+    /// Send a CAR request to a peer (request DAG as CARv1).
+    SendCarRequest {
+        peer_id: PeerId,
+        root_cid: Cid,
+        response: oneshot::Sender<Result<()>>,
+    },
+
+    /// Send a CAR response to a peer (CARv1 bytes).
+    SendCarResponse {
+        peer_id: PeerId,
+        car_data: Vec<u8>,
+        response: oneshot::Sender<Result<()>>,
+    },
+
     /// Get connected peers with their full multiaddrs (Go-compatible ActivePeers).
     PeerAddresses {
         response: oneshot::Sender<Vec<String>>,

--- a/crates/p2p/src/host/command_handler/messaging.rs
+++ b/crates/p2p/src/host/command_handler/messaging.rs
@@ -1,5 +1,6 @@
 //! PushLog, TwoStream, DocSync, BranchableSync, and SE messaging commands.
 
+use cid::Cid;
 use iroh_bitswap::Store;
 use libp2p::PeerId;
 use tracing::debug;
@@ -188,6 +189,38 @@ impl<S: Store> P2PHost<S> {
             let result = h.send_se_artifacts_fire_and_forget(peer_id, request).await;
             if response.send(result).is_err() {
                 debug!(peer_id = %peer_id, "SendSEArtifacts command response dropped - caller cancelled");
+            }
+        });
+    }
+
+    pub(super) fn handle_send_car_request(
+        &mut self,
+        peer_id: PeerId,
+        root_cid: Cid,
+        response: tokio::sync::oneshot::Sender<Result<()>>,
+    ) {
+        let handler = self.two_stream_handler.clone();
+        self.spawned_tasks.spawn(async move {
+            let mut h = handler.lock().await;
+            let result = h.send_car_request(peer_id, root_cid).await;
+            if response.send(result).is_err() {
+                debug!(peer_id = %peer_id, "SendCarRequest command response dropped");
+            }
+        });
+    }
+
+    pub(super) fn handle_send_car_response(
+        &mut self,
+        peer_id: PeerId,
+        car_data: Vec<u8>,
+        response: tokio::sync::oneshot::Sender<Result<()>>,
+    ) {
+        let handler = self.two_stream_handler.clone();
+        self.spawned_tasks.spawn(async move {
+            let mut h = handler.lock().await;
+            let result = h.send_car_response(peer_id, car_data).await;
+            if response.send(result).is_err() {
+                debug!(peer_id = %peer_id, "SendCarResponse command response dropped");
             }
         });
     }

--- a/crates/p2p/src/host/command_handler/mod.rs
+++ b/crates/p2p/src/host/command_handler/mod.rs
@@ -158,6 +158,20 @@ impl<S: Store> P2PHost<S> {
                     debug!(peer_id = %peer_id, "GetReplicator command response dropped - caller cancelled");
                 }
             }
+            HostCommand::SendCarRequest {
+                peer_id,
+                root_cid,
+                response,
+            } => {
+                self.handle_send_car_request(peer_id, root_cid, response);
+            }
+            HostCommand::SendCarResponse {
+                peer_id,
+                car_data,
+                response,
+            } => {
+                self.handle_send_car_response(peer_id, car_data, response);
+            }
             HostCommand::BitswapSync {
                 cid,
                 providers,

--- a/crates/p2p/src/host/event.rs
+++ b/crates/p2p/src/host/event.rs
@@ -94,4 +94,14 @@ pub enum HostEvent {
         peer_id: PeerId,
         reply: crate::message::BranchableSyncReply,
     },
+
+    /// Received a CAR fetch request (peer wants a DAG packaged as CARv1).
+    CarFetchRequest { peer_id: PeerId, root_cid: Cid },
+
+    /// Received a CAR fetch response (CARv1 bytes containing a DAG).
+    CarFetchResponse {
+        peer_id: PeerId,
+        root_cid: Cid,
+        car_data: Vec<u8>,
+    },
 }

--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -503,6 +503,34 @@ impl P2PHostHandle {
         response_rx.await.map_err(|_| Error::ChannelReceive)?
     }
 
+    /// Send a CAR request to a peer (request DAG as CARv1).
+    pub async fn send_car_request(&self, peer_id: PeerId, root_cid: Cid) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(HostCommand::SendCarRequest {
+                peer_id,
+                root_cid,
+                response: response_tx,
+            })
+            .await
+            .map_err(|_| Error::ChannelSend)?;
+        response_rx.await.map_err(|_| Error::ChannelReceive)?
+    }
+
+    /// Send a CAR response to a peer (CARv1 bytes).
+    pub async fn send_car_response(&self, peer_id: PeerId, car_data: Vec<u8>) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(HostCommand::SendCarResponse {
+                peer_id,
+                car_data,
+                response: response_tx,
+            })
+            .await
+            .map_err(|_| Error::ChannelSend)?;
+        response_rx.await.map_err(|_| Error::ChannelReceive)?
+    }
+
     /// Poll until a peer is connected or timeout expires.
     ///
     /// Uses 50ms polling interval (matches Go behavior).

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -241,6 +241,12 @@ impl<S: Store> P2PHost<S> {
         let se_response_streams = control
             .accept(TwoStreamHandler::se_response_protocol())
             .map_err(|_| Error::Behaviour("Failed to register SE response protocol".into()))?;
+        let car_request_streams = control
+            .accept(TwoStreamHandler::car_request_protocol())
+            .map_err(|_| Error::Behaviour("Failed to register CAR request protocol".into()))?;
+        let car_response_streams = control
+            .accept(TwoStreamHandler::car_response_protocol())
+            .map_err(|_| Error::Behaviour("Failed to register CAR response protocol".into()))?;
 
         let handler = TwoStreamHandler::new(control);
         let pending = handler.pending_responses();
@@ -254,6 +260,8 @@ impl<S: Store> P2PHost<S> {
             response_streams,
             se_request_streams,
             se_response_streams,
+            car_request_streams,
+            car_response_streams,
             two_stream_event_tx,
         );
         tokio::spawn(runner.run());

--- a/crates/p2p/src/host/p2p_host/two_stream.rs
+++ b/crates/p2p/src/host/p2p_host/two_stream.rs
@@ -114,6 +114,45 @@ impl<S: Store> P2PHost<S> {
                     );
                 }
             }
+            TwoStreamEvent::CarFetchRequest { peer_id, root_cid } => {
+                debug!(
+                    peer_id = %peer_id,
+                    root_cid = %root_cid,
+                    "Host received CAR fetch request"
+                );
+                if self
+                    .event_tx
+                    .send(HostEvent::CarFetchRequest { peer_id, root_cid })
+                    .await
+                    .is_err()
+                {
+                    error!(peer_id = %peer_id, "Failed to send CarFetchRequest event");
+                }
+            }
+            TwoStreamEvent::CarFetchResponse {
+                peer_id,
+                root_cid,
+                car_data,
+            } => {
+                debug!(
+                    peer_id = %peer_id,
+                    root_cid = %root_cid,
+                    car_bytes = car_data.len(),
+                    "Host received CAR fetch response"
+                );
+                if self
+                    .event_tx
+                    .send(HostEvent::CarFetchResponse {
+                        peer_id,
+                        root_cid,
+                        car_data,
+                    })
+                    .await
+                    .is_err()
+                {
+                    error!(peer_id = %peer_id, "Failed to send CarFetchResponse event");
+                }
+            }
             TwoStreamEvent::DecodeError { peer_id, error } => {
                 warn!(
                     peer_id = %peer_id,

--- a/crates/p2p/src/protocol.rs
+++ b/crates/p2p/src/protocol.rs
@@ -49,6 +49,12 @@ pub const SE_REQUEST_PROTOCOL: &str = "/defradb/rep_se_req/0.0.1";
 /// Go uses "rep_se" as the channel name: `/defradb/rep_se_resp/0.0.1`
 pub const SE_RESPONSE_PROTOCOL: &str = "/defradb/rep_se_resp/0.0.1";
 
+/// CAR (Content ARchive) request protocol ID.
+pub const CAR_REQUEST_PROTOCOL: &str = "/defradb/car_req/0.0.1";
+
+/// CAR (Content ARchive) response protocol ID.
+pub const CAR_RESPONSE_PROTOCOL: &str = "/defradb/car_resp/0.0.1";
+
 /// StreamProtocol for the SE request protocol.
 pub fn se_request_protocol() -> StreamProtocol {
     StreamProtocol::new(SE_REQUEST_PROTOCOL)
@@ -57,6 +63,16 @@ pub fn se_request_protocol() -> StreamProtocol {
 /// StreamProtocol for the SE response protocol.
 pub fn se_response_protocol() -> StreamProtocol {
     StreamProtocol::new(SE_RESPONSE_PROTOCOL)
+}
+
+/// StreamProtocol for the CAR request protocol.
+pub fn car_request_protocol() -> StreamProtocol {
+    StreamProtocol::new(CAR_REQUEST_PROTOCOL)
+}
+
+/// StreamProtocol for the CAR response protocol.
+pub fn car_response_protocol() -> StreamProtocol {
+    StreamProtocol::new(CAR_RESPONSE_PROTOCOL)
 }
 
 // Legacy aliases for backwards compatibility with existing code

--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -1,0 +1,292 @@
+//! CARv1 encoding/decoding for DAG transfer.
+//!
+//! CARv1 (Content ARchive) packs a set of IPLD blocks with their CIDs into a
+//! single byte stream, enabling single-round-trip DAG transfer over P2P.
+
+use std::collections::HashSet;
+
+use blockstore::Blockstore;
+use cid::Cid;
+
+use crate::error::{Error, Result};
+
+/// Encode blocks as a CARv1 byte stream.
+///
+/// Format: varint-prefixed DAG-CBOR header, then varint-prefixed (CID + data) sections.
+pub fn encode_car(roots: &[Cid], blocks: &[(&Cid, &[u8])]) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+
+    // Header: DAG-CBOR map {version: 1, roots: [CID]}
+    let header = encode_car_header(roots)?;
+    write_varint_prefixed(&mut out, &header);
+
+    // Each block: varint(len(cid_bytes + data)) + cid_bytes + data
+    for (cid, data) in blocks {
+        let cid_bytes = cid.to_bytes();
+        let section_len = cid_bytes.len() + data.len();
+        write_varint(&mut out, section_len as u64);
+        out.extend_from_slice(&cid_bytes);
+        out.extend_from_slice(data);
+    }
+
+    Ok(out)
+}
+
+/// Decoded CAR contents: root CIDs and blocks (CID + data pairs).
+pub type CarContents = (Vec<Cid>, Vec<(Cid, Vec<u8>)>);
+
+/// Decode a CARv1 byte stream into roots + blocks.
+pub fn decode_car(data: &[u8]) -> Result<CarContents> {
+    let mut cursor = data;
+
+    // Read header
+    let header_len = read_varint(&mut cursor)?;
+    if header_len as usize > cursor.len() {
+        return Err(Error::Codec("CAR header length exceeds data".into()));
+    }
+    let header_bytes = &cursor[..header_len as usize];
+    cursor = &cursor[header_len as usize..];
+    let roots = decode_car_header(header_bytes)?;
+
+    // Read blocks
+    let mut blocks = Vec::new();
+    while !cursor.is_empty() {
+        let section_len = read_varint(&mut cursor)?;
+        if section_len as usize > cursor.len() {
+            return Err(Error::Codec("CAR block section length exceeds data".into()));
+        }
+        let section = &cursor[..section_len as usize];
+        cursor = &cursor[section_len as usize..];
+
+        let cid = Cid::read_bytes(section)
+            .map_err(|e| Error::InvalidCid(format!("failed to read CID from CAR block: {}", e)))?;
+        let cid_len = cid.to_bytes().len();
+        let block_data = section[cid_len..].to_vec();
+        blocks.push((cid, block_data));
+    }
+
+    Ok((roots, blocks))
+}
+
+/// Traverse DAG from root, collect all reachable blocks from blockstore.
+pub async fn collect_dag_blocks<B: Blockstore>(
+    blockstore: &B,
+    root_cid: &Cid,
+) -> Result<Vec<(Cid, Vec<u8>)>> {
+    let mut blocks = Vec::new();
+    let mut visited = HashSet::new();
+    collect_recursive(blockstore, root_cid, &mut blocks, &mut visited).await?;
+    Ok(blocks)
+}
+
+fn collect_recursive<'a, B: Blockstore + 'a>(
+    blockstore: &'a B,
+    cid: &'a Cid,
+    blocks: &'a mut Vec<(Cid, Vec<u8>)>,
+    visited: &'a mut HashSet<Cid>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
+    Box::pin(async move {
+        if !visited.insert(*cid) {
+            return Ok(());
+        }
+
+        let data = match blockstore.get(cid).await {
+            Ok(Some(d)) => d,
+            Ok(None) => return Ok(()),
+            Err(e) => {
+                return Err(Error::BlockstoreError(format!(
+                    "failed to get block {}: {}",
+                    cid, e
+                )));
+            }
+        };
+
+        // Extract child links
+        let refs = extract_links(&data);
+        blocks.push((*cid, data));
+
+        for child_cid in refs {
+            collect_recursive(blockstore, &child_cid, blocks, visited).await?;
+        }
+
+        Ok(())
+    })
+}
+
+/// Extract CID links from a DAG-CBOR block.
+fn extract_links(block_data: &[u8]) -> Vec<Cid> {
+    use libipld::multihash::{Code, MultihashDigest};
+    use libipld::{Block, DefaultParams};
+
+    let hash = Code::Sha2_256.digest(block_data);
+    let dummy_cid = Cid::new_v1(0x71, hash);
+
+    let mut refs = Vec::new();
+    let block = Block::<DefaultParams>::new_unchecked(dummy_cid, block_data.to_vec());
+    if block.references(&mut refs).is_err() {
+        return Vec::new();
+    }
+    refs
+}
+
+// --- CARv1 header encode/decode ---
+//
+// Uses CBOR map {"roots": [<cid bytes>, ...], "version": 1}.
+// CIDs are stored as plain CBOR byte strings (no tag 42) since this
+// is an internal Rust-to-Rust protocol.
+
+fn encode_car_header(roots: &[Cid]) -> Result<Vec<u8>> {
+    use serde_cbor::Value;
+    let roots_val: Vec<Value> = roots
+        .iter()
+        .map(|cid| Value::Bytes(cid.to_bytes()))
+        .collect();
+
+    let mut map = std::collections::BTreeMap::new();
+    map.insert(Value::Text("roots".into()), Value::Array(roots_val));
+    map.insert(Value::Text("version".into()), Value::Integer(1));
+
+    serde_cbor::to_vec(&Value::Map(map))
+        .map_err(|e| Error::Codec(format!("failed to encode CAR header: {}", e)))
+}
+
+fn decode_car_header(data: &[u8]) -> Result<Vec<Cid>> {
+    use serde_cbor::Value;
+
+    let value: Value = serde_cbor::from_slice(data)
+        .map_err(|e| Error::Codec(format!("invalid CAR header: {}", e)))?;
+
+    let map = match value {
+        Value::Map(m) => m,
+        _ => return Err(Error::Codec("CAR header is not a CBOR map".into())),
+    };
+
+    let version_key = Value::Text("version".into());
+    match map.get(&version_key) {
+        Some(Value::Integer(1)) => {}
+        _ => return Err(Error::Codec("CAR header version must be 1".into())),
+    }
+
+    let roots_key = Value::Text("roots".into());
+    let roots_array = match map.get(&roots_key) {
+        Some(Value::Array(a)) => a,
+        _ => return Err(Error::Codec("CAR header 'roots' must be an array".into())),
+    };
+
+    let mut roots = Vec::new();
+    for val in roots_array {
+        let bytes = match val {
+            Value::Bytes(b) => b,
+            Value::Tag(42, inner) => match inner.as_ref() {
+                Value::Bytes(b) => {
+                    // DAG-CBOR tag 42: strip 0x00 prefix if present
+                    if b.first() == Some(&0x00) {
+                        &b[1..]
+                    } else {
+                        b
+                    }
+                }
+                _ => return Err(Error::Codec("CAR root tag 42 does not wrap bytes".into())),
+            },
+            _ => return Err(Error::Codec("CAR root is not a byte string".into())),
+        };
+        let cid = Cid::read_bytes(std::io::Cursor::new(bytes))
+            .map_err(|e| Error::InvalidCid(format!("invalid CID in CAR roots: {}", e)))?;
+        roots.push(cid);
+    }
+
+    Ok(roots)
+}
+
+// --- Varint helpers ---
+
+fn write_varint(buf: &mut Vec<u8>, value: u64) {
+    let mut tmp = unsigned_varint::encode::u64_buffer();
+    let encoded = unsigned_varint::encode::u64(value, &mut tmp);
+    buf.extend_from_slice(encoded);
+}
+
+fn write_varint_prefixed(buf: &mut Vec<u8>, data: &[u8]) {
+    write_varint(buf, data.len() as u64);
+    buf.extend_from_slice(data);
+}
+
+fn read_varint(cursor: &mut &[u8]) -> Result<u64> {
+    let (value, rest) = unsigned_varint::decode::u64(cursor)
+        .map_err(|e| Error::Codec(format!("failed to read varint: {}", e)))?;
+    *cursor = rest;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libipld::multihash::{Code, MultihashDigest};
+
+    fn make_cid(data: &[u8]) -> Cid {
+        let hash = Code::Sha2_256.digest(data);
+        Cid::new_v1(0x71, hash)
+    }
+
+    #[test]
+    fn round_trip_single_block() {
+        let data = b"hello world";
+        let cid = make_cid(data);
+        let encoded = encode_car(&[cid], &[(&cid, data.as_slice())]).unwrap();
+        let (roots, blocks) = decode_car(&encoded).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0], cid);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].0, cid);
+        assert_eq!(blocks[0].1, data);
+    }
+
+    #[test]
+    fn round_trip_multi_block() {
+        let data1 = b"block one";
+        let data2 = b"block two";
+        let data3 = b"block three";
+        let cid1 = make_cid(data1);
+        let cid2 = make_cid(data2);
+        let cid3 = make_cid(data3);
+
+        let blocks_in = vec![
+            (&cid1, data1.as_slice()),
+            (&cid2, data2.as_slice()),
+            (&cid3, data3.as_slice()),
+        ];
+        let encoded = encode_car(&[cid1], &blocks_in).unwrap();
+        let (roots, blocks) = decode_car(&encoded).unwrap();
+
+        assert_eq!(roots, vec![cid1]);
+        assert_eq!(blocks.len(), 3);
+        assert_eq!(blocks[0].1, data1);
+        assert_eq!(blocks[1].1, data2);
+        assert_eq!(blocks[2].1, data3);
+    }
+
+    #[test]
+    fn round_trip_empty_blocks() {
+        let cid = make_cid(b"root");
+        let encoded = encode_car(&[cid], &[]).unwrap();
+        let (roots, blocks) = decode_car(&encoded).unwrap();
+        assert_eq!(roots, vec![cid]);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn round_trip_multiple_roots() {
+        let data1 = b"root1";
+        let data2 = b"root2";
+        let cid1 = make_cid(data1);
+        let cid2 = make_cid(data2);
+        let encoded = encode_car(
+            &[cid1, cid2],
+            &[(&cid1, data1.as_slice()), (&cid2, data2.as_slice())],
+        )
+        .unwrap();
+        let (roots, blocks) = decode_car(&encoded).unwrap();
+        assert_eq!(roots, vec![cid1, cid2]);
+        assert_eq!(blocks.len(), 2);
+    }
+}

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -1,8 +1,7 @@
 //! Poll-based DAG fetcher for DocSync and BranchableSync.
 //!
-//! Uses bitswap_sync + blockstore polling instead of the event-driven
-//! pending DAG + BitswapComplete + retry mechanism. The poll-based approach
-//! is more reliable for multi-level DAG fetching.
+//! Tries CAR fetch first (single round-trip for entire DAG), then falls back
+//! to bitswap_sync + blockstore polling for any remaining blocks.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,10 +16,9 @@ use crate::host::P2PHostHandle;
 use crate::sync::manager::links::find_all_missing_links;
 use crate::sync::manager::SyncEvent;
 
-/// Fetch an entire DAG rooted at `root_cid` using poll-based Bitswap.
+/// Fetch an entire DAG rooted at `root_cid`.
 ///
-/// Walks the DAG level by level, fetching missing blocks via Bitswap
-/// and polling the blockstore until they appear. Emits DagReady when complete.
+/// Strategy: try CAR fetch first (one round-trip), then Bitswap for any missing blocks.
 #[allow(clippy::too_many_arguments)]
 pub async fn poll_fetch_dag<B: Blockstore + 'static>(
     host: P2PHostHandle,
@@ -36,10 +34,37 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static>(
         root_cid = %root_cid,
         doc_id = %doc_id,
         source_peer = %source_peer,
-        "Starting poll-based DAG fetch"
+        "Starting DAG fetch (CAR-first, Bitswap fallback)"
     );
 
-    // Fetch root block
+    // Try CAR fetch first — single round-trip for the entire DAG
+    if try_car_fetch(&host, &blockstore, &root_cid, source_peer).await {
+        // Verify completeness
+        if let Ok(Some(root_data)) = blockstore.get(&root_cid).await {
+            let missing = find_all_missing_links(blockstore.as_ref(), &root_data)
+                .await
+                .unwrap_or_default();
+            if missing.is_empty() {
+                info!(root_cid = %root_cid, doc_id = %doc_id, "DAG fetch complete via CAR");
+                let _ = event_tx
+                    .send(SyncEvent::DagReady {
+                        root_cid,
+                        doc_id,
+                        collection_id,
+                        schema_version_id,
+                    })
+                    .await;
+                return;
+            }
+            debug!(
+                root_cid = %root_cid,
+                missing_count = missing.len(),
+                "CAR fetch was partial, falling through to Bitswap"
+            );
+        }
+    }
+
+    // Bitswap fallback: fetch root block
     if !poll_fetch_block(&root_cid, &host, &blockstore, source_peer).await {
         warn!(root_cid = %root_cid, "Failed to fetch root block");
         return;
@@ -71,7 +96,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static>(
             root_cid = %root_cid,
             iteration = iteration,
             missing_count = missing.len(),
-            "Fetching missing DAG blocks"
+            "Fetching missing DAG blocks via Bitswap"
         );
 
         for cid in &missing {
@@ -112,6 +137,36 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static>(
             "DAG fetch incomplete"
         );
     }
+}
+
+/// Try to fetch an entire DAG via a single CAR request.
+///
+/// Sends a CAR request to the source peer, waits for the response
+/// (which arrives via the event pipeline and is stored by the coordinator),
+/// then checks if the root block appeared in the blockstore.
+async fn try_car_fetch<B: Blockstore>(
+    host: &P2PHostHandle,
+    blockstore: &Arc<B>,
+    root_cid: &Cid,
+    source_peer: PeerId,
+) -> bool {
+    if let Err(e) = host.send_car_request(source_peer, *root_cid).await {
+        debug!(root_cid = %root_cid, error = %e, "CAR request failed, will use Bitswap");
+        return false;
+    }
+
+    // Poll blockstore for the root block (CAR response is stored by coordinator)
+    let timeout = Duration::from_secs(10);
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(true) = blockstore.has(root_cid).await {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    debug!(root_cid = %root_cid, "CAR fetch timed out (10s), falling back to Bitswap");
+    false
 }
 
 /// Fetch a single block via Bitswap + blockstore polling.

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -1,0 +1,81 @@
+//! CAR fetch event handling for the sync coordinator.
+
+use blockstore::Blockstore;
+use cid::Cid;
+use libp2p::PeerId;
+
+use crate::error::Result;
+use crate::sync::car::{collect_dag_blocks, decode_car, encode_car};
+use crate::sync::coordinator::SyncCoordinator;
+
+impl<B: Blockstore + 'static> SyncCoordinator<B> {
+    /// Handle an inbound CAR fetch request: collect the DAG and send CARv1 response.
+    pub(crate) async fn handle_car_fetch_request(
+        &self,
+        peer_id: PeerId,
+        root_cid: Cid,
+    ) -> Result<()> {
+        let blocks = collect_dag_blocks(self.manager.blockstore().as_ref(), &root_cid).await?;
+
+        if blocks.is_empty() {
+            tracing::debug!(
+                root_cid = %root_cid,
+                peer_id = %peer_id,
+                "CAR request for unknown DAG, ignoring"
+            );
+            return Ok(());
+        }
+
+        let block_refs: Vec<(&Cid, &[u8])> =
+            blocks.iter().map(|(c, d)| (c, d.as_slice())).collect();
+        let car_data = encode_car(&[root_cid], &block_refs)?;
+
+        tracing::debug!(
+            root_cid = %root_cid,
+            peer_id = %peer_id,
+            blocks = blocks.len(),
+            car_bytes = car_data.len(),
+            "Sending CAR response"
+        );
+
+        self.host.send_car_response(peer_id, car_data).await?;
+        Ok(())
+    }
+
+    /// Handle an inbound CAR fetch response: decode and store blocks.
+    pub(crate) async fn handle_car_fetch_response(
+        &self,
+        peer_id: PeerId,
+        root_cid: Cid,
+        car_data: Vec<u8>,
+    ) -> Result<()> {
+        let (_roots, blocks) = decode_car(&car_data)?;
+
+        if blocks.is_empty() {
+            tracing::warn!(
+                root_cid = %root_cid,
+                peer_id = %peer_id,
+                "Received empty CAR response"
+            );
+            return Ok(());
+        }
+
+        let block_refs: Vec<(&Cid, &[u8])> =
+            blocks.iter().map(|(c, d)| (c, d.as_slice())).collect();
+        self.manager
+            .blockstore()
+            .as_ref()
+            .put_many(&block_refs)
+            .await
+            .map_err(|e| crate::error::Error::BlockstoreError(e.to_string()))?;
+
+        tracing::debug!(
+            root_cid = %root_cid,
+            peer_id = %peer_id,
+            blocks_stored = blocks.len(),
+            "Stored blocks from CAR response"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -2,6 +2,7 @@
 
 mod bitswap;
 mod branchable_sync;
+pub(crate) mod car;
 mod doc_sync;
 mod gossip;
 mod pushlog;
@@ -82,6 +83,17 @@ impl<B: Blockstore + 'static> SyncCoordinator<B> {
             }
             HostEvent::BranchableSyncReply { peer_id, reply } => {
                 self.handle_branchable_sync_reply(peer_id, reply).await?;
+            }
+            HostEvent::CarFetchRequest { peer_id, root_cid } => {
+                self.handle_car_fetch_request(peer_id, root_cid).await?;
+            }
+            HostEvent::CarFetchResponse {
+                peer_id,
+                root_cid,
+                car_data,
+            } => {
+                self.handle_car_fetch_response(peer_id, root_cid, car_data)
+                    .await?;
             }
             other => {
                 // Other events (peer discovery, listening, etc.) don't need sync handling

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -34,6 +34,7 @@
 //! ```
 
 mod broadcaster;
+pub(crate) mod car;
 mod collection_store;
 mod coordinator;
 mod dag_sync;

--- a/crates/p2p/src/two_stream/event.rs
+++ b/crates/p2p/src/two_stream/event.rs
@@ -1,5 +1,6 @@
 //! Two-stream protocol events.
 
+use cid::Cid;
 use libp2p::PeerId;
 
 use crate::message::{
@@ -33,6 +34,14 @@ pub enum TwoStreamEvent {
     BranchableSyncReply {
         peer_id: PeerId,
         reply: BranchableSyncReply,
+    },
+    /// Received a CAR fetch request (peer wants a DAG packaged as CARv1).
+    CarFetchRequest { peer_id: PeerId, root_cid: Cid },
+    /// Received a CAR fetch response (CARv1 bytes containing a DAG).
+    CarFetchResponse {
+        peer_id: PeerId,
+        root_cid: Cid,
+        car_data: Vec<u8>,
     },
     /// Failed to decode an incoming message.
     DecodeError { peer_id: PeerId, error: String },

--- a/crates/p2p/src/two_stream/handler/car.rs
+++ b/crates/p2p/src/two_stream/handler/car.rs
@@ -1,0 +1,119 @@
+//! CAR stream protocol handler methods.
+
+use cid::Cid;
+use libp2p::PeerId;
+use libp2p::Stream;
+
+use crate::error::{Error, Result};
+use crate::two_stream::event::TwoStreamEvent;
+
+use super::TwoStreamHandler;
+
+async fn read_stream(stream: &mut Stream) -> std::io::Result<Vec<u8>> {
+    use futures::AsyncReadExt;
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await?;
+    Ok(buf)
+}
+
+impl TwoStreamHandler {
+    /// Handle an incoming CAR request stream.
+    ///
+    /// The request is raw CID bytes (self-describing, no CBOR wrapper).
+    pub async fn handle_car_request_stream(
+        peer_id: PeerId,
+        mut stream: Stream,
+    ) -> Result<TwoStreamEvent> {
+        let buf = read_stream(&mut stream)
+            .await
+            .map_err(|e| Error::Transport(format!("failed to read CAR request: {}", e)))?;
+
+        let root_cid = Cid::read_bytes(std::io::Cursor::new(&buf))
+            .map_err(|e| Error::InvalidCid(format!("invalid CID in CAR request: {}", e)))?;
+
+        Ok(TwoStreamEvent::CarFetchRequest { peer_id, root_cid })
+    }
+
+    /// Handle an incoming CAR response stream.
+    ///
+    /// The response is raw CARv1 bytes. The first root CID from the header
+    /// is extracted to identify which request this responds to.
+    pub async fn handle_car_response_stream(
+        peer_id: PeerId,
+        mut stream: Stream,
+    ) -> Result<TwoStreamEvent> {
+        let car_data = read_stream(&mut stream)
+            .await
+            .map_err(|e| Error::Transport(format!("failed to read CAR response: {}", e)))?;
+
+        // Extract the root CID from the CAR header for event routing
+        let (roots, _) = crate::sync::car::decode_car(&car_data)?;
+        let root_cid = roots
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::Codec("CAR response has no roots".into()))?;
+
+        Ok(TwoStreamEvent::CarFetchResponse {
+            peer_id,
+            root_cid,
+            car_data,
+        })
+    }
+
+    /// Send a CAR request to a peer (raw CID bytes on the CAR request protocol).
+    pub async fn send_car_request(&mut self, peer_id: PeerId, root_cid: Cid) -> Result<()> {
+        use futures::AsyncWriteExt;
+
+        let mut stream = self
+            .control
+            .open_stream(peer_id, Self::car_request_protocol())
+            .await
+            .map_err(|e| Error::Transport(format!("failed to open CAR request stream: {}", e)))?;
+
+        let cid_bytes = root_cid.to_bytes();
+        stream
+            .write_all(&cid_bytes)
+            .await
+            .map_err(|e| Error::Transport(format!("failed to write CAR request: {}", e)))?;
+        stream
+            .close()
+            .await
+            .map_err(|e| Error::Transport(format!("failed to close CAR request stream: {}", e)))?;
+
+        tracing::debug!(
+            peer_id = %peer_id,
+            root_cid = %root_cid,
+            "Sent CAR request"
+        );
+
+        Ok(())
+    }
+
+    /// Send a CAR response to a peer (raw CARv1 bytes on the CAR response protocol).
+    pub async fn send_car_response(&mut self, peer_id: PeerId, car_data: Vec<u8>) -> Result<()> {
+        use futures::AsyncWriteExt;
+
+        let mut stream = self
+            .control
+            .open_stream(peer_id, Self::car_response_protocol())
+            .await
+            .map_err(|e| Error::Transport(format!("failed to open CAR response stream: {}", e)))?;
+
+        stream
+            .write_all(&car_data)
+            .await
+            .map_err(|e| Error::Transport(format!("failed to write CAR response: {}", e)))?;
+        stream
+            .close()
+            .await
+            .map_err(|e| Error::Transport(format!("failed to close CAR response stream: {}", e)))?;
+
+        tracing::debug!(
+            peer_id = %peer_id,
+            car_bytes = car_data.len(),
+            "Sent CAR response"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/p2p/src/two_stream/handler/mod.rs
+++ b/crates/p2p/src/two_stream/handler/mod.rs
@@ -8,6 +8,7 @@
 //! This module implements Go's pattern for interoperability using libp2p-stream.
 
 mod branchable_se;
+mod car;
 mod doc_sync;
 mod inbound;
 mod pushlog;
@@ -23,7 +24,8 @@ use tokio::sync::oneshot;
 
 use crate::message::{PushLogReply, PushLogRequest};
 use crate::protocol::{
-    REP_REQUEST_PROTOCOL, REP_RESPONSE_PROTOCOL, SE_REQUEST_PROTOCOL, SE_RESPONSE_PROTOCOL,
+    CAR_REQUEST_PROTOCOL, CAR_RESPONSE_PROTOCOL, REP_REQUEST_PROTOCOL, REP_RESPONSE_PROTOCOL,
+    SE_REQUEST_PROTOCOL, SE_RESPONSE_PROTOCOL,
 };
 
 /// Timeout for waiting for a response.
@@ -81,6 +83,16 @@ impl TwoStreamHandler {
     /// Get the SE response protocol.
     pub fn se_response_protocol() -> StreamProtocol {
         StreamProtocol::new(SE_RESPONSE_PROTOCOL)
+    }
+
+    /// Get the CAR request protocol.
+    pub fn car_request_protocol() -> StreamProtocol {
+        StreamProtocol::new(CAR_REQUEST_PROTOCOL)
+    }
+
+    /// Get the CAR response protocol.
+    pub fn car_response_protocol() -> StreamProtocol {
+        StreamProtocol::new(CAR_RESPONSE_PROTOCOL)
     }
 
     /// Clean up a pending response channel (used on timeout or cancellation).

--- a/crates/p2p/src/two_stream/runner.rs
+++ b/crates/p2p/src/two_stream/runner.rs
@@ -29,18 +29,25 @@ pub struct TwoStreamRunner {
     se_request_streams: stream::IncomingStreams,
     /// Incoming SE response streams.
     se_response_streams: stream::IncomingStreams,
+    /// Incoming CAR request streams.
+    car_request_streams: stream::IncomingStreams,
+    /// Incoming CAR response streams.
+    car_response_streams: stream::IncomingStreams,
     /// Channel to send events.
     event_tx: mpsc::Sender<TwoStreamEvent>,
 }
 
 impl TwoStreamRunner {
     /// Create a new runner.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         pending: Arc<Mutex<PendingResponses>>,
         request_streams: stream::IncomingStreams,
         response_streams: stream::IncomingStreams,
         se_request_streams: stream::IncomingStreams,
         se_response_streams: stream::IncomingStreams,
+        car_request_streams: stream::IncomingStreams,
+        car_response_streams: stream::IncomingStreams,
         event_tx: mpsc::Sender<TwoStreamEvent>,
     ) -> Self {
         Self {
@@ -49,6 +56,8 @@ impl TwoStreamRunner {
             response_streams,
             se_request_streams,
             se_response_streams,
+            car_request_streams,
+            car_response_streams,
             event_tx,
         }
     }
@@ -162,6 +171,38 @@ impl TwoStreamRunner {
                             buf_len = buf.len(),
                             "Received SE response (acknowledgement)"
                         );
+                    });
+                }
+                // Handle incoming CAR request streams
+                Some((peer_id, stream)) = self.car_request_streams.next() => {
+                    let event_tx = self.event_tx.clone();
+                    tokio::spawn(async move {
+                        match TwoStreamHandler::handle_car_request_stream(peer_id, stream).await {
+                            Ok(event) => {
+                                if event_tx.send(event).await.is_err() {
+                                    tracing::warn!(peer_id = %peer_id, "Failed to send CAR request event");
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(peer_id = %peer_id, error = %e, "Failed to handle CAR request stream");
+                            }
+                        }
+                    });
+                }
+                // Handle incoming CAR response streams
+                Some((peer_id, stream)) = self.car_response_streams.next() => {
+                    let event_tx = self.event_tx.clone();
+                    tokio::spawn(async move {
+                        match TwoStreamHandler::handle_car_response_stream(peer_id, stream).await {
+                            Ok(event) => {
+                                if event_tx.send(event).await.is_err() {
+                                    tracing::warn!(peer_id = %peer_id, "Failed to send CAR response event");
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(peer_id = %peer_id, error = %e, "Failed to handle CAR response stream");
+                            }
+                        }
                     });
                 }
                 else => {


### PR DESCRIPTION
## Summary

- Add CARv1 (Content ARchive) encoding/decoding to package entire DAGs into single transfers, replacing per-block Bitswap round-trips
- Implement CAR two-stream protocol (`/defradb/car_req/0.0.1`, `/defradb/car_resp/0.0.1`) with full event pipeline integration
- DAG fetcher now tries CAR fetch first (10s timeout), falls back to Bitswap for any remaining blocks

## Test plan

- [x] 4 unit tests for CARv1 round-trip encode/decode (single block, multi-block, empty, multiple roots)
- [x] `cargo test -p p2p` — all 76 tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [ ] FFI integration tests for P2P sync scenarios
- [ ] Manual two-node test verifying CAR transfer completes in single round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)