### PR TITLE
refactor: abstract SourceHub client behind SourceHubProvider trait

### DIFF
--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -500,17 +500,17 @@ impl Node {
                     )
                 })?;
 
-                let client = sourcehub::SourceHubClient::new(
-                    config.acp.sourcehub_address.clone(),
-                    config.acp.sourcehub_comet_address.clone(),
+                let provider = Arc::new(
+                    sourcehub::CosmosProvider::new(
+                        config.acp.sourcehub_address.clone(),
+                        config.acp.sourcehub_comet_address.clone(),
+                        signer_key_bytes,
+                        &config.acp.sourcehub_chain_id,
+                    )
+                    .map_err(|e| Error::InvalidConfig(format!("SourceHub provider: {}", e)))?,
                 );
-                let signer = sourcehub::TxSigner::from_secp256k1_bytes(
-                    signer_key_bytes,
-                    &config.acp.sourcehub_chain_id,
-                )
-                .map_err(|e| Error::InvalidConfig(format!("SourceHub signer: {}", e)))?;
 
-                let sh_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(client, signer));
+                let sh_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(provider));
                 let sh_adapter = crate::sourcehub_acp_adapter::SourceHubAcpAdapter::new_arc(
                     sh_acp.clone(),
                     zanzibar_store.clone(),

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use identity::Identity;
+use sourcehub::SourceHubProvider;
 
 use crate::state::{FfiStore, NodeState, PolicyStore, NODES};
 use crate::try_ffi;
@@ -224,11 +225,12 @@ pub extern "C" fn new_node(options: NodeInitOptions) -> NewNodeResult {
                     "sourcehub_signer_key is required when SourceHub is configured".to_string(),
                 );
             };
-            let sh_client = sourcehub::SourceHubClient::new(grpc_addr, comet_addr);
-            let sh_signer = sourcehub::TxSigner::from_secp256k1_bytes(signer_key, &chain_id)
-                .map_err(|e| format!("failed to create SourceHub signer: {}", e))?;
-            tracing::debug!(validator = %sh_signer.address(), "SourceHub ACP configured");
-            let sh_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(sh_client, sh_signer));
+            let provider = Arc::new(
+                sourcehub::CosmosProvider::new(grpc_addr, comet_addr, signer_key, &chain_id)
+                    .map_err(|e| format!("failed to create SourceHub provider: {}", e))?,
+            );
+            tracing::debug!(validator = %provider.authorized_account(), "SourceHub ACP configured");
+            let sh_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(provider));
             (sh_acp.clone() as Arc<dyn acp::DocumentACP>, Some(sh_acp))
         } else if db_path_opt.is_some() {
             // File-based storage: use persistent ACP store (namespace isolated in main DB)

--- a/crates/ffi/src/p2p/node.rs
+++ b/crates/ffi/src/p2p/node.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use identity::Identity;
+use sourcehub::SourceHubProvider;
 
 use blockstore::DefraBlockstore;
 use p2p::bitswap::BitswapStoreAdapter;
@@ -474,11 +475,12 @@ pub unsafe extern "C" fn new_node_with_p2p(
             } else {
                 return Err("sourcehub_signer_key is required when SourceHub is configured".to_string());
             };
-            let sh_client = sourcehub::SourceHubClient::new(grpc_addr, comet_addr);
-            let sh_signer = sourcehub::TxSigner::from_secp256k1_bytes(signer_key, &chain_id)
-                .map_err(|e| format!("failed to create SourceHub signer: {}", e))?;
-            tracing::debug!(validator = %sh_signer.address(), "SourceHub ACP configured");
-            let sh_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(sh_client, sh_signer));
+            let provider = Arc::new(
+                sourcehub::CosmosProvider::new(grpc_addr, comet_addr, signer_key, &chain_id)
+                    .map_err(|e| format!("failed to create SourceHub provider: {}", e))?,
+            );
+            tracing::debug!(validator = %provider.authorized_account(), "SourceHub ACP configured");
+            let sh_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(provider));
             (sh_acp.clone() as Arc<dyn acp::DocumentACP>, Some(sh_acp))
         } else if db_path_opt.is_some() {
             // File-based storage: use persistent ACP store (namespace isolated in main DB)

--- a/crates/sourcehub/src/client.rs
+++ b/crates/sourcehub/src/client.rs
@@ -2,7 +2,7 @@
 ///
 /// Uses the Cosmos LCD REST API for queries (avoids proto compilation)
 /// and CometBFT JSON-RPC for transaction broadcast.
-pub struct SourceHubClient {
+pub(crate) struct SourceHubClient {
     /// LCD/REST base URL derived from gRPC address (same host, port 1317 or LCD port)
     grpc_address: String,
     /// CometBFT RPC address for broadcast_tx_sync
@@ -12,7 +12,7 @@ pub struct SourceHubClient {
 }
 
 impl SourceHubClient {
-    pub fn new(grpc_address: String, comet_rpc_address: String) -> Self {
+    pub(crate) fn new(grpc_address: String, comet_rpc_address: String) -> Self {
         Self {
             grpc_address,
             comet_rpc_address,
@@ -21,7 +21,10 @@ impl SourceHubClient {
     }
 
     /// Query a policy by ID.
-    pub async fn query_policy(&self, policy_id: &str) -> Result<Option<PolicyInfo>, ClientError> {
+    pub(crate) async fn query_policy(
+        &self,
+        policy_id: &str,
+    ) -> Result<Option<PolicyInfo>, ClientError> {
         let url = format!(
             "{}/sourcenetwork/sourcehub/acp/policy/{}",
             self.rest_base_url(),
@@ -53,7 +56,7 @@ impl SourceHubClient {
 
     /// Query the owner of an object registered under a policy.
     /// Returns (is_registered, owner_did).
-    pub async fn query_object_owner(
+    pub(crate) async fn query_object_owner(
         &self,
         policy_id: &str,
         resource: &str,
@@ -87,7 +90,7 @@ impl SourceHubClient {
     ///
     /// Uses CometBFT ABCI query with protobuf-encoded request since
     /// the REST/LCD endpoint doesn't support repeated nested fields in GET params.
-    pub async fn verify_access(
+    pub(crate) async fn verify_access(
         &self,
         policy_id: &str,
         resource: &str,
@@ -140,7 +143,7 @@ impl SourceHubClient {
     }
 
     /// Query account number and sequence for transaction signing.
-    pub async fn query_account(&self, address: &str) -> Result<(u64, u64), ClientError> {
+    pub(crate) async fn query_account(&self, address: &str) -> Result<(u64, u64), ClientError> {
         let url = format!(
             "{}/cosmos/auth/v1beta1/accounts/{}",
             self.rest_base_url(),
@@ -169,7 +172,7 @@ impl SourceHubClient {
 
     /// Broadcast a signed transaction via CometBFT JSON-RPC.
     /// Returns the tx hash on success.
-    pub async fn broadcast_tx_sync(&self, tx_bytes: &[u8]) -> Result<String, ClientError> {
+    pub(crate) async fn broadcast_tx_sync(&self, tx_bytes: &[u8]) -> Result<String, ClientError> {
         let tx_b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, tx_bytes);
         let url = self.comet_rpc_base_url();
         let body = serde_json::json!({
@@ -198,7 +201,7 @@ impl SourceHubClient {
 
     /// Wait for a transaction to be included in a block.
     /// Returns the full CometBFT tx query response on success.
-    pub async fn await_tx(
+    pub(crate) async fn await_tx(
         &self,
         tx_hash: &str,
         timeout_ms: u64,
@@ -261,13 +264,13 @@ impl SourceHubClient {
 }
 
 #[derive(Debug, Clone)]
-pub struct PolicyInfo {
+pub(crate) struct PolicyInfo {
     pub id: String,
     pub name: String,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum ClientError {
+pub(crate) enum ClientError {
     #[error("HTTP request failed: {0}")]
     Http(#[from] reqwest::Error),
 

--- a/crates/sourcehub/src/cosmos.rs
+++ b/crates/sourcehub/src/cosmos.rs
@@ -1,0 +1,189 @@
+use async_trait::async_trait;
+
+use crate::client::SourceHubClient;
+use crate::provider::{ProviderError, ProviderPolicyInfo, SourceHubProvider, SubjectRef};
+use crate::tx::TxSigner;
+
+/// SourceHub provider backed by Cosmos SDK (REST/LCD + CometBFT).
+pub struct CosmosProvider {
+    client: SourceHubClient,
+    signer: TxSigner,
+}
+
+impl CosmosProvider {
+    pub fn new(
+        grpc_address: String,
+        comet_address: String,
+        signer_key: &[u8],
+        chain_id: &str,
+    ) -> Result<Self, ProviderError> {
+        let client = SourceHubClient::new(grpc_address, comet_address);
+        let signer = TxSigner::from_secp256k1_bytes(signer_key, chain_id)
+            .map_err(|e| ProviderError::Config(e.to_string()))?;
+        Ok(Self { client, signer })
+    }
+}
+
+fn subject_to_json(subject: &SubjectRef) -> serde_json::Value {
+    match subject {
+        SubjectRef::Actor(did) => serde_json::json!({ "actor": { "id": did } }),
+        SubjectRef::AllActors => serde_json::json!({ "all_actors": {} }),
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl SourceHubProvider for CosmosProvider {
+    fn authorized_account(&self) -> String {
+        self.signer.address()
+    }
+
+    async fn create_policy(&self, policy_yaml: &str) -> Result<String, ProviderError> {
+        self.signer
+            .create_policy(&self.client, policy_yaml)
+            .await
+            .map_err(|e| ProviderError::Transaction(e.to_string()))
+    }
+
+    async fn register_object(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+    ) -> Result<(), ProviderError> {
+        let cmd = serde_json::json!({
+            "register_object_cmd": {
+                "object": { "resource": resource, "id": object_id }
+            }
+        });
+        self.signer
+            .bearer_policy_cmd(&self.client, bearer_token, policy_id, cmd)
+            .await
+            .map_err(|e| ProviderError::Transaction(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn archive_object(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+    ) -> Result<(), ProviderError> {
+        let cmd = serde_json::json!({
+            "archive_object_cmd": {
+                "object": { "resource": resource, "id": object_id }
+            }
+        });
+        self.signer
+            .bearer_policy_cmd(&self.client, bearer_token, policy_id, cmd)
+            .await
+            .map_err(|e| ProviderError::Transaction(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn set_relationship(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        subject: &SubjectRef,
+    ) -> Result<bool, ProviderError> {
+        let cmd = serde_json::json!({
+            "set_relationship_cmd": {
+                "relationship": {
+                    "object": { "resource": resource, "id": object_id },
+                    "relation": relation,
+                    "subject": subject_to_json(subject),
+                }
+            }
+        });
+        let result = self
+            .signer
+            .bearer_policy_cmd(&self.client, bearer_token, policy_id, cmd)
+            .await
+            .map_err(|e| ProviderError::Transaction(e.to_string()))?;
+
+        let record_existed = result
+            .get("record_existed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        Ok(!record_existed)
+    }
+
+    async fn delete_relationship(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        subject: &SubjectRef,
+    ) -> Result<bool, ProviderError> {
+        let cmd = serde_json::json!({
+            "delete_relationship_cmd": {
+                "relationship": {
+                    "object": { "resource": resource, "id": object_id },
+                    "relation": relation,
+                    "subject": subject_to_json(subject),
+                }
+            }
+        });
+        let result = self
+            .signer
+            .bearer_policy_cmd(&self.client, bearer_token, policy_id, cmd)
+            .await
+            .map_err(|e| ProviderError::Transaction(e.to_string()))?;
+
+        let record_found = result
+            .get("record_found")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        Ok(record_found)
+    }
+
+    async fn query_policy(
+        &self,
+        policy_id: &str,
+    ) -> Result<Option<ProviderPolicyInfo>, ProviderError> {
+        self.client
+            .query_policy(policy_id)
+            .await
+            .map(|opt| {
+                opt.map(|p| ProviderPolicyInfo {
+                    id: p.id,
+                    name: p.name,
+                })
+            })
+            .map_err(|e| ProviderError::Query(e.to_string()))
+    }
+
+    async fn query_object_owner(
+        &self,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+    ) -> Result<(bool, String), ProviderError> {
+        self.client
+            .query_object_owner(policy_id, resource, object_id)
+            .await
+            .map_err(|e| ProviderError::Query(e.to_string()))
+    }
+
+    async fn verify_access(
+        &self,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        permission: &str,
+        actor_did: &str,
+    ) -> Result<bool, ProviderError> {
+        self.client
+            .verify_access(policy_id, resource, object_id, permission, actor_did)
+            .await
+            .map_err(|e| ProviderError::Query(e.to_string()))
+    }
+}

--- a/crates/sourcehub/src/dac.rs
+++ b/crates/sourcehub/src/dac.rs
@@ -1,8 +1,10 @@
 //! SourceHub DocumentACP implementation.
 //!
-//! Implements the `DocumentACP` trait by communicating with a SourceHub
-//! blockchain node via REST/LCD queries and CometBFT transaction broadcast.
+//! Implements the `DocumentACP` trait by delegating to a `SourceHubProvider`
+//! for all on-chain communication. The provider abstraction allows swapping
+//! between Cosmos SDK and EVM backends.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -10,37 +12,33 @@ use identity::Did;
 
 use acp::{DocumentACP, DocumentPermission, Identity, Result};
 
-use crate::client::SourceHubClient;
-use crate::tx::TxSigner;
+use crate::provider::{ProviderError, SourceHubProvider, SubjectRef};
 
 /// DocumentACP backed by SourceHub's on-chain x/acp module.
 ///
-/// Write operations (register, relationship changes) are submitted as
-/// Cosmos SDK transactions using bearer token authentication.
-/// Read operations (is_registered, check_access) use REST/LCD queries.
+/// Delegates write and read operations to a `SourceHubProvider` implementation.
 pub struct SourceHubDocumentACP {
-    client: SourceHubClient,
-    signer: TxSigner,
+    provider: Arc<dyn SourceHubProvider>,
 }
 
 impl SourceHubDocumentACP {
-    pub fn new(client: SourceHubClient, signer: TxSigner) -> Self {
-        Self { client, signer }
+    pub fn new(provider: Arc<dyn SourceHubProvider>) -> Self {
+        Self { provider }
     }
 
-    /// Create a policy on SourceHub. Returns the tx hash.
+    /// Create a policy on SourceHub. Returns the policy ID.
     pub async fn add_policy(
         &self,
         _creator_did: &str,
         policy_yaml: &str,
-    ) -> std::result::Result<String, crate::tx::TxSignerError> {
-        self.signer.create_policy(&self.client, policy_yaml).await
+    ) -> std::result::Result<String, ProviderError> {
+        self.provider.create_policy(policy_yaml).await
     }
 
     /// Generate a bearer token for the given DID.
     ///
     /// Looks up the identity's signing config from the global store,
-    /// creates a JWT with `authorized_account` set to the validator address.
+    /// creates a JWT with `authorized_account` set to the provider's account.
     fn create_bearer_token(&self, did: &str) -> std::result::Result<String, acp::Error> {
         let signing_config = defra_core::signing::get_identity(did).ok_or_else(|| {
             acp::Error::PermissionDenied(format!("no signing config found for DID: {}", did))
@@ -67,7 +65,7 @@ impl SourceHubDocumentACP {
             &raw_identity,
             Duration::from_secs(300), // 5 minute validity
             None,
-            Some(self.signer.address()),
+            Some(self.provider.authorized_account()),
         )
         .map_err(|e| {
             acp::Error::PermissionDenied(format!("failed to create bearer token: {}", e))
@@ -77,30 +75,18 @@ impl SourceHubDocumentACP {
             acp::Error::PermissionDenied(format!("bearer token is not valid UTF-8: {}", e))
         })
     }
+}
 
-    /// Execute a bearer policy command transaction.
-    async fn bearer_cmd(
-        &self,
-        did: &str,
-        policy_id: &str,
-        cmd: serde_json::Value,
-    ) -> Result<serde_json::Value> {
-        let bearer_token = self.create_bearer_token(did)?;
-        self.signer
-            .bearer_policy_cmd(&self.client, &bearer_token, policy_id, cmd)
-            .await
-            .map_err(|e| acp::Error::Storage(format!("SourceHub tx failed: {}", e)))
+fn did_to_subject(target: &Did) -> SubjectRef {
+    if target.as_str() == "*" {
+        SubjectRef::AllActors
+    } else {
+        SubjectRef::Actor(target.as_str().to_string())
     }
 }
 
-/// Build a JSON subject for SourceHub protobuf encoding.
-/// Wildcard DID (`*`) maps to `all_actors`, regular DIDs map to `actor`.
-fn build_subject_json(target: &Did) -> serde_json::Value {
-    if target.as_str() == "*" {
-        serde_json::json!({ "all_actors": {} })
-    } else {
-        serde_json::json!({ "actor": { "id": target.as_str() } })
-    }
+fn provider_err(e: ProviderError) -> acp::Error {
+    acp::Error::Storage(format!("SourceHub: {}", e))
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -113,16 +99,11 @@ impl DocumentACP for SourceHubDocumentACP {
         resource_name: &str,
         doc_id: &str,
     ) -> Result<()> {
-        let cmd = serde_json::json!({
-            "register_object_cmd": {
-                "object": {
-                    "resource": resource_name,
-                    "id": doc_id,
-                }
-            }
-        });
-        self.bearer_cmd(identity.as_str(), policy_id, cmd).await?;
-        Ok(())
+        let bearer_token = self.create_bearer_token(identity.as_str())?;
+        self.provider
+            .register_object(&bearer_token, policy_id, resource_name, doc_id)
+            .await
+            .map_err(provider_err)
     }
 
     async fn is_doc_registered(
@@ -132,10 +113,10 @@ impl DocumentACP for SourceHubDocumentACP {
         doc_id: &str,
     ) -> Result<bool> {
         let (is_registered, _owner) = self
-            .client
+            .provider
             .query_object_owner(policy_id, resource_name, doc_id)
             .await
-            .map_err(|e| acp::Error::Storage(format!("SourceHub query failed: {}", e)))?;
+            .map_err(provider_err)?;
         Ok(is_registered)
     }
 
@@ -149,10 +130,10 @@ impl DocumentACP for SourceHubDocumentACP {
     ) -> Result<bool> {
         // Unregistered docs are public
         let (is_registered, _owner) = self
-            .client
+            .provider
             .query_object_owner(policy_id, resource_name, doc_id)
             .await
-            .map_err(|e| acp::Error::Storage(format!("SourceHub query failed: {}", e)))?;
+            .map_err(provider_err)?;
 
         if !is_registered {
             return Ok(true);
@@ -182,10 +163,10 @@ impl DocumentACP for SourceHubDocumentACP {
 
         for perm in permissions_to_check {
             let has_access = self
-                .client
+                .provider
                 .verify_access(policy_id, resource_name, doc_id, perm.as_str(), &actor_did)
                 .await
-                .map_err(|e| acp::Error::Storage(format!("SourceHub query failed: {}", e)))?;
+                .map_err(provider_err)?;
 
             if has_access {
                 return Ok(true);
@@ -205,28 +186,19 @@ impl DocumentACP for SourceHubDocumentACP {
         relation: &str,
         _managing_relations: &[String],
     ) -> Result<bool> {
-        let subject = build_subject_json(target);
-        let cmd = serde_json::json!({
-            "set_relationship_cmd": {
-                "relationship": {
-                    "object": {
-                        "resource": resource_name,
-                        "id": doc_id,
-                    },
-                    "relation": relation,
-                    "subject": subject,
-                }
-            }
-        });
-        let result = self.bearer_cmd(requestor.as_str(), policy_id, cmd).await?;
-
-        // SourceHub returns RecordExisted in the tx result.
-        // Go wrapper: ExistedAlready = !added. So added = !record_existed.
-        let record_existed = result
-            .get("record_existed")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        Ok(!record_existed)
+        let bearer_token = self.create_bearer_token(requestor.as_str())?;
+        let subject = did_to_subject(target);
+        self.provider
+            .set_relationship(
+                &bearer_token,
+                policy_id,
+                resource_name,
+                doc_id,
+                relation,
+                &subject,
+            )
+            .await
+            .map_err(provider_err)
     }
 
     async fn delete_actor_relationship(
@@ -239,28 +211,19 @@ impl DocumentACP for SourceHubDocumentACP {
         relation: &str,
         _managing_relations: &[String],
     ) -> Result<bool> {
-        let subject = build_subject_json(target);
-        let cmd = serde_json::json!({
-            "delete_relationship_cmd": {
-                "relationship": {
-                    "object": {
-                        "resource": resource_name,
-                        "id": doc_id,
-                    },
-                    "relation": relation,
-                    "subject": subject,
-                }
-            }
-        });
-        let result = self.bearer_cmd(requestor.as_str(), policy_id, cmd).await?;
-
-        // SourceHub returns RecordFound in the tx result.
-        // Go wrapper: RecordFound = deleted. No negation needed.
-        let record_found = result
-            .get("record_found")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
-        Ok(record_found)
+        let bearer_token = self.create_bearer_token(requestor.as_str())?;
+        let subject = did_to_subject(target);
+        self.provider
+            .delete_relationship(
+                &bearer_token,
+                policy_id,
+                resource_name,
+                doc_id,
+                relation,
+                &subject,
+            )
+            .await
+            .map_err(provider_err)
     }
 
     async fn unregister_doc_object(
@@ -272,24 +235,19 @@ impl DocumentACP for SourceHubDocumentACP {
         // Unregister needs a bearer token from the owner.
         // Query the owner first, then use their identity.
         let (_is_registered, owner_did) = self
-            .client
+            .provider
             .query_object_owner(policy_id, resource_name, doc_id)
             .await
-            .map_err(|e| acp::Error::Storage(format!("SourceHub query failed: {}", e)))?;
+            .map_err(provider_err)?;
 
         if owner_did.is_empty() {
             return Ok(());
         }
 
-        let cmd = serde_json::json!({
-            "archive_object_cmd": {
-                "object": {
-                    "resource": resource_name,
-                    "id": doc_id,
-                }
-            }
-        });
-        self.bearer_cmd(&owner_did, policy_id, cmd).await?;
-        Ok(())
+        let bearer_token = self.create_bearer_token(&owner_did)?;
+        self.provider
+            .archive_object(&bearer_token, policy_id, resource_name, doc_id)
+            .await
+            .map_err(provider_err)
     }
 }

--- a/crates/sourcehub/src/lib.rs
+++ b/crates/sourcehub/src/lib.rs
@@ -1,7 +1,9 @@
 mod client;
+mod cosmos;
 mod dac;
+mod provider;
 mod tx;
 
-pub use client::SourceHubClient;
+pub use cosmos::CosmosProvider;
 pub use dac::SourceHubDocumentACP;
-pub use tx::TxSigner;
+pub use provider::{ProviderError, ProviderPolicyInfo, SourceHubProvider, SubjectRef};

--- a/crates/sourcehub/src/provider.rs
+++ b/crates/sourcehub/src/provider.rs
@@ -1,0 +1,89 @@
+use async_trait::async_trait;
+use defra_core::thread_bounds::MaybeSendSync;
+
+pub enum SubjectRef {
+    Actor(String),
+    AllActors,
+}
+
+pub struct ProviderPolicyInfo {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    #[error("query error: {0}")]
+    Query(String),
+
+    #[error("transaction error: {0}")]
+    Transaction(String),
+
+    #[error("config error: {0}")]
+    Config(String),
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait SourceHubProvider: MaybeSendSync {
+    fn authorized_account(&self) -> String;
+
+    async fn create_policy(&self, policy_yaml: &str) -> Result<String, ProviderError>;
+
+    async fn register_object(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+    ) -> Result<(), ProviderError>;
+
+    async fn archive_object(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+    ) -> Result<(), ProviderError>;
+
+    async fn set_relationship(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        subject: &SubjectRef,
+    ) -> Result<bool, ProviderError>;
+
+    async fn delete_relationship(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        subject: &SubjectRef,
+    ) -> Result<bool, ProviderError>;
+
+    async fn query_policy(
+        &self,
+        policy_id: &str,
+    ) -> Result<Option<ProviderPolicyInfo>, ProviderError>;
+
+    async fn query_object_owner(
+        &self,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+    ) -> Result<(bool, String), ProviderError>;
+
+    async fn verify_access(
+        &self,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        permission: &str,
+        actor_did: &str,
+    ) -> Result<bool, ProviderError>;
+}

--- a/crates/sourcehub/src/tx.rs
+++ b/crates/sourcehub/src/tx.rs
@@ -9,7 +9,7 @@ use crate::client::SourceHubClient;
 /// Uses cosmrs for standard Cosmos SDK tx building (TxBody, AuthInfo, SignDoc,
 /// signing) and hand-encoded protobuf only for SourceHub-specific messages
 /// (MsgCreatePolicy, MsgBearerPolicyCmd) that aren't in cosmos-sdk-proto.
-pub struct TxSigner {
+pub(crate) struct TxSigner {
     signing_key: SigningKey,
     account_id: AccountId,
     chain_id: cosmrs::tendermint::chain::Id,
@@ -17,7 +17,10 @@ pub struct TxSigner {
 
 impl TxSigner {
     /// Create a signer from raw secp256k1 private key bytes.
-    pub fn from_secp256k1_bytes(key_bytes: &[u8], chain_id: &str) -> Result<Self, TxSignerError> {
+    pub(crate) fn from_secp256k1_bytes(
+        key_bytes: &[u8],
+        chain_id: &str,
+    ) -> Result<Self, TxSignerError> {
         let signing_key = SigningKey::from_slice(key_bytes)
             .map_err(|e| TxSignerError::Key(format!("invalid secp256k1 key: {}", e)))?;
 
@@ -38,13 +41,13 @@ impl TxSigner {
     }
 
     /// Get the bech32 account address (e.g., "source1...").
-    pub fn address(&self) -> String {
+    pub(crate) fn address(&self) -> String {
         self.account_id.to_string()
     }
 
     /// Build, sign, and broadcast a MsgCreatePolicy transaction.
     /// Returns the policy ID extracted from the tx result.
-    pub async fn create_policy(
+    pub(crate) async fn create_policy(
         &self,
         client: &SourceHubClient,
         policy_yaml: &str,
@@ -76,7 +79,7 @@ impl TxSigner {
 
     /// Build, sign, and broadcast a MsgBearerPolicyCmd transaction.
     /// Returns a JSON object with `tx_hash` and optionally `record_existed`/`record_found`.
-    pub async fn bearer_policy_cmd(
+    pub(crate) async fn bearer_policy_cmd(
         &self,
         client: &SourceHubClient,
         bearer_token: &str,
@@ -512,7 +515,7 @@ fn decode_bool_field(data: &[u8], target_field: u32) -> bool {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum TxSignerError {
+pub(crate) enum TxSignerError {
     #[error("key error: {0}")]
     Key(String),
 


### PR DESCRIPTION
## Summary

- Extract `SourceHubProvider` trait so the Cosmos SDK client becomes one implementation (`CosmosProvider`) and an EVM backend can slot in later
- `SourceHubDocumentACP` now holds `Arc<dyn SourceHubProvider>` instead of concrete `SourceHubClient` + `TxSigner`
- Restrict `client.rs` and `tx.rs` visibility to `pub(crate)` — these are now internal to `CosmosProvider`

## Test plan

- [x] `cargo build` compiles clean
- [x] `cargo clippy --all -- -D warnings` — no warnings
- [x] `cargo fmt --all` — formatted
- [x] `cargo test` — all unit tests pass
- [ ] `cargo test -p integration-test --test sourcehub_smoke -- --ignored` — SourceHub ACP works (requires SourceHub node)
- [ ] `cargo test -p integration-test --test acp_basic -- --ignored` — local ACP unaffected

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)