### PR TITLE
fix(p2p): add 30s timeout to iroh request-response path

### DIFF
--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -30,6 +30,13 @@ use super::config::{IrohDiscoveryConfig, IrohRelayModeConfig};
 use super::peer_map::{endpoint_id_to_peer_id, parse_endpoint_id, PeerMap};
 use super::protocols;
 
+/// Timeout for request-response round trips.
+///
+/// Covers the time from sending the request to receiving the full response.
+/// Longer than the fire-and-forget timeout (5 s) because the remote peer
+/// needs time to process the request before replying.
+const REQUEST_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Handle to a gossip topic subscription.
 struct TopicSubscription {
     sender: iroh_gossip::api::GossipSender,
@@ -1036,7 +1043,19 @@ where
     send.finish()
         .map_err(|e| crate::error::Error::Transport(e.to_string()))?;
 
-    let response: Resp = protocols::read_message(&mut recv).await?;
+    let response: Resp =
+        tokio::time::timeout(REQUEST_RESPONSE_TIMEOUT, protocols::read_message(&mut recv))
+            .await
+            .map_err(|_| {
+                let alpn_str = String::from_utf8_lossy(alpn);
+                warn!(
+                    peer_id = %peer_id,
+                    alpn = %alpn_str,
+                    timeout_secs = REQUEST_RESPONSE_TIMEOUT.as_secs(),
+                    "request-response timed out waiting for peer"
+                );
+                crate::error::Error::ResponseTimeout
+            })??;
     Ok(response)
 }
 


### PR DESCRIPTION
## Summary

- Add `REQUEST_RESPONSE_TIMEOUT` constant (30 seconds) to the iroh endpoint
- Wrap the response-reading portion of `handle_request_response` with `tokio::time::timeout`
- On timeout, log a warning with `peer_id` and ALPN for debugging, then return `Error::ResponseTimeout`

Previously, if a remote peer accepted the connection but never sent a response, `handle_request_response` would block indefinitely until the QUIC idle timeout. The fire-and-forget path already had a 5-second timeout as precedent; 30 seconds is used here because the remote peer needs time to process the request before replying.

## Test plan

- [ ] `cargo clippy -p p2p --features iroh-transport -- -D warnings` passes
- [ ] `cargo fmt --all` clean
- [ ] `cargo test -p p2p --features iroh-transport` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)