### PR TITLE
fix(p2p): register missing ALPN_DOCSYNC_RESP and ALPN_BRANCHABLE_RESP

### DIFF
--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -396,6 +396,35 @@ async fn dispatch_stream(
                 }
             }
         }
+        x if x == protocols::ALPN_DOCSYNC_RESP => {
+            let reply: crate::message::DocSyncReply = protocols::read_message(recv).await?;
+            debug!(peer_id = %peer_id, "Received doc sync response via fire-and-forget");
+            if event_tx
+                .send(TransportEvent::DocSyncReply {
+                    peer_id: peer_id.clone(),
+                    reply,
+                })
+                .await
+                .is_err()
+            {
+                warn!("Event channel closed, cannot emit DocSyncReply");
+            }
+        }
+        x if x == protocols::ALPN_BRANCHABLE_RESP => {
+            let reply: crate::message::BranchableSyncReply =
+                protocols::read_message(recv).await?;
+            debug!(peer_id = %peer_id, "Received branchable sync response via fire-and-forget");
+            if event_tx
+                .send(TransportEvent::BranchableSyncReply {
+                    peer_id: peer_id.clone(),
+                    reply,
+                })
+                .await
+                .is_err()
+            {
+                warn!("Event channel closed, cannot emit BranchableSyncReply");
+            }
+        }
         x if x == protocols::ALPN_SE => {
             let request: crate::message::PushSEArtifactsRequest =
                 protocols::read_message(recv).await?;

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -411,8 +411,7 @@ async fn dispatch_stream(
             }
         }
         x if x == protocols::ALPN_BRANCHABLE_RESP => {
-            let reply: crate::message::BranchableSyncReply =
-                protocols::read_message(recv).await?;
+            let reply: crate::message::BranchableSyncReply = protocols::read_message(recv).await?;
             debug!(peer_id = %peer_id, "Received branchable sync response via fire-and-forget");
             if event_tx
                 .send(TransportEvent::BranchableSyncReply {

--- a/crates/p2p/src/iroh/protocols.rs
+++ b/crates/p2p/src/iroh/protocols.rs
@@ -33,7 +33,9 @@ pub const ALPN_TWOSTREAM: &[u8] = b"/defra-iroh/twostream/0.1";
 pub const ALL_ALPNS: &[&[u8]] = &[
     ALPN_PUSHLOG,
     ALPN_DOCSYNC,
+    ALPN_DOCSYNC_RESP,
     ALPN_BRANCHABLE,
+    ALPN_BRANCHABLE_RESP,
     ALPN_CAR,
     ALPN_CAR_RESP,
     ALPN_SE,


### PR DESCRIPTION
## Summary

- Add `ALPN_DOCSYNC_RESP` and `ALPN_BRANCHABLE_RESP` to the `ALL_ALPNS` array in `protocols.rs` so the iroh endpoint accepts incoming connections on these ALPNs
- Add `dispatch_stream` match arms in `endpoint.rs` that read the response message and emit `DocSyncReply` / `BranchableSyncReply` transport events, matching the existing `ALPN_CAR_RESP` pattern

The fire-and-forget path (`handle_fire_and_forget`) already sends doc sync and branchable sync responses using these ALPNs, but the receiving node was rejecting them because the ALPNs were not registered. `ALPN_CAR_RESP` was already registered — this was an oversight where the two other response ALPNs were missed.

## Test plan

- [x] `cargo clippy -p p2p --features iroh-transport -- -D warnings` passes
- [x] `cargo fmt --all` clean
- [ ] Integration P2P tests with iroh transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)