### PR TITLE
feat(acp): instrument hub.rs writes and expose light client state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11585,6 +11585,7 @@ dependencies = [
  "cosmrs",
  "crypto",
  "defra-core",
+ "events",
  "hex",
  "identity",
  "k256",

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -991,6 +991,7 @@ impl Node {
                         config.acp.hub_rs_address.clone(),
                         signer_key_bytes,
                         &tuning,
+                        Some(event_bus.clone()),
                     )
                     .await
                     .map_err(|e| Error::InvalidConfig(format!("hub.rs provider: {}", e)))?,

--- a/crates/cli/src/sourcehub_acp_adapter.rs
+++ b/crates/cli/src/sourcehub_acp_adapter.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use acp::{Policy, StorePolicyOptions, ZanzibarStore};
-use defra_http::router::{AcpOperations, PolicyInfo};
+use defra_http::router::{AcpLightClientStatus, AcpOperations, PolicyInfo};
 
 /// Adapter that implements AcpOperations with SourceHub for writes and local store for reads.
 pub struct SourceHubAcpAdapter {
@@ -118,5 +118,20 @@ impl AcpOperations for SourceHubAcpAdapter {
             .map_err(|e| format!("failed to get policy: {}", e))?;
 
         Ok(policy.as_ref().map(policy_to_info))
+    }
+
+    async fn get_light_client_status(&self) -> Result<AcpLightClientStatus, String> {
+        let status = self
+            .sourcehub_acp
+            .acp_light_client_status()
+            .map_err(|e| format!("failed to get ACP light client status: {}", e))?;
+
+        Ok(AcpLightClientStatus {
+            height: status.height,
+            module_state_root: status.module_state_root,
+            cache_entries: status.cache_entries,
+            last_invalidation_height: status.last_invalidation_height,
+            connected: status.connected,
+        })
     }
 }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -19,6 +19,10 @@ pub enum EventName {
     TopicPeerEvent,
     /// SE artifact received after merge (encrypted index document).
     SEArtifactReceived,
+    /// ACP light client advanced to a new finalized header.
+    AcpHeightAdvanced,
+    /// ACP light client invalidated cached entries after a root change.
+    AcpCacheInvalidated,
 }
 
 impl EventName {
@@ -41,6 +45,8 @@ impl std::fmt::Display for EventName {
             EventName::ReplicatorCompleted => write!(f, "replicator-completed"),
             EventName::TopicPeerEvent => write!(f, "topic-peer-event"),
             EventName::SEArtifactReceived => write!(f, "se-artifact-received"),
+            EventName::AcpHeightAdvanced => write!(f, "acp-height-advanced"),
+            EventName::AcpCacheInvalidated => write!(f, "acp-cache-invalidated"),
         }
     }
 }
@@ -74,6 +80,28 @@ pub struct TopicPeerEventData {
 pub struct SEArtifactReceivedData {
     /// Document ID the artifact is for.
     pub doc_id: String,
+}
+
+/// ACP light client height advancement event data.
+#[derive(Debug, Clone)]
+pub struct AcpHeightAdvancedData {
+    /// Latest finalized height observed by the ACP light client.
+    pub height: u64,
+    /// Latest finalized ACP module state root.
+    pub module_state_root: String,
+}
+
+/// ACP light client cache invalidation event data.
+#[derive(Debug, Clone)]
+pub struct AcpCacheInvalidatedData {
+    /// Height at which the new module state root was observed.
+    pub height: u64,
+    /// New ACP module state root.
+    pub module_state_root: String,
+    /// Previous ACP module state root.
+    pub previous_root: String,
+    /// Number of cache entries invalidated for the old root.
+    pub entries_invalidated: usize,
 }
 
 /// Document update event data.
@@ -138,6 +166,10 @@ pub enum MessageData {
     TopicPeerEvent(TopicPeerEventData),
     /// SE artifact received after merge.
     SEArtifactReceived(SEArtifactReceivedData),
+    /// ACP light client finalized height advanced.
+    AcpHeightAdvanced(AcpHeightAdvancedData),
+    /// ACP light client cache invalidated after a root change.
+    AcpCacheInvalidated(AcpCacheInvalidatedData),
 }
 
 impl Message {
@@ -189,6 +221,22 @@ impl Message {
         }
     }
 
+    /// Create a new ACP height advanced message.
+    pub fn acp_height_advanced(data: AcpHeightAdvancedData) -> Self {
+        Self {
+            name: EventName::AcpHeightAdvanced,
+            data: MessageData::AcpHeightAdvanced(data),
+        }
+    }
+
+    /// Create a new ACP cache invalidated message.
+    pub fn acp_cache_invalidated(data: AcpCacheInvalidatedData) -> Self {
+        Self {
+            name: EventName::AcpCacheInvalidated,
+            data: MessageData::AcpCacheInvalidated(data),
+        }
+    }
+
     /// Get the SEArtifactReceivedData if this is an SEArtifactReceived message.
     pub fn as_se_artifact_received(&self) -> Option<&SEArtifactReceivedData> {
         match &self.data {
@@ -217,6 +265,22 @@ impl Message {
     pub fn as_merge_complete(&self) -> Option<&MergeCompleteData> {
         match &self.data {
             MessageData::MergeComplete(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    /// Get the AcpHeightAdvancedData if this is an ACP height advanced message.
+    pub fn as_acp_height_advanced(&self) -> Option<&AcpHeightAdvancedData> {
+        match &self.data {
+            MessageData::AcpHeightAdvanced(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    /// Get the AcpCacheInvalidatedData if this is an ACP cache invalidated message.
+    pub fn as_acp_cache_invalidated(&self) -> Option<&AcpCacheInvalidatedData> {
+        match &self.data {
+            MessageData::AcpCacheInvalidated(d) => Some(d),
             _ => None,
         }
     }

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -14,7 +14,8 @@ pub use bus::Bus;
 #[cfg(feature = "channel")]
 pub use channel_bus::{ChannelBus, ChannelBusConfig};
 pub use event::{
-    EventName, MergeCompleteData, Message, SEArtifactReceivedData, TopicPeerEventData, Update,
+    AcpCacheInvalidatedData, AcpHeightAdvancedData, EventName, MergeCompleteData, Message,
+    SEArtifactReceivedData, TopicPeerEventData, Update,
 };
 pub use noop_bus::NoOpBus;
 pub use subscription::Subscription;

--- a/crates/ffi/src/subscription/create.rs
+++ b/crates/ffi/src/subscription/create.rs
@@ -151,6 +151,8 @@ pub(crate) fn message_to_json(message: &events::Message) -> String {
         events::EventName::ReplicatorCompleted => "replicator_completed",
         events::EventName::TopicPeerEvent => "topic_peer_event",
         events::EventName::SEArtifactReceived => "se_artifact_received",
+        events::EventName::AcpHeightAdvanced => "acp_height_advanced",
+        events::EventName::AcpCacheInvalidated => "acp_cache_invalidated",
         events::EventName::WildCard => "wildcard",
     };
     serde_json::json!({

--- a/crates/http/src/handlers/acp.rs
+++ b/crates/http/src/handlers/acp.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::HttpError;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
-use crate::router::{AppState, NodePermission, PolicyInfo};
+use crate::router::{AcpLightClientStatus, AppState, NodePermission, PolicyInfo};
 
 /// Response for adding a policy.
 #[derive(Debug, Clone, Serialize)]
@@ -97,6 +97,26 @@ pub async fn get_policy(
         .ok_or_else(|| HttpError::NotFound(format!("Policy '{}' not found", id)))?;
 
     Ok(Json(policy))
+}
+
+/// Get ACP light client status.
+///
+/// GET /api/v0/acp/status
+///
+/// Requires `DacStatus` permission when NAC is enabled.
+pub async fn get_status(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+) -> Result<Json<AcpLightClientStatus>, HttpError> {
+    require_permission(&state, &identity, NodePermission::DacStatus).await?;
+
+    let acp = state.require_acp()?;
+    let status = acp
+        .get_light_client_status()
+        .await
+        .map_err(HttpError::ServiceUnavailable)?;
+
+    Ok(Json(status))
 }
 
 /// Request body for document ACP relationship operations (Go-compatible).

--- a/crates/http/src/handlers/events.rs
+++ b/crates/http/src/handlers/events.rs
@@ -29,6 +29,8 @@ pub async fn events_sse(
         .ok_or_else(|| HttpError::ServiceUnavailable("event bus is not available".to_string()))?;
 
     let filter = match params.event.as_deref() {
+        Some("acp-cache-invalidated") => vec![events::EventName::AcpCacheInvalidated],
+        Some("acp-height-advanced") => vec![events::EventName::AcpHeightAdvanced],
         Some("topic-peer-event") => vec![events::EventName::TopicPeerEvent],
         Some("update") => vec![events::EventName::Update],
         Some("merge-complete") => vec![events::EventName::MergeComplete],
@@ -65,6 +67,24 @@ pub async fn events_sse(
                         "cid": data.cid.to_string(),
                         "collection_id": data.collection_id,
                         "by_peer": data.by_peer,
+                    }
+                })
+            } else if let Some(data) = message.as_acp_height_advanced() {
+                serde_json::json!({
+                    "name": "acp-height-advanced",
+                    "data": {
+                        "height": data.height,
+                        "module_state_root": data.module_state_root,
+                    }
+                })
+            } else if let Some(data) = message.as_acp_cache_invalidated() {
+                serde_json::json!({
+                    "name": "acp-cache-invalidated",
+                    "data": {
+                        "height": data.height,
+                        "module_state_root": data.module_state_root,
+                        "previous_root": data.previous_root,
+                        "entries_invalidated": data.entries_invalidated,
                     }
                 })
             } else if message.name == events::EventName::ReplicatorCompleted {

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -83,10 +83,11 @@ pub mod mock;
 pub use error::{HttpError, Result};
 pub use identity_extractor::{ExtractIdentity, ExtractTokenIdentity, IdentityExtractionError};
 pub use router::{
-    create_router, create_router_with_rest, create_router_with_state, AcpOperations, AppState,
-    AppStateBuilder, BackupOperations, BlockOperations, DocumentAcpOperations, IndexFieldInfo,
-    IndexInfo, IndexOperations, NacStatus, NacStatusInfo, NodeAcpOperations, NodePermission,
-    P2POperations, PolicyInfo, ReplicatorInfo, TransactionOperations, ViewOperations,
+    create_router, create_router_with_rest, create_router_with_state, AcpLightClientStatus,
+    AcpOperations, AppState, AppStateBuilder, BackupOperations, BlockOperations,
+    DocumentAcpOperations, IndexFieldInfo, IndexInfo, IndexOperations, NacStatus, NacStatusInfo,
+    NodeAcpOperations, NodePermission, P2POperations, PolicyInfo, ReplicatorInfo,
+    TransactionOperations, ViewOperations,
 };
 pub use server::{Server, ServerConfig};
 

--- a/crates/http/src/mock/acp.rs
+++ b/crates/http/src/mock/acp.rs
@@ -3,13 +3,14 @@
 use async_trait::async_trait;
 use std::sync::{Arc, RwLock};
 
-use crate::router::{AcpOperations, PolicyInfo};
+use crate::router::{AcpLightClientStatus, AcpOperations, PolicyInfo};
 
 /// Mock ACP operations for testing ACP handlers.
 #[derive(Debug)]
 pub struct MockAcpOperations {
     policies: Arc<RwLock<Vec<PolicyInfo>>>,
     next_id: Arc<RwLock<u64>>,
+    light_client_status: Arc<RwLock<Option<AcpLightClientStatus>>>,
 }
 
 impl Clone for MockAcpOperations {
@@ -17,6 +18,7 @@ impl Clone for MockAcpOperations {
         Self {
             policies: Arc::clone(&self.policies),
             next_id: Arc::clone(&self.next_id),
+            light_client_status: Arc::clone(&self.light_client_status),
         }
     }
 }
@@ -33,6 +35,7 @@ impl MockAcpOperations {
         Self {
             policies: Arc::new(RwLock::new(vec![])),
             next_id: Arc::new(RwLock::new(1)),
+            light_client_status: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -46,6 +49,12 @@ impl MockAcpOperations {
             actor: None,
             creation_time: Some("2024-01-01T00:00:00Z".to_string()),
         });
+        self
+    }
+
+    /// Create with a pre-existing ACP light client status.
+    pub fn with_light_client_status(self, status: AcpLightClientStatus) -> Self {
+        *self.light_client_status.write().unwrap() = Some(status);
         self
     }
 }
@@ -77,6 +86,14 @@ impl AcpOperations for MockAcpOperations {
         let policies = self.policies.read().unwrap();
         Ok(policies.iter().find(|p| p.id == id).cloned())
     }
+
+    async fn get_light_client_status(&self) -> Result<AcpLightClientStatus, String> {
+        self.light_client_status
+            .read()
+            .unwrap()
+            .clone()
+            .ok_or_else(|| "ACP light client status is not configured in this mock".to_string())
+    }
 }
 
 /// Mock ACP operations that always fails with a configurable error.
@@ -105,6 +122,10 @@ impl AcpOperations for FailingMockAcpOperations {
     }
 
     async fn get_policy(&self, _id: &str) -> Result<Option<PolicyInfo>, String> {
+        Err(self.error.clone())
+    }
+
+    async fn get_light_client_status(&self) -> Result<AcpLightClientStatus, String> {
         Err(self.error.clone())
     }
 }

--- a/crates/http/src/router/mod.rs
+++ b/crates/http/src/router/mod.rs
@@ -7,10 +7,11 @@ mod traits;
 pub use routes::{create_router, create_router_with_rest, create_router_with_state};
 pub use state::{AppState, AppStateBuilder};
 pub use traits::{
-    AcpOperations, BackupOperations, BlockOperations, CollectionManagementOperations,
-    DocumentAcpOperations, DumpOperations, EncryptedIndexInfo, EncryptedIndexOperations,
-    ImportResult, IndexFieldInfo, IndexInfo, IndexOperations, LensOperations, NacStatus,
-    NacStatusInfo, NodeAcpOperations, NodePermission, P2POperations, P2pDocumentInfo,
-    P2pDocumentRequest, PolicyInfo, ReplicatorInfo, SchemaOperations, SyncBranchableRequest,
-    SyncDocumentsRequest, SyncVersionsRequest, TransactionOperations, ViewOperations,
+    AcpLightClientStatus, AcpOperations, BackupOperations, BlockOperations,
+    CollectionManagementOperations, DocumentAcpOperations, DumpOperations, EncryptedIndexInfo,
+    EncryptedIndexOperations, ImportResult, IndexFieldInfo, IndexInfo, IndexOperations,
+    LensOperations, NacStatus, NacStatusInfo, NodeAcpOperations, NodePermission, P2POperations,
+    P2pDocumentInfo, P2pDocumentRequest, PolicyInfo, ReplicatorInfo, SchemaOperations,
+    SyncBranchableRequest, SyncDocumentsRequest, SyncVersionsRequest, TransactionOperations,
+    ViewOperations,
 };

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -139,6 +139,7 @@ pub fn create_router_with_state(state: AppState) -> Router {
 
     // ACP routes
     let acp_routes = Router::new()
+        .route("/status", get(handlers::acp::get_status))
         .route("/policy", post(handlers::acp::add_policy))
         .route("/policy", get(handlers::acp::list_policies))
         .route("/policy/:id", get(handlers::acp::get_policy))

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -148,6 +148,11 @@ pub trait AcpOperations: Send + Sync {
     /// Returns `Ok(None)` if the policy doesn't exist, `Ok(Some(info))` if found,
     /// or `Err(message)` on internal errors.
     async fn get_policy(&self, id: &str) -> Result<Option<PolicyInfo>, String>;
+
+    /// Get ACP light client status when this ACP backend exposes one.
+    async fn get_light_client_status(&self) -> Result<AcpLightClientStatus, String> {
+        Err("ACP light client status is not available for this ACP backend".to_string())
+    }
 }
 
 /// Policy information for HTTP responses.
@@ -164,6 +169,16 @@ pub struct PolicyInfo {
     pub actor: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub creation_time: Option<String>,
+}
+
+/// ACP light client status for observability/debugging.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct AcpLightClientStatus {
+    pub height: u64,
+    pub module_state_root: String,
+    pub cache_entries: usize,
+    pub last_invalidation_height: u64,
+    pub connected: bool,
 }
 
 /// Trait for index operations.

--- a/crates/orbis/src/client.rs
+++ b/crates/orbis/src/client.rs
@@ -6,7 +6,7 @@
 //! (which runs inside `spawn_blocking` → `Handle::block_on`).
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
@@ -129,11 +129,17 @@ impl OrbisClient {
 
     /// Sign data via the Orbis ring (async).
     async fn sign_async(&self, data: &[u8]) -> Result<Vec<u8>, String> {
+        let connect_start = Instant::now();
         let channel = Channel::from_shared(self.endpoint.clone())
             .map_err(|e| format!("invalid Orbis endpoint: {}", e))?
             .connect()
             .await
             .map_err(|e| format!("failed to connect to Orbis: {}", e))?;
+        info!(
+            ring_id = %self.ring_id,
+            elapsed = ?connect_start.elapsed(),
+            "Orbis gRPC channel connected"
+        );
 
         let bearer_token = self.create_bearer_token()?;
 
@@ -147,6 +153,7 @@ impl OrbisClient {
                 Ok(req)
             });
 
+        let sign_rpc_start = Instant::now();
         let resp = client
             .sign(SignRequest {
                 ring_id: self.ring_id.clone(),
@@ -157,6 +164,11 @@ impl OrbisClient {
             })
             .await
             .map_err(|e| format!("Orbis Sign RPC failed: {}", e))?;
+        info!(
+            ring_id = %self.ring_id,
+            elapsed = ?sign_rpc_start.elapsed(),
+            "Orbis Sign RPC completed"
+        );
 
         let signature = resp.into_inner().signature;
         if signature.is_empty() {

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -4,7 +4,7 @@ use acp::DocumentPermission;
 use chrono::{DateTime, FixedOffset, Utc};
 use identity::Did;
 use serde_json::{Map, Value as JsonValue};
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use crate::document::{document_to_plan_doc, DocumentMapping};
 use crate::error::{QueryError, Result};
@@ -428,13 +428,18 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             e
         };
 
+        let plan_execution_start = Instant::now();
         plan.init().await.map_err(&map_doc_not_found)?;
         plan.start().await.map_err(&map_doc_not_found)?;
 
         let mut results = Vec::new();
+        let mut result_doc_ids = Vec::new();
 
         while plan.next().await.map_err(&map_doc_not_found)? {
             let doc = plan.value();
+            if let Some(doc_id) = doc.doc_id() {
+                result_doc_ids.push(doc_id.to_string());
+            }
             let json = self.doc_to_json(doc, &mapping)?;
             results.push(json);
         }
@@ -443,6 +448,15 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         defra_core::encryption::set_encryption_config(None);
 
         plan.close().await.map_err(&map_doc_not_found)?;
+
+        let plan_execution_elapsed = plan_execution_start.elapsed();
+        for doc_id in &result_doc_ids {
+            tracing::info!(
+                doc_id = %doc_id,
+                elapsed = ?plan_execution_elapsed,
+                "Mutation plan execution completed"
+            );
+        }
 
         // Clear broadcast identity after plan execution (but keep request bearer
         // token alive — ACP registration below needs it for hub.rs auth).
@@ -474,6 +488,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
                         // Only register if not already registered (new document)
                         if !is_registered {
+                            let acp_registration_start = Instant::now();
                             acp.register_doc_object(
                                 identity_did,
                                 &policy.id,
@@ -489,6 +504,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 );
                                 QueryError::acp_registration_failed(doc_id, e)
                             })?;
+                            tracing::info!(
+                                doc_id = %doc_id,
+                                elapsed = ?acp_registration_start.elapsed(),
+                                "ACP document registration completed"
+                            );
                         }
                     }
                 }

--- a/crates/sourcehub/Cargo.toml
+++ b/crates/sourcehub/Cargo.toml
@@ -36,6 +36,7 @@ zanzibar = { path = "../zanzibar" }
 identity = { path = "../identity" }
 defra-core = { path = "../defra-core" }
 crypto = { path = "../crypto" }
+events = { path = "../events" }
 
 # Logging
 tracing.workspace = true

--- a/crates/sourcehub/src/cosmos/dac.rs
+++ b/crates/sourcehub/src/cosmos/dac.rs
@@ -13,7 +13,7 @@ use identity::Did;
 use acp::{DocumentACP, DocumentPermission, Identity, Result};
 
 use crate::access_cache::AccessCache;
-use crate::provider::{ProviderError, SourceHubProvider, SubjectRef};
+use crate::provider::{AcpLightClientStatus, ProviderError, SourceHubProvider, SubjectRef};
 
 /// DocumentACP backed by SourceHub's on-chain x/acp module.
 ///
@@ -46,6 +46,12 @@ impl SourceHubDocumentACP {
             .create_bearer_token(did)
             .await
             .map_err(provider_err)
+    }
+
+    pub fn acp_light_client_status(
+        &self,
+    ) -> std::result::Result<AcpLightClientStatus, ProviderError> {
+        self.provider.acp_light_client_status()
     }
 }
 

--- a/crates/sourcehub/src/hub_rs/client.rs
+++ b/crates/sourcehub/src/hub_rs/client.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use alloy_primitives::{Address, Bytes, B256};
 
@@ -135,7 +136,9 @@ impl HubRsClient {
     }
 
     pub async fn wait_for_receipt(&self, tx_hash: B256) -> Result<serde_json::Value, ClientError> {
-        let start = std::time::Instant::now();
+        let start = Instant::now();
+        let tx_hash_hex = format!("0x{}", hex::encode(tx_hash));
+        let mut polls = 0u64;
         loop {
             if start.elapsed() > self.receipt_timeout {
                 return Err(ClientError::Timeout(format!(
@@ -143,11 +146,12 @@ impl HubRsClient {
                     tx_hash
                 )));
             }
+            polls += 1;
             let body = serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": self.next_id(),
                 "method": "eth_getTransactionReceipt",
-                "params": [format!("0x{}", hex::encode(tx_hash))]
+                "params": [tx_hash_hex.clone()]
             });
             let resp: serde_json::Value = self
                 .http
@@ -166,6 +170,12 @@ impl HubRsClient {
                         tx_hash, status
                     )));
                 }
+                tracing::info!(
+                    tx_hash = %tx_hash_hex,
+                    polls,
+                    elapsed = ?start.elapsed(),
+                    "hub.rs transaction receipt found"
+                );
                 return Ok(resp["result"].clone());
             }
             tokio::time::sleep(RECEIPT_POLL_INTERVAL).await;

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -1,12 +1,15 @@
-use std::sync::Mutex;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
-use crate::provider::{ProviderError, ProviderPolicyInfo, SourceHubProvider, SubjectRef};
+use crate::provider::{
+    AcpLightClientStatus, ProviderError, ProviderPolicyInfo, SourceHubProvider, SubjectRef,
+};
 use crate::tuning::AcpTuning;
 use acp_light_client::AcpLightClient;
 use alloy_primitives::{Bytes, FixedBytes};
 use alloy_sol_types::SolCall;
 use async_trait::async_trait;
+use events::{AcpCacheInvalidatedData, AcpHeightAdvancedData, Bus, Message};
 use k256::ecdsa::SigningKey;
 
 use super::abi::{IAcp, ACP_ADDRESS};
@@ -15,11 +18,18 @@ use super::client::{ClientError, HubRsClient};
 use super::signer::EvmSigner;
 
 pub struct HubRsProvider {
-    light_client: AcpLightClient,
+    light_client: Arc<AcpLightClient>,
     client: HubRsClient,
     signer: EvmSigner,
     signing_key: SigningKey,
     nonce: Mutex<u64>,
+    light_client_observability: Arc<Mutex<HubRsLightClientObservability>>,
+    light_client_observer_handle: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Debug, Default)]
+struct HubRsLightClientObservability {
+    last_invalidation_height: Option<u64>,
 }
 
 fn derive_ws_url(rpc_url: &str) -> String {
@@ -33,11 +43,16 @@ impl HubRsProvider {
         rpc_url: String,
         private_key: &[u8],
         tuning: &AcpTuning,
+        event_bus: Option<Arc<dyn Bus>>,
     ) -> Result<Self, ProviderError> {
         let ws_url = derive_ws_url(&rpc_url);
-        let light_client = AcpLightClient::new(&rpc_url, &ws_url, 10)
-            .await
-            .map_err(|e| ProviderError::Config(format!("light client: {}", e)))?;
+        let light_client = Arc::new(
+            AcpLightClient::new(&rpc_url, &ws_url, 10)
+                .await
+                .map_err(|e| ProviderError::Config(format!("light client: {}", e)))?,
+        );
+        let light_client_observability =
+            Arc::new(Mutex::new(HubRsLightClientObservability::default()));
 
         let client = HubRsClient::new(rpc_url, tuning.request_timeout, tuning.receipt_timeout)
             .map_err(|e| ProviderError::Config(format!("HTTP client: {}", e)))?;
@@ -53,12 +68,21 @@ impl HubRsProvider {
             .get_nonce(signer.address())
             .await
             .map_err(|e| ProviderError::Config(format!("nonce: {}", e)))?;
+
+        let light_client_observer_handle = tokio::spawn(run_light_client_observer(
+            light_client.clone(),
+            light_client_observability.clone(),
+            event_bus,
+        ));
+
         Ok(Self {
             light_client,
             client,
             signer,
             signing_key,
             nonce: Mutex::new(nonce),
+            light_client_observability,
+            light_client_observer_handle,
         })
     }
 
@@ -110,14 +134,72 @@ impl HubRsProvider {
         arr[start..].copy_from_slice(&bytes[..bytes.len().min(32)]);
         FixedBytes::from(arr)
     }
+}
 
-    async fn wait_for_state_update(&self) {
-        if let Some(root) = self.light_client.header_chain().latest_module_state_root() {
-            let _ = self
-                .light_client
-                .wait_for_root_change(root, Duration::from_secs(5))
-                .await;
+impl Drop for HubRsProvider {
+    fn drop(&mut self) {
+        self.light_client_observer_handle.abort();
+    }
+}
+
+fn format_root(root: alloy_primitives::B256) -> String {
+    format!("0x{}", hex::encode(root))
+}
+
+async fn run_light_client_observer(
+    light_client: Arc<AcpLightClient>,
+    observability: Arc<Mutex<HubRsLightClientObservability>>,
+    event_bus: Option<Arc<dyn Bus>>,
+) {
+    let mut next_height = 1u64;
+    let mut previous_root = None;
+
+    loop {
+        let sync = match light_client
+            .wait_for_height(next_height, Duration::from_secs(24 * 60 * 60))
+            .await
+        {
+            Ok(sync) => sync,
+            Err(error) => {
+                tracing::debug!(error = %error, "ACP light client observer wait_for_height failed");
+                next_height = light_client
+                    .header_chain()
+                    .latest_height()
+                    .saturating_add(1);
+                continue;
+            }
+        };
+
+        let module_state_root = format_root(sync.module_state_root);
+        if let Some(ref bus) = event_bus {
+            bus.publish(Message::acp_height_advanced(AcpHeightAdvancedData {
+                height: sync.height,
+                module_state_root: module_state_root.clone(),
+            }));
         }
+
+        if let Some(previous_root_value) = previous_root {
+            if previous_root_value != sync.module_state_root {
+                let entries_invalidated = light_client
+                    .cache()
+                    .invalidate_stale(sync.module_state_root);
+                if let Ok(mut state) = observability.lock() {
+                    state.last_invalidation_height = Some(sync.height);
+                }
+
+                if let Some(ref bus) = event_bus {
+                    bus.publish(Message::acp_cache_invalidated(AcpCacheInvalidatedData {
+                        height: sync.height,
+                        module_state_root: module_state_root.clone(),
+                        previous_root: format_root(previous_root_value),
+                        entries_invalidated,
+                    }));
+                }
+            }
+        }
+
+        previous_root = Some(sync.module_state_root);
+        next_height = sync.height.saturating_add(1);
     }
 }
 
@@ -267,9 +349,13 @@ impl SourceHubProvider for HubRsProvider {
             cmd: Bytes::from(cmd),
         };
         let calldata = Bytes::from(call.abi_encode());
+        let send_tx_start = Instant::now();
         self.send_tx(calldata).await?;
-
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.wait_for_state_update()).await;
+        tracing::info!(
+            doc_id = %object_id,
+            elapsed = ?send_tx_start.elapsed(),
+            "hub.rs register_object send_tx completed"
+        );
 
         Ok(())
     }
@@ -290,8 +376,6 @@ impl SourceHubProvider for HubRsProvider {
         };
         let calldata = Bytes::from(call.abi_encode());
         self.send_tx(calldata).await?;
-
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.wait_for_state_update()).await;
 
         Ok(())
     }
@@ -315,8 +399,6 @@ impl SourceHubProvider for HubRsProvider {
         let calldata = Bytes::from(call.abi_encode());
         self.send_tx(calldata).await?;
 
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.wait_for_state_update()).await;
-
         Ok(true)
     }
 
@@ -338,8 +420,6 @@ impl SourceHubProvider for HubRsProvider {
         };
         let calldata = Bytes::from(call.abi_encode());
         self.send_tx(calldata).await?;
-
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.wait_for_state_update()).await;
 
         Ok(true)
     }
@@ -448,5 +528,25 @@ impl SourceHubProvider for HubRsProvider {
         }
 
         Ok(false)
+    }
+
+    fn acp_light_client_status(&self) -> Result<AcpLightClientStatus, ProviderError> {
+        let sync = self.light_client.header_chain().state();
+        let last_invalidation_height = self
+            .light_client_observability
+            .lock()
+            .map_err(|_| ProviderError::Query("light client observability lock poisoned".into()))?
+            .last_invalidation_height
+            .unwrap_or_default();
+
+        Ok(AcpLightClientStatus {
+            height: sync.as_ref().map_or(0, |state| state.height),
+            module_state_root: sync
+                .as_ref()
+                .map_or_else(String::new, |state| format_root(state.module_state_root)),
+            cache_entries: self.light_client.cache().len(),
+            last_invalidation_height,
+            connected: sync.is_some(),
+        })
     }
 }

--- a/crates/sourcehub/src/lib.rs
+++ b/crates/sourcehub/src/lib.rs
@@ -8,5 +8,7 @@ mod tuning;
 
 pub use cosmos::{CosmosProvider, SourceHubDocumentACP};
 pub use hub_rs::HubRsProvider;
-pub use provider::{ProviderError, ProviderPolicyInfo, SourceHubProvider, SubjectRef};
+pub use provider::{
+    AcpLightClientStatus, ProviderError, ProviderPolicyInfo, SourceHubProvider, SubjectRef,
+};
 pub use tuning::AcpTuning;

--- a/crates/sourcehub/src/provider.rs
+++ b/crates/sourcehub/src/provider.rs
@@ -11,6 +11,15 @@ pub struct ProviderPolicyInfo {
     pub name: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct AcpLightClientStatus {
+    pub height: u64,
+    pub module_state_root: String,
+    pub cache_entries: usize,
+    pub last_invalidation_height: u64,
+    pub connected: bool,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError {
     #[error("query error: {0}")]
@@ -95,4 +104,10 @@ pub trait SourceHubProvider: MaybeSendSync {
         permission: &str,
         actor_did: &str,
     ) -> Result<bool, ProviderError>;
+
+    fn acp_light_client_status(&self) -> Result<AcpLightClientStatus, ProviderError> {
+        Err(ProviderError::Unavailable(
+            "ACP light client status is not available for this provider".into(),
+        ))
+    }
 }


### PR DESCRIPTION
## Summary
- add write-path timing instrumentation for mutation execution, hub.rs ACP registration, receipt polling, and Orbis signing
- remove blocking `wait_for_state_update()` from hub.rs write methods so ACP writes no longer wait on local light-client cache freshness
- expose ACP light client observability via `/api/v0/acp/status` and SSE events for height advancement and cache invalidation
- wire hub.rs provider events into the existing event bus and clean up the observer task on provider drop

Closes #548

## Testing
- cargo fmt --all
- cargo check -p events -p defra-http -p sourcehub -p cli -p ffi -p query -p orbis