### PR TITLE
feat(db): consolidate embedding system to single OpenAI-compatible client

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -207,6 +207,18 @@ pub struct StartArgs {
     /// ACP receipt polling timeout in seconds for hub.rs transactions (default: 30)
     #[arg(long, env = "DEFRA_ACP_RECEIPT_TIMEOUT")]
     pub acp_receipt_timeout: Option<u64>,
+
+    /// OpenAI-compatible embedding base URL (without /embeddings suffix)
+    #[arg(long, env = "DEFRA_EMBEDDING_URL")]
+    pub embedding_url: Option<String>,
+
+    /// Embedding model name used when schema model is empty
+    #[arg(long, env = "DEFRA_EMBEDDING_MODEL")]
+    pub embedding_model: Option<String>,
+
+    /// Environment variable name containing the embedding API key
+    #[arg(long, env = "DEFRA_EMBEDDING_API_KEY_ENV")]
+    pub embedding_api_key_env: Option<String>,
 }
 
 impl StartArgs {
@@ -462,6 +474,15 @@ impl StartArgs {
         }
         if let Some(timeout) = self.acp_receipt_timeout {
             config.acp.receipt_timeout = timeout;
+        }
+        if let Some(ref url) = self.embedding_url {
+            config.embedding.url = url.clone();
+        }
+        if let Some(ref model) = self.embedding_model {
+            config.embedding.model = model.clone();
+        }
+        if let Some(ref api_key_env) = self.embedding_api_key_env {
+            config.embedding.api_key_env = api_key_env.clone();
         }
         Ok(())
     }

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -82,6 +82,33 @@ impl Node {
             db_options = db_options.with_node_identity_arc(identity);
             info!("Database configured with user identity");
         }
+        let embedding_api_key = if config.embedding.api_key_env.is_empty() {
+            String::new()
+        } else {
+            match std::env::var(&config.embedding.api_key_env) {
+                Ok(value) => value,
+                Err(std::env::VarError::NotPresent) => {
+                    if !config.embedding.url.is_empty() || !config.embedding.model.is_empty() {
+                        warn!(
+                            env_var = %config.embedding.api_key_env,
+                            "embedding API key env var is not set; requests will be sent without Authorization header"
+                        );
+                    }
+                    String::new()
+                }
+                Err(std::env::VarError::NotUnicode(_)) => {
+                    warn!(
+                        env_var = %config.embedding.api_key_env,
+                        "embedding API key env var is not valid Unicode; requests will be sent without Authorization header"
+                    );
+                    String::new()
+                }
+            }
+        };
+        db_options = db_options
+            .with_embedding_url(config.embedding.url.clone())
+            .with_embedding_model(config.embedding.model.clone())
+            .with_embedding_api_key(embedding_api_key);
 
         // Open database and load collections from storage
         let mut database = db::DB::open_from_arc_with_options(store.clone(), db_options)

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -18,7 +18,9 @@ use crate::cli::Cli;
 use crate::error::{Error, Result};
 
 // Re-export types and sections for external use
-pub use sections::{AcpConfig, ApiConfig, DatastoreConfig, KeyringConfig, LogConfig, NetConfig};
+pub use sections::{
+    AcpConfig, ApiConfig, DatastoreConfig, EmbeddingConfig, KeyringConfig, LogConfig, NetConfig,
+};
 pub use types::{AcpDocumentType, DatastoreType, LogFormat, LogLevel, LogOutput, TransportType};
 // KeyringBackend is available but not currently used externally
 #[allow(unused_imports)]
@@ -31,6 +33,8 @@ pub struct Config {
     pub rootdir: PathBuf,
     pub log: LogConfig,
     pub api: ApiConfig,
+    #[serde(default)]
+    pub embedding: EmbeddingConfig,
     pub datastore: DatastoreConfig,
     pub net: NetConfig,
     pub keyring: KeyringConfig,
@@ -49,6 +53,7 @@ impl Default for Config {
             rootdir: PathBuf::new(),
             log: LogConfig::default(),
             api: ApiConfig::default(),
+            embedding: EmbeddingConfig::default(),
             datastore: DatastoreConfig::default(),
             net: NetConfig::default(),
             keyring: KeyringConfig::default(),

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -123,6 +123,31 @@ impl ApiConfig {
     }
 }
 
+/// Embedding configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingConfig {
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default = "default_embedding_api_key_env")]
+    pub api_key_env: String,
+}
+
+fn default_embedding_api_key_env() -> String {
+    "OPENAI_API_KEY".to_string()
+}
+
+impl Default for EmbeddingConfig {
+    fn default() -> Self {
+        Self {
+            url: String::new(),
+            model: String::new(),
+            api_key_env: default_embedding_api_key_env(),
+        }
+    }
+}
+
 /// Datastore configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatastoreConfig {

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -101,6 +101,9 @@ fn test_config_defaults() {
     let config = Config::default();
     assert!(config.rootdir.as_os_str().is_empty());
     assert_eq!(config.api.address, "127.0.0.1:9181");
+    assert_eq!(config.embedding.url, "");
+    assert_eq!(config.embedding.model, "");
+    assert_eq!(config.embedding.api_key_env, "OPENAI_API_KEY");
     assert_eq!(config.datastore.store, DatastoreType::Redb);
     assert!(!config.development);
     assert_eq!(config.secret_file, ".env");
@@ -176,5 +179,11 @@ fn test_config_serialization_roundtrip() {
     assert_eq!(original.log.level, deserialized.log.level);
     assert_eq!(original.datastore.store, deserialized.datastore.store);
     assert_eq!(original.api.address, deserialized.api.address);
+    assert_eq!(original.embedding.url, deserialized.embedding.url);
+    assert_eq!(original.embedding.model, deserialized.embedding.model);
+    assert_eq!(
+        original.embedding.api_key_env,
+        deserialized.embedding.api_key_env
+    );
     assert_eq!(original.keyring.backend, deserialized.keyring.backend);
 }

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -50,6 +50,9 @@ fn default_start_args() -> StartArgs {
         acp_circuit_breaker_reset_timeout: None,
         acp_request_timeout: None,
         acp_receipt_timeout: None,
+        embedding_url: None,
+        embedding_model: None,
+        embedding_api_key_env: None,
     }
 }
 
@@ -134,6 +137,9 @@ fn test_apply_to_config_all_flags() {
         acp_circuit_breaker_reset_timeout: None,
         acp_request_timeout: None,
         acp_receipt_timeout: None,
+        embedding_url: Some("http://localhost:11434/v1".to_string()),
+        embedding_model: Some("nomic-embed-text".to_string()),
+        embedding_api_key_env: Some("CUSTOM_EMBEDDING_KEY".to_string()),
     };
 
     let result = args.apply_to_config(&mut config);
@@ -169,4 +175,7 @@ fn test_apply_to_config_all_flags() {
     assert!(config.datastore.no_searchable_encryption);
     assert_eq!(config.replicator_retry_intervals, vec![10, 20, 30]);
     assert_eq!(config.api.query_timeout, 45);
+    assert_eq!(config.embedding.url, "http://localhost:11434/v1");
+    assert_eq!(config.embedding.model, "nomic-embed-text");
+    assert_eq!(config.embedding.api_key_env, "CUSTOM_EMBEDDING_KEY");
 }

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -151,12 +151,14 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
     ) -> query::error::Result<CreateResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
+        let embedding_config = self.db.options().embedding_config();
 
         crate::embedding::set_embedding(
             &collection.schema().vector_embeddings,
             &mut doc,
             true,
             None,
+            &embedding_config,
         )
         .await
         .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;
@@ -287,12 +289,14 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
     ) -> query::error::Result<UpdateResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
+        let embedding_config = self.db.options().embedding_config();
 
         let generated = crate::embedding::set_embedding(
             &collection.schema().vector_embeddings,
             &mut doc,
             false,
             Some(&modified_fields),
+            &embedding_config,
         )
         .await
         .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -15,11 +15,13 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         })?;
 
         // Generate embeddings before doc ID (embedding values affect content hash)
+        let embedding_config = self.db.options().embedding_config();
         crate::embedding::set_embedding(
             &collection.schema().vector_embeddings,
             &mut doc,
             true,
             None,
+            &embedding_config,
         )
         .await
         .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -40,12 +40,14 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
         // === Phase 1: Prepare documents (sequential — embeddings are async/external) ===
         let mut prepared_docs: Vec<(Document, bool)> = Vec::with_capacity(docs.len());
+        let embedding_config = self.db.options().embedding_config();
         for mut doc in docs {
             crate::embedding::set_embedding(
                 &collection.schema().vector_embeddings,
                 &mut doc,
                 true,
                 None,
+                &embedding_config,
             )
             .await
             .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -13,12 +13,14 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         // Generate embeddings if source fields were modified
         let mut doc = doc;
         let mut modified_fields = modified_fields;
+        let embedding_config = self.db.options().embedding_config();
 
         let generated = crate::embedding::set_embedding(
             &collection.schema().vector_embeddings,
             &mut doc,
             false,
             Some(&modified_fields),
+            &embedding_config,
         )
         .await
         .map_err(|e| query::error::QueryError::execution(format!("embedding error: {}", e)))?;

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -20,6 +20,45 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use storage::corekv::Store;
 
+/// Embedding client configuration for OpenAI-compatible endpoints.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct EmbeddingClientConfig {
+    pub url: String,
+    pub model: String,
+    pub api_key: String,
+}
+
+impl std::fmt::Debug for EmbeddingClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EmbeddingClientConfig")
+            .field("url", &self.url)
+            .field("model", &self.model)
+            .field("api_key_configured", &!self.api_key.is_empty())
+            .finish()
+    }
+}
+
+impl EmbeddingClientConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+        self.url = url.into();
+        self
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    pub fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = api_key.into();
+        self
+    }
+}
+
 /// Database options.
 #[derive(Clone, Default)]
 pub struct DbOptions {
@@ -34,6 +73,12 @@ pub struct DbOptions {
     /// - Authenticating with the ACP (Access Control Policy) system
     /// - Identifying this node in P2P interactions
     pub node_identity: Option<Arc<RawIdentity>>,
+    /// Fallback OpenAI-compatible embedding base URL.
+    pub embedding_url: String,
+    /// Fallback embedding model name.
+    pub embedding_model: String,
+    /// Resolved embedding API key value.
+    pub embedding_api_key: String,
 }
 
 impl std::fmt::Debug for DbOptions {
@@ -48,6 +93,12 @@ impl std::fmt::Debug for DbOptions {
                         .map(|d| d.to_string())
                         .unwrap_or_else(|_| "<invalid>".to_string())
                 }),
+            )
+            .field("embedding_url", &self.embedding_url)
+            .field("embedding_model", &self.embedding_model)
+            .field(
+                "embedding_api_key_configured",
+                &!self.embedding_api_key.is_empty(),
             )
             .finish()
     }
@@ -81,6 +132,32 @@ impl DbOptions {
     pub fn with_chunk_size(mut self, size: usize) -> Self {
         self.chunk_size = Some(size);
         self
+    }
+
+    /// Sets the fallback embedding base URL.
+    pub fn with_embedding_url(mut self, url: impl Into<String>) -> Self {
+        self.embedding_url = url.into();
+        self
+    }
+
+    /// Sets the fallback embedding model name.
+    pub fn with_embedding_model(mut self, model: impl Into<String>) -> Self {
+        self.embedding_model = model.into();
+        self
+    }
+
+    /// Sets the resolved embedding API key value.
+    pub fn with_embedding_api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.embedding_api_key = api_key.into();
+        self
+    }
+
+    /// Returns the embedding client configuration for this database.
+    pub fn embedding_config(&self) -> EmbeddingClientConfig {
+        EmbeddingClientConfig::new()
+            .with_url(self.embedding_url.clone())
+            .with_model(self.embedding_model.clone())
+            .with_api_key(self.embedding_api_key.clone())
     }
 }
 

--- a/crates/db/src/definition_validation/global_validators.rs
+++ b/crates/db/src/definition_validation/global_validators.rs
@@ -234,33 +234,6 @@ pub(super) fn validate_embedding_fields_for_generation(
     errs
 }
 
-/// Matches Go's validateEmbeddingProviderAndModel.
-pub(super) fn validate_embedding_provider_and_model(
-    new_state: &DefinitionState,
-    _old_state: &DefinitionState,
-) -> Vec<String> {
-    let mut errs = Vec::new();
-    for col in &new_state.collections {
-        for embedding in &col.vector_embeddings {
-            if embedding.provider.is_empty() {
-                errs.push("embedding Provider cannot be empty".to_string());
-            }
-
-            if !is_known_embedding_provider(&embedding.provider) {
-                errs.push(format!(
-                    "unknown embedding provider. Provider: {}",
-                    embedding.provider
-                ));
-            }
-
-            if embedding.model.is_empty() {
-                errs.push("embedding Model cannot be empty".to_string());
-            }
-        }
-    }
-    errs
-}
-
 /// Validates that no index references a CRDT counter field.
 /// Matches Go's check in NewCollectionIndex: counter fields cannot be indexed.
 pub(super) fn validate_index_fields_not_counter(

--- a/crates/db/src/definition_validation/helpers.rs
+++ b/crates/db/src/definition_validation/helpers.rs
@@ -35,11 +35,6 @@ pub(super) fn is_valid_embedding_generation_kind(kind: &FieldKind) -> bool {
     )
 }
 
-/// Known embedding providers (matches Go's supportedEmbeddingProviders).
-pub(super) fn is_known_embedding_provider(provider: &str) -> bool {
-    matches!(provider, "openai" | "ollama" | "custom")
-}
-
 /// Format a CType for error messages (matches Go's CType.String()).
 pub(super) fn format_crdt_type(crdt: CType) -> String {
     match crdt {

--- a/crates/db/src/definition_validation/mod.rs
+++ b/crates/db/src/definition_validation/mod.rs
@@ -75,12 +75,11 @@ const GLOBAL_VALIDATORS: &[Validator] = &[
     validate_materialized_has_no_policy,
     validate_embedding_and_kind_compatible,
     validate_embedding_fields_for_generation,
-    validate_embedding_provider_and_model,
 ];
 
 /// Validates embedding definitions on newly created collections.
 ///
-/// Only runs embedding-specific validators (type, fields, provider/model).
+/// Only runs embedding-specific validators (type and fields).
 /// Other global validators are not appropriate at create time.
 pub fn validate_new_collections(new_collections: &[CollectionVersion]) -> Result<(), String> {
     let new_state = DefinitionState::new(new_collections);
@@ -89,7 +88,6 @@ pub fn validate_new_collections(new_collections: &[CollectionVersion]) -> Result
     let validators: &[Validator] = &[
         validate_embedding_and_kind_compatible,
         validate_embedding_fields_for_generation,
-        validate_embedding_provider_and_model,
         validate_index_fields_not_counter,
     ];
 

--- a/crates/db/src/embedding.rs
+++ b/crates/db/src/embedding.rs
@@ -1,6 +1,9 @@
+use crate::EmbeddingClientConfig;
 use document::{Document, NormalValue};
 use schema::VectorEmbeddingDescription;
 use std::collections::HashSet;
+use std::sync::OnceLock;
+use tracing::warn;
 
 #[cfg(not(target_arch = "wasm32"))]
 type EmbeddingError = Box<dyn std::error::Error + Send + Sync>;
@@ -24,6 +27,7 @@ pub async fn set_embedding(
     doc: &mut Document,
     is_create: bool,
     modified_fields: Option<&HashSet<String>>,
+    embedding_config: &EmbeddingClientConfig,
 ) -> Result<Vec<String>, EmbeddingError> {
     let mut generated = Vec::new();
 
@@ -51,6 +55,34 @@ pub async fn set_embedding(
             }
         }
 
+        if !embedding.provider.is_empty() && embedding.provider != "openai" {
+            warn!(
+                provider = %embedding.provider,
+                field = %embedding.field_name,
+                "embedding provider is not recognized, using OpenAI-compatible API"
+            );
+        }
+
+        let resolved_config = match resolve_embedding_config(embedding, embedding_config) {
+            Ok(config) => config,
+            // Missing runtime config is non-fatal by design: collection schemas may
+            // declare embeddings while node-level defaults are intentionally absent.
+            Err(MissingEmbeddingConfig::Url) => {
+                warn!(
+                    field = %embedding.field_name,
+                    "embedding URL is empty, skipping embedding generation"
+                );
+                continue;
+            }
+            Err(MissingEmbeddingConfig::Model) => {
+                warn!(
+                    field = %embedding.field_name,
+                    "embedding model is empty, skipping embedding generation"
+                );
+                continue;
+            }
+        };
+
         // Build text from source field values
         let mut text = String::new();
         for field_name in &embedding.fields {
@@ -61,10 +93,13 @@ pub async fn set_embedding(
             }
         }
 
-        // Call embedding provider
-        let vec =
-            call_embedding_provider(&embedding.provider, &embedding.model, &embedding.url, &text)
-                .await?;
+        let vec = call_embedding(
+            resolved_config.url,
+            resolved_config.model,
+            &embedding_config.api_key,
+            &text,
+        )
+        .await?;
 
         doc.set(&embedding.field_name, NormalValue::Float64Array(vec));
         generated.push(embedding.field_name.clone());
@@ -84,93 +119,196 @@ fn normal_value_to_string(val: &NormalValue) -> String {
     }
 }
 
-async fn call_embedding_provider(
-    provider: &str,
-    model: &str,
+#[derive(Debug, PartialEq, Eq)]
+enum MissingEmbeddingConfig {
+    Url,
+    Model,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ResolvedEmbeddingConfig<'a> {
+    url: &'a str,
+    model: &'a str,
+}
+
+fn resolve_embedding_config<'a>(
+    embedding: &'a VectorEmbeddingDescription,
+    embedding_config: &'a EmbeddingClientConfig,
+) -> Result<ResolvedEmbeddingConfig<'a>, MissingEmbeddingConfig> {
+    let url = if embedding.url.is_empty() {
+        embedding_config.url.as_str()
+    } else {
+        embedding.url.as_str()
+    };
+    if url.is_empty() {
+        return Err(MissingEmbeddingConfig::Url);
+    }
+
+    let model = if embedding.model.is_empty() {
+        embedding_config.model.as_str()
+    } else {
+        embedding.model.as_str()
+    };
+    if model.is_empty() {
+        return Err(MissingEmbeddingConfig::Model);
+    }
+
+    Ok(ResolvedEmbeddingConfig { url, model })
+}
+
+async fn call_embedding(
     url: &str,
+    model: &str,
+    api_key: &str,
     text: &str,
 ) -> Result<Vec<f64>, EmbeddingError> {
-    match provider {
-        "ollama" => call_ollama(model, url, text).await,
-        "openai" => call_openai(model, url, text).await,
-        other => Err(format!("unsupported embedding provider: {}", other).into()),
-    }
-}
-
-async fn call_ollama(model: &str, url: &str, text: &str) -> Result<Vec<f64>, EmbeddingError> {
-    let base = if url.is_empty() {
-        "http://localhost:11434/api"
-    } else {
-        url
-    };
-    let endpoint = format!("{}/embeddings", base.trim_end_matches('/'));
-
-    let client = reqwest::Client::new();
-    let body = serde_json::json!({
-        "model": model,
-        "prompt": text,
-    });
-
-    let resp = client.post(&endpoint).json(&body).send().await?;
-    let status = resp.status();
-    if !status.is_success() {
-        let text = resp.text().await.unwrap_or_default();
-        return Err(format!("ollama returned {}: {}", status, text).into());
-    }
-
-    let result: serde_json::Value = resp.json().await?;
-    let embedding = result
-        .get("embedding")
-        .and_then(|v| v.as_array())
-        .ok_or("ollama response missing 'embedding' array")?;
-
-    let vec: Vec<f64> = embedding
-        .iter()
-        .map(|v| v.as_f64().unwrap_or(0.0))
-        .collect();
-
-    Ok(vec)
-}
-
-async fn call_openai(model: &str, url: &str, text: &str) -> Result<Vec<f64>, EmbeddingError> {
-    let base = if url.is_empty() {
-        "https://api.openai.com/v1"
-    } else {
-        url
-    };
-    let endpoint = format!("{}/embeddings", base.trim_end_matches('/'));
-
-    let api_key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
-
-    let client = reqwest::Client::new();
+    let endpoint = format!("{}/embeddings", url.trim_end_matches('/'));
     let body = serde_json::json!({
         "model": model,
         "input": text,
     });
 
-    let resp = client
-        .post(&endpoint)
-        .header("Authorization", format!("Bearer {}", api_key))
-        .json(&body)
-        .send()
-        .await?;
+    let mut request = embedding_client().post(&endpoint);
+    if !api_key.is_empty() {
+        request = request.bearer_auth(api_key);
+    }
+
+    let resp = request.json(&body).send().await?;
 
     let status = resp.status();
     if !status.is_success() {
         let text = resp.text().await.unwrap_or_default();
-        return Err(format!("openai returned {}: {}", status, text).into());
+        return Err(format!("embedding provider returned {}: {}", status, text).into());
     }
 
     let result: serde_json::Value = resp.json().await?;
     let embedding = result
         .pointer("/data/0/embedding")
         .and_then(|v| v.as_array())
-        .ok_or("openai response missing embedding data")?;
+        .ok_or("embedding response missing data[0].embedding")?;
 
-    let vec: Vec<f64> = embedding
-        .iter()
-        .map(|v| v.as_f64().unwrap_or(0.0))
-        .collect();
+    let vec = parse_embedding_vector(embedding).map_err(|err| -> EmbeddingError { err.into() })?;
 
     Ok(vec)
+}
+
+fn embedding_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+fn parse_embedding_vector(embedding: &[serde_json::Value]) -> Result<Vec<f64>, String> {
+    embedding
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            value
+                .as_f64()
+                .ok_or_else(|| format!("embedding value at index {} is not numeric", index))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn embedding_with(url: &str, model: &str) -> VectorEmbeddingDescription {
+        VectorEmbeddingDescription {
+            field_name: "content_v".to_string(),
+            fields: vec!["content".to_string()],
+            model: model.to_string(),
+            provider: "openai".to_string(),
+            template: String::new(),
+            url: url.to_string(),
+        }
+    }
+
+    #[test]
+    fn resolve_embedding_config_prefers_schema_values() {
+        let embedding = embedding_with("https://schema.example/v1", "schema-model");
+        let config = EmbeddingClientConfig::new()
+            .with_url("https://node.example/v1")
+            .with_model("node-model")
+            .with_api_key("secret");
+
+        let resolved = resolve_embedding_config(&embedding, &config).unwrap();
+
+        assert_eq!(
+            resolved,
+            ResolvedEmbeddingConfig {
+                url: "https://schema.example/v1",
+                model: "schema-model",
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_embedding_config_falls_back_to_node_values() {
+        let embedding = embedding_with("", "");
+        let config = EmbeddingClientConfig::new()
+            .with_url("https://node.example/v1")
+            .with_model("node-model");
+
+        let resolved = resolve_embedding_config(&embedding, &config).unwrap();
+
+        assert_eq!(
+            resolved,
+            ResolvedEmbeddingConfig {
+                url: "https://node.example/v1",
+                model: "node-model",
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_embedding_config_requires_url() {
+        let embedding = embedding_with("", "schema-model");
+        let config = EmbeddingClientConfig::new();
+
+        assert_eq!(
+            resolve_embedding_config(&embedding, &config),
+            Err(MissingEmbeddingConfig::Url)
+        );
+    }
+
+    #[test]
+    fn resolve_embedding_config_requires_model() {
+        let embedding = embedding_with("https://schema.example/v1", "");
+        let config = EmbeddingClientConfig::new();
+
+        assert_eq!(
+            resolve_embedding_config(&embedding, &config),
+            Err(MissingEmbeddingConfig::Model)
+        );
+    }
+
+    #[test]
+    fn parse_embedding_vector_errors_on_non_numeric_value() {
+        let values = vec![serde_json::json!(1.0), serde_json::json!("bad")];
+
+        let err = parse_embedding_vector(&values).unwrap_err();
+
+        assert_eq!(err, "embedding value at index 1 is not numeric");
+    }
+
+    #[tokio::test]
+    async fn set_embedding_skips_when_effective_config_is_missing() {
+        let embeddings = vec![embedding_with("", "")];
+        let mut doc = Document::new();
+        doc.set("content", "hello");
+
+        let generated = set_embedding(
+            &embeddings,
+            &mut doc,
+            true,
+            None,
+            &EmbeddingClientConfig::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(generated.is_empty());
+        assert!(doc.get("content_v").is_none());
+    }
 }

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -118,7 +118,7 @@ pub use collection_name::CollectionName;
 pub use collection_provider::DbCollectionProvider;
 pub use collection_snapshot::CollectionSnapshot;
 pub use commits_fetcher::{CommitsFetcher, CommitsQueryOptions};
-pub use database::{DbOptions, DB};
+pub use database::{DbOptions, EmbeddingClientConfig, DB};
 pub use defra_core::encryption::{set_encryption_config, EncryptionConfig};
 pub use doc_fetcher::DbDocFetcher;
 pub use doc_mutator::DbDocMutator;


### PR DESCRIPTION
## Summary

- Replace provider-specific `call_ollama` and `call_openai` with a single `call_embedding` function using the OpenAI `/v1/embeddings` API format — works with any OpenAI-compatible server (OpenAI, Ollama `/v1`, vLLM-MLX, TEI, LiteLLM, LocalAI)
- Add node-level fallback config via `--embedding-url`, `--embedding-model`, `--embedding-api-key-env` CLI flags and `DEFRA_EMBEDDING_*` env vars
- Schema `@embedding` directive values take priority; node config is the fallback when schema values are empty
- `EmbeddingClientConfig` struct groups url/model/api_key with Debug redaction
- Static `reqwest::Client` via `OnceLock` for connection pooling
- `parse_embedding_vector` errors on non-numeric values instead of silently injecting 0.0
- Startup warning when configured API key env var is missing
- Remove compile-time provider/model validation (now runtime resolved)

## Test plan

- [x] `cargo test -p db -- embedding` — 6 unit tests for fallback resolution, vector parsing, skip behavior
- [x] `cargo test -p cli` — config defaults, serialization roundtrip, flag application
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo build --target wasm32-unknown-unknown -p defra-wasm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)