### PR TITLE
fix(acp): allow difference and tuple-to-userset operators in DPI policies

### DIFF
--- a/crates/acp/src/error.rs
+++ b/crates/acp/src/error.rs
@@ -93,12 +93,12 @@ pub enum Error {
     #[error("DPI violation: resource '{resource}' must have an 'owner' relation")]
     DpiMissingOwner { resource: String },
 
-    /// DPI compliance violation: expression doesn't start with owner
+    /// DPI compliance violation: expression doesn't include owner access
     #[error("DPI violation: permission '{relation}' on resource '{resource}' must include 'owner' in its expression")]
     DpiExpressionMissingOwner { resource: String, relation: String },
 
     /// DPI compliance violation: disallowed operation
-    #[error("DPI violation: resource '{resource}' relation '{relation}' uses disallowed operation '{operation}' (only union allowed)")]
+    #[error("DPI violation: resource '{resource}' relation '{relation}' uses disallowed operation '{operation}'")]
     DpiDisallowedOperation {
         resource: String,
         relation: String,

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -21,8 +21,9 @@
 //! # DPI Rules (DefraDB Policy Interface)
 //!
 //! - Every resource MUST have `owner` relation
-//! - Every permission expression MUST start with `owner`
-//! - Only union (`+`) operations allowed: `owner + reader`
+//! - Every permission expression MUST include `owner` access
+//! - Difference (`-`) and tuple-to-userset (`->`) are allowed
+//! - Intersection (`&`) is not allowed in DPI-enforced policies
 
 mod auth_error;
 mod dac;

--- a/crates/acp/src/policy_yaml/validate.rs
+++ b/crates/acp/src/policy_yaml/validate.rs
@@ -4,8 +4,8 @@ use super::ParsedPolicy;
 ///
 /// Checks:
 /// 1. Expressions cannot reference the reserved `owner` relation
-/// 2. Expression operators must be valid (`+` and `-` only)
-/// 3. Expressions can only reference relations declared in the same resource
+/// 2. Expressions can use Zanzibar operators, including TTU (`->`)
+/// 3. Direct relation references and TTU tuple relations must exist in the same resource
 pub fn validate_policy_expressions(policy: &ParsedPolicy) -> Result<(), String> {
     for resource in &policy.resources {
         // 'owner' is a reserved relation name, auto-injected by the system
@@ -26,6 +26,7 @@ pub fn validate_policy_expressions(policy: &ParsedPolicy) -> Result<(), String> 
             }
 
             let tokens = tokenize_expression(&permission.expr)?;
+            let mut skip_local_relation_check = false;
 
             for token in &tokens {
                 match token {
@@ -33,6 +34,11 @@ pub fn validate_policy_expressions(policy: &ParsedPolicy) -> Result<(), String> 
                         // Check for owner reference
                         if name == "owner" {
                             return Err("permission cannot reference `owner` relation".to_string());
+                        }
+
+                        if skip_local_relation_check {
+                            skip_local_relation_check = false;
+                            continue;
                         }
 
                         // Check that the relation exists in this resource
@@ -48,6 +54,9 @@ pub fn validate_policy_expressions(policy: &ParsedPolicy) -> Result<(), String> 
                             return Err("BAD_INPUT".to_string());
                         }
                     }
+                    ExprToken::TupleToUserset => {
+                        skip_local_relation_check = true;
+                    }
                     ExprToken::Operator | ExprToken::Paren => {}
                 }
             }
@@ -60,11 +69,12 @@ pub fn validate_policy_expressions(policy: &ParsedPolicy) -> Result<(), String> 
 enum ExprToken {
     Identifier(String),
     Operator,
+    TupleToUserset,
     Paren,
 }
 
 /// Tokenize a permission expression like "reader + writer - admin".
-/// Valid operators: +, -
+/// Valid operators: +, -, ->, &
 /// Valid tokens: identifiers (alphanumeric + underscore), operators, parentheses
 fn tokenize_expression(expr: &str) -> Result<Vec<ExprToken>, String> {
     let mut tokens = Vec::new();
@@ -84,7 +94,7 @@ fn tokenize_expression(expr: &str) -> Result<Vec<ExprToken>, String> {
                         // This is a TTU operator "->", consume both
                         chars.next();
                         chars.next();
-                        tokens.push(ExprToken::Operator);
+                        tokens.push(ExprToken::TupleToUserset);
                         continue;
                     }
                 }
@@ -123,7 +133,16 @@ fn tokenize_expression(expr: &str) -> Result<Vec<ExprToken>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::policy_yaml::parse_policy_yaml;
+    use crate::policy_yaml::{build_policy, parse_policy_yaml};
+
+    fn assert_policy_loads(yaml: &str) {
+        let parsed = parse_policy_yaml(yaml).unwrap();
+        validate_policy_expressions(&parsed).unwrap();
+
+        let policy = build_policy(&parsed, 1).unwrap();
+        assert!(policy.validate().is_ok());
+        assert!(policy.validate_dpi().is_ok());
+    }
 
     #[test]
     fn test_owner_reference_error() {
@@ -211,5 +230,134 @@ resources:
         let result = validate_policy_expressions(&policy);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("BAD_INPUT"));
+    }
+
+    #[test]
+    fn test_difference_expression_loads() {
+        let yaml = r#"
+name: public_except_blocked
+resources:
+- name: document
+  permissions:
+  - name: read
+    expr: reader - blocked
+  - name: update
+    expr: writer - blocked
+  - name: delete
+    expr: admin
+  relations:
+  - name: reader
+    types: [actor]
+  - name: writer
+    types: [actor]
+  - name: blocked
+    types: [actor]
+  - name: admin
+    manages: [reader, writer, blocked]
+    types: [actor]
+"#;
+
+        assert_policy_loads(yaml);
+    }
+
+    #[test]
+    fn test_ttu_expression_loads() {
+        let yaml = r#"
+name: filesystem
+resources:
+- name: file
+  permissions:
+  - name: read
+    expr: parent->read
+  - name: update
+    expr: writer
+  - name: delete
+    expr: writer
+  relations:
+  - name: parent
+    types: [directory]
+  - name: writer
+    types: [actor]
+- name: directory
+  permissions:
+  - name: read
+    expr: reader + writer
+  - name: update
+    expr: writer
+  - name: delete
+    expr: writer
+  relations:
+  - name: reader
+    types: [actor]
+  - name: writer
+    types: [actor]
+"#;
+
+        assert_policy_loads(yaml);
+    }
+
+    #[test]
+    fn test_nested_difference_expression_loads() {
+        let yaml = r#"
+name: nested_difference
+resources:
+- name: document
+  permissions:
+  - name: read
+    expr: (reader + writer) - blocked
+  - name: update
+    expr: writer
+  - name: delete
+    expr: admin
+  relations:
+  - name: reader
+    types: [actor]
+  - name: writer
+    types: [actor]
+  - name: blocked
+    types: [actor]
+  - name: admin
+    types: [actor]
+"#;
+
+        assert_policy_loads(yaml);
+    }
+
+    #[test]
+    fn test_nested_ttu_expression_loads() {
+        let yaml = r#"
+name: filesystem
+resources:
+- name: file
+  permissions:
+  - name: read
+    expr: reader + parent->read
+  - name: update
+    expr: writer + parent->update
+  - name: delete
+    expr: writer
+  relations:
+  - name: parent
+    types: [directory]
+  - name: reader
+    types: [actor]
+  - name: writer
+    types: [actor]
+- name: directory
+  permissions:
+  - name: read
+    expr: reader + writer
+  - name: update
+    expr: writer
+  - name: delete
+    expr: writer
+  relations:
+  - name: reader
+    types: [actor]
+  - name: writer
+    types: [actor]
+"#;
+
+        assert_policy_loads(yaml);
     }
 }

--- a/crates/acp/tests/zanzibar_types_tests.rs
+++ b/crates/acp/tests/zanzibar_types_tests.rs
@@ -398,7 +398,7 @@ fn test_dpi_disallowed_intersection() {
 }
 
 #[test]
-fn test_dpi_disallowed_difference() {
+fn test_dpi_allows_difference() {
     let policy = Policy::new("policy1", "Test").with_resource(
         Resource::new("document")
             .with_relation(Relation::direct("owner"))
@@ -412,12 +412,7 @@ fn test_dpi_disallowed_difference() {
             )),
     );
 
-    let result = policy.validate_dpi();
-    assert!(
-        matches!(result, Err(Error::DpiDisallowedOperation { .. })),
-        "Expected DpiDisallowedOperation, got {:?}",
-        result
-    );
+    assert!(policy.validate_dpi().is_ok());
 }
 
 #[test]
@@ -437,6 +432,65 @@ fn test_dpi_owner_via_ttu() {
                 )),
         )
         .with_resource(Resource::new("folder").with_relation(Relation::direct("owner")));
+
+    assert!(policy.validate_dpi().is_ok());
+}
+
+#[test]
+fn test_dpi_allows_nested_difference() {
+    let policy = Policy::new("policy1", "Test").with_resource(
+        Resource::new("document")
+            .with_relation(Relation::direct("owner"))
+            .with_relation(Relation::direct("reader"))
+            .with_relation(Relation::direct("writer"))
+            .with_relation(Relation::direct("blocked"))
+            .with_relation(Relation::computed(
+                "viewer",
+                RelationExpression::union(vec![
+                    RelationExpression::computed_userset("owner"),
+                    RelationExpression::difference(
+                        RelationExpression::union(vec![
+                            RelationExpression::computed_userset("reader"),
+                            RelationExpression::computed_userset("writer"),
+                        ]),
+                        RelationExpression::computed_userset("blocked"),
+                    ),
+                ]),
+            )),
+    );
+
+    assert!(policy.validate_dpi().is_ok());
+}
+
+#[test]
+fn test_dpi_allows_ttu_in_union() {
+    let policy = Policy::new("policy1", "Test")
+        .with_resource(
+            Resource::new("file")
+                .with_relation(Relation::direct("owner"))
+                .with_relation(Relation::direct("parent"))
+                .with_relation(Relation::direct("reader"))
+                .with_relation(Relation::computed(
+                    "read",
+                    RelationExpression::union(vec![
+                        RelationExpression::computed_userset("owner"),
+                        RelationExpression::computed_userset("reader"),
+                        RelationExpression::tuple_to_userset("parent", "read"),
+                    ]),
+                )),
+        )
+        .with_resource(
+            Resource::new("directory")
+                .with_relation(Relation::direct("owner"))
+                .with_relation(Relation::direct("reader"))
+                .with_relation(Relation::computed(
+                    "read",
+                    RelationExpression::union(vec![
+                        RelationExpression::computed_userset("owner"),
+                        RelationExpression::computed_userset("reader"),
+                    ]),
+                )),
+        );
 
     assert!(policy.validate_dpi().is_ok());
 }

--- a/crates/zanzibar/src/error.rs
+++ b/crates/zanzibar/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
     #[error("DPI violation: permission '{relation}' on resource '{resource}' must include 'owner' in its expression")]
     DpiExpressionMissingOwner { resource: String, relation: String },
 
-    #[error("DPI violation: resource '{resource}' relation '{relation}' uses disallowed operation '{operation}' (only union allowed)")]
+    #[error("DPI violation: resource '{resource}' relation '{relation}' uses disallowed operation '{operation}'")]
     DpiDisallowedOperation {
         resource: String,
         relation: String,

--- a/crates/zanzibar/src/types/policy.rs
+++ b/crates/zanzibar/src/types/policy.rs
@@ -119,15 +119,13 @@ impl Policy {
             RelationExpression::ComputedUserset { .. } => None,
             RelationExpression::TupleToUserset { .. } => None,
             RelationExpression::Union(exprs) => {
-                for e in exprs {
-                    if let Some(op) = Self::find_disallowed_operation(e) {
-                        return Some(op);
-                    }
-                }
-                None
+                exprs.iter().find_map(Self::find_disallowed_operation)
             }
             RelationExpression::Intersection(_) => Some("intersection (&)".to_string()),
-            RelationExpression::Difference { .. } => Some("difference (-)".to_string()),
+            RelationExpression::Difference { base, subtract } => {
+                Self::find_disallowed_operation(base)
+                    .or_else(|| Self::find_disallowed_operation(subtract))
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- relax DPI validation to allow difference (`-`) while continuing to reject intersection (`&`)
- fix YAML policy expression validation so tuple-to-userset (`->`) expressions load successfully
- add coverage for difference and TTU policy loading plus DPI acceptance cases

## Testing
- cargo test -p acp
- cargo test -p zanzibar
- cargo clippy -p acp -p zanzibar --all-targets -- -D warnings
- cargo test (fails due to unrelated existing `schema` test compile issue in `crates/schema/tests/property_tests.rs`)
- cargo clippy --all-targets -- -D warnings (blocked by the same unrelated `schema` test compile issue)

Closes #628