### PR TITLE
fix(acp): make ACP state mutations transactional (#627)

### DIFF
--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -7,7 +7,7 @@
 use crate::collection::Collection;
 use crate::collection_cache::CollectionCache;
 use crate::error::{Error, Result};
-use datastore::{BasicTxn, NamespaceView, RootView, TxnCallback};
+use datastore::{AsyncCallback, BasicTxn, NamespaceView, RootView, TxnCallback};
 use schema::CollectionVersion;
 use std::sync::Arc;
 use storage::corekv::{IterOptions, Key, Store};
@@ -183,6 +183,18 @@ impl<S: Store> DbTxn<S> {
     pub fn on_error(&mut self, callback: TxnCallback) -> Result<()> {
         if let Some(txn) = &mut self.txn {
             txn.on_error(callback);
+            Ok(())
+        } else {
+            Err(Error::TxnNotActive)
+        }
+    }
+
+    /// Register an async callback for successful commit.
+    ///
+    /// Returns an error if the transaction has been committed or discarded.
+    pub fn on_success_async(&mut self, callback: AsyncCallback) -> Result<()> {
+        if let Some(txn) = &mut self.txn {
+            txn.on_success_async(callback);
             Ok(())
         } else {
             Err(Error::TxnNotActive)

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -3,7 +3,7 @@
 use query::fetcher::CollectionProvider;
 use query::mutator::DocMutator;
 use query::runner::DocFetcher;
-use query::txn::TransactionContext;
+use query::txn::{DeferredAcpMutations, TransactionContext};
 use std::sync::Arc;
 use std::time::Instant;
 use storage::corekv::Store;
@@ -24,6 +24,7 @@ pub struct DbTransactionContext<S: Store> {
     id: String,
     readonly: bool,
     fetcher: Arc<LensedDocFetcher<S>>,
+    deferred_acp_mutations: Arc<DeferredAcpMutations>,
     created_at: Instant,
 }
 
@@ -34,12 +35,14 @@ impl<S: Store> DbTransactionContext<S> {
         id: String,
         readonly: bool,
         fetcher: Arc<LensedDocFetcher<S>>,
+        deferred_acp_mutations: Arc<DeferredAcpMutations>,
     ) -> Self {
         Self {
             db,
             id,
             readonly,
             fetcher,
+            deferred_acp_mutations,
             created_at: Instant::now(),
         }
     }
@@ -120,5 +123,9 @@ impl<S: Store + 'static> TransactionContext for DbTransactionContext<S> {
             self.db.clone(),
             self.fetcher.shared_txn(),
         )))
+    }
+
+    fn deferred_acp_mutations(&self) -> Option<Arc<DeferredAcpMutations>> {
+        Some(self.deferred_acp_mutations.clone())
     }
 }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -17,7 +17,8 @@ use async_trait::async_trait;
 use document::Document;
 use query::error::TransactionError;
 use query::txn::{
-    GetTransactionResult, TransactionContext, TransactionHandle, TransactionRegistry,
+    DeferredAcpMutations, GetTransactionResult, TransactionContext, TransactionHandle,
+    TransactionRegistry,
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -377,11 +378,25 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
     ) -> std::result::Result<TransactionHandle, TransactionError> {
         let txn_id = self.id_counter.fetch_add(1, Ordering::SeqCst).to_string();
 
-        let db_txn = self
+        let mut db_txn = self
             .db
             .new_txn(readonly)
             .await
             .map_err(|e| TransactionError::execution(format!("storage error: {}", e)))?;
+        let deferred_acp_mutations = Arc::new(DeferredAcpMutations::new());
+        let deferred_acp_mutations_for_commit = deferred_acp_mutations.clone();
+        db_txn
+            .on_success_async(Box::new(move || {
+                Box::pin(async move {
+                    deferred_acp_mutations_for_commit.run_all_logged().await;
+                })
+            }))
+            .map_err(|e| {
+                TransactionError::execution(format!(
+                    "failed to register deferred ACP commit hook: {}",
+                    e
+                ))
+            })?;
 
         // Transaction-scoped collection caching: collections are loaded lazily
         // from the SystemStore on first access within the transaction. Once loaded,
@@ -394,6 +409,7 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             txn_id.clone(),
             readonly,
             fetcher,
+            deferred_acp_mutations,
         ));
 
         self.transactions

--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -12,6 +12,7 @@ use identity::Did;
 use crate::document::DocumentMapping;
 use crate::error::Result;
 use crate::planner::{Doc, PlanNode};
+use crate::txn::check_doc_access_with_overlay;
 
 /// PermissionFilterNode filters documents based on ACP permissions.
 ///
@@ -90,27 +91,26 @@ impl PermissionFilterNode {
             return Ok(true);
         }
 
-        Ok(self
-            .acp
-            .check_doc_access(
-                &self.identity,
-                DocumentPermission::Read,
-                &self.policy_id,
-                &self.resource_name,
-                doc_id,
-            )
-            .await
-            .unwrap_or_else(|e| {
-                tracing::warn!(
-                    doc_id = %doc_id,
-                    policy_id = %self.policy_id,
-                    resource_name = %self.resource_name,
-                    identity = %self.identity,
-                    error = %e,
-                    "Permission check failed, denying access to document"
-                );
-                false
-            }))
+        Ok(check_doc_access_with_overlay(
+            self.acp.as_ref(),
+            &self.identity,
+            DocumentPermission::Read,
+            &self.policy_id,
+            &self.resource_name,
+            doc_id,
+        )
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!(
+                doc_id = %doc_id,
+                policy_id = %self.policy_id,
+                resource_name = %self.resource_name,
+                identity = %self.identity,
+                error = %e,
+                "Permission check failed, denying access to document"
+            );
+            false
+        }))
     }
 }
 

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -750,15 +750,15 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     // Check against all policies -- at least one must grant access.
                     let mut any_granted = false;
                     for &(policy_id, resource_name) in &policies {
-                        match acp
-                            .check_doc_access(
-                                &identity,
-                                DocumentPermission::Read,
-                                policy_id,
-                                resource_name,
-                                &doc_id,
-                            )
-                            .await
+                        match crate::txn::check_doc_access_with_overlay(
+                            acp.as_ref(),
+                            &identity,
+                            DocumentPermission::Read,
+                            policy_id,
+                            resource_name,
+                            &doc_id,
+                        )
+                        .await
                         {
                             Ok(true) => {
                                 any_granted = true;

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -391,14 +391,34 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             }
         };
 
-        // If the transaction provides a collection provider, set it as the task-local
-        // override so all collection resolution within this execution uses the
-        // transaction's uncommitted state.
+        let deferred_acp_mutations = txn_ctx.deferred_acp_mutations();
+
+        // If the transaction provides a collection provider or deferred ACP
+        // projection, set them as task-local overrides so this execution sees
+        // the transaction's uncommitted schema and ACP state.
         #[cfg(not(target_arch = "wasm32"))]
         let result = if let Some(provider) = txn_provider {
-            super::TXN_COLLECTION_PROVIDER
-                .scope(provider, await_with_timeout(execution, self.query_timeout))
-                .await
+            if let Some(deferred_acp_mutations) = deferred_acp_mutations {
+                super::TXN_COLLECTION_PROVIDER
+                    .scope(
+                        provider,
+                        crate::txn::scope_deferred_acp_mutations(
+                            deferred_acp_mutations,
+                            await_with_timeout(execution, self.query_timeout),
+                        ),
+                    )
+                    .await
+            } else {
+                super::TXN_COLLECTION_PROVIDER
+                    .scope(provider, await_with_timeout(execution, self.query_timeout))
+                    .await
+            }
+        } else if let Some(deferred_acp_mutations) = deferred_acp_mutations {
+            crate::txn::scope_deferred_acp_mutations(
+                deferred_acp_mutations,
+                await_with_timeout(execution, self.query_timeout),
+            )
+            .await
         } else {
             await_with_timeout(execution, self.query_timeout).await
         };

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -263,16 +263,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         let mut visible_doc_ids = Vec::new();
                         for doc_id in doc_ids {
                             // Phase 1: Check if the identity can read the document
-                            let can_read = acp
-                                .check_doc_access(
-                                    &identity_for_acp,
-                                    DocumentPermission::Read,
-                                    &policy.id,
-                                    &policy.resource_name,
-                                    doc_id,
-                                )
-                                .await
-                                .unwrap_or(false);
+                            let can_read = crate::txn::check_doc_access_with_overlay(
+                                acp.as_ref(),
+                                &identity_for_acp,
+                                DocumentPermission::Read,
+                                &policy.id,
+                                &policy.resource_name,
+                                doc_id,
+                            )
+                            .await
+                            .unwrap_or(false);
 
                             if !can_read {
                                 // Document is invisible to this identity -- skip silently
@@ -280,16 +280,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             }
 
                             // Phase 2: Check if the identity can update the document
-                            let can_update = acp
-                                .check_doc_access(
-                                    &identity_for_acp,
-                                    DocumentPermission::Update,
-                                    &policy.id,
-                                    &policy.resource_name,
-                                    doc_id,
-                                )
-                                .await
-                                .map_err(|e| QueryError::acp_check_failed("update", doc_id, e))?;
+                            let can_update = crate::txn::check_doc_access_with_overlay(
+                                acp.as_ref(),
+                                &identity_for_acp,
+                                DocumentPermission::Update,
+                                &policy.id,
+                                &policy.resource_name,
+                                doc_id,
+                            )
+                            .await
+                            .map_err(|e| QueryError::acp_check_failed("update", doc_id, e))?;
 
                             if !can_update {
                                 return Err(QueryError::document_not_found(
@@ -307,16 +307,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         let mut visible_doc_ids = Vec::new();
                         for doc_id in doc_ids {
                             // Phase 1: Check if the identity can read the document
-                            let can_read = acp
-                                .check_doc_access(
-                                    &identity_for_acp,
-                                    DocumentPermission::Read,
-                                    &policy.id,
-                                    &policy.resource_name,
-                                    doc_id,
-                                )
-                                .await
-                                .unwrap_or(false);
+                            let can_read = crate::txn::check_doc_access_with_overlay(
+                                acp.as_ref(),
+                                &identity_for_acp,
+                                DocumentPermission::Read,
+                                &policy.id,
+                                &policy.resource_name,
+                                doc_id,
+                            )
+                            .await
+                            .unwrap_or(false);
 
                             if !can_read {
                                 // Document is invisible to this identity -- skip silently
@@ -324,16 +324,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             }
 
                             // Phase 2: Check if the identity can delete the document
-                            let can_delete = acp
-                                .check_doc_access(
-                                    &identity_for_acp,
-                                    DocumentPermission::Delete,
-                                    &policy.id,
-                                    &policy.resource_name,
-                                    doc_id,
-                                )
-                                .await
-                                .map_err(|e| QueryError::acp_check_failed("delete", doc_id, e))?;
+                            let can_delete = crate::txn::check_doc_access_with_overlay(
+                                acp.as_ref(),
+                                &identity_for_acp,
+                                DocumentPermission::Delete,
+                                &policy.id,
+                                &policy.resource_name,
+                                doc_id,
+                            )
+                            .await
+                            .map_err(|e| QueryError::acp_check_failed("delete", doc_id, e))?;
 
                             if !can_delete {
                                 return Err(QueryError::document_not_found(
@@ -633,63 +633,101 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 for result in &results {
                     if let Some(doc_id) = result.get("_docID").and_then(|v| v.as_str()) {
                         // Check if document is already registered (for upsert of existing doc)
-                        let is_registered = acp
-                            .is_doc_registered(&policy.id, &policy.resource_name, doc_id)
-                            .await
-                            .map_err(|e| {
-                                tracing::warn!(
-                                    doc_id = %doc_id,
-                                    policy_id = %policy.id,
-                                    error = %e,
-                                    "Failed to check ACP registration status - propagating error"
-                                );
-                                QueryError::acp_registration_check_failed(doc_id, e)
-                            })?;
+                        let is_registered = crate::txn::is_doc_registered_with_overlay(
+                            acp.as_ref(),
+                            &policy.id,
+                            &policy.resource_name,
+                            doc_id,
+                        )
+                        .await
+                        .map_err(|e| {
+                            tracing::warn!(
+                                doc_id = %doc_id,
+                                policy_id = %policy.id,
+                                error = %e,
+                                "Failed to check ACP registration status - propagating error"
+                            );
+                            QueryError::acp_registration_check_failed(doc_id, e)
+                        })?;
 
                         // Only register if not already registered (new document)
                         if !is_registered {
-                            let acp_registration_start = Instant::now();
-                            acp.register_doc_object(
-                                identity_did,
-                                &policy.id,
-                                &policy.resource_name,
-                                doc_id,
-                            )
-                            .await
-                            .map_err(|e| {
-                                tracing::error!(
-                                    doc_id = %doc_id,
-                                    error = %e,
-                                    "Failed to register document with ACP - aborting mutation"
+                            if let Some(deferred_acp_mutations) =
+                                crate::txn::current_deferred_acp_mutations()
+                            {
+                                let request_bearer_token = defra_core::signing::get_request_bearer_token(
+                                    identity_did.as_str(),
                                 );
-                                QueryError::acp_registration_failed(doc_id, e)
-                            })?;
-                            tracing::info!(
-                                doc_id = %doc_id,
-                                elapsed = ?acp_registration_start.elapsed(),
-                                "ACP document registration completed"
-                            );
+                                deferred_acp_mutations
+                                    .schedule_register_doc_object(
+                                        acp.clone(),
+                                        identity_did.clone(),
+                                        policy.id.clone(),
+                                        policy.resource_name.clone(),
+                                        doc_id.to_string(),
+                                        request_bearer_token,
+                                    )
+                                    .map_err(QueryError::execution)?;
+                            } else {
+                                let acp_registration_start = Instant::now();
+                                acp.register_doc_object(
+                                    identity_did,
+                                    &policy.id,
+                                    &policy.resource_name,
+                                    doc_id,
+                                )
+                                .await
+                                .map_err(|e| {
+                                    tracing::error!(
+                                        doc_id = %doc_id,
+                                        error = %e,
+                                        "Failed to register document with ACP - aborting mutation"
+                                    );
+                                    QueryError::acp_registration_failed(doc_id, e)
+                                })?;
+                                tracing::info!(
+                                    doc_id = %doc_id,
+                                    elapsed = ?acp_registration_start.elapsed(),
+                                    "ACP document registration completed"
+                                );
+                            }
                         }
                     }
                 }
             }
         }
 
-        // Clear request bearer token after ACP registration is complete
-        if let Some(ref identity_did) = caller_identity {
-            defra_core::signing::clear_request_bearer_token(identity_did.as_str());
-        }
-
         // For DELETE operations: unregister deleted docs from ACP
         // This cleans up ACP state to prevent orphaned registrations
         if matches!(mutation.mutation_type, MutationType::Delete) {
             if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+                let request_bearer_token = caller_identity
+                    .as_ref()
+                    .and_then(|did| defra_core::signing::get_request_bearer_token(did.as_str()));
                 for result in &results {
                     if let Some(doc_id) = result.get("_docID").and_then(|v| v.as_str()) {
                         // Best-effort unregistration - log failures but don't fail the delete
                         // The document is already deleted from storage; ACP cleanup failure
                         // leaves orphaned metadata but doesn't affect data integrity
-                        if let Err(e) = acp
+                        if let Some(deferred_acp_mutations) =
+                            crate::txn::current_deferred_acp_mutations()
+                        {
+                            if let Err(err) = deferred_acp_mutations.schedule_unregister_doc_object(
+                                acp.clone(),
+                                policy.id.clone(),
+                                policy.resource_name.clone(),
+                                doc_id.to_string(),
+                                caller_identity.clone(),
+                                request_bearer_token.clone(),
+                            ) {
+                                tracing::warn!(
+                                    doc_id = %doc_id,
+                                    policy_id = %policy.id,
+                                    error = %err,
+                                    "Failed to defer ACP unregister for deleted document"
+                                );
+                            }
+                        } else if let Err(e) = acp
                             .unregister_doc_object(&policy.id, &policy.resource_name, doc_id)
                             .await
                         {
@@ -709,6 +747,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     }
                 }
             }
+        }
+
+        // Clear request bearer token after all ACP post-write work is queued or applied.
+        if let Some(ref identity_did) = caller_identity {
+            defra_core::signing::clear_request_bearer_token(identity_did.as_str());
         }
 
         // Enrich results with _version data if requested.

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -45,16 +45,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             for doc in plan_docs {
                 if let Some(doc_id_val) = doc.get(0) {
                     if let Some(doc_id) = doc_id_val.as_str() {
-                        let has_access = acp
-                            .check_doc_access(
-                                &acp_identity,
-                                DocumentPermission::Read,
-                                &policy.id,
-                                &policy.resource_name,
-                                doc_id,
-                            )
-                            .await
-                            .unwrap_or(false);
+                        let has_access = crate::txn::check_doc_access_with_overlay(
+                            acp.as_ref(),
+                            &acp_identity,
+                            DocumentPermission::Read,
+                            &policy.id,
+                            &policy.resource_name,
+                            doc_id,
+                        )
+                        .await
+                        .unwrap_or(false);
                         if has_access {
                             filtered.push(doc);
                         }

--- a/crates/query/src/runner/query/select.rs
+++ b/crates/query/src/runner/query/select.rs
@@ -388,23 +388,23 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let mut allowed = Vec::with_capacity(doc_ids.len());
 
         for doc_id in doc_ids {
-            let has_access = acp
-                .check_doc_access(
-                    &identity,
-                    DocumentPermission::Read,
-                    &policy.id,
-                    &policy.resource_name,
-                    doc_id,
-                )
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::warn!(
-                        doc_id = %doc_id,
-                        error = %e,
-                        "ACP check failed for encrypted search result, denying access"
-                    );
-                    false
-                });
+            let has_access = crate::txn::check_doc_access_with_overlay(
+                acp.as_ref(),
+                &identity,
+                DocumentPermission::Read,
+                &policy.id,
+                &policy.resource_name,
+                doc_id,
+            )
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    doc_id = %doc_id,
+                    error = %e,
+                    "ACP check failed for encrypted search result, denying access"
+                );
+                false
+            });
 
             if has_access {
                 allowed.push(doc_id.clone());

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -78,15 +78,15 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     Some(id) => id.to_string(),
                     None => continue,
                 };
-                match acp
-                    .check_doc_access(
-                        &identity,
-                        DocumentPermission::Read,
-                        &policy.id,
-                        &policy.resource_name,
-                        &doc_id,
-                    )
-                    .await
+                match crate::txn::check_doc_access_with_overlay(
+                    acp.as_ref(),
+                    &identity,
+                    DocumentPermission::Read,
+                    &policy.id,
+                    &policy.resource_name,
+                    &doc_id,
+                )
+                .await
                 {
                     Ok(true) => permitted.push(doc),
                     Ok(false) => {

--- a/crates/query/src/txn/context.rs
+++ b/crates/query/src/txn/context.rs
@@ -1,11 +1,352 @@
 //! Transaction context trait.
 
+use acp::error::{Error as AcpError, Result as AcpResult};
+use acp::DocumentACP;
+use acp::DocumentPermission;
+use acp::Identity;
+use defra_core::thread_bounds::MaybeBoxFuture;
+use futures::FutureExt;
+use identity::Did;
+use std::collections::HashMap;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use storage::corekv::MaybeSendSync;
 
 use crate::fetcher::CollectionProvider;
 use crate::mutator::DocMutator;
 use crate::runner::DocFetcher;
+
+#[cfg(not(target_arch = "wasm32"))]
+tokio::task_local! {
+    static TXN_DEFERRED_ACP_MUTATIONS: Arc<DeferredAcpMutations>;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+type DeferredAcpHook = Box<dyn FnOnce() -> MaybeBoxFuture<'static, Result<(), String>> + Send>;
+#[cfg(target_arch = "wasm32")]
+type DeferredAcpHook = Box<dyn FnOnce() -> MaybeBoxFuture<'static, Result<(), String>>>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ProjectedDocRegistration {
+    Registered { owner: Did },
+    Unregistered,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct DocRegistrationKey {
+    policy_id: String,
+    resource_name: String,
+    doc_id: String,
+}
+
+struct DeferredAcpHookEntry {
+    description: &'static str,
+    callback: DeferredAcpHook,
+}
+
+#[derive(Default)]
+struct DeferredAcpState {
+    projected_registrations: HashMap<DocRegistrationKey, ProjectedDocRegistration>,
+    hooks: Vec<DeferredAcpHookEntry>,
+}
+
+/// Deferred ACP mutations and their transaction-local registration projection.
+///
+/// Explicit database transactions use this to:
+/// - buffer ACP writes until commit succeeds
+/// - expose projected registration state to permission checks within the txn
+#[derive(Default)]
+pub struct DeferredAcpMutations {
+    state: std::sync::Mutex<DeferredAcpState>,
+}
+
+impl DeferredAcpMutations {
+    /// Create an empty deferred ACP state container.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn doc_key(policy_id: &str, resource_name: &str, doc_id: &str) -> DocRegistrationKey {
+        DocRegistrationKey {
+            policy_id: policy_id.to_string(),
+            resource_name: resource_name.to_string(),
+            doc_id: doc_id.to_string(),
+        }
+    }
+
+    fn lock_state(&self) -> Result<std::sync::MutexGuard<'_, DeferredAcpState>, String> {
+        self.state
+            .lock()
+            .map_err(|_| "deferred ACP mutation state lock poisoned".to_string())
+    }
+
+    fn push_hook(
+        &self,
+        description: &'static str,
+        callback: DeferredAcpHook,
+    ) -> Result<(), String> {
+        let mut state = self.lock_state()?;
+        state.hooks.push(DeferredAcpHookEntry {
+            description,
+            callback,
+        });
+        Ok(())
+    }
+
+    fn with_request_bearer_token(
+        did: &Did,
+        token: Option<String>,
+    ) -> Option<RequestBearerTokenGuard> {
+        let token = token?;
+        Some(RequestBearerTokenGuard::new(did.as_str(), token))
+    }
+
+    /// Return the projected registration state for a document within the current transaction.
+    fn projected_registration(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> AcpResult<Option<ProjectedDocRegistration>> {
+        let state = self
+            .lock_state()
+            .map_err(AcpError::Storage)?;
+        Ok(state
+            .projected_registrations
+            .get(&Self::doc_key(policy_id, resource_name, doc_id))
+            .cloned())
+    }
+
+    /// Schedule a document registration to run after the storage transaction commits.
+    pub fn schedule_register_doc_object(
+        &self,
+        acp: Arc<dyn DocumentACP>,
+        identity: Did,
+        policy_id: String,
+        resource_name: String,
+        doc_id: String,
+        request_bearer_token: Option<String>,
+    ) -> Result<(), String> {
+        {
+            let mut state = self.lock_state()?;
+            state.projected_registrations.insert(
+                Self::doc_key(&policy_id, &resource_name, &doc_id),
+                ProjectedDocRegistration::Registered {
+                    owner: identity.clone(),
+                },
+            );
+        }
+
+        let doc_id_for_log = doc_id.clone();
+        let policy_id_for_log = policy_id.clone();
+        self.push_hook(
+            "register_doc_object",
+            Box::new(move || {
+                Box::pin(async move {
+                    let _request_token_guard =
+                        Self::with_request_bearer_token(&identity, request_bearer_token);
+                    acp.register_doc_object(&identity, &policy_id, &resource_name, &doc_id)
+                        .await
+                        .map_err(|e| {
+                            format!(
+                                "failed to register ACP document '{}' for policy '{}': {}",
+                                doc_id_for_log, policy_id_for_log, e
+                            )
+                        })
+                })
+            }),
+        )
+    }
+
+    /// Schedule a document unregistration to run after the storage transaction commits.
+    pub fn schedule_unregister_doc_object(
+        &self,
+        acp: Arc<dyn DocumentACP>,
+        policy_id: String,
+        resource_name: String,
+        doc_id: String,
+        caller_identity: Option<Did>,
+        request_bearer_token: Option<String>,
+    ) -> Result<(), String> {
+        {
+            let mut state = self.lock_state()?;
+            state.projected_registrations.insert(
+                Self::doc_key(&policy_id, &resource_name, &doc_id),
+                ProjectedDocRegistration::Unregistered,
+            );
+        }
+
+        let doc_id_for_log = doc_id.clone();
+        let policy_id_for_log = policy_id.clone();
+        self.push_hook(
+            "unregister_doc_object",
+            Box::new(move || {
+                Box::pin(async move {
+                    let _request_token_guard = caller_identity
+                        .as_ref()
+                        .and_then(|did| Self::with_request_bearer_token(did, request_bearer_token));
+
+                    if let Err(err) = acp
+                        .unregister_doc_object(&policy_id, &resource_name, &doc_id)
+                        .await
+                    {
+                        tracing::warn!(
+                            doc_id = %doc_id_for_log,
+                            policy_id = %policy_id_for_log,
+                            error = %err,
+                            "Deferred ACP unregister failed after commit"
+                        );
+                    }
+
+                    Ok(())
+                })
+            }),
+        )
+    }
+
+    /// Run all deferred ACP hooks in registration order.
+    pub async fn run_all_logged(&self) {
+        let hooks = match self.lock_state() {
+            Ok(mut state) => std::mem::take(&mut state.hooks),
+            Err(err) => {
+                tracing::error!(error = %err, "Failed to drain deferred ACP hooks");
+                return;
+            }
+        };
+
+        for hook in hooks {
+            let description = hook.description;
+            let result = AssertUnwindSafe((hook.callback)())
+                .catch_unwind()
+                .await;
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    tracing::error!(
+                        hook = description,
+                        error = %err,
+                        "Deferred ACP hook failed after transaction commit"
+                    );
+                }
+                Err(panic) => {
+                    tracing::error!(
+                        hook = description,
+                        panic = ?panic,
+                        "Deferred ACP hook panicked after transaction commit"
+                    );
+                }
+            }
+        }
+    }
+}
+
+struct RequestBearerTokenGuard {
+    did: String,
+    previous_token: Option<String>,
+}
+
+impl RequestBearerTokenGuard {
+    fn new(did: &str, new_token: String) -> Self {
+        let previous_token = defra_core::signing::get_request_bearer_token(did);
+        defra_core::signing::set_request_bearer_token(did, new_token);
+        Self {
+            did: did.to_string(),
+            previous_token,
+        }
+    }
+}
+
+impl Drop for RequestBearerTokenGuard {
+    fn drop(&mut self) {
+        if let Some(previous_token) = self.previous_token.take() {
+            defra_core::signing::set_request_bearer_token(&self.did, previous_token);
+        } else {
+            defra_core::signing::clear_request_bearer_token(&self.did);
+        }
+    }
+}
+
+/// Execute a future with the given deferred ACP mutation projection in scope.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn scope_deferred_acp_mutations<Fut, T>(
+    mutations: Arc<DeferredAcpMutations>,
+    future: Fut,
+) -> T
+where
+    Fut: Future<Output = T>,
+{
+    TXN_DEFERRED_ACP_MUTATIONS.scope(mutations, future).await
+}
+
+/// Execute a future with the given deferred ACP mutation projection in scope.
+#[cfg(target_arch = "wasm32")]
+pub async fn scope_deferred_acp_mutations<Fut, T>(
+    _mutations: Arc<DeferredAcpMutations>,
+    future: Fut,
+) -> T
+where
+    Fut: Future<Output = T>,
+{
+    future.await
+}
+
+/// Return the current transaction's deferred ACP projection, if any.
+pub fn current_deferred_acp_mutations() -> Option<Arc<DeferredAcpMutations>> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        TXN_DEFERRED_ACP_MUTATIONS
+            .try_with(|mutations| mutations.clone())
+            .ok()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        None
+    }
+}
+
+/// Check document registration while honoring any ACP mutations buffered in the current txn.
+pub async fn is_doc_registered_with_overlay(
+    acp: &dyn DocumentACP,
+    policy_id: &str,
+    resource_name: &str,
+    doc_id: &str,
+) -> AcpResult<bool> {
+    if let Some(mutations) = current_deferred_acp_mutations() {
+        if let Some(projected) = mutations.projected_registration(policy_id, resource_name, doc_id)?
+        {
+            return Ok(matches!(projected, ProjectedDocRegistration::Registered { .. }));
+        }
+    }
+
+    acp.is_doc_registered(policy_id, resource_name, doc_id).await
+}
+
+/// Check document access while honoring any ACP mutations buffered in the current txn.
+pub async fn check_doc_access_with_overlay(
+    acp: &dyn DocumentACP,
+    identity: &Identity,
+    permission: DocumentPermission,
+    policy_id: &str,
+    resource_name: &str,
+    doc_id: &str,
+) -> AcpResult<bool> {
+    if let Some(mutations) = current_deferred_acp_mutations() {
+        if let Some(projected) = mutations.projected_registration(policy_id, resource_name, doc_id)?
+        {
+            return Ok(match projected {
+                ProjectedDocRegistration::Unregistered => true,
+                ProjectedDocRegistration::Registered { owner } => {
+                    matches!(identity, Identity::Authenticated(did) if did == &owner)
+                }
+            });
+        }
+    }
+
+    acp.check_doc_access(identity, permission, policy_id, resource_name, doc_id)
+        .await
+}
 
 /// Transaction context that provides storage access within a transaction.
 ///
@@ -41,6 +382,15 @@ pub trait TransactionContext: MaybeSendSync {
         None
     }
 
+    /// Get deferred ACP mutations for this transaction.
+    ///
+    /// Implementations with transactional ACP buffering should override this to
+    /// return a shared state object that can be used both for commit-time hooks
+    /// and for transaction-local ACP projections.
+    fn deferred_acp_mutations(&self) -> Option<Arc<DeferredAcpMutations>> {
+        None
+    }
+
     /// Check if the transaction is still active (not yet committed or rolled back).
     ///
     /// Returns `true` if the transaction can still be used for queries.
@@ -55,4 +405,177 @@ pub trait TransactionContext: MaybeSendSync {
     fn is_active(&self) -> bool {
         true
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn projected_registration_reports_registered_and_owner_only_access() {
+        let mutations = Arc::new(DeferredAcpMutations::new());
+        let owner: Did = "did:key:z6MksQ6mYqY1YxR4KQ2NW6y6x8vJrNs2LEd8w5pYxHw3rroA"
+            .parse()
+            .expect("owner did");
+        let stranger: Did = "did:key:z6MkwQm1zZ1p9raM2AfU4vX9y1Aq5PEYB9H9n1tFoZT3zh7T"
+            .parse()
+            .expect("stranger did");
+
+        mutations
+            .lock_state()
+            .expect("state lock")
+            .projected_registrations
+            .insert(
+                DeferredAcpMutations::doc_key("policy", "User", "doc-1"),
+                ProjectedDocRegistration::Registered {
+                    owner: owner.clone(),
+                },
+            );
+
+        let access = scope_deferred_acp_mutations(
+            mutations.clone(),
+            check_doc_access_with_overlay(
+                &NoopDocumentAcp,
+                &Identity::Authenticated(owner),
+                DocumentPermission::Read,
+                "policy",
+                "User",
+                "doc-1",
+            ),
+        )
+        .await
+        .expect("owner access");
+        assert!(access);
+
+        let access = scope_deferred_acp_mutations(
+            mutations,
+            check_doc_access_with_overlay(
+                &NoopDocumentAcp,
+                &Identity::Authenticated(stranger),
+                DocumentPermission::Read,
+                "policy",
+                "User",
+                "doc-1",
+            ),
+        )
+        .await
+        .expect("stranger access");
+        assert!(!access);
+    }
+
+    #[tokio::test]
+    async fn projected_unregistration_reports_public_access() {
+        let mutations = Arc::new(DeferredAcpMutations::new());
+        mutations
+            .lock_state()
+            .expect("state lock")
+            .projected_registrations
+            .insert(
+                DeferredAcpMutations::doc_key("policy", "User", "doc-1"),
+                ProjectedDocRegistration::Unregistered,
+            );
+
+        let access = scope_deferred_acp_mutations(
+            mutations.clone(),
+            check_doc_access_with_overlay(
+                &NoopDocumentAcp,
+                &Identity::Anonymous,
+                DocumentPermission::Read,
+                "policy",
+                "User",
+                "doc-1",
+            ),
+        )
+        .await
+        .expect("anonymous access");
+        assert!(access);
+
+        let registered = scope_deferred_acp_mutations(
+            mutations,
+            is_doc_registered_with_overlay(&NoopDocumentAcp, "policy", "User", "doc-1"),
+        )
+        .await
+        .expect("registration");
+        assert!(!registered);
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    impl DocumentACP for NoopDocumentAcp {
+        async fn register_doc_object(
+            &self,
+            _identity: &Did,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> AcpResult<()> {
+            Ok(())
+        }
+
+        async fn is_doc_registered(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> AcpResult<bool> {
+            Ok(false)
+        }
+
+        async fn get_doc_owner(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> AcpResult<Option<Did>> {
+            Ok(None)
+        }
+
+        async fn check_doc_access(
+            &self,
+            _identity: &Identity,
+            _permission: DocumentPermission,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> AcpResult<bool> {
+            Ok(false)
+        }
+
+        async fn add_actor_relationship(
+            &self,
+            _requestor: &Did,
+            _target: &Did,
+            _policy_id: &str,
+            _collection_id: &str,
+            _doc_id: &str,
+            _relation: &str,
+            _managing_relations: &[String],
+        ) -> AcpResult<bool> {
+            Ok(false)
+        }
+
+        async fn delete_actor_relationship(
+            &self,
+            _requestor: &Did,
+            _target: &Did,
+            _policy_id: &str,
+            _collection_id: &str,
+            _doc_id: &str,
+            _relation: &str,
+            _managing_relations: &[String],
+        ) -> AcpResult<bool> {
+            Ok(false)
+        }
+
+        async fn unregister_doc_object(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> AcpResult<()> {
+            Ok(())
+        }
+    }
+
+    struct NoopDocumentAcp;
 }

--- a/crates/query/src/txn/mod.rs
+++ b/crates/query/src/txn/mod.rs
@@ -10,7 +10,10 @@ mod registry;
 mod result;
 
 // Re-export all public types
-pub use context::TransactionContext;
+pub use context::{
+    check_doc_access_with_overlay, current_deferred_acp_mutations, is_doc_registered_with_overlay,
+    scope_deferred_acp_mutations, DeferredAcpMutations, TransactionContext,
+};
 pub use guard::TransactionGuard;
 pub use handle::TransactionHandle;
 pub use registry::{NoOpTransactionRegistry, TransactionRegistry};

--- a/tools/integration-test/tests/acp.rs
+++ b/tools/integration-test/tests/acp.rs
@@ -16,5 +16,7 @@ mod node_access;
 mod p2p;
 #[path = "acp/revoke_lifecycle.rs"]
 mod revoke_lifecycle;
+#[path = "acp/transaction_rollback.rs"]
+mod transaction_rollback;
 #[path = "acp/xarchive_access_matrix.rs"]
 mod xarchive_access_matrix;

--- a/tools/integration-test/tests/acp/transaction_rollback.rs
+++ b/tools/integration-test/tests/acp/transaction_rollback.rs
@@ -1,0 +1,202 @@
+use std::time::Duration;
+
+use integration_test::{generate_identity, users_schema_with_policy, TestCluster, USER_ACP_POLICY};
+use serde_json::Value;
+
+fn auth_token(identity_hex: &str, audience: &str) -> String {
+    let key_bytes = hex::decode(identity_hex).expect("identity hex must decode");
+    let key_type = match key_bytes.len() {
+        32 => crypto::KeyType::Secp256k1,
+        64 => crypto::KeyType::Ed25519,
+        len => panic!("unsupported identity length: {len}"),
+    };
+    let identity =
+        identity::RawIdentity::from_bytes(key_type, &key_bytes).expect("raw identity from bytes");
+    let audience_host = audience
+        .strip_prefix("https://")
+        .or_else(|| audience.strip_prefix("http://"))
+        .unwrap_or(audience);
+    let token = identity::new_token(
+        &identity,
+        Duration::from_secs(15 * 60),
+        Some(audience_host.to_string()),
+        None,
+    )
+    .expect("generate auth token");
+    String::from_utf8(token).expect("token must be utf-8")
+}
+
+async fn tx_create(client: &reqwest::Client, api_url: &str) -> String {
+    let response = client
+        .post(format!("{api_url}/api/v0/tx"))
+        .send()
+        .await
+        .expect("create transaction request");
+    let status = response.status();
+    let body = response.text().await.expect("transaction create body");
+    assert!(
+        status.is_success(),
+        "tx create failed: status={} body={}",
+        status,
+        body
+    );
+    let json: Value = serde_json::from_str(&body).expect("tx create must return JSON");
+    json["id"]
+        .as_u64()
+        .expect("transaction create response must include numeric id")
+        .to_string()
+}
+
+async fn tx_discard(client: &reqwest::Client, api_url: &str, tx_id: &str) {
+    let response = client
+        .delete(format!("{api_url}/api/v0/tx/{tx_id}"))
+        .send()
+        .await
+        .expect("discard transaction request");
+    let status = response.status();
+    let body = response.text().await.expect("transaction discard body");
+    assert!(
+        status.is_success(),
+        "tx discard failed: status={} body={}",
+        status,
+        body
+    );
+}
+
+async fn graphql_query(
+    client: &reqwest::Client,
+    api_url: &str,
+    identity_hex: &str,
+    query: &str,
+    tx_id: Option<&str>,
+) -> Value {
+    let mut body = serde_json::json!({ "query": query });
+    if let Some(tx_id) = tx_id {
+        body["txn_id"] = serde_json::json!(tx_id);
+    }
+    let response = client
+        .post(format!("{api_url}/api/v0/graphql"))
+        .bearer_auth(auth_token(identity_hex, api_url))
+        .json(&body)
+        .send()
+        .await
+        .expect("graphql request");
+    let status = response.status();
+    let response_body = response.text().await.expect("graphql response body");
+    assert!(
+        status.is_success(),
+        "graphql request failed: status={} body={}",
+        status,
+        response_body
+    );
+    let json: Value = serde_json::from_str(&response_body).expect("graphql response JSON");
+    let errors = json["errors"].as_array().cloned().unwrap_or_default();
+    assert!(
+        errors.is_empty(),
+        "graphql returned errors: {}",
+        response_body
+    );
+    json["data"].clone()
+}
+
+async fn acp_transaction_rollback_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary = node.binary_path().to_path_buf();
+    let api_url = cluster.api_url(0).to_string();
+    let http = reqwest::Client::new();
+
+    let alice = generate_identity(&binary).expect("Alice identity");
+    let bob = generate_identity(&binary).expect("Bob identity");
+
+    let policy = node
+        .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+        .expect("add ACP policy");
+    let policy_id = policy["PolicyID"]
+        .as_str()
+        .or_else(|| policy["policyID"].as_str())
+        .expect("missing policy id");
+    let schema = users_schema_with_policy(policy_id);
+    node.schema_add_with_identity(&schema, &alice.private_key_hex)
+        .expect("add schema");
+
+    let created = node
+        .query_with_identity(
+            r#"mutation { add_User(input: {name: "RollbackDoc", age: 7}) { _docID } }"#,
+            &alice.private_key_hex,
+        )
+        .expect("create document");
+    let doc_id = created["add_User"][0]["_docID"]
+        .as_str()
+        .expect("created document should have _docID")
+        .to_string();
+
+    node.acp_relationship_add("User", &doc_id, "reader", &bob.did, &alice.private_key_hex)
+        .expect("grant reader relationship");
+
+    let read_query = "query { User { _docID name age } }";
+    let bob_before = node
+        .query_with_identity(read_query, &bob.private_key_hex)
+        .expect("Bob query before transaction");
+    let bob_before_docs = bob_before["User"].as_array().expect("Bob User array");
+    assert_eq!(bob_before_docs.len(), 1, "Bob should see the shared document");
+    assert_eq!(bob_before_docs[0]["_docID"], doc_id);
+
+    let tx_id = tx_create(&http, &api_url).await;
+    let delete_query = format!(r#"mutation {{ delete_User(docID: "{}") {{ _docID }} }}"#, doc_id);
+    let delete_result = graphql_query(
+        &http,
+        &api_url,
+        &alice.private_key_hex,
+        &delete_query,
+        Some(&tx_id),
+    )
+    .await;
+    let deleted_docs = delete_result["delete_User"]
+        .as_array()
+        .expect("delete_User should be an array");
+    assert_eq!(deleted_docs.len(), 1, "delete in txn should affect one document");
+    assert_eq!(deleted_docs[0]["_docID"], doc_id);
+
+    let inside_tx = graphql_query(
+        &http,
+        &api_url,
+        &alice.private_key_hex,
+        read_query,
+        Some(&tx_id),
+    )
+    .await;
+    let inside_tx_docs = inside_tx["User"].as_array().expect("inside-tx User array");
+    assert_eq!(
+        inside_tx_docs.len(),
+        0,
+        "document should be absent inside the uncommitted delete transaction"
+    );
+
+    tx_discard(&http, &api_url, &tx_id).await;
+
+    let alice_after = node
+        .query_with_identity(read_query, &alice.private_key_hex)
+        .expect("Alice query after rollback");
+    let alice_after_docs = alice_after["User"].as_array().expect("Alice User array");
+    assert_eq!(alice_after_docs.len(), 1, "Alice should still see the document");
+    assert_eq!(alice_after_docs[0]["_docID"], doc_id);
+
+    let bob_after = node
+        .query_with_identity(read_query, &bob.private_key_hex)
+        .expect("Bob query after rollback");
+    let bob_after_docs = bob_after["User"].as_array().expect("Bob User array");
+    assert_eq!(bob_after_docs.len(), 1, "Bob should still see the document");
+    assert_eq!(bob_after_docs[0]["_docID"], doc_id);
+}
+
+#[tokio::test]
+async fn rust_acp_transaction_rollback() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_acp_local()
+        .build()
+        .await
+        .expect("build cluster");
+    acp_transaction_rollback_test(cluster).await;
+}


### PR DESCRIPTION
Fixes #627.

Summary:
- defer ACP document registration and unregistration until explicit transaction commit
- project deferred ACP registration state into transaction-scoped ACP checks so reads and mutations see uncommitted ACP effects consistently inside the txn
- add a regression test covering rollback of a delete on a local ACP-enabled node

Tests:
- cargo test -p query projected_ -- --nocapture
- cargo test -p db txn_registry -- --nocapture
- cargo test -p query -p db --quiet
- cargo test -p integration-test --test acp rust_acp_transaction_rollback -- --nocapture

Notes:
- cargo clippy --all-targets -- -D warnings still fails on unrelated pre-existing workspace lint violations outside this change set