### PR TITLE
fix: add encrypted index validation during collection patching (#595)

### DIFF
--- a/crates/db/src/definition_validation/mod.rs
+++ b/crates/db/src/definition_validation/mod.rs
@@ -58,6 +58,7 @@ const UPDATE_VALIDATORS: &[Validator] = &[
     validate_field_not_mutated,
     validate_policy_not_modified,
     validate_indexes_not_modified,
+    validate_encrypted_indexes_not_modified,
     validate_sources_not_redefined,
     validate_source_belongs_to_host,
     validate_branchable_not_mutated,

--- a/crates/db/src/definition_validation/update_validators.rs
+++ b/crates/db/src/definition_validation/update_validators.rs
@@ -305,6 +305,39 @@ pub(super) fn validate_indexes_not_modified(
     errs
 }
 
+/// Matches Go's validateEncryptedIndexesNotModified.
+pub(super) fn validate_encrypted_indexes_not_modified(
+    new_state: &DefinitionState,
+    old_state: &DefinitionState,
+) -> Vec<String> {
+    let mut errs = Vec::new();
+    for new_col in &new_state.collections {
+        let old_col = match old_state.collections_by_id.get(&new_col.version_id) {
+            Some(c) => c,
+            None => {
+                match old_state
+                    .active_by_collection_id
+                    .get(&new_col.collection_id)
+                {
+                    Some(c) => c,
+                    None => continue,
+                }
+            }
+        };
+        if old_col.is_placeholder {
+            continue;
+        }
+
+        if new_col.encrypted_indexes != old_col.encrypted_indexes {
+            errs.push(format!(
+                "collection encrypted indexes cannot be mutated. CollectionID: {}",
+                new_col.version_id
+            ));
+        }
+    }
+    errs
+}
+
 /// Matches Go's validateSourcesNotRedefined.
 /// Checks that PreviousVersion and Query sources are not added/removed/mutated.
 pub(super) fn validate_sources_not_redefined(


### PR DESCRIPTION
## Summary

- Adds `validate_encrypted_indexes_not_modified` validator to prevent encrypted indexes from being silently mutated via collection patch
- Ports Go DefraDB fix from PR #4611 which fixed an index-out-of-range panic
- Rust uses idiomatic `!=` comparison on the full `Vec` (no slice-length bug possible)

Closes #595

## Test plan

- [x] `cargo test -p db` passes
- [x] `cargo clippy --all -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)