### PR TITLE
feat: add 12 NAC permission variants, fix 14 handler gates

### DIFF
--- a/crates/acp/src/nac/permission.rs
+++ b/crates/acp/src/nac/permission.rs
@@ -1,35 +1,14 @@
 //! Node-level permission types for NAC.
 //!
-//! Defines the 36 node-level permissions that control access to
+//! Defines the 48 node-level permissions that control access to
 //! database operations when Node Access Control is enabled.
 
 use serde::{Deserialize, Serialize};
 
-/// Node-level permissions (matches Go DefraDB's 36 node permissions).
+/// Node-level permissions (matches Go DefraDB's 48 node permissions).
 ///
 /// These permissions control access to node-level operations when NAC is enabled.
 /// By default (NAC disabled), all operations are allowed without authentication.
-///
-/// # Implementation Status
-///
-/// **Currently implemented (20 permissions):**
-/// - Collection: `CollectionGet`, `CollectionPatch`
-/// - Document: `DocumentRead`, `DocumentUpdate`, `DocumentDelete`
-/// - Index: `IndexList`, `IndexCreate`, `IndexDrop`
-/// - P2P: `P2pPeerConnect`, `P2pReplicatorCreate`, `P2pReplicatorDelete`, `P2pReplicatorList`,
-///   `P2pCollectionCreate`, `P2pCollectionDelete`, `P2pCollectionList`
-/// - ACP: `DacPolicyAdd`, `DacStatus`
-/// - NAC: `NacStatus`, `NacRelationAdd`, `NacRelationDelete`
-///
-/// **Not yet implemented (13 permissions):**
-/// - DAC management: `DacBypass`, `DacEnable`, `DacDisable`, `DacPurge`,
-///   `DacRelationAdd`, `DacRelationDelete`
-/// - NAC management: `NacReEnable`, `NacDisable`, `NacPurge`
-/// - P2P document replication: `P2pDocumentCreate`, `P2pDocumentDelete`, `P2pDocumentList`
-/// - Other: `SignatureVerify`, `LensList`
-///
-/// These permissions are defined for Go DefraDB compatibility but do not yet have
-/// corresponding HTTP endpoints in the Rust implementation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum NodePermission {
@@ -37,30 +16,24 @@ pub enum NodePermission {
     // DAC (Document Access Control) Operations
     // =========================================================================
     /// Bypass DAC checks entirely (super-admin only)
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     DacBypass,
 
     /// Enable DAC on the node
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     DacEnable,
 
     /// Disable DAC on the node
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     DacDisable,
 
     /// Purge all DAC data (dev mode only)
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     DacPurge,
 
     /// View DAC status (used by GET /api/v0/acp/policy and GET /api/v0/acp/policy/:id)
     DacStatus,
 
     /// Add DAC relation on a document
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     DacRelationAdd,
 
     /// Delete DAC relation on a document
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     DacRelationDelete,
 
     /// Add a new DAC policy (used by POST /api/v0/acp/policy)
@@ -70,15 +43,12 @@ pub enum NodePermission {
     // NAC (Node Access Control) Operations
     // =========================================================================
     /// Re-enable NAC after temporary disable
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     NacReEnable,
 
     /// Temporarily disable NAC
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     NacDisable,
 
     /// Purge all NAC data (dev mode only)
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     NacPurge,
 
     /// View NAC status (used by GET /api/v0/nac/status)
@@ -109,7 +79,6 @@ pub enum NodePermission {
     DocumentRead,
 
     /// Update documents (used by POST/PATCH document endpoints, POST /api/v0/graphql, transaction endpoints)
-    /// Note: This permission covers both create and update operations.
     DocumentUpdate,
 
     /// Delete documents (used by DELETE /api/v0/collections/:name/:doc_id)
@@ -127,11 +96,29 @@ pub enum NodePermission {
     /// Drop an index (used by DELETE /api/v0/collections/:name/indexes/:index)
     IndexDrop,
 
+    /// Create an encrypted index (used by POST /api/v0/collections/:name/encrypted-indexes)
+    EncryptedIndexCreate,
+
+    /// List encrypted indexes for a collection (used by GET /api/v0/collections/:name/encrypted-indexes)
+    EncryptedIndexList,
+
+    /// List all encrypted indexes across collections (used by GET /api/v0/encrypted-indexes)
+    EncryptedIndexListAll,
+
+    /// Delete an encrypted index (used by DELETE /api/v0/collections/:name/encrypted-indexes/:field)
+    EncryptedIndexDelete,
+
     // =========================================================================
     // P2P Operations
     // =========================================================================
-    /// Connect to a peer (used by P2P info, list, and connect endpoints)
+    /// Get P2P peer info (used by GET /api/v0/p2p/info)
+    P2pPeerInfo,
+
+    /// Connect to a peer (used by P2P connect and list endpoints)
     P2pPeerConnect,
+
+    /// List active peers (used by GET /api/v0/p2p/active-peers)
+    P2pPeerActive,
 
     /// Create a replicator (used by POST /api/v0/p2p/replicators)
     P2pReplicatorCreate,
@@ -151,33 +138,53 @@ pub enum NodePermission {
     /// List P2P collections (used by GET /api/v0/p2p/collections)
     P2pCollectionList,
 
-    /// Get P2P peer info (used by GET /api/v0/p2p/info)
-    P2pPeerInfo,
-
-    /// Add document to P2P replication
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
+    /// Add document to P2P replication (used by POST /api/v0/p2p/documents)
     P2pDocumentCreate,
 
-    /// Remove document from P2P replication
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
+    /// Remove document from P2P replication (used by DELETE /api/v0/p2p/documents)
     P2pDocumentDelete,
 
-    /// List P2P replicated documents
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
+    /// List P2P replicated documents (used by GET /api/v0/p2p/documents)
     P2pDocumentList,
+
+    /// Sync specific documents from peers (used by POST /api/v0/p2p/documents/sync)
+    P2pSyncDocuments,
+
+    /// Sync collection versions from peers (used by POST /api/v0/p2p/collections/sync-versions)
+    P2pSyncCollectionVersions,
+
+    /// Sync branchable collection from peers (used by POST /api/v0/p2p/collections/sync-branchable)
+    P2pSyncBranchableCollection,
 
     // =========================================================================
     // Other Operations
     // =========================================================================
     /// Verify signatures
-    /// **NOT YET IMPLEMENTED** - No HTTP endpoint exists
     SignatureVerify,
 
     // =========================================================================
     // Lens Operations
     // =========================================================================
+    /// Create a lens migration (used by POST /api/v0/lens)
+    LensCreate,
+
     /// List lens transforms (used by GET /api/v0/lens)
     LensList,
+
+    // =========================================================================
+    // View Operations
+    // =========================================================================
+    /// Refresh materialized views (used by POST /api/v0/views/refresh)
+    ViewRefresh,
+
+    /// Add a view (used by POST /api/v0/views)
+    ViewAdd,
+
+    // =========================================================================
+    // Migration Operations
+    // =========================================================================
+    /// Set a lens migration between schema versions (used by POST /api/v0/lens/set)
+    MigrationSet,
 }
 
 impl NodePermission {
@@ -216,29 +223,45 @@ impl NodePermission {
             Self::IndexList => "index-list",
             Self::IndexCreate => "index-create",
             Self::IndexDrop => "index-drop",
+            Self::EncryptedIndexCreate => "encrypted-index-create",
+            Self::EncryptedIndexList => "encrypted-index-list",
+            Self::EncryptedIndexListAll => "encrypted-index-list-all",
+            Self::EncryptedIndexDelete => "encrypted-index-delete",
 
             // P2P operations
+            Self::P2pPeerInfo => "p2p-peer-info",
             Self::P2pPeerConnect => "p2p-peer-connect",
+            Self::P2pPeerActive => "p2p-peer-active",
             Self::P2pReplicatorCreate => "p2p-replicator-create",
             Self::P2pReplicatorDelete => "p2p-replicator-delete",
             Self::P2pReplicatorList => "p2p-replicator-list",
             Self::P2pCollectionCreate => "p2p-collection-create",
             Self::P2pCollectionDelete => "p2p-collection-delete",
             Self::P2pCollectionList => "p2p-collection-list",
-            Self::P2pPeerInfo => "p2p-peer-info",
             Self::P2pDocumentCreate => "p2p-document-create",
             Self::P2pDocumentDelete => "p2p-document-delete",
             Self::P2pDocumentList => "p2p-document-list",
+            Self::P2pSyncDocuments => "p2p-sync-documents",
+            Self::P2pSyncCollectionVersions => "p2p-sync-collection-versions",
+            Self::P2pSyncBranchableCollection => "p2p-sync-branchable-collection",
 
             // Other
             Self::SignatureVerify => "signature-verify",
 
             // Lens
+            Self::LensCreate => "lens-create",
             Self::LensList => "lens-list",
+
+            // View
+            Self::ViewRefresh => "view-refresh",
+            Self::ViewAdd => "view-add",
+
+            // Migration
+            Self::MigrationSet => "migration-set",
         }
     }
 
-    /// Returns all 36 node permissions.
+    /// Returns all 48 node permissions.
     pub fn all() -> &'static [NodePermission] {
         &[
             // DAC
@@ -269,22 +292,36 @@ impl NodePermission {
             Self::IndexList,
             Self::IndexCreate,
             Self::IndexDrop,
+            Self::EncryptedIndexCreate,
+            Self::EncryptedIndexList,
+            Self::EncryptedIndexListAll,
+            Self::EncryptedIndexDelete,
             // P2P
+            Self::P2pPeerInfo,
             Self::P2pPeerConnect,
+            Self::P2pPeerActive,
             Self::P2pReplicatorCreate,
             Self::P2pReplicatorDelete,
             Self::P2pReplicatorList,
             Self::P2pCollectionCreate,
             Self::P2pCollectionDelete,
             Self::P2pCollectionList,
-            Self::P2pPeerInfo,
             Self::P2pDocumentCreate,
             Self::P2pDocumentDelete,
             Self::P2pDocumentList,
+            Self::P2pSyncDocuments,
+            Self::P2pSyncCollectionVersions,
+            Self::P2pSyncBranchableCollection,
             // Other
             Self::SignatureVerify,
             // Lens
+            Self::LensCreate,
             Self::LensList,
+            // View
+            Self::ViewRefresh,
+            Self::ViewAdd,
+            // Migration
+            Self::MigrationSet,
         ]
     }
 
@@ -319,33 +356,45 @@ impl NodePermission {
             "index-list" => Self::IndexList,
             "index-create" => Self::IndexCreate,
             "index-drop" => Self::IndexDrop,
+            "encrypted-index-create" => Self::EncryptedIndexCreate,
+            "encrypted-index-list" => Self::EncryptedIndexList,
+            "encrypted-index-list-all" => Self::EncryptedIndexListAll,
+            "encrypted-index-delete" => Self::EncryptedIndexDelete,
             // P2P
+            "p2p-peer-info" => Self::P2pPeerInfo,
             "p2p-peer-connect" => Self::P2pPeerConnect,
+            "p2p-peer-active" => Self::P2pPeerActive,
             "p2p-replicator-create" => Self::P2pReplicatorCreate,
             "p2p-replicator-delete" => Self::P2pReplicatorDelete,
             "p2p-replicator-list" => Self::P2pReplicatorList,
             "p2p-collection-create" => Self::P2pCollectionCreate,
             "p2p-collection-delete" => Self::P2pCollectionDelete,
             "p2p-collection-list" => Self::P2pCollectionList,
-            "p2p-peer-info" => Self::P2pPeerInfo,
             "p2p-document-create" => Self::P2pDocumentCreate,
             "p2p-document-delete" => Self::P2pDocumentDelete,
             "p2p-document-list" => Self::P2pDocumentList,
+            "p2p-sync-documents" => Self::P2pSyncDocuments,
+            "p2p-sync-collection-versions" => Self::P2pSyncCollectionVersions,
+            "p2p-sync-branchable-collection" => Self::P2pSyncBranchableCollection,
             // Other
             "signature-verify" => Self::SignatureVerify,
             // Lens
+            "lens-create" => Self::LensCreate,
             "lens-list" => Self::LensList,
+            // View
+            "view-refresh" => Self::ViewRefresh,
+            "view-add" => Self::ViewAdd,
+            // Migration
+            "migration-set" => Self::MigrationSet,
             _ => return None,
         })
     }
 
     /// Check if this permission is admin-only (requires owner or admin relation).
     ///
-    /// In Go DefraDB, all 36 node permissions are defined with `expr: owner + admin`,
+    /// In Go DefraDB, all 48 node permissions are defined with `expr: owner + admin`,
     /// meaning they all require either the owner or admin relation to be granted.
-    /// This matches that behavior.
     pub fn is_admin_only(&self) -> bool {
-        // All node permissions require owner or admin relation per Go implementation
         true
     }
 }
@@ -362,7 +411,7 @@ mod tests {
 
     #[test]
     fn test_all_permissions_count() {
-        assert_eq!(NodePermission::all().len(), 36);
+        assert_eq!(NodePermission::all().len(), 48);
     }
 
     #[test]
@@ -385,7 +434,6 @@ mod tests {
 
     #[test]
     fn test_admin_only_permissions() {
-        // All 36 permissions require owner or admin relation (matches Go behavior)
         for perm in NodePermission::all() {
             assert!(
                 perm.is_admin_only(),

--- a/crates/acp/src/nac/policy.rs
+++ b/crates/acp/src/nac/policy.rs
@@ -3,7 +3,7 @@
 //! The NAC policy uses the Zanzibar permission model with:
 //! - `owner` relation: the node identity that enabled NAC
 //! - `admin` relation: identities with admin access (can manage other relations)
-//! - 36 permission relations: one for each NodePermission
+//! - 48 permission relations: one for each NodePermission
 //!
 //! All permissions have expression: `owner + admin` meaning either the owner
 //! or any admin can perform any operation.
@@ -26,7 +26,7 @@ pub const ADMIN_RELATION: &str = "admin";
 /// This policy defines:
 /// - `owner`: Direct relation for the node identity
 /// - `admin`: Computed relation (owner + direct admin), can manage all non-owner relations
-/// - All 36 permissions with expression `owner + admin`
+/// - All 48 permissions with expression `owner + admin`
 ///
 /// The admin relation has `manages` set to all permission relation names,
 /// allowing admins to grant/revoke any permission (except owner).
@@ -54,7 +54,7 @@ pub fn create_node_policy() -> Policy {
 
     resource = resource.with_relation(admin_relation);
 
-    // Add a relation for each of the 36 permissions
+    // Add a relation for each of the 48 permissions
     // Each permission has expression: owner + admin
     for perm in NodePermission::all() {
         let perm_relation = Relation::computed(
@@ -119,8 +119,8 @@ mod tests {
 
         let resource = policy.get_resource(NODE_RESOURCE_NAME).unwrap();
 
-        // Should have owner, admin, and 36 permission relations = 38 total
-        assert_eq!(resource.relations.len(), 38);
+        // Should have owner, admin, and 48 permission relations = 50 total
+        assert_eq!(resource.relations.len(), 50);
     }
 
     #[test]
@@ -142,8 +142,8 @@ mod tests {
         let resource = policy.get_resource(NODE_RESOURCE_NAME).unwrap();
         let admin = resource.get_relation(ADMIN_RELATION).unwrap();
 
-        // Admin should manage all 36 permissions
-        assert_eq!(admin.manages.len(), 36);
+        // Admin should manage all 48 permissions
+        assert_eq!(admin.manages.len(), 48);
     }
 
     #[test]

--- a/crates/http/src/handlers/encrypted_index.rs
+++ b/crates/http/src/handlers/encrypted_index.rs
@@ -32,7 +32,7 @@ pub async fn go_create_encrypted_index(
     Path(collection): Path<String>,
     body: Option<Json<GoCreateEncryptedIndexRequest>>,
 ) -> Result<Json<EncryptedIndexInfo>, HttpError> {
-    require_permission(&state, &identity, NodePermission::IndexCreate).await?;
+    require_permission(&state, &identity, NodePermission::EncryptedIndexCreate).await?;
 
     let ops = state.require_encrypted_index()?;
 
@@ -64,7 +64,7 @@ pub async fn go_list_encrypted_indexes(
     identity: ExtractIdentity,
     Path(collection): Path<String>,
 ) -> Result<Json<Vec<EncryptedIndexInfo>>, HttpError> {
-    require_permission(&state, &identity, NodePermission::IndexList).await?;
+    require_permission(&state, &identity, NodePermission::EncryptedIndexList).await?;
 
     let ops = state.require_encrypted_index()?;
 
@@ -90,7 +90,7 @@ pub async fn go_list_all_encrypted_indexes(
     State(state): State<AppState>,
     identity: ExtractIdentity,
 ) -> Result<Json<Vec<EncryptedIndexInfo>>, HttpError> {
-    require_permission(&state, &identity, NodePermission::IndexList).await?;
+    require_permission(&state, &identity, NodePermission::EncryptedIndexListAll).await?;
 
     let ops = state.require_encrypted_index()?;
 
@@ -110,7 +110,7 @@ pub async fn go_delete_encrypted_index(
     identity: ExtractIdentity,
     Path((collection, field)): Path<(String, String)>,
 ) -> Result<StatusCode, HttpError> {
-    require_permission(&state, &identity, NodePermission::IndexDrop).await?;
+    require_permission(&state, &identity, NodePermission::EncryptedIndexDelete).await?;
 
     let ops = state.require_encrypted_index()?;
 

--- a/crates/http/src/handlers/lens.rs
+++ b/crates/http/src/handlers/lens.rs
@@ -41,13 +41,13 @@ pub struct SetMigrationResponse {
 /// }
 /// ```
 ///
-/// Requires `CollectionPatch` permission when NAC is enabled.
+/// Requires `MigrationSet` permission when NAC is enabled.
 pub async fn set_migration(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     body: String,
 ) -> Result<Json<SetMigrationResponse>, HttpError> {
-    require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
+    require_permission(&state, &identity, NodePermission::MigrationSet).await?;
 
     let lens = state.require_lens()?;
 
@@ -92,13 +92,13 @@ pub async fn reload(
 ///
 /// Accepts lens configuration wrapped as `{"lens": <config>}`.
 ///
-/// Requires `CollectionPatch` permission when NAC is enabled.
+/// Requires `LensCreate` permission when NAC is enabled.
 pub async fn add_lens(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     body: String,
 ) -> Result<Json<SetMigrationResponse>, HttpError> {
-    require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
+    require_permission(&state, &identity, NodePermission::LensCreate).await?;
 
     let lens = state.require_lens()?;
 
@@ -125,12 +125,12 @@ pub async fn add_lens(
 ///
 /// GET /api/v0/lens
 ///
-/// Requires `CollectionGet` permission when NAC is enabled.
+/// Requires `LensList` permission when NAC is enabled.
 pub async fn list_lenses(
     State(state): State<AppState>,
     identity: ExtractIdentity,
 ) -> Result<Json<serde_json::Value>, HttpError> {
-    require_permission(&state, &identity, NodePermission::CollectionGet).await?;
+    require_permission(&state, &identity, NodePermission::LensList).await?;
 
     let lens = state.require_lens()?;
 

--- a/crates/http/src/handlers/p2p/collections.rs
+++ b/crates/http/src/handlers/p2p/collections.rs
@@ -102,13 +102,18 @@ pub async fn remove_collections(
 ///
 /// Accepts JSON body: `{"collectionID": "..."}`
 ///
-/// Requires `P2pCollectionCreate` permission when NAC is enabled (per Go behavior).
+/// Requires `P2pSyncBranchableCollection` permission when NAC is enabled.
 pub async fn sync_branchable(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     Json(body): Json<SyncBranchableRequest>,
 ) -> Result<Json<()>, HttpError> {
-    require_permission(&state, &identity, NodePermission::P2pCollectionCreate).await?;
+    require_permission(
+        &state,
+        &identity,
+        NodePermission::P2pSyncBranchableCollection,
+    )
+    .await?;
 
     let p2p = state.require_p2p()?;
 
@@ -125,13 +130,13 @@ pub async fn sync_branchable(
 ///
 /// Accepts JSON body: `{"versionIDs": ["bafyrei...", ...]}`
 ///
-/// Requires `P2pCollectionCreate` permission when NAC is enabled (per Go behavior).
+/// Requires `P2pSyncCollectionVersions` permission when NAC is enabled.
 pub async fn sync_versions(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     Json(body): Json<SyncVersionsRequest>,
 ) -> Result<Json<()>, HttpError> {
-    require_permission(&state, &identity, NodePermission::P2pCollectionCreate).await?;
+    require_permission(&state, &identity, NodePermission::P2pSyncCollectionVersions).await?;
 
     let p2p = state.require_p2p()?;
 

--- a/crates/http/src/handlers/p2p/documents.rs
+++ b/crates/http/src/handlers/p2p/documents.rs
@@ -126,13 +126,13 @@ pub async fn remove_documents(
 ///
 /// Accepts JSON body: `{"collectionName": "...", "docIDs": ["..."]}`
 ///
-/// Requires `P2pDocumentCreate` permission when NAC is enabled (per Go behavior).
+/// Requires `P2pSyncDocuments` permission when NAC is enabled.
 pub async fn sync_documents(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     Json(body): Json<SyncDocumentsRequest>,
 ) -> Result<Json<()>, HttpError> {
-    require_permission(&state, &identity, NodePermission::P2pDocumentCreate).await?;
+    require_permission(&state, &identity, NodePermission::P2pSyncDocuments).await?;
 
     let p2p = state.require_p2p()?;
 

--- a/crates/http/src/handlers/p2p/peers.rs
+++ b/crates/http/src/handlers/p2p/peers.rs
@@ -35,12 +35,12 @@ pub struct ConnectPeerRequest {
 /// Returns array of full multiaddrs with peer ID embedded.
 /// Example: ["/ip4/127.0.0.1/tcp/9181/p2p/12D3KooWxyz..."]
 ///
-/// Requires `P2pPeerConnect` permission when NAC is enabled.
+/// Requires `P2pPeerInfo` permission when NAC is enabled.
 pub async fn get_info(
     State(state): State<AppState>,
     identity: ExtractIdentity,
 ) -> Result<Json<P2pInfoResponse>, HttpError> {
-    require_permission(&state, &identity, NodePermission::P2pPeerConnect).await?;
+    require_permission(&state, &identity, NodePermission::P2pPeerInfo).await?;
 
     let p2p = state.require_p2p()?;
 
@@ -86,12 +86,12 @@ pub async fn list_peers(
 ///
 /// Returns array of connected peer IDs as strings.
 ///
-/// Requires `P2pPeerConnect` permission when NAC is enabled.
+/// Requires `P2pPeerActive` permission when NAC is enabled.
 pub async fn active_peers(
     State(state): State<AppState>,
     identity: ExtractIdentity,
 ) -> Result<Json<Vec<String>>, HttpError> {
-    require_permission(&state, &identity, NodePermission::P2pPeerConnect).await?;
+    require_permission(&state, &identity, NodePermission::P2pPeerActive).await?;
 
     let p2p = state.require_p2p()?;
 

--- a/crates/http/src/handlers/views.rs
+++ b/crates/http/src/handlers/views.rs
@@ -32,13 +32,13 @@ pub struct RefreshViewsRequest {
 ///
 /// Creates a new Defra View from a GQL query and SDL schema.
 ///
-/// Requires `CollectionPatch` permission when NAC is enabled.
+/// Requires `ViewAdd` permission when NAC is enabled.
 pub async fn add_view(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     Json(body): Json<AddViewRequest>,
 ) -> Result<Json<Vec<CollectionVersion>>, HttpError> {
-    require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
+    require_permission(&state, &identity, NodePermission::ViewAdd).await?;
 
     let view_ops = state.require_view()?;
 
@@ -60,7 +60,7 @@ pub async fn refresh_views(
     identity: ExtractIdentity,
     Json(body): Json<RefreshViewsRequest>,
 ) -> Result<Json<serde_json::Value>, HttpError> {
-    require_permission(&state, &identity, NodePermission::CollectionGet).await?;
+    require_permission(&state, &identity, NodePermission::ViewRefresh).await?;
 
     let view_ops = state.require_view()?;
 

--- a/tools/integration-test/src/client/mod.rs
+++ b/tools/integration-test/src/client/mod.rs
@@ -978,4 +978,301 @@ impl DefraClient {
             ],
         )
     }
+
+    // -- Identity-aware collection operations --
+
+    /// List collections with identity.
+    pub fn collection_list_with_identity(&self, hex_key: &str) -> Result<Vec<String>> {
+        let out = self.exec_with_identity(hex_key, &["client", "collection", "list"])?;
+        let val: Value =
+            serde_json::from_str(&out).context("failed to parse collection_list output")?;
+        let arr = val.as_array().context("collection_list not an array")?;
+        Ok(arr
+            .iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect())
+    }
+
+    /// Describe a collection with identity.
+    pub fn collection_describe_with_identity(&self, name: &str, hex_key: &str) -> Result<Value> {
+        let out = self.exec_with_identity(
+            hex_key,
+            &["client", "collection", "describe", "--name", name],
+        )?;
+        serde_json::from_str(&out).context("failed to parse collection_describe output")
+    }
+
+    /// Create a document with identity.
+    pub fn collection_create_with_identity(
+        &self,
+        name: &str,
+        doc: &str,
+        hex_key: &str,
+    ) -> Result<Value> {
+        let out = self.exec_with_identity(
+            hex_key,
+            &["client", "collection", "create", "--name", name, doc],
+        )?;
+        serde_json::from_str(&out).context("failed to parse collection_create output")
+    }
+
+    /// Delete a document with identity.
+    pub fn collection_delete_with_identity(
+        &self,
+        name: &str,
+        doc_id: &str,
+        hex_key: &str,
+    ) -> Result<String> {
+        self.exec_with_identity(
+            hex_key,
+            &[
+                "client",
+                "collection",
+                "delete",
+                "--name",
+                name,
+                "--docID",
+                doc_id,
+            ],
+        )
+    }
+
+    /// Update a document with identity.
+    pub fn collection_update_with_identity(
+        &self,
+        name: &str,
+        doc_id: &str,
+        updater: &str,
+        hex_key: &str,
+    ) -> Result<String> {
+        self.exec_with_identity(
+            hex_key,
+            &[
+                "client",
+                "collection",
+                "update",
+                "--name",
+                name,
+                "--docID",
+                doc_id,
+                "--updater",
+                updater,
+            ],
+        )
+    }
+
+    /// Truncate a collection with identity.
+    pub fn collection_truncate_with_identity(&self, name: &str, hex_key: &str) -> Result<String> {
+        self.exec_with_identity(
+            hex_key,
+            &["client", "collection", "truncate", "--name", name],
+        )
+    }
+
+    /// Patch a collection schema with identity.
+    pub fn collection_patch_with_identity(&self, patch: &str, hex_key: &str) -> Result<String> {
+        self.exec_with_identity(hex_key, &["client", "collection", "patch", patch])
+    }
+
+    // -- Identity-aware index operations --
+
+    /// Create an index with identity.
+    pub fn index_create_with_identity(
+        &self,
+        collection: &str,
+        fields: &[&str],
+        name: Option<&str>,
+        unique: bool,
+        hex_key: &str,
+    ) -> Result<Value> {
+        let fields_csv = fields.join(",");
+        let out = self
+            .try_index_create_with_identity_args(
+                collection,
+                &fields_csv,
+                name,
+                unique,
+                false,
+                hex_key,
+            )
+            .or_else(|_| {
+                self.try_index_create_with_identity_args(
+                    collection,
+                    &fields_csv,
+                    name,
+                    unique,
+                    true,
+                    hex_key,
+                )
+            })?;
+        serde_json::from_str(&out).context("failed to parse index_create output")
+    }
+
+    fn try_index_create_with_identity_args(
+        &self,
+        collection: &str,
+        fields_csv: &str,
+        name: Option<&str>,
+        unique: bool,
+        use_flag: bool,
+        hex_key: &str,
+    ) -> Result<String> {
+        let mut args = vec!["client", "index", "create"];
+        if use_flag {
+            args.push("--collection");
+        }
+        args.push(collection);
+        args.push("--fields");
+        args.push(fields_csv);
+        if let Some(n) = name {
+            args.push("--name");
+            args.push(n);
+        }
+        if unique {
+            args.push("--unique");
+        }
+        self.exec_with_identity(hex_key, &args)
+    }
+
+    /// List indexes with identity.
+    pub fn index_list_with_identity(
+        &self,
+        collection: Option<&str>,
+        hex_key: &str,
+    ) -> Result<Value> {
+        let out = if let Some(c) = collection {
+            self.exec_with_identity(hex_key, &["client", "index", "list", c])
+                .or_else(|_| {
+                    self.exec_with_identity(
+                        hex_key,
+                        &["client", "index", "list", "--collection", c],
+                    )
+                })?
+        } else {
+            self.exec_with_identity(hex_key, &["client", "index", "list"])?
+        };
+        serde_json::from_str(&out).context("failed to parse index_list output")
+    }
+
+    /// Drop an index with identity.
+    pub fn index_drop_with_identity(
+        &self,
+        collection: &str,
+        name: &str,
+        hex_key: &str,
+    ) -> Result<String> {
+        self.exec_with_identity(hex_key, &["client", "index", "drop", collection, name])
+            .or_else(|_| {
+                self.exec_with_identity(
+                    hex_key,
+                    &[
+                        "client",
+                        "index",
+                        "drop",
+                        "--collection",
+                        collection,
+                        "--name",
+                        name,
+                    ],
+                )
+            })
+    }
+
+    // -- Identity-aware P2P operations --
+
+    /// Connect to peers with identity.
+    pub fn p2p_connect_with_identity(&self, addrs: &[&str], hex_key: &str) -> Result<String> {
+        let mut args = vec!["client", "p2p", "connect"];
+        args.extend(addrs);
+        self.exec_with_identity(hex_key, &args)
+    }
+
+    /// Create P2P collections with identity.
+    pub fn p2p_collection_add_with_identity(
+        &self,
+        collections: &[&str],
+        hex_key: &str,
+    ) -> Result<String> {
+        let cols = collections.join(",");
+        self.exec_with_identity(hex_key, &["client", "p2p", "collection", "create", &cols])
+    }
+
+    /// List P2P collections with identity.
+    pub fn p2p_collection_list_with_identity(&self, hex_key: &str) -> Result<Value> {
+        let out = self.exec_with_identity(hex_key, &["client", "p2p", "collection", "list"])?;
+        serde_json::from_str(&out).context("failed to parse p2p_collection_list output")
+    }
+
+    /// Delete P2P collections with identity.
+    pub fn p2p_collection_delete_with_identity(
+        &self,
+        collections: &[&str],
+        hex_key: &str,
+    ) -> Result<String> {
+        let cols = collections.join(",");
+        self.exec_with_identity(hex_key, &["client", "p2p", "collection", "delete", &cols])
+    }
+
+    /// Add documents to P2P subscription with identity.
+    pub fn p2p_document_create_with_identity(
+        &self,
+        doc_ids: &[&str],
+        hex_key: &str,
+    ) -> Result<String> {
+        let mut args = vec!["client", "p2p", "document", "create"];
+        args.extend(doc_ids);
+        self.exec_with_identity(hex_key, &args)
+    }
+
+    /// List P2P document subscriptions with identity.
+    pub fn p2p_document_list_with_identity(&self, hex_key: &str) -> Result<Value> {
+        let out = self.exec_with_identity(hex_key, &["client", "p2p", "document", "list"])?;
+        serde_json::from_str(&out).context("failed to parse p2p_document_list output")
+    }
+
+    /// Delete documents from P2P subscription with identity.
+    pub fn p2p_document_delete_with_identity(
+        &self,
+        doc_ids: &[&str],
+        hex_key: &str,
+    ) -> Result<String> {
+        let mut args = vec!["client", "p2p", "document", "delete"];
+        args.extend(doc_ids);
+        self.exec_with_identity(hex_key, &args)
+    }
+
+    /// Create a replicator with identity.
+    pub fn p2p_replicator_set_with_identity(
+        &self,
+        collections: &[&str],
+        addr: &str,
+        hex_key: &str,
+    ) -> Result<String> {
+        let cols = collections.join(",");
+        self.exec_with_identity(
+            hex_key,
+            &["client", "p2p", "replicator", "create", "-c", &cols, addr],
+        )
+    }
+
+    /// List replicators with identity.
+    pub fn p2p_replicator_list_with_identity(&self, hex_key: &str) -> Result<Value> {
+        let out = self.exec_with_identity(hex_key, &["client", "p2p", "replicator", "list"])?;
+        serde_json::from_str(&out).context("failed to parse p2p_replicator_list output")
+    }
+
+    /// Delete a replicator with identity.
+    pub fn p2p_replicator_delete_with_identity(
+        &self,
+        collections: &[&str],
+        peer_addr: Option<&str>,
+        hex_key: &str,
+    ) -> Result<String> {
+        let cols = collections.join(",");
+        let mut args = vec!["client", "p2p", "replicator", "delete", "-c", &cols];
+        if let Some(addr) = peer_addr {
+            args.push(addr);
+        }
+        self.exec_with_identity(hex_key, &args)
+    }
 }

--- a/tools/integration-test/src/client/mod.rs
+++ b/tools/integration-test/src/client/mod.rs
@@ -931,7 +931,11 @@ impl DefraClient {
         } else {
             self.exec_with_identity(hex_key, &["client", "view", "refresh"])?
         };
-        serde_json::from_str(&out).context("failed to parse view_refresh output")
+        let trimmed = out.trim();
+        if trimmed.is_empty() {
+            return Ok(serde_json::json!({}));
+        }
+        serde_json::from_str(trimmed).context("failed to parse view_refresh output")
     }
 
     /// Sync documents with identity.

--- a/tools/integration-test/src/client/mod.rs
+++ b/tools/integration-test/src/client/mod.rs
@@ -53,6 +53,18 @@ impl DefraClient {
         }
     }
 
+    fn exec_with_identity(&self, hex_key: &str, args: &[&str]) -> Result<String> {
+        let mut full_args = vec!["client", "-i", hex_key];
+        // Skip the leading "client" in args if present
+        let skip = if args.first() == Some(&"client") {
+            1
+        } else {
+            0
+        };
+        full_args.extend(&args[skip..]);
+        self.exec(&full_args)
+    }
+
     /// Deploy a schema via `client schema add '<sdl>'`.
     pub fn schema_add(&self, sdl: &str) -> Result<Value> {
         let out = self.exec(&["client", "schema", "add", sdl])?;
@@ -779,5 +791,187 @@ impl DefraClient {
         // Fall back to CLI describe (Go CLI returns full CollectionVersion JSON)
         let out = self.exec(&["client", "collection", "describe", "--name", name])?;
         serde_json::from_str(&out).context("failed to parse collection describe output")
+    }
+
+    // -- Identity-aware variants for NAC testing --
+
+    /// Get P2P node info with identity.
+    pub fn p2p_info_with_identity(&self, hex_key: &str) -> Result<Value> {
+        let out = self.exec_with_identity(hex_key, &["client", "p2p", "info"])?;
+        serde_json::from_str(&out).context("failed to parse p2p_info output")
+    }
+
+    /// List active peers with identity.
+    pub fn p2p_active_peers_with_identity(&self, hex_key: &str) -> Result<Value> {
+        let out = self.exec_with_identity(hex_key, &["client", "p2p", "active-peers"])?;
+        serde_json::from_str(&out).context("failed to parse p2p_active_peers output")
+    }
+
+    /// Create an encrypted index with identity.
+    pub fn encrypted_index_create_with_identity(
+        &self,
+        collection: &str,
+        field: &str,
+        hex_key: &str,
+    ) -> Result<Value> {
+        let out = self
+            .exec_with_identity(
+                hex_key,
+                &["client", "encrypted-index", "create", collection, field],
+            )
+            .or_else(|_| {
+                self.exec_with_identity(
+                    hex_key,
+                    &[
+                        "client",
+                        "encrypted-index",
+                        "create",
+                        "--collection",
+                        collection,
+                        "--field",
+                        field,
+                    ],
+                )
+            })?;
+        serde_json::from_str(&out).context("failed to parse encrypted_index_create output")
+    }
+
+    /// List encrypted indexes with identity.
+    pub fn encrypted_index_list_with_identity(
+        &self,
+        collection: &str,
+        hex_key: &str,
+    ) -> Result<Value> {
+        let out = self
+            .exec_with_identity(hex_key, &["client", "encrypted-index", "list", collection])
+            .or_else(|_| {
+                self.exec_with_identity(
+                    hex_key,
+                    &[
+                        "client",
+                        "encrypted-index",
+                        "list",
+                        "--collection",
+                        collection,
+                    ],
+                )
+            })?;
+        serde_json::from_str(&out).context("failed to parse encrypted_index_list output")
+    }
+
+    /// Delete an encrypted index with identity.
+    pub fn encrypted_index_delete_with_identity(
+        &self,
+        collection: &str,
+        field: &str,
+        hex_key: &str,
+    ) -> Result<String> {
+        self.exec_with_identity(
+            hex_key,
+            &["client", "encrypted-index", "delete", collection, field],
+        )
+        .or_else(|_| {
+            self.exec_with_identity(
+                hex_key,
+                &[
+                    "client",
+                    "encrypted-index",
+                    "delete",
+                    "--collection",
+                    collection,
+                    "--field",
+                    field,
+                ],
+            )
+        })
+    }
+
+    /// Add a lens migration with identity.
+    pub fn lens_add_with_identity(&self, config: &str, hex_key: &str) -> Result<Value> {
+        let out = self.exec_with_identity(hex_key, &["client", "lens", "add", config])?;
+        serde_json::from_str(&out).context("failed to parse lens_add output")
+    }
+
+    /// List lens migrations with identity.
+    pub fn lens_list_with_identity(&self, hex_key: &str) -> Result<Value> {
+        let out = self.exec_with_identity(hex_key, &["client", "lens", "list"])?;
+        serde_json::from_str(&out).context("failed to parse lens_list output")
+    }
+
+    /// Set a lens migration with identity.
+    pub fn lens_set_with_identity(
+        &self,
+        src: &str,
+        dst: &str,
+        config: &str,
+        hex_key: &str,
+    ) -> Result<Value> {
+        let out = self.exec_with_identity(hex_key, &["client", "lens", "set", src, dst, config])?;
+        serde_json::from_str(&out).context("failed to parse lens_set output")
+    }
+
+    /// Add a view with identity.
+    pub fn view_add_with_identity(
+        &self,
+        gql_query: &str,
+        sdl: &str,
+        hex_key: &str,
+    ) -> Result<Value> {
+        let out = self.exec_with_identity(
+            hex_key,
+            &["client", "view", "add", "--query", gql_query, "--sdl", sdl],
+        )?;
+        serde_json::from_str(&out).context("failed to parse view_add output")
+    }
+
+    /// Refresh views with identity.
+    pub fn view_refresh_with_identity(&self, name: Option<&str>, hex_key: &str) -> Result<Value> {
+        let out = if let Some(n) = name {
+            self.exec_with_identity(hex_key, &["client", "view", "refresh", "--name", n])?
+        } else {
+            self.exec_with_identity(hex_key, &["client", "view", "refresh"])?
+        };
+        serde_json::from_str(&out).context("failed to parse view_refresh output")
+    }
+
+    /// Sync documents with identity.
+    pub fn p2p_document_sync_with_identity(
+        &self,
+        collection: &str,
+        doc_ids: &[&str],
+        hex_key: &str,
+    ) -> Result<String> {
+        let mut args = vec!["client", "p2p", "document", "sync", collection];
+        args.extend(doc_ids);
+        self.exec_with_identity(hex_key, &args)
+    }
+
+    /// Sync collection versions with identity.
+    pub fn p2p_collection_sync_versions_with_identity(
+        &self,
+        version_ids: &[&str],
+        hex_key: &str,
+    ) -> Result<String> {
+        let mut args = vec!["client", "p2p", "collection", "sync-versions"];
+        args.extend(version_ids);
+        self.exec_with_identity(hex_key, &args)
+    }
+
+    /// Sync branchable collection with identity.
+    pub fn p2p_collection_sync_branchable_with_identity(
+        &self,
+        collection_id: &str,
+        hex_key: &str,
+    ) -> Result<String> {
+        self.exec_with_identity(
+            hex_key,
+            &[
+                "client",
+                "p2p",
+                "collection",
+                "sync-branchable",
+                collection_id,
+            ],
+        )
     }
 }

--- a/tools/integration-test/tests/nac_core_operations.rs
+++ b/tools/integration-test/tests/nac_core_operations.rs
@@ -1,0 +1,192 @@
+use integration_test::{for_each_runtime, generate_identity, TestCluster, PRODUCT_SCHEMA};
+
+for_each_runtime!(
+    nac_core_operations_gate,
+    nac_core_operations_gate_test,
+    .with_acp_local().with_nac()
+);
+
+async fn nac_core_operations_gate_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary = node.binary_path().to_path_buf();
+
+    let admin_key = cluster
+        .startup_identity()
+        .expect("NAC cluster must have startup identity")
+        .to_string();
+
+    let outsider = generate_identity(&binary).expect("outsider identity");
+    let outsider_key = &outsider.private_key_hex;
+
+    // Setup: admin deploys schema and creates a document
+    node.schema_add_with_identity(PRODUCT_SCHEMA, &admin_key)
+        .expect("deploy schema");
+
+    let data = node
+        .query_with_identity(
+            r#"mutation { create_Product(input: {name: "Widget", sku: "W001", price: 100}) { _docID } }"#,
+            &admin_key,
+        )
+        .expect("create product");
+    let doc_id = data["create_Product"][0]["_docID"]
+        .as_str()
+        .expect("_docID")
+        .to_string();
+
+    // =========================================================================
+    // collection list — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.collection_list().is_err(),
+        "anonymous should be rejected from collection list"
+    );
+    assert!(
+        node.collection_list_with_identity(outsider_key).is_err(),
+        "outsider should be rejected from collection list"
+    );
+    let collections = node
+        .collection_list_with_identity(&admin_key)
+        .expect("admin should list collections");
+    assert!(!collections.is_empty(), "admin should see collections");
+
+    // =========================================================================
+    // collection describe — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.collection_describe("Product").is_err(),
+        "anonymous should be rejected from collection describe"
+    );
+    assert!(
+        node.collection_describe_with_identity("Product", outsider_key)
+            .is_err(),
+        "outsider should be rejected from collection describe"
+    );
+    node.collection_describe_with_identity("Product", &admin_key)
+        .expect("admin should describe collection");
+
+    // =========================================================================
+    // collection truncate — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.collection_truncate("Product").is_err(),
+        "anonymous should be rejected from collection truncate"
+    );
+    assert!(
+        node.collection_truncate_with_identity("Product", outsider_key)
+            .is_err(),
+        "outsider should be rejected from collection truncate"
+    );
+
+    // =========================================================================
+    // index create — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.index_create("Product", &["name"], None, false)
+            .is_err(),
+        "anonymous should be rejected from index create"
+    );
+    assert!(
+        node.index_create_with_identity(
+            "Product",
+            &["name"],
+            Some("idx_name"),
+            false,
+            outsider_key
+        )
+        .is_err(),
+        "outsider should be rejected from index create"
+    );
+    node.index_create_with_identity("Product", &["name"], Some("idx_name"), false, &admin_key)
+        .expect("admin should create index");
+
+    // =========================================================================
+    // index list — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.index_list(Some("Product")).is_err(),
+        "anonymous should be rejected from index list"
+    );
+    assert!(
+        node.index_list_with_identity(Some("Product"), outsider_key)
+            .is_err(),
+        "outsider should be rejected from index list"
+    );
+    node.index_list_with_identity(Some("Product"), &admin_key)
+        .expect("admin should list indexes");
+
+    // =========================================================================
+    // index drop — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.index_drop("Product", "idx_name").is_err(),
+        "anonymous should be rejected from index drop"
+    );
+    assert!(
+        node.index_drop_with_identity("Product", "idx_name", outsider_key)
+            .is_err(),
+        "outsider should be rejected from index drop"
+    );
+    node.index_drop_with_identity("Product", "idx_name", &admin_key)
+        .expect("admin should drop index");
+
+    // =========================================================================
+    // collection create (document mutation) — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.collection_create("Product", r#"{"name":"Anon","sku":"A001","price":1}"#)
+            .is_err(),
+        "anonymous should be rejected from collection create"
+    );
+    assert!(
+        node.collection_create_with_identity(
+            "Product",
+            r#"{"name":"Out","sku":"O001","price":2}"#,
+            outsider_key,
+        )
+        .is_err(),
+        "outsider should be rejected from collection create"
+    );
+    node.collection_create_with_identity(
+        "Product",
+        r#"{"name":"Admin","sku":"AD01","price":3}"#,
+        &admin_key,
+    )
+    .expect("admin should create document");
+
+    // =========================================================================
+    // collection update (document mutation) — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.collection_update("Product", &doc_id, r#"{"price": 200}"#)
+            .is_err(),
+        "anonymous should be rejected from collection update"
+    );
+    assert!(
+        node.collection_update_with_identity("Product", &doc_id, r#"{"price": 200}"#, outsider_key)
+            .is_err(),
+        "outsider should be rejected from collection update"
+    );
+    node.collection_update_with_identity("Product", &doc_id, r#"{"price": 200}"#, &admin_key)
+        .expect("admin should update document");
+
+    // =========================================================================
+    // collection delete (document mutation) — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.collection_delete("Product", &doc_id).is_err(),
+        "anonymous should be rejected from collection delete"
+    );
+    assert!(
+        node.collection_delete_with_identity("Product", &doc_id, outsider_key)
+            .is_err(),
+        "outsider should be rejected from collection delete"
+    );
+    node.collection_delete_with_identity("Product", &doc_id, &admin_key)
+        .expect("admin should delete document");
+
+    // =========================================================================
+    // Admin truncate (run last since it removes all docs)
+    // =========================================================================
+    node.collection_truncate_with_identity("Product", &admin_key)
+        .expect("admin should truncate collection");
+}

--- a/tools/integration-test/tests/nac_document_acp.rs
+++ b/tools/integration-test/tests/nac_document_acp.rs
@@ -46,6 +46,17 @@ async fn nac_document_acp_test(cluster: TestCluster) {
 
     let query = "query { User { _docID name age } }";
 
+    // --- Test 0: Anonymous (no identity) query -> DENY ---
+    let anon_result = node.query(query);
+    let anon_sees_nothing = match &anon_result {
+        Err(_) => true,
+        Ok(val) => val["User"].as_array().map(|a| a.is_empty()).unwrap_or(true),
+    };
+    assert!(
+        anon_sees_nothing,
+        "anonymous (no identity) should see no data under NAC"
+    );
+
     // --- Test 1: Jack (NAC admin + doc owner) reads -> ALLOW ---
     let jack_result = node
         .query_with_identity(query, &jack_key)

--- a/tools/integration-test/tests/nac_operations.rs
+++ b/tools/integration-test/tests/nac_operations.rs
@@ -5,6 +5,9 @@
 
 use integration_test::{for_each_runtime, generate_identity, TestCluster, PRODUCT_SCHEMA};
 
+// ---------------------------------------------------------------------------
+// Non-P2P operations: encrypted index create, lens, views
+// ---------------------------------------------------------------------------
 for_each_runtime!(
     nac_operations_gate,
     nac_operations_gate_test,
@@ -35,30 +38,6 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
     .expect("create product");
 
     // =========================================================================
-    // P2P peer info — outsider rejected, admin accepted
-    // =========================================================================
-    assert!(
-        node.p2p_info_with_identity(outsider_key).is_err(),
-        "outsider should be rejected from p2p info"
-    );
-    assert!(
-        node.p2p_info_with_identity(&admin_key).is_ok(),
-        "admin should access p2p info"
-    );
-
-    // =========================================================================
-    // P2P active peers — outsider rejected, admin accepted
-    // =========================================================================
-    assert!(
-        node.p2p_active_peers_with_identity(outsider_key).is_err(),
-        "outsider should be rejected from active peers"
-    );
-    assert!(
-        node.p2p_active_peers_with_identity(&admin_key).is_ok(),
-        "admin should access active peers"
-    );
-
-    // =========================================================================
     // Encrypted index create — outsider rejected, admin accepted
     // =========================================================================
     assert!(
@@ -68,28 +47,6 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
     );
     node.encrypted_index_create_with_identity("Product", "name", &admin_key)
         .expect("admin should create encrypted index");
-
-    // =========================================================================
-    // Encrypted index list — outsider rejected, admin accepted
-    // =========================================================================
-    assert!(
-        node.encrypted_index_list_with_identity("Product", outsider_key)
-            .is_err(),
-        "outsider should be rejected from encrypted index list"
-    );
-    node.encrypted_index_list_with_identity("Product", &admin_key)
-        .expect("admin should list encrypted indexes");
-
-    // =========================================================================
-    // Encrypted index delete — outsider rejected, admin accepted
-    // =========================================================================
-    assert!(
-        node.encrypted_index_delete_with_identity("Product", "name", outsider_key)
-            .is_err(),
-        "outsider should be rejected from encrypted index delete"
-    );
-    node.encrypted_index_delete_with_identity("Product", "name", &admin_key)
-        .expect("admin should delete encrypted index");
 
     // =========================================================================
     // Lens list — outsider rejected, admin accepted
@@ -103,10 +60,11 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
 
     // =========================================================================
     // View add — outsider rejected, admin accepted
+    // Note: query must NOT include the "query" keyword prefix.
     // =========================================================================
     assert!(
         node.view_add_with_identity(
-            "query { Product { name } }",
+            "Product { name }",
             "type ProductView { name: String }",
             outsider_key,
         )
@@ -114,7 +72,7 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
         "outsider should be rejected from view add"
     );
     node.view_add_with_identity(
-        "query { Product { name } }",
+        "Product { name }",
         "type ProductView { name: String }",
         &admin_key,
     )
@@ -129,4 +87,46 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
     );
     node.view_refresh_with_identity(None, &admin_key)
         .expect("admin should refresh views");
+}
+
+// ---------------------------------------------------------------------------
+// P2P operations: peer info, active peers (requires P2P subsystem)
+// ---------------------------------------------------------------------------
+for_each_runtime!(
+    nac_p2p_operations_gate,
+    nac_p2p_operations_gate_test,
+    .with_acp_local().with_nac().with_p2p()
+);
+
+async fn nac_p2p_operations_gate_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary = node.binary_path().to_path_buf();
+
+    let admin_key = cluster
+        .startup_identity()
+        .expect("NAC cluster must have startup identity")
+        .to_string();
+
+    let outsider = generate_identity(&binary).expect("outsider identity");
+    let outsider_key = &outsider.private_key_hex;
+
+    // =========================================================================
+    // P2P peer info — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_info_with_identity(outsider_key).is_err(),
+        "outsider should be rejected from p2p info"
+    );
+    node.p2p_info_with_identity(&admin_key)
+        .expect("admin should access p2p info");
+
+    // =========================================================================
+    // P2P active peers — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_active_peers_with_identity(outsider_key).is_err(),
+        "outsider should be rejected from active peers"
+    );
+    node.p2p_active_peers_with_identity(&admin_key)
+        .expect("admin should access active peers");
 }

--- a/tools/integration-test/tests/nac_operations.rs
+++ b/tools/integration-test/tests/nac_operations.rs
@@ -1,0 +1,132 @@
+//! NAC operation gate tests.
+//!
+//! Verifies that each NAC-gated HTTP endpoint rejects unauthenticated callers
+//! and accepts the startup admin identity.
+
+use integration_test::{for_each_runtime, generate_identity, TestCluster, PRODUCT_SCHEMA};
+
+for_each_runtime!(
+    nac_operations_gate,
+    nac_operations_gate_test,
+    .with_acp_local().with_nac().with_encryption()
+);
+
+async fn nac_operations_gate_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary = node.binary_path().to_path_buf();
+
+    let admin_key = cluster
+        .startup_identity()
+        .expect("NAC cluster must have startup identity")
+        .to_string();
+
+    let outsider = generate_identity(&binary).expect("outsider identity");
+    let outsider_key = &outsider.private_key_hex;
+
+    // Deploy a schema so encrypted-index and view operations have a collection
+    node.schema_add_with_identity(PRODUCT_SCHEMA, &admin_key)
+        .expect("deploy schema");
+
+    // Create a document so the collection is non-empty
+    node.query_with_identity(
+        r#"mutation { create_Product(input: {name: "Widget", sku: "W001", price: 100}) { _docID } }"#,
+        &admin_key,
+    )
+    .expect("create product");
+
+    // =========================================================================
+    // P2P peer info — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_info_with_identity(outsider_key).is_err(),
+        "outsider should be rejected from p2p info"
+    );
+    assert!(
+        node.p2p_info_with_identity(&admin_key).is_ok(),
+        "admin should access p2p info"
+    );
+
+    // =========================================================================
+    // P2P active peers — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_active_peers_with_identity(outsider_key).is_err(),
+        "outsider should be rejected from active peers"
+    );
+    assert!(
+        node.p2p_active_peers_with_identity(&admin_key).is_ok(),
+        "admin should access active peers"
+    );
+
+    // =========================================================================
+    // Encrypted index create — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.encrypted_index_create_with_identity("Product", "name", outsider_key)
+            .is_err(),
+        "outsider should be rejected from encrypted index create"
+    );
+    node.encrypted_index_create_with_identity("Product", "name", &admin_key)
+        .expect("admin should create encrypted index");
+
+    // =========================================================================
+    // Encrypted index list — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.encrypted_index_list_with_identity("Product", outsider_key)
+            .is_err(),
+        "outsider should be rejected from encrypted index list"
+    );
+    node.encrypted_index_list_with_identity("Product", &admin_key)
+        .expect("admin should list encrypted indexes");
+
+    // =========================================================================
+    // Encrypted index delete — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.encrypted_index_delete_with_identity("Product", "name", outsider_key)
+            .is_err(),
+        "outsider should be rejected from encrypted index delete"
+    );
+    node.encrypted_index_delete_with_identity("Product", "name", &admin_key)
+        .expect("admin should delete encrypted index");
+
+    // =========================================================================
+    // Lens list — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.lens_list_with_identity(outsider_key).is_err(),
+        "outsider should be rejected from lens list"
+    );
+    node.lens_list_with_identity(&admin_key)
+        .expect("admin should list lenses");
+
+    // =========================================================================
+    // View add — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.view_add_with_identity(
+            "query { Product { name } }",
+            "type ProductView { name: String }",
+            outsider_key,
+        )
+        .is_err(),
+        "outsider should be rejected from view add"
+    );
+    node.view_add_with_identity(
+        "query { Product { name } }",
+        "type ProductView { name: String }",
+        &admin_key,
+    )
+    .expect("admin should add view");
+
+    // =========================================================================
+    // View refresh — outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.view_refresh_with_identity(None, outsider_key).is_err(),
+        "outsider should be rejected from view refresh"
+    );
+    node.view_refresh_with_identity(None, &admin_key)
+        .expect("admin should refresh views");
+}

--- a/tools/integration-test/tests/nac_operations.rs
+++ b/tools/integration-test/tests/nac_operations.rs
@@ -38,8 +38,12 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
     .expect("create product");
 
     // =========================================================================
-    // Encrypted index create — outsider rejected, admin accepted
+    // Encrypted index create — anonymous rejected, outsider rejected, admin accepted
     // =========================================================================
+    assert!(
+        node.encrypted_index_create("Product", "name").is_err(),
+        "anonymous should be rejected from encrypted index create"
+    );
     assert!(
         node.encrypted_index_create_with_identity("Product", "name", outsider_key)
             .is_err(),
@@ -49,8 +53,12 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
         .expect("admin should create encrypted index");
 
     // =========================================================================
-    // Lens list — outsider rejected, admin accepted
+    // Lens list — anonymous rejected, outsider rejected, admin accepted
     // =========================================================================
+    assert!(
+        node.lens_list().is_err(),
+        "anonymous should be rejected from lens list"
+    );
     assert!(
         node.lens_list_with_identity(outsider_key).is_err(),
         "outsider should be rejected from lens list"
@@ -59,9 +67,14 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
         .expect("admin should list lenses");
 
     // =========================================================================
-    // View add — outsider rejected, admin accepted
+    // View add — anonymous rejected, outsider rejected, admin accepted
     // Note: query must NOT include the "query" keyword prefix.
     // =========================================================================
+    assert!(
+        node.view_add("Product { name }", "type ProductView { name: String }")
+            .is_err(),
+        "anonymous should be rejected from view add"
+    );
     assert!(
         node.view_add_with_identity(
             "Product { name }",
@@ -79,8 +92,12 @@ async fn nac_operations_gate_test(cluster: TestCluster) {
     .expect("admin should add view");
 
     // =========================================================================
-    // View refresh — outsider rejected, admin accepted
+    // View refresh — anonymous rejected, outsider rejected, admin accepted
     // =========================================================================
+    assert!(
+        node.view_refresh(None).is_err(),
+        "anonymous should be rejected from view refresh"
+    );
     assert!(
         node.view_refresh_with_identity(None, outsider_key).is_err(),
         "outsider should be rejected from view refresh"
@@ -111,8 +128,12 @@ async fn nac_p2p_operations_gate_test(cluster: TestCluster) {
     let outsider_key = &outsider.private_key_hex;
 
     // =========================================================================
-    // P2P peer info — outsider rejected, admin accepted
+    // P2P peer info — anonymous rejected, outsider rejected, admin accepted
     // =========================================================================
+    assert!(
+        node.p2p_info().is_err(),
+        "anonymous should be rejected from p2p info"
+    );
     assert!(
         node.p2p_info_with_identity(outsider_key).is_err(),
         "outsider should be rejected from p2p info"
@@ -121,8 +142,12 @@ async fn nac_p2p_operations_gate_test(cluster: TestCluster) {
         .expect("admin should access p2p info");
 
     // =========================================================================
-    // P2P active peers — outsider rejected, admin accepted
+    // P2P active peers — anonymous rejected, outsider rejected, admin accepted
     // =========================================================================
+    assert!(
+        node.p2p_active_peers().is_err(),
+        "anonymous should be rejected from active peers"
+    );
     assert!(
         node.p2p_active_peers_with_identity(outsider_key).is_err(),
         "outsider should be rejected from active peers"

--- a/tools/integration-test/tests/nac_p2p_management.rs
+++ b/tools/integration-test/tests/nac_p2p_management.rs
@@ -1,0 +1,139 @@
+use integration_test::{for_each_runtime, generate_identity, TestCluster, PRODUCT_SCHEMA};
+
+for_each_runtime!(
+    nac_p2p_management_gate,
+    nac_p2p_management_gate_test,
+    .with_acp_local().with_nac().with_p2p()
+);
+
+async fn nac_p2p_management_gate_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary = node.binary_path().to_path_buf();
+
+    let admin_key = cluster
+        .startup_identity()
+        .expect("NAC cluster must have startup identity")
+        .to_string();
+
+    let outsider = generate_identity(&binary).expect("outsider identity");
+    let outsider_key = &outsider.private_key_hex;
+
+    // Setup: admin deploys schema and creates a document
+    node.schema_add_with_identity(PRODUCT_SCHEMA, &admin_key)
+        .expect("deploy schema");
+
+    let data = node
+        .query_with_identity(
+            r#"mutation { create_Product(input: {name: "Widget", sku: "W001", price: 100}) { _docID } }"#,
+            &admin_key,
+        )
+        .expect("create product");
+    let doc_id = data["create_Product"][0]["_docID"]
+        .as_str()
+        .expect("_docID")
+        .to_string();
+
+    // =========================================================================
+    // P2P collection add — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_collection_add(&["Product"]).is_err(),
+        "anonymous should be rejected from p2p collection add"
+    );
+    assert!(
+        node.p2p_collection_add_with_identity(&["Product"], outsider_key)
+            .is_err(),
+        "outsider should be rejected from p2p collection add"
+    );
+    node.p2p_collection_add_with_identity(&["Product"], &admin_key)
+        .expect("admin should add p2p collection");
+
+    // =========================================================================
+    // P2P collection list — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_collection_list().is_err(),
+        "anonymous should be rejected from p2p collection list"
+    );
+    assert!(
+        node.p2p_collection_list_with_identity(outsider_key)
+            .is_err(),
+        "outsider should be rejected from p2p collection list"
+    );
+    node.p2p_collection_list_with_identity(&admin_key)
+        .expect("admin should list p2p collections");
+
+    // =========================================================================
+    // P2P collection delete — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_collection_delete(&["Product"]).is_err(),
+        "anonymous should be rejected from p2p collection delete"
+    );
+    assert!(
+        node.p2p_collection_delete_with_identity(&["Product"], outsider_key)
+            .is_err(),
+        "outsider should be rejected from p2p collection delete"
+    );
+    node.p2p_collection_delete_with_identity(&["Product"], &admin_key)
+        .expect("admin should delete p2p collection");
+
+    // =========================================================================
+    // P2P document create — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_document_create(&[&doc_id]).is_err(),
+        "anonymous should be rejected from p2p document create"
+    );
+    assert!(
+        node.p2p_document_create_with_identity(&[&doc_id], outsider_key)
+            .is_err(),
+        "outsider should be rejected from p2p document create"
+    );
+    node.p2p_document_create_with_identity(&[&doc_id], &admin_key)
+        .expect("admin should add p2p document");
+
+    // =========================================================================
+    // P2P document list — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_document_list().is_err(),
+        "anonymous should be rejected from p2p document list"
+    );
+    assert!(
+        node.p2p_document_list_with_identity(outsider_key).is_err(),
+        "outsider should be rejected from p2p document list"
+    );
+    node.p2p_document_list_with_identity(&admin_key)
+        .expect("admin should list p2p documents");
+
+    // =========================================================================
+    // P2P document delete — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_document_delete(&[&doc_id]).is_err(),
+        "anonymous should be rejected from p2p document delete"
+    );
+    assert!(
+        node.p2p_document_delete_with_identity(&[&doc_id], outsider_key)
+            .is_err(),
+        "outsider should be rejected from p2p document delete"
+    );
+    node.p2p_document_delete_with_identity(&[&doc_id], &admin_key)
+        .expect("admin should delete p2p document");
+
+    // =========================================================================
+    // P2P replicator list — anonymous rejected, outsider rejected, admin accepted
+    // =========================================================================
+    assert!(
+        node.p2p_replicator_list().is_err(),
+        "anonymous should be rejected from p2p replicator list"
+    );
+    assert!(
+        node.p2p_replicator_list_with_identity(outsider_key)
+            .is_err(),
+        "outsider should be rejected from p2p replicator list"
+    );
+    node.p2p_replicator_list_with_identity(&admin_key)
+        .expect("admin should list p2p replicators");
+}

--- a/tools/integration-test/tests/nac_relation_admin.rs
+++ b/tools/integration-test/tests/nac_relation_admin.rs
@@ -1,0 +1,166 @@
+use integration_test::{for_each_runtime, generate_identity, TestCluster, PRODUCT_SCHEMA};
+
+for_each_runtime!(
+    nac_relation_admin,
+    nac_relation_admin_test,
+    .with_acp_local().with_nac()
+);
+
+async fn nac_relation_admin_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary = node.binary_path().to_path_buf();
+
+    let admin_key = cluster
+        .startup_identity()
+        .expect("NAC cluster must have startup identity")
+        .to_string();
+
+    let outsider = generate_identity(&binary).expect("outsider identity");
+    let outsider_key = &outsider.private_key_hex;
+
+    // Admin deploys schema and creates a document
+    node.schema_add_with_identity(PRODUCT_SCHEMA, &admin_key)
+        .expect("deploy schema");
+    node.query_with_identity(
+        r#"mutation { create_Product(input: {name: "Widget", sku: "W001", price: 100}) { _docID } }"#,
+        &admin_key,
+    )
+    .expect("create product");
+
+    // =========================================================================
+    // Phase 1: Verify outsider is DENIED
+    // =========================================================================
+
+    // schema_add → error
+    assert!(
+        node.schema_add_with_identity("type Gadget { label: String }", outsider_key,)
+            .is_err(),
+        "outsider should be denied schema_add before grant"
+    );
+
+    // query → error or empty results
+    let outsider_query = node.query_with_identity("query { Product { name } }", outsider_key);
+    let outsider_sees_nothing = match &outsider_query {
+        Err(_) => true,
+        Ok(val) => val["Product"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true),
+    };
+    assert!(
+        outsider_sees_nothing,
+        "outsider should see no data before grant"
+    );
+
+    // collection_list → error
+    assert!(
+        node.collection_list_with_identity(outsider_key).is_err(),
+        "outsider should be denied collection_list before grant"
+    );
+
+    // index_create → error
+    assert!(
+        node.index_create_with_identity(
+            "Product",
+            &["name"],
+            Some("idx_outsider"),
+            false,
+            outsider_key,
+        )
+        .is_err(),
+        "outsider should be denied index_create before grant"
+    );
+
+    // =========================================================================
+    // Phase 2: Admin grants NAC admin to outsider
+    // =========================================================================
+    node.acp_node_relationship_add("admin", &outsider.did, &admin_key)
+        .expect("grant outsider NAC admin");
+
+    // =========================================================================
+    // Phase 3: Verify outsider is now ALLOWED
+    // =========================================================================
+
+    // schema_add → succeeds
+    node.schema_add_with_identity("type Gadget { label: String }", outsider_key)
+        .expect("outsider should add schema after grant");
+
+    // query → returns data
+    let outsider_query = node
+        .query_with_identity("query { Product { name } }", outsider_key)
+        .expect("outsider should query after grant");
+    let count = outsider_query["Product"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert!(count > 0, "outsider should see data after grant");
+
+    // collection_list → returns list
+    let cols = node
+        .collection_list_with_identity(outsider_key)
+        .expect("outsider should list collections after grant");
+    assert!(
+        !cols.is_empty(),
+        "outsider should see collections after grant"
+    );
+
+    // index_create → succeeds
+    node.index_create_with_identity(
+        "Product",
+        &["name"],
+        Some("idx_outsider"),
+        false,
+        outsider_key,
+    )
+    .expect("outsider should create index after grant");
+
+    // =========================================================================
+    // Phase 4: Admin revokes NAC admin from outsider
+    // =========================================================================
+    node.acp_node_relationship_delete("admin", &outsider.did, &admin_key)
+        .expect("revoke outsider NAC admin");
+
+    // =========================================================================
+    // Phase 5: Verify outsider is DENIED again
+    // =========================================================================
+
+    // schema_add → error
+    assert!(
+        node.schema_add_with_identity("type Widget { code: String }", outsider_key,)
+            .is_err(),
+        "outsider should be denied schema_add after revoke"
+    );
+
+    // query → error or empty
+    let outsider_query = node.query_with_identity("query { Product { name } }", outsider_key);
+    let outsider_sees_nothing = match &outsider_query {
+        Err(_) => true,
+        Ok(val) => val["Product"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true),
+    };
+    assert!(
+        outsider_sees_nothing,
+        "outsider should see no data after revoke"
+    );
+
+    // collection_list → error
+    assert!(
+        node.collection_list_with_identity(outsider_key).is_err(),
+        "outsider should be denied collection_list after revoke"
+    );
+
+    // index_create → error
+    assert!(
+        node.index_create_with_identity(
+            "Product",
+            &["sku"],
+            Some("idx_revoked"),
+            false,
+            outsider_key,
+        )
+        .is_err(),
+        "outsider should be denied index_create after revoke"
+    );
+}


### PR DESCRIPTION
## Summary

- Add 12 missing `NodePermission` variants to match Go DefraDB's 48 node permissions (from merged PRs #4282-#4532 and open PRs #4528, #4534, #4540)
- Fix 14 HTTP handlers that used incorrect generic permissions (e.g., `IndexCreate` for encrypted index create, `P2pPeerConnect` for peer info) instead of dedicated operation-specific ones
- Add identity-aware client helpers and integration test (`nac_operations.rs`) verifying outsider rejection and admin acceptance for all gated endpoints

### New permissions
`EncryptedIndexCreate`, `EncryptedIndexList`, `EncryptedIndexListAll`, `EncryptedIndexDelete`, `P2pPeerActive`, `P2pSyncDocuments`, `P2pSyncCollectionVersions`, `P2pSyncBranchableCollection`, `LensCreate`, `ViewRefresh`, `ViewAdd`, `MigrationSet`

### Handler fixes (14 total)
| Handler | Old Permission | New Permission |
|---------|----------------|----------------|
| `encrypted_index.rs:go_create_encrypted_index` | `IndexCreate` | `EncryptedIndexCreate` |
| `encrypted_index.rs:go_list_encrypted_indexes` | `IndexList` | `EncryptedIndexList` |
| `encrypted_index.rs:go_list_all_encrypted_indexes` | `IndexList` | `EncryptedIndexListAll` |
| `encrypted_index.rs:go_delete_encrypted_index` | `IndexDrop` | `EncryptedIndexDelete` |
| `lens.rs:add_lens` | `CollectionPatch` | `LensCreate` |
| `lens.rs:set_migration` | `CollectionPatch` | `MigrationSet` |
| `lens.rs:list_lenses` | `CollectionGet` | `LensList` |
| `views.rs:add_view` | `CollectionPatch` | `ViewAdd` |
| `views.rs:refresh_views` | `CollectionGet` | `ViewRefresh` |
| `p2p/peers.rs:get_info` | `P2pPeerConnect` | `P2pPeerInfo` |
| `p2p/peers.rs:active_peers` | `P2pPeerConnect` | `P2pPeerActive` |
| `p2p/collections.rs:sync_branchable` | `P2pCollectionCreate` | `P2pSyncBranchableCollection` |
| `p2p/collections.rs:sync_versions` | `P2pCollectionCreate` | `P2pSyncCollectionVersions` |
| `p2p/documents.rs:sync_documents` | `P2pDocumentCreate` | `P2pSyncDocuments` |

## Test plan
- [x] `cargo test -p acp` — 54 tests pass (permission count, roundtrip, policy)
- [x] `cargo test` — all workspace tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [ ] `cargo test -p integration-test --test nac_operations -- --ignored` — NAC gate tests

Closes #455, closes #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)