### PR TITLE
feat(http): require dev-mode for backup import/export (#596)

### DIFF
--- a/crates/http/src/handlers/backup.rs
+++ b/crates/http/src/handlers/backup.rs
@@ -4,6 +4,7 @@
 //! - Export database to JSON
 //! - Import database from JSON
 //!
+//! Both import and export require development mode to be enabled.
 //! All endpoints enforce NAC permissions when NAC is enabled.
 //! Export requires `DocumentRead` permission.
 //! Import requires `DocumentUpdate` permission.
@@ -84,6 +85,12 @@ pub async fn export(
 ) -> Result<Response, HttpError> {
     require_permission(&state, &identity, NodePermission::DocumentRead).await?;
 
+    if !state.dev_mode {
+        return Err(HttpError::BadRequest(
+            "backup export is not permitted when development mode is disabled".into(),
+        ));
+    }
+
     let backup = state.require_backup()?;
 
     // Log warning if filepath was provided (Go-compatibility note)
@@ -162,6 +169,12 @@ pub async fn import(
     body: Bytes,
 ) -> Result<StatusCode, HttpError> {
     require_permission(&state, &identity, NodePermission::DocumentUpdate).await?;
+
+    if !state.dev_mode {
+        return Err(HttpError::BadRequest(
+            "backup import is not permitted when development mode is disabled".into(),
+        ));
+    }
 
     let backup = state.require_backup()?;
 

--- a/tools/integration-test/tests/backup.rs
+++ b/tools/integration-test/tests/backup.rs
@@ -1,3 +1,5 @@
+#[path = "backup/dev_mode.rs"]
+mod dev_mode;
 #[path = "backup/dump.rs"]
 mod dump;
 #[path = "backup/purge.rs"]

--- a/tools/integration-test/tests/backup/dev_mode.rs
+++ b/tools/integration-test/tests/backup/dev_mode.rs
@@ -1,0 +1,54 @@
+use integration_test::{for_each_runtime, TestCluster};
+
+async fn export_requires_dev_mode_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type Note { text: String }")
+        .expect("failed to add schema");
+
+    let node_dir = cluster.nodes[0].rootdir.to_str().unwrap().to_string();
+    let path = format!("{}/backup.json", node_dir);
+
+    let result = client.backup_export(&path, &[], false);
+    assert!(
+        result.is_err(),
+        "backup export should fail when not in dev mode"
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("development mode"),
+        "error should mention development mode, got: {}",
+        err_msg
+    );
+}
+
+async fn import_requires_dev_mode_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type Note { text: String }")
+        .expect("failed to add schema");
+
+    let node_dir = cluster.nodes[0].rootdir.to_str().unwrap().to_string();
+    let path = format!("{}/backup.json", node_dir);
+
+    std::fs::write(&path, r#"{"Note": [{"text": "hello"}]}"#).expect("failed to write file");
+
+    let result = client.backup_import(&path);
+    assert!(
+        result.is_err(),
+        "backup import should fail when not in dev mode"
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("development mode"),
+        "error should mention development mode, got: {}",
+        err_msg
+    );
+}
+
+for_each_runtime!(export_requires_dev_mode, export_requires_dev_mode_test);
+for_each_runtime!(import_requires_dev_mode, import_requires_dev_mode_test);


### PR DESCRIPTION
## Summary

- Adds dev-mode guard to backup export and import HTTP handlers
- Returns HTTP 400 with clear error message when dev-mode is disabled
- Follows existing pattern from `purge`/`dump` handlers
- Adds integration tests verifying both operations fail without dev-mode
- Ports Go DefraDB PR #4569

Closes #596

## Test plan

- [x] `cargo test -p defra-http` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] New integration tests: `export_requires_dev_mode`, `import_requires_dev_mode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)