### PR TITLE
fix(txn): transaction-scoped schema resolution and HTTP schema-in-txn endpoint (#594)

### DIFF
--- a/crates/cli/src/txn_adapter.rs
+++ b/crates/cli/src/txn_adapter.rs
@@ -66,4 +66,26 @@ impl<S: Store + 'static> TransactionOperations for TxnRegistryAdapter<S> {
         .await
         .map_err(|e| format!("task join error: {}", e))?
     }
+
+    async fn add_schema_in_txn(
+        &self,
+        txn_id: &str,
+        sdl: &str,
+    ) -> Result<Vec<schema::CollectionVersion>, String> {
+        let registry = self.registry.clone();
+        let txn_id = txn_id.to_string();
+        let sdl = sdl.to_string();
+        let handle = tokio::runtime::Handle::current();
+
+        tokio::task::spawn_blocking(move || {
+            handle.block_on(async {
+                registry
+                    .add_schema_in_txn(&txn_id, &sdl)
+                    .await
+                    .map_err(|e| format!("{}", e))
+            })
+        })
+        .await
+        .map_err(|e| format!("task join error: {}", e))?
+    }
 }

--- a/crates/db/src/collection_provider.rs
+++ b/crates/db/src/collection_provider.rs
@@ -1,16 +1,23 @@
-//! CollectionProvider implementation for the database.
+//! CollectionProvider implementations for the database.
 //!
 //! This module implements the `CollectionProvider` trait from the query crate,
 //! enabling on-demand collection resolution from the database at query time.
+//!
+//! Two providers are available:
+//! - `DbCollectionProvider`: reads from the process-wide collection cache
+//! - `TxnCollectionProvider`: reads from a transaction's systemstore first,
+//!   falling back to the process-wide cache for schemas not yet in the transaction
 
+use async_lock::Mutex as AsyncMutex;
 use async_trait::async_trait;
 use query::error::{QueryError, Result as QueryResult};
 use query::fetcher::CollectionProvider;
 use schema::CollectionVersion;
 use std::sync::Arc;
-use storage::corekv::Store;
+use storage::corekv::{Key, Store};
 
 use crate::database::DB;
+use crate::txn::DbTxn;
 
 /// Wrapper around Arc<DB> that implements CollectionProvider.
 ///
@@ -47,5 +54,113 @@ impl<S: Store + 'static> CollectionProvider for DbCollectionProvider<S> {
         self.db
             .list_collections()
             .map_err(|e| QueryError::execution(e.to_string()))
+    }
+}
+
+/// Transaction-aware collection provider.
+///
+/// Reads from the transaction's systemstore first (which includes uncommitted
+/// writes like newly added schemas), then falls back to the process-wide cache.
+pub struct TxnCollectionProvider<S: Store + 'static> {
+    db: Arc<DB<S>>,
+    shared_txn: Arc<AsyncMutex<Option<DbTxn<S>>>>,
+}
+
+impl<S: Store + 'static> TxnCollectionProvider<S> {
+    /// Create a new transaction-aware collection provider.
+    pub fn new(db: Arc<DB<S>>, shared_txn: Arc<AsyncMutex<Option<DbTxn<S>>>>) -> Self {
+        Self { db, shared_txn }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<S: Store + 'static> CollectionProvider for TxnCollectionProvider<S> {
+    async fn get_collection(&self, name: &str) -> QueryResult<Option<Arc<CollectionVersion>>> {
+        let txn_guard = self.shared_txn.lock().await;
+        if let Some(txn) = txn_guard.as_ref() {
+            let systemstore = txn
+                .systemstore()
+                .map_err(|e| QueryError::execution(e.to_string()))?;
+
+            let name_key = storage::keys::systemstore::CollectionNameKey::new(name);
+            let maybe_version_id = systemstore
+                .get(&name_key.bytes())
+                .await
+                .map_err(|e| QueryError::execution(e.to_string()))?;
+
+            if let Some(data) = maybe_version_id {
+                let version_id = match String::from_utf8(data.clone()) {
+                    Ok(vid) if !vid.starts_with('{') => vid,
+                    _ => {
+                        let schema: CollectionVersion = serde_json::from_slice(&data)
+                            .map_err(|e| QueryError::execution(e.to_string()))?;
+                        return Ok(Some(Arc::new(schema)));
+                    }
+                };
+
+                let collection_key = storage::keys::systemstore::CollectionKey::new(&version_id);
+                if let Some(data) = systemstore
+                    .get(&collection_key.bytes())
+                    .await
+                    .map_err(|e| QueryError::execution(e.to_string()))?
+                {
+                    let schema: CollectionVersion = serde_json::from_slice(&data)
+                        .map_err(|e| QueryError::execution(e.to_string()))?;
+                    return Ok(Some(Arc::new(schema)));
+                }
+            }
+        }
+        drop(txn_guard);
+
+        match self.db.get_collection(name) {
+            Ok(Some(coll)) => Ok(Some(Arc::new(coll.schema().clone()))),
+            Ok(None) => Ok(None),
+            Err(e) => Err(QueryError::execution(e.to_string())),
+        }
+    }
+
+    async fn list_collections(&self) -> QueryResult<Vec<String>> {
+        let mut names: std::collections::HashSet<String> = self
+            .db
+            .list_collections()
+            .map_err(|e| QueryError::execution(e.to_string()))?
+            .into_iter()
+            .collect();
+
+        let txn_guard = self.shared_txn.lock().await;
+        if let Some(txn) = txn_guard.as_ref() {
+            let systemstore = txn
+                .systemstore()
+                .map_err(|e| QueryError::execution(e.to_string()))?;
+
+            let prefix = storage::keys::systemstore::CollectionNameKey::name_prefix();
+            let opts = storage::corekv::IterOptions::new().with_prefix(prefix.clone());
+            let mut iter = systemstore
+                .iterator(opts)
+                .await
+                .map_err(|e| QueryError::execution(e.to_string()))?;
+
+            let prefix_str =
+                String::from_utf8(prefix).map_err(|e| QueryError::execution(e.to_string()))?;
+
+            while let Some(pair) = iter
+                .next()
+                .await
+                .map_err(|e| QueryError::execution(e.to_string()))?
+            {
+                if let Ok(key_str) = String::from_utf8(pair.key.to_vec()) {
+                    if let Some(name) = key_str.strip_prefix(&prefix_str) {
+                        names.insert(name.to_string());
+                    }
+                }
+            }
+
+            iter.close()
+                .await
+                .map_err(|e| QueryError::execution(e.to_string()))?;
+        }
+
+        Ok(names.into_iter().collect())
     }
 }

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -1,5 +1,6 @@
 //! Transaction context for query execution.
 
+use query::fetcher::CollectionProvider;
 use query::mutator::DocMutator;
 use query::runner::DocFetcher;
 use query::txn::TransactionContext;
@@ -7,6 +8,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use storage::corekv::Store;
 
+use crate::collection_provider::TxnCollectionProvider;
 use crate::database::DB;
 use crate::doc_mutator::DbDocMutator;
 use crate::lensed_fetcher::LensedDocFetcher;
@@ -111,5 +113,12 @@ impl<S: Store + 'static> TransactionContext for DbTransactionContext<S> {
         } else {
             Some(self.doc_mutator())
         }
+    }
+
+    fn collection_provider(&self) -> Option<Arc<dyn CollectionProvider>> {
+        Some(Arc::new(TxnCollectionProvider::new(
+            self.db.clone(),
+            self.fetcher.shared_txn(),
+        )))
     }
 }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -277,6 +277,57 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         self.db.set_migration_in_txn(txn, config).await
     }
 
+    /// Add a schema within an existing transaction.
+    ///
+    /// Parses the SDL and creates collections within the transaction.
+    /// The collections are only visible after the transaction is committed,
+    /// but can be used by queries within the same transaction.
+    pub async fn add_schema_in_txn(
+        &self,
+        txn_id: &str,
+        sdl: &str,
+    ) -> Result<Vec<schema::CollectionVersion>> {
+        let ctx = self
+            .get_ctx(txn_id)?
+            .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+
+        let shared_txn = ctx.fetcher_shared_txn();
+        let mut txn_guard = shared_txn.lock().await;
+        let txn = txn_guard.as_mut().ok_or(Error::TxnNotActive)?;
+
+        let known_types: std::collections::HashSet<String> = self
+            .db
+            .list_collections()
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+
+        let collections = query::parse_sdl_with_known_types(sdl, known_types)
+            .map_err(|e| Error::Other(format!("failed to parse SDL: {}", e)))?;
+
+        crate::definition_validation::validate_new_collections(&collections)
+            .map_err(|e| Error::Other(format!("failed to validate schema: {}", e)))?;
+
+        let mut finalized = Vec::new();
+        for collection in collections {
+            let schema = self.db.create_collection_with_txn(txn, collection).await?;
+            finalized.push(schema);
+        }
+
+        // Register on_success callback to update the process-wide cache after commit
+        let db = self.db.clone();
+        let schemas_for_cache = finalized.clone();
+        txn.on_success(Box::new(move || {
+            if let Ok(mut cache) = db.collections.write() {
+                for schema in &schemas_for_cache {
+                    cache.insert(schema.name.clone(), Collection::new(schema.clone()));
+                }
+            }
+        }))?;
+
+        Ok(finalized)
+    }
+
     /// Get all collection versions visible within a transaction.
     ///
     /// This reads from the transaction's systemstore, which includes both

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -298,7 +298,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let known_types: std::collections::HashSet<String> = self
             .db
             .list_collections()
-            .unwrap_or_default()
+            .map_err(|e| Error::Other(format!("failed to list collections: {}", e)))?
             .into_iter()
             .collect();
 

--- a/crates/http/src/handlers/txn_ops.rs
+++ b/crates/http/src/handlers/txn_ops.rs
@@ -47,7 +47,7 @@ pub async fn set_migration_in_txn(
 
     let txn_ops = state.require_txn_ops()?;
 
-    let txn_id = format!("txn-{}", params.id);
+    let txn_id = params.id.clone();
 
     let transform_id = txn_ops
         .set_migration_in_txn(&txn_id, &body.config)
@@ -74,10 +74,42 @@ pub async fn get_collections_in_txn(
 
     let txn_ops = state.require_txn_ops()?;
 
-    let txn_id = format!("txn-{}", params.id);
+    let txn_id = params.id.clone();
 
     let collections = txn_ops
         .get_collections_in_txn(&txn_id)
+        .await
+        .map_err(HttpError::BadRequest)?;
+
+    Ok(Json(collections))
+}
+
+/// Add a schema within an existing transaction.
+///
+/// POST /api/v0/tx/{id}/schema
+///
+/// Body: SDL text (text/plain)
+/// Returns: Array of created CollectionVersions
+///
+/// The collections are created within the transaction and only become
+/// visible globally after the transaction is committed. Queries within
+/// the same transaction can use the new collections immediately.
+///
+/// Requires `CollectionPatch` permission when NAC is enabled.
+pub async fn add_schema_in_txn(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Path(params): Path<TxnPathParam>,
+    body: String,
+) -> Result<Json<Vec<schema::CollectionVersion>>, HttpError> {
+    require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
+
+    let txn_ops = state.require_txn_ops()?;
+
+    let txn_id = params.id.clone();
+
+    let collections = txn_ops
+        .add_schema_in_txn(&txn_id, &body)
         .await
         .map_err(HttpError::BadRequest)?;
 

--- a/crates/http/src/mock/txn_ops.rs
+++ b/crates/http/src/mock/txn_ops.rs
@@ -36,4 +36,12 @@ impl TransactionOperations for MockTransactionOperations {
     ) -> Result<Vec<schema::CollectionVersion>, String> {
         Ok(vec![mock_collection_version("MockCollection")])
     }
+
+    async fn add_schema_in_txn(
+        &self,
+        _txn_id: &str,
+        _sdl: &str,
+    ) -> Result<Vec<schema::CollectionVersion>, String> {
+        Ok(vec![mock_collection_version("MockCollection")])
+    }
 }

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -62,6 +62,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         "/api/v0/tx/:id" => RoutePermission::IdentityOnly,
         "/api/v0/tx/:id/lens" => RoutePermission::Required(NodePermission::CollectionPatch),
         "/api/v0/tx/:id/collections" => RoutePermission::Required(NodePermission::CollectionGet),
+        "/api/v0/tx/:id/schema" => RoutePermission::Required(NodePermission::CollectionPatch),
 
         // =====================================================================
         // Collections
@@ -497,6 +498,11 @@ mod tests {
                 "/api/v0/tx/:id/collections",
                 Method::GET,
                 RoutePermission::Required(NodePermission::CollectionGet),
+            ),
+            (
+                "/api/v0/tx/:id/schema",
+                Method::POST,
+                RoutePermission::Required(NodePermission::CollectionPatch),
             ),
             // Collections
             (

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -53,7 +53,8 @@ pub fn create_router_with_state(state: AppState) -> Router {
         .route(
             "/:id/collections",
             get(handlers::txn_ops::get_collections_in_txn),
-        );
+        )
+        .route("/:id/schema", post(handlers::txn_ops::add_schema_in_txn));
 
     // Collection routes (REST API)
     // Static routes must come before parametric `:name` routes

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -574,7 +574,8 @@ pub trait BackupOperations: Send + Sync {
 /// Trait for transaction-scoped operations.
 ///
 /// Provides access to operations that must execute within an existing transaction,
-/// such as setting migrations or reading collection versions including uncommitted writes.
+/// such as setting migrations, adding schemas, or reading collection versions
+/// including uncommitted writes.
 #[async_trait::async_trait]
 pub trait TransactionOperations: Send + Sync {
     /// Set a migration within an existing transaction.
@@ -591,6 +592,17 @@ pub trait TransactionOperations: Send + Sync {
     async fn get_collections_in_txn(
         &self,
         txn_id: &str,
+    ) -> Result<Vec<schema::CollectionVersion>, String>;
+
+    /// Add a schema within an existing transaction.
+    ///
+    /// Parses the SDL and creates collections within the transaction.
+    /// The collections are only visible after the transaction is committed,
+    /// but can be used by queries within the same transaction.
+    async fn add_schema_in_txn(
+        &self,
+        txn_id: &str,
+        sdl: &str,
     ) -> Result<Vec<schema::CollectionVersion>, String>;
 }
 

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -278,6 +278,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         // Resolve effective identity: request identity takes precedence over default
         let identity = self.resolve_identity(request.identity);
 
+        // Get transaction-scoped collection provider if available
+        let txn_provider = txn_ctx.collection_provider();
+
         // Route to appropriate handler based on operation type
         let execution = async {
             match parsed {
@@ -346,7 +349,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             }
         };
 
-        let result = await_with_timeout(execution, self.query_timeout).await;
+        // If the transaction provides a collection provider, set it as the task-local
+        // override so all collection resolution within this execution uses the
+        // transaction's uncommitted state.
+        let result = if let Some(provider) = txn_provider {
+            super::TXN_COLLECTION_PROVIDER
+                .scope(provider, await_with_timeout(execution, self.query_timeout))
+                .await
+        } else {
+            await_with_timeout(execution, self.query_timeout).await
+        };
 
         match result {
             Ok(data) => QueryResponse {

--- a/crates/query/src/runner/explain/execute.rs
+++ b/crates/query/src/runner/explain/execute.rs
@@ -148,7 +148,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         // Get collection schema
         let collection = self
-            .collection_provider
+            .effective_provider()
             .get_collection(&select.collection_name)
             .await?
             .ok_or_else(|| QueryError::collection_not_found(&select.collection_name))?;

--- a/crates/query/src/runner/explain/mutation.rs
+++ b/crates/query/src/runner/explain/mutation.rs
@@ -346,7 +346,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Build the inner select plan explanation
         // Mutations in Go have: mutationNode -> selectTopNode -> selectNode -> scanNode
         let collection = self
-            .collection_provider
+            .effective_provider()
             .get_collection(&mutation.collection_name)
             .await?
             .ok_or_else(|| QueryError::collection_not_found(&mutation.collection_name))?;

--- a/crates/query/src/runner/explain/select.rs
+++ b/crates/query/src/runner/explain/select.rs
@@ -37,7 +37,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         // Get collection schema
         let collection = self
-            .collection_provider
+            .effective_provider()
             .get_collection(&select.collection_name)
             .await?
             .ok_or_else(|| QueryError::collection_not_found(&select.collection_name))?;
@@ -147,10 +147,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         explain_type: ExplainType,
     ) -> Result<JsonValue> {
         // Build the plan using the Planner
-        let collection_names = self.collection_provider.list_collections().await?;
+        let provider = self.effective_provider();
+        let collection_names = provider.list_collections().await?;
         let mut collections = Vec::new();
         for name in collection_names {
-            if let Some(coll) = self.collection_provider.get_collection(&name).await? {
+            if let Some(coll) = provider.get_collection(&name).await? {
                 collections.push((*coll).clone());
             }
         }

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -48,6 +48,14 @@ use crate::mutator::DocMutator;
 use crate::planner::Doc;
 use crate::txn::{NoOpTransactionRegistry, TransactionRegistry};
 
+tokio::task_local! {
+    /// Per-request collection provider override for transaction-scoped schema resolution.
+    ///
+    /// When a query executes within a transaction that has uncommitted schema changes,
+    /// this is set to a transaction-aware provider so `get_collection()` sees the new schemas.
+    static TXN_COLLECTION_PROVIDER: Arc<dyn CollectionProvider>;
+}
+
 // Re-export for backwards compatibility
 pub use crate::fetcher::{DocFetcher, FetchByIdsResult, IndexScanResult};
 
@@ -259,11 +267,21 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         request_identity.or_else(|| self.default_identity.clone())
     }
 
+    /// Get the effective collection provider.
+    ///
+    /// Returns the transaction-scoped provider if set (via task-local storage),
+    /// otherwise returns the default process-wide provider.
+    fn effective_provider(&self) -> Arc<dyn CollectionProvider> {
+        TXN_COLLECTION_PROVIDER
+            .try_with(|p| p.clone())
+            .unwrap_or_else(|_| self.collection_provider.clone())
+    }
+
     /// Get the names of all collections.
     ///
     /// Returns a sorted list of collection names registered with this runner.
     pub async fn collection_names(&self) -> Result<Vec<String>> {
-        let mut names = self.collection_provider.list_collections().await?;
+        let mut names = self.effective_provider().list_collections().await?;
         names.sort();
         Ok(names)
     }
@@ -271,7 +289,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Check if a collection exists.
     pub async fn has_collection(&self, name: &str) -> Result<bool> {
         Ok(self
-            .collection_provider
+            .effective_provider()
             .get_collection(name)
             .await?
             .is_some())
@@ -281,7 +299,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     ///
     /// Returns the collection schema or an error if not found.
     pub(crate) async fn get_collection(&self, name: &str) -> Result<Arc<CollectionVersion>> {
-        self.collection_provider
+        self.effective_provider()
             .get_collection(name)
             .await?
             .ok_or_else(|| QueryError::collection_not_found(name))
@@ -292,10 +310,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// This is used internally for plan building which requires access to multiple
     /// collection schemas simultaneously (e.g., for joins).
     pub(crate) async fn collections_map(&self) -> Result<HashMap<String, Arc<CollectionVersion>>> {
-        let names = self.collection_provider.list_collections().await?;
+        let provider = self.effective_provider();
+        let names = provider.list_collections().await?;
         let mut map = HashMap::new();
         for name in names {
-            if let Some(coll) = self.collection_provider.get_collection(&name).await? {
+            if let Some(coll) = provider.get_collection(&name).await? {
                 map.insert(name, coll);
             }
         }
@@ -312,11 +331,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Introspection queries are executed against a dynamically generated GraphQL
     /// schema based on the current collections, rather than against document storage.
     pub(crate) async fn execute_introspection(&self, query: &str) -> Result<JsonValue> {
-        // Get all collections for schema generation
-        let collections = self.collection_provider.list_collections().await?;
+        let provider = self.effective_provider();
+        let collections = provider.list_collections().await?;
         let mut collection_versions = Vec::new();
         for name in collections {
-            if let Some(coll) = self.collection_provider.get_collection(&name).await? {
+            if let Some(coll) = provider.get_collection(&name).await? {
                 collection_versions.push((*coll).clone());
             }
         }

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -377,15 +377,17 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let field = parent_collection.field_by_name(relation_field_name)?;
         let target_id = field.kind.relation_collection_id()?;
 
+        let provider = self.effective_provider();
+
         // For Named fields, target_id is the collection name directly
-        if let Ok(Some(coll)) = self.collection_provider.get_collection(target_id).await {
+        if let Ok(Some(coll)) = provider.get_collection(target_id).await {
             return Some(coll.name.clone());
         }
 
         // For Relation fields, target_id is a collection_id/version_id — search by ID
-        if let Ok(names) = self.collection_provider.list_collections().await {
+        if let Ok(names) = provider.list_collections().await {
             for name in names {
-                if let Ok(Some(coll)) = self.collection_provider.get_collection(&name).await {
+                if let Ok(Some(coll)) = provider.get_collection(&name).await {
                     if coll.collection_id == target_id || coll.version_id == target_id {
                         return Some(coll.name.clone());
                     }

--- a/crates/query/src/txn/context.rs
+++ b/crates/query/src/txn/context.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use storage::corekv::MaybeSendSync;
 
+use crate::fetcher::CollectionProvider;
 use crate::mutator::DocMutator;
 use crate::runner::DocFetcher;
 
@@ -28,6 +29,15 @@ pub trait TransactionContext: MaybeSendSync {
     /// The mutator shares the same underlying transaction as the fetcher,
     /// so all read and write operations are within the same transaction context.
     fn doc_mutator(&self) -> Option<Arc<dyn DocMutator>> {
+        None
+    }
+
+    /// Get a collection provider scoped to this transaction.
+    ///
+    /// Returns `None` by default. Implementations that support transaction-scoped
+    /// schema resolution should override this to return a provider that reads
+    /// from the transaction's uncommitted state (falling back to the process-wide cache).
+    fn collection_provider(&self) -> Option<Arc<dyn CollectionProvider>> {
         None
     }
 

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -1,5 +1,80 @@
 use integration_test::{for_each_runtime, TestCluster};
 
+async fn txn_schema_add_and_mutate(cluster: TestCluster) {
+    let client = cluster.client(0);
+    let api_url = cluster.api_url(0);
+
+    // 1. Create a transaction
+    let tx_id = client.tx_create().expect("tx_create failed");
+
+    // 2. Add a schema within the transaction via HTTP
+    let http_client = reqwest::Client::new();
+    let resp = http_client
+        .post(format!("{}/api/v0/tx/{}/schema", api_url, tx_id))
+        .body("type Widget { name: String  weight: Int }")
+        .send()
+        .await
+        .expect("schema add in txn request failed");
+    assert!(
+        resp.status().is_success(),
+        "schema add in txn failed with status: {} body: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+
+    // 3. Run a mutation on the new collection within the same transaction
+    let create_result = client
+        .query_with_tx(
+            r#"mutation { add_Widget(input: {name: "Sprocket", weight: 42}) { _docID name weight } }"#,
+            &tx_id,
+        )
+        .expect("create Widget in tx");
+    let widget_id = create_result["add_Widget"][0]["_docID"]
+        .as_str()
+        .expect("missing Widget _docID");
+    assert!(!widget_id.is_empty(), "Widget _docID should be non-empty");
+    assert_eq!(create_result["add_Widget"][0]["name"], "Sprocket");
+    assert_eq!(create_result["add_Widget"][0]["weight"], 42);
+
+    // 4. Query within the same transaction to verify the data is visible
+    let query_result = client
+        .query_with_tx("query { Widget { name weight } }", &tx_id)
+        .expect("query Widget in tx");
+    let widgets = query_result["Widget"]
+        .as_array()
+        .expect("Widget result not array");
+    assert_eq!(widgets.len(), 1, "expected 1 Widget in tx");
+    assert_eq!(widgets[0]["name"], "Sprocket");
+
+    // 5. Query outside the transaction - Widget collection should not exist yet
+    let outside = client.query("query { Widget { name weight } }");
+    assert!(
+        outside.is_err(),
+        "Widget should not be visible outside uncommitted transaction"
+    );
+
+    // 6. Commit the transaction
+    client.tx_commit(&tx_id).expect("tx_commit failed");
+
+    // 7. Verify the data persists after commit
+    let after_commit = client
+        .query("query { Widget { name weight } }")
+        .expect("query Widget after commit");
+    let committed_widgets = after_commit["Widget"]
+        .as_array()
+        .expect("committed Widget result not array");
+    assert_eq!(committed_widgets.len(), 1, "expected 1 Widget after commit");
+    assert_eq!(committed_widgets[0]["name"], "Sprocket");
+    assert_eq!(committed_widgets[0]["weight"], 42);
+}
+
+#[tokio::test]
+async fn rust_txn_schema_add_and_mutate() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    txn_schema_add_and_mutate(cluster).await;
+}
+
 async fn transactions_test(cluster: TestCluster) {
     let client = cluster.client(0);
 


### PR DESCRIPTION
## Summary

Ports Go DefraDB PR #4587 — fixes broken transaction behavior where schemas added within a transaction weren't visible to subsequent queries/mutations in the same transaction.

### Changes

- **`TxnCollectionProvider`** — new provider that reads from the transaction's systemstore first, falling back to the process-wide cache for schemas not in the transaction
- **Task-local provider override** — `execute_in_txn` sets a `tokio::task_local` provider so all collection resolution within the execution sees uncommitted schemas
- **`POST /api/v0/tx/{id}/schema`** — new HTTP endpoint to add schemas within an existing transaction
- **`on_success` callback** — updates the process-wide collection cache after transaction commit
- **Integration test** — full flow: create txn → add schema → mutate → verify isolation → commit → verify persistence

### Architecture Note

Unlike Go, the Rust parser doesn't validate against schemas at parse time (it's purely syntactic). The bug manifested at execution time when `CollectionProvider` couldn't find uncommitted schemas. The fix is in the provider layer, not the parser.

Closes #594

## Test plan

- [x] `cargo test -p db -p query -p defra-http` — 744 tests pass
- [x] `cargo test -p integration-test --test basic -- rust_` — all 10 tests pass
- [x] `cargo clippy --all -- -D warnings` clean
- [x] New integration test: `rust_txn_schema_add_and_mutate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)