### PR TITLE
fix: return "collection not found" instead of "key not found" (#598)

### DIFF
--- a/crates/db/src/backup/export.rs
+++ b/crates/db/src/backup/export.rs
@@ -34,7 +34,7 @@ pub async fn export_database<S: Store>(
         for name in collections {
             if !all_names.contains(name) {
                 return Err(format!(
-                    "failed to get collection: key not found. Name: {}",
+                    "failed to get collection: collection not found. Name: {}",
                     name
                 ));
             }
@@ -48,7 +48,12 @@ pub async fn export_database<S: Store>(
         let col = database
             .get_collection(name)
             .map_err(|e| format!("failed to get collection '{}': {}", name, e))?
-            .ok_or_else(|| format!("failed to get collection: key not found. Name: {}", name))?;
+            .ok_or_else(|| {
+                format!(
+                    "failed to get collection: collection not found. Name: {}",
+                    name
+                )
+            })?;
         name_cid_pairs.push((name.clone(), col.schema().collection_id.clone()));
     }
     name_cid_pairs.sort_by(|a, b| a.1.cmp(&b.1));
@@ -75,7 +80,12 @@ pub async fn export_database<S: Store>(
         let collection = database
             .get_collection(name)
             .map_err(|e| format!("failed to get collection '{}': {}", name, e))?
-            .ok_or_else(|| format!("failed to get collection: key not found. Name: {}", name))?;
+            .ok_or_else(|| {
+                format!(
+                    "failed to get collection: collection not found. Name: {}",
+                    name
+                )
+            })?;
 
         let schema = collection.schema().clone();
         let fields = classify_schema_fields(&schema);

--- a/crates/db/src/backup/import.rs
+++ b/crates/db/src/backup/import.rs
@@ -53,7 +53,7 @@ pub async fn import_database<S: Store>(
             .map_err(|e| format!("failed to get collection: {}", e))?
             .ok_or_else(|| {
                 format!(
-                    "failed to get collection: key not found. Name: {}",
+                    "failed to get collection: collection not found. Name: {}",
                     collection_name
                 )
             })?;

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     #[error("collection '{0}' not found")]
     CollectionNotFound(String),
 
-    #[error("key not found. collection version: {0}")]
+    #[error("collection not found. collection version: {0}")]
     CollectionVersionNotFound(String),
 
     #[error("collection version ID can't be empty")]


### PR DESCRIPTION
## Summary

- Changes error messages from generic "key not found" to "collection not found" for clarity
- CLI already returns proper errors (not help text) — no CLI changes needed
- HTTP already maps `CollectionNotFound` to 404 — no HTTP changes needed
- Ports Go DefraDB PR #4592

Closes #598

## Test plan

- [x] `cargo test -p db` passes
- [x] `cargo clippy --all -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)