### PR TITLE
feat(query): batch top-level mutation requests

### DIFF
--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -1,0 +1,513 @@
+use async_lock::Mutex as TokioMutex;
+use async_trait::async_trait;
+use cid::Cid;
+use document::{DocID, Document};
+use events::{Message, Update};
+use query::mutator::{
+    CreateResult, DeleteResult, DocMutator, MutationBatchController, UpdateResult,
+};
+use std::collections::HashSet;
+use std::sync::Arc;
+use storage::corekv::Store;
+use tracing::warn;
+
+use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
+use crate::collection::collection_short_id;
+use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
+use crate::database::DB;
+use crate::txn::DbTxn;
+use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
+use defra_core::signing::get_signing_config;
+
+struct PendingUpdateEvent {
+    collection_id: String,
+    branchable: bool,
+    doc_id: String,
+    cid: Cid,
+}
+
+pub(crate) struct BatchMutator<S: Store> {
+    db: Arc<DB<S>>,
+    txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
+    pending_events: TokioMutex<Vec<PendingUpdateEvent>>,
+}
+
+impl<S: Store> BatchMutator<S> {
+    pub(crate) fn new(db: Arc<DB<S>>, txn: Arc<TokioMutex<Option<DbTxn<S>>>>) -> Self {
+        Self {
+            db,
+            txn,
+            pending_events: TokioMutex::new(Vec::new()),
+        }
+    }
+
+    async fn blockstore(&self) -> query::error::Result<datastore::NamespaceView> {
+        let txn = self.txn.lock().await;
+        let txn = txn.as_ref().ok_or_else(|| {
+            query::error::QueryError::execution("mutation batch transaction is no longer active")
+        })?;
+        txn.blockstore().map_err(|e| {
+            query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
+        })
+    }
+
+    async fn headstore(&self) -> query::error::Result<datastore::NamespaceView> {
+        let txn = self.txn.lock().await;
+        let txn = txn.as_ref().ok_or_else(|| {
+            query::error::QueryError::execution("mutation batch transaction is no longer active")
+        })?;
+        txn.headstore().map_err(|e| {
+            query::error::QueryError::execution(format!("failed to get headstore: {}", e))
+        })
+    }
+
+    async fn take_txn(&self) -> query::error::Result<DbTxn<S>> {
+        self.txn.lock().await.take().ok_or_else(|| {
+            query::error::QueryError::execution("mutation batch transaction is no longer active")
+        })
+    }
+
+    async fn queue_update_event(
+        &self,
+        collection_id: String,
+        branchable: bool,
+        doc_id: String,
+        cid: Cid,
+    ) {
+        self.pending_events.lock().await.push(PendingUpdateEvent {
+            collection_id,
+            branchable,
+            doc_id,
+            cid,
+        });
+    }
+
+    fn emit_update_event(&self, event: PendingUpdateEvent) {
+        if let Some(bus) = self.db.event_bus() {
+            let update = Update::new(
+                event.doc_id,
+                event.cid,
+                event.collection_id.clone(),
+                vec![],
+                false,
+                false,
+            );
+            bus.publish(Message::update(update));
+
+            if event.branchable {
+                let collection_update = Update::new(
+                    String::new(),
+                    event.cid,
+                    event.collection_id,
+                    vec![],
+                    false,
+                    false,
+                );
+                bus.publish(Message::update(collection_update));
+            }
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S: Store + 'static> MutationBatchController for BatchMutator<S> {
+    async fn commit(&self) -> query::error::Result<()> {
+        let txn = self.take_txn().await?;
+
+        if let Err(e) = txn.commit().await {
+            self.pending_events.lock().await.clear();
+            return Err(query::error::QueryError::execution(format!(
+                "commit error: {}",
+                e
+            )));
+        }
+
+        let pending_events = std::mem::take(&mut *self.pending_events.lock().await);
+        for event in pending_events {
+            self.emit_update_event(event);
+        }
+
+        Ok(())
+    }
+
+    async fn rollback(&self) -> query::error::Result<()> {
+        let txn = self.take_txn().await?;
+        self.pending_events.lock().await.clear();
+
+        txn.discard()
+            .map_err(|e| query::error::QueryError::execution(format!("discard error: {}", e)))
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S: Store + 'static> DocMutator for BatchMutator<S> {
+    #[allow(clippy::type_complexity)]
+    async fn create(
+        &self,
+        collection_name: &str,
+        mut doc: Document,
+    ) -> query::error::Result<CreateResult> {
+        let (collection, datastore, index_manager) =
+            get_collection_with_index_manager(&self.txn, collection_name).await?;
+
+        crate::embedding::set_embedding(
+            &collection.schema().vector_embeddings,
+            &mut doc,
+            true,
+            None,
+        )
+        .await
+        .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;
+
+        let id_was_generated = doc.id().is_none();
+        if id_was_generated {
+            doc.generate_and_set_doc_id().map_err(|e| {
+                query::error::QueryError::execution(format!("failed to generate DocID: {}", e))
+            })?;
+        }
+
+        let doc_id = doc.id().cloned().ok_or_else(|| {
+            query::error::QueryError::execution("document should have ID after generation")
+        })?;
+
+        collection
+            .create_with_indexes(&datastore, &doc, &index_manager, id_was_generated)
+            .await
+            .map_err(|e| {
+                let msg = e.to_string();
+                if msg.contains("can not index a doc's field(s) that violates unique index") {
+                    query::error::QueryError::execution(
+                        "can not index a doc's field(s) that violates unique index.".to_string(),
+                    )
+                } else {
+                    query::error::QueryError::execution(format!("create error: {}", e))
+                }
+            })?;
+
+        let short_id = collection_short_id(collection.collection_id());
+        let schema_version_id = collection.version_id();
+        let enc_config = get_encryption_config();
+        let sign_config = get_signing_config();
+
+        let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = {
+            let blockstore = self.blockstore().await?;
+            let headstore = self.headstore().await?;
+
+            match write_document_blocks(
+                &blockstore,
+                &headstore,
+                &doc,
+                schema_version_id,
+                None,
+                enc_config.as_ref(),
+                sign_config.as_ref(),
+            )
+            .await
+            {
+                Ok(block_result) => {
+                    if let Some(ref config) = enc_config {
+                        store_doc_encryption(&doc_id.to_string(), config.clone());
+                    }
+
+                    let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+                    if collection.schema().is_branchable {
+                        match write_collection_block(
+                            &blockstore,
+                            &headstore,
+                            short_id,
+                            schema_version_id,
+                            block_result.cid,
+                            sign_config.as_ref(),
+                        )
+                        .await
+                        {
+                            Ok((col_cid, col_bytes)) => {
+                                col_block_data = Some((col_cid, col_bytes));
+                            }
+                            Err(e) => {
+                                warn!(
+                                    collection = %collection_name,
+                                    error = %e,
+                                    "Failed to write collection block for branchable create"
+                                );
+                            }
+                        }
+                    }
+
+                    Some((block_result.cid, block_result.block, col_block_data))
+                }
+                Err(e) => {
+                    warn!(
+                        collection = %collection_name,
+                        error = %e,
+                        "Failed to write document blocks - commits queries may not work"
+                    );
+                    None
+                }
+            }
+        };
+
+        let cid = commit_result
+            .as_ref()
+            .map(|(cid, _, _)| *cid)
+            .unwrap_or_default();
+        self.queue_update_event(
+            collection.collection_id().to_string(),
+            collection.schema().is_branchable,
+            doc_id.to_string(),
+            cid,
+        )
+        .await;
+
+        match commit_result {
+            Some((cid, block, col_data)) => {
+                let mut result = CreateResult::with_commit(doc_id, doc, cid, block);
+                if let Some((col_cid, col_bytes)) = col_data {
+                    result.broadcast_cid = Some(col_cid);
+                    result.broadcast_block = Some(col_bytes);
+                }
+                Ok(result)
+            }
+            None => Ok(CreateResult::new(doc_id, doc)),
+        }
+    }
+
+    async fn update(
+        &self,
+        collection_name: &str,
+        mut doc: Document,
+        mut modified_fields: HashSet<String>,
+    ) -> query::error::Result<UpdateResult> {
+        let (collection, datastore, index_manager) =
+            get_collection_with_index_manager(&self.txn, collection_name).await?;
+
+        let generated = crate::embedding::set_embedding(
+            &collection.schema().vector_embeddings,
+            &mut doc,
+            false,
+            Some(&modified_fields),
+        )
+        .await
+        .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;
+
+        for field in generated {
+            modified_fields.insert(field);
+        }
+
+        collection
+            .update_with_indexes(&datastore, &doc, &index_manager)
+            .await
+            .map_err(|e| match e {
+                crate::error::Error::DocumentNotFound(id) => {
+                    query::error::QueryError::document_not_found(id)
+                }
+                other => {
+                    let msg = other.to_string();
+                    if msg.contains("can not index a doc's field(s) that violates unique index") {
+                        query::error::QueryError::execution(
+                            "can not index a doc's field(s) that violates unique index."
+                                .to_string(),
+                        )
+                    } else {
+                        query::error::QueryError::execution(format!("update error: {}", other))
+                    }
+                }
+            })?;
+
+        let short_id = collection_short_id(collection.collection_id());
+        let schema_version_id = collection.version_id();
+        let enc_config = get_encryption_config()
+            .or_else(|| doc.id().and_then(|id| get_doc_encryption(&id.to_string())));
+        let sign_config = get_signing_config();
+
+        let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = {
+            let blockstore = self.blockstore().await?;
+            let headstore = self.headstore().await?;
+
+            match write_document_blocks(
+                &blockstore,
+                &headstore,
+                &doc,
+                schema_version_id,
+                Some(&modified_fields),
+                enc_config.as_ref(),
+                sign_config.as_ref(),
+            )
+            .await
+            {
+                Ok(block_result) => {
+                    let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+                    if collection.schema().is_branchable {
+                        match write_collection_block(
+                            &blockstore,
+                            &headstore,
+                            short_id,
+                            schema_version_id,
+                            block_result.cid,
+                            sign_config.as_ref(),
+                        )
+                        .await
+                        {
+                            Ok((col_cid, col_bytes)) => {
+                                col_block_data = Some((col_cid, col_bytes));
+                            }
+                            Err(e) => {
+                                warn!(
+                                    collection = %collection_name,
+                                    error = %e,
+                                    "Failed to write collection block for branchable update"
+                                );
+                            }
+                        }
+                    }
+
+                    Some((block_result.cid, block_result.block, col_block_data))
+                }
+                Err(e) => {
+                    warn!(
+                        collection = %collection_name,
+                        error = %e,
+                        "Failed to write document blocks - commits queries may not work"
+                    );
+                    None
+                }
+            }
+        };
+
+        if let Some(doc_id) = doc.id() {
+            let cid = commit_result
+                .as_ref()
+                .map(|(cid, _, _)| *cid)
+                .unwrap_or_default();
+            self.queue_update_event(
+                collection.collection_id().to_string(),
+                collection.schema().is_branchable,
+                doc_id.to_string(),
+                cid,
+            )
+            .await;
+        }
+
+        let fields_modified = doc.values().len();
+        match commit_result {
+            Some((cid, block, col_data)) => {
+                let mut result = UpdateResult::with_commit(doc, fields_modified, cid, block);
+                if let Some((col_cid, col_bytes)) = col_data {
+                    result.broadcast_cid = Some(col_cid);
+                    result.broadcast_block = Some(col_bytes);
+                }
+                Ok(result)
+            }
+            None => Ok(UpdateResult::new(doc, fields_modified)),
+        }
+    }
+
+    async fn delete(
+        &self,
+        collection_name: &str,
+        doc_id: &DocID,
+    ) -> query::error::Result<DeleteResult> {
+        let (collection, datastore, index_manager) =
+            get_collection_with_index_manager(&self.txn, collection_name).await?;
+
+        let existed = collection
+            .delete_with_indexes(&datastore, doc_id, &index_manager)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))?;
+
+        let short_id = collection_short_id(collection.collection_id());
+        let schema_version_id = collection.version_id();
+        let sign_config = get_signing_config();
+
+        let commit_result: Option<(Cid, Vec<u8>)> = {
+            let blockstore = self.blockstore().await?;
+            let headstore = self.headstore().await?;
+
+            match write_delete_block(
+                &blockstore,
+                &headstore,
+                &doc_id.to_string(),
+                schema_version_id,
+                sign_config.as_ref(),
+            )
+            .await
+            {
+                Ok(block_result) => {
+                    let composite_cid = block_result.cid;
+
+                    if collection.schema().is_branchable {
+                        if let Err(e) = write_collection_block(
+                            &blockstore,
+                            &headstore,
+                            short_id,
+                            schema_version_id,
+                            composite_cid,
+                            sign_config.as_ref(),
+                        )
+                        .await
+                        .map(|_| ())
+                        {
+                            warn!(
+                                collection = %collection_name,
+                                error = %e,
+                                "Failed to write collection block for branchable delete"
+                            );
+                        }
+                    }
+
+                    Some((composite_cid, block_result.block))
+                }
+                Err(e) => {
+                    warn!(
+                        collection = %collection_name,
+                        error = %e,
+                        "Failed to write delete block - commits queries may not work"
+                    );
+                    None
+                }
+            }
+        };
+
+        let cid = commit_result
+            .as_ref()
+            .map(|(cid, _)| *cid)
+            .unwrap_or_default();
+        self.queue_update_event(
+            collection.collection_id().to_string(),
+            collection.schema().is_branchable,
+            doc_id.to_string(),
+            cid,
+        )
+        .await;
+
+        Ok(DeleteResult::new(doc_id.clone(), existed))
+    }
+
+    async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
+
+        collection
+            .exists_with_datastore(&datastore, doc_id)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("exists error: {}", e)))
+    }
+
+    async fn get_for_update(
+        &self,
+        collection_name: &str,
+        doc_id: &DocID,
+    ) -> query::error::Result<Option<Document>> {
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
+
+        collection
+            .get_with_datastore(&datastore, doc_id)
+            .await
+            .map_err(|e| {
+                query::error::QueryError::execution(format!("get_for_update error: {}", e))
+            })
+    }
+}

--- a/crates/db/src/auto_commit_mutator/mod.rs
+++ b/crates/db/src/auto_commit_mutator/mod.rs
@@ -5,6 +5,7 @@
 //! without explicit transaction management while still providing proper
 //! transactional semantics per operation.
 
+mod batch;
 mod create;
 mod create_many;
 mod delete;
@@ -17,7 +18,7 @@ use async_trait::async_trait;
 use cid::Cid;
 use document::{DocID, Document};
 use events::{Message, Update};
-use query::mutator::{CreateResult, DeleteResult, DocMutator, UpdateResult};
+use query::mutator::{CreateResult, DeleteResult, DocMutator, MutationBatch, UpdateResult};
 use std::sync::Arc;
 use storage::corekv::Store;
 use tracing::warn;
@@ -26,8 +27,11 @@ use crate::block_builder::{write_collection_block, write_delete_block, write_doc
 use crate::collection::collection_short_id;
 use crate::database::DB;
 use crate::index_manager::IndexManager;
+use crate::lensed_fetcher::LensedDocFetcher;
 use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
 use defra_core::signing::get_signing_config;
+
+pub(crate) use batch::BatchMutator;
 
 /// Document mutator that auto-commits transactions for each operation.
 ///
@@ -50,11 +54,29 @@ impl<S: Store> AutoCommitMutator<S> {
     pub fn new(db: Arc<DB<S>>) -> Self {
         Self { db }
     }
+
+    pub(crate) async fn new_batch_components(
+        &self,
+    ) -> query::error::Result<(Arc<BatchMutator<S>>, Arc<LensedDocFetcher<S>>)> {
+        let txn = self.db.new_txn(false).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+        let fetcher = Arc::new(LensedDocFetcher::new(txn, self.db.lens_store.clone()));
+        let batch = Arc::new(BatchMutator::new(self.db.clone(), fetcher.shared_txn()));
+        Ok((batch, fetcher))
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: Store + 'static> DocMutator for AutoCommitMutator<S> {
+    async fn begin_batch(&self) -> query::error::Result<Option<MutationBatch>> {
+        let (batch, fetcher) = self.new_batch_components().await?;
+        let mutator: Arc<dyn DocMutator> = batch.clone();
+        let controller: Arc<dyn query::mutator::MutationBatchController> = batch;
+        Ok(Some(MutationBatch::new(mutator, fetcher, controller)))
+    }
+
     async fn create(
         &self,
         collection_name: &str,

--- a/crates/ffi/src/acp/identity.rs
+++ b/crates/ffi/src/acp/identity.rs
@@ -88,7 +88,7 @@ fn validate_public_key_bytes(
 ) -> Result<(), String> {
     let crypto_key_type = parse_crypto_key_type(key_type)?;
 
-    let public_key = crypto::public_key_from_bytes(crypto_key_type, &public_key_bytes)
+    let public_key = crypto::public_key_from_bytes(crypto_key_type, public_key_bytes)
         .map_err(|error| format!("invalid public key bytes: {}", error))?;
     let derived_did = public_key
         .did()

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -43,7 +43,10 @@ pub use error::{QueryError, Result, TransactionError};
 pub use executor::{QueryExecutor, QueryRequest, QueryResponse, QueryResponseError};
 pub use fetcher::{CollectionProvider, StaticCollectionProvider};
 pub use mapper::{Filter, Mutation, MutationType, Select};
-pub use mutator::{BroadcastStatus, CreateResult, DeleteResult, DocMutator, UpdateResult};
+pub use mutator::{
+    BroadcastStatus, CreateResult, DeleteResult, DocMutator, MutationBatch,
+    MutationBatchController, UpdateResult,
+};
 pub use plan::{
     CreateInput, CreateNode, DeleteNode, JoinDirection, JoinSide, LimitNode, ScanNode, SelectNode,
     TypeJoinMany, TypeJoinOne, UpdateInput, UpdateNode, UpsertAction, UpsertInput, UpsertNode,

--- a/crates/query/src/mutator.rs
+++ b/crates/query/src/mutator.rs
@@ -6,6 +6,7 @@
 use async_trait::async_trait;
 use cid::Cid;
 use document::{DocID, Document};
+use std::sync::Arc;
 use storage::corekv::MaybeSendSync;
 
 use crate::error::Result;
@@ -234,6 +235,63 @@ impl DeleteResult {
     }
 }
 
+/// Controller for a request-scoped mutation batch.
+///
+/// Implementations own the shared transaction lifecycle for an implicit
+/// GraphQL mutation request and are responsible for committing or rolling
+/// back all writes performed through the paired mutator/fetcher.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait MutationBatchController: MaybeSendSync {
+    /// Commit the shared transaction backing this batch.
+    async fn commit(&self) -> Result<()>;
+
+    /// Roll back the shared transaction backing this batch.
+    async fn rollback(&self) -> Result<()>;
+}
+
+/// A request-scoped mutation batch with a shared mutator and fetcher.
+pub struct MutationBatch {
+    mutator: Arc<dyn DocMutator>,
+    fetcher: Arc<dyn crate::fetcher::DocFetcher>,
+    controller: Arc<dyn MutationBatchController>,
+}
+
+impl MutationBatch {
+    /// Create a new mutation batch wrapper.
+    pub fn new(
+        mutator: Arc<dyn DocMutator>,
+        fetcher: Arc<dyn crate::fetcher::DocFetcher>,
+        controller: Arc<dyn MutationBatchController>,
+    ) -> Self {
+        Self {
+            mutator,
+            fetcher,
+            controller,
+        }
+    }
+
+    /// Get the shared mutator for this batch.
+    pub fn mutator(&self) -> Arc<dyn DocMutator> {
+        self.mutator.clone()
+    }
+
+    /// Get the shared fetcher for this batch.
+    pub fn fetcher(&self) -> Arc<dyn crate::fetcher::DocFetcher> {
+        self.fetcher.clone()
+    }
+
+    /// Commit the batch transaction.
+    pub async fn commit(&self) -> Result<()> {
+        self.controller.commit().await
+    }
+
+    /// Roll back the batch transaction.
+    pub async fn rollback(&self) -> Result<()> {
+        self.controller.rollback().await
+    }
+}
+
 /// Storage abstraction for mutating documents.
 ///
 /// This trait provides write operations for mutations, complementing `DocFetcher`
@@ -261,6 +319,15 @@ impl DeleteResult {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait DocMutator: MaybeSendSync {
+    /// Begin a request-scoped mutation batch.
+    ///
+    /// Implementations can override this to provide a shared transaction for
+    /// multiple top-level GraphQL mutations in one request. The default
+    /// implementation disables batching.
+    async fn begin_batch(&self) -> Result<Option<MutationBatch>> {
+        Ok(None)
+    }
+
     /// Create a new document in a collection.
     ///
     /// The document should NOT have an ID set - the mutator will generate

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -108,6 +108,68 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let utc_offset = FixedOffset::east_opt(0).unwrap();
         let request_time = Utc::now().with_timezone(&utc_offset);
 
+        // Batch implicit multi-mutation requests when the mutator supports it.
+        //
+        // Explicit `/tx` requests already provide their own shared transaction
+        // through `fetcher_override`. Requests touching policy-backed collections
+        // still use the legacy per-mutation path because ACP post-write side
+        // effects are applied outside the storage transaction.
+        let has_policy_backed_mutation = if fetcher_override.is_none() {
+            let mut has_policy = false;
+            for mutation in &mutations {
+                match self.get_collection(&mutation.collection_name).await {
+                    Ok(collection) => {
+                        if collection.policy.is_some() {
+                            has_policy = true;
+                            break;
+                        }
+                    }
+                    Err(QueryError::CollectionNotFound(_)) => {}
+                    Err(err) => return Err(err),
+                }
+            }
+            has_policy
+        } else {
+            false
+        };
+
+        if mutations.len() > 1 && fetcher_override.is_none() && !has_policy_backed_mutation {
+            if let Some(batch) = mutator.begin_batch().await? {
+                let batch_mutator = batch.mutator();
+                let batch_fetcher = batch.fetcher();
+                let mut results = Map::new();
+
+                for mutation in mutations {
+                    let result = match self
+                        .execute_single_mutation(
+                            &mutation,
+                            batch_mutator.clone(),
+                            caller_identity.clone(),
+                            request_time,
+                            Some(batch_fetcher.clone()),
+                        )
+                        .await
+                    {
+                        Ok(result) => result,
+                        Err(err) => {
+                            if let Err(rollback_err) = batch.rollback().await {
+                                tracing::warn!(
+                                    error = %rollback_err,
+                                    "Failed to rollback implicit mutation batch"
+                                );
+                            }
+                            return Err(err);
+                        }
+                    };
+
+                    results.insert(mutation.output_name(), result);
+                }
+
+                batch.commit().await?;
+                return Ok(JsonValue::Object(results));
+            }
+        }
+
         let mut results = Map::new();
 
         for mutation in mutations {

--- a/tools/integration-test/tests/basic.rs
+++ b/tools/integration-test/tests/basic.rs
@@ -1,3 +1,5 @@
+#[path = "basic/batch_mutations.rs"]
+mod batch_mutations;
 #[path = "basic/collection_management.rs"]
 mod collection_management;
 #[path = "basic/document_lifecycle.rs"]

--- a/tools/integration-test/tests/basic/batch_mutations.rs
+++ b/tools/integration-test/tests/basic/batch_mutations.rs
@@ -1,0 +1,105 @@
+use integration_test::{for_each_runtime, TestCluster};
+
+async fn batched_mutation_aliases_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type User { name: String  email: String }")
+        .expect("failed to add schema");
+    client
+        .index_create("User", &["email"], Some("idx_email_unique"), true)
+        .expect("failed to add unique email index");
+
+    let data = client
+        .query(
+            r#"mutation {
+                alice: add_User(input: {name: "Alice", email: "alice@example.com"}) {
+                    _docID
+                    name
+                    email
+                }
+                bob: add_User(input: {name: "Bob", email: "bob@example.com"}) {
+                    _docID
+                    name
+                    email
+                }
+            }"#,
+        )
+        .expect("batched aliased mutation should succeed");
+
+    assert_eq!(data["alice"][0]["name"], "Alice");
+    assert_eq!(data["alice"][0]["email"], "alice@example.com");
+    assert_eq!(data["bob"][0]["name"], "Bob");
+    assert_eq!(data["bob"][0]["email"], "bob@example.com");
+
+    let query = client
+        .query("query { User { name email } }")
+        .expect("query users after batched create");
+    let users = query["User"].as_array().expect("users result not array");
+    assert_eq!(
+        users.len(),
+        2,
+        "expected 2 committed users, got {:?}",
+        query
+    );
+
+    let names: Vec<&str> = users
+        .iter()
+        .filter_map(|user| user["name"].as_str())
+        .collect();
+    assert!(
+        names.contains(&"Alice"),
+        "Alice missing after batched create"
+    );
+    assert!(names.contains(&"Bob"), "Bob missing after batched create");
+}
+
+async fn batched_mutation_rollback_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type User { name: String  email: String }")
+        .expect("failed to add schema");
+
+    let result = client.query(
+        r#"mutation {
+            first: add_User(input: {name: "Alice", email: "alice@example.com"}) {
+                _docID
+            }
+            second: add_Missing(input: {name: "Bob"}) {
+                _docID
+            }
+        }"#,
+    );
+
+    match result {
+        Ok(data) => {
+            assert!(
+                data.is_null(),
+                "failed batched mutation should not return successful data, got {:?}",
+                data
+            );
+        }
+        Err(err) => {
+            let err_msg = err.to_string();
+            assert!(
+                err_msg.contains("collection") || err_msg.contains("not found"),
+                "expected collection-not-found error, got: {}",
+                err_msg
+            );
+        }
+    }
+
+    let query = client
+        .query("query { User { name email } }")
+        .expect("query users after failed batch");
+    let users = query["User"].as_array().expect("users result not array");
+    assert!(
+        users.is_empty(),
+        "failed batched mutation should leave no committed users, got {:?}",
+        query
+    );
+}
+
+for_each_runtime!(batched_mutation_aliases, batched_mutation_aliases_test);
+for_each_runtime!(batched_mutation_rollback, batched_mutation_rollback_test);


### PR DESCRIPTION
## Summary
- batch implicit GraphQL requests with multiple top-level mutations onto one shared DB transaction
- add a shared-transaction auto-commit batch mutator and matching fetcher/controller wiring
- add basic integration coverage for aliased success and all-or-nothing rollback

## Validation
- cargo fmt --all
- cargo test -p integration-test --test basic
- cargo clippy --all -- -D warnings

## Notes
- explicit /tx requests still use the existing transaction path unchanged
- requests touching policy-backed collections keep the legacy per-mutation path for now because ACP post-write side effects still happen outside the storage transaction

Closes #555