### PR TITLE
fix(p2p): make add_replicator idempotent and throttle initial replay

### DIFF
--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -185,18 +185,31 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         // Check existing replicator state before creating/updating so we can
         // skip the expensive initial replay when the replicator already exists
         // with the same collections (idempotent reconnect path).
-        let existing_collection_ids: HashSet<String> =
-            if let Some(ref coordinator) = self.sync_coordinator {
-                coordinator.get_replicator(&peer_id).await.ok().flatten()
+        let existing_collection_ids: HashSet<String> = {
+            let result = if let Some(ref coordinator) = self.sync_coordinator {
+                coordinator
+                    .get_replicator(&peer_id)
+                    .await
+                    .map_err(|e| e.to_string())
             } else {
                 self.transport
                     .get_replicator(&peer_id)
                     .await
-                    .ok()
-                    .flatten()
+                    .map_err(|e| e.to_string())
+            };
+            match result {
+                Ok(Some(info)) => info.collections.into_iter().collect(),
+                Ok(None) => HashSet::new(),
+                Err(e) => {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Failed to check existing replicator state; falling back to full replay"
+                    );
+                    HashSet::new()
+                }
             }
-            .map(|info| info.collections.into_iter().collect())
-            .unwrap_or_default();
+        };
 
         self.transport
             .dial(&peer_id, direct_addrs)

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -182,6 +182,22 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             collection_cids.clone_from(&effective_collections);
         }
 
+        // Check existing replicator state before creating/updating so we can
+        // skip the expensive initial replay when the replicator already exists
+        // with the same collections (idempotent reconnect path).
+        let existing_collection_ids: HashSet<String> =
+            if let Some(ref coordinator) = self.sync_coordinator {
+                coordinator.get_replicator(&peer_id).await.ok().flatten()
+            } else {
+                self.transport
+                    .get_replicator(&peer_id)
+                    .await
+                    .ok()
+                    .flatten()
+            }
+            .map(|info| info.collections.into_iter().collect())
+            .unwrap_or_default();
+
         self.transport
             .dial(&peer_id, direct_addrs)
             .await
@@ -212,27 +228,52 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             }
         }
 
-        if let Some(ref pusher) = self.doc_pusher {
-            let push_pusher = Arc::clone(pusher);
-            let push_event_bus = self.event_bus.clone();
-            let push_collections = effective_collections;
-            let push_peer = peer_id;
+        // Only replay collections that weren't already replicated by this peer.
+        // This makes add_replicator idempotent for reconnect paths — calling it
+        // again with the same collections is a no-op instead of a full replay storm.
+        let new_collection_names: Vec<String> = effective_collections
+            .iter()
+            .zip(collection_cids.iter())
+            .filter(|(_, cid)| !existing_collection_ids.contains(*cid))
+            .map(|(name, _)| name.clone())
+            .collect();
 
-            tokio::spawn(async move {
-                if let Err(e) = push_pusher
-                    .push_existing_docs(&push_peer, &push_collections, None)
-                    .await
-                {
-                    tracing::error!(error = %e, "Failed to push existing docs to replicator");
-                }
-                if let Some(bus) = push_event_bus {
-                    tracing::debug!("publishing ReplicatorCompleted event");
-                    bus.publish(events::Message::replicator_completed());
-                    tracing::debug!("ReplicatorCompleted event published");
-                }
-            });
-        } else if let Some(ref bus) = self.event_bus {
-            bus.publish(events::Message::replicator_completed());
+        if !new_collection_names.is_empty() {
+            if let Some(ref pusher) = self.doc_pusher {
+                let push_pusher = Arc::clone(pusher);
+                let push_event_bus = self.event_bus.clone();
+                let push_peer = peer_id;
+
+                tracing::info!(
+                    peer_id = %push_peer,
+                    new_collections = ?new_collection_names,
+                    "Replaying existing docs for new collections only"
+                );
+
+                tokio::spawn(async move {
+                    if let Err(e) = push_pusher
+                        .push_existing_docs(&push_peer, &new_collection_names, None)
+                        .await
+                    {
+                        tracing::error!(error = %e, "Failed to push existing docs to replicator");
+                    }
+                    if let Some(bus) = push_event_bus {
+                        tracing::debug!("publishing ReplicatorCompleted event");
+                        bus.publish(events::Message::replicator_completed());
+                        tracing::debug!("ReplicatorCompleted event published");
+                    }
+                });
+            } else if let Some(ref bus) = self.event_bus {
+                bus.publish(events::Message::replicator_completed());
+            }
+        } else {
+            tracing::debug!(
+                peer_id = %peer_id,
+                "Replicator already exists with same collections, skipping initial replay"
+            );
+            if let Some(ref bus) = self.event_bus {
+                bus.publish(events::Message::replicator_completed());
+            }
         }
 
         Ok(())

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -620,6 +620,36 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             );
         }
 
+        // Check existing replicator state before creating/updating so we can
+        // skip the expensive initial replay when the replicator already exists
+        // with the same collections (idempotent reconnect path).
+        let existing_collection_ids: HashSet<String> = {
+            let result = if let Some(ref coordinator) = self.sync_coordinator {
+                let transport_pid = p2p::transport::PeerId::from(peer_id);
+                coordinator
+                    .get_replicator(&transport_pid)
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                self.handle
+                    .get_replicator(peer_id)
+                    .await
+                    .map_err(|e| e.to_string())
+            };
+            match result {
+                Ok(Some(info)) => info.collections.into_iter().collect(),
+                Ok(None) => HashSet::new(),
+                Err(e) => {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Failed to check existing replicator state; falling back to full replay"
+                    );
+                    HashSet::new()
+                }
+            }
+        };
+
         // Dial peer
         self.handle
             .dial(peer_id, vec![parsed.transport_addr])
@@ -655,28 +685,56 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             }
         }
 
-        // Spawn background task: push existing docs → emit ReplicatorCompleted
-        if let Some(ref pusher) = self.doc_pusher {
-            let push_handle = self.handle.clone();
-            let push_pusher = Arc::clone(pusher);
-            let push_event_bus = self.event_bus.clone();
-            let push_collections = effective_collections;
+        // Only replay collections that weren't already replicated by this peer.
+        let new_collection_names: Vec<String> = effective_collections
+            .iter()
+            .zip(collection_cids.iter())
+            .filter(|(_, cid)| !existing_collection_ids.contains(*cid))
+            .map(|(name, _)| name.clone())
+            .collect();
 
-            tokio::spawn(async move {
-                if let Err(e) = push_pusher
-                    .push_existing_docs(&push_handle, peer_id, &push_collections, None, None)
-                    .await
-                {
-                    tracing::error!(error = %e, "Failed to push existing docs to replicator");
-                }
-                if let Some(bus) = push_event_bus {
-                    tracing::debug!("publishing ReplicatorCompleted event");
-                    bus.publish(events::Message::replicator_completed());
-                    tracing::debug!("ReplicatorCompleted event published");
-                }
-            });
-        } else if let Some(ref bus) = self.event_bus {
-            bus.publish(events::Message::replicator_completed());
+        if !new_collection_names.is_empty() {
+            if let Some(ref pusher) = self.doc_pusher {
+                let push_handle = self.handle.clone();
+                let push_pusher = Arc::clone(pusher);
+                let push_event_bus = self.event_bus.clone();
+
+                tracing::info!(
+                    peer_id = %peer_id,
+                    new_collections = ?new_collection_names,
+                    "Replaying existing docs for new collections only"
+                );
+
+                tokio::spawn(async move {
+                    if let Err(e) = push_pusher
+                        .push_existing_docs(
+                            &push_handle,
+                            peer_id,
+                            &new_collection_names,
+                            None,
+                            None,
+                        )
+                        .await
+                    {
+                        tracing::error!(error = %e, "Failed to push existing docs to replicator");
+                    }
+                    if let Some(bus) = push_event_bus {
+                        tracing::debug!("publishing ReplicatorCompleted event");
+                        bus.publish(events::Message::replicator_completed());
+                        tracing::debug!("ReplicatorCompleted event published");
+                    }
+                });
+            } else if let Some(ref bus) = self.event_bus {
+                bus.publish(events::Message::replicator_completed());
+            }
+        } else {
+            tracing::debug!(
+                peer_id = %peer_id,
+                "Replicator already exists with same collections, skipping initial replay"
+            );
+            if let Some(ref bus) = self.event_bus {
+                bus.publish(events::Message::replicator_completed());
+            }
         }
 
         Ok(())

--- a/crates/db/src/push_docs_transport.rs
+++ b/crates/db/src/push_docs_transport.rs
@@ -159,6 +159,11 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
                 let sem = replay_semaphore.clone();
                 push_handles.push(tokio::spawn(async move {
                     let Ok(_permit) = sem.acquire().await else {
+                        tracing::error!(
+                            peer_id = %pid,
+                            request_count = requests.len(),
+                            "Replay semaphore closed; document push requests abandoned"
+                        );
                         return;
                     };
                     for req in requests {
@@ -190,7 +195,9 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
 
     tracing::debug!(task_count = push_handles.len(), "awaiting push tasks");
     for jh in push_handles {
-        let _ = jh.await;
+        if let Err(e) = jh.await {
+            tracing::error!(error = %e, "Replay push task panicked or was cancelled");
+        }
     }
     tracing::debug!("all push tasks completed");
 

--- a/crates/db/src/push_docs_transport.rs
+++ b/crates/db/src/push_docs_transport.rs
@@ -1,10 +1,17 @@
 use std::str::FromStr;
+use std::sync::Arc;
 
 use acp::DocumentACP;
 use p2p::message::PushLogRequest;
 use p2p::transport::PeerId;
 use p2p::P2PTransport;
 use storage::corekv::{IterOptions, Reader, Store};
+
+/// Maximum concurrent per-document push tasks during initial replay.
+///
+/// Lower than the coordinator's live push limit (32) because initial replay
+/// is background work that shouldn't starve real-time sync traffic.
+const MAX_CONCURRENT_REPLAY_TASKS: usize = 8;
 
 use crate::database::DB;
 use crate::push_docs_common::{load_push_dag_blocks, resolve_push_creator};
@@ -52,6 +59,7 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
         .map_err(|e| format!("failed to get datastore: {}", e))?;
 
     let mut push_handles = Vec::new();
+    let replay_semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_REPLAY_TASKS));
 
     for col_name in collections {
         let collection = match db
@@ -148,7 +156,9 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
             if !requests.is_empty() {
                 let t = transport.clone();
                 let pid = peer_id.clone();
+                let sem = replay_semaphore.clone();
                 push_handles.push(tokio::spawn(async move {
+                    let _permit = sem.acquire().await;
                     for req in requests {
                         let cid = req.cid.clone();
                         match t.send_two_stream_request(&pid, req).await {

--- a/crates/db/src/push_docs_transport.rs
+++ b/crates/db/src/push_docs_transport.rs
@@ -158,7 +158,9 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
                 let pid = peer_id.clone();
                 let sem = replay_semaphore.clone();
                 push_handles.push(tokio::spawn(async move {
-                    let _permit = sem.acquire().await;
+                    let Ok(_permit) = sem.acquire().await else {
+                        return;
+                    };
                     for req in requests {
                         let cid = req.cid.clone();
                         match t.send_two_stream_request(&pid, req).await {

--- a/crates/db/src/push_docs_transport.rs
+++ b/crates/db/src/push_docs_transport.rs
@@ -30,8 +30,22 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
 ) -> Result<(), String> {
     let conn_timeout = std::time::Duration::from_secs(15);
     let conn_start = std::time::Instant::now();
+    let mut logged_conn_error = false;
     loop {
-        let peers = transport.connected_peers().await.unwrap_or_default();
+        let peers = match transport.connected_peers().await {
+            Ok(peers) => peers,
+            Err(e) => {
+                if !logged_conn_error {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "connected_peers check failed during replay wait"
+                    );
+                    logged_conn_error = true;
+                }
+                Vec::new()
+            }
+        };
         if peers.iter().any(|p| p == peer_id) {
             break;
         }

--- a/crates/embedded/src/iroh_adapter.rs
+++ b/crates/embedded/src/iroh_adapter.rs
@@ -189,6 +189,35 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             collection_cids.clone_from(&effective_collections);
         }
 
+        // Check existing replicator state before creating/updating so we can
+        // skip the expensive initial replay when the replicator already exists
+        // with the same collections (idempotent reconnect path).
+        let existing_collection_ids: HashSet<String> = {
+            let result = if let Some(ref coordinator) = self.sync_coordinator {
+                coordinator
+                    .get_replicator(&peer_id)
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                self.transport
+                    .get_replicator(&peer_id)
+                    .await
+                    .map_err(|e| e.to_string())
+            };
+            match result {
+                Ok(Some(info)) => info.collections.into_iter().collect(),
+                Ok(None) => HashSet::new(),
+                Err(e) => {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Failed to check existing replicator state; falling back to full replay"
+                    );
+                    HashSet::new()
+                }
+            }
+        };
+
         self.transport
             .dial(&peer_id, direct_addrs)
             .await
@@ -219,25 +248,53 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             }
         }
 
-        if let Some(ref pusher) = self.doc_pusher {
-            let push_pusher = Arc::clone(pusher);
-            let push_event_bus = self.event_bus.clone();
-            let push_collections = effective_collections;
-            let push_peer = peer_id;
-            let push_se_key = push_options.se_encryption_key;
-            tokio::spawn(async move {
-                if let Err(error) = push_pusher
-                    .push_existing_docs(&push_peer, &push_collections, push_se_key.as_deref())
-                    .await
-                {
-                    tracing::error!(error = %error, "Failed to push existing docs to replicator");
-                }
-                if let Some(bus) = push_event_bus {
-                    bus.publish(events::Message::replicator_completed());
-                }
-            });
-        } else if let Some(ref bus) = self.event_bus {
-            bus.publish(events::Message::replicator_completed());
+        // Only replay collections that weren't already replicated by this peer.
+        let new_collection_names: Vec<String> = effective_collections
+            .iter()
+            .zip(collection_cids.iter())
+            .filter(|(_, cid)| !existing_collection_ids.contains(*cid))
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        if !new_collection_names.is_empty() {
+            if let Some(ref pusher) = self.doc_pusher {
+                let push_pusher = Arc::clone(pusher);
+                let push_event_bus = self.event_bus.clone();
+                let push_peer = peer_id;
+                let push_se_key = push_options.se_encryption_key;
+
+                tracing::info!(
+                    peer_id = %push_peer,
+                    new_collections = ?new_collection_names,
+                    "Replaying existing docs for new collections only"
+                );
+
+                tokio::spawn(async move {
+                    if let Err(error) = push_pusher
+                        .push_existing_docs(
+                            &push_peer,
+                            &new_collection_names,
+                            push_se_key.as_deref(),
+                        )
+                        .await
+                    {
+                        tracing::error!(error = %error, "Failed to push existing docs to replicator");
+                    }
+                    if let Some(bus) = push_event_bus {
+                        bus.publish(events::Message::replicator_completed());
+                    }
+                });
+            } else if let Some(ref bus) = self.event_bus {
+                bus.publish(events::Message::replicator_completed());
+            }
+        } else {
+            tracing::debug!(
+                peer_id = %peer_id,
+                "Replicator already exists with same collections, skipping initial replay"
+            );
+            if let Some(ref bus) = self.event_bus {
+                bus.publish(events::Message::replicator_completed());
+            }
         }
 
         Ok(())

--- a/crates/embedded/src/libp2p_adapter.rs
+++ b/crates/embedded/src/libp2p_adapter.rs
@@ -392,6 +392,37 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         }
 
         let peer_id = parsed.peer_id;
+
+        // Check existing replicator state before creating/updating so we can
+        // skip the expensive initial replay when the replicator already exists
+        // with the same collections (idempotent reconnect path).
+        let existing_collection_ids: HashSet<String> = {
+            let result = if let Some(ref coordinator) = self.sync_coordinator {
+                let transport_peer_id = p2p::transport::PeerId::from(peer_id);
+                coordinator
+                    .get_replicator(&transport_peer_id)
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                self.handle
+                    .get_replicator(peer_id)
+                    .await
+                    .map_err(|e| e.to_string())
+            };
+            match result {
+                Ok(Some(info)) => info.collections.into_iter().collect(),
+                Ok(None) => HashSet::new(),
+                Err(e) => {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Failed to check existing replicator state; falling back to full replay"
+                    );
+                    HashSet::new()
+                }
+            }
+        };
+
         self.handle
             .dial(peer_id, vec![parsed.transport_addr])
             .await
@@ -422,32 +453,56 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             }
         }
 
-        if let Some(ref pusher) = self.doc_pusher {
-            let push_handle = self.handle.clone();
-            let push_pusher = Arc::clone(pusher);
-            let push_event_bus = self.event_bus.clone();
-            let push_collections = effective_collections;
-            let push_se_key = push_options.se_encryption_key;
-            let push_identity = push_options.se_identity_pubkey;
-            tokio::spawn(async move {
-                if let Err(error) = push_pusher
-                    .push_existing_docs(
-                        &push_handle,
-                        peer_id,
-                        &push_collections,
-                        push_se_key.as_deref(),
-                        push_identity.as_deref(),
-                    )
-                    .await
-                {
-                    tracing::error!(error = %error, "Failed to push existing docs to replicator");
-                }
-                if let Some(bus) = push_event_bus {
-                    bus.publish(events::Message::replicator_completed());
-                }
-            });
-        } else if let Some(ref bus) = self.event_bus {
-            bus.publish(events::Message::replicator_completed());
+        // Only replay collections that weren't already replicated by this peer.
+        let new_collection_names: Vec<String> = effective_collections
+            .iter()
+            .zip(collection_cids.iter())
+            .filter(|(_, cid)| !existing_collection_ids.contains(*cid))
+            .map(|(name, _)| name.clone())
+            .collect();
+
+        if !new_collection_names.is_empty() {
+            if let Some(ref pusher) = self.doc_pusher {
+                let push_handle = self.handle.clone();
+                let push_pusher = Arc::clone(pusher);
+                let push_event_bus = self.event_bus.clone();
+                let push_se_key = push_options.se_encryption_key;
+                let push_identity = push_options.se_identity_pubkey;
+
+                tracing::info!(
+                    peer_id = %peer_id,
+                    new_collections = ?new_collection_names,
+                    "Replaying existing docs for new collections only"
+                );
+
+                tokio::spawn(async move {
+                    if let Err(error) = push_pusher
+                        .push_existing_docs(
+                            &push_handle,
+                            peer_id,
+                            &new_collection_names,
+                            push_se_key.as_deref(),
+                            push_identity.as_deref(),
+                        )
+                        .await
+                    {
+                        tracing::error!(error = %error, "Failed to push existing docs to replicator");
+                    }
+                    if let Some(bus) = push_event_bus {
+                        bus.publish(events::Message::replicator_completed());
+                    }
+                });
+            } else if let Some(ref bus) = self.event_bus {
+                bus.publish(events::Message::replicator_completed());
+            }
+        } else {
+            tracing::debug!(
+                peer_id = %peer_id,
+                "Replicator already exists with same collections, skipping initial replay"
+            );
+            if let Some(ref bus) = self.event_bus {
+                bus.publish(events::Message::replicator_completed());
+            }
         }
 
         Ok(())

--- a/tools/integration-test/tests/p2p.rs
+++ b/tools/integration-test/tests/p2p.rs
@@ -1,5 +1,7 @@
 #[path = "p2p/document.rs"]
 mod document;
+#[path = "p2p/idempotent_replay.rs"]
+mod idempotent_replay;
 #[path = "p2p/management.rs"]
 mod management;
 #[path = "p2p/replication.rs"]

--- a/tools/integration-test/tests/p2p/idempotent_replay.rs
+++ b/tools/integration-test/tests/p2p/idempotent_replay.rs
@@ -36,8 +36,12 @@ async fn idempotent_reconnect_test(cluster: TestCluster) {
 
     // Set up replicator (first time)
     node0.p2p_connect(&[&addr1]).expect("p2p_connect");
-    node0.p2p_collection_add(&["User"]).expect("collection add node0");
-    node1.p2p_collection_add(&["User"]).expect("collection add node1");
+    node0
+        .p2p_collection_add(&["User"])
+        .expect("collection add node0");
+    node1
+        .p2p_collection_add(&["User"])
+        .expect("collection add node1");
     node0
         .p2p_replicator_set(&["User"], &addr1)
         .expect("first replicator_set");
@@ -94,10 +98,7 @@ async fn idempotent_reconnect_test(cluster: TestCluster) {
     let users = final_result["User"].as_array().expect("User not array");
     assert_eq!(users.len(), 2, "expected 2 users on node1");
 
-    let names: Vec<&str> = users
-        .iter()
-        .map(|u| u["name"].as_str().unwrap())
-        .collect();
+    let names: Vec<&str> = users.iter().map(|u| u["name"].as_str().unwrap()).collect();
     assert!(names.contains(&"Alice"), "Alice missing from node1");
     assert!(names.contains(&"Bob"), "Bob missing from node1");
 }

--- a/tools/integration-test/tests/p2p/idempotent_replay.rs
+++ b/tools/integration-test/tests/p2p/idempotent_replay.rs
@@ -1,0 +1,105 @@
+use std::time::Duration;
+
+use integration_test::{for_each_p2p_topology, poll_until, TestCluster};
+
+/// Calling add_replicator twice with the same collections should be idempotent:
+/// the second call must succeed without error and live replication must continue
+/// working after the duplicate call.
+async fn idempotent_reconnect_test(cluster: TestCluster) {
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0
+        .schema_add("type User { name: String  age: Int }")
+        .expect("schema add node0");
+    node1
+        .schema_add("type User { name: String  age: Int }")
+        .expect("schema add node1");
+
+    let timeout = Duration::from_secs(15);
+    cluster
+        .wait_for_log(0, "p2p_listening", timeout)
+        .await
+        .expect("node0 P2P listener did not start");
+    cluster
+        .wait_for_log(1, "p2p_listening", timeout)
+        .await
+        .expect("node1 P2P listener did not start");
+
+    let info1 = node1.p2p_info().expect("p2p_info node1");
+    let addr1 = info1
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("node1 has no P2P address")
+        .to_string();
+
+    // Set up replicator (first time)
+    node0.p2p_connect(&[&addr1]).expect("p2p_connect");
+    node0.p2p_collection_add(&["User"]).expect("collection add node0");
+    node1.p2p_collection_add(&["User"]).expect("collection add node1");
+    node0
+        .p2p_replicator_set(&["User"], &addr1)
+        .expect("first replicator_set");
+
+    // Create doc and verify live replication works
+    node0
+        .query(r#"mutation { add_User(input: {name: "Alice", age: 30}) { _docID } }"#)
+        .expect("create Alice on node0");
+
+    let node1_ref = &node1;
+    poll_until(
+        || {
+            let result = node1_ref.query("query { User { name } }").unwrap();
+            result["User"]
+                .as_array()
+                .map(|arr| arr.len() == 1)
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "Alice did not replicate to node1",
+    )
+    .await;
+
+    // Call add_replicator AGAIN with the same collections (idempotent reconnect).
+    // This must not error, must not trigger a full replay storm, and must not
+    // break the existing replicator.
+    node0
+        .p2p_replicator_set(&["User"], &addr1)
+        .expect("second replicator_set (idempotent)");
+
+    // Create another document after the duplicate call
+    node0
+        .query(r#"mutation { add_User(input: {name: "Bob", age: 25}) { _docID } }"#)
+        .expect("create Bob on node0");
+
+    // Verify Bob arrives via live replication (proves the replicator still works)
+    poll_until(
+        || {
+            let result = node1_ref.query("query { User { name } }").unwrap();
+            result["User"]
+                .as_array()
+                .map(|arr| arr.len() == 2)
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "Bob did not replicate to node1 after idempotent replicator_set",
+    )
+    .await;
+
+    // Verify both documents have correct data
+    let final_result = node1.query("query { User { name age } }").unwrap();
+    let users = final_result["User"].as_array().expect("User not array");
+    assert_eq!(users.len(), 2, "expected 2 users on node1");
+
+    let names: Vec<&str> = users
+        .iter()
+        .map(|u| u["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"Alice"), "Alice missing from node1");
+    assert!(names.contains(&"Bob"), "Bob missing from node1");
+}
+
+for_each_p2p_topology!(idempotent_reconnect, idempotent_reconnect_test, .with_p2p());


### PR DESCRIPTION
## Summary

Addresses P2P replay storm issues that cause connection saturation on reconnect.

### Idempotent add_replicator (#590)

Before this change, every call to `add_replicator` unconditionally spawned `push_existing_docs`, replaying all documents to the peer. On reconnect paths that re-call `add_replicator`, this created a full data replay storm.

Now all four adapters check existing replicator state first:
- If the peer already replicates the same collections → skip replay entirely
- If new collections are added → replay only those new collections
- If `get_replicator` fails → log warning, fall back to full replay (never silently swallow)

**Adapters fixed:**
- `crates/cli/src/iroh_p2p_adapter.rs` (iroh CLI)
- `crates/embedded/src/iroh_adapter.rs` (iroh embedded/FFI)
- `crates/embedded/src/libp2p_adapter.rs` (libp2p embedded/FFI)
- `crates/cli/src/p2p_adapter.rs` (libp2p CLI)

### Bounded replay concurrency (#591)

The initial replay path in `push_existing_docs_via_transport` spawned one unbounded Tokio task per document, bypassing the coordinator's existing 32-task push semaphore. Now bounded by a dedicated 8-task semaphore (lower than live push since replay is background work).

### Error visibility improvements

- `get_replicator` errors during idempotency check are logged as warnings instead of silently falling back via `.ok()`
- Semaphore acquire failure logs an error instead of silently dropping document pushes
- Task panics in replay are logged instead of discarded by `let _ = jh.await`
- `connected_peers` errors in the replay wait loop are logged on first occurrence instead of silently swallowed by `unwrap_or_default()`

## Changes

| File | Change |
|------|--------|
| `crates/cli/src/iroh_p2p_adapter.rs` | Idempotent replay, error logging |
| `crates/cli/src/p2p_adapter.rs` | Idempotent replay, error logging |
| `crates/embedded/src/iroh_adapter.rs` | Idempotent replay, error logging |
| `crates/embedded/src/libp2p_adapter.rs` | Idempotent replay, error logging |
| `crates/db/src/push_docs_transport.rs` | Replay semaphore, error logging |
| `tools/integration-test/tests/p2p/idempotent_replay.rs` | New test |
| `tools/integration-test/tests/p2p.rs` | Register new test module |

## Test plan

- [x] `cargo test -p integration-test --test p2p` — 27 passed, 0 failed, 11 ignored
- [x] New `idempotent_reconnect` test passes all 3 topologies (rust-rust, go-go, go-rust)
- [x] `cargo clippy --all -- -D warnings` clean
- [ ] Functional testing with mobile/FFI client reconnect path

Closes #590
Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)