### PR TITLE
fix(p2p): make DAG fetch and push concurrency limits configurable

### DIFF
--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -181,6 +181,12 @@ pub struct P2PConfig {
     /// Reload collection subscriptions persisted in the local store on startup.
     /// When false, only explicit subscribe calls in the current process take effect.
     pub load_persisted_collections: bool,
+    /// Maximum concurrent DAG fetch tasks. Lower values reduce resource pressure
+    /// on constrained clients (mobile, embedded). Default: 16.
+    pub max_concurrent_dag_fetches: usize,
+    /// Maximum concurrent push tasks for sending blocks to replicators.
+    /// Default: 32.
+    pub max_concurrent_push_tasks: usize,
 }
 
 /// Type-erased P2P operations exposed on EmbeddedNode.
@@ -769,10 +775,15 @@ impl NodeBuilder {
             Arc::new(p2p::sync::P2PCollectionStore::new(store.clone()));
 
         // 7. SyncCoordinator (transport-generic — same constructor, different type param)
+        let sync_config = p2p::sync::SyncConfig {
+            max_concurrent_dag_fetches: config.max_concurrent_dag_fetches,
+            max_concurrent_push_tasks: config.max_concurrent_push_tasks,
+            ..Default::default()
+        };
         let (mut coordinator, sync_events) = p2p::sync::SyncCoordinator::with_collection_store(
             transport.clone(),
             sync_blockstore.clone(),
-            p2p::sync::SyncConfig::default(),
+            sync_config,
             p2p::AccessMode::Open,
             collection_store,
         )

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -25,7 +25,9 @@ use crate::sync::peer_state::PeerStateTracker;
 use crate::sync::rate_limiter::PeerRateLimiter;
 use crate::transport::{PeerId, ResponseToken, TransportEvent};
 
-use super::{SyncCoordinator, MAX_CONCURRENT_DAG_FETCHES, MAX_CONCURRENT_PUSH_TASKS};
+use super::{
+    SyncCoordinator, DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+};
 
 type TestBlockstore = DefraBlockstore<MemoryStore>;
 const BLOCK_DATA: &[u8] = b"block data";
@@ -60,8 +62,12 @@ fn create_test_coordinator(
         collection_store: Arc::new(NoOpCollectionStorage),
         head_provider: Arc::new(NoOpHeadProvider),
         failure_tx: None,
-        dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_DAG_FETCHES)),
-        push_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PUSH_TASKS)),
+        dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(
+            DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
+        )),
+        push_semaphore: Arc::new(tokio::sync::Semaphore::new(
+            DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+        )),
         rate_limiter: Arc::new(PeerRateLimiter::default()),
     };
 

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -95,8 +95,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let local_peer_id = transport.local_peer_id().to_string();
         let broadcaster = Broadcaster::new(transport.clone());
         let peer_state = Arc::new(PeerStateTracker::new());
-        let max_dag_fetches = config.max_concurrent_dag_fetches;
-        let max_push_tasks = config.max_concurrent_push_tasks;
+        let max_dag_fetches = config.max_concurrent_dag_fetches.max(1);
+        let max_push_tasks = config.max_concurrent_push_tasks.max(1);
         let (manager, events) = SyncManager::new(blockstore, peer_state.clone(), config);
 
         Ok((

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use blockstore::Blockstore;
 use tokio::sync::mpsc;
 
-use super::{SyncCoordinator, MAX_CONCURRENT_DAG_FETCHES, MAX_CONCURRENT_PUSH_TASKS};
+use super::SyncCoordinator;
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Result;
 use crate::sync::broadcaster::Broadcaster;
@@ -95,6 +95,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let local_peer_id = transport.local_peer_id().to_string();
         let broadcaster = Broadcaster::new(transport.clone());
         let peer_state = Arc::new(PeerStateTracker::new());
+        let max_dag_fetches = config.max_concurrent_dag_fetches;
+        let max_push_tasks = config.max_concurrent_push_tasks;
         let (manager, events) = SyncManager::new(blockstore, peer_state.clone(), config);
 
         Ok((
@@ -112,10 +114,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 collection_store,
                 head_provider,
                 failure_tx: None,
-                dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(
-                    MAX_CONCURRENT_DAG_FETCHES,
-                )),
-                push_semaphore: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PUSH_TASKS)),
+                dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(max_dag_fetches)),
+                push_semaphore: Arc::new(tokio::sync::Semaphore::new(max_push_tasks)),
                 rate_limiter: Arc::new(PeerRateLimiter::default()),
             },
             events,

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -68,17 +68,10 @@ use super::manager::SyncManager;
 use super::peer_state::PeerStateTracker;
 use super::rate_limiter::PeerRateLimiter;
 
-/// Maximum number of concurrent DAG fetch tasks spawned by the coordinator.
-///
-/// Caps fan-out from DocSync and BranchableSync replies to prevent resource
-/// exhaustion from a peer advertising a large number of head CIDs.
-pub(crate) const MAX_CONCURRENT_DAG_FETCHES: usize = 16;
-
-/// Maximum number of concurrent push tasks for sending blocks to replicators.
-///
-/// Caps fan-out from `push_dag_to_replicators` and `push_to_replicators` to
-/// prevent resource exhaustion when many documents are created in a burst.
-pub(crate) const MAX_CONCURRENT_PUSH_TASKS: usize = 32;
+#[cfg(test)]
+pub(crate) use super::manager::{
+    DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+};
 
 /// A push failure notification sent when a PushLog to a replicator peer fails.
 ///

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -121,10 +121,10 @@ pub struct SyncCoordinator<B: Blockstore, T: P2PTransport> {
     /// Channel for reporting push failures to the FFI layer for retry tracking.
     pub(super) failure_tx: Option<tokio::sync::mpsc::UnboundedSender<PushFailure>>,
 
-    /// Semaphore limiting concurrent DAG fetch tasks (capped at MAX_CONCURRENT_DAG_FETCHES).
+    /// Semaphore limiting concurrent DAG fetch tasks (configurable via SyncConfig).
     pub(super) dag_fetch_semaphore: Arc<tokio::sync::Semaphore>,
 
-    /// Semaphore limiting concurrent push tasks (capped at MAX_CONCURRENT_PUSH_TASKS).
+    /// Semaphore limiting concurrent push tasks (configurable via SyncConfig).
     pub(super) push_semaphore: Arc<tokio::sync::Semaphore>,
 
     /// Per-peer rate limiter applied at event dispatch to throttle abusive peers.

--- a/crates/p2p/src/sync/manager/config.rs
+++ b/crates/p2p/src/sync/manager/config.rs
@@ -1,16 +1,36 @@
 //! Sync manager configuration.
 
+/// Default maximum number of concurrent DAG fetch tasks.
+pub const DEFAULT_MAX_CONCURRENT_DAG_FETCHES: usize = 16;
+
+/// Default maximum number of concurrent push tasks.
+pub const DEFAULT_MAX_CONCURRENT_PUSH_TASKS: usize = 32;
+
 /// Configuration for the SyncManager.
 #[derive(Debug, Clone)]
 pub struct SyncConfig {
     /// Size of the event channel buffer.
     pub event_buffer_size: usize,
+
+    /// Maximum number of concurrent DAG fetch tasks spawned by the coordinator.
+    ///
+    /// Caps fan-out from DocSync and BranchableSync replies to prevent resource
+    /// exhaustion from a peer advertising a large number of head CIDs.
+    pub max_concurrent_dag_fetches: usize,
+
+    /// Maximum number of concurrent push tasks for sending blocks to replicators.
+    ///
+    /// Caps fan-out from `push_dag_to_replicators` and `push_to_replicators` to
+    /// prevent resource exhaustion when many documents are created in a burst.
+    pub max_concurrent_push_tasks: usize,
 }
 
 impl Default for SyncConfig {
     fn default() -> Self {
         Self {
             event_buffer_size: 256,
+            max_concurrent_dag_fetches: DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
+            max_concurrent_push_tasks: DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
         }
     }
 }

--- a/crates/p2p/src/sync/manager/mod.rs
+++ b/crates/p2p/src/sync/manager/mod.rs
@@ -18,6 +18,8 @@ pub(crate) mod links;
 mod pending;
 mod process;
 
-pub use config::SyncConfig;
+pub use config::{
+    SyncConfig, DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+};
 pub use events::SyncEvent;
 pub use process::SyncManager;

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -30,7 +30,10 @@ pub use coordinator::{
 };
 pub use dag_sync::{DagSync, DagSyncConfig, DagSyncState, NeedsFetchData, SyncPlan};
 pub use head_provider::{DocumentHeadProvider, NoOpHeadProvider};
-pub use manager::{SyncConfig, SyncEvent, SyncManager};
+pub use manager::{
+    SyncConfig, SyncEvent, SyncManager, DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
+    DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+};
 pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
 pub use peer_state::{PeerStateTracker, PeerStats};
 pub use queue::ProcessQueue;


### PR DESCRIPTION
## Summary

Makes `MAX_CONCURRENT_DAG_FETCHES` (16) and `MAX_CONCURRENT_PUSH_TASKS` (32) configurable via `P2PConfig` instead of hardcoded constants.

The hardcoded values cause connection collapse when mobile clients (iPhone) connect — 16 concurrent DAG fetchers exhaust the rate limiter, overflow the event bus, and crash the QUIC transport.

### Changes

- Adds `max_concurrent_dag_fetches` and `max_concurrent_push_tasks` to `SyncConfig` and `P2PConfig`
- Renames constants to `DEFAULT_MAX_CONCURRENT_DAG_FETCHES` / `DEFAULT_MAX_CONCURRENT_PUSH_TASKS`
- Threads config values through `setup_p2p` → `SyncCoordinator` constructor
- Backward compatible — defaults match previous hardcoded values

## Test plan

- [x] `cargo build -p p2p -p defra-node` passes
- [x] `cargo clippy --all -- -D warnings` clean
- [x] Existing tests updated for renamed constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)