### PR TITLE
feat(query): accept arrays of CIDs in GraphQL queries (#599)

### DIFF
--- a/crates/query/src/mapper/types.rs
+++ b/crates/query/src/mapper/types.rs
@@ -424,7 +424,7 @@ pub struct Select {
     /// Document ID filter
     pub doc_ids: Option<Vec<String>>,
     /// CID filter (for versioned queries)
-    pub cid: Option<String>,
+    pub cid: Option<Vec<String>>,
     /// Depth for commits queries (how deep to traverse the DAG)
     pub depth: Option<u64>,
     /// Whether to include deleted documents
@@ -533,7 +533,7 @@ impl Select {
 
     /// Set CID filter
     pub fn with_cid(mut self, cid: String) -> Self {
-        self.cid = Some(cid);
+        self.cid = Some(vec![cid]);
         self
     }
 

--- a/crates/query/src/query_parse/parser.rs
+++ b/crates/query/src/query_parse/parser.rs
@@ -606,8 +606,13 @@ fn parse_field_to_select(
             "cid" => {
                 // null means "no cid filter" (skip setting it)
                 if !matches!(arg_value, Value::Null) {
-                    let cid_val = resolve_string_value(arg_value, variables, "cid")?;
-                    select.cid = Some(cid_val);
+                    let cids = parse_cid_value(arg_value, variables)?;
+                    if cids.len() > 1 {
+                        return Err(QueryError::parse(
+                            "querying by multiple cids is not yet supported",
+                        ));
+                    }
+                    select.cid = Some(cids);
                 }
             }
             "showDeleted" => {
@@ -1123,6 +1128,73 @@ pub(super) fn parse_doc_ids_value(
             }
         }
         _ => Err(QueryError::parse("docIDs must be a string or list")),
+    }
+}
+
+/// Parse cid argument into vector of strings.
+///
+/// Accepts `[String!]` (array) or a single `String` (wrapped into a vec).
+fn parse_cid_value(
+    value: &Value<'_, String>,
+    variables: Option<&HashMap<String, JsonValue>>,
+) -> Result<Vec<String>> {
+    match value {
+        Value::List(items) => {
+            let cids: Result<Vec<String>> = items
+                .iter()
+                .map(|v| match v {
+                    Value::String(s) => Ok(s.clone()),
+                    Value::Variable(name) => {
+                        let vars = variables.ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "variable '{}' used but no variables provided",
+                                name
+                            ))
+                        })?;
+                        let json_val = vars.get(name).ok_or_else(|| {
+                            QueryError::parse(format!("Variable \"${}\" was not provided", name))
+                        })?;
+                        json_val.as_str().map(|s| s.to_string()).ok_or_else(|| {
+                            QueryError::parse(format!(
+                                "Variable \"${}\" must be of type String",
+                                name
+                            ))
+                        })
+                    }
+                    _ => Err(QueryError::parse("cid items must be strings")),
+                })
+                .collect();
+            cids
+        }
+        Value::String(s) => Ok(vec![s.clone()]),
+        Value::Variable(name) => {
+            let vars = variables.ok_or_else(|| {
+                QueryError::parse(format!(
+                    "variable '{}' used but no variables provided",
+                    name
+                ))
+            })?;
+            let json_val = vars.get(name).ok_or_else(|| {
+                QueryError::parse(format!("Variable \"${}\" was not provided", name))
+            })?;
+            if let Some(s) = json_val.as_str() {
+                Ok(vec![s.to_string()])
+            } else if let Some(arr) = json_val.as_array() {
+                arr.iter()
+                    .map(|v| {
+                        v.as_str()
+                            .map(|s| s.to_string())
+                            .ok_or_else(|| QueryError::parse("cid items must be strings"))
+                    })
+                    .collect()
+            } else {
+                Err(QueryError::parse(format!(
+                    "Variable \"${}\" must be of type String or [String]",
+                    name
+                )))
+            }
+        }
+        _ => Err(QueryError::parse("cid must be a string or list")),
     }
 }
 

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -985,7 +985,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Build options from the select
         let options = CommitsQueryOptions {
             doc_id: select.doc_ids.as_ref().and_then(|ids| ids.first().cloned()),
-            cid: select.cid.clone(),
+            cid: select.cid.as_ref().and_then(|cids| cids.first().cloned()),
             depth: select.depth,
             height_start: match &height_range {
                 HeightRangeExtraction::Range(range) => Some(range.start),

--- a/crates/query/src/runner/explain/select.rs
+++ b/crates/query/src/runner/explain/select.rs
@@ -245,8 +245,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let mut dag_scan_attrs = serde_json::Map::new();
 
         // cid: the specific commit CID if provided, else null
-        if let Some(ref cid) = select.cid {
-            dag_scan_attrs.insert("cid".to_string(), serde_json::json!(cid));
+        if let Some(ref cids) = select.cid {
+            dag_scan_attrs.insert("cid".to_string(), serde_json::json!(cids));
         } else {
             dag_scan_attrs.insert("cid".to_string(), serde_json::Value::Null);
         }

--- a/crates/query/src/runner/introspection/collection.rs
+++ b/crates/query/src/runner/introspection/collection.rs
@@ -251,7 +251,7 @@ pub(super) fn build_commit_type() -> Object {
 
     fn with_commit_link_args(field: Field) -> Field {
         field
-            .argument(InputValue::new("cid", TypeRef::named("ID")))
+            .argument(InputValue::new("cid", TypeRef::named_nn_list("ID")))
             .argument(InputValue::new("docID", TypeRef::named_nn_list("ID")))
             .argument(InputValue::new(
                 "filter",

--- a/crates/query/src/runner/introspection/mod.rs
+++ b/crates/query/src/runner/introspection/mod.rs
@@ -122,7 +122,7 @@ pub fn build_introspection_schema(
                 TypeRef::named_nn_list_nn(&collection.name),
                 move |_ctx| FieldFuture::new(async move { Ok(Some(GqlValue::List(vec![]))) }),
             )
-            .argument(InputValue::new("cid", TypeRef::named("String")))
+            .argument(InputValue::new("cid", TypeRef::named_nn_list("ID")))
             .argument(InputValue::new("docID", TypeRef::named_nn_list("ID")))
             .argument(InputValue::new(
                 "filter",
@@ -159,7 +159,7 @@ pub fn build_introspection_schema(
         Field::new("_commits", TypeRef::named_list("Commit"), |_| {
             FieldFuture::new(async { Ok(Some(GqlValue::List(vec![]))) })
         })
-        .argument(InputValue::new("cid", TypeRef::named("ID")))
+        .argument(InputValue::new("cid", TypeRef::named_nn_list("ID")))
         .argument(InputValue::new("depth", TypeRef::named("Int")))
         .argument(InputValue::new("docID", TypeRef::named_nn_list("ID")))
         .argument(InputValue::new(

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -35,8 +35,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         caller_identity: Option<Did>,
         version_selection: Option<&Select>,
     ) -> Result<JsonValue> {
-        let cid = select.cid.as_ref().ok_or_else(|| {
+        let cids = select.cid.as_ref().ok_or_else(|| {
             QueryError::internal("execute_cid_query called without CID - this is a bug")
+        })?;
+        let cid = cids.first().ok_or_else(|| {
+            QueryError::internal("execute_cid_query called with empty CID array - this is a bug")
         })?;
 
         // Get expected docID from select.doc_ids (optional validation)

--- a/crates/query/src/subscription.rs
+++ b/crates/query/src/subscription.rs
@@ -99,7 +99,7 @@ pub fn is_commits_subscription(query: &str) -> bool {
 /// Convert a _commits subscription to a query scoped to a specific CID.
 ///
 /// Transforms: `subscription { _commits(docID: "...") { fields } }`
-/// Into: `{ _commits(cid: "bafyrei-xxx") { fields } }`
+/// Into: `{ _commits(cid: ["bafyrei-xxx"]) { fields } }`
 pub fn subscription_to_commits_query_with_cid(subscription_query: &str, cid: &str) -> String {
     // Step 1: Remove "subscription" keyword
     let trimmed = subscription_query.trim_start();
@@ -152,14 +152,14 @@ pub fn subscription_to_commits_query_with_cid(subscription_query: &str, cid: &st
             }
         }
         format!(
-            "{}(cid: \"{}\"){}",
+            "{}(cid: [\"{}\"]){}",
             &query[..paren_start_abs],
             cid,
             &query[close_paren_abs + 1..]
         )
     } else {
         format!(
-            "{}(cid: \"{}\"){}",
+            "{}(cid: [\"{}\"]){}",
             &query[..after_field],
             cid,
             &query[after_field..]

--- a/crates/query/tests/query_parse_tests.rs
+++ b/crates/query/tests/query_parse_tests.rs
@@ -405,7 +405,7 @@ fn test_parse_cid_wrong_type_returns_error() {
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("cid argument must be a string"));
+        .contains("cid must be a string or list"));
 }
 
 #[test]

--- a/tools/integration-test/tests/acp/audit.rs
+++ b/tools/integration-test/tests/acp/audit.rs
@@ -101,7 +101,7 @@ async fn cid_time_travel_acp_bypass_test(cluster: TestCluster) {
     let alice_cid_result = node
         .query_with_identity(
             &format!(
-                r#"query {{ User(cid: "{}") {{ _docID name age }} }}"#,
+                r#"query {{ User(cid: ["{}"])  {{ _docID name age }} }}"#,
                 historical_cid
             ),
             &alice.private_key_hex,
@@ -120,7 +120,7 @@ async fn cid_time_travel_acp_bypass_test(cluster: TestCluster) {
     let bob_cid_result = node
         .query_with_identity(
             &format!(
-                r#"query {{ User(cid: "{}") {{ _docID name age }} }}"#,
+                r#"query {{ User(cid: ["{}"])  {{ _docID name age }} }}"#,
                 historical_cid
             ),
             &bob.private_key_hex,
@@ -161,7 +161,7 @@ async fn cid_time_travel_acp_bypass_test(cluster: TestCluster) {
     let bob_cid_after_grant = node
         .query_with_identity(
             &format!(
-                r#"query {{ User(cid: "{}") {{ _docID name age }} }}"#,
+                r#"query {{ User(cid: ["{}"])  {{ _docID name age }} }}"#,
                 historical_cid
             ),
             &bob.private_key_hex,


### PR DESCRIPTION
## Summary

- Changes GraphQL `cid` argument type from `String`/`ID` to `[ID!]` (array)
- Accepts both single string and array syntax for backward compat
- Returns error if more than one CID provided (matching Go behavior — multi-CID not yet implemented)
- Updates introspection schema, parser, commits, version queries, explain, and subscriptions
- Ports Go DefraDB PR #4571

Closes #599

## Test plan

- [x] 444 query crate tests pass
- [x] `cargo clippy --all -- -D warnings` clean
- [x] Updated integration test assertions for array CID syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)