### PR TITLE
Make defradb.rs a first-class iOS embedding target

### DIFF
--- a/crates/db/src/block_builder/mod.rs
+++ b/crates/db/src/block_builder/mod.rs
@@ -31,7 +31,7 @@ use datastore::NamespaceView;
 use defra_core::block::{
     generate_cid_from_bytes, Block, CollectionDeltaPayload, CompositeDeltaPayload,
     CounterDeltaPayload, CrdtDelta, DAGLink, Encryption, LwwDeltaPayload, Signature,
-    SignatureHeader, SignatureType,
+    SignatureHeader,
 };
 use defra_core::encryption::EncryptionConfig;
 use defra_core::signing::SigningConfig;
@@ -66,41 +66,41 @@ pub(super) fn compute_signature(
         .to_dag_cbor()
         .map_err(|e| format!("Failed to encode block for signing: {}", e))?;
 
-    // Determine signature type and sign
-    let (sig_type, sig_bytes) = match signer.key_type.as_str() {
-        "ed25519" => {
-            let private_key = crypto::Ed25519PrivateKey::from_bytes(&signer.private_key_bytes)
-                .map_err(|e| format!("Failed to load Ed25519 private key: {}", e))?;
-            let sig = private_key
-                .sign(&block_bytes)
-                .map_err(|e| format!("Failed to sign block: {}", e))?;
-            (SignatureType::EdDSA, sig)
+    // Determine signature type and sign. Remote signers can back any supported
+    // key type so mobile/TEE and Orbis-backed identities use the same path.
+    let sig_type = signer.signature_type()?;
+    let sig_bytes = if let Some(remote) = signer.remote_signer.as_ref() {
+        remote.sign_sync(&block_bytes)?
+    } else {
+        match signer.key_type.as_str() {
+            "ed25519" => {
+                let private_key = crypto::Ed25519PrivateKey::from_bytes(&signer.private_key_bytes)
+                    .map_err(|e| format!("Failed to load Ed25519 private key: {}", e))?;
+                private_key
+                    .sign(&block_bytes)
+                    .map_err(|e| format!("Failed to sign block: {}", e))?
+            }
+            "secp256k1" => {
+                let private_key =
+                    crypto::Secp256k1PrivateKey::from_bytes(&signer.private_key_bytes)
+                        .map_err(|e| format!("Failed to load secp256k1 private key: {}", e))?;
+                private_key
+                    .sign(&block_bytes)
+                    .map_err(|e| format!("Failed to sign block: {}", e))?
+            }
+            "secp256r1" => {
+                let private_key =
+                    crypto::Secp256r1PrivateKey::from_bytes(&signer.private_key_bytes)
+                        .map_err(|e| format!("Failed to load secp256r1 private key: {}", e))?;
+                private_key
+                    .sign(&block_bytes)
+                    .map_err(|e| format!("Failed to sign block: {}", e))?
+            }
+            "bls" => {
+                return Err("BLS signing requires a remote signer".to_string());
+            }
+            other => return Err(format!("Unsupported key type for signing: {}", other)),
         }
-        "secp256k1" => {
-            let private_key = crypto::Secp256k1PrivateKey::from_bytes(&signer.private_key_bytes)
-                .map_err(|e| format!("Failed to load secp256k1 private key: {}", e))?;
-            let sig = private_key
-                .sign(&block_bytes)
-                .map_err(|e| format!("Failed to sign block: {}", e))?;
-            (SignatureType::ES256K, sig)
-        }
-        "secp256r1" => {
-            let private_key = crypto::Secp256r1PrivateKey::from_bytes(&signer.private_key_bytes)
-                .map_err(|e| format!("Failed to load secp256r1 private key: {}", e))?;
-            let sig = private_key
-                .sign(&block_bytes)
-                .map_err(|e| format!("Failed to sign block: {}", e))?;
-            (SignatureType::ES256, sig)
-        }
-        "bls" => {
-            let remote = signer
-                .remote_signer
-                .as_ref()
-                .ok_or("BLS signing requires a remote signer (Orbis)")?;
-            let sig = remote.sign_sync(&block_bytes)?;
-            (SignatureType::BLS, sig)
-        }
-        other => return Err(format!("Unsupported key type for signing: {}", other)),
     };
 
     // Create signature block.

--- a/crates/db/src/block_builder/tests.rs
+++ b/crates/db/src/block_builder/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use blockstore::{Blockstore, DefraBlockstore};
 use crypto::keys::PublicKey;
+use defra_core::SignatureType;
 use std::sync::Arc;
 use storage::backends::MemoryStore;
 

--- a/crates/db/src/block_builder/tests.rs
+++ b/crates/db/src/block_builder/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use blockstore::{Blockstore, DefraBlockstore};
+use crypto::keys::PublicKey;
 use std::sync::Arc;
 use storage::backends::MemoryStore;
 
@@ -110,4 +111,61 @@ async fn test_composite_block_has_field_links() {
     for field_cid in &result.field_cids {
         assert!(link_cids.contains(field_cid));
     }
+}
+
+struct TestRemoteSecp256r1Signer {
+    private_key: crypto::Secp256r1PrivateKey,
+}
+
+impl defra_core::signing::RemoteSigner for TestRemoteSecp256r1Signer {
+    fn sign_sync(&self, data: &[u8]) -> Result<Vec<u8>, String> {
+        self.private_key
+            .sign(data)
+            .map_err(|error| format!("remote sign failed: {}", error))
+    }
+}
+
+#[test]
+fn test_compute_signature_supports_remote_secp256r1() {
+    let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
+    let public_key = private_key.public_key();
+
+    let block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc-1".to_vec(),
+            schema_version_id: "schema-v1".to_string(),
+            status: 1,
+            priority: 1,
+        }),
+        Vec::new(),
+        Vec::new(),
+    );
+
+    let signer = defra_core::signing::SigningConfig {
+        key_type: "secp256r1".to_string(),
+        private_key_bytes: Vec::new(),
+        public_key_bytes: public_key.raw(),
+        public_key_hex: hex::encode(public_key.raw()),
+        remote_signer: Some(Arc::new(TestRemoteSecp256r1Signer { private_key })),
+    };
+
+    let (sig_cid, sig_cbor) = compute_signature(&block, &signer)
+        .expect("signature should succeed")
+        .expect("composite block should be signed");
+    assert!(!sig_cid.to_bytes().is_empty());
+
+    let signature = Signature::from_dag_cbor(&sig_cbor).expect("signature block should decode");
+    assert_eq!(signature.header.sig_type, SignatureType::ES256);
+    assert_eq!(
+        signature.header.identity,
+        signer.public_key_hex.as_bytes().to_vec()
+    );
+
+    let public_key = crypto::Secp256r1PublicKey::from_bytes(&signer.public_key_bytes)
+        .expect("public key should decode");
+    let signed_bytes = block.to_dag_cbor().expect("block should encode");
+    let valid = public_key
+        .verify(&signed_bytes, &signature.value)
+        .expect("verification should succeed");
+    assert!(valid, "remote secp256r1 signature should verify");
 }

--- a/crates/defra-core/src/signing.rs
+++ b/crates/defra-core/src/signing.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-/// Remote signing delegate (e.g. Orbis ring threshold signing).
+/// Remote signing delegate (e.g. Orbis, Secure Enclave host callbacks).
 ///
 /// Implementations call an external service to produce signatures.
 /// `sign_sync` must be callable from synchronous contexts (the block builder
@@ -39,6 +39,29 @@ impl Clone for SigningConfig {
             public_key_bytes: self.public_key_bytes.clone(),
             public_key_hex: self.public_key_hex.clone(),
             remote_signer: self.remote_signer.clone(),
+        }
+    }
+}
+
+impl SigningConfig {
+    /// Returns true if this identity has locally exportable private key bytes.
+    pub fn has_local_private_key(&self) -> bool {
+        !self.private_key_bytes.is_empty()
+    }
+
+    /// Returns true if this identity can sign by delegating to a remote signer.
+    pub fn has_remote_signer(&self) -> bool {
+        self.remote_signer.is_some()
+    }
+
+    /// Map the identity key type to a block signature type.
+    pub fn signature_type(&self) -> Result<crate::block::SignatureType, String> {
+        match self.key_type.as_str() {
+            "ed25519" => Ok(crate::block::SignatureType::EdDSA),
+            "secp256k1" => Ok(crate::block::SignatureType::ES256K),
+            "secp256r1" => Ok(crate::block::SignatureType::ES256),
+            "bls" => Ok(crate::block::SignatureType::BLS),
+            other => Err(format!("unsupported signing key type: {}", other)),
         }
     }
 }

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -146,12 +146,16 @@ pub enum SigningConfig {
     Enabled {
         key: Option<SigningKey>,
     },
+    RegisteredIdentity {
+        did: String,
+    },
 }
 
 /// Explicit node signing key material.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SigningKey {
     Secp256k1(Vec<u8>),
+    Secp256r1(Vec<u8>),
     Ed25519(Vec<u8>),
 }
 

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -111,6 +111,11 @@ impl NodeBuilder {
         self
     }
 
+    pub fn with_signing_identity_did(mut self, did: impl Into<String>) -> Self {
+        self.config.signing = SigningConfig::RegisteredIdentity { did: did.into() };
+        self
+    }
+
     pub fn with_sourcehub(mut self, config: SourceHubConfig) -> Self {
         self.config.document_acp = DocumentAcpConfig::SourceHub(config);
         self
@@ -293,52 +298,118 @@ where
 fn create_node_identity(
     config: &SigningConfig,
 ) -> Result<(Option<identity::RawIdentity>, Option<String>)> {
-    let SigningConfig::Enabled { key } = config else {
-        return Ok((None, None));
-    };
+    match config {
+        SigningConfig::Disabled => Ok((None, None)),
+        SigningConfig::Enabled { key } => {
+            let raw_identity = match key {
+                Some(SigningKey::Secp256k1(bytes)) => {
+                    let private_key = crypto::Secp256k1PrivateKey::from_bytes(bytes)
+                        .map_err(|error| anyhow!("failed to load secp256k1 key: {error}"))?;
+                    identity::RawIdentity::from_secp256k1(private_key)
+                        .map_err(|error| anyhow!("failed to create node identity: {error}"))?
+                }
+                Some(SigningKey::Secp256r1(bytes)) => {
+                    let private_key = crypto::Secp256r1PrivateKey::from_bytes(bytes)
+                        .map_err(|error| anyhow!("failed to load secp256r1 key: {error}"))?;
+                    identity::RawIdentity::from_secp256r1(private_key)
+                        .map_err(|error| anyhow!("failed to create node identity: {error}"))?
+                }
+                Some(SigningKey::Ed25519(bytes)) => {
+                    let private_key = crypto::Ed25519PrivateKey::from_bytes(bytes)
+                        .map_err(|error| anyhow!("failed to load ed25519 key: {error}"))?;
+                    identity::RawIdentity::from_ed25519(private_key)
+                        .map_err(|error| anyhow!("failed to create node identity: {error}"))?
+                }
+                None => {
+                    let private_key = crypto::generate_secp256k1()
+                        .map_err(|error| anyhow!("failed to generate node signing key: {error}"))?;
+                    identity::RawIdentity::from_secp256k1(private_key)
+                        .map_err(|error| anyhow!("failed to create node identity: {error}"))?
+                }
+            };
 
-    let raw_identity = match key {
-        Some(SigningKey::Secp256k1(bytes)) => {
-            let private_key = crypto::Secp256k1PrivateKey::from_bytes(bytes)
-                .map_err(|error| anyhow!("failed to load secp256k1 key: {error}"))?;
-            identity::RawIdentity::from_secp256k1(private_key)
-                .map_err(|error| anyhow!("failed to create node identity: {error}"))?
+            let did = raw_identity
+                .did()
+                .map_err(|error| anyhow!("failed to derive node DID: {error}"))?;
+            let did_str = did.to_string();
+            let key_type = match key {
+                Some(SigningKey::Ed25519(_)) => "ed25519".to_string(),
+                Some(SigningKey::Secp256r1(_)) => "secp256r1".to_string(),
+                _ => "secp256k1".to_string(),
+            };
+
+            defra_core::signing::store_identity(
+                &did_str,
+                defra_core::signing::SigningConfig {
+                    key_type,
+                    private_key_bytes: raw_identity.private_key_bytes().to_vec(),
+                    public_key_bytes: raw_identity.public_key_bytes().to_vec(),
+                    public_key_hex: hex::encode(raw_identity.public_key_bytes()),
+                    remote_signer: None,
+                },
+            );
+
+            Ok((Some(raw_identity), Some(did_str)))
         }
-        Some(SigningKey::Ed25519(bytes)) => {
-            let private_key = crypto::Ed25519PrivateKey::from_bytes(bytes)
-                .map_err(|error| anyhow!("failed to load ed25519 key: {error}"))?;
+        SigningConfig::RegisteredIdentity { did } => {
+            let stored = defra_core::signing::get_identity(did)
+                .ok_or_else(|| anyhow!("no signing identity registered for DID: {}", did))?;
+            if !stored.has_local_private_key() && !stored.has_remote_signer() {
+                return Err(anyhow!(
+                    "registered identity {} has neither a local key nor a remote signer",
+                    did
+                ));
+            }
+
+            let raw_identity = if stored.has_local_private_key() {
+                let raw_identity = raw_identity_from_stored_config(&stored)?;
+                let derived_did = raw_identity
+                    .did()
+                    .map_err(|error| anyhow!("failed to derive stored identity DID: {error}"))?;
+                if derived_did.as_str() != did {
+                    return Err(anyhow!(
+                        "registered identity DID mismatch: expected {}, derived {}",
+                        did,
+                        derived_did
+                    ));
+                }
+                Some(raw_identity)
+            } else {
+                None
+            };
+
+            Ok((raw_identity, Some(did.clone())))
+        }
+    }
+}
+
+fn raw_identity_from_stored_config(
+    config: &defra_core::signing::SigningConfig,
+) -> Result<identity::RawIdentity> {
+    match config.key_type.as_str() {
+        "ed25519" => {
+            let private_key = crypto::Ed25519PrivateKey::from_bytes(&config.private_key_bytes)
+                .map_err(|error| anyhow!("failed to load stored ed25519 key: {error}"))?;
             identity::RawIdentity::from_ed25519(private_key)
-                .map_err(|error| anyhow!("failed to create node identity: {error}"))?
+                .map_err(|error| anyhow!("failed to create stored ed25519 identity: {error}"))
         }
-        None => {
-            let private_key = crypto::generate_secp256k1()
-                .map_err(|error| anyhow!("failed to generate node signing key: {error}"))?;
+        "secp256k1" => {
+            let private_key = crypto::Secp256k1PrivateKey::from_bytes(&config.private_key_bytes)
+                .map_err(|error| anyhow!("failed to load stored secp256k1 key: {error}"))?;
             identity::RawIdentity::from_secp256k1(private_key)
-                .map_err(|error| anyhow!("failed to create node identity: {error}"))?
+                .map_err(|error| anyhow!("failed to create stored secp256k1 identity: {error}"))
         }
-    };
-
-    let did = raw_identity
-        .did()
-        .map_err(|error| anyhow!("failed to derive node DID: {error}"))?;
-    let did_str = did.to_string();
-    let key_type = match key {
-        Some(SigningKey::Ed25519(_)) => "ed25519".to_string(),
-        _ => "secp256k1".to_string(),
-    };
-
-    defra_core::signing::store_identity(
-        &did_str,
-        defra_core::signing::SigningConfig {
-            key_type,
-            private_key_bytes: raw_identity.private_key_bytes().to_vec(),
-            public_key_bytes: raw_identity.public_key_bytes().to_vec(),
-            public_key_hex: hex::encode(raw_identity.public_key_bytes()),
-            remote_signer: None,
-        },
-    );
-
-    Ok((Some(raw_identity), Some(did_str)))
+        "secp256r1" => {
+            let private_key = crypto::Secp256r1PrivateKey::from_bytes(&config.private_key_bytes)
+                .map_err(|error| anyhow!("failed to load stored secp256r1 key: {error}"))?;
+            identity::RawIdentity::from_secp256r1(private_key)
+                .map_err(|error| anyhow!("failed to create stored secp256r1 identity: {error}"))
+        }
+        other => Err(anyhow!(
+            "stored identity {} cannot be used as a node identity",
+            other
+        )),
+    }
 }
 
 async fn create_document_acp<S>(

--- a/crates/ffi/cbindgen.toml
+++ b/crates/ffi/cbindgen.toml
@@ -21,6 +21,7 @@ documentation_style = "c"
 
 [export]
 include = [
+    "DefraRemoteSignCallback",
     "FfiResult",
     "NewNodeResult",
     "NewTxnResult",

--- a/crates/ffi/src/acp/identity.rs
+++ b/crates/ffi/src/acp/identity.rs
@@ -1,10 +1,94 @@
-use std::ffi::c_char;
+use std::ffi::{c_char, CString};
+use std::sync::Arc;
 
 use identity::Identity;
 
 use crate::helpers::{get_node_database, get_rt};
-use crate::types::{c_str_to_string, FfiResult};
+use crate::state::NODES;
+use crate::types::{c_str_to_string, DefraRemoteSignCallback, FfiResult};
 use crate::{ffi_async, ffi_entry, try_ffi};
+
+const MAX_REMOTE_SIGNATURE_LEN: usize = 512;
+
+struct FfiRemoteSigner {
+    did: CString,
+    key_type: CString,
+    signer_handle: usize,
+    callback: DefraRemoteSignCallback,
+}
+
+impl defra_core::signing::RemoteSigner for FfiRemoteSigner {
+    fn sign_sync(&self, data: &[u8]) -> Result<Vec<u8>, String> {
+        let mut signature = vec![0u8; MAX_REMOTE_SIGNATURE_LEN];
+        let mut signature_len = 0usize;
+        let status = unsafe {
+            (self.callback)(
+                self.signer_handle,
+                self.did.as_ptr(),
+                self.key_type.as_ptr(),
+                data.as_ptr(),
+                data.len(),
+                signature.as_mut_ptr(),
+                signature.len(),
+                &mut signature_len,
+            )
+        };
+
+        if status != 0 {
+            return Err(format!(
+                "remote signer callback failed with status {}",
+                status
+            ));
+        }
+        if signature_len == 0 {
+            return Err("remote signer callback returned an empty signature".to_string());
+        }
+        if signature_len > signature.len() {
+            return Err(format!(
+                "remote signer callback reported {} bytes, exceeding the {} byte limit",
+                signature_len, MAX_REMOTE_SIGNATURE_LEN
+            ));
+        }
+
+        signature.truncate(signature_len);
+        Ok(signature)
+    }
+}
+
+fn parse_crypto_key_type(key_type: &str) -> Result<crypto::KeyType, String> {
+    match key_type {
+        "ed25519" => Ok(crypto::KeyType::Ed25519),
+        "secp256k1" => Ok(crypto::KeyType::Secp256k1),
+        "secp256r1" => Ok(crypto::KeyType::Secp256r1),
+        "bls" => Ok(crypto::KeyType::Bls12381),
+        other => Err(format!("unsupported key type: {}", other)),
+    }
+}
+
+fn decode_and_validate_public_key(
+    did: &str,
+    public_key_hex: &str,
+    key_type: &str,
+) -> Result<Vec<u8>, String> {
+    let crypto_key_type = parse_crypto_key_type(key_type)?;
+    let public_key_bytes = hex::decode(public_key_hex)
+        .map_err(|error| format!("invalid public key hex: {}", error))?;
+
+    let public_key = crypto::public_key_from_bytes(crypto_key_type, &public_key_bytes)
+        .map_err(|error| format!("invalid public key bytes: {}", error))?;
+    let derived_did = public_key
+        .did()
+        .map_err(|error| format!("failed to derive DID from public key: {}", error))?;
+
+    if derived_did != did {
+        return Err(format!(
+            "public key DID mismatch: expected {}, derived {}",
+            did, derived_did
+        ));
+    }
+
+    Ok(public_key_bytes)
+}
 
 /// Get the node's identity (DID).
 ///
@@ -17,6 +101,10 @@ use crate::{ffi_async, ffi_entry, try_ffi};
 #[no_mangle]
 pub extern "C" fn get_node_identity(node_ptr: usize) -> FfiResult {
     ffi_entry! {
+        if let Some(Some(did)) = NODES.get(node_ptr, |state| state.node_identity_did.clone()) {
+            return FfiResult::success(serde_json::json!({ "did": did }).to_string());
+        }
+
         let rt = try_ffi!(get_rt());
         let database = try_ffi!(get_node_database(node_ptr));
 
@@ -95,6 +183,125 @@ pub extern "C" fn RegisterIdentity(
     }
 }
 
+/// Register an identity whose private key stays outside DefraDB.
+///
+/// The host provides the DID, public key, key type, and a signing callback.
+/// This supports device-bound keys (for example Secure Enclave P-256 keys) and
+/// remote identity providers such as Orbis without exporting private key bytes.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn register_remote_identity(
+    did: *const c_char,
+    public_key_hex: *const c_char,
+    key_type: *const c_char,
+    signer_handle: usize,
+    callback: Option<DefraRemoteSignCallback>,
+) -> FfiResult {
+    ffi_entry! {
+        let result = (|| {
+            let did_str = unsafe { c_str_to_string(did) }.ok_or("invalid did parameter")?;
+            let pub_hex =
+                unsafe { c_str_to_string(public_key_hex) }.ok_or("invalid public_key_hex parameter")?;
+            let key_type_str =
+                unsafe { c_str_to_string(key_type) }.unwrap_or_else(|| "secp256r1".to_string());
+            let callback = callback.ok_or("remote signer callback is required")?;
+
+            let public_key_bytes =
+                decode_and_validate_public_key(&did_str, &pub_hex, &key_type_str)?;
+
+            let signer = Arc::new(FfiRemoteSigner {
+                did: CString::new(did_str.clone())
+                    .map_err(|_| "did contains an embedded null byte".to_string())?,
+                key_type: CString::new(key_type_str.clone())
+                    .map_err(|_| "key_type contains an embedded null byte".to_string())?,
+                signer_handle,
+                callback,
+            });
+
+            defra_core::signing::store_identity(
+                &did_str,
+                defra_core::signing::SigningConfig {
+                    key_type: key_type_str,
+                    private_key_bytes: Vec::new(),
+                    public_key_bytes,
+                    public_key_hex: pub_hex,
+                    remote_signer: Some(signer),
+                },
+            );
+
+            Ok::<String, String>("{}".to_string())
+        })();
+
+        match result {
+            Ok(json) => FfiResult::success(json),
+            Err(error) => FfiResult::error(error),
+        }
+    }
+}
+
+/// Bind a host-provided bearer token to a logical DID for delegated ACP access.
+///
+/// This is intentionally a passthrough: the token may be signed by a device-
+/// bound key that has been authorized to act on behalf of the logical DID.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn bind_identity_bearer_token(
+    did: *const c_char,
+    bearer_token: *const c_char,
+) -> FfiResult {
+    ffi_entry! {
+        let did_str = match unsafe { c_str_to_string(did) } {
+            Some(value) if !value.is_empty() => value,
+            _ => return FfiResult::error("invalid did parameter"),
+        };
+        let token = match unsafe { c_str_to_string(bearer_token) } {
+            Some(value) if !value.is_empty() => value,
+            _ => return FfiResult::error("invalid bearer_token parameter"),
+        };
+        if let Err(error) = identity::Did::new(did_str.clone()) {
+            return FfiResult::error(format!("invalid DID: {}", error));
+        }
+
+        defra_core::signing::set_request_bearer_token(&did_str, token);
+        FfiResult::success(serde_json::json!({ "did": did_str }).to_string())
+    }
+}
+
+/// Set or clear the node's default signing identity.
+///
+/// When `did` is empty or null the default identity is cleared. Otherwise the
+/// DID must already be registered via `RegisterIdentity` or
+/// `register_remote_identity`.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn node_set_default_identity(node_ptr: usize, did: *const c_char) -> FfiResult {
+    ffi_entry! {
+        let did_str = unsafe { c_str_to_string(did) }.unwrap_or_default();
+        if !did_str.is_empty() && defra_core::signing::get_identity(&did_str).is_none() {
+            return FfiResult::error(format!("no signing identity registered for DID: {}", did_str));
+        }
+
+        let updated = NODES.get_mut(node_ptr, |state| {
+            state.node_identity_did = if did_str.is_empty() {
+                None
+            } else {
+                Some(did_str.clone())
+            };
+        });
+
+        match updated {
+            Some(()) => {
+                if did_str.is_empty() {
+                    FfiResult::success("{}".to_string())
+                } else {
+                    FfiResult::success(serde_json::json!({ "did": did_str }).to_string())
+                }
+            }
+            None => FfiResult::error(crate::ERR_INVALID_NODE_HANDLE),
+        }
+    }
+}
+
 /// Create a new identity (Ed25519 keypair).
 ///
 /// Generates a fresh Ed25519 keypair and returns the DID and private key.
@@ -160,7 +367,46 @@ mod tests {
     use super::*;
     use crate::node::{new_node, node_close};
     use crate::types::NodeInitOptions;
-    use std::ffi::CStr;
+    use crypto::{keys::Key, keys::PublicKey, PrivateKey};
+    use std::ffi::{CStr, CString};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Duration;
+
+    fn remote_key_store() -> &'static Mutex<Vec<u8>> {
+        static STORE: OnceLock<Mutex<Vec<u8>>> = OnceLock::new();
+        STORE.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    unsafe extern "C" fn test_remote_sign_callback(
+        _signer_handle: usize,
+        _did: *const c_char,
+        _key_type: *const c_char,
+        payload_ptr: *const u8,
+        payload_len: usize,
+        out_signature_ptr: *mut u8,
+        out_signature_capacity: usize,
+        out_signature_len: *mut usize,
+    ) -> i32 {
+        let key_bytes = remote_key_store().lock().unwrap().clone();
+        let private_key = match crypto::Secp256r1PrivateKey::from_bytes(&key_bytes) {
+            Ok(key) => key,
+            Err(_) => return 1,
+        };
+
+        let payload = std::slice::from_raw_parts(payload_ptr, payload_len);
+        let signature = match private_key.sign(payload) {
+            Ok(signature) => signature,
+            Err(_) => return 2,
+        };
+
+        if signature.len() > out_signature_capacity {
+            return 3;
+        }
+
+        std::ptr::copy_nonoverlapping(signature.as_ptr(), out_signature_ptr, signature.len());
+        *out_signature_len = signature.len();
+        0
+    }
 
     #[test]
     fn test_get_node_identity_not_configured() {
@@ -222,5 +468,125 @@ mod tests {
 
         assert_ne!(did, did2, "two calls should produce different DIDs");
         unsafe { crate::types::defra_free_string(result2.value) };
+    }
+
+    #[test]
+    fn test_register_remote_identity() {
+        let private_key = crypto::generate_secp256r1().unwrap();
+        *remote_key_store().lock().unwrap() = private_key.raw();
+
+        let raw_identity = identity::RawIdentity::from_secp256r1(private_key).unwrap();
+        let did = raw_identity.did().unwrap().to_string();
+        let public_key_hex = hex::encode(raw_identity.public_key_bytes());
+
+        let did_c = CString::new(did.clone()).unwrap();
+        let pub_c = CString::new(public_key_hex.clone()).unwrap();
+        let key_type_c = CString::new("secp256r1").unwrap();
+
+        let result = register_remote_identity(
+            did_c.as_ptr(),
+            pub_c.as_ptr(),
+            key_type_c.as_ptr(),
+            42,
+            Some(test_remote_sign_callback),
+        );
+        assert_eq!(result.status, 0, "register_remote_identity should succeed");
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        let config = defra_core::signing::get_identity(&did).expect("identity should be stored");
+        assert_eq!(config.key_type, "secp256r1");
+        assert!(config.private_key_bytes.is_empty());
+        assert!(config.remote_signer.is_some());
+
+        let message = b"remote-signature-test";
+        let signature = config
+            .remote_signer
+            .as_ref()
+            .unwrap()
+            .sign_sync(message)
+            .expect("remote signing should succeed");
+        let public_key = crypto::Secp256r1PublicKey::from_bytes(&config.public_key_bytes).unwrap();
+        let valid = public_key.verify(message, &signature).unwrap();
+        assert!(
+            valid,
+            "signature from registered remote signer should verify"
+        );
+    }
+
+    #[test]
+    fn test_bind_identity_bearer_token_allows_delegated_binding() {
+        let device_key = crypto::generate_secp256r1().unwrap();
+        let device_identity = identity::RawIdentity::from_secp256r1(device_key).unwrap();
+        let token = String::from_utf8(
+            identity::new_token(&device_identity, Duration::from_secs(300), None, None).unwrap(),
+        )
+        .unwrap();
+
+        let logical_identity =
+            identity::RawIdentity::from_ed25519(crypto::generate_ed25519().unwrap()).unwrap();
+        let logical_did = logical_identity.did().unwrap().to_string();
+
+        let did_c = CString::new(logical_did.clone()).unwrap();
+        let token_c = CString::new(token.clone()).unwrap();
+
+        let result = bind_identity_bearer_token(did_c.as_ptr(), token_c.as_ptr());
+        assert_eq!(
+            result.status, 0,
+            "bind_identity_bearer_token should succeed"
+        );
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        let stored = defra_core::signing::get_request_bearer_token(&logical_did)
+            .expect("token should exist");
+        assert_eq!(stored, token);
+    }
+
+    #[test]
+    fn test_node_set_default_identity_uses_registered_remote_identity() {
+        assert!(crate::runtime::init_runtime());
+
+        let private_key = crypto::generate_secp256r1().unwrap();
+        *remote_key_store().lock().unwrap() = private_key.raw();
+
+        let raw_identity = identity::RawIdentity::from_secp256r1(private_key).unwrap();
+        let did = raw_identity.did().unwrap().to_string();
+        let public_key_hex = hex::encode(raw_identity.public_key_bytes());
+
+        let did_c = CString::new(did.clone()).unwrap();
+        let pub_c = CString::new(public_key_hex).unwrap();
+        let key_type_c = CString::new("secp256r1").unwrap();
+
+        let register = register_remote_identity(
+            did_c.as_ptr(),
+            pub_c.as_ptr(),
+            key_type_c.as_ptr(),
+            1,
+            Some(test_remote_sign_callback),
+        );
+        assert_eq!(register.status, 0);
+        if !register.value.is_null() {
+            unsafe { crate::types::defra_free_string(register.value) };
+        }
+
+        let node_result = new_node(NodeInitOptions::default());
+        assert_eq!(node_result.status, 0, "new_node should succeed");
+        let node = node_result.node_ptr;
+        let result = node_set_default_identity(node, did_c.as_ptr());
+        assert_eq!(result.status, 0, "node_set_default_identity should succeed");
+        if !result.value.is_null() {
+            unsafe { crate::types::defra_free_string(result.value) };
+        }
+
+        let identity_result = get_node_identity(node);
+        assert_eq!(identity_result.status, 0);
+        let value = unsafe { CStr::from_ptr(identity_result.value).to_string_lossy() };
+        assert!(value.contains(&did));
+
+        unsafe { crate::types::defra_free_string(identity_result.value) };
+        node_close(node);
     }
 }

--- a/crates/ffi/src/acp/mod.rs
+++ b/crates/ffi/src/acp/mod.rs
@@ -12,7 +12,10 @@ pub use dac::{
     add_dac_actor_relationship, add_dac_policy, delete_dac_actor_relationship, get_dac_policy,
     list_dac_policies,
 };
-pub use identity::{create_identity, get_node_identity, RegisterIdentity};
+pub use identity::{
+    bind_identity_bearer_token, create_identity, get_node_identity, node_set_default_identity,
+    register_remote_identity, RegisterIdentity,
+};
 pub use nac::{
     add_nac_actor_relationship, delete_nac_actor_relationship, disable_nac, enable_nac,
     get_nac_status, re_enable_nac,

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -43,6 +43,7 @@ pub mod encrypted_index;
 pub mod helpers;
 pub mod index;
 pub mod lens;
+pub mod mobile;
 pub mod nac_check;
 pub mod node;
 pub mod p2p;
@@ -136,10 +137,11 @@ macro_rules! ffi_async_ok {
 
 // Re-export FFI functions at crate root
 pub use acp::{
-    add_dac_actor_relationship, add_dac_policy, add_nac_actor_relationship, create_identity,
-    delete_dac_actor_relationship, delete_nac_actor_relationship, disable_nac, enable_nac,
-    get_dac_policy, get_nac_status, get_node_identity, list_dac_policies, re_enable_nac,
-    RegisterIdentity,
+    add_dac_actor_relationship, add_dac_policy, add_nac_actor_relationship,
+    bind_identity_bearer_token, create_identity, delete_dac_actor_relationship,
+    delete_nac_actor_relationship, disable_nac, enable_nac, get_dac_policy, get_nac_status,
+    get_node_identity, list_dac_policies, node_set_default_identity, re_enable_nac,
+    register_remote_identity, RegisterIdentity,
 };
 pub use backup::{basic_export, basic_import};
 pub use batch::{batch_sign, batch_start};
@@ -156,6 +158,11 @@ pub use encrypted_index::{
 };
 pub use index::{create_index, delete_index, get_indexes, list_all_indexes};
 pub use lens::{lens_add, lens_list};
+pub use mobile::{
+    defra_mobile_close_node, defra_mobile_connect, defra_mobile_ensure_schema,
+    defra_mobile_execute, defra_mobile_init, defra_mobile_open_node, defra_mobile_peer_info,
+    defra_mobile_sync_collection,
+};
 pub use node::{new_node, node_close};
 pub use p2p::{
     new_node_with_p2p, p2p_active_peers, p2p_add_collections, p2p_add_documents,

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -1,0 +1,663 @@
+//! Thin mobile-oriented FFI wrappers for Swift/Xcode embedding.
+
+use std::collections::HashSet;
+use std::ffi::{c_char, CString};
+use std::ptr;
+
+use acp::nac::NodePermission;
+
+use crate::helpers::get_rt;
+use crate::nac_check::check_nac_for_node;
+use crate::node::{new_node, node_close};
+use crate::p2p::{
+    new_node_with_p2p, p2p_connect, p2p_peer_info, p2p_sync_branchable_collection,
+    p2p_sync_collection_versions, p2p_sync_documents,
+};
+use crate::query::exec_request;
+use crate::schema::validate_collection_policy;
+use crate::state::NODES;
+use crate::types::{c_str_to_string, defra_free_string, FfiResult, NewNodeResult, NodeInitOptions};
+use crate::{ffi_async, ffi_entry, try_ffi, ERR_INVALID_NODE_HANDLE};
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileNodeConfig {
+    db_path: Option<String>,
+    in_memory: Option<bool>,
+    datastore_backend: Option<String>,
+    signing: Option<MobileSigningConfig>,
+    default_identity_did: Option<String>,
+    sourcehub: Option<MobileSourceHubConfig>,
+    p2p: Option<MobileP2pConfig>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileSigningConfig {
+    enable: Option<bool>,
+    key_type: Option<String>,
+    private_key_hex: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileSourceHubConfig {
+    grpc_address: String,
+    comet_rpc_address: String,
+    chain_id: String,
+    signer_key_hex: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileP2pConfig {
+    transport: Option<String>,
+    listen_address: Option<String>,
+    iroh: Option<MobileIrohConfig>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileIrohConfig {
+    relay_url: Option<String>,
+    bind_address: Option<String>,
+    bind_port: Option<u16>,
+    discovery: Option<bool>,
+    key_path: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileExecuteRequest {
+    identity_did: Option<String>,
+    query: String,
+    operation_name: Option<String>,
+    variables: Option<serde_json::Value>,
+    batch_session_id: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MobileSyncRequest {
+    identity_did: Option<String>,
+    collection_id: Option<String>,
+    collection_name: Option<String>,
+    doc_ids: Option<Vec<String>>,
+    version_ids: Option<Vec<String>>,
+}
+
+fn maybe_cstring(value: Option<&str>, field_name: &str) -> Result<Option<CString>, String> {
+    value
+        .map(|value| {
+            CString::new(value)
+                .map_err(|_| format!("{} contains an embedded null byte", field_name))
+        })
+        .transpose()
+}
+
+fn decode_hex_field(value: Option<&str>, field_name: &str) -> Result<Vec<u8>, String> {
+    match value {
+        Some(value) if !value.is_empty() => {
+            hex::decode(value).map_err(|error| format!("invalid {} hex: {}", field_name, error))
+        }
+        _ => Ok(Vec::new()),
+    }
+}
+
+fn c_string_ptr(value: &Option<CString>) -> *const c_char {
+    value.as_ref().map_or(ptr::null(), |value| value.as_ptr())
+}
+
+fn ffi_result_error(result: FfiResult) -> String {
+    let message = if result.error.is_null() {
+        "unknown FFI error".to_string()
+    } else {
+        unsafe { std::ffi::CStr::from_ptr(result.error) }
+            .to_string_lossy()
+            .into_owned()
+    };
+
+    unsafe {
+        if !result.error.is_null() {
+            defra_free_string(result.error);
+        }
+        if !result.value.is_null() {
+            defra_free_string(result.value);
+        }
+    }
+
+    message
+}
+
+fn default_identity_cstring(node_ptr: usize) -> Result<Option<CString>, String> {
+    let Some(identity_did) = NODES.get(node_ptr, |state| state.node_identity_did.clone()) else {
+        return Err(ERR_INVALID_NODE_HANDLE.to_string());
+    };
+    maybe_cstring(identity_did.as_deref(), "default identity")
+}
+
+/// Initialize the runtime for mobile embedding.
+#[no_mangle]
+pub extern "C" fn defra_mobile_init() -> FfiResult {
+    ffi_entry! {
+        crate::defra_init();
+        FfiResult::success(serde_json::json!({ "version": env!("CARGO_PKG_VERSION") }).to_string())
+    }
+}
+
+/// Open a node from a single JSON config blob.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_mobile_open_node(config_json: *const c_char) -> NewNodeResult {
+    ffi_entry! {
+        crate::defra_init();
+
+        let config_str = match unsafe { c_str_to_string(config_json) } {
+            Some(value) => value,
+            None => return NewNodeResult::error("invalid config_json parameter"),
+        };
+
+        let config: MobileNodeConfig = match serde_json::from_str(&config_str) {
+            Ok(config) => config,
+            Err(error) => return NewNodeResult::error(format!("invalid config_json: {}", error)),
+        };
+
+        let db_path = match maybe_cstring(config.db_path.as_deref(), "dbPath") {
+            Ok(value) => value,
+            Err(error) => return NewNodeResult::error(error),
+        };
+        let datastore_backend =
+            match maybe_cstring(config.datastore_backend.as_deref(), "datastoreBackend") {
+                Ok(value) => value,
+                Err(error) => return NewNodeResult::error(error),
+            };
+
+        let mut signing_key_type = None;
+        let signing_key_bytes = if let Some(signing) = config.signing.as_ref() {
+            if signing.private_key_hex.is_none() && signing.key_type.is_some() {
+                return NewNodeResult::error(
+                    "signing.privateKeyHex is required when signing.keyType is provided",
+                );
+            }
+            signing_key_type = match maybe_cstring(signing.key_type.as_deref(), "signing.keyType")
+            {
+                Ok(value) => value,
+                Err(error) => return NewNodeResult::error(error),
+            };
+            match decode_hex_field(signing.private_key_hex.as_deref(), "signing.privateKeyHex") {
+                Ok(bytes) => bytes,
+                Err(error) => return NewNodeResult::error(error),
+            }
+        } else {
+            Vec::new()
+        };
+        let enable_signing = config
+            .signing
+            .as_ref()
+            .and_then(|signing| signing.enable)
+            .unwrap_or_else(|| !signing_key_bytes.is_empty());
+
+        let (sourcehub_grpc_address, sourcehub_comet_rpc_address, sourcehub_chain_id, sourcehub_signer_key) =
+            if let Some(sourcehub) = config.sourcehub.as_ref() {
+                let grpc = match maybe_cstring(Some(sourcehub.grpc_address.as_str()), "sourcehub.grpcAddress") {
+                    Ok(Some(value)) => Some(value),
+                    Ok(None) => None,
+                    Err(error) => return NewNodeResult::error(error),
+                };
+                let comet = match maybe_cstring(
+                    Some(sourcehub.comet_rpc_address.as_str()),
+                    "sourcehub.cometRpcAddress",
+                ) {
+                    Ok(Some(value)) => Some(value),
+                    Ok(None) => None,
+                    Err(error) => return NewNodeResult::error(error),
+                };
+                let chain = match maybe_cstring(Some(sourcehub.chain_id.as_str()), "sourcehub.chainId")
+                {
+                    Ok(Some(value)) => Some(value),
+                    Ok(None) => None,
+                    Err(error) => return NewNodeResult::error(error),
+                };
+                let signer_key =
+                    match decode_hex_field(Some(sourcehub.signer_key_hex.as_str()), "sourcehub.signerKeyHex")
+                    {
+                        Ok(bytes) => bytes,
+                        Err(error) => return NewNodeResult::error(error),
+                    };
+                (grpc, comet, chain, signer_key)
+            } else {
+                (None, None, None, Vec::new())
+            };
+
+        let p2p_transport_name = config
+            .p2p
+            .as_ref()
+            .and_then(|p2p| p2p.transport.clone().or_else(|| p2p.iroh.as_ref().map(|_| "iroh".to_string())));
+        let p2p_transport =
+            match maybe_cstring(p2p_transport_name.as_deref(), "p2p.transport") {
+                Ok(value) => value,
+                Err(error) => return NewNodeResult::error(error),
+            };
+        let iroh_relay_url = match maybe_cstring(
+            config
+                .p2p
+                .as_ref()
+                .and_then(|p2p| p2p.iroh.as_ref())
+                .and_then(|iroh| iroh.relay_url.as_deref()),
+            "p2p.iroh.relayUrl",
+        ) {
+            Ok(value) => value,
+            Err(error) => return NewNodeResult::error(error),
+        };
+        let iroh_bind_addr = match maybe_cstring(
+            config
+                .p2p
+                .as_ref()
+                .and_then(|p2p| p2p.iroh.as_ref())
+                .and_then(|iroh| iroh.bind_address.as_deref()),
+            "p2p.iroh.bindAddress",
+        ) {
+            Ok(value) => value,
+            Err(error) => return NewNodeResult::error(error),
+        };
+        let iroh_key_path = match maybe_cstring(
+            config
+                .p2p
+                .as_ref()
+                .and_then(|p2p| p2p.iroh.as_ref())
+                .and_then(|iroh| iroh.key_path.as_deref()),
+            "p2p.iroh.keyPath",
+        ) {
+            Ok(value) => value,
+            Err(error) => return NewNodeResult::error(error),
+        };
+        let listen_address = match maybe_cstring(
+            config
+                .p2p
+                .as_ref()
+                .and_then(|p2p| p2p.listen_address.as_deref()),
+            "p2p.listenAddress",
+        ) {
+            Ok(value) => value,
+            Err(error) => return NewNodeResult::error(error),
+        };
+
+        let options = NodeInitOptions {
+            db_path: c_string_ptr(&db_path),
+            in_memory: i32::from(config.in_memory.unwrap_or_else(|| config.db_path.is_none())),
+            datastore_backend: c_string_ptr(&datastore_backend),
+            enable_signing: i32::from(enable_signing),
+            signing_key_type: c_string_ptr(&signing_key_type),
+            signing_private_key: if signing_key_bytes.is_empty() {
+                ptr::null()
+            } else {
+                signing_key_bytes.as_ptr()
+            },
+            signing_private_key_len: signing_key_bytes.len(),
+            sourcehub_grpc_address: c_string_ptr(&sourcehub_grpc_address),
+            sourcehub_comet_rpc_address: c_string_ptr(&sourcehub_comet_rpc_address),
+            sourcehub_chain_id: c_string_ptr(&sourcehub_chain_id),
+            sourcehub_signer_key: if sourcehub_signer_key.is_empty() {
+                ptr::null()
+            } else {
+                sourcehub_signer_key.as_ptr()
+            },
+            sourcehub_signer_key_len: sourcehub_signer_key.len(),
+            p2p_transport: c_string_ptr(&p2p_transport),
+            iroh_relay_url: c_string_ptr(&iroh_relay_url),
+            iroh_bind_addr: c_string_ptr(&iroh_bind_addr),
+            iroh_bind_port: config
+                .p2p
+                .as_ref()
+                .and_then(|p2p| p2p.iroh.as_ref())
+                .and_then(|iroh| iroh.bind_port)
+                .unwrap_or_default(),
+            iroh_discovery: i32::from(
+                config
+                    .p2p
+                    .as_ref()
+                    .and_then(|p2p| p2p.iroh.as_ref())
+                    .and_then(|iroh| iroh.discovery)
+                    .unwrap_or(true),
+            ),
+            iroh_key_path: c_string_ptr(&iroh_key_path),
+        };
+
+        let mut result = if config.p2p.is_some() {
+            unsafe {
+                new_node_with_p2p(
+                    options,
+                    listen_address
+                        .as_ref()
+                        .map_or(ptr::null(), |value| value.as_ptr()),
+                )
+            }
+        } else {
+            new_node(options)
+        };
+
+        if result.status != 0 {
+            return result;
+        }
+
+        if let Some(default_identity_did) = config.default_identity_did.as_deref() {
+            let did = match CString::new(default_identity_did) {
+                Ok(value) => value,
+                Err(_) => {
+                    let _ = node_close(result.node_ptr);
+                    return NewNodeResult::error("defaultIdentityDid contains an embedded null byte");
+                }
+            };
+            let set_identity = crate::acp::node_set_default_identity(result.node_ptr, did.as_ptr());
+            if set_identity.status != 0 {
+                let error = ffi_result_error(set_identity);
+                let _ = node_close(result.node_ptr);
+                result = NewNodeResult::error(error);
+            } else {
+                unsafe {
+                    if !set_identity.value.is_null() {
+                        defra_free_string(set_identity.value);
+                    }
+                }
+            }
+        }
+
+        result
+    }
+}
+
+/// Close a node opened via the mobile wrapper.
+#[no_mangle]
+pub extern "C" fn defra_mobile_close_node(node_ptr: usize) -> FfiResult {
+    node_close(node_ptr)
+}
+
+/// Idempotently ensure an SDL schema exists on a node.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_mobile_ensure_schema(
+    node_ptr: usize,
+    schema_sdl: *const c_char,
+) -> FfiResult {
+    ffi_entry! {
+        let schema_str = match unsafe { c_str_to_string(schema_sdl) } {
+            Some(value) => value,
+            None => return FfiResult::error("invalid schema_sdl parameter"),
+        };
+        let rt = try_ffi!(get_rt());
+        let default_identity = match default_identity_cstring(node_ptr) {
+            Ok(value) => value,
+            Err(error) => return FfiResult::error(error),
+        };
+        try_ffi!(check_nac_for_node(
+            rt,
+            node_ptr,
+            c_string_ptr(&default_identity),
+            NodePermission::CollectionPatch
+        ));
+
+        let (database, policy_store) = match NODES.get(node_ptr, |state| {
+            (state.database.clone(), state.policy_store.clone())
+        }) {
+            Some(value) => value,
+            None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
+        };
+
+        ffi_async!(rt, {
+            let existing_collections: HashSet<String> =
+                database.list_collections().unwrap_or_default().into_iter().collect();
+            let known_types = existing_collections.clone();
+            let collections = query::parse_sdl_with_known_types(&schema_str, known_types)
+                .map_err(|error| format!("failed to parse schema: {}", error))?;
+
+            let mut to_create = Vec::new();
+            let mut skipped = Vec::new();
+            for collection in collections {
+                if existing_collections.contains(&collection.name) {
+                    skipped.push(collection.name.clone());
+                } else {
+                    to_create.push(collection);
+                }
+            }
+
+            db::definition_validation::validate_new_collections(&to_create)
+                .map_err(|error| format!("failed to validate schema: {}", error))?;
+
+            let mut created = Vec::new();
+            for collection in to_create {
+                if let Some(ref policy) = collection.policy {
+                    validate_collection_policy(policy, &policy_store)?;
+                }
+                created.push(collection.name.clone());
+                database
+                    .create_collection(collection)
+                    .await
+                    .map_err(|error| format!("failed to create collection: {}", error))?;
+            }
+
+            Ok(serde_json::json!({
+                "created": created,
+                "skipped": skipped,
+            })
+            .to_string())
+        })
+    }
+}
+
+/// Execute a GraphQL request from a single JSON payload.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_mobile_execute(node_ptr: usize, request_json: *const c_char) -> FfiResult {
+    ffi_entry! {
+        let request_str = match unsafe { c_str_to_string(request_json) } {
+            Some(value) => value,
+            None => return FfiResult::error("invalid request_json parameter"),
+        };
+
+        let request: MobileExecuteRequest = match serde_json::from_str(&request_str) {
+            Ok(request) => request,
+            Err(error) => return FfiResult::error(format!("invalid request_json: {}", error)),
+        };
+
+        let identity_did = if request.identity_did.is_some() {
+            match maybe_cstring(request.identity_did.as_deref(), "identityDid") {
+                Ok(value) => value,
+                Err(error) => return FfiResult::error(error),
+            }
+        } else {
+            match default_identity_cstring(node_ptr) {
+                Ok(value) => value,
+                Err(error) => return FfiResult::error(error),
+            }
+        };
+        let query = match CString::new(request.query) {
+            Ok(value) => value,
+            Err(_) => return FfiResult::error("query contains an embedded null byte"),
+        };
+        let operation_name =
+            match maybe_cstring(request.operation_name.as_deref(), "operationName") {
+                Ok(value) => value,
+                Err(error) => return FfiResult::error(error),
+            };
+        let variables_json = match request.variables {
+            Some(value) => match CString::new(value.to_string()) {
+                Ok(value) => Some(value),
+                Err(_) => return FfiResult::error("variables contains an embedded null byte"),
+            },
+            None => None,
+        };
+        let batch_session_id =
+            match maybe_cstring(request.batch_session_id.as_deref(), "batchSessionId") {
+                Ok(value) => value,
+                Err(error) => return FfiResult::error(error),
+            };
+
+        unsafe {
+            exec_request(
+                node_ptr,
+                c_string_ptr(&identity_did),
+                query.as_ptr(),
+                c_string_ptr(&operation_name),
+                c_string_ptr(&variables_json),
+                c_string_ptr(&batch_session_id),
+            )
+        }
+    }
+}
+
+/// Return local peer info for the configured mobile transport.
+#[no_mangle]
+pub extern "C" fn defra_mobile_peer_info(node_ptr: usize) -> FfiResult {
+    let identity = match default_identity_cstring(node_ptr) {
+        Ok(value) => value,
+        Err(error) => return FfiResult::error(error),
+    };
+    unsafe { p2p_peer_info(node_ptr, c_string_ptr(&identity)) }
+}
+
+/// Connect the node to a peer address.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_mobile_connect(node_ptr: usize, addr: *const c_char) -> FfiResult {
+    let identity = match default_identity_cstring(node_ptr) {
+        Ok(value) => value,
+        Err(error) => return FfiResult::error(error),
+    };
+    unsafe { p2p_connect(node_ptr, c_string_ptr(&identity), addr) }
+}
+
+/// Sync branchable collections, schema versions, or specific documents.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_mobile_sync_collection(
+    node_ptr: usize,
+    request_json: *const c_char,
+) -> FfiResult {
+    ffi_entry! {
+        let request_str = match unsafe { c_str_to_string(request_json) } {
+            Some(value) => value,
+            None => return FfiResult::error("invalid request_json parameter"),
+        };
+        let request: MobileSyncRequest = match serde_json::from_str(&request_str) {
+            Ok(request) => request,
+            Err(error) => return FfiResult::error(format!("invalid request_json: {}", error)),
+        };
+
+        let identity_did = if request.identity_did.is_some() {
+            match maybe_cstring(request.identity_did.as_deref(), "identityDid") {
+                Ok(value) => value,
+                Err(error) => return FfiResult::error(error),
+            }
+        } else {
+            match default_identity_cstring(node_ptr) {
+                Ok(value) => value,
+                Err(error) => return FfiResult::error(error),
+            }
+        };
+
+        if let Some(version_ids) = request.version_ids {
+            let version_ids = match CString::new(serde_json::to_string(&version_ids).unwrap_or_default()) {
+                Ok(value) => value,
+                Err(_) => return FfiResult::error("versionIds contains an embedded null byte"),
+            };
+            return unsafe {
+                p2p_sync_collection_versions(
+                    node_ptr,
+                    c_string_ptr(&identity_did),
+                    version_ids.as_ptr(),
+                )
+            };
+        }
+
+        if let Some(doc_ids) = request.doc_ids {
+            let collection_name = match request.collection_name {
+                Some(value) => value,
+                None => return FfiResult::error("collectionName is required when docIds are provided"),
+            };
+            let collection_name = match CString::new(collection_name) {
+                Ok(value) => value,
+                Err(_) => return FfiResult::error("collectionName contains an embedded null byte"),
+            };
+            let doc_ids = match CString::new(serde_json::to_string(&doc_ids).unwrap_or_default()) {
+                Ok(value) => value,
+                Err(_) => return FfiResult::error("docIds contains an embedded null byte"),
+            };
+            return unsafe {
+                p2p_sync_documents(
+                    node_ptr,
+                    c_string_ptr(&identity_did),
+                    collection_name.as_ptr(),
+                    doc_ids.as_ptr(),
+                )
+            };
+        }
+
+        if let Some(collection_id) = request.collection_id {
+            let collection_id = match CString::new(collection_id) {
+                Ok(value) => value,
+                Err(_) => return FfiResult::error("collectionId contains an embedded null byte"),
+            };
+            return unsafe {
+                p2p_sync_branchable_collection(
+                    node_ptr,
+                    c_string_ptr(&identity_did),
+                    collection_id.as_ptr(),
+                )
+            };
+        }
+
+        FfiResult::error(
+            "request_json must include versionIds, docIds, or collectionId".to_string(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+
+    #[test]
+    fn test_mobile_open_schema_and_execute() {
+        let init = defra_mobile_init();
+        assert_eq!(init.status, 0);
+        unsafe { defra_free_string(init.value) };
+
+        let config = CString::new(r#"{"inMemory":true}"#).unwrap();
+        let node = defra_mobile_open_node(config.as_ptr());
+        assert_eq!(node.status, 0, "mobile open should succeed");
+
+        let schema = CString::new("type Book { name: String }").unwrap();
+        let ensure = defra_mobile_ensure_schema(node.node_ptr, schema.as_ptr());
+        assert_eq!(ensure.status, 0, "mobile ensure schema should succeed");
+        unsafe { defra_free_string(ensure.value) };
+
+        let mutation = CString::new(
+            r#"{"query":"mutation { add_Book(input: {name: \"Dune\"}) { _docID } }"}"#,
+        )
+        .unwrap();
+        let mutation_result = defra_mobile_execute(node.node_ptr, mutation.as_ptr());
+        assert_eq!(mutation_result.status, 0, "mobile execute should succeed");
+        let mutation_json = unsafe { CStr::from_ptr(mutation_result.value).to_string_lossy() };
+        let parsed: serde_json::Value =
+            serde_json::from_str(&mutation_json).expect("mutation response should be valid JSON");
+        assert!(
+            parsed
+                .get("errors")
+                .and_then(|value| value.as_array())
+                .map(|errors| errors.is_empty())
+                .unwrap_or(true),
+            "mutation should not return errors: {}",
+            mutation_json
+        );
+        assert!(
+            parsed["data"].get("add_Book").is_some(),
+            "mutation should include add_Book data: {}",
+            mutation_json
+        );
+        unsafe { defra_free_string(mutation_result.value) };
+
+        let close = defra_mobile_close_node(node.node_ptr);
+        assert_eq!(close.status, 0, "mobile close should succeed");
+    }
+}

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -195,7 +195,7 @@ pub extern "C" fn defra_mobile_open_node(config_json: *const c_char) -> NewNodeR
             .signing
             .as_ref()
             .and_then(|signing| signing.enable)
-            .unwrap_or_else(|| !signing_key_bytes.is_empty());
+            .unwrap_or(!signing_key_bytes.is_empty());
 
         let (sourcehub_grpc_address, sourcehub_comet_rpc_address, sourcehub_chain_id, sourcehub_signer_key) =
             if let Some(sourcehub) = config.sourcehub.as_ref() {

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -141,6 +141,7 @@ fn resolve_embedded_config(
 
             Some(match key_type.as_str() {
                 "secp256k1" => embedded::SigningKey::Secp256k1(key_bytes),
+                "secp256r1" => embedded::SigningKey::Secp256r1(key_bytes),
                 "ed25519" => embedded::SigningKey::Ed25519(key_bytes),
                 other => return Err(format!("unsupported signing key type: {}", other)),
             })

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn get_collections_in_txn(
 }
 
 /// Validate that a collection's policy references a valid, well-formed policy.
-fn validate_collection_policy(
+pub(crate) fn validate_collection_policy(
     policy: &schema::PolicyDescription,
     store: &Arc<PolicyStore>,
 ) -> Result<(), String> {

--- a/crates/ffi/src/types.rs
+++ b/crates/ffi/src/types.rs
@@ -3,6 +3,22 @@
 use std::ffi::{c_char, c_int, CStr, CString};
 use std::ptr;
 
+/// Host callback used for non-exportable signing keys.
+///
+/// The callback must write the raw signature bytes into `out_signature_ptr`,
+/// set `out_signature_len`, and return `0` on success. For ECDSA keys the
+/// expected signature format is DER, matching DefraDB's local crypto library.
+pub type DefraRemoteSignCallback = unsafe extern "C" fn(
+    signer_handle: usize,
+    did: *const c_char,
+    key_type: *const c_char,
+    payload_ptr: *const u8,
+    payload_len: usize,
+    out_signature_ptr: *mut u8,
+    out_signature_capacity: usize,
+    out_signature_len: *mut usize,
+) -> c_int;
+
 /// FFI result type matching Go's Result struct.
 ///
 /// Status codes:
@@ -147,7 +163,7 @@ pub struct NodeInitOptions {
     /// If signing_private_key is provided, that key is used.
     /// Otherwise, a random secp256k1 key pair is generated.
     pub enable_signing: c_int,
-    /// Optional: signing key type string (e.g. "secp256k1", "ed25519").
+    /// Optional: signing key type string (e.g. "secp256k1", "secp256r1", "ed25519").
     /// Null to auto-generate secp256k1.
     pub signing_key_type: *const c_char,
     /// Optional: raw private key bytes for signing.

--- a/crates/sourcehub/src/cosmos/cosmos_provider.rs
+++ b/crates/sourcehub/src/cosmos/cosmos_provider.rs
@@ -86,6 +86,47 @@ fn subject_to_json(subject: &SubjectRef) -> serde_json::Value {
     }
 }
 
+fn resolve_cosmos_bearer_token(
+    did: &str,
+    authorized_account: &str,
+) -> Result<Option<String>, ProviderError> {
+    let Some(signing_config) = defra_core::signing::get_identity(did) else {
+        return Ok(defra_core::signing::get_request_bearer_token(did));
+    };
+
+    if !signing_config.has_local_private_key() {
+        return Ok(defra_core::signing::get_request_bearer_token(did));
+    }
+
+    let key_type: crypto::KeyType = match signing_config.key_type.as_str() {
+        "ed25519" => crypto::KeyType::Ed25519,
+        "secp256k1" => crypto::KeyType::Secp256k1,
+        "secp256r1" => crypto::KeyType::Secp256r1,
+        other => {
+            return Err(ProviderError::Config(format!(
+                "unsupported key type: {}",
+                other
+            )))
+        }
+    };
+
+    let raw_identity =
+        identity::RawIdentity::from_bytes(key_type, &signing_config.private_key_bytes)
+            .map_err(|e| ProviderError::Config(format!("failed to create identity: {}", e)))?;
+
+    let token_bytes = identity::new_token(
+        &raw_identity,
+        Duration::from_secs(300),
+        None,
+        Some(authorized_account.to_string()),
+    )
+    .map_err(|e| ProviderError::Config(format!("failed to create bearer token: {}", e)))?;
+
+    String::from_utf8(token_bytes)
+        .map(Some)
+        .map_err(|e| ProviderError::Config(format!("bearer token is not valid UTF-8: {}", e)))
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl SourceHubProvider for CosmosProvider {
@@ -94,52 +135,18 @@ impl SourceHubProvider for CosmosProvider {
     }
 
     async fn create_bearer_token(&self, did: &str) -> Result<String, ProviderError> {
-        let signing_config = match defra_core::signing::get_identity(did) {
-            Some(config) => config,
-            None => {
-                // Fall back to the original JWT from the HTTP request.
-                // Go DefraDB's BearerToken() pattern: the user's JWT is already signed
-                // by their private key, so we can forward it to SourceHub as-is.
-                if let Some(token) = defra_core::signing::get_request_bearer_token(did) {
-                    return Ok(token);
-                }
-                tracing::warn!(
-                    did,
-                    "SourceHub bearer token creation failed: no signing config for DID \
-                     and no request token. The identity may have been unregistered."
-                );
-                return Err(ProviderError::Config(format!(
-                    "no signing config found for DID: {}",
-                    did
-                )));
-            }
-        };
+        if let Some(token) = resolve_cosmos_bearer_token(did, &self.signer.address())? {
+            return Ok(token);
+        }
 
-        let key_type: crypto::KeyType = match signing_config.key_type.as_str() {
-            "ed25519" => crypto::KeyType::Ed25519,
-            "secp256k1" => crypto::KeyType::Secp256k1,
-            other => {
-                return Err(ProviderError::Config(format!(
-                    "unsupported key type: {}",
-                    other
-                )))
-            }
-        };
-
-        let raw_identity =
-            identity::RawIdentity::from_bytes(key_type, &signing_config.private_key_bytes)
-                .map_err(|e| ProviderError::Config(format!("failed to create identity: {}", e)))?;
-
-        let token_bytes = identity::new_token(
-            &raw_identity,
-            Duration::from_secs(300),
-            None,
-            Some(self.signer.address()),
-        )
-        .map_err(|e| ProviderError::Config(format!("failed to create bearer token: {}", e)))?;
-
-        String::from_utf8(token_bytes)
-            .map_err(|e| ProviderError::Config(format!("bearer token is not valid UTF-8: {}", e)))
+        tracing::warn!(
+            did,
+            "SourceHub bearer token creation failed: no signing config and no request token"
+        );
+        Err(ProviderError::Config(format!(
+            "no signing config found for DID: {}",
+            did
+        )))
     }
 
     fn self_did(&self) -> Option<String> {
@@ -310,5 +317,76 @@ impl SourceHubProvider for CosmosProvider {
                 .verify_access(policy_id, resource, object_id, permission, actor_did)
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crypto::PrivateKey;
+    use identity::Identity;
+
+    fn store_remote_secp256r1_identity(did: &str) {
+        let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
+        let public_key = private_key.public_key();
+        defra_core::signing::store_identity(
+            did,
+            defra_core::signing::SigningConfig {
+                key_type: "secp256r1".to_string(),
+                private_key_bytes: Vec::new(),
+                public_key_bytes: public_key.raw(),
+                public_key_hex: hex::encode(public_key.raw()),
+                remote_signer: None,
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_cosmos_bearer_token_uses_request_token_for_remote_identity() {
+        let did = "did:key:zRemoteCosmosToken";
+        let token = "delegated.jwt.token".to_string();
+        defra_core::signing::clear_identity_store();
+        defra_core::signing::clear_request_bearer_token(did);
+
+        store_remote_secp256r1_identity(did);
+        defra_core::signing::set_request_bearer_token(did, token.clone());
+
+        let resolved = resolve_cosmos_bearer_token(did, "cosmos1delegated")
+            .expect("resolution should succeed")
+            .expect("token should resolve");
+        assert_eq!(resolved, token);
+
+        defra_core::signing::clear_request_bearer_token(did);
+        defra_core::signing::clear_identity_store();
+    }
+
+    #[test]
+    fn resolve_cosmos_bearer_token_builds_local_secp256r1_token() {
+        let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
+        let raw_identity =
+            identity::RawIdentity::from_secp256r1(private_key).expect("identity should build");
+        let did = raw_identity.did().expect("did should derive").to_string();
+
+        defra_core::signing::clear_identity_store();
+        defra_core::signing::store_identity(
+            &did,
+            defra_core::signing::SigningConfig {
+                key_type: "secp256r1".to_string(),
+                private_key_bytes: raw_identity.private_key_bytes().to_vec(),
+                public_key_bytes: raw_identity.public_key_bytes().to_vec(),
+                public_key_hex: hex::encode(raw_identity.public_key_bytes()),
+                remote_signer: None,
+            },
+        );
+
+        let token = resolve_cosmos_bearer_token(&did, "cosmos1device")
+            .expect("resolution should succeed")
+            .expect("token should resolve");
+        let parsed = identity::from_token(token.as_bytes()).expect("token should parse");
+        assert_eq!(parsed.did().expect("did should parse").as_str(), did);
+        assert_eq!(parsed.authorized_account(), Some("cosmos1device"));
+
+        defra_core::signing::clear_request_bearer_token(&did);
+        defra_core::signing::clear_identity_store();
     }
 }

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -180,6 +180,25 @@ fn encode_delete_relationship_cmd(
     .unwrap_or_default()
 }
 
+fn resolve_registered_or_passthrough_bearer_token(
+    did: &str,
+) -> Result<Option<String>, ProviderError> {
+    if let Some(signing_config) = defra_core::signing::get_identity(did) {
+        if signing_config.has_local_private_key() && signing_config.key_type == "secp256k1" {
+            let key = SigningKey::from_slice(&signing_config.private_key_bytes)
+                .map_err(|e| ProviderError::Config(format!("invalid signing key: {}", e)))?;
+
+            return bearer::create_bearer_token(&key, did, 300)
+                .map(Some)
+                .map_err(|e| {
+                    ProviderError::Config(format!("bearer token creation failed: {}", e))
+                });
+        }
+    }
+
+    Ok(defra_core::signing::get_request_bearer_token(did))
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl SourceHubProvider for HubRsProvider {
@@ -194,20 +213,7 @@ impl SourceHubProvider for HubRsProvider {
             });
         }
 
-        // Try locally stored signing config (e.g. from create_identity)
-        if let Some(signing_config) = defra_core::signing::get_identity(did) {
-            let key = SigningKey::from_slice(&signing_config.private_key_bytes)
-                .map_err(|e| ProviderError::Config(format!("invalid signing key: {}", e)))?;
-
-            return bearer::create_bearer_token(&key, did, 300).map_err(|e| {
-                ProviderError::Config(format!("bearer token creation failed: {}", e))
-            });
-        }
-
-        // Fall back to the original JWT from the HTTP request.
-        // Go DefraDB's BearerToken() pattern: the user's JWT is already signed
-        // by their private key, so we can forward it to hub.rs as-is.
-        if let Some(token) = defra_core::signing::get_request_bearer_token(did) {
+        if let Some(token) = resolve_registered_or_passthrough_bearer_token(did)? {
             return Ok(token);
         }
 
@@ -448,5 +454,74 @@ impl SourceHubProvider for HubRsProvider {
         }
 
         Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crypto::PrivateKey;
+    use identity::Identity;
+
+    fn store_remote_secp256r1_identity(did: &str) {
+        let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
+        let public_key = private_key.public_key();
+        defra_core::signing::store_identity(
+            did,
+            defra_core::signing::SigningConfig {
+                key_type: "secp256r1".to_string(),
+                private_key_bytes: Vec::new(),
+                public_key_bytes: public_key.raw(),
+                public_key_hex: hex::encode(public_key.raw()),
+                remote_signer: None,
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_registered_or_passthrough_bearer_token_uses_request_token_for_remote_identity() {
+        let did = "did:key:zRemoteHubRsToken";
+        let token = "device.jwt.token".to_string();
+        defra_core::signing::clear_identity_store();
+        defra_core::signing::clear_request_bearer_token(did);
+
+        store_remote_secp256r1_identity(did);
+        defra_core::signing::set_request_bearer_token(did, token.clone());
+
+        let resolved = resolve_registered_or_passthrough_bearer_token(did)
+            .expect("resolution should succeed")
+            .expect("token should resolve");
+        assert_eq!(resolved, token);
+
+        defra_core::signing::clear_request_bearer_token(did);
+        defra_core::signing::clear_identity_store();
+    }
+
+    #[test]
+    fn resolve_registered_or_passthrough_bearer_token_builds_local_secp256k1_token() {
+        let private_key = crypto::generate_secp256k1().expect("should generate secp256k1 key");
+        let raw_identity =
+            identity::RawIdentity::from_secp256k1(private_key).expect("identity should build");
+        let did = raw_identity.did().expect("did should derive").to_string();
+
+        defra_core::signing::clear_identity_store();
+        defra_core::signing::store_identity(
+            &did,
+            defra_core::signing::SigningConfig {
+                key_type: "secp256k1".to_string(),
+                private_key_bytes: raw_identity.private_key_bytes().to_vec(),
+                public_key_bytes: raw_identity.public_key_bytes().to_vec(),
+                public_key_hex: hex::encode(raw_identity.public_key_bytes()),
+                remote_signer: None,
+            },
+        );
+
+        let resolved = resolve_registered_or_passthrough_bearer_token(&did)
+            .expect("resolution should succeed")
+            .expect("token should resolve");
+        assert_eq!(resolved.matches('.').count(), 2);
+
+        defra_core::signing::clear_request_bearer_token(&did);
+        defra_core::signing::clear_identity_store();
     }
 }

--- a/tools/apple/README.md
+++ b/tools/apple/README.md
@@ -1,12 +1,13 @@
 # Apple Embedding
 
-`tools/apple/build-ffi.sh` packages the `ffi` crate for Apple embedding with header generation, per-target static libraries, and `.xcframework` assembly when `xcodebuild` is available.
+`tools/apple/build-ffi.sh` packages the `ffi` crate for Apple embedding with a modern iOS deployment target, per-target static libraries, a Clang module map, `.xcframework` assembly, and a local Swift Package wrapper for Xcode.
 
 ## Prerequisites
 
 - `cargo`
 - `rustup`
 - `cbindgen`
+- `xcrun`
 - Apple Rust targets:
   - `aarch64-apple-ios`
   - `aarch64-apple-ios-sim`
@@ -21,25 +22,93 @@ tools/apple/build-ffi.sh
 ```
 
 The script defaults to an iroh-capable build by setting `FEATURES=iroh`.
+It also defaults to `APPLE_DEPLOYMENT_TARGET=15.0` so Rust and native dependencies
+are linked against a modern iOS target instead of Rust's legacy iOS 10 default.
 
 Override the defaults with environment variables when needed:
 
 ```bash
+APPLE_DEPLOYMENT_TARGET=16.0 \
 FEATURES="iroh rocksdb" \
 OUT_DIR="$PWD/dist/apple" \
 FRAMEWORK_NAME="DefraMobile" \
 tools/apple/build-ffi.sh
 ```
 
+`CARGO_TARGET_DIR` can also be overridden when you want the Apple build cache
+somewhere other than `target/apple-cargo/<deployment-target>`.
+
 ## Outputs
 
 The default output root is `target/apple-ffi/`.
 
 - `include/defra.h`
+- `include/module.modulemap`
 - `lib/aarch64-apple-ios/libffi.a`
 - `lib/aarch64-apple-ios-sim/libffi.a`
 - `lib/x86_64-apple-ios/libffi.a`
 - `lib/simulator/libffi.a`
 - `xcframework/DefraFFI.xcframework`
+- `swift/Package.swift`
 
 If `xcodebuild` is unavailable, the script still emits the header and static libraries and skips the `.xcframework` step with a clear warning.
+
+## Swift / Xcode
+
+There are two supported integration paths:
+
+1. Add `target/apple-ffi/swift` as a local Swift package in Xcode.
+   The generated `Package.swift` wraps the XCFramework directly.
+2. Add `target/apple-ffi/xcframework/DefraFFI.xcframework` to Xcode manually.
+   The build script injects `module.modulemap` into every slice so Swift can
+   `import DefraFFI` without a bridging header.
+
+The generated C module is named after `FRAMEWORK_NAME` and defaults to `DefraFFI`.
+
+## Mobile FFI Surface
+
+The mobile-oriented entry points are:
+
+- `defra_mobile_init()`
+- `defra_mobile_open_node(config_json)`
+- `defra_mobile_close_node(node)`
+- `defra_mobile_ensure_schema(node, schema_sdl)`
+- `defra_mobile_execute(node, request_json)`
+- `defra_mobile_peer_info(node)`
+- `defra_mobile_connect(node, addr)`
+- `defra_mobile_sync_collection(node, request_json)`
+- `register_remote_identity(...)`
+- `bind_identity_bearer_token(did, bearer_token)`
+- `node_set_default_identity(node, did)`
+
+`defra_mobile_open_node` accepts a JSON blob so Swift can avoid hand-building
+`NodeInitOptions`. Example:
+
+```json
+{
+  "dbPath": "/path/to/defra.redb",
+  "defaultIdentityDid": "did:key:z...",
+  "p2p": {
+    "transport": "iroh",
+    "iroh": {
+      "relayUrl": "https://relay.iroh.network",
+      "discovery": true
+    }
+  }
+}
+```
+
+`defra_mobile_execute` accepts:
+
+```json
+{
+  "identityDid": "did:key:z...",
+  "query": "mutation { add_Book(input: {name: \"Dune\"}) { _docID } }"
+}
+```
+
+For device-bound or delegated identities:
+
+- register the logical signing identity with `register_remote_identity`
+- bind the host-issued bearer token to that DID with `bind_identity_bearer_token`
+- set that DID as the node default via `node_set_default_identity`

--- a/tools/apple/build-ffi.sh
+++ b/tools/apple/build-ffi.sh
@@ -3,12 +3,16 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT_DIR="${OUT_DIR:-$ROOT_DIR/target/apple-ffi}"
+APPLE_DEPLOYMENT_TARGET="${APPLE_DEPLOYMENT_TARGET:-15.0}"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT_DIR/target/apple-cargo/$APPLE_DEPLOYMENT_TARGET}"
 HEADER_PATH="$OUT_DIR/include/defra.h"
+MODULEMAP_PATH="$OUT_DIR/include/module.modulemap"
 FRAMEWORK_NAME="${FRAMEWORK_NAME:-DefraFFI}"
 LIB_NAME="${LIB_NAME:-ffi}"
 FEATURES="${FEATURES:-iroh}"
 DEVICE_TARGET="${DEVICE_TARGET:-aarch64-apple-ios}"
 SIM_TARGETS="${SIM_TARGETS:-aarch64-apple-ios-sim x86_64-apple-ios}"
+SWIFT_PACKAGE_DIR="$OUT_DIR/swift"
 
 require_tool() {
     if ! command -v "$1" >/dev/null 2>&1; then
@@ -20,25 +24,86 @@ require_tool() {
 require_tool cargo
 require_tool rustup
 require_tool cbindgen
+require_tool xcrun
 
-mkdir -p "$OUT_DIR/include" "$OUT_DIR/lib" "$OUT_DIR/xcframework"
+rm -rf "$OUT_DIR/include" "$OUT_DIR/lib" "$OUT_DIR/xcframework" "$SWIFT_PACKAGE_DIR"
+mkdir -p "$OUT_DIR/include" "$OUT_DIR/lib" "$OUT_DIR/xcframework" "$SWIFT_PACKAGE_DIR"
 
 feature_args=()
 if [[ -n "$FEATURES" ]]; then
     feature_args=(--features "$FEATURES")
 fi
 
+write_modulemap() {
+    cat >"$MODULEMAP_PATH" <<EOF
+module ${FRAMEWORK_NAME} {
+    header "defra.h"
+    export *
+}
+EOF
+}
+
+write_swift_package() {
+    local major_version="${APPLE_DEPLOYMENT_TARGET%%.*}"
+    cat >"$SWIFT_PACKAGE_DIR/Package.swift" <<EOF
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "${FRAMEWORK_NAME}",
+    platforms: [
+        .iOS(.v${major_version})
+    ],
+    products: [
+        .library(name: "${FRAMEWORK_NAME}", targets: ["${FRAMEWORK_NAME}"])
+    ],
+    targets: [
+        .binaryTarget(
+            name: "${FRAMEWORK_NAME}",
+            path: "../xcframework/${FRAMEWORK_NAME}.xcframework"
+        )
+    ]
+)
+EOF
+}
+
+inject_modulemap_into_xcframework() {
+    local xcframework_path="$1"
+    find "$xcframework_path" -type d -name Headers | while read -r headers_dir; do
+        local slice_dir
+        slice_dir="$(dirname "$headers_dir")"
+        mkdir -p "$slice_dir/Modules"
+        cat >"$slice_dir/Modules/module.modulemap" <<EOF
+module ${FRAMEWORK_NAME} {
+    header "../Headers/defra.h"
+    export *
+}
+EOF
+    done
+}
+
 build_target() {
     local target="$1"
-    rustup target add "$target" >/dev/null
+    local sdk="iphoneos"
 
-    cargo build \
+    if [[ "$target" == *"-ios-sim" || "$target" == "x86_64-apple-ios" ]]; then
+        sdk="iphonesimulator"
+    fi
+
+    rustup target add "$target" >/dev/null
+    SDKROOT="$(xcrun --sdk "$sdk" --show-sdk-path)"
+
+    env \
+        CARGO_TARGET_DIR="$CARGO_TARGET_DIR" \
+        IPHONEOS_DEPLOYMENT_TARGET="$APPLE_DEPLOYMENT_TARGET" \
+        SDKROOT="$SDKROOT" \
+        cargo build \
         --release \
         -p ffi \
         --target "$target" \
         "${feature_args[@]}"
 
-    local src="$ROOT_DIR/target/$target/release/lib${LIB_NAME}.a"
+    local src="$CARGO_TARGET_DIR/$target/release/lib${LIB_NAME}.a"
     local dest="$OUT_DIR/lib/$target"
     mkdir -p "$dest"
     cp "$src" "$dest/lib${LIB_NAME}.a"
@@ -55,6 +120,7 @@ cbindgen \
     --config "$ROOT_DIR/crates/ffi/cbindgen.toml" \
     --crate ffi \
     --output "$HEADER_PATH"
+write_modulemap
 
 simulator_libs=()
 for target in "${simulator_targets[@]}"; do
@@ -89,14 +155,21 @@ if command -v xcodebuild >/dev/null 2>&1; then
         -library "$SIM_UNIVERSAL_LIB" \
         -headers "$OUT_DIR/include" \
         -output "$XCFRAMEWORK_PATH"
+    inject_modulemap_into_xcframework "$XCFRAMEWORK_PATH"
 else
     echo "xcodebuild not found; skipped xcframework assembly" >&2
 fi
 
+write_swift_package
+
 cat <<EOF
 Apple FFI artifacts:
+  deployment_target: $APPLE_DEPLOYMENT_TARGET
+  cargo_target_dir: $CARGO_TARGET_DIR
   header: $HEADER_PATH
+  modulemap: $MODULEMAP_PATH
   device: $OUT_DIR/lib/$DEVICE_TARGET/lib${LIB_NAME}.a
   simulator: $SIM_UNIVERSAL_LIB
   xcframework: $XCFRAMEWORK_PATH
+  swift_package: $SWIFT_PACKAGE_DIR
 EOF


### PR DESCRIPTION
## Summary
- finish the Apple FFI packaging flow for iPhone device + simulator builds with a configurable modern deployment target, XCFramework module maps, and a local Swift package wrapper
- add a mobile-oriented JSON FFI surface for runtime init, node open/close, schema ensure, execute, peer/connect, and collection sync so Swift/Xcode integrations do not need to hand-build low-level C structs
- add delegated identity support for non-exportable keys via `register_remote_identity`, `bind_identity_bearer_token`, and `node_set_default_identity`, and generalize remote block signing so secp256r1 / ES256 device-backed identities work without private key export
- preserve existing local-signing flows while updating SourceHub bearer handling to fall back to host-provided JWT passthrough for remote or device-bound identities

## Validation
- `cargo test -p db test_compute_signature_supports_remote_secp256r1 --lib`
- `cargo test -p sourcehub resolve_ --lib`
- `cargo test -p ffi remote_identity --lib -- --test-threads=1`
- `cargo test -p ffi bearer_token --lib -- --test-threads=1`
- `cargo test -p ffi test_mobile_open_schema_and_execute --lib -- --test-threads=1`
- `tools/apple/build-ffi.sh`
- `swift package dump-package` in `target/apple-ffi/swift`

## Notes
- the Apple build now emits predictable artifacts under `target/apple-ffi/`
- the generated header exports the new mobile and delegated-identity entry points
- standalone `cargo check -p embedded --tests` and `cargo check -p identity --tests` were started but not carried to completion after the higher-signal crate tests and Apple build passed