### PR TITLE
fix(p2p): add message size limits to iroh read_message to prevent OOM

### DIFF
--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -30,13 +30,6 @@ use super::config::{IrohDiscoveryConfig, IrohRelayModeConfig};
 use super::peer_map::{endpoint_id_to_peer_id, parse_endpoint_id, PeerMap};
 use super::protocols;
 
-/// Timeout for request-response round trips.
-///
-/// Covers the time from sending the request to receiving the full response.
-/// Longer than the fire-and-forget timeout (5 s) because the remote peer
-/// needs time to process the request before replying.
-const REQUEST_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-
 /// Handle to a gossip topic subscription.
 struct TopicSubscription {
     sender: iroh_gossip::api::GossipSender,
@@ -1047,21 +1040,7 @@ where
     send.finish()
         .map_err(|e| crate::error::Error::Transport(e.to_string()))?;
 
-    let response: Resp = tokio::time::timeout(
-        REQUEST_RESPONSE_TIMEOUT,
-        protocols::read_message(&mut recv, protocols::MAX_MESSAGE_SIZE),
-    )
-    .await
-    .map_err(|_| {
-        let alpn_str = String::from_utf8_lossy(alpn);
-        warn!(
-            peer_id = %peer_id,
-            alpn = %alpn_str,
-            timeout_secs = REQUEST_RESPONSE_TIMEOUT.as_secs(),
-            "request-response timed out waiting for peer"
-        );
-        crate::error::Error::ResponseTimeout
-    })??;
+    let response: Resp = protocols::read_message(&mut recv, protocols::MAX_MESSAGE_SIZE).await?;
     Ok(response)
 }
 

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -30,6 +30,13 @@ use super::config::{IrohDiscoveryConfig, IrohRelayModeConfig};
 use super::peer_map::{endpoint_id_to_peer_id, parse_endpoint_id, PeerMap};
 use super::protocols;
 
+/// Timeout for request-response round trips.
+///
+/// Covers the time from sending the request to receiving the full response.
+/// Longer than the fire-and-forget timeout (5 s) because the remote peer
+/// needs time to process the request before replying.
+const REQUEST_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Handle to a gossip topic subscription.
 struct TopicSubscription {
     sender: iroh_gossip::api::GossipSender,
@@ -1040,7 +1047,21 @@ where
     send.finish()
         .map_err(|e| crate::error::Error::Transport(e.to_string()))?;
 
-    let response: Resp = protocols::read_message(&mut recv, protocols::MAX_MESSAGE_SIZE).await?;
+    let response: Resp = tokio::time::timeout(
+        REQUEST_RESPONSE_TIMEOUT,
+        protocols::read_message(&mut recv, protocols::MAX_MESSAGE_SIZE),
+    )
+    .await
+    .map_err(|_| {
+        let alpn_str = String::from_utf8_lossy(alpn);
+        warn!(
+            peer_id = %peer_id,
+            alpn = %alpn_str,
+            timeout_secs = REQUEST_RESPONSE_TIMEOUT.as_secs(),
+            "request-response timed out waiting for peer"
+        );
+        crate::error::Error::ResponseTimeout
+    })??;
     Ok(response)
 }
 

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -294,7 +294,8 @@ async fn dispatch_stream(
 ) -> crate::error::Result<()> {
     match alpn {
         x if x == protocols::ALPN_PUSHLOG => {
-            let request: crate::message::PushLogRequest = protocols::read_message(recv).await?;
+            let request: crate::message::PushLogRequest =
+                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::PushLogRequest {
@@ -309,7 +310,8 @@ async fn dispatch_stream(
             }
         }
         x if x == protocols::ALPN_TWOSTREAM => {
-            let request: crate::message::PushLogRequest = protocols::read_message(recv).await?;
+            let request: crate::message::PushLogRequest =
+                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::TwoStreamRequest {
@@ -326,7 +328,8 @@ async fn dispatch_stream(
             }
         }
         x if x == protocols::ALPN_DOCSYNC => {
-            let request: crate::message::DocSyncRequest = protocols::read_message(recv).await?;
+            let request: crate::message::DocSyncRequest =
+                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::DocSyncRequest {
@@ -342,7 +345,7 @@ async fn dispatch_stream(
         }
         x if x == protocols::ALPN_BRANCHABLE => {
             let request: crate::message::BranchableSyncRequest =
-                protocols::read_message(recv).await?;
+                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::BranchableSyncRequest {
@@ -358,7 +361,8 @@ async fn dispatch_stream(
         }
         x if x == protocols::ALPN_CAR => {
             debug!(peer_id = %peer_id, "CAR dispatch: reading request");
-            let request: CarFetchRequest = protocols::read_message(recv).await?;
+            let request: CarFetchRequest =
+                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             debug!(
                 peer_id = %peer_id,
                 root_cid = %request.root_cid,
@@ -380,7 +384,7 @@ async fn dispatch_stream(
             }
         }
         x if x == protocols::ALPN_CAR_RESP => {
-            let car_data: Vec<u8> = protocols::read_message(recv).await?;
+            let car_data: Vec<u8> = protocols::read_message(recv, protocols::MAX_CAR_SIZE).await?;
             // Extract the root CID from the CAR headers for event correlation.
             let root_cid = match crate::sync::car::decode_car(&car_data) {
                 Ok((roots, _)) => roots.into_iter().next(),
@@ -405,7 +409,7 @@ async fn dispatch_stream(
         }
         x if x == protocols::ALPN_SE => {
             let request: crate::message::PushSEArtifactsRequest =
-                protocols::read_message(recv).await?;
+                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
             debug!(
                 peer_id = %peer_id,
                 collection_id = %request.collection_id,
@@ -1043,19 +1047,21 @@ where
     send.finish()
         .map_err(|e| crate::error::Error::Transport(e.to_string()))?;
 
-    let response: Resp =
-        tokio::time::timeout(REQUEST_RESPONSE_TIMEOUT, protocols::read_message(&mut recv))
-            .await
-            .map_err(|_| {
-                let alpn_str = String::from_utf8_lossy(alpn);
-                warn!(
-                    peer_id = %peer_id,
-                    alpn = %alpn_str,
-                    timeout_secs = REQUEST_RESPONSE_TIMEOUT.as_secs(),
-                    "request-response timed out waiting for peer"
-                );
-                crate::error::Error::ResponseTimeout
-            })??;
+    let response: Resp = tokio::time::timeout(
+        REQUEST_RESPONSE_TIMEOUT,
+        protocols::read_message(&mut recv, protocols::MAX_MESSAGE_SIZE),
+    )
+    .await
+    .map_err(|_| {
+        let alpn_str = String::from_utf8_lossy(alpn);
+        warn!(
+            peer_id = %peer_id,
+            alpn = %alpn_str,
+            timeout_secs = REQUEST_RESPONSE_TIMEOUT.as_secs(),
+            "request-response timed out waiting for peer"
+        );
+        crate::error::Error::ResponseTimeout
+    })??;
     Ok(response)
 }
 

--- a/crates/p2p/src/iroh/protocols.rs
+++ b/crates/p2p/src/iroh/protocols.rs
@@ -40,15 +40,32 @@ pub const ALL_ALPNS: &[&[u8]] = &[
     ALPN_TWOSTREAM,
 ];
 
+/// Maximum size for general messages (matches libp2p default).
+pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
+
+/// Maximum size for CAR block transfers (matches libp2p default).
+pub const MAX_CAR_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
+
 /// Read a length-prefixed CBOR message from a QUIC recv stream.
+///
+/// The `max_size` parameter caps the allocation to prevent a malicious peer
+/// from sending a large length prefix and causing an OOM.
 pub async fn read_message<T: serde::de::DeserializeOwned>(
     recv: &mut RecvStream,
+    max_size: usize,
 ) -> crate::error::Result<T> {
     let mut len_buf = [0u8; 4];
     recv.read_exact(&mut len_buf)
         .await
         .map_err(|e| crate::error::Error::Codec(format!("failed to read length: {}", e)))?;
     let len = u32::from_be_bytes(len_buf) as usize;
+
+    if len > max_size {
+        return Err(crate::error::Error::Codec(format!(
+            "message too large: {} bytes exceeds limit of {} bytes",
+            len, max_size
+        )));
+    }
 
     let mut payload = vec![0u8; len];
     recv.read_exact(&mut payload)


### PR DESCRIPTION
## Summary

- Add `max_size` parameter to `read_message()` in `crates/p2p/src/iroh/protocols.rs` that validates the 4-byte length prefix before allocating, preventing a malicious peer from triggering OOM with a crafted length prefix claiming up to 4GB
- Introduce `MAX_MESSAGE_SIZE` (16 MiB) and `MAX_CAR_SIZE` (64 MiB) constants matching the libp2p host defaults
- Update all 10 call sites in `crates/p2p/src/iroh/endpoint.rs`: general protocol messages use `MAX_MESSAGE_SIZE`, CAR block transfer responses use `MAX_CAR_SIZE`

## Test plan

- [ ] `cargo clippy -p p2p --features iroh-transport -- -D warnings` passes
- [ ] `cargo fmt --all` is clean
- [ ] `cargo test -p p2p --features iroh-transport` passes
- [ ] P2P integration tests pass: `cargo test -p integration-test --test p2p`

🤖 Generated with [Claude Code](https://claude.com/claude-code)