### PR TITLE
feat(fs): add FUSE filesystem overlay for DefraDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,7 @@ dependencies = [
  "crypto",
  "db",
  "defra-core",
+ "defra-fs",
  "defra-http",
  "defra-version",
  "dirs",
@@ -3616,6 +3617,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "defra-fs"
+version = "0.5.0"
+dependencies = [
+ "db",
+ "document",
+ "fuser",
+ "libc",
+ "parking_lot 0.12.5",
+ "schema",
+ "serde_json",
+ "storage",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "defra-harness"
 version = "0.1.0"
 source = "git+https://github.com/sourcenetwork/backbone.git?branch=main#35677ab57eec8122b184bc0a95ffae13c58fdc4f"
@@ -4583,6 +4600,22 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "fuser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.29.0",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy",
+]
 
 [[package]]
 name = "futures"
@@ -8686,6 +8719,16 @@ dependencies = [
  "unsigned-varint 0.8.0",
  "uuid",
  "void",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "crates/orbis",
     "crates/wasm",
     "crates/pg-compat",
+    "crates/fs",
     "tools/ffi-test",
     "tools/integration-test",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,6 +36,7 @@ orbis = { path = "../orbis" }
 sourcehub = { path = "../sourcehub" }
 defra-version = { path = "../defra-version" }
 pg-compat = { path = "../pg-compat" }
+defra-fs = { path = "../fs", optional = true }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
@@ -107,6 +108,7 @@ fjall = ["storage/fjall"]
 rocksdb = ["storage/rocksdb"]
 vendored-openssl = ["dep:openssl-sys"]
 iroh = ["p2p/iroh-transport", "dep:iroh-net", "dep:rand"]
+fuse = ["dep:defra-fs", "defra-fs/fuse"]
 
 [dev-dependencies]
 tempfile = "3.17"

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -183,6 +183,10 @@ pub struct StartArgs {
     /// Address for Postgres wire protocol compatibility (e.g., "127.0.0.1:5433")
     #[arg(long)]
     pub pg_address: Option<String>,
+
+    /// Mount DefraDB as a FUSE filesystem at this path (requires --features fuse)
+    #[arg(long)]
+    pub mount: Option<std::path::PathBuf>,
 }
 
 impl StartArgs {
@@ -208,7 +212,7 @@ impl StartArgs {
         }
 
         // Start the node
-        let node = Node::new(config, user_identity).await?;
+        let node = Node::new(config, user_identity, self.mount).await?;
         node.run().await
     }
 

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -45,6 +45,9 @@ pub struct Node {
     /// Stored for future use in request context injection.
     #[allow(dead_code)]
     user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
+    /// FUSE mount handle (kept alive; dropped on shutdown to unmount).
+    #[allow(dead_code)]
+    pub(super) mount_handle: Option<Box<dyn std::any::Any + Send>>,
 }
 
 impl Node {
@@ -53,6 +56,7 @@ impl Node {
     pub async fn new(
         config: Config,
         user_identity: Option<std::sync::Arc<identity::RawIdentity>>,
+        mount_path: Option<std::path::PathBuf>,
     ) -> Result<Self> {
         info!("Initializing DefraDB node");
         info!("Root directory: {}", config.rootdir.display());
@@ -71,117 +75,121 @@ impl Node {
             };
 
         // Initialize storage, database, and set up P2P and HTTP server
-        let (p2p_handle, p2p_tasks, http_server, pg_server) = match config.datastore.store {
-            DatastoreType::Memory => {
-                info!("Using in-memory datastore");
-                let store = Arc::new(storage::MemoryStore::new());
-                // Use in-memory ACP store for memory datastore
-                let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
-                let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
-                    Arc::new(acp::MemoryZanzibarStore::new());
-                info!("Using in-memory ACP store");
-                Self::init_store_and_server(
-                    store,
-                    &config,
-                    peer_keypair,
-                    user_identity.clone(),
-                    acp_store,
-                    zanzibar_store,
-                    node_identity_did.clone(),
-                )
-                .await?
-            }
-            DatastoreType::Redb => {
-                info!("Using Redb datastore at {}", config.data_path().display());
-                let opts = RedbStoreOptions::new()
-                    .with_durability(config.datastore.durability)
-                    .with_cache_size(256 * 1024 * 1024);
-                let store = Arc::new(storage::RedbStore::open_with_options(
-                    config.data_path(),
-                    opts,
-                )?);
-                // Use unified ACP store backed by main database with namespace isolation
-                info!("Using unified ACP store (namespace isolated in main database)");
-                let acp_store: Arc<dyn acp::AcpStore> =
-                    Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
-                let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
-                    Arc::new(acp::PersistentZanzibarStore::from_store(store.clone()));
-                Self::init_store_and_server(
-                    store,
-                    &config,
-                    peer_keypair,
-                    user_identity.clone(),
-                    acp_store,
-                    zanzibar_store,
-                    node_identity_did.clone(),
-                )
-                .await?
-            }
-            #[cfg(feature = "fjall")]
-            DatastoreType::Fjall => {
-                info!("Using Fjall datastore at {}", config.data_path().display());
-                let opts = FjallStoreOptions::new().with_durability(config.datastore.durability);
-                let store = Arc::new(storage::FjallStore::open_with_options(
-                    config.data_path(),
-                    opts,
-                )?);
-                info!("Using unified ACP store (namespace isolated in main database)");
-                let acp_store: Arc<dyn acp::AcpStore> =
-                    Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
-                let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
-                    Arc::new(acp::PersistentZanzibarStore::from_store(store.clone()));
-                Self::init_store_and_server(
-                    store,
-                    &config,
-                    peer_keypair,
-                    user_identity.clone(),
-                    acp_store,
-                    zanzibar_store,
-                    node_identity_did.clone(),
-                )
-                .await?
-            }
-            #[cfg(not(feature = "fjall"))]
-            DatastoreType::Fjall => {
-                return Err(crate::error::Error::InvalidDatastore(
-                    "fjall backend not enabled. Rebuild with --features fjall".into(),
-                ));
-            }
-            #[cfg(feature = "rocksdb")]
-            DatastoreType::RocksDb => {
-                info!(
-                    "Using RocksDB datastore at {}",
-                    config.data_path().display()
-                );
-                let opts =
-                    RocksDbStoreOptions::from_env().with_durability(config.datastore.durability);
-                let store = Arc::new(storage::RocksDbStore::open_with_options(
-                    config.data_path(),
-                    opts,
-                )?);
-                info!("Using unified ACP store (namespace isolated in main database)");
-                let acp_store: Arc<dyn acp::AcpStore> =
-                    Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
-                let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
-                    Arc::new(acp::PersistentZanzibarStore::from_store(store.clone()));
-                Self::init_store_and_server(
-                    store,
-                    &config,
-                    peer_keypair,
-                    user_identity.clone(),
-                    acp_store,
-                    zanzibar_store,
-                    node_identity_did.clone(),
-                )
-                .await?
-            }
-            #[cfg(not(feature = "rocksdb"))]
-            DatastoreType::RocksDb => {
-                return Err(crate::error::Error::InvalidDatastore(
-                    "rocksdb backend not enabled. Rebuild with --features rocksdb".into(),
-                ));
-            }
-        };
+        let (p2p_handle, p2p_tasks, http_server, pg_server, mount_handle) =
+            match config.datastore.store {
+                DatastoreType::Memory => {
+                    info!("Using in-memory datastore");
+                    let store = Arc::new(storage::MemoryStore::new());
+                    let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
+                    let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
+                        Arc::new(acp::MemoryZanzibarStore::new());
+                    info!("Using in-memory ACP store");
+                    Self::init_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        acp_store,
+                        zanzibar_store,
+                        node_identity_did.clone(),
+                        mount_path,
+                    )
+                    .await?
+                }
+                DatastoreType::Redb => {
+                    info!("Using Redb datastore at {}", config.data_path().display());
+                    let opts = RedbStoreOptions::new()
+                        .with_durability(config.datastore.durability)
+                        .with_cache_size(256 * 1024 * 1024);
+                    let store = Arc::new(storage::RedbStore::open_with_options(
+                        config.data_path(),
+                        opts,
+                    )?);
+                    info!("Using unified ACP store (namespace isolated in main database)");
+                    let acp_store: Arc<dyn acp::AcpStore> =
+                        Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
+                    let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
+                        Arc::new(acp::PersistentZanzibarStore::from_store(store.clone()));
+                    Self::init_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        acp_store,
+                        zanzibar_store,
+                        node_identity_did.clone(),
+                        mount_path,
+                    )
+                    .await?
+                }
+                #[cfg(feature = "fjall")]
+                DatastoreType::Fjall => {
+                    info!("Using Fjall datastore at {}", config.data_path().display());
+                    let opts =
+                        FjallStoreOptions::new().with_durability(config.datastore.durability);
+                    let store = Arc::new(storage::FjallStore::open_with_options(
+                        config.data_path(),
+                        opts,
+                    )?);
+                    info!("Using unified ACP store (namespace isolated in main database)");
+                    let acp_store: Arc<dyn acp::AcpStore> =
+                        Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
+                    let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
+                        Arc::new(acp::PersistentZanzibarStore::from_store(store.clone()));
+                    Self::init_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        acp_store,
+                        zanzibar_store,
+                        node_identity_did.clone(),
+                        mount_path,
+                    )
+                    .await?
+                }
+                #[cfg(not(feature = "fjall"))]
+                DatastoreType::Fjall => {
+                    return Err(crate::error::Error::InvalidDatastore(
+                        "fjall backend not enabled. Rebuild with --features fjall".into(),
+                    ));
+                }
+                #[cfg(feature = "rocksdb")]
+                DatastoreType::RocksDb => {
+                    info!(
+                        "Using RocksDB datastore at {}",
+                        config.data_path().display()
+                    );
+                    let opts = RocksDbStoreOptions::from_env()
+                        .with_durability(config.datastore.durability);
+                    let store = Arc::new(storage::RocksDbStore::open_with_options(
+                        config.data_path(),
+                        opts,
+                    )?);
+                    info!("Using unified ACP store (namespace isolated in main database)");
+                    let acp_store: Arc<dyn acp::AcpStore> =
+                        Arc::new(acp::PersistentAcpStore::from_store(store.clone()));
+                    let zanzibar_store: Arc<dyn acp::ZanzibarStore> =
+                        Arc::new(acp::PersistentZanzibarStore::from_store(store.clone()));
+                    Self::init_store_and_server(
+                        store,
+                        &config,
+                        peer_keypair,
+                        user_identity.clone(),
+                        acp_store,
+                        zanzibar_store,
+                        node_identity_did.clone(),
+                        mount_path,
+                    )
+                    .await?
+                }
+                #[cfg(not(feature = "rocksdb"))]
+                DatastoreType::RocksDb => {
+                    return Err(crate::error::Error::InvalidDatastore(
+                        "rocksdb backend not enabled. Rebuild with --features rocksdb".into(),
+                    ));
+                }
+            };
 
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
 
@@ -194,6 +202,7 @@ impl Node {
             shutdown_tx,
             shutdown_rx,
             user_identity,
+            mount_handle,
         })
     }
 }

--- a/crates/cli/src/commands/start/run.rs
+++ b/crates/cli/src/commands/start/run.rs
@@ -140,6 +140,13 @@ impl Node {
             }
         }
 
+        // Unmount FUSE filesystem
+        if self.mount_handle.is_some() {
+            info!("Unmounting FUSE filesystem...");
+            drop(self.mount_handle.take());
+            info!("FUSE filesystem unmounted");
+        }
+
         // Shutdown P2P tasks first, then the handle
         if let Some(tasks) = self.p2p_tasks.take() {
             info!("Stopping P2P background tasks...");

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -23,6 +23,7 @@ impl Node {
     ///
     /// Returns a tuple of (P2PHostHandle, P2PTasks, HTTP Server) where the tasks
     /// are tracked for graceful shutdown.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn init_store_and_server<S>(
         store: Arc<S>,
         config: &Config,
@@ -31,11 +32,13 @@ impl Node {
         acp_store: Arc<dyn acp::AcpStore>,
         zanzibar_store: Arc<dyn acp::ZanzibarStore>,
         node_identity_did: Option<String>,
+        mount_path: Option<std::path::PathBuf>,
     ) -> Result<(
         Option<p2p::P2PHostHandle>,
         Option<P2PTasks>,
         defra_http::Server,
         Option<pg_compat::PgServer>,
+        Option<Box<dyn std::any::Any + Send>>,
     )>
     where
         S: storage::corekv::Store + 'static,
@@ -99,6 +102,29 @@ impl Node {
             .map_err(|e| Error::Storage(storage::Error::Other(e.to_string())))?
             .len();
         info!("Loaded {} collection schema(s)", collection_count);
+
+        // Mount FUSE filesystem if configured
+        #[allow(unused_variables)]
+        let mount_handle: Option<Box<dyn std::any::Any + Send>> = if let Some(ref path) = mount_path
+        {
+            #[cfg(feature = "fuse")]
+            {
+                info!("Mounting FUSE filesystem at {}", path.display());
+                let handle =
+                    defra_fs::mount(database.clone(), path, tokio::runtime::Handle::current())
+                        .map_err(|e| Error::InvalidConfig(format!("FUSE mount failed: {}", e)))?;
+                info!("FUSE filesystem mounted at {}", path.display());
+                Some(Box::new(handle))
+            }
+            #[cfg(not(feature = "fuse"))]
+            {
+                return Err(Error::InvalidConfig(
+                    "--mount requires the 'fuse' feature. Rebuild with --features fuse".into(),
+                ));
+            }
+        } else {
+            None
+        };
 
         // Set up P2P if enabled
         // Clone store before potential move for sync coordinator blockstore
@@ -1243,6 +1269,6 @@ impl Node {
             (server, p2p_tasks, pg_server)
         };
 
-        Ok((p2p, p2p_tasks, http_server, pg_server))
+        Ok((p2p, p2p_tasks, http_server, pg_server, mount_handle))
     }
 }

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -8,8 +8,12 @@ license.workspace = true
 repository.workspace = true
 description = "FUSE filesystem overlay for DefraDB"
 
+[features]
+default = []
+fuse = ["dep:fuser"]
+
 [dependencies]
-fuser = "0.15"
+fuser = { version = "0.15", optional = true }
 libc = "0.2"
 db = { path = "../db" }
 document = { path = "../document" }

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "defra-fs"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "FUSE filesystem overlay for DefraDB"
+
+[dependencies]
+fuser = "0.15"
+libc = "0.2"
+db = { path = "../db" }
+document = { path = "../document" }
+storage = { path = "../storage" }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+parking_lot = { workspace = true }

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -13,6 +13,7 @@ fuser = "0.15"
 libc = "0.2"
 db = { path = "../db" }
 document = { path = "../document" }
+schema = { path = "../schema" }
 storage = { path = "../storage" }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/fs/src/cache.rs
+++ b/crates/fs/src/cache.rs
@@ -1,0 +1,112 @@
+/// Content cache for virtual files and document JSON.
+///
+/// Caches generated content (e.g. `_view.json`, `_schema.graphql`) to avoid
+/// regenerating on every FUSE read/getattr/lookup call. Entries expire
+/// after a TTL. Write operations invalidate the relevant collection.
+///
+/// Key convention:
+/// - `"col:{name}:_view.json"` — collection materialized view
+/// - `"col:{name}:_schema.graphql"` — collection SDL
+/// - `"root:_schema.graphql"` — root-level combined schema
+/// - `"root:_collections.json"` — root-level collection listing
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+const CACHE_TTL: Duration = Duration::from_secs(5);
+
+struct Entry {
+    content: Vec<u8>,
+    cached_at: Instant,
+}
+
+impl Entry {
+    fn is_valid(&self) -> bool {
+        self.cached_at.elapsed() < CACHE_TTL
+    }
+}
+
+pub struct ContentCache {
+    entries: HashMap<String, Entry>,
+}
+
+impl ContentCache {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&[u8]> {
+        self.entries
+            .get(key)
+            .filter(|e| e.is_valid())
+            .map(|e| e.content.as_slice())
+    }
+
+    pub fn insert(&mut self, key: String, content: Vec<u8>) {
+        self.entries.insert(
+            key,
+            Entry {
+                content,
+                cached_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Invalidate all entries for a collection and root-level aggregates.
+    pub fn invalidate_collection(&mut self, collection: &str) {
+        let prefix = format!("col:{}:", collection);
+        self.entries.retain(|k, _| !k.starts_with(&prefix));
+        self.entries.retain(|k, _| !k.starts_with("root:"));
+    }
+}
+
+pub fn col_key(collection: &str, filename: &str) -> String {
+    format!("col:{}:{}", collection, filename)
+}
+
+pub fn root_key(filename: &str) -> String {
+    format!("root:{}", filename)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_returns_none_for_missing_key() {
+        let cache = ContentCache::new();
+        assert!(cache.get("missing").is_none());
+    }
+
+    #[test]
+    fn insert_then_get_returns_content() {
+        let mut cache = ContentCache::new();
+        cache.insert("k".into(), b"hello".to_vec());
+        assert_eq!(cache.get("k"), Some(b"hello".as_slice()));
+    }
+
+    #[test]
+    fn invalidate_collection_removes_matching_entries() {
+        let mut cache = ContentCache::new();
+        cache.insert(col_key("Users", "_view.json"), b"data".to_vec());
+        cache.insert(col_key("Users", "_schema.graphql"), b"sdl".to_vec());
+        cache.insert(col_key("Posts", "_view.json"), b"other".to_vec());
+        cache.insert(root_key("_schema.graphql"), b"root".to_vec());
+
+        cache.invalidate_collection("Users");
+
+        assert!(cache.get(&col_key("Users", "_view.json")).is_none());
+        assert!(cache.get(&col_key("Users", "_schema.graphql")).is_none());
+        // Root files are also invalidated (they aggregate all collections)
+        assert!(cache.get(&root_key("_schema.graphql")).is_none());
+        // Other collections are untouched
+        assert!(cache.get(&col_key("Posts", "_view.json")).is_some());
+    }
+
+    #[test]
+    fn key_helpers() {
+        assert_eq!(col_key("Users", "_view.json"), "col:Users:_view.json");
+        assert_eq!(root_key("_schema.graphql"), "root:_schema.graphql");
+    }
+}

--- a/crates/fs/src/errno.rs
+++ b/crates/fs/src/errno.rs
@@ -1,0 +1,66 @@
+/// Map a db::Error to a POSIX errno value.
+///
+/// Ensures FUSE never returns generic EIO when a more specific errno applies:
+/// - Validation/format errors → EINVAL
+/// - Not found → ENOENT
+/// - ACP/permission denial → EACCES
+/// - Already exists → EEXIST
+/// - Storage/internal → EIO
+pub fn db_err_to_errno(err: &db::Error) -> i32 {
+    match err {
+        db::Error::DocumentNotFound(_) | db::Error::CollectionNotFound(_) => libc::ENOENT,
+
+        db::Error::InvalidDocument(_)
+        | db::Error::InvalidCollectionName(_)
+        | db::Error::InvalidPatch(_)
+        | db::Error::Serialization(_)
+        | db::Error::CollectionVersionIDEmpty
+        | db::Error::CollectionVersionNotFound(_) => libc::EINVAL,
+
+        db::Error::Acp(_) | db::Error::UnsafePolicyTransition(_) => libc::EACCES,
+
+        db::Error::CollectionAlreadyExists(_) => libc::EEXIST,
+
+        db::Error::Document(doc_err) => doc_err_to_errno(doc_err),
+
+        db::Error::Schema(_)
+        | db::Error::Storage(_)
+        | db::Error::Datastore(_)
+        | db::Error::Query(_)
+        | db::Error::DatabaseClosed
+        | db::Error::TxnNotActive
+        | db::Error::ExplicitTxnMustUseForce
+        | db::Error::UnsupportedTxnType
+        | db::Error::TransactionNotFound(_)
+        | db::Error::LockPoisoned(_)
+        | db::Error::CacheUpdateFailedAfterCommit(_)
+        | db::Error::Lens(_)
+        | db::Error::JsonPatch(_)
+        | db::Error::Other(_) => libc::EIO,
+    }
+}
+
+/// Map a document::Error to a POSIX errno value.
+fn doc_err_to_errno(err: &document::Error) -> i32 {
+    match err {
+        document::Error::MalformedDocID
+        | document::Error::InvalidDocIDVersion(_)
+        | document::Error::EmptyFieldName
+        | document::Error::TypeMismatch { .. }
+        | document::Error::InvalidFieldValue { .. }
+        | document::Error::MissingRequiredField(_)
+        | document::Error::JsonParse(_)
+        | document::Error::JsonNumberOutOfRange(_)
+        | document::Error::NonFiniteFloat(_)
+        | document::Error::IncompatibleCrdtType { .. }
+        | document::Error::UuidParse(_)
+        | document::Error::MultibaseDecode(_) => libc::EINVAL,
+
+        document::Error::FieldNotFound(_) => libc::ENOENT,
+
+        document::Error::CborEncode(_)
+        | document::Error::CborDecode(_)
+        | document::Error::Cid(_)
+        | document::Error::Schema(_) => libc::EIO,
+    }
+}

--- a/crates/fs/src/error.rs
+++ b/crates/fs/src/error.rs
@@ -1,0 +1,21 @@
+/// Errors for the defra-fs crate.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("database error: {0}")]
+    Db(#[from] db::Error),
+
+    #[error("document error: {0}")]
+    Document(#[from] document::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("collection not found: {0}")]
+    CollectionNotFound(String),
+
+    #[error("document not found: {0}")]
+    DocumentNotFound(String),
+}

--- a/crates/fs/src/inode.rs
+++ b/crates/fs/src/inode.rs
@@ -9,6 +9,11 @@ use std::collections::HashMap;
 /// The root directory inode (standard FUSE convention).
 pub const ROOT_INO: u64 = 1;
 
+/// Reserved field name for filesystem display names.
+/// If a document has this field, its value is used as the filename
+/// instead of the raw docID.
+pub const NAME_FIELD: &str = "_name";
+
 /// Represents what a filesystem inode maps to in DefraDB.
 #[derive(Debug, Clone)]
 pub enum InodeTarget {
@@ -17,19 +22,23 @@ pub enum InodeTarget {
     /// A collection directory.
     Collection { name: String },
     /// A document JSON file within a collection.
-    Document { collection: String, doc_id: String },
+    Document {
+        collection: String,
+        doc_id: String,
+        /// Filesystem display name (from _name field, or doc_id if unset).
+        display_name: String,
+    },
 }
 
 /// Bidirectional mapping between inodes and DefraDB entities.
 pub struct InodeTable {
     next_ino: u64,
     by_ino: HashMap<u64, InodeTarget>,
-    /// Reverse lookup: collection name -> inode
     collection_inos: HashMap<String, u64>,
-    /// Reverse lookup: (collection, doc_id) -> inode
+    /// Forward: (collection, doc_id) -> inode
     doc_inos: HashMap<(String, String), u64>,
-    /// Track which collections have had their documents loaded.
-    populated_collections: std::collections::HashSet<String>,
+    /// Reverse: (collection, display_name) -> doc_id
+    name_to_doc_id: HashMap<(String, String), String>,
 }
 
 impl InodeTable {
@@ -42,7 +51,7 @@ impl InodeTable {
             by_ino,
             collection_inos: HashMap::new(),
             doc_inos: HashMap::new(),
-            populated_collections: std::collections::HashSet::new(),
+            name_to_doc_id: HashMap::new(),
         }
     }
 
@@ -69,7 +78,8 @@ impl InodeTable {
     }
 
     /// Allocate or return existing inode for a document.
-    pub fn doc_ino(&mut self, collection: &str, doc_id: &str) -> u64 {
+    /// `display_name` is either the `_name` field value or the doc_id.
+    pub fn doc_ino(&mut self, collection: &str, doc_id: &str, display_name: &str) -> u64 {
         let key = (collection.to_string(), doc_id.to_string());
         if let Some(&ino) = self.doc_inos.get(&key) {
             return ino;
@@ -81,22 +91,50 @@ impl InodeTable {
             InodeTarget::Document {
                 collection: collection.to_string(),
                 doc_id: doc_id.to_string(),
+                display_name: display_name.to_string(),
             },
         );
         self.doc_inos.insert(key, ino);
+        self.name_to_doc_id.insert(
+            (collection.to_string(), display_name.to_string()),
+            doc_id.to_string(),
+        );
         ino
+    }
+
+    /// Resolve a display name (filename without .json) to a doc_id.
+    pub fn resolve_name(&self, collection: &str, display_name: &str) -> Option<&str> {
+        let key = (collection.to_string(), display_name.to_string());
+        self.name_to_doc_id.get(&key).map(|s| s.as_str())
     }
 
     /// Remove a document inode (for unlink/delete).
     pub fn remove_doc(&mut self, collection: &str, doc_id: &str) {
         let key = (collection.to_string(), doc_id.to_string());
         if let Some(ino) = self.doc_inos.remove(&key) {
-            self.by_ino.remove(&ino);
+            if let Some(InodeTarget::Document { display_name, .. }) = self.by_ino.remove(&ino) {
+                self.name_to_doc_id
+                    .remove(&(collection.to_string(), display_name));
+            }
         }
     }
 
-    /// Invalidate a collection's population status (after write).
-    pub fn invalidate(&mut self, collection: &str) {
-        self.populated_collections.remove(collection);
+    /// Clear all document inodes for a collection (forces re-scan on next readdir).
+    pub fn invalidate_collection(&mut self, collection: &str) {
+        let doc_keys: Vec<(String, String)> = self
+            .doc_inos
+            .keys()
+            .filter(|(c, _)| c == collection)
+            .cloned()
+            .collect();
+
+        for key in doc_keys {
+            if let Some(ino) = self.doc_inos.remove(&key) {
+                if let Some(InodeTarget::Document { display_name, .. }) = self.by_ino.remove(&ino) {
+                    self.name_to_doc_id
+                        .remove(&(collection.to_string(), display_name));
+                }
+            }
+        }
     }
 }

--- a/crates/fs/src/inode.rs
+++ b/crates/fs/src/inode.rs
@@ -1,0 +1,102 @@
+/// Inode mapping between filesystem inodes and DefraDB entities.
+///
+/// Inode layout:
+/// - 1: root directory (mountpoint)
+/// - 2..N: collection directories (allocated on first readdir of root)
+/// - N+1..: document files (allocated on first readdir/lookup of collection)
+use std::collections::HashMap;
+
+/// The root directory inode (standard FUSE convention).
+pub const ROOT_INO: u64 = 1;
+
+/// Represents what a filesystem inode maps to in DefraDB.
+#[derive(Debug, Clone)]
+pub enum InodeTarget {
+    /// Root directory containing all collections.
+    Root,
+    /// A collection directory.
+    Collection { name: String },
+    /// A document JSON file within a collection.
+    Document { collection: String, doc_id: String },
+}
+
+/// Bidirectional mapping between inodes and DefraDB entities.
+pub struct InodeTable {
+    next_ino: u64,
+    by_ino: HashMap<u64, InodeTarget>,
+    /// Reverse lookup: collection name -> inode
+    collection_inos: HashMap<String, u64>,
+    /// Reverse lookup: (collection, doc_id) -> inode
+    doc_inos: HashMap<(String, String), u64>,
+    /// Track which collections have had their documents loaded.
+    populated_collections: std::collections::HashSet<String>,
+}
+
+impl InodeTable {
+    pub fn new() -> Self {
+        let mut by_ino = HashMap::new();
+        by_ino.insert(ROOT_INO, InodeTarget::Root);
+
+        Self {
+            next_ino: 2,
+            by_ino,
+            collection_inos: HashMap::new(),
+            doc_inos: HashMap::new(),
+            populated_collections: std::collections::HashSet::new(),
+        }
+    }
+
+    /// Get the target for an inode.
+    pub fn get(&self, ino: u64) -> Option<&InodeTarget> {
+        self.by_ino.get(&ino)
+    }
+
+    /// Allocate or return existing inode for a collection.
+    pub fn collection_ino(&mut self, name: &str) -> u64 {
+        if let Some(&ino) = self.collection_inos.get(name) {
+            return ino;
+        }
+        let ino = self.next_ino;
+        self.next_ino += 1;
+        self.by_ino.insert(
+            ino,
+            InodeTarget::Collection {
+                name: name.to_string(),
+            },
+        );
+        self.collection_inos.insert(name.to_string(), ino);
+        ino
+    }
+
+    /// Allocate or return existing inode for a document.
+    pub fn doc_ino(&mut self, collection: &str, doc_id: &str) -> u64 {
+        let key = (collection.to_string(), doc_id.to_string());
+        if let Some(&ino) = self.doc_inos.get(&key) {
+            return ino;
+        }
+        let ino = self.next_ino;
+        self.next_ino += 1;
+        self.by_ino.insert(
+            ino,
+            InodeTarget::Document {
+                collection: collection.to_string(),
+                doc_id: doc_id.to_string(),
+            },
+        );
+        self.doc_inos.insert(key, ino);
+        ino
+    }
+
+    /// Remove a document inode (for unlink/delete).
+    pub fn remove_doc(&mut self, collection: &str, doc_id: &str) {
+        let key = (collection.to_string(), doc_id.to_string());
+        if let Some(ino) = self.doc_inos.remove(&key) {
+            self.by_ino.remove(&ino);
+        }
+    }
+
+    /// Invalidate a collection's population status (after write).
+    pub fn invalidate(&mut self, collection: &str) {
+        self.populated_collections.remove(collection);
+    }
+}

--- a/crates/fs/src/inode.rs
+++ b/crates/fs/src/inode.rs
@@ -2,35 +2,32 @@
 ///
 /// Inode layout:
 /// - 1: root directory (mountpoint)
-/// - 2..N: collection directories (allocated on first readdir of root)
-/// - N+1..: document files (allocated on first readdir/lookup of collection)
+/// - 2..N: root virtual files, collection directories
+/// - N+1..: collection virtual files, document files
 use std::collections::HashMap;
 
-/// The root directory inode (standard FUSE convention).
 pub const ROOT_INO: u64 = 1;
 
 /// Reserved field name for filesystem display names.
-/// If a document has this field, its value is used as the filename
-/// instead of the raw docID.
 pub const NAME_FIELD: &str = "_name";
 
 /// Represents what a filesystem inode maps to in DefraDB.
 #[derive(Debug, Clone)]
 pub enum InodeTarget {
-    /// Root directory containing all collections.
     Root,
-    /// A collection directory.
-    Collection { name: String },
-    /// A document JSON file within a collection.
+    Collection {
+        name: String,
+    },
     Document {
         collection: String,
         doc_id: String,
-        /// Filesystem display name (from _name field, or doc_id if unset).
         display_name: String,
     },
-    /// A virtual read-only file within a collection directory.
     VirtualFile {
         collection: String,
+        filename: String,
+    },
+    RootVirtualFile {
         filename: String,
     },
 }
@@ -40,12 +37,10 @@ pub struct InodeTable {
     next_ino: u64,
     by_ino: HashMap<u64, InodeTarget>,
     collection_inos: HashMap<String, u64>,
-    /// Forward: (collection, doc_id) -> inode
     doc_inos: HashMap<(String, String), u64>,
-    /// Reverse: (collection, display_name) -> doc_id
     name_to_doc_id: HashMap<(String, String), String>,
-    /// Virtual file inodes: (collection, filename) -> inode
     virtual_inos: HashMap<(String, String), u64>,
+    root_virtual_inos: HashMap<String, u64>,
 }
 
 impl InodeTable {
@@ -60,21 +55,19 @@ impl InodeTable {
             doc_inos: HashMap::new(),
             name_to_doc_id: HashMap::new(),
             virtual_inos: HashMap::new(),
+            root_virtual_inos: HashMap::new(),
         }
     }
 
-    /// Get the target for an inode.
     pub fn get(&self, ino: u64) -> Option<&InodeTarget> {
         self.by_ino.get(&ino)
     }
 
-    /// Allocate or return existing inode for a collection.
     pub fn collection_ino(&mut self, name: &str) -> u64 {
         if let Some(&ino) = self.collection_inos.get(name) {
             return ino;
         }
-        let ino = self.next_ino;
-        self.next_ino += 1;
+        let ino = self.alloc();
         self.by_ino.insert(
             ino,
             InodeTarget::Collection {
@@ -85,15 +78,12 @@ impl InodeTable {
         ino
     }
 
-    /// Allocate or return existing inode for a document.
-    /// `display_name` is either the `_name` field value or the doc_id.
     pub fn doc_ino(&mut self, collection: &str, doc_id: &str, display_name: &str) -> u64 {
         let key = (collection.to_string(), doc_id.to_string());
         if let Some(&ino) = self.doc_inos.get(&key) {
             return ino;
         }
-        let ino = self.next_ino;
-        self.next_ino += 1;
+        let ino = self.alloc();
         self.by_ino.insert(
             ino,
             InodeTarget::Document {
@@ -110,14 +100,12 @@ impl InodeTable {
         ino
     }
 
-    /// Allocate or return existing inode for a virtual file.
     pub fn virtual_ino(&mut self, collection: &str, filename: &str) -> u64 {
         let key = (collection.to_string(), filename.to_string());
         if let Some(&ino) = self.virtual_inos.get(&key) {
             return ino;
         }
-        let ino = self.next_ino;
-        self.next_ino += 1;
+        let ino = self.alloc();
         self.by_ino.insert(
             ino,
             InodeTarget::VirtualFile {
@@ -129,13 +117,26 @@ impl InodeTable {
         ino
     }
 
-    /// Resolve a display name (filename without .json) to a doc_id.
+    pub fn root_virtual_ino(&mut self, filename: &str) -> u64 {
+        if let Some(&ino) = self.root_virtual_inos.get(filename) {
+            return ino;
+        }
+        let ino = self.alloc();
+        self.by_ino.insert(
+            ino,
+            InodeTarget::RootVirtualFile {
+                filename: filename.to_string(),
+            },
+        );
+        self.root_virtual_inos.insert(filename.to_string(), ino);
+        ino
+    }
+
     pub fn resolve_name(&self, collection: &str, display_name: &str) -> Option<&str> {
         let key = (collection.to_string(), display_name.to_string());
         self.name_to_doc_id.get(&key).map(|s| s.as_str())
     }
 
-    /// Remove a document inode (for unlink/delete).
     pub fn remove_doc(&mut self, collection: &str, doc_id: &str) {
         let key = (collection.to_string(), doc_id.to_string());
         if let Some(ino) = self.doc_inos.remove(&key) {
@@ -146,7 +147,6 @@ impl InodeTable {
         }
     }
 
-    /// Clear all document inodes for a collection (forces re-scan on next readdir).
     pub fn invalidate_collection(&mut self, collection: &str) {
         let doc_keys: Vec<(String, String)> = self
             .doc_inos
@@ -163,5 +163,82 @@ impl InodeTable {
                 }
             }
         }
+    }
+
+    fn alloc(&mut self) -> u64 {
+        let ino = self.next_ino;
+        self.next_ino += 1;
+        ino
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_is_inode_1() {
+        let table = InodeTable::new();
+        assert!(matches!(table.get(ROOT_INO), Some(InodeTarget::Root)));
+    }
+
+    #[test]
+    fn collection_ino_is_stable() {
+        let mut table = InodeTable::new();
+        let ino1 = table.collection_ino("Users");
+        let ino2 = table.collection_ino("Users");
+        assert_eq!(ino1, ino2);
+        assert!(ino1 > ROOT_INO);
+    }
+
+    #[test]
+    fn different_collections_get_different_inodes() {
+        let mut table = InodeTable::new();
+        let ino1 = table.collection_ino("Users");
+        let ino2 = table.collection_ino("Posts");
+        assert_ne!(ino1, ino2);
+    }
+
+    #[test]
+    fn doc_ino_with_name_resolution() {
+        let mut table = InodeTable::new();
+        let ino = table.doc_ino("Users", "bae-abc123", "alice");
+        assert!(ino > ROOT_INO);
+        assert_eq!(table.resolve_name("Users", "alice"), Some("bae-abc123"));
+    }
+
+    #[test]
+    fn remove_doc_cleans_up_name_mapping() {
+        let mut table = InodeTable::new();
+        table.doc_ino("Users", "bae-abc123", "alice");
+        table.remove_doc("Users", "bae-abc123");
+        assert!(table.resolve_name("Users", "alice").is_none());
+    }
+
+    #[test]
+    fn invalidate_collection_clears_all_docs() {
+        let mut table = InodeTable::new();
+        table.doc_ino("Users", "bae-1", "alice");
+        table.doc_ino("Users", "bae-2", "bob");
+        table.doc_ino("Posts", "bae-3", "post1");
+
+        table.invalidate_collection("Users");
+
+        assert!(table.resolve_name("Users", "alice").is_none());
+        assert!(table.resolve_name("Users", "bob").is_none());
+        // Other collections untouched
+        assert_eq!(table.resolve_name("Posts", "post1"), Some("bae-3"));
+    }
+
+    #[test]
+    fn root_virtual_ino_is_stable() {
+        let mut table = InodeTable::new();
+        let ino1 = table.root_virtual_ino("_schema.graphql");
+        let ino2 = table.root_virtual_ino("_schema.graphql");
+        assert_eq!(ino1, ino2);
+        assert!(matches!(
+            table.get(ino1),
+            Some(InodeTarget::RootVirtualFile { .. })
+        ));
     }
 }

--- a/crates/fs/src/inode.rs
+++ b/crates/fs/src/inode.rs
@@ -28,6 +28,11 @@ pub enum InodeTarget {
         /// Filesystem display name (from _name field, or doc_id if unset).
         display_name: String,
     },
+    /// A virtual read-only file within a collection directory.
+    VirtualFile {
+        collection: String,
+        filename: String,
+    },
 }
 
 /// Bidirectional mapping between inodes and DefraDB entities.
@@ -39,6 +44,8 @@ pub struct InodeTable {
     doc_inos: HashMap<(String, String), u64>,
     /// Reverse: (collection, display_name) -> doc_id
     name_to_doc_id: HashMap<(String, String), String>,
+    /// Virtual file inodes: (collection, filename) -> inode
+    virtual_inos: HashMap<(String, String), u64>,
 }
 
 impl InodeTable {
@@ -52,6 +59,7 @@ impl InodeTable {
             collection_inos: HashMap::new(),
             doc_inos: HashMap::new(),
             name_to_doc_id: HashMap::new(),
+            virtual_inos: HashMap::new(),
         }
     }
 
@@ -99,6 +107,25 @@ impl InodeTable {
             (collection.to_string(), display_name.to_string()),
             doc_id.to_string(),
         );
+        ino
+    }
+
+    /// Allocate or return existing inode for a virtual file.
+    pub fn virtual_ino(&mut self, collection: &str, filename: &str) -> u64 {
+        let key = (collection.to_string(), filename.to_string());
+        if let Some(&ino) = self.virtual_inos.get(&key) {
+            return ino;
+        }
+        let ino = self.next_ino;
+        self.next_ino += 1;
+        self.by_ino.insert(
+            ino,
+            InodeTarget::VirtualFile {
+                collection: collection.to_string(),
+                filename: filename.to_string(),
+            },
+        );
+        self.virtual_inos.insert(key, ino);
         ino
     }
 

--- a/crates/fs/src/lib.rs
+++ b/crates/fs/src/lib.rs
@@ -13,10 +13,11 @@
 /// │   └── ...
 /// └── ...
 /// ```
+mod errno;
 mod error;
 mod inode;
 mod mount;
 mod ops;
 
 pub use error::Error;
-pub use mount::{mount, MountHandle};
+pub use mount::{mount, MountHandle, MountOptions};

--- a/crates/fs/src/lib.rs
+++ b/crates/fs/src/lib.rs
@@ -2,26 +2,43 @@
 ///
 /// Maps collections to directories and documents to JSON files,
 /// enabling AI agents to interact with DefraDB using standard
-/// filesystem operations (ls, cat, echo, rm).
+/// filesystem operations (ls, cat, grep, jq).
 ///
 /// # Layout
 ///
 /// ```text
 /// <mountpoint>/
+/// ├── _schema.graphql              # virtual: all types (read-only)
+/// ├── _collections.json            # virtual: collection list + doc counts (read-only)
 /// ├── <collection_name>/           # directory per collection
 /// │   ├── _schema.graphql          # virtual: collection SDL (read-only)
-/// │   ├── _view.json               # virtual: all docs as JSON array (read-only)
+/// │   ├── _view.json               # virtual: all docs as JSON array (read-only, greppable)
 /// │   ├── alice.json               # document (via _name field)
 /// │   ├── <bae-docid>.json         # document (raw docID)
 /// │   └── ...
 /// └── ...
 /// ```
-mod errno;
+///
+/// # Agent Workflow
+///
+/// The primary search surface is `_view.json` per collection — a materialized
+/// view of all documents as a JSON array. Agents should `grep` or `jq` this
+/// file rather than iterating individual doc files.
+#[cfg_attr(not(feature = "fuse"), allow(dead_code))]
+pub(crate) mod cache;
+#[cfg_attr(not(feature = "fuse"), allow(dead_code))]
+pub(crate) mod errno;
 mod error;
-mod inode;
+#[cfg_attr(not(feature = "fuse"), allow(dead_code))]
+pub(crate) mod inode;
+#[cfg_attr(not(feature = "fuse"), allow(dead_code))]
+pub(crate) mod virtual_files;
+
+#[cfg(feature = "fuse")]
 mod mount;
+#[cfg(feature = "fuse")]
 mod ops;
-mod virtual_files;
 
 pub use error::Error;
+#[cfg(feature = "fuse")]
 pub use mount::{mount, MountHandle};

--- a/crates/fs/src/lib.rs
+++ b/crates/fs/src/lib.rs
@@ -1,0 +1,22 @@
+/// FUSE filesystem overlay for DefraDB.
+///
+/// Maps collections to directories and documents to JSON files,
+/// enabling AI agents to interact with DefraDB using standard
+/// filesystem operations (ls, cat, echo, rm).
+///
+/// # Layout
+///
+/// ```text
+/// <mountpoint>/
+/// ├── <collection_name>/           # directory per collection
+/// │   ├── <bae-docid>.json         # file per document
+/// │   └── ...
+/// └── ...
+/// ```
+mod error;
+mod inode;
+mod mount;
+mod ops;
+
+pub use error::Error;
+pub use mount::{mount, MountHandle};

--- a/crates/fs/src/lib.rs
+++ b/crates/fs/src/lib.rs
@@ -20,4 +20,4 @@ mod mount;
 mod ops;
 
 pub use error::Error;
-pub use mount::{mount, MountHandle, MountOptions};
+pub use mount::{mount, MountHandle};

--- a/crates/fs/src/lib.rs
+++ b/crates/fs/src/lib.rs
@@ -9,7 +9,10 @@
 /// ```text
 /// <mountpoint>/
 /// ├── <collection_name>/           # directory per collection
-/// │   ├── <bae-docid>.json         # file per document
+/// │   ├── _schema.graphql          # virtual: collection SDL (read-only)
+/// │   ├── _view.json               # virtual: all docs as JSON array (read-only)
+/// │   ├── alice.json               # document (via _name field)
+/// │   ├── <bae-docid>.json         # document (raw docID)
 /// │   └── ...
 /// └── ...
 /// ```
@@ -18,6 +21,7 @@ mod error;
 mod inode;
 mod mount;
 mod ops;
+mod virtual_files;
 
 pub use error::Error;
 pub use mount::{mount, MountHandle};

--- a/crates/fs/src/mount.rs
+++ b/crates/fs/src/mount.rs
@@ -20,16 +20,17 @@ impl MountHandle {
     }
 }
 
-/// Mount a DefraDB instance as a FUSE filesystem.
+/// Mount a DefraDB instance as a FUSE filesystem at `mountpoint`.
 ///
-/// The mount is always read-write at the FUSE level. Access control
-/// is enforced by DefraDB's ACP system — permission denials surface
-/// as EACCES errors on individual operations.
+/// Creates the mount directory if it doesn't exist. The mount is read-write
+/// at the FUSE level; access control is enforced by DefraDB's ACP system.
 pub fn mount<S: Store + 'static>(
     db: Arc<db::DB<S>>,
     mountpoint: &Path,
     rt: tokio::runtime::Handle,
 ) -> Result<MountHandle, crate::Error> {
+    std::fs::create_dir_all(mountpoint)?;
+
     let fs = DefraFs::new(db, rt);
 
     let options = &[

--- a/crates/fs/src/mount.rs
+++ b/crates/fs/src/mount.rs
@@ -1,0 +1,50 @@
+/// Mount/unmount lifecycle for the DefraDB FUSE filesystem.
+use std::path::Path;
+use std::sync::Arc;
+
+use storage::corekv::Store;
+
+use crate::ops::DefraFs;
+
+/// Handle to a mounted DefraDB filesystem.
+///
+/// The filesystem is unmounted when this handle is dropped.
+pub struct MountHandle {
+    session: fuser::BackgroundSession,
+}
+
+impl MountHandle {
+    /// Unmount the filesystem.
+    pub fn unmount(self) {
+        drop(self.session);
+    }
+}
+
+/// Mount a DefraDB instance as a FUSE filesystem.
+///
+/// Returns a `MountHandle` that keeps the filesystem mounted.
+/// The filesystem is unmounted when the handle is dropped.
+///
+/// # Arguments
+///
+/// * `db` - The DefraDB instance to expose
+/// * `mountpoint` - Directory to mount on (must exist)
+/// * `rt` - Tokio runtime handle for async DB operations
+pub fn mount<S: Store + 'static>(
+    db: Arc<db::DB<S>>,
+    mountpoint: &Path,
+    rt: tokio::runtime::Handle,
+) -> Result<MountHandle, crate::Error> {
+    let fs = DefraFs::new(db, rt);
+
+    let options = &[
+        fuser::MountOption::RW,
+        fuser::MountOption::FSName("defradb".into()),
+        fuser::MountOption::AutoUnmount,
+        fuser::MountOption::AllowOther,
+    ];
+
+    let session = fuser::spawn_mount2(fs, mountpoint, options)?;
+
+    Ok(MountHandle { session })
+}

--- a/crates/fs/src/mount.rs
+++ b/crates/fs/src/mount.rs
@@ -6,6 +6,25 @@ use storage::corekv::Store;
 
 use crate::ops::DefraFs;
 
+/// Options for mounting the DefraDB filesystem.
+pub struct MountOptions {
+    /// Mount as read-only (disables write/create/unlink).
+    /// When true, all mutating operations return EROFS.
+    pub read_only: bool,
+}
+
+impl Default for MountOptions {
+    fn default() -> Self {
+        Self { read_only: false }
+    }
+}
+
+impl MountOptions {
+    pub fn read_only() -> Self {
+        Self { read_only: true }
+    }
+}
+
 /// Handle to a mounted DefraDB filesystem.
 ///
 /// The filesystem is unmounted when this handle is dropped.
@@ -24,27 +43,27 @@ impl MountHandle {
 ///
 /// Returns a `MountHandle` that keeps the filesystem mounted.
 /// The filesystem is unmounted when the handle is dropped.
-///
-/// # Arguments
-///
-/// * `db` - The DefraDB instance to expose
-/// * `mountpoint` - Directory to mount on (must exist)
-/// * `rt` - Tokio runtime handle for async DB operations
 pub fn mount<S: Store + 'static>(
     db: Arc<db::DB<S>>,
     mountpoint: &Path,
     rt: tokio::runtime::Handle,
+    options: MountOptions,
 ) -> Result<MountHandle, crate::Error> {
-    let fs = DefraFs::new(db, rt);
+    let fs = DefraFs::new(db, rt, options.read_only);
 
-    let options = &[
-        fuser::MountOption::RW,
+    let mut fuse_options = vec![
         fuser::MountOption::FSName("defradb".into()),
         fuser::MountOption::AutoUnmount,
         fuser::MountOption::AllowOther,
     ];
 
-    let session = fuser::spawn_mount2(fs, mountpoint, options)?;
+    if options.read_only {
+        fuse_options.push(fuser::MountOption::RO);
+    } else {
+        fuse_options.push(fuser::MountOption::RW);
+    }
+
+    let session = fuser::spawn_mount2(fs, mountpoint, &fuse_options)?;
 
     Ok(MountHandle { session })
 }

--- a/crates/fs/src/mount.rs
+++ b/crates/fs/src/mount.rs
@@ -6,25 +6,6 @@ use storage::corekv::Store;
 
 use crate::ops::DefraFs;
 
-/// Options for mounting the DefraDB filesystem.
-pub struct MountOptions {
-    /// Mount as read-only (disables write/create/unlink).
-    /// When true, all mutating operations return EROFS.
-    pub read_only: bool,
-}
-
-impl Default for MountOptions {
-    fn default() -> Self {
-        Self { read_only: false }
-    }
-}
-
-impl MountOptions {
-    pub fn read_only() -> Self {
-        Self { read_only: true }
-    }
-}
-
 /// Handle to a mounted DefraDB filesystem.
 ///
 /// The filesystem is unmounted when this handle is dropped.
@@ -41,29 +22,24 @@ impl MountHandle {
 
 /// Mount a DefraDB instance as a FUSE filesystem.
 ///
-/// Returns a `MountHandle` that keeps the filesystem mounted.
-/// The filesystem is unmounted when the handle is dropped.
+/// The mount is always read-write at the FUSE level. Access control
+/// is enforced by DefraDB's ACP system — permission denials surface
+/// as EACCES errors on individual operations.
 pub fn mount<S: Store + 'static>(
     db: Arc<db::DB<S>>,
     mountpoint: &Path,
     rt: tokio::runtime::Handle,
-    options: MountOptions,
 ) -> Result<MountHandle, crate::Error> {
-    let fs = DefraFs::new(db, rt, options.read_only);
+    let fs = DefraFs::new(db, rt);
 
-    let mut fuse_options = vec![
+    let options = &[
+        fuser::MountOption::RW,
         fuser::MountOption::FSName("defradb".into()),
         fuser::MountOption::AutoUnmount,
         fuser::MountOption::AllowOther,
     ];
 
-    if options.read_only {
-        fuse_options.push(fuser::MountOption::RO);
-    } else {
-        fuse_options.push(fuser::MountOption::RW);
-    }
-
-    let session = fuser::spawn_mount2(fs, mountpoint, &fuse_options)?;
+    let session = fuser::spawn_mount2(fs, mountpoint, options)?;
 
     Ok(MountHandle { session })
 }

--- a/crates/fs/src/ops.rs
+++ b/crates/fs/src/ops.rs
@@ -32,6 +32,7 @@ use tokio::runtime::Handle;
 
 use crate::errno::db_err_to_errno;
 use crate::inode::{InodeTable, InodeTarget, NAME_FIELD, ROOT_INO};
+use crate::virtual_files::{self, SCHEMA_FILE, VIEW_FILE};
 
 const TTL: Duration = Duration::from_secs(1);
 const EPOCH: SystemTime = UNIX_EPOCH;
@@ -93,6 +94,56 @@ impl<S: Store> DefraFs<S> {
             blksize: 512,
             flags: 0,
         }
+    }
+
+    fn readonly_file_attr(ino: u64, size: u64) -> FileAttr {
+        FileAttr {
+            ino,
+            size,
+            blocks: (size + 511) / 512,
+            atime: EPOCH,
+            mtime: EPOCH,
+            ctime: EPOCH,
+            crtime: EPOCH,
+            kind: FileType::RegularFile,
+            perm: 0o444,
+            nlink: 1,
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            blksize: 512,
+            flags: 0,
+        }
+    }
+
+    /// Generate content for a virtual file (_schema.graphql or _view.json).
+    fn fetch_virtual_content(&self, collection: &str, filename: &str) -> Result<Vec<u8>, i32> {
+        let db = self.db.clone();
+        let collection = collection.to_string();
+        let filename = filename.to_string();
+
+        self.rt.block_on(async move {
+            let col = db
+                .get_collection(&collection)
+                .map_err(|e| db_err_to_errno(&e))?
+                .ok_or(libc::ENOENT)?;
+
+            if filename == SCHEMA_FILE {
+                let sdl = virtual_files::generate_sdl(col.schema());
+                Ok(sdl.into_bytes())
+            } else if filename == VIEW_FILE {
+                let txn = db.new_txn(true).await.map_err(|e| db_err_to_errno(&e))?;
+                let docs = col.get_all(&txn).await.map_err(|e| db_err_to_errno(&e))?;
+                txn.commit().await.map_err(|e| db_err_to_errno(&e))?;
+                let maps: Vec<_> = docs
+                    .iter()
+                    .filter_map(|d| d.to_map().ok())
+                    .collect();
+                Ok(virtual_files::generate_view_json(&maps))
+            } else {
+                Err(libc::ENOENT)
+            }
+        })
     }
 
     /// Fetch document JSON bytes by doc_id.
@@ -219,6 +270,22 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 _ => reply.error(libc::ENOENT),
             },
             Some(InodeTarget::Collection { name: col_name }) => {
+                // Check for virtual files first
+                if name_str == SCHEMA_FILE || name_str == VIEW_FILE {
+                    match self.fetch_virtual_content(&col_name, name_str) {
+                        Ok(content) => {
+                            let ino = inodes.virtual_ino(&col_name, name_str);
+                            reply.entry(
+                                &TTL,
+                                &Self::readonly_file_attr(ino, content.len() as u64),
+                                0,
+                            );
+                        }
+                        Err(errno) => reply.error(errno),
+                    }
+                    return;
+                }
+
                 let filename = strip_json_suffix(name_str);
                 let doc_id = match self.resolve_filename(&mut inodes, &col_name, filename) {
                     Ok(id) => id,
@@ -253,6 +320,20 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 drop(inodes);
                 match self.fetch_doc_json(&col, &did) {
                     Ok(json) => reply.attr(&TTL, &Self::file_attr(ino, json.len() as u64)),
+                    Err(errno) => reply.error(errno),
+                }
+            }
+            Some(InodeTarget::VirtualFile {
+                collection,
+                filename,
+            }) => {
+                let col = collection.clone();
+                let fname = filename.clone();
+                drop(inodes);
+                match self.fetch_virtual_content(&col, &fname) {
+                    Ok(content) => {
+                        reply.attr(&TTL, &Self::readonly_file_attr(ino, content.len() as u64))
+                    }
                     Err(errno) => reply.error(errno),
                 }
             }
@@ -296,6 +377,12 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                     (col_ino, FileType::Directory, ".".into()),
                     (ROOT_INO, FileType::Directory, "..".into()),
                 ];
+                // Virtual files
+                let schema_ino = inodes.virtual_ino(&col_name, SCHEMA_FILE);
+                entries.push((schema_ino, FileType::RegularFile, SCHEMA_FILE.into()));
+                let view_ino = inodes.virtual_ino(&col_name, VIEW_FILE);
+                entries.push((view_ino, FileType::RegularFile, VIEW_FILE.into()));
+                // Document files
                 for (doc_id, display_name) in &docs {
                     let child_ino = inodes.doc_ino(&col_name, doc_id, display_name);
                     entries.push((
@@ -343,6 +430,21 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                     Err(errno) => reply.error(errno),
                 }
             }
+            Some(InodeTarget::VirtualFile { collection, filename }) => {
+                drop(inodes);
+                match self.fetch_virtual_content(&collection, &filename) {
+                    Ok(content) => {
+                        let start = offset as usize;
+                        let end = (start + size as usize).min(content.len());
+                        if start >= content.len() {
+                            reply.data(&[]);
+                        } else {
+                            reply.data(&content[start..end]);
+                        }
+                    }
+                    Err(errno) => reply.error(errno),
+                }
+            }
             _ => reply.error(libc::EISDIR),
         }
     }
@@ -372,6 +474,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 buf[offset as usize..end].copy_from_slice(data);
                 reply.written(data.len() as u32);
             }
+            Some(InodeTarget::VirtualFile { .. }) => reply.error(libc::EPERM),
             _ => reply.error(libc::EBADF),
         }
     }
@@ -522,6 +625,12 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
 
         let filename = strip_json_suffix(name_str);
 
+        // Virtual files cannot be deleted
+        if name_str == SCHEMA_FILE || name_str == VIEW_FILE {
+            reply.error(libc::EPERM);
+            return;
+        }
+
         let mut inodes = self.inodes.lock();
         let target = inodes.get(parent).cloned();
 
@@ -631,6 +740,20 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 let actual_size = size.unwrap_or(buf_size);
                 reply.attr(&TTL, &Self::file_attr(ino, actual_size));
             }
+            Some(InodeTarget::VirtualFile {
+                collection,
+                filename,
+            }) => {
+                let col = collection.clone();
+                let fname = filename.clone();
+                drop(inodes);
+                match self.fetch_virtual_content(&col, &fname) {
+                    Ok(content) => {
+                        reply.attr(&TTL, &Self::readonly_file_attr(ino, content.len() as u64))
+                    }
+                    Err(errno) => reply.error(errno),
+                }
+            }
             None => reply.error(libc::ENOENT),
         }
     }
@@ -638,7 +761,9 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
     fn open(&mut self, _req: &Request<'_>, ino: u64, _flags: i32, reply: fuser::ReplyOpen) {
         let inodes = self.inodes.lock();
         match inodes.get(ino) {
-            Some(InodeTarget::Document { .. }) => reply.opened(0, 0),
+            Some(InodeTarget::Document { .. }) | Some(InodeTarget::VirtualFile { .. }) => {
+                reply.opened(0, 0)
+            }
             _ => reply.error(libc::EISDIR),
         }
     }

--- a/crates/fs/src/ops.rs
+++ b/crates/fs/src/ops.rs
@@ -1,23 +1,18 @@
 /// FUSE filesystem implementation backed by DefraDB.
 ///
 /// Maps FUSE operations to DefraDB collection/document CRUD:
-/// - readdir(root) → list_collections()
-/// - readdir(collection) → collection.get_all()
+/// - readdir(root) → list_collections() + root virtual files
+/// - readdir(collection) → collection.get_all() + collection virtual files
 /// - lookup/read(doc) → collection.get()
 /// - write/create → collection.save()
 /// - unlink → collection.delete() (soft delete — data preserved in CRDT DAG)
 /// - rmdir → EPERM (collections cannot be dropped via fs)
 ///
-/// # Filename Convention
+/// # Caching
 ///
-/// Documents with a `_name` field use that value as the filename:
-///   `{_name}.json`  (e.g. `alice.json`)
-///
-/// Documents without `_name` use the raw docID:
-///   `{bae-xxx}.json`
-///
-/// When creating a file with a non-docID name (e.g. `touch notes.json`),
-/// the `_name` field is set automatically in the document.
+/// Virtual file content (`_view.json`, `_schema.graphql`) is cached for 5 seconds
+/// and invalidated on any write or delete operation. This makes `grep` across
+/// `_view.json` fast without sacrificing consistency.
 use std::ffi::OsStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -30,19 +25,19 @@ use parking_lot::Mutex;
 use storage::corekv::Store;
 use tokio::runtime::Handle;
 
+use crate::cache::{self, ContentCache};
 use crate::errno::db_err_to_errno;
 use crate::inode::{InodeTable, InodeTarget, NAME_FIELD, ROOT_INO};
-use crate::virtual_files::{self, SCHEMA_FILE, VIEW_FILE};
+use crate::virtual_files::{self, ROOT_COLLECTIONS_FILE, ROOT_SCHEMA_FILE, SCHEMA_FILE, VIEW_FILE};
 
 const TTL: Duration = Duration::from_secs(1);
 const EPOCH: SystemTime = UNIX_EPOCH;
 
-/// FUSE filesystem backed by a DefraDB instance.
 pub struct DefraFs<S: Store> {
     db: Arc<db::DB<S>>,
     inodes: Mutex<InodeTable>,
+    cache: Mutex<ContentCache>,
     rt: Handle,
-    /// Per-inode write buffers for accumulating write() data before flush.
     write_buffers: Mutex<std::collections::HashMap<u64, Vec<u8>>>,
 }
 
@@ -51,6 +46,7 @@ impl<S: Store> DefraFs<S> {
         Self {
             db,
             inodes: Mutex::new(InodeTable::new()),
+            cache: Mutex::new(ContentCache::new()),
             rt,
             write_buffers: Mutex::new(std::collections::HashMap::new()),
         }
@@ -116,13 +112,19 @@ impl<S: Store> DefraFs<S> {
         }
     }
 
-    /// Generate content for a virtual file (_schema.graphql or _view.json).
+    /// Fetch or generate cached content for a collection virtual file.
     fn fetch_virtual_content(&self, collection: &str, filename: &str) -> Result<Vec<u8>, i32> {
+        let cache_key = cache::col_key(collection, filename);
+
+        if let Some(cached) = self.cache.lock().get(&cache_key) {
+            return Ok(cached.to_vec());
+        }
+
         let db = self.db.clone();
         let collection = collection.to_string();
         let filename = filename.to_string();
 
-        self.rt.block_on(async move {
+        let content = self.rt.block_on(async move {
             let col = db
                 .get_collection(&collection)
                 .map_err(|e| db_err_to_errno(&e))?
@@ -135,18 +137,63 @@ impl<S: Store> DefraFs<S> {
                 let txn = db.new_txn(true).await.map_err(|e| db_err_to_errno(&e))?;
                 let docs = col.get_all(&txn).await.map_err(|e| db_err_to_errno(&e))?;
                 txn.commit().await.map_err(|e| db_err_to_errno(&e))?;
-                let maps: Vec<_> = docs
-                    .iter()
-                    .filter_map(|d| d.to_map().ok())
-                    .collect();
+                let maps: Vec<_> = docs.iter().filter_map(|d| d.to_map().ok()).collect();
                 Ok(virtual_files::generate_view_json(&maps))
             } else {
                 Err(libc::ENOENT)
             }
-        })
+        })?;
+
+        self.cache.lock().insert(cache_key, content.clone());
+        Ok(content)
     }
 
-    /// Fetch document JSON bytes by doc_id.
+    /// Fetch or generate cached content for a root virtual file.
+    fn fetch_root_virtual_content(&self, filename: &str) -> Result<Vec<u8>, i32> {
+        let cache_key = cache::root_key(filename);
+
+        if let Some(cached) = self.cache.lock().get(&cache_key) {
+            return Ok(cached.to_vec());
+        }
+
+        let db = self.db.clone();
+        let filename = filename.to_string();
+
+        let content = self.rt.block_on(async move {
+            let collection_names = db.list_collections().map_err(|e| db_err_to_errno(&e))?;
+
+            if filename == ROOT_SCHEMA_FILE {
+                let schemas: Vec<_> = collection_names
+                    .iter()
+                    .filter_map(|name| db.get_collection(name).ok()?)
+                    .map(|col| col.schema().clone())
+                    .collect();
+                let schema_refs: Vec<_> = schemas.iter().collect();
+                Ok(virtual_files::generate_root_sdl(&schema_refs).into_bytes())
+            } else if filename == ROOT_COLLECTIONS_FILE {
+                let mut collections = Vec::new();
+                for name in &collection_names {
+                    let count = match db.get_collection(name) {
+                        Ok(Some(col)) => {
+                            let txn = db.new_txn(true).await.map_err(|e| db_err_to_errno(&e))?;
+                            let docs = col.get_all(&txn).await.unwrap_or_default();
+                            let _ = txn.commit().await;
+                            docs.len()
+                        }
+                        _ => 0,
+                    };
+                    collections.push((name.clone(), count));
+                }
+                Ok(virtual_files::generate_collections_json(&collections))
+            } else {
+                Err(libc::ENOENT)
+            }
+        })?;
+
+        self.cache.lock().insert(cache_key, content.clone());
+        Ok(content)
+    }
+
     fn fetch_doc_json(&self, collection_name: &str, doc_id_str: &str) -> Result<Vec<u8>, i32> {
         let db = self.db.clone();
         let collection_name = collection_name.to_string();
@@ -170,63 +217,50 @@ impl<S: Store> DefraFs<S> {
         })
     }
 
-    /// List all documents in a collection, returning (doc_id, display_name) pairs.
-    /// display_name is the `_name` field value if present, otherwise the doc_id.
-    fn list_docs(&self, collection_name: &str) -> Vec<(String, String)> {
+    fn list_docs(&self, collection_name: &str) -> Result<Vec<(String, String)>, i32> {
         let db = self.db.clone();
         let collection_name = collection_name.to_string();
 
         self.rt.block_on(async move {
-            let col = match db.get_collection(&collection_name) {
-                Ok(Some(c)) => c,
-                _ => return vec![],
-            };
-            let txn = match db.new_txn(true).await {
-                Ok(t) => t,
-                _ => return vec![],
-            };
-            let docs = match col.get_all(&txn).await {
-                Ok(d) => d,
-                _ => return vec![],
-            };
-            let _ = txn.commit().await;
-            docs.iter()
+            let col = db
+                .get_collection(&collection_name)
+                .map_err(|e| db_err_to_errno(&e))?
+                .ok_or(libc::ENOENT)?;
+            let txn = db.new_txn(true).await.map_err(|e| db_err_to_errno(&e))?;
+            let docs = col.get_all(&txn).await.map_err(|e| db_err_to_errno(&e))?;
+            txn.commit().await.map_err(|e| db_err_to_errno(&e))?;
+            Ok(docs
+                .iter()
                 .filter_map(|d| {
                     let doc_id = d.id()?.to_string();
                     let display_name = extract_name_field(d).unwrap_or_else(|| doc_id.clone());
                     Some((doc_id, display_name))
                 })
-                .collect()
+                .collect())
         })
     }
 
-    /// Resolve a filename (without .json) to a doc_id.
-    /// First checks the inode cache, then falls back to scanning the collection.
     fn resolve_filename(
         &self,
         inodes: &mut InodeTable,
         collection: &str,
         filename: &str,
     ) -> Result<String, i32> {
-        // If it's already a valid docID, use it directly
         if filename.starts_with("bae-") {
             if document::DocID::from_string(filename).is_ok() {
                 return Ok(filename.to_string());
             }
         }
 
-        // Check inode cache
         if let Some(doc_id) = inodes.resolve_name(collection, filename) {
             return Ok(doc_id.to_string());
         }
 
-        // Cache miss — scan collection for a doc with _name matching
-        let docs = self.list_docs(collection);
+        let docs = self.list_docs(collection)?;
         for (doc_id, display_name) in &docs {
             inodes.doc_ino(collection, doc_id, display_name);
         }
 
-        // Try again after populating
         inodes
             .resolve_name(collection, filename)
             .map(|s| s.to_string())
@@ -234,7 +268,6 @@ impl<S: Store> DefraFs<S> {
     }
 }
 
-/// Extract the `_name` field from a document if present.
 fn extract_name_field(doc: &document::Document) -> Option<String> {
     let val = doc.get(NAME_FIELD)?;
     match val {
@@ -243,9 +276,26 @@ fn extract_name_field(doc: &document::Document) -> Option<String> {
     }
 }
 
-/// Strip the .json suffix from a filename.
 fn strip_json_suffix(name: &str) -> &str {
     name.strip_suffix(".json").unwrap_or(name)
+}
+
+fn is_root_virtual_file(name: &str) -> bool {
+    name == ROOT_SCHEMA_FILE || name == ROOT_COLLECTIONS_FILE
+}
+
+fn is_collection_virtual_file(name: &str) -> bool {
+    name == SCHEMA_FILE || name == VIEW_FILE
+}
+
+/// Slice content for a FUSE read with offset and size.
+fn read_slice(content: &[u8], offset: i64, size: u32) -> &[u8] {
+    let start = offset as usize;
+    if start >= content.len() {
+        return &[];
+    }
+    let end = (start + size as usize).min(content.len());
+    &content[start..end]
 }
 
 impl<S: Store + 'static> Filesystem for DefraFs<S> {
@@ -262,16 +312,34 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         let target = inodes.get(parent).cloned();
 
         match target {
-            Some(InodeTarget::Root) => match self.db.get_collection(name_str) {
-                Ok(Some(_)) => {
-                    let ino = inodes.collection_ino(name_str);
-                    reply.entry(&TTL, &Self::dir_attr(ino), 0);
+            Some(InodeTarget::Root) => {
+                // Root virtual files
+                if is_root_virtual_file(name_str) {
+                    match self.fetch_root_virtual_content(name_str) {
+                        Ok(content) => {
+                            let ino = inodes.root_virtual_ino(name_str);
+                            reply.entry(
+                                &TTL,
+                                &Self::readonly_file_attr(ino, content.len() as u64),
+                                0,
+                            );
+                        }
+                        Err(errno) => reply.error(errno),
+                    }
+                    return;
                 }
-                _ => reply.error(libc::ENOENT),
-            },
+
+                // Collection directories
+                match self.db.get_collection(name_str) {
+                    Ok(Some(_)) => {
+                        let ino = inodes.collection_ino(name_str);
+                        reply.entry(&TTL, &Self::dir_attr(ino), 0);
+                    }
+                    _ => reply.error(libc::ENOENT),
+                }
+            }
             Some(InodeTarget::Collection { name: col_name }) => {
-                // Check for virtual files first
-                if name_str == SCHEMA_FILE || name_str == VIEW_FILE {
+                if is_collection_virtual_file(name_str) {
                     match self.fetch_virtual_content(&col_name, name_str) {
                         Ok(content) => {
                             let ino = inodes.virtual_ino(&col_name, name_str);
@@ -337,6 +405,16 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                     Err(errno) => reply.error(errno),
                 }
             }
+            Some(InodeTarget::RootVirtualFile { filename }) => {
+                let fname = filename.clone();
+                drop(inodes);
+                match self.fetch_root_virtual_content(&fname) {
+                    Ok(content) => {
+                        reply.attr(&TTL, &Self::readonly_file_attr(ino, content.len() as u64))
+                    }
+                    Err(errno) => reply.error(errno),
+                }
+            }
             None => reply.error(libc::ENOENT),
         }
     }
@@ -359,6 +437,16 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                     (ROOT_INO, FileType::Directory, ".".into()),
                     (ROOT_INO, FileType::Directory, "..".into()),
                 ];
+                // Root virtual files
+                let schema_ino = inodes.root_virtual_ino(ROOT_SCHEMA_FILE);
+                entries.push((schema_ino, FileType::RegularFile, ROOT_SCHEMA_FILE.into()));
+                let cols_ino = inodes.root_virtual_ino(ROOT_COLLECTIONS_FILE);
+                entries.push((
+                    cols_ino,
+                    FileType::RegularFile,
+                    ROOT_COLLECTIONS_FILE.into(),
+                ));
+                // Collection directories
                 for name in &collections {
                     let child_ino = inodes.collection_ino(name);
                     entries.push((child_ino, FileType::Directory, name.clone()));
@@ -372,12 +460,12 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
             }
             Some(InodeTarget::Collection { name: col_name }) => {
                 let col_ino = ino;
-                let docs = self.list_docs(&col_name);
+                let docs = self.list_docs(&col_name).unwrap_or_default();
                 let mut entries: Vec<(u64, FileType, String)> = vec![
                     (col_ino, FileType::Directory, ".".into()),
                     (ROOT_INO, FileType::Directory, "..".into()),
                 ];
-                // Virtual files
+                // Collection virtual files
                 let schema_ino = inodes.virtual_ino(&col_name, SCHEMA_FILE);
                 entries.push((schema_ino, FileType::RegularFile, SCHEMA_FILE.into()));
                 let view_ino = inodes.virtual_ino(&col_name, VIEW_FILE);
@@ -415,33 +503,29 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
     ) {
         let inodes = self.inodes.lock();
         match inodes.get(ino).cloned() {
-            Some(InodeTarget::Document { collection, doc_id, .. }) => {
+            Some(InodeTarget::Document {
+                collection, doc_id, ..
+            }) => {
                 drop(inodes);
                 match self.fetch_doc_json(&collection, &doc_id) {
-                    Ok(json) => {
-                        let start = offset as usize;
-                        let end = (start + size as usize).min(json.len());
-                        if start >= json.len() {
-                            reply.data(&[]);
-                        } else {
-                            reply.data(&json[start..end]);
-                        }
-                    }
+                    Ok(json) => reply.data(read_slice(&json, offset, size)),
                     Err(errno) => reply.error(errno),
                 }
             }
-            Some(InodeTarget::VirtualFile { collection, filename }) => {
+            Some(InodeTarget::VirtualFile {
+                collection,
+                filename,
+            }) => {
                 drop(inodes);
                 match self.fetch_virtual_content(&collection, &filename) {
-                    Ok(content) => {
-                        let start = offset as usize;
-                        let end = (start + size as usize).min(content.len());
-                        if start >= content.len() {
-                            reply.data(&[]);
-                        } else {
-                            reply.data(&content[start..end]);
-                        }
-                    }
+                    Ok(content) => reply.data(read_slice(&content, offset, size)),
+                    Err(errno) => reply.error(errno),
+                }
+            }
+            Some(InodeTarget::RootVirtualFile { filename }) => {
+                drop(inodes);
+                match self.fetch_root_virtual_content(&filename) {
+                    Ok(content) => reply.data(read_slice(&content, offset, size)),
                     Err(errno) => reply.error(errno),
                 }
             }
@@ -474,7 +558,9 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 buf[offset as usize..end].copy_from_slice(data);
                 reply.written(data.len() as u32);
             }
-            Some(InodeTarget::VirtualFile { .. }) => reply.error(libc::EPERM),
+            Some(InodeTarget::VirtualFile { .. } | InodeTarget::RootVirtualFile { .. }) => {
+                reply.error(libc::EPERM)
+            }
             _ => reply.error(libc::EBADF),
         }
     }
@@ -513,12 +599,10 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                     let doc_id_parsed =
                         document::DocID::from_string(&doc_id).map_err(|_| libc::EINVAL)?;
 
-                    let mut doc =
-                        document::Document::from_json(&buf).map_err(|_| libc::EINVAL)?;
+                    let mut doc = document::Document::from_json(&buf).map_err(|_| libc::EINVAL)?;
                     doc.set_id(doc_id_parsed);
                     doc.set_collection(col.schema().clone());
 
-                    // Preserve _name field if the file was created with a friendly name
                     if display_name != doc_id && !doc.has_field(NAME_FIELD) {
                         doc.set(NAME_FIELD, document::NormalValue::String(display_name));
                     }
@@ -534,6 +618,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 match result {
                     Ok(()) => {
                         self.inodes.lock().invalidate_collection(&col_name);
+                        self.cache.lock().invalidate_collection(&col_name);
                         reply.ok();
                     }
                     Err(errno) => reply.error(errno),
@@ -541,6 +626,20 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
             }
             _ => reply.ok(),
         }
+    }
+
+    fn release(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        _flush: bool,
+        reply: ReplyEmpty,
+    ) {
+        self.write_buffers.lock().remove(&ino);
+        reply.ok();
     }
 
     fn create(
@@ -568,9 +667,6 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
 
         match target {
             Some(InodeTarget::Collection { name: col_name }) => {
-                // For friendly names, we need a placeholder doc_id.
-                // Generate one by creating and immediately saving an empty doc
-                // with the _name field set, so the docID is content-addressed.
                 let doc_id = if display_name.starts_with("bae-") {
                     match document::DocID::from_string(display_name) {
                         Ok(_) => display_name.to_string(),
@@ -580,7 +676,6 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                         }
                     }
                 } else {
-                    // Create a doc with _name to get a deterministic docID
                     let db = self.db.clone();
                     let col_name_clone = col_name.clone();
                     let display = display_name.to_string();
@@ -592,8 +687,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                         let mut doc = document::Document::new();
                         doc.set_collection(col.schema().clone());
                         doc.set(NAME_FIELD, document::NormalValue::String(display));
-                        doc.generate_and_set_doc_id()
-                            .map_err(|_| libc::EIO)?;
+                        doc.generate_and_set_doc_id().map_err(|_| libc::EIO)?;
                         Ok::<String, i32>(doc.id().unwrap().to_string())
                     });
                     match result {
@@ -625,8 +719,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
 
         let filename = strip_json_suffix(name_str);
 
-        // Virtual files cannot be deleted
-        if name_str == SCHEMA_FILE || name_str == VIEW_FILE {
+        if is_collection_virtual_file(name_str) {
             reply.error(libc::EPERM);
             return;
         }
@@ -674,6 +767,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                     Ok(()) => {
                         let mut inodes = self.inodes.lock();
                         inodes.remove_doc(&col_name, &doc_id);
+                        self.cache.lock().invalidate_collection(&col_name);
                         reply.ok();
                     }
                     Err(errno) => reply.error(errno),
@@ -683,8 +777,6 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         }
     }
 
-    /// rmdir on a collection directory is not allowed.
-    /// Collections contain schema and data — dropping them via `rm -r` would be destructive.
     fn rmdir(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
         let name_str = match name.to_str() {
             Some(n) => n,
@@ -722,7 +814,6 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         _flags: Option<u32>,
         reply: ReplyAttr,
     ) {
-        // Support truncate (size=0) for write-then-flush pattern.
         if let Some(new_size) = size {
             if new_size == 0 {
                 self.write_buffers.lock().remove(&ino);
@@ -754,6 +845,16 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                     Err(errno) => reply.error(errno),
                 }
             }
+            Some(InodeTarget::RootVirtualFile { filename }) => {
+                let fname = filename.clone();
+                drop(inodes);
+                match self.fetch_root_virtual_content(&fname) {
+                    Ok(content) => {
+                        reply.attr(&TTL, &Self::readonly_file_attr(ino, content.len() as u64))
+                    }
+                    Err(errno) => reply.error(errno),
+                }
+            }
             None => reply.error(libc::ENOENT),
         }
     }
@@ -761,9 +862,11 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
     fn open(&mut self, _req: &Request<'_>, ino: u64, _flags: i32, reply: fuser::ReplyOpen) {
         let inodes = self.inodes.lock();
         match inodes.get(ino) {
-            Some(InodeTarget::Document { .. }) | Some(InodeTarget::VirtualFile { .. }) => {
-                reply.opened(0, 0)
-            }
+            Some(
+                InodeTarget::Document { .. }
+                | InodeTarget::VirtualFile { .. }
+                | InodeTarget::RootVirtualFile { .. },
+            ) => reply.opened(0, 0),
             _ => reply.error(libc::EISDIR),
         }
     }
@@ -776,5 +879,9 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
             }
             _ => reply.error(libc::ENOTDIR),
         }
+    }
+
+    fn statfs(&mut self, _req: &Request<'_>, _ino: u64, reply: fuser::ReplyStatfs) {
+        reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
     }
 }

--- a/crates/fs/src/ops.rs
+++ b/crates/fs/src/ops.rs
@@ -6,6 +6,7 @@
 /// - lookup/read(doc) → collection.get()
 /// - write/create → collection.create() or collection.save()
 /// - unlink → collection.delete()
+/// - rmdir → ENOTEMPTY (collections cannot be dropped via fs)
 use std::ffi::OsStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -18,6 +19,7 @@ use parking_lot::Mutex;
 use storage::corekv::Store;
 use tokio::runtime::Handle;
 
+use crate::errno::db_err_to_errno;
 use crate::inode::{InodeTable, InodeTarget, ROOT_INO};
 
 /// TTL for filesystem attributes (short, since DB can change).
@@ -31,22 +33,23 @@ pub struct DefraFs<S: Store> {
     db: Arc<db::DB<S>>,
     inodes: Mutex<InodeTable>,
     rt: Handle,
+    read_only: bool,
     /// Per-inode write buffers for accumulating write() data before flush.
     write_buffers: Mutex<std::collections::HashMap<u64, Vec<u8>>>,
 }
 
 impl<S: Store> DefraFs<S> {
-    pub fn new(db: Arc<db::DB<S>>, rt: Handle) -> Self {
+    pub fn new(db: Arc<db::DB<S>>, rt: Handle, read_only: bool) -> Self {
         Self {
             db,
             inodes: Mutex::new(InodeTable::new()),
             rt,
+            read_only,
             write_buffers: Mutex::new(std::collections::HashMap::new()),
         }
     }
 
-    /// Build a directory FileAttr.
-    fn dir_attr(ino: u64) -> FileAttr {
+    fn dir_attr(ino: u64, perm: u16) -> FileAttr {
         FileAttr {
             ino,
             size: 0,
@@ -56,7 +59,7 @@ impl<S: Store> DefraFs<S> {
             ctime: EPOCH,
             crtime: EPOCH,
             kind: FileType::Directory,
-            perm: 0o755,
+            perm,
             nlink: 2,
             uid: 0,
             gid: 0,
@@ -66,8 +69,7 @@ impl<S: Store> DefraFs<S> {
         }
     }
 
-    /// Build a regular file FileAttr.
-    fn file_attr(ino: u64, size: u64) -> FileAttr {
+    fn file_attr(ino: u64, size: u64, perm: u16) -> FileAttr {
         FileAttr {
             ino,
             size,
@@ -77,7 +79,7 @@ impl<S: Store> DefraFs<S> {
             ctime: EPOCH,
             crtime: EPOCH,
             kind: FileType::RegularFile,
-            perm: 0o644,
+            perm,
             nlink: 1,
             uid: 0,
             gid: 0,
@@ -87,22 +89,37 @@ impl<S: Store> DefraFs<S> {
         }
     }
 
+    fn dir_perm(&self) -> u16 {
+        if self.read_only { 0o555 } else { 0o755 }
+    }
+
+    fn file_perm(&self) -> u16 {
+        if self.read_only { 0o444 } else { 0o644 }
+    }
+
     /// Fetch document JSON bytes for a given collection + doc_id.
-    fn fetch_doc_json(&self, collection_name: &str, doc_id_str: &str) -> Option<Vec<u8>> {
+    /// Returns Ok(bytes) on success, Err(errno) on failure.
+    fn fetch_doc_json(&self, collection_name: &str, doc_id_str: &str) -> Result<Vec<u8>, i32> {
         let db = self.db.clone();
         let collection_name = collection_name.to_string();
         let doc_id_str = doc_id_str.to_string();
 
-        self.rt
-            .block_on(async move {
-                let col = db.get_collection(&collection_name).ok()??;
-                let doc_id = document::DocID::from_string(&doc_id_str).ok()?;
-                let txn = db.new_txn(true).await.ok()?;
-                let doc = col.get(&txn, &doc_id).await.ok()??;
-                txn.commit().await.ok()?;
-                let map = doc.to_map().ok()?;
-                serde_json::to_vec_pretty(&map).ok()
-            })
+        self.rt.block_on(async move {
+            let col = db
+                .get_collection(&collection_name)
+                .map_err(|e| db_err_to_errno(&e))?
+                .ok_or(libc::ENOENT)?;
+            let doc_id = document::DocID::from_string(&doc_id_str).map_err(|_| libc::EINVAL)?;
+            let txn = db.new_txn(true).await.map_err(|e| db_err_to_errno(&e))?;
+            let doc = col
+                .get(&txn, &doc_id)
+                .await
+                .map_err(|e| db_err_to_errno(&e))?
+                .ok_or(libc::ENOENT)?;
+            txn.commit().await.map_err(|e| db_err_to_errno(&e))?;
+            let map = doc.to_map().map_err(|_| libc::EIO)?;
+            serde_json::to_vec_pretty(&map).map_err(|_| libc::EIO)
+        })
     }
 
     /// List all doc IDs in a collection.
@@ -129,6 +146,18 @@ impl<S: Store> DefraFs<S> {
                 .collect()
         })
     }
+
+    /// Validate that a filename represents a valid doc ID.
+    /// Strips .json suffix and checks the bae-xxx format.
+    fn parse_doc_id_from_filename(name: &str) -> Result<&str, i32> {
+        let doc_id_str = name.strip_suffix(".json").unwrap_or(name);
+        if !doc_id_str.starts_with("bae-") {
+            return Err(libc::EINVAL);
+        }
+        // Validate it parses as a DocID
+        document::DocID::from_string(doc_id_str).map_err(|_| libc::EINVAL)?;
+        Ok(doc_id_str)
+    }
 }
 
 impl<S: Store + 'static> Filesystem for DefraFs<S> {
@@ -146,24 +175,29 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
 
         match target {
             Some(InodeTarget::Root) => {
-                // Looking up a collection directory
                 match self.db.get_collection(name_str) {
                     Ok(Some(_)) => {
                         let ino = inodes.collection_ino(name_str);
-                        reply.entry(&TTL, &Self::dir_attr(ino), 0);
+                        reply.entry(&TTL, &Self::dir_attr(ino, self.dir_perm()), 0);
                     }
                     _ => reply.error(libc::ENOENT),
                 }
             }
             Some(InodeTarget::Collection { name: col_name }) => {
-                // Looking up a document file
-                let doc_id_str = name_str.strip_suffix(".json").unwrap_or(name_str);
-                match self.fetch_doc_json(&col_name, doc_id_str) {
-                    Some(json) => {
-                        let ino = inodes.doc_ino(&col_name, doc_id_str);
-                        reply.entry(&TTL, &Self::file_attr(ino, json.len() as u64), 0);
+                let doc_id_str = match Self::parse_doc_id_from_filename(name_str) {
+                    Ok(id) => id.to_string(),
+                    Err(errno) => {
+                        reply.error(errno);
+                        return;
                     }
-                    None => reply.error(libc::ENOENT),
+                };
+                match self.fetch_doc_json(&col_name, &doc_id_str) {
+                    Ok(json) => {
+                        let ino = inodes.doc_ino(&col_name, &doc_id_str);
+                        let attr = Self::file_attr(ino, json.len() as u64, self.file_perm());
+                        reply.entry(&TTL, &attr, 0);
+                    }
+                    Err(errno) => reply.error(errno),
                 }
             }
             _ => reply.error(libc::ENOENT),
@@ -174,7 +208,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         let inodes = self.inodes.lock();
         match inodes.get(ino) {
             Some(InodeTarget::Root) | Some(InodeTarget::Collection { .. }) => {
-                reply.attr(&TTL, &Self::dir_attr(ino));
+                reply.attr(&TTL, &Self::dir_attr(ino, self.dir_perm()));
             }
             Some(InodeTarget::Document {
                 collection, doc_id, ..
@@ -183,8 +217,11 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 let did = doc_id.clone();
                 drop(inodes);
                 match self.fetch_doc_json(&col, &did) {
-                    Some(json) => reply.attr(&TTL, &Self::file_attr(ino, json.len() as u64)),
-                    None => reply.error(libc::ENOENT),
+                    Ok(json) => {
+                        let attr = Self::file_attr(ino, json.len() as u64, self.file_perm());
+                        reply.attr(&TTL, &attr);
+                    }
+                    Err(errno) => reply.error(errno),
                 }
             }
             None => reply.error(libc::ENOENT),
@@ -262,7 +299,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
             Some(InodeTarget::Document { collection, doc_id }) => {
                 drop(inodes);
                 match self.fetch_doc_json(&collection, &doc_id) {
-                    Some(json) => {
+                    Ok(json) => {
                         let start = offset as usize;
                         let end = (start + size as usize).min(json.len());
                         if start >= json.len() {
@@ -271,7 +308,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                             reply.data(&json[start..end]);
                         }
                     }
-                    None => reply.error(libc::ENOENT),
+                    Err(errno) => reply.error(errno),
                 }
             }
             _ => reply.error(libc::EISDIR),
@@ -290,6 +327,11 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         _lock_owner: Option<u64>,
         reply: ReplyWrite,
     ) {
+        if self.read_only {
+            reply.error(libc::EROFS);
+            return;
+        }
+
         let inodes = self.inodes.lock();
         match inodes.get(ino).cloned() {
             Some(InodeTarget::Document { .. }) => {
@@ -307,7 +349,14 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         }
     }
 
-    fn flush(&mut self, _req: &Request<'_>, ino: u64, _fh: u64, _lock_owner: u64, reply: ReplyEmpty) {
+    fn flush(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        reply: ReplyEmpty,
+    ) {
         let data = self.write_buffers.lock().remove(&ino);
         let Some(buf) = data else {
             reply.ok();
@@ -325,16 +374,21 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 let result = self.rt.block_on(async move {
                     let col = db
                         .get_collection(&collection)
-                        .map_err(|_| libc::EIO)?
+                        .map_err(|e| db_err_to_errno(&e))?
                         .ok_or(libc::ENOENT)?;
                     let doc_id_parsed =
                         document::DocID::from_string(&doc_id).map_err(|_| libc::EINVAL)?;
-                    let mut doc = document::Document::from_json(&buf).map_err(|_| libc::EINVAL)?;
+
+                    let mut doc =
+                        document::Document::from_json(&buf).map_err(|_| libc::EINVAL)?;
                     doc.set_id(doc_id_parsed);
                     doc.set_collection(col.schema().clone());
-                    let txn = db.new_txn(false).await.map_err(|_| libc::EIO)?;
-                    col.save(&txn, &doc).await.map_err(|_| libc::EIO)?;
-                    txn.commit().await.map_err(|_| libc::EIO)?;
+
+                    let txn = db.new_txn(false).await.map_err(|e| db_err_to_errno(&e))?;
+                    col.save(&txn, &doc)
+                        .await
+                        .map_err(|e| db_err_to_errno(&e))?;
+                    txn.commit().await.map_err(|e| db_err_to_errno(&e))?;
                     Ok::<(), i32>(())
                 });
 
@@ -360,6 +414,11 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         _flags: i32,
         reply: ReplyCreate,
     ) {
+        if self.read_only {
+            reply.error(libc::EROFS);
+            return;
+        }
+
         let name_str = match name.to_str() {
             Some(n) => n,
             None => {
@@ -368,27 +427,10 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
             }
         };
 
-        let mut inodes = self.inodes.lock();
-        let target = inodes.get(parent).cloned();
-
-        match target {
-            Some(InodeTarget::Collection { name: col_name }) => {
-                let doc_id_str = name_str.strip_suffix(".json").unwrap_or(name_str);
-                let ino = inodes.doc_ino(&col_name, doc_id_str);
-                inodes.invalidate(&col_name);
-                drop(inodes);
-                let attr = Self::file_attr(ino, 0);
-                reply.created(&TTL, &attr, 0, 0, 0);
-            }
-            _ => reply.error(libc::ENOTDIR),
-        }
-    }
-
-    fn unlink(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
-        let name_str = match name.to_str() {
-            Some(n) => n,
-            None => {
-                reply.error(libc::ENOENT);
+        let doc_id_str = match Self::parse_doc_id_from_filename(name_str) {
+            Ok(id) => id.to_string(),
+            Err(errno) => {
+                reply.error(errno);
                 return;
             }
         };
@@ -398,23 +440,62 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
 
         match target {
             Some(InodeTarget::Collection { name: col_name }) => {
-                let doc_id_str = name_str.strip_suffix(".json").unwrap_or(name_str);
+                let ino = inodes.doc_ino(&col_name, &doc_id_str);
+                inodes.invalidate(&col_name);
+                drop(inodes);
+                let attr = Self::file_attr(ino, 0, self.file_perm());
+                reply.created(&TTL, &attr, 0, 0, 0);
+            }
+            _ => reply.error(libc::ENOTDIR),
+        }
+    }
+
+    fn unlink(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+        if self.read_only {
+            reply.error(libc::EROFS);
+            return;
+        }
+
+        let name_str = match name.to_str() {
+            Some(n) => n,
+            None => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+
+        let doc_id_str = match Self::parse_doc_id_from_filename(name_str) {
+            Ok(id) => id.to_string(),
+            Err(errno) => {
+                reply.error(errno);
+                return;
+            }
+        };
+
+        let mut inodes = self.inodes.lock();
+        let target = inodes.get(parent).cloned();
+
+        match target {
+            Some(InodeTarget::Collection { name: col_name }) => {
                 let db = self.db.clone();
                 let col_name_clone = col_name.clone();
-                let doc_id_string = doc_id_str.to_string();
+                let doc_id_string = doc_id_str.clone();
 
                 drop(inodes);
 
                 let result = self.rt.block_on(async move {
                     let col = db
                         .get_collection(&col_name_clone)
-                        .map_err(|_| libc::EIO)?
+                        .map_err(|e| db_err_to_errno(&e))?
                         .ok_or(libc::ENOENT)?;
                     let doc_id =
                         document::DocID::from_string(&doc_id_string).map_err(|_| libc::EINVAL)?;
-                    let txn = db.new_txn(false).await.map_err(|_| libc::EIO)?;
-                    let deleted = col.delete(&txn, &doc_id).await.map_err(|_| libc::EIO)?;
-                    txn.commit().await.map_err(|_| libc::EIO)?;
+                    let txn = db.new_txn(false).await.map_err(|e| db_err_to_errno(&e))?;
+                    let deleted = col
+                        .delete(&txn, &doc_id)
+                        .await
+                        .map_err(|e| db_err_to_errno(&e))?;
+                    txn.commit().await.map_err(|e| db_err_to_errno(&e))?;
                     if deleted {
                         Ok(())
                     } else {
@@ -425,11 +506,34 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 match result {
                     Ok(()) => {
                         let mut inodes = self.inodes.lock();
-                        inodes.remove_doc(&col_name, doc_id_str);
+                        inodes.remove_doc(&col_name, &doc_id_str);
                         inodes.invalidate(&col_name);
                         reply.ok();
                     }
                     Err(errno) => reply.error(errno),
+                }
+            }
+            _ => reply.error(libc::ENOTDIR),
+        }
+    }
+
+    /// rmdir on a collection directory is not allowed.
+    /// Collections contain schema and data — dropping them via `rm -r` would be destructive.
+    fn rmdir(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+        let name_str = match name.to_str() {
+            Some(n) => n,
+            None => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+
+        let inodes = self.inodes.lock();
+        match inodes.get(parent) {
+            Some(InodeTarget::Root) => {
+                match self.db.get_collection(name_str) {
+                    Ok(Some(_)) => reply.error(libc::EPERM),
+                    _ => reply.error(libc::ENOENT),
                 }
             }
             _ => reply.error(libc::ENOTDIR),
@@ -454,6 +558,11 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         _flags: Option<u32>,
         reply: ReplyAttr,
     ) {
+        if size.is_some() && self.read_only {
+            reply.error(libc::EROFS);
+            return;
+        }
+
         // Support truncate (size=0) for write-then-flush pattern.
         if let Some(new_size) = size {
             if new_size == 0 {
@@ -464,13 +573,13 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         let inodes = self.inodes.lock();
         match inodes.get(ino) {
             Some(InodeTarget::Root) | Some(InodeTarget::Collection { .. }) => {
-                reply.attr(&TTL, &Self::dir_attr(ino));
+                reply.attr(&TTL, &Self::dir_attr(ino, self.dir_perm()));
             }
             Some(InodeTarget::Document { .. }) => {
                 let buffers = self.write_buffers.lock();
                 let buf_size = buffers.get(&ino).map(|b| b.len() as u64).unwrap_or(0);
                 let actual_size = size.unwrap_or(buf_size);
-                reply.attr(&TTL, &Self::file_attr(ino, actual_size));
+                reply.attr(&TTL, &Self::file_attr(ino, actual_size, self.file_perm()));
             }
             None => reply.error(libc::ENOENT),
         }

--- a/crates/fs/src/ops.rs
+++ b/crates/fs/src/ops.rs
@@ -4,9 +4,20 @@
 /// - readdir(root) → list_collections()
 /// - readdir(collection) → collection.get_all()
 /// - lookup/read(doc) → collection.get()
-/// - write/create → collection.create() or collection.save()
-/// - unlink → collection.delete()
-/// - rmdir → ENOTEMPTY (collections cannot be dropped via fs)
+/// - write/create → collection.save()
+/// - unlink → collection.delete() (soft delete — data preserved in CRDT DAG)
+/// - rmdir → EPERM (collections cannot be dropped via fs)
+///
+/// # Filename Convention
+///
+/// Documents with a `_name` field use that value as the filename:
+///   `{_name}.json`  (e.g. `alice.json`)
+///
+/// Documents without `_name` use the raw docID:
+///   `{bae-xxx}.json`
+///
+/// When creating a file with a non-docID name (e.g. `touch notes.json`),
+/// the `_name` field is set automatically in the document.
 use std::ffi::OsStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -20,12 +31,9 @@ use storage::corekv::Store;
 use tokio::runtime::Handle;
 
 use crate::errno::db_err_to_errno;
-use crate::inode::{InodeTable, InodeTarget, ROOT_INO};
+use crate::inode::{InodeTable, InodeTarget, NAME_FIELD, ROOT_INO};
 
-/// TTL for filesystem attributes (short, since DB can change).
 const TTL: Duration = Duration::from_secs(1);
-
-/// Epoch time used for all file timestamps.
 const EPOCH: SystemTime = UNIX_EPOCH;
 
 /// FUSE filesystem backed by a DefraDB instance.
@@ -33,23 +41,21 @@ pub struct DefraFs<S: Store> {
     db: Arc<db::DB<S>>,
     inodes: Mutex<InodeTable>,
     rt: Handle,
-    read_only: bool,
     /// Per-inode write buffers for accumulating write() data before flush.
     write_buffers: Mutex<std::collections::HashMap<u64, Vec<u8>>>,
 }
 
 impl<S: Store> DefraFs<S> {
-    pub fn new(db: Arc<db::DB<S>>, rt: Handle, read_only: bool) -> Self {
+    pub fn new(db: Arc<db::DB<S>>, rt: Handle) -> Self {
         Self {
             db,
             inodes: Mutex::new(InodeTable::new()),
             rt,
-            read_only,
             write_buffers: Mutex::new(std::collections::HashMap::new()),
         }
     }
 
-    fn dir_attr(ino: u64, perm: u16) -> FileAttr {
+    fn dir_attr(ino: u64) -> FileAttr {
         FileAttr {
             ino,
             size: 0,
@@ -59,7 +65,7 @@ impl<S: Store> DefraFs<S> {
             ctime: EPOCH,
             crtime: EPOCH,
             kind: FileType::Directory,
-            perm,
+            perm: 0o755,
             nlink: 2,
             uid: 0,
             gid: 0,
@@ -69,7 +75,7 @@ impl<S: Store> DefraFs<S> {
         }
     }
 
-    fn file_attr(ino: u64, size: u64, perm: u16) -> FileAttr {
+    fn file_attr(ino: u64, size: u64) -> FileAttr {
         FileAttr {
             ino,
             size,
@@ -79,7 +85,7 @@ impl<S: Store> DefraFs<S> {
             ctime: EPOCH,
             crtime: EPOCH,
             kind: FileType::RegularFile,
-            perm,
+            perm: 0o644,
             nlink: 1,
             uid: 0,
             gid: 0,
@@ -89,16 +95,7 @@ impl<S: Store> DefraFs<S> {
         }
     }
 
-    fn dir_perm(&self) -> u16 {
-        if self.read_only { 0o555 } else { 0o755 }
-    }
-
-    fn file_perm(&self) -> u16 {
-        if self.read_only { 0o444 } else { 0o644 }
-    }
-
-    /// Fetch document JSON bytes for a given collection + doc_id.
-    /// Returns Ok(bytes) on success, Err(errno) on failure.
+    /// Fetch document JSON bytes by doc_id.
     fn fetch_doc_json(&self, collection_name: &str, doc_id_str: &str) -> Result<Vec<u8>, i32> {
         let db = self.db.clone();
         let collection_name = collection_name.to_string();
@@ -122,8 +119,9 @@ impl<S: Store> DefraFs<S> {
         })
     }
 
-    /// List all doc IDs in a collection.
-    fn list_doc_ids(&self, collection_name: &str) -> Vec<String> {
+    /// List all documents in a collection, returning (doc_id, display_name) pairs.
+    /// display_name is the `_name` field value if present, otherwise the doc_id.
+    fn list_docs(&self, collection_name: &str) -> Vec<(String, String)> {
         let db = self.db.clone();
         let collection_name = collection_name.to_string();
 
@@ -142,22 +140,61 @@ impl<S: Store> DefraFs<S> {
             };
             let _ = txn.commit().await;
             docs.iter()
-                .filter_map(|d| d.id().map(|id| id.to_string()))
+                .filter_map(|d| {
+                    let doc_id = d.id()?.to_string();
+                    let display_name = extract_name_field(d).unwrap_or_else(|| doc_id.clone());
+                    Some((doc_id, display_name))
+                })
                 .collect()
         })
     }
 
-    /// Validate that a filename represents a valid doc ID.
-    /// Strips .json suffix and checks the bae-xxx format.
-    fn parse_doc_id_from_filename(name: &str) -> Result<&str, i32> {
-        let doc_id_str = name.strip_suffix(".json").unwrap_or(name);
-        if !doc_id_str.starts_with("bae-") {
-            return Err(libc::EINVAL);
+    /// Resolve a filename (without .json) to a doc_id.
+    /// First checks the inode cache, then falls back to scanning the collection.
+    fn resolve_filename(
+        &self,
+        inodes: &mut InodeTable,
+        collection: &str,
+        filename: &str,
+    ) -> Result<String, i32> {
+        // If it's already a valid docID, use it directly
+        if filename.starts_with("bae-") {
+            if document::DocID::from_string(filename).is_ok() {
+                return Ok(filename.to_string());
+            }
         }
-        // Validate it parses as a DocID
-        document::DocID::from_string(doc_id_str).map_err(|_| libc::EINVAL)?;
-        Ok(doc_id_str)
+
+        // Check inode cache
+        if let Some(doc_id) = inodes.resolve_name(collection, filename) {
+            return Ok(doc_id.to_string());
+        }
+
+        // Cache miss — scan collection for a doc with _name matching
+        let docs = self.list_docs(collection);
+        for (doc_id, display_name) in &docs {
+            inodes.doc_ino(collection, doc_id, display_name);
+        }
+
+        // Try again after populating
+        inodes
+            .resolve_name(collection, filename)
+            .map(|s| s.to_string())
+            .ok_or(libc::ENOENT)
     }
+}
+
+/// Extract the `_name` field from a document if present.
+fn extract_name_field(doc: &document::Document) -> Option<String> {
+    let val = doc.get(NAME_FIELD)?;
+    match val {
+        document::NormalValue::String(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Strip the .json suffix from a filename.
+fn strip_json_suffix(name: &str) -> &str {
+    name.strip_suffix(".json").unwrap_or(name)
 }
 
 impl<S: Store + 'static> Filesystem for DefraFs<S> {
@@ -174,28 +211,26 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         let target = inodes.get(parent).cloned();
 
         match target {
-            Some(InodeTarget::Root) => {
-                match self.db.get_collection(name_str) {
-                    Ok(Some(_)) => {
-                        let ino = inodes.collection_ino(name_str);
-                        reply.entry(&TTL, &Self::dir_attr(ino, self.dir_perm()), 0);
-                    }
-                    _ => reply.error(libc::ENOENT),
+            Some(InodeTarget::Root) => match self.db.get_collection(name_str) {
+                Ok(Some(_)) => {
+                    let ino = inodes.collection_ino(name_str);
+                    reply.entry(&TTL, &Self::dir_attr(ino), 0);
                 }
-            }
+                _ => reply.error(libc::ENOENT),
+            },
             Some(InodeTarget::Collection { name: col_name }) => {
-                let doc_id_str = match Self::parse_doc_id_from_filename(name_str) {
-                    Ok(id) => id.to_string(),
+                let filename = strip_json_suffix(name_str);
+                let doc_id = match self.resolve_filename(&mut inodes, &col_name, filename) {
+                    Ok(id) => id,
                     Err(errno) => {
                         reply.error(errno);
                         return;
                     }
                 };
-                match self.fetch_doc_json(&col_name, &doc_id_str) {
+                match self.fetch_doc_json(&col_name, &doc_id) {
                     Ok(json) => {
-                        let ino = inodes.doc_ino(&col_name, &doc_id_str);
-                        let attr = Self::file_attr(ino, json.len() as u64, self.file_perm());
-                        reply.entry(&TTL, &attr, 0);
+                        let ino = inodes.doc_ino(&col_name, &doc_id, filename);
+                        reply.entry(&TTL, &Self::file_attr(ino, json.len() as u64), 0);
                     }
                     Err(errno) => reply.error(errno),
                 }
@@ -208,7 +243,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         let inodes = self.inodes.lock();
         match inodes.get(ino) {
             Some(InodeTarget::Root) | Some(InodeTarget::Collection { .. }) => {
-                reply.attr(&TTL, &Self::dir_attr(ino, self.dir_perm()));
+                reply.attr(&TTL, &Self::dir_attr(ino));
             }
             Some(InodeTarget::Document {
                 collection, doc_id, ..
@@ -217,10 +252,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 let did = doc_id.clone();
                 drop(inodes);
                 match self.fetch_doc_json(&col, &did) {
-                    Ok(json) => {
-                        let attr = Self::file_attr(ino, json.len() as u64, self.file_perm());
-                        reply.attr(&TTL, &attr);
-                    }
+                    Ok(json) => reply.attr(&TTL, &Self::file_attr(ino, json.len() as u64)),
                     Err(errno) => reply.error(errno),
                 }
             }
@@ -259,17 +291,17 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
             }
             Some(InodeTarget::Collection { name: col_name }) => {
                 let col_ino = ino;
-                let doc_ids = self.list_doc_ids(&col_name);
+                let docs = self.list_docs(&col_name);
                 let mut entries: Vec<(u64, FileType, String)> = vec![
                     (col_ino, FileType::Directory, ".".into()),
                     (ROOT_INO, FileType::Directory, "..".into()),
                 ];
-                for doc_id in &doc_ids {
-                    let child_ino = inodes.doc_ino(&col_name, doc_id);
+                for (doc_id, display_name) in &docs {
+                    let child_ino = inodes.doc_ino(&col_name, doc_id, display_name);
                     entries.push((
                         child_ino,
                         FileType::RegularFile,
-                        format!("{}.json", doc_id),
+                        format!("{}.json", display_name),
                     ));
                 }
                 for (i, (ino, kind, name)) in entries.iter().enumerate().skip(offset as usize) {
@@ -296,7 +328,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
     ) {
         let inodes = self.inodes.lock();
         match inodes.get(ino).cloned() {
-            Some(InodeTarget::Document { collection, doc_id }) => {
+            Some(InodeTarget::Document { collection, doc_id, .. }) => {
                 drop(inodes);
                 match self.fetch_doc_json(&collection, &doc_id) {
                     Ok(json) => {
@@ -327,11 +359,6 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         _lock_owner: Option<u64>,
         reply: ReplyWrite,
     ) {
-        if self.read_only {
-            reply.error(libc::EROFS);
-            return;
-        }
-
         let inodes = self.inodes.lock();
         match inodes.get(ino).cloned() {
             Some(InodeTarget::Document { .. }) => {
@@ -368,7 +395,11 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         drop(inodes);
 
         match target {
-            Some(InodeTarget::Document { collection, doc_id }) => {
+            Some(InodeTarget::Document {
+                collection,
+                doc_id,
+                display_name,
+            }) => {
                 let db = self.db.clone();
                 let col_name = collection.clone();
                 let result = self.rt.block_on(async move {
@@ -384,6 +415,11 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                     doc.set_id(doc_id_parsed);
                     doc.set_collection(col.schema().clone());
 
+                    // Preserve _name field if the file was created with a friendly name
+                    if display_name != doc_id && !doc.has_field(NAME_FIELD) {
+                        doc.set(NAME_FIELD, document::NormalValue::String(display_name));
+                    }
+
                     let txn = db.new_txn(false).await.map_err(|e| db_err_to_errno(&e))?;
                     col.save(&txn, &doc)
                         .await
@@ -394,7 +430,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
 
                 match result {
                     Ok(()) => {
-                        self.inodes.lock().invalidate(&col_name);
+                        self.inodes.lock().invalidate_collection(&col_name);
                         reply.ok();
                     }
                     Err(errno) => reply.error(errno),
@@ -414,11 +450,6 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         _flags: i32,
         reply: ReplyCreate,
     ) {
-        if self.read_only {
-            reply.error(libc::EROFS);
-            return;
-        }
-
         let name_str = match name.to_str() {
             Some(n) => n,
             None => {
@@ -427,35 +458,60 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
             }
         };
 
-        let doc_id_str = match Self::parse_doc_id_from_filename(name_str) {
-            Ok(id) => id.to_string(),
-            Err(errno) => {
-                reply.error(errno);
-                return;
-            }
-        };
+        let display_name = strip_json_suffix(name_str);
 
         let mut inodes = self.inodes.lock();
         let target = inodes.get(parent).cloned();
 
         match target {
             Some(InodeTarget::Collection { name: col_name }) => {
-                let ino = inodes.doc_ino(&col_name, &doc_id_str);
-                inodes.invalidate(&col_name);
+                // For friendly names, we need a placeholder doc_id.
+                // Generate one by creating and immediately saving an empty doc
+                // with the _name field set, so the docID is content-addressed.
+                let doc_id = if display_name.starts_with("bae-") {
+                    match document::DocID::from_string(display_name) {
+                        Ok(_) => display_name.to_string(),
+                        Err(_) => {
+                            reply.error(libc::EINVAL);
+                            return;
+                        }
+                    }
+                } else {
+                    // Create a doc with _name to get a deterministic docID
+                    let db = self.db.clone();
+                    let col_name_clone = col_name.clone();
+                    let display = display_name.to_string();
+                    let result = self.rt.block_on(async move {
+                        let col = db
+                            .get_collection(&col_name_clone)
+                            .map_err(|e| db_err_to_errno(&e))?
+                            .ok_or(libc::ENOENT)?;
+                        let mut doc = document::Document::new();
+                        doc.set_collection(col.schema().clone());
+                        doc.set(NAME_FIELD, document::NormalValue::String(display));
+                        doc.generate_and_set_doc_id()
+                            .map_err(|_| libc::EIO)?;
+                        Ok::<String, i32>(doc.id().unwrap().to_string())
+                    });
+                    match result {
+                        Ok(id) => id,
+                        Err(errno) => {
+                            reply.error(errno);
+                            return;
+                        }
+                    }
+                };
+
+                let ino = inodes.doc_ino(&col_name, &doc_id, display_name);
+                inodes.invalidate_collection(&col_name);
                 drop(inodes);
-                let attr = Self::file_attr(ino, 0, self.file_perm());
-                reply.created(&TTL, &attr, 0, 0, 0);
+                reply.created(&TTL, &Self::file_attr(ino, 0), 0, 0, 0);
             }
             _ => reply.error(libc::ENOTDIR),
         }
     }
 
     fn unlink(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
-        if self.read_only {
-            reply.error(libc::EROFS);
-            return;
-        }
-
         let name_str = match name.to_str() {
             Some(n) => n,
             None => {
@@ -464,22 +520,24 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
             }
         };
 
-        let doc_id_str = match Self::parse_doc_id_from_filename(name_str) {
-            Ok(id) => id.to_string(),
-            Err(errno) => {
-                reply.error(errno);
-                return;
-            }
-        };
+        let filename = strip_json_suffix(name_str);
 
         let mut inodes = self.inodes.lock();
         let target = inodes.get(parent).cloned();
 
         match target {
             Some(InodeTarget::Collection { name: col_name }) => {
+                let doc_id = match self.resolve_filename(&mut inodes, &col_name, filename) {
+                    Ok(id) => id,
+                    Err(errno) => {
+                        reply.error(errno);
+                        return;
+                    }
+                };
+
                 let db = self.db.clone();
                 let col_name_clone = col_name.clone();
-                let doc_id_string = doc_id_str.clone();
+                let doc_id_clone = doc_id.clone();
 
                 drop(inodes);
 
@@ -488,11 +546,11 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                         .get_collection(&col_name_clone)
                         .map_err(|e| db_err_to_errno(&e))?
                         .ok_or(libc::ENOENT)?;
-                    let doc_id =
-                        document::DocID::from_string(&doc_id_string).map_err(|_| libc::EINVAL)?;
+                    let doc_id_parsed =
+                        document::DocID::from_string(&doc_id_clone).map_err(|_| libc::EINVAL)?;
                     let txn = db.new_txn(false).await.map_err(|e| db_err_to_errno(&e))?;
                     let deleted = col
-                        .delete(&txn, &doc_id)
+                        .delete(&txn, &doc_id_parsed)
                         .await
                         .map_err(|e| db_err_to_errno(&e))?;
                     txn.commit().await.map_err(|e| db_err_to_errno(&e))?;
@@ -506,8 +564,7 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
                 match result {
                     Ok(()) => {
                         let mut inodes = self.inodes.lock();
-                        inodes.remove_doc(&col_name, &doc_id_str);
-                        inodes.invalidate(&col_name);
+                        inodes.remove_doc(&col_name, &doc_id);
                         reply.ok();
                     }
                     Err(errno) => reply.error(errno),
@@ -530,12 +587,10 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
 
         let inodes = self.inodes.lock();
         match inodes.get(parent) {
-            Some(InodeTarget::Root) => {
-                match self.db.get_collection(name_str) {
-                    Ok(Some(_)) => reply.error(libc::EPERM),
-                    _ => reply.error(libc::ENOENT),
-                }
-            }
+            Some(InodeTarget::Root) => match self.db.get_collection(name_str) {
+                Ok(Some(_)) => reply.error(libc::EPERM),
+                _ => reply.error(libc::ENOENT),
+            },
             _ => reply.error(libc::ENOTDIR),
         }
     }
@@ -558,11 +613,6 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         _flags: Option<u32>,
         reply: ReplyAttr,
     ) {
-        if size.is_some() && self.read_only {
-            reply.error(libc::EROFS);
-            return;
-        }
-
         // Support truncate (size=0) for write-then-flush pattern.
         if let Some(new_size) = size {
             if new_size == 0 {
@@ -573,13 +623,13 @@ impl<S: Store + 'static> Filesystem for DefraFs<S> {
         let inodes = self.inodes.lock();
         match inodes.get(ino) {
             Some(InodeTarget::Root) | Some(InodeTarget::Collection { .. }) => {
-                reply.attr(&TTL, &Self::dir_attr(ino, self.dir_perm()));
+                reply.attr(&TTL, &Self::dir_attr(ino));
             }
             Some(InodeTarget::Document { .. }) => {
                 let buffers = self.write_buffers.lock();
                 let buf_size = buffers.get(&ino).map(|b| b.len() as u64).unwrap_or(0);
                 let actual_size = size.unwrap_or(buf_size);
-                reply.attr(&TTL, &Self::file_attr(ino, actual_size, self.file_perm()));
+                reply.attr(&TTL, &Self::file_attr(ino, actual_size));
             }
             None => reply.error(libc::ENOENT),
         }

--- a/crates/fs/src/ops.rs
+++ b/crates/fs/src/ops.rs
@@ -1,0 +1,496 @@
+/// FUSE filesystem implementation backed by DefraDB.
+///
+/// Maps FUSE operations to DefraDB collection/document CRUD:
+/// - readdir(root) → list_collections()
+/// - readdir(collection) → collection.get_all()
+/// - lookup/read(doc) → collection.get()
+/// - write/create → collection.create() or collection.save()
+/// - unlink → collection.delete()
+use std::ffi::OsStr;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use fuser::{
+    FileAttr, FileType, Filesystem, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory, ReplyEmpty,
+    ReplyEntry, ReplyWrite, Request,
+};
+use parking_lot::Mutex;
+use storage::corekv::Store;
+use tokio::runtime::Handle;
+
+use crate::inode::{InodeTable, InodeTarget, ROOT_INO};
+
+/// TTL for filesystem attributes (short, since DB can change).
+const TTL: Duration = Duration::from_secs(1);
+
+/// Epoch time used for all file timestamps.
+const EPOCH: SystemTime = UNIX_EPOCH;
+
+/// FUSE filesystem backed by a DefraDB instance.
+pub struct DefraFs<S: Store> {
+    db: Arc<db::DB<S>>,
+    inodes: Mutex<InodeTable>,
+    rt: Handle,
+    /// Per-inode write buffers for accumulating write() data before flush.
+    write_buffers: Mutex<std::collections::HashMap<u64, Vec<u8>>>,
+}
+
+impl<S: Store> DefraFs<S> {
+    pub fn new(db: Arc<db::DB<S>>, rt: Handle) -> Self {
+        Self {
+            db,
+            inodes: Mutex::new(InodeTable::new()),
+            rt,
+            write_buffers: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Build a directory FileAttr.
+    fn dir_attr(ino: u64) -> FileAttr {
+        FileAttr {
+            ino,
+            size: 0,
+            blocks: 0,
+            atime: EPOCH,
+            mtime: EPOCH,
+            ctime: EPOCH,
+            crtime: EPOCH,
+            kind: FileType::Directory,
+            perm: 0o755,
+            nlink: 2,
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            blksize: 512,
+            flags: 0,
+        }
+    }
+
+    /// Build a regular file FileAttr.
+    fn file_attr(ino: u64, size: u64) -> FileAttr {
+        FileAttr {
+            ino,
+            size,
+            blocks: (size + 511) / 512,
+            atime: EPOCH,
+            mtime: EPOCH,
+            ctime: EPOCH,
+            crtime: EPOCH,
+            kind: FileType::RegularFile,
+            perm: 0o644,
+            nlink: 1,
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            blksize: 512,
+            flags: 0,
+        }
+    }
+
+    /// Fetch document JSON bytes for a given collection + doc_id.
+    fn fetch_doc_json(&self, collection_name: &str, doc_id_str: &str) -> Option<Vec<u8>> {
+        let db = self.db.clone();
+        let collection_name = collection_name.to_string();
+        let doc_id_str = doc_id_str.to_string();
+
+        self.rt
+            .block_on(async move {
+                let col = db.get_collection(&collection_name).ok()??;
+                let doc_id = document::DocID::from_string(&doc_id_str).ok()?;
+                let txn = db.new_txn(true).await.ok()?;
+                let doc = col.get(&txn, &doc_id).await.ok()??;
+                txn.commit().await.ok()?;
+                let map = doc.to_map().ok()?;
+                serde_json::to_vec_pretty(&map).ok()
+            })
+    }
+
+    /// List all doc IDs in a collection.
+    fn list_doc_ids(&self, collection_name: &str) -> Vec<String> {
+        let db = self.db.clone();
+        let collection_name = collection_name.to_string();
+
+        self.rt.block_on(async move {
+            let col = match db.get_collection(&collection_name) {
+                Ok(Some(c)) => c,
+                _ => return vec![],
+            };
+            let txn = match db.new_txn(true).await {
+                Ok(t) => t,
+                _ => return vec![],
+            };
+            let docs = match col.get_all(&txn).await {
+                Ok(d) => d,
+                _ => return vec![],
+            };
+            let _ = txn.commit().await;
+            docs.iter()
+                .filter_map(|d| d.id().map(|id| id.to_string()))
+                .collect()
+        })
+    }
+}
+
+impl<S: Store + 'static> Filesystem for DefraFs<S> {
+    fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
+        let name_str = match name.to_str() {
+            Some(n) => n,
+            None => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+
+        let mut inodes = self.inodes.lock();
+        let target = inodes.get(parent).cloned();
+
+        match target {
+            Some(InodeTarget::Root) => {
+                // Looking up a collection directory
+                match self.db.get_collection(name_str) {
+                    Ok(Some(_)) => {
+                        let ino = inodes.collection_ino(name_str);
+                        reply.entry(&TTL, &Self::dir_attr(ino), 0);
+                    }
+                    _ => reply.error(libc::ENOENT),
+                }
+            }
+            Some(InodeTarget::Collection { name: col_name }) => {
+                // Looking up a document file
+                let doc_id_str = name_str.strip_suffix(".json").unwrap_or(name_str);
+                match self.fetch_doc_json(&col_name, doc_id_str) {
+                    Some(json) => {
+                        let ino = inodes.doc_ino(&col_name, doc_id_str);
+                        reply.entry(&TTL, &Self::file_attr(ino, json.len() as u64), 0);
+                    }
+                    None => reply.error(libc::ENOENT),
+                }
+            }
+            _ => reply.error(libc::ENOENT),
+        }
+    }
+
+    fn getattr(&mut self, _req: &Request<'_>, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+        let inodes = self.inodes.lock();
+        match inodes.get(ino) {
+            Some(InodeTarget::Root) | Some(InodeTarget::Collection { .. }) => {
+                reply.attr(&TTL, &Self::dir_attr(ino));
+            }
+            Some(InodeTarget::Document {
+                collection, doc_id, ..
+            }) => {
+                let col = collection.clone();
+                let did = doc_id.clone();
+                drop(inodes);
+                match self.fetch_doc_json(&col, &did) {
+                    Some(json) => reply.attr(&TTL, &Self::file_attr(ino, json.len() as u64)),
+                    None => reply.error(libc::ENOENT),
+                }
+            }
+            None => reply.error(libc::ENOENT),
+        }
+    }
+
+    fn readdir(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: ReplyDirectory,
+    ) {
+        let mut inodes = self.inodes.lock();
+        let target = inodes.get(ino).cloned();
+
+        match target {
+            Some(InodeTarget::Root) => {
+                let collections = self.db.list_collections().unwrap_or_default();
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (ROOT_INO, FileType::Directory, ".".into()),
+                    (ROOT_INO, FileType::Directory, "..".into()),
+                ];
+                for name in &collections {
+                    let child_ino = inodes.collection_ino(name);
+                    entries.push((child_ino, FileType::Directory, name.clone()));
+                }
+                for (i, (ino, kind, name)) in entries.iter().enumerate().skip(offset as usize) {
+                    if reply.add(*ino, (i + 1) as i64, *kind, name) {
+                        break;
+                    }
+                }
+                reply.ok();
+            }
+            Some(InodeTarget::Collection { name: col_name }) => {
+                let col_ino = ino;
+                let doc_ids = self.list_doc_ids(&col_name);
+                let mut entries: Vec<(u64, FileType, String)> = vec![
+                    (col_ino, FileType::Directory, ".".into()),
+                    (ROOT_INO, FileType::Directory, "..".into()),
+                ];
+                for doc_id in &doc_ids {
+                    let child_ino = inodes.doc_ino(&col_name, doc_id);
+                    entries.push((
+                        child_ino,
+                        FileType::RegularFile,
+                        format!("{}.json", doc_id),
+                    ));
+                }
+                for (i, (ino, kind, name)) in entries.iter().enumerate().skip(offset as usize) {
+                    if reply.add(*ino, (i + 1) as i64, *kind, name) {
+                        break;
+                    }
+                }
+                reply.ok();
+            }
+            _ => reply.error(libc::ENOTDIR),
+        }
+    }
+
+    fn read(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        size: u32,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        reply: ReplyData,
+    ) {
+        let inodes = self.inodes.lock();
+        match inodes.get(ino).cloned() {
+            Some(InodeTarget::Document { collection, doc_id }) => {
+                drop(inodes);
+                match self.fetch_doc_json(&collection, &doc_id) {
+                    Some(json) => {
+                        let start = offset as usize;
+                        let end = (start + size as usize).min(json.len());
+                        if start >= json.len() {
+                            reply.data(&[]);
+                        } else {
+                            reply.data(&json[start..end]);
+                        }
+                    }
+                    None => reply.error(libc::ENOENT),
+                }
+            }
+            _ => reply.error(libc::EISDIR),
+        }
+    }
+
+    fn write(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        data: &[u8],
+        _write_flags: u32,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        reply: ReplyWrite,
+    ) {
+        let inodes = self.inodes.lock();
+        match inodes.get(ino).cloned() {
+            Some(InodeTarget::Document { .. }) => {
+                drop(inodes);
+                let mut buffers = self.write_buffers.lock();
+                let buf = buffers.entry(ino).or_default();
+                let end = offset as usize + data.len();
+                if buf.len() < end {
+                    buf.resize(end, 0);
+                }
+                buf[offset as usize..end].copy_from_slice(data);
+                reply.written(data.len() as u32);
+            }
+            _ => reply.error(libc::EBADF),
+        }
+    }
+
+    fn flush(&mut self, _req: &Request<'_>, ino: u64, _fh: u64, _lock_owner: u64, reply: ReplyEmpty) {
+        let data = self.write_buffers.lock().remove(&ino);
+        let Some(buf) = data else {
+            reply.ok();
+            return;
+        };
+
+        let inodes = self.inodes.lock();
+        let target = inodes.get(ino).cloned();
+        drop(inodes);
+
+        match target {
+            Some(InodeTarget::Document { collection, doc_id }) => {
+                let db = self.db.clone();
+                let col_name = collection.clone();
+                let result = self.rt.block_on(async move {
+                    let col = db
+                        .get_collection(&collection)
+                        .map_err(|_| libc::EIO)?
+                        .ok_or(libc::ENOENT)?;
+                    let doc_id_parsed =
+                        document::DocID::from_string(&doc_id).map_err(|_| libc::EINVAL)?;
+                    let mut doc = document::Document::from_json(&buf).map_err(|_| libc::EINVAL)?;
+                    doc.set_id(doc_id_parsed);
+                    doc.set_collection(col.schema().clone());
+                    let txn = db.new_txn(false).await.map_err(|_| libc::EIO)?;
+                    col.save(&txn, &doc).await.map_err(|_| libc::EIO)?;
+                    txn.commit().await.map_err(|_| libc::EIO)?;
+                    Ok::<(), i32>(())
+                });
+
+                match result {
+                    Ok(()) => {
+                        self.inodes.lock().invalidate(&col_name);
+                        reply.ok();
+                    }
+                    Err(errno) => reply.error(errno),
+                }
+            }
+            _ => reply.ok(),
+        }
+    }
+
+    fn create(
+        &mut self,
+        _req: &Request<'_>,
+        parent: u64,
+        name: &OsStr,
+        _mode: u32,
+        _umask: u32,
+        _flags: i32,
+        reply: ReplyCreate,
+    ) {
+        let name_str = match name.to_str() {
+            Some(n) => n,
+            None => {
+                reply.error(libc::EINVAL);
+                return;
+            }
+        };
+
+        let mut inodes = self.inodes.lock();
+        let target = inodes.get(parent).cloned();
+
+        match target {
+            Some(InodeTarget::Collection { name: col_name }) => {
+                let doc_id_str = name_str.strip_suffix(".json").unwrap_or(name_str);
+                let ino = inodes.doc_ino(&col_name, doc_id_str);
+                inodes.invalidate(&col_name);
+                drop(inodes);
+                let attr = Self::file_attr(ino, 0);
+                reply.created(&TTL, &attr, 0, 0, 0);
+            }
+            _ => reply.error(libc::ENOTDIR),
+        }
+    }
+
+    fn unlink(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+        let name_str = match name.to_str() {
+            Some(n) => n,
+            None => {
+                reply.error(libc::ENOENT);
+                return;
+            }
+        };
+
+        let mut inodes = self.inodes.lock();
+        let target = inodes.get(parent).cloned();
+
+        match target {
+            Some(InodeTarget::Collection { name: col_name }) => {
+                let doc_id_str = name_str.strip_suffix(".json").unwrap_or(name_str);
+                let db = self.db.clone();
+                let col_name_clone = col_name.clone();
+                let doc_id_string = doc_id_str.to_string();
+
+                drop(inodes);
+
+                let result = self.rt.block_on(async move {
+                    let col = db
+                        .get_collection(&col_name_clone)
+                        .map_err(|_| libc::EIO)?
+                        .ok_or(libc::ENOENT)?;
+                    let doc_id =
+                        document::DocID::from_string(&doc_id_string).map_err(|_| libc::EINVAL)?;
+                    let txn = db.new_txn(false).await.map_err(|_| libc::EIO)?;
+                    let deleted = col.delete(&txn, &doc_id).await.map_err(|_| libc::EIO)?;
+                    txn.commit().await.map_err(|_| libc::EIO)?;
+                    if deleted {
+                        Ok(())
+                    } else {
+                        Err(libc::ENOENT)
+                    }
+                });
+
+                match result {
+                    Ok(()) => {
+                        let mut inodes = self.inodes.lock();
+                        inodes.remove_doc(&col_name, doc_id_str);
+                        inodes.invalidate(&col_name);
+                        reply.ok();
+                    }
+                    Err(errno) => reply.error(errno),
+                }
+            }
+            _ => reply.error(libc::ENOTDIR),
+        }
+    }
+
+    fn setattr(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _mode: Option<u32>,
+        _uid: Option<u32>,
+        _gid: Option<u32>,
+        size: Option<u64>,
+        _atime: Option<fuser::TimeOrNow>,
+        _mtime: Option<fuser::TimeOrNow>,
+        _ctime: Option<SystemTime>,
+        _fh: Option<u64>,
+        _crtime: Option<SystemTime>,
+        _chgtime: Option<SystemTime>,
+        _bkuptime: Option<SystemTime>,
+        _flags: Option<u32>,
+        reply: ReplyAttr,
+    ) {
+        // Support truncate (size=0) for write-then-flush pattern.
+        if let Some(new_size) = size {
+            if new_size == 0 {
+                self.write_buffers.lock().remove(&ino);
+            }
+        }
+
+        let inodes = self.inodes.lock();
+        match inodes.get(ino) {
+            Some(InodeTarget::Root) | Some(InodeTarget::Collection { .. }) => {
+                reply.attr(&TTL, &Self::dir_attr(ino));
+            }
+            Some(InodeTarget::Document { .. }) => {
+                let buffers = self.write_buffers.lock();
+                let buf_size = buffers.get(&ino).map(|b| b.len() as u64).unwrap_or(0);
+                let actual_size = size.unwrap_or(buf_size);
+                reply.attr(&TTL, &Self::file_attr(ino, actual_size));
+            }
+            None => reply.error(libc::ENOENT),
+        }
+    }
+
+    fn open(&mut self, _req: &Request<'_>, ino: u64, _flags: i32, reply: fuser::ReplyOpen) {
+        let inodes = self.inodes.lock();
+        match inodes.get(ino) {
+            Some(InodeTarget::Document { .. }) => reply.opened(0, 0),
+            _ => reply.error(libc::EISDIR),
+        }
+    }
+
+    fn opendir(&mut self, _req: &Request<'_>, ino: u64, _flags: i32, reply: fuser::ReplyOpen) {
+        let inodes = self.inodes.lock();
+        match inodes.get(ino) {
+            Some(InodeTarget::Root) | Some(InodeTarget::Collection { .. }) => {
+                reply.opened(0, 0);
+            }
+            _ => reply.error(libc::ENOTDIR),
+        }
+    }
+}

--- a/crates/fs/src/virtual_files.rs
+++ b/crates/fs/src/virtual_files.rs
@@ -1,15 +1,23 @@
-/// Virtual files that appear in each collection directory.
+/// Virtual files that appear in collection and root directories.
 ///
+/// Collection-level:
 /// - `_schema.graphql`: SDL representation of the collection schema
-/// - `_view.json`: All documents in the collection as a JSON array
+/// - `_view.json`: All documents as a JSON array (primary grep target)
+///
+/// Root-level:
+/// - `_schema.graphql`: Combined SDL of all collection schemas
+/// - `_collections.json`: Collection names and document counts
+#[cfg(feature = "fuse")]
 use schema::{CollectionVersion, FieldKind, ScalarArrayKind, ScalarKind};
 use std::collections::HashMap;
 
-/// Virtual file names (prefixed with _ to avoid docID collisions).
 pub const SCHEMA_FILE: &str = "_schema.graphql";
 pub const VIEW_FILE: &str = "_view.json";
+pub const ROOT_SCHEMA_FILE: &str = "_schema.graphql";
+pub const ROOT_COLLECTIONS_FILE: &str = "_collections.json";
 
-/// Generate GraphQL SDL for a collection schema.
+/// Generate GraphQL SDL for a single collection schema.
+#[cfg(feature = "fuse")]
 pub fn generate_sdl(schema: &CollectionVersion) -> String {
     let mut sdl = format!("type {} {{\n", schema.name);
 
@@ -22,6 +30,39 @@ pub fn generate_sdl(schema: &CollectionVersion) -> String {
     sdl
 }
 
+/// Generate combined SDL for all collection schemas.
+#[cfg(feature = "fuse")]
+pub fn generate_root_sdl(schemas: &[&CollectionVersion]) -> String {
+    let mut sdl = String::new();
+    for (i, schema) in schemas.iter().enumerate() {
+        if i > 0 {
+            sdl.push_str("\n\n");
+        }
+        sdl.push_str(&generate_sdl(schema));
+    }
+    sdl
+}
+
+/// Generate a JSON array listing all collections with document counts.
+pub fn generate_collections_json(collections: &[(String, usize)]) -> Vec<u8> {
+    let entries: Vec<serde_json::Value> = collections
+        .iter()
+        .map(|(name, count)| {
+            serde_json::json!({
+                "name": name,
+                "documents": count,
+            })
+        })
+        .collect();
+    serde_json::to_vec_pretty(&entries).unwrap_or_default()
+}
+
+/// Generate a JSON array of all documents in a collection.
+pub fn generate_view_json(docs: &[HashMap<String, serde_json::Value>]) -> Vec<u8> {
+    serde_json::to_vec_pretty(docs).unwrap_or_default()
+}
+
+#[cfg(feature = "fuse")]
 fn field_kind_to_graphql(kind: &FieldKind) -> String {
     match kind {
         FieldKind::Scalar(scalar) => scalar_to_graphql(*scalar).to_string(),
@@ -46,6 +87,7 @@ fn field_kind_to_graphql(kind: &FieldKind) -> String {
     }
 }
 
+#[cfg(feature = "fuse")]
 fn scalar_to_graphql(kind: ScalarKind) -> &'static str {
     match kind {
         ScalarKind::None => "None",
@@ -61,11 +103,7 @@ fn scalar_to_graphql(kind: ScalarKind) -> &'static str {
     }
 }
 
-/// Generate a JSON array of all documents in a collection.
-pub fn generate_view_json(docs: &[HashMap<String, serde_json::Value>]) -> Vec<u8> {
-    serde_json::to_vec_pretty(docs).unwrap_or_default()
-}
-
+#[cfg(feature = "fuse")]
 fn scalar_array_to_graphql(kind: ScalarArrayKind) -> &'static str {
     match kind {
         ScalarArrayKind::BoolArray => "Boolean",
@@ -78,5 +116,30 @@ fn scalar_array_to_graphql(kind: ScalarArrayKind) -> &'static str {
         ScalarArrayKind::NillableFloat64Array => "Float",
         ScalarArrayKind::NillableFloat32Array => "Float",
         ScalarArrayKind::NillableStringArray => "String",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collections_json_format() {
+        let cols = vec![("Users".into(), 5), ("Posts".into(), 12)];
+        let json = generate_collections_json(&cols);
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&json).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["name"], "Users");
+        assert_eq!(parsed[0]["documents"], 5);
+        assert_eq!(parsed[1]["name"], "Posts");
+        assert_eq!(parsed[1]["documents"], 12);
+    }
+
+    #[test]
+    fn view_json_empty_collection() {
+        let docs: Vec<HashMap<String, serde_json::Value>> = vec![];
+        let json = generate_view_json(&docs);
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&json).unwrap();
+        assert!(parsed.is_empty());
     }
 }

--- a/crates/fs/src/virtual_files.rs
+++ b/crates/fs/src/virtual_files.rs
@@ -1,0 +1,82 @@
+/// Virtual files that appear in each collection directory.
+///
+/// - `_schema.graphql`: SDL representation of the collection schema
+/// - `_view.json`: All documents in the collection as a JSON array
+use schema::{CollectionVersion, FieldKind, ScalarArrayKind, ScalarKind};
+use std::collections::HashMap;
+
+/// Virtual file names (prefixed with _ to avoid docID collisions).
+pub const SCHEMA_FILE: &str = "_schema.graphql";
+pub const VIEW_FILE: &str = "_view.json";
+
+/// Generate GraphQL SDL for a collection schema.
+pub fn generate_sdl(schema: &CollectionVersion) -> String {
+    let mut sdl = format!("type {} {{\n", schema.name);
+
+    for field in &schema.fields {
+        let gql_type = field_kind_to_graphql(&field.kind);
+        sdl.push_str(&format!("  {}: {}\n", field.name, gql_type));
+    }
+
+    sdl.push('}');
+    sdl
+}
+
+fn field_kind_to_graphql(kind: &FieldKind) -> String {
+    match kind {
+        FieldKind::Scalar(scalar) => scalar_to_graphql(*scalar).to_string(),
+        FieldKind::ScalarArray(arr) => format!("[{}]", scalar_array_to_graphql(*arr)),
+        FieldKind::Relation {
+            collection_id,
+            is_array,
+        } => {
+            if *is_array {
+                format!("[{}]", collection_id)
+            } else {
+                collection_id.clone()
+            }
+        }
+        FieldKind::SelfRef { is_array, .. } | FieldKind::Named { is_array, .. } => {
+            if *is_array {
+                "[Self]".to_string()
+            } else {
+                "Self".to_string()
+            }
+        }
+    }
+}
+
+fn scalar_to_graphql(kind: ScalarKind) -> &'static str {
+    match kind {
+        ScalarKind::None => "None",
+        ScalarKind::DocID => "ID",
+        ScalarKind::Bool => "Boolean",
+        ScalarKind::Int => "Int",
+        ScalarKind::Float64 => "Float",
+        ScalarKind::Float32 => "Float",
+        ScalarKind::DateTime => "DateTime",
+        ScalarKind::String => "String",
+        ScalarKind::Blob => "Blob",
+        ScalarKind::Json => "JSON",
+    }
+}
+
+/// Generate a JSON array of all documents in a collection.
+pub fn generate_view_json(docs: &[HashMap<String, serde_json::Value>]) -> Vec<u8> {
+    serde_json::to_vec_pretty(docs).unwrap_or_default()
+}
+
+fn scalar_array_to_graphql(kind: ScalarArrayKind) -> &'static str {
+    match kind {
+        ScalarArrayKind::BoolArray => "Boolean",
+        ScalarArrayKind::IntArray => "Int",
+        ScalarArrayKind::Float64Array => "Float",
+        ScalarArrayKind::Float32Array => "Float",
+        ScalarArrayKind::StringArray => "String",
+        ScalarArrayKind::NillableBoolArray => "Boolean",
+        ScalarArrayKind::NillableIntArray => "Int",
+        ScalarArrayKind::NillableFloat64Array => "Float",
+        ScalarArrayKind::NillableFloat32Array => "Float",
+        ScalarArrayKind::NillableStringArray => "String",
+    }
+}


### PR DESCRIPTION
Adds the defra-fs crate that exposes DefraDB collections and documents
as a FUSE filesystem, enabling AI agents to interact with the database
using standard file operations (ls, cat, echo, rm).

Layout: collections map to directories, documents to .json files.
Operations: readdir lists collections/docs, read/write perform CRUD,
unlink deletes documents, create+write+flush creates new documents.

https://claude.ai/code/session_01PSWu8UTgwDx87tJ3rL5wbw