### PR TITLE
feat: recursive execute explain for nested joins (Go PR #4471)

### DIFF
--- a/crates/query/src/plan/select.rs
+++ b/crates/query/src/plan/select.rs
@@ -176,51 +176,54 @@ impl SelectNode {
 
     /// Detect chained typeIndexJoin nodes in execute explain and flatten into a parallelNode.
     ///
-    /// In execute mode, the structure differs from default/debug:
+    /// With recursive execute explain, the structure is:
     /// ```json
-    /// { "typeIndexJoin": { "iterations": N, "typeIndexJoin": {...}, "subTypeScanNode": {...} } }
+    /// { "typeIndexJoin": { "iterations": N, "typeJoinMany": {
+    ///     "root": { "typeIndexJoin": { ... inner chain ... } },
+    ///     "subType": { ... }
+    /// } } }
     /// ```
-    /// The nested `typeIndexJoin` key (from parent_plan.explain_execute()) indicates a chain.
-    /// The innermost join's `scanNode` is the shared root.
+    /// The nested `typeIndexJoin` inside `root` indicates a chain.
+    /// The innermost join's `root` contains the shared scanNode.
     fn flatten_execute_join_chain(explain: &serde_json::Value) -> Option<serde_json::Value> {
         let obj = explain.as_object()?;
         let join_content = obj.get("typeIndexJoin")?.as_object()?;
 
-        // Check if this join contains another typeIndexJoin (indicating a chain)
-        join_content.get("typeIndexJoin")?;
+        // Navigate through the join type wrapper to find root
+        let root = Self::get_join_root(join_content)?;
+
+        // Check if root contains another typeIndexJoin (indicating a chain)
+        root.as_object()?.get("typeIndexJoin")?;
 
         // Walk the chain collecting all joins
         let mut joins_data: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
         let mut current = join_content.clone();
 
-        loop {
-            if let Some(inner_join) = current.get("typeIndexJoin").and_then(|v| v.as_object()) {
+        while let Some(r) = Self::get_join_root(&current) {
+            let current_root = r.clone();
+            if let Some(inner_join) = current_root
+                .as_object()
+                .and_then(|o| o.get("typeIndexJoin"))
+                .and_then(|v| v.as_object())
+            {
                 joins_data.push(current.clone());
                 current = inner_join.clone();
                 continue;
             }
-            // Innermost join - contains scanNode directly
+            // Innermost join - root contains the shared scanNode
             joins_data.push(current);
             break;
         }
 
-        // The innermost join has the scanNode (shared root metrics)
+        // The innermost join's root is the shared scanNode (e.g., {"scanNode": {...}})
         let innermost = joins_data.last()?;
-        let shared_scan_node = innermost.get("scanNode")?.clone();
+        let shared_root = Self::get_join_root(innermost)?.clone();
 
         // Build the parallel array in reverse order (innermost first = Go convention)
         let mut parallel_items: Vec<serde_json::Value> = Vec::new();
         for join_data in joins_data.iter().rev() {
-            let mut join_copy = serde_json::Map::new();
-            // Copy iterations and subTypeScanNode from this join
-            if let Some(iter) = join_data.get("iterations") {
-                join_copy.insert("iterations".to_string(), iter.clone());
-            }
-            // Set the shared scanNode on every join
-            join_copy.insert("scanNode".to_string(), shared_scan_node.clone());
-            if let Some(sub) = join_data.get("subTypeScanNode") {
-                join_copy.insert("subTypeScanNode".to_string(), sub.clone());
-            }
+            let mut join_copy = join_data.clone();
+            Self::set_join_root(&mut join_copy, shared_root.clone());
             parallel_items.push(serde_json::json!({
                 "typeIndexJoin": serde_json::Value::Object(join_copy)
             }));

--- a/crates/query/src/plan/type_join/type_join_many/plan_node.rs
+++ b/crates/query/src/plan/type_join/type_join_many/plan_node.rs
@@ -431,19 +431,52 @@ impl PlanNode for TypeJoinMany {
             serde_json::json!(self.exec_info.iterations),
         );
 
-        let parent_execute = self.parent_plan.explain_execute();
-        if let Some(parent_obj) = parent_execute.as_object() {
-            for (key, value) in parent_obj {
-                obj.insert(key.clone(), value.clone());
-            }
-        }
+        let mut inner_obj = serde_json::Map::new();
 
-        // Use simulated Go-compatible metrics for the child scan.
-        // Go re-initializes the child scanNode per parent, reading ALL children
-        // from the collection each time with an FK filter. Metrics accumulate.
+        // root = parent plan's execute explain
+        inner_obj.insert("root".to_string(), self.parent_plan.explain_execute());
+
+        // subType = child plan's execute explain wrapped in selectTopNode > selectNode
+        let child_execute = self.child_plan.explain_execute();
+        let child_is_select = self.child_plan.kind() == "selectNode";
+
+        let select_node_content = if child_is_select {
+            // Extract inner content to avoid double wrapping (selectNode > selectNode)
+            child_execute
+                .as_object()
+                .and_then(|o| o.get("selectNode"))
+                .cloned()
+                .unwrap_or(child_execute)
+        } else {
+            // Child is not a SelectNode (e.g., ScanNode or nested join).
+            // Synthesize selectNode metrics from captured child exec info.
+            let mut select_inner = serde_json::Map::new();
+            select_inner.insert(
+                "iterations".to_string(),
+                serde_json::json!(self.child_exec_info.iterations),
+            );
+            select_inner.insert(
+                "filterMatches".to_string(),
+                serde_json::json!(self.child_exec_info.docs_fetched),
+            );
+            if let Some(child_obj) = child_execute.as_object() {
+                for (key, value) in child_obj {
+                    select_inner.insert(key.clone(), value.clone());
+                }
+            }
+            serde_json::Value::Object(select_inner)
+        };
+
+        let sub_type = serde_json::json!({
+            "selectTopNode": {
+                "selectNode": select_node_content
+                }
+        });
+        inner_obj.insert("subType".to_string(), sub_type);
+
         obj.insert(
-            "subTypeScanNode".to_string(),
-            self.go_child_metrics.to_json(),
+            "typeJoinMany".to_string(),
+            serde_json::Value::Object(inner_obj),
         );
 
         serde_json::Value::Object(obj)

--- a/crates/query/src/plan/type_join/type_join_one.rs
+++ b/crates/query/src/plan/type_join/type_join_one.rs
@@ -864,39 +864,74 @@ impl PlanNode for TypeJoinOne {
             serde_json::json!(self.exec_info.iterations),
         );
 
+        let mut inner_obj = serde_json::Map::new();
+
         if matches!(
             self.direction,
             JoinDirection::InvertedIndex { .. } | JoinDirection::OrderedInvertedPrimary { .. }
         ) {
-            // Inverted/ordered modes: child index scan is the "root" scanNode,
-            // parent lookups are the "subType" scanNode.
-            let child_execute = self.child_plan.explain_execute();
-            if let Some(child_obj) = child_execute.as_object() {
-                for (key, value) in child_obj {
-                    obj.insert(key.clone(), value.clone());
-                }
-            }
-            // Parent lookup metrics accumulated per-child
-            obj.insert(
-                "subTypeScanNode".to_string(),
-                self.go_child_metrics.to_json(),
-            );
-        } else {
-            let parent_execute = self.parent_plan.explain_execute();
-            if let Some(parent_obj) = parent_execute.as_object() {
-                for (key, value) in parent_obj {
-                    obj.insert(key.clone(), value.clone());
-                }
-            }
+            // Inverted/ordered modes: child drives the loop, parent is looked up per-child.
+            // root = child plan's execute explain (the driving scan)
+            inner_obj.insert("root".to_string(), self.child_plan.explain_execute());
 
-            // Use simulated Go-compatible metrics for the child scan.
-            // Go re-initializes the child scanNode per parent with a docID-specific prefix,
-            // calling Next() once per parent. Metrics accumulate across all parent lookups.
-            obj.insert(
-                "subTypeScanNode".to_string(),
-                self.go_child_metrics.to_json(),
-            );
+            // subType = parent lookup metrics as a synthetic scanNode
+            let sub_type = serde_json::json!({
+                "selectTopNode": {
+                    "selectNode": {
+                        "scanNode": self.go_child_metrics.to_json()
+                    }
+                }
+            });
+            inner_obj.insert("subType".to_string(), sub_type);
+        } else {
+            // Normal (Primary/Inverted) mode:
+            // root = parent plan's execute explain
+            inner_obj.insert("root".to_string(), self.parent_plan.explain_execute());
+
+            // subType = child plan's execute explain wrapped in selectTopNode > selectNode
+            let child_execute = self.child_plan.explain_execute();
+            let child_is_select = self.child_plan.kind() == "selectNode";
+
+            let select_node_content = if child_is_select {
+                // Extract inner content to avoid double wrapping (selectNode > selectNode)
+                child_execute
+                    .as_object()
+                    .and_then(|o| o.get("selectNode"))
+                    .cloned()
+                    .unwrap_or(child_execute)
+            } else {
+                // Child is not a SelectNode (e.g., ScanNode or nested TypeJoinOne).
+                // Synthesize selectNode metrics from captured child exec info,
+                // matching Go's selectNode wrapper which tracks its own iterations.
+                let mut select_inner = serde_json::Map::new();
+                select_inner.insert(
+                    "iterations".to_string(),
+                    serde_json::json!(self.child_exec_info.iterations),
+                );
+                select_inner.insert(
+                    "filterMatches".to_string(),
+                    serde_json::json!(self.child_exec_info.docs_fetched),
+                );
+                if let Some(child_obj) = child_execute.as_object() {
+                    for (key, value) in child_obj {
+                        select_inner.insert(key.clone(), value.clone());
+                    }
+                }
+                serde_json::Value::Object(select_inner)
+            };
+
+            let sub_type = serde_json::json!({
+                "selectTopNode": {
+                    "selectNode": select_node_content
+                }
+            });
+            inner_obj.insert("subType".to_string(), sub_type);
         }
+
+        obj.insert(
+            "typeJoinOne".to_string(),
+            serde_json::Value::Object(inner_obj),
+        );
 
         serde_json::Value::Object(obj)
     }

--- a/tools/integration-test/tests/explain_nested.rs
+++ b/tools/integration-test/tests/explain_nested.rs
@@ -1,0 +1,260 @@
+use integration_test::{for_each_runtime, TestCluster};
+use serde_json::Value;
+
+/// Verify that a node object contains the standard scanNode metrics as numbers.
+fn assert_scan_node_metrics(node: &Value, context: &str) {
+    for key in &["iterations", "docFetches", "fieldFetches", "indexFetches"] {
+        let val = node
+            .get(key)
+            .unwrap_or_else(|| panic!("{context}: scanNode missing '{key}'"));
+        assert!(
+            val.is_number(),
+            "{context}: scanNode '{key}' should be numeric, got {val}"
+        );
+    }
+}
+
+/// Test recursive execute explain with 2-level deep nested one-to-one joins.
+///
+/// Mirrors Go's TestExecuteExplainWithTwoLevelDeepNestedJoins from PR #4471.
+/// Schema: Author -> AuthorContact -> ContactAddress (3-level, all one-to-one)
+///
+/// Expected structure:
+/// ```
+/// selectTopNode > selectNode > typeIndexJoin > typeJoinOne > {
+///   root: { scanNode: {...} },
+///   subType: { selectTopNode > selectNode > typeIndexJoin > typeJoinOne > {
+///     root: { scanNode: {...} },
+///     subType: { selectTopNode > selectNode > scanNode: {...} }
+///   }}
+/// }
+/// ```
+async fn explain_nested_execute_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    // Schema matching Go's explain test fixture (one-to-one with @primary)
+    client
+        .schema_add(
+            r#"
+            type Author {
+                name: String
+                age: Int
+                verified: Boolean
+                contact: AuthorContact @primary
+            }
+            type AuthorContact {
+                cell: String
+                email: String
+                author: Author
+                address: ContactAddress @primary
+            }
+            type ContactAddress {
+                city: String
+                country: String
+                contact: AuthorContact
+            }
+            "#,
+        )
+        .expect("schema add failed");
+
+    // Create test data (bottom-up to satisfy FK constraints)
+
+    // 2 ContactAddress documents
+    client
+        .query(r#"mutation { create_ContactAddress(input: {city: "Waterloo", country: "Canada"}) { _docID } }"#)
+        .expect("create address 1");
+    let addr2 = client
+        .query(r#"mutation { create_ContactAddress(input: {city: "Brampton", country: "Canada"}) { _docID } }"#)
+        .expect("create address 2");
+    let _ = addr2["create_ContactAddress"][0]["_docID"]
+        .as_str()
+        .expect("address 2 _docID");
+
+    // 2 AuthorContact documents (linked to addresses via _addressID)
+    // First query for address IDs
+    let addresses = client
+        .query(r#"query { ContactAddress { _docID city } }"#)
+        .expect("query addresses");
+    let addr_arr = addresses["ContactAddress"]
+        .as_array()
+        .expect("address array");
+    let addr_id_0 = addr_arr[0]["_docID"].as_str().expect("addr 0 id");
+    let addr_id_1 = addr_arr[1]["_docID"].as_str().expect("addr 1 id");
+
+    client
+        .query(&format!(
+            r#"mutation {{ create_AuthorContact(input: {{cell: "5197212301", email: "john@example.com", address_id: "{addr_id_0}"}}) {{ _docID }} }}"#,
+        ))
+        .expect("create contact 1");
+    client
+        .query(&format!(
+            r#"mutation {{ create_AuthorContact(input: {{cell: "5197212302", email: "cornelia@example.com", address_id: "{addr_id_1}"}}) {{ _docID }} }}"#,
+        ))
+        .expect("create contact 2");
+
+    // 2 Author documents (linked to contacts via _contactID)
+    let contacts = client
+        .query(r#"query { AuthorContact { _docID email } }"#)
+        .expect("query contacts");
+    let contact_arr = contacts["AuthorContact"].as_array().expect("contact array");
+    let contact_id_0 = contact_arr[0]["_docID"].as_str().expect("contact 0 id");
+    let contact_id_1 = contact_arr[1]["_docID"].as_str().expect("contact 1 id");
+
+    client
+        .query(&format!(
+            r#"mutation {{ create_Author(input: {{name: "John Grisham", age: 65, verified: true, contact_id: "{contact_id_0}"}}) {{ _docID }} }}"#,
+        ))
+        .expect("create author 1");
+    client
+        .query(&format!(
+            r#"mutation {{ create_Author(input: {{name: "Cornelia Funke", age: 62, verified: false, contact_id: "{contact_id_1}"}}) {{ _docID }} }}"#,
+        ))
+        .expect("create author 2");
+
+    // Run execute explain on the 3-level nested query (matches Go test exactly)
+    let explain_result = client
+        .query(
+            r#"query @explain(type: execute) {
+                Author {
+                    name
+                    contact {
+                        email
+                        address {
+                            city
+                        }
+                    }
+                }
+            }"#,
+        )
+        .expect("explain query");
+
+    // The result may be wrapped in an array (explain returns operationNode array)
+    let explain = if explain_result.is_array() {
+        explain_result[0].clone()
+    } else {
+        explain_result.clone()
+    };
+
+    // Navigate the explain tree.
+    // Go wraps in: explain > operationNode > [{ selectTopNode > ... }]
+    // Rust may return the tree directly or wrapped.
+    let select_top = explain
+        .get("explain")
+        .and_then(|e| {
+            e.get("operationNode")
+                .and_then(|op| op.as_array())
+                .and_then(|arr| arr.first())
+                .and_then(|first| first.get("selectTopNode"))
+                .or_else(|| e.get("selectTopNode"))
+        })
+        .or_else(|| explain.get("selectTopNode"))
+        .unwrap_or_else(|| panic!("Expected selectTopNode in explain output: {explain}"));
+
+    let select_node = select_top
+        .get("selectNode")
+        .unwrap_or_else(|| panic!("Expected selectNode: {select_top}"));
+
+    // selectNode: iterations and filterMatches
+    assert!(
+        select_node.get("iterations").unwrap().is_number(),
+        "selectNode iterations should be numeric"
+    );
+    assert!(
+        select_node.get("filterMatches").unwrap().is_number(),
+        "selectNode filterMatches should be numeric"
+    );
+
+    // Level 1: Author -> AuthorContact (typeIndexJoin > typeJoinOne)
+    let outer_join = select_node
+        .get("typeIndexJoin")
+        .unwrap_or_else(|| panic!("Expected typeIndexJoin in selectNode: {select_node}"));
+
+    assert!(
+        outer_join.get("iterations").unwrap().is_number(),
+        "outer typeIndexJoin iterations should be numeric"
+    );
+
+    let join_one = outer_join
+        .get("typeJoinOne")
+        .unwrap_or_else(|| panic!("Expected typeJoinOne in outer join: {outer_join}"));
+
+    // root: Author scanNode
+    let root = join_one
+        .get("root")
+        .unwrap_or_else(|| panic!("Expected root in typeJoinOne: {join_one}"));
+    let root_scan = root
+        .get("scanNode")
+        .unwrap_or_else(|| panic!("Expected scanNode in root: {root}"));
+    assert_scan_node_metrics(root_scan, "Author root scanNode");
+
+    // subType: selectTopNode > selectNode > (nested join or scanNode)
+    let sub_type = join_one
+        .get("subType")
+        .unwrap_or_else(|| panic!("Expected subType in typeJoinOne: {join_one}"));
+    let sub_select_top = sub_type
+        .get("selectTopNode")
+        .unwrap_or_else(|| panic!("Expected selectTopNode in subType: {sub_type}"));
+    let sub_select = sub_select_top
+        .get("selectNode")
+        .unwrap_or_else(|| panic!("Expected selectNode in sub selectTopNode: {sub_select_top}"));
+
+    assert!(
+        sub_select.get("iterations").unwrap().is_number(),
+        "sub selectNode iterations should be numeric"
+    );
+    assert!(
+        sub_select.get("filterMatches").unwrap().is_number(),
+        "sub selectNode filterMatches should be numeric"
+    );
+
+    // Level 2: AuthorContact -> ContactAddress (nested typeIndexJoin > typeJoinOne)
+    let inner_join = sub_select
+        .get("typeIndexJoin")
+        .unwrap_or_else(|| panic!("Expected nested typeIndexJoin in sub selectNode: {sub_select}"));
+
+    assert!(
+        inner_join.get("iterations").unwrap().is_number(),
+        "inner typeIndexJoin iterations should be numeric"
+    );
+
+    let inner_join_one = inner_join
+        .get("typeJoinOne")
+        .unwrap_or_else(|| panic!("Expected typeJoinOne in inner join: {inner_join}"));
+
+    // inner root: AuthorContact scanNode
+    let inner_root = inner_join_one
+        .get("root")
+        .unwrap_or_else(|| panic!("Expected root in inner typeJoinOne: {inner_join_one}"));
+    let inner_root_scan = inner_root
+        .get("scanNode")
+        .unwrap_or_else(|| panic!("Expected scanNode in inner root: {inner_root}"));
+    assert_scan_node_metrics(inner_root_scan, "AuthorContact inner root scanNode");
+
+    // inner subType: selectTopNode > selectNode > scanNode (leaf level)
+    let inner_sub_type = inner_join_one
+        .get("subType")
+        .unwrap_or_else(|| panic!("Expected subType in inner typeJoinOne: {inner_join_one}"));
+    let inner_sub_select_top = inner_sub_type
+        .get("selectTopNode")
+        .unwrap_or_else(|| panic!("Expected selectTopNode in inner subType: {inner_sub_type}"));
+    let inner_sub_select = inner_sub_select_top.get("selectNode").unwrap_or_else(|| {
+        panic!("Expected selectNode in inner sub selectTopNode: {inner_sub_select_top}")
+    });
+
+    assert!(
+        inner_sub_select.get("iterations").unwrap().is_number(),
+        "inner sub selectNode iterations should be numeric"
+    );
+    assert!(
+        inner_sub_select.get("filterMatches").unwrap().is_number(),
+        "inner sub selectNode filterMatches should be numeric"
+    );
+
+    // Leaf scanNode: ContactAddress
+    let leaf_scan = inner_sub_select
+        .get("scanNode")
+        .unwrap_or_else(|| panic!("Expected scanNode in inner sub selectNode: {inner_sub_select}"));
+    assert_scan_node_metrics(leaf_scan, "ContactAddress leaf scanNode");
+}
+
+for_each_runtime!(explain_nested_execute, explain_nested_execute_test);


### PR DESCRIPTION
## Summary

- Make `@explain(type: execute)` recursively traverse nested join sub-nodes so the full plan tree is visible for multi-level relations (e.g., Author → Contact → Address)
- Previously, execute explain produced flat `subTypeScanNode` metrics; now it produces recursive `typeJoinOne`/`typeJoinMany` wrappers with `root` and `subType`, matching Go's structure from PR #4471
- Update `SelectNode::flatten_execute_join_chain()` to navigate through the new `typeJoinOne`/`typeJoinMany` wrappers when detecting parallel join chains
- Add integration test mirroring Go's `TestExecuteExplainWithTwoLevelDeepNestedJoins`

## Test plan

- [x] `cargo test -p query` — unit tests pass
- [x] `cargo clippy --all -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo test -p integration-test --test explain_nested -- --ignored rust_explain_nested_execute` — new test passes
- [ ] Full Rust integration test suite (`cargo test -p integration-test -- --ignored rust_`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)