### PR TITLE
fix(db): acquire replay permits before spawn

### DIFF
--- a/crates/db/src/push_docs.rs
+++ b/crates/db/src/push_docs.rs
@@ -1,11 +1,14 @@
 use std::str::FromStr;
+use std::sync::Arc;
 
 use acp::DocumentACP;
 use p2p::message::PushLogRequest;
 use storage::corekv::{IterOptions, Reader, Store};
 
 use crate::database::DB;
-use crate::push_docs_common::{load_push_dag_blocks, resolve_push_creator};
+use crate::push_docs_common::{
+    load_push_dag_blocks, resolve_push_creator, MAX_CONCURRENT_REPLAY_TASKS,
+};
 
 /// Push existing documents to a replicator peer.
 ///
@@ -62,6 +65,7 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
 
     // Collect JoinHandles so we can await all pushes before signaling completion.
     let mut push_handles = Vec::new();
+    let replay_semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_REPLAY_TASKS));
 
     for col_name in collections {
         let collection = match db
@@ -169,7 +173,13 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
 
             if !requests.is_empty() {
                 let push_h = handle.clone();
+                let permit = replay_semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| "replay semaphore closed before scheduling push".to_string())?;
                 push_handles.push(tokio::spawn(async move {
+                    let _permit = permit;
                     for req in requests {
                         let cid = req.cid.clone();
                         match push_h.send_two_stream_request(peer_id, req).await {

--- a/crates/db/src/push_docs_common.rs
+++ b/crates/db/src/push_docs_common.rs
@@ -6,6 +6,12 @@ use storage::corekv::Reader;
 
 use crate::Collection;
 
+/// Maximum concurrent per-document push tasks during initial replay.
+///
+/// Lower than the coordinator's live push limit (32) because initial replay
+/// is background work that shouldn't starve real-time sync traffic.
+pub(crate) const MAX_CONCURRENT_REPLAY_TASKS: usize = 8;
+
 pub(crate) async fn resolve_push_creator(
     document_acp: Option<&dyn DocumentACP>,
     collection: &Collection,

--- a/crates/db/src/push_docs_transport.rs
+++ b/crates/db/src/push_docs_transport.rs
@@ -7,14 +7,10 @@ use p2p::transport::PeerId;
 use p2p::P2PTransport;
 use storage::corekv::{IterOptions, Reader, Store};
 
-/// Maximum concurrent per-document push tasks during initial replay.
-///
-/// Lower than the coordinator's live push limit (32) because initial replay
-/// is background work that shouldn't starve real-time sync traffic.
-const MAX_CONCURRENT_REPLAY_TASKS: usize = 8;
-
 use crate::database::DB;
-use crate::push_docs_common::{load_push_dag_blocks, resolve_push_creator};
+use crate::push_docs_common::{
+    load_push_dag_blocks, resolve_push_creator, MAX_CONCURRENT_REPLAY_TASKS,
+};
 
 /// Push existing documents to a replicator peer via a generic transport.
 ///
@@ -170,16 +166,13 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
             if !requests.is_empty() {
                 let t = transport.clone();
                 let pid = peer_id.clone();
-                let sem = replay_semaphore.clone();
+                let permit = replay_semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| "replay semaphore closed before scheduling push".to_string())?;
                 push_handles.push(tokio::spawn(async move {
-                    let Ok(_permit) = sem.acquire().await else {
-                        tracing::error!(
-                            peer_id = %pid,
-                            request_count = requests.len(),
-                            "Replay semaphore closed; document push requests abandoned"
-                        );
-                        return;
-                    };
+                    let _permit = permit;
                     for req in requests {
                         let cid = req.cid.clone();
                         match t.send_two_stream_request(&pid, req).await {


### PR DESCRIPTION
## Summary

Fixes the follow-up issue in #603 where replay throttling happened inside each spawned task instead of before task creation.

Before this change, replay would still create one Tokio task per document and only block after the task started. That limited active sends, but it did not limit task fan-out or the amount of per-document request state buffered in memory.

Now both replay entry points gate scheduling before `tokio::spawn`:
- `crates/db/src/push_docs.rs`
- `crates/db/src/push_docs_transport.rs`

The shared replay concurrency limit remains 8, but the loop now stops spawning new tasks once the limit is saturated.

## Changes

- Move `MAX_CONCURRENT_REPLAY_TASKS` into `push_docs_common` so both replay paths use the same ceiling
- Acquire an owned semaphore permit before spawning each replay task
- Hold that permit for the full lifetime of the spawned replay task

## Verification

- [x] `cargo fmt --all --check`
- [ ] Cargo compile/test pass not completed locally; cold workspace build was too slow for this pass

Follow-up to #603.
