### PR TITLE
feat: add profiling toolkit for Phase 2 performance audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,6 +2262,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-chrome",
  "tracing-subscriber",
  "url",
  "urlencoding",
@@ -3045,6 +3046,7 @@ dependencies = [
  "storage",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4472,6 +4474,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-chrome",
+ "tracing-subscriber",
  "zeroize",
 ]
 
@@ -12759,6 +12763,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,3 +150,9 @@ overflow-checks = true
 
 [profile.bench]
 opt-level = 3
+
+[profile.profile]
+inherits = "release"
+strip = false
+debug = 1
+lto = "thin"

--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -58,6 +58,7 @@ use storage::corekv::{IterOptions, Key, Store};
 use storage::keys::blockstore::{BlockstoreKey, ToMergeIndexKey};
 use storage::stores::blockstore::BlockstoreTxn;
 use storage::stores::Blockstore as InternalBlockstore;
+use tracing::instrument;
 
 /// Default number of entries in the block cache (matches Go's 1M entry LRU).
 const DEFAULT_BLOCK_CACHE_SIZE: usize = 1_000_000;
@@ -180,6 +181,7 @@ impl<S: Store + 'static> DefraBlockstore<S> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: Store + 'static> Blockstore for DefraBlockstore<S> {
+    #[instrument(level = "trace", skip(self))]
     async fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>> {
         // Check LRU cache first (skip cache when hash verification is enabled,
         // since cached data may not have been verified yet)
@@ -212,6 +214,7 @@ impl<S: Store + 'static> Blockstore for DefraBlockstore<S> {
         Ok(result)
     }
 
+    #[instrument(level = "trace", skip(self))]
     async fn put(&self, cid: &Cid, data: &[u8]) -> Result<()> {
         // Check cache for existence (avoids storage read for recently-written blocks)
         if self.cache.lock().contains(cid) {

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -53,6 +53,7 @@ serde_yaml = "0.9"
 # Logging
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-chrome = { version = "0.7", optional = true }
 
 # Error handling
 thiserror = { workspace = true }
@@ -107,6 +108,7 @@ fjall = ["storage/fjall"]
 rocksdb = ["storage/rocksdb"]
 vendored-openssl = ["dep:openssl-sys"]
 iroh = ["p2p/iroh-transport", "dep:iroh-net", "dep:rand"]
+profiling = ["dep:tracing-chrome"]
 
 [dev-dependencies]
 tempfile = "3.17"

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -27,6 +27,10 @@ const DEV_MODE_BANNER: &str = r#"
 /// Arguments for the start command
 #[derive(Args, Debug)]
 pub struct StartArgs {
+    /// Emit a Chrome trace file for profiling
+    #[arg(long)]
+    pub profile: bool,
+
     /// List of peers to connect to
     #[arg(long, value_delimiter = ',')]
     pub peers: Option<Vec<String>>,

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -1,26 +1,74 @@
 //! Logging initialization
 
 use tracing::Level;
-use tracing_subscriber::fmt::format::FmtSpan;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::{self, format::FmtSpan};
+use tracing_subscriber::layer::SubscriberExt;
+#[cfg(feature = "profiling")]
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+#[cfg(feature = "profiling")]
+use std::fs::File;
+#[cfg(feature = "profiling")]
+use std::path::PathBuf;
+#[cfg(feature = "profiling")]
+use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(feature = "profiling")]
+use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
 
 use crate::config::{Config, LogFormat, LogLevel, LogOutput};
 use crate::error::{Error, Result};
 
-/// Initialize logging based on configuration
-pub fn init(config: &Config) -> Result<()> {
+pub struct LoggingHandle {
+    #[cfg(feature = "profiling")]
+    profiling: Option<ProfilingTrace>,
+}
+
+#[cfg(feature = "profiling")]
+struct ProfilingTrace {
+    path: PathBuf,
+    guard: FlushGuard,
+}
+
+impl LoggingHandle {
+    fn none() -> Self {
+        Self {
+            #[cfg(feature = "profiling")]
+            profiling: None,
+        }
+    }
+
+    #[cfg(feature = "profiling")]
+    fn with_profile(profiling: ProfilingTrace) -> Self {
+        Self {
+            profiling: Some(profiling),
+        }
+    }
+
+    pub fn finish(self) {
+        #[cfg(feature = "profiling")]
+        if let Some(profiling) = self.profiling {
+            let path = profiling.path;
+            drop(profiling.guard);
+            eprintln!("Chrome trace written to {}", path.display());
+        }
+    }
+}
+
+/// Initialize logging based on configuration.
+pub fn init(config: &Config, enable_profiling: bool) -> Result<LoggingHandle> {
     let level = match config.log.level {
         LogLevel::Debug => Level::DEBUG,
         LogLevel::Info => Level::INFO,
         LogLevel::Error => Level::ERROR,
-        LogLevel::Fatal => Level::ERROR, // tracing doesn't have FATAL, use ERROR
+        LogLevel::Fatal => Level::ERROR,
     };
 
     let filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level.to_string()));
 
-    let builder = tracing_subscriber::fmt()
-        .with_env_filter(filter)
+    let builder = fmt::layer()
         .with_target(true)
         .with_thread_ids(false)
         .with_thread_names(false)
@@ -28,24 +76,102 @@ pub fn init(config: &Config) -> Result<()> {
         .with_line_number(config.log.source)
         .with_ansi(!config.log.color_disabled);
 
-    // Configure span events based on stacktrace setting
     let builder = if config.log.stacktrace {
         builder.with_span_events(FmtSpan::CLOSE)
     } else {
         builder.with_span_events(FmtSpan::NONE)
     };
 
-    // Select output
-    let result = match (config.log.format, config.log.output) {
-        (LogFormat::Json, LogOutput::Stdout) => {
-            builder.json().with_writer(std::io::stdout).try_init()
-        }
-        (LogFormat::Json, LogOutput::Stderr) => {
-            builder.json().with_writer(std::io::stderr).try_init()
-        }
-        (LogFormat::Text, LogOutput::Stdout) => builder.with_writer(std::io::stdout).try_init(),
-        (LogFormat::Text, LogOutput::Stderr) => builder.with_writer(std::io::stderr).try_init(),
-    };
+    match (config.log.format, config.log.output) {
+        (LogFormat::Json, LogOutput::Stdout) => init_subscriber(
+            filter,
+            builder.json().with_writer(std::io::stdout),
+            enable_profiling,
+        ),
+        (LogFormat::Json, LogOutput::Stderr) => init_subscriber(
+            filter,
+            builder.json().with_writer(std::io::stderr),
+            enable_profiling,
+        ),
+        (LogFormat::Text, LogOutput::Stdout) => init_subscriber(
+            filter,
+            builder.with_writer(std::io::stdout),
+            enable_profiling,
+        ),
+        (LogFormat::Text, LogOutput::Stderr) => init_subscriber(
+            filter,
+            builder.with_writer(std::io::stderr),
+            enable_profiling,
+        ),
+    }
+}
 
-    result.map_err(|e| Error::LoggingInit(e.to_string()))
+fn init_subscriber<L>(
+    filter: EnvFilter,
+    fmt_layer: L,
+    enable_profiling: bool,
+) -> Result<LoggingHandle>
+where
+    L: tracing_subscriber::Layer<Registry> + Send + Sync + 'static,
+{
+    #[cfg(not(feature = "profiling"))]
+    if enable_profiling {
+        return Err(Error::LoggingInit(
+            "profiling support requires building the CLI with `--features profiling`".into(),
+        ));
+    }
+
+    #[cfg(feature = "profiling")]
+    if enable_profiling {
+        let (chrome_layer, profiling) =
+            build_chrome_layer::<tracing_subscriber::layer::Layered<L, Registry>>()?;
+        tracing_subscriber::registry()
+            .with(fmt_layer)
+            .with(chrome_layer)
+            .with(filter)
+            .try_init()
+            .map_err(|error| Error::LoggingInit(error.to_string()))?;
+        return Ok(LoggingHandle::with_profile(profiling));
+    }
+
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(filter)
+        .try_init()
+        .map_err(|error| Error::LoggingInit(error.to_string()))?;
+
+    Ok(LoggingHandle::none())
+}
+
+#[cfg(feature = "profiling")]
+fn build_chrome_layer<S>() -> Result<(tracing_chrome::ChromeLayer<S>, ProfilingTrace)>
+where
+    S: tracing::Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
+{
+    let path = trace_output_path()?;
+    let file = File::create(&path).map_err(|error| {
+        Error::LoggingInit(format!(
+            "failed to create profiling trace file {}: {}",
+            path.display(),
+            error
+        ))
+    })?;
+    let (layer, guard) = ChromeLayerBuilder::new()
+        .writer(file)
+        .include_args(true)
+        .build();
+
+    Ok((layer, ProfilingTrace { path, guard }))
+}
+
+#[cfg(feature = "profiling")]
+fn trace_output_path() -> Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| Error::LoggingInit(format!("failed to read system time: {}", error)))?
+        .as_millis();
+
+    Ok(std::env::current_dir()
+        .map_err(Error::Io)?
+        .join(format!("defra-trace-{}.json", timestamp)))
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,7 +8,7 @@ use std::process::ExitCode;
 use clap::Parser;
 use tracing::error;
 
-use cli::cli::Cli;
+use cli::cli::{Cli, Command};
 use cli::config::Config;
 use cli::error::Result;
 
@@ -31,8 +31,14 @@ async fn run() -> Result<()> {
     let config = Config::load(&cli)?;
 
     // Initialize logging based on config
-    cli::logging::init(&config)?;
+    let logging = cli::logging::init(&config, should_profile(&cli))?;
 
     // Execute the command
-    cli.execute(config).await
+    let result = cli.execute(config).await;
+    logging.finish();
+    result
+}
+
+fn should_profile(cli: &Cli) -> bool {
+    matches!(&cli.command, Command::Start(args) if args.profile)
 }

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -6,6 +6,7 @@ use cli::error::Error;
 
 fn default_start_args() -> StartArgs {
     StartArgs {
+        profile: false,
         peers: None,
         max_txn_retries: None,
         store: None,
@@ -89,6 +90,7 @@ fn test_apply_to_config_redb_store_succeeds() {
 fn test_apply_to_config_all_flags() {
     let mut config = Config::default();
     let args = StartArgs {
+        profile: false,
         peers: Some(vec!["peer1".to_string(), "peer2".to_string()]),
         max_txn_retries: Some(10),
         store: Some("memory".to_string()),

--- a/crates/crdt/Cargo.toml
+++ b/crates/crdt/Cargo.toml
@@ -20,6 +20,7 @@ serde_json.workspace = true
 
 # Error handling
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/crdt/src/lww.rs
+++ b/crates/crdt/src/lww.rs
@@ -11,6 +11,7 @@ use defra_core::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use storage::{Reader, ReaderWriter};
+use tracing::instrument;
 
 /// LWW Delta - represents a change to an LWW register
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -281,6 +282,7 @@ impl Lww {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl ReplicatedData for Lww {
+    #[instrument(level = "trace", skip(self, rw, ctx, delta))]
     async fn merge(
         &self,
         rw: &mut dyn ReaderWriter,

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 fjall = ["storage/fjall"]
 rocksdb = ["storage/rocksdb"]
 iroh = ["embedded/iroh", "p2p/iroh-transport"]
+profiling = ["dep:tracing-chrome", "dep:tracing-subscriber"]
 
 [dependencies]
 # Async runtime
@@ -37,6 +38,8 @@ thiserror.workspace = true
 
 # Logging
 tracing.workspace = true
+tracing-chrome = { version = "0.7", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"], optional = true }
 
 # Synchronization
 parking_lot.workspace = true

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -48,6 +48,8 @@ pub mod nac_check;
 pub mod node;
 pub mod p2p;
 mod policy_yaml;
+#[cfg(feature = "profiling")]
+pub mod profiling;
 pub mod query;
 pub mod runtime;
 pub mod schema;

--- a/crates/ffi/src/profiling.rs
+++ b/crates/ffi/src/profiling.rs
@@ -1,0 +1,82 @@
+use std::ffi::c_char;
+use std::fs::File;
+use std::sync::{Mutex, OnceLock};
+
+use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+
+use crate::helpers::require_c_str;
+use crate::types::FfiResult;
+use crate::{ffi_entry, try_ffi};
+
+static PROFILING_GUARD: OnceLock<Mutex<Option<FlushGuard>>> = OnceLock::new();
+
+fn guard_slot() -> &'static Mutex<Option<FlushGuard>> {
+    PROFILING_GUARD.get_or_init(|| Mutex::new(None))
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_profiling_start(output_path: *const c_char) -> FfiResult {
+    ffi_entry! {
+        let output_path = try_ffi!(unsafe { require_c_str(output_path, "output_path") });
+
+        let mut guard = match guard_slot().lock() {
+            Ok(guard) => guard,
+            Err(_) => return FfiResult::error("profiling guard mutex poisoned"),
+        };
+
+        if guard.is_some() {
+            return FfiResult::error("profiling is already running");
+        }
+
+        let file = match File::create(&output_path) {
+            Ok(file) => file,
+            Err(error) => {
+                return FfiResult::error(format!(
+                    "failed to create profiling trace file {}: {}",
+                    output_path, error
+                ))
+            }
+        };
+
+        let filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        let (chrome_layer, flush_guard) = ChromeLayerBuilder::new()
+            .writer(file)
+            .include_args(true)
+            .build();
+
+        let subscriber = tracing_subscriber::registry()
+            .with(filter)
+            .with(chrome_layer);
+
+        if let Err(error) = tracing::subscriber::set_global_default(subscriber) {
+            return FfiResult::error(format!(
+                "failed to initialize profiling subscriber: {}",
+                error
+            ));
+        }
+
+        *guard = Some(flush_guard);
+        FfiResult::ok()
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn defra_profiling_stop() -> FfiResult {
+    ffi_entry! {
+        let mut guard = match guard_slot().lock() {
+            Ok(guard) => guard,
+            Err(_) => return FfiResult::error("profiling guard mutex poisoned"),
+        };
+
+        let Some(flush_guard) = guard.take() else {
+            return FfiResult::error("profiling is not running");
+        };
+
+        drop(flush_guard);
+        FfiResult::ok()
+    }
+}

--- a/crates/query/src/mapper/filter/filter_impl.rs
+++ b/crates/query/src/mapper/filter/filter_impl.rs
@@ -1,6 +1,7 @@
 //! Filter types and evaluation for query conditions
 
 use serde_json::{Map, Value as JsonValue};
+use tracing::instrument;
 
 use super::eval::{eval_op, values_equal};
 use super::op::FilterOp;
@@ -57,6 +58,7 @@ impl Filter {
     }
 
     /// Evaluate the filter against document fields
+    #[instrument(level = "trace", skip(self, fields, mapping))]
     pub fn matches(&self, fields: &[Option<JsonValue>], mapping: &DocumentMapping) -> Result<bool> {
         if self.conditions.is_empty() {
             return Ok(true);

--- a/crates/storage/src/backends/redb/transaction.rs
+++ b/crates/storage/src/backends/redb/transaction.rs
@@ -4,6 +4,7 @@ use redb::{Database, ReadTransaction};
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use tracing::instrument;
 
 use super::config::DurabilityMode;
 use super::group_commit::{GroupCommitBuffer, PendingCommit};
@@ -146,6 +147,7 @@ impl RedbTxn {
 
 #[async_trait]
 impl Reader for RedbTxn {
+    #[instrument(level = "trace", skip(self))]
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
@@ -249,6 +251,7 @@ impl Reader for RedbTxn {
 
 #[async_trait]
 impl Writer for RedbTxn {
+    #[instrument(level = "trace", skip(self))]
     async fn set(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
         if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
@@ -288,6 +291,7 @@ impl Writer for RedbTxn {
 
 #[async_trait]
 impl Txn for RedbTxn {
+    #[instrument(level = "trace", skip(self))]
     async fn commit(self: Box<Self>) -> Result<()> {
         // Note: active_txn_count is decremented by Drop impl when self is dropped
         // at the end of this function (on any exit path).

--- a/tools/integration-test/tests/backup/restore.rs
+++ b/tools/integration-test/tests/backup/restore.rs
@@ -156,4 +156,4 @@ async fn backup_restore_test(cluster: TestCluster) {
     );
 }
 
-for_each_runtime!(backup_restore, backup_restore_test);
+for_each_runtime!(backup_restore, backup_restore_test, .with_development());


### PR DESCRIPTION
## Summary

- Add `profile` Cargo build profile (optimized + debug symbols for flamegraphs)
- Add `profiling` feature flag on CLI and FFI crates, gating `tracing-chrome` for Chrome Trace Format output
- CLI: `--profile` flag on `defra start`, writes `defra-trace-{timestamp}.json` and prints path on shutdown
- FFI: `defra_profiling_start/stop` functions for embedded builds (repo indexer, data indexer)
- Add `#[instrument(level = "trace")]` spans to storage get/set/commit, blockstore get/put, CRDT merge, and filter matches
- Fix backup restore integration test to use development mode (consistent with dump/purge tests)

## Test plan

- [x] `cargo build --profile profile` succeeds
- [x] `cargo build -p cli --features profiling` succeeds
- [x] `cargo build -p ffi --features profiling` succeeds
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo test` passes (hubrs failure is pre-existing external RPC issue)
- [x] Smoke tested: started node with `--profile`, ran schema/document/query operations, verified trace JSON output with correct span hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)