### PR TITLE
fix(zanzibar): implement difference operator evaluation in permission checks (#628)

### DIFF
--- a/crates/acp/src/zanzibar/acp/document_acp.rs
+++ b/crates/acp/src/zanzibar/acp/document_acp.rs
@@ -178,13 +178,13 @@ impl<S: ZanzibarStore + 'static> DocumentACP for ZanzibarDocumentACP<S> {
         &self,
         requestor: &Did,
         target: &Did,
-        _policy_id: &str,
+        policy_id: &str,
         collection_id: &str,
         doc_id: &str,
         relation: &str,
         _managing_relations: &[String],
     ) -> Result<bool> {
-        self.ensure_policy(collection_id, collection_id).await?;
+        self.ensure_policy(policy_id, collection_id).await?;
 
         if relation == OWNER_RELATION {
             return Err(Error::InvalidRelation(
@@ -194,7 +194,7 @@ impl<S: ZanzibarStore + 'static> DocumentACP for ZanzibarDocumentACP<S> {
 
         self.check_manage_relation(
             requestor,
-            collection_id,
+            policy_id,
             collection_id,
             doc_id,
             relation,
@@ -205,7 +205,7 @@ impl<S: ZanzibarStore + 'static> DocumentACP for ZanzibarDocumentACP<S> {
         let has = self
             .store
             .has_relationship(
-                collection_id,
+                policy_id,
                 collection_id,
                 doc_id,
                 relation,
@@ -228,7 +228,7 @@ impl<S: ZanzibarStore + 'static> DocumentACP for ZanzibarDocumentACP<S> {
         }
 
         let rel = Relationship::with_entity(collection_id, doc_id, relation, target.clone());
-        self.store.store_relationship(collection_id, &rel).await?;
+        self.store.store_relationship(policy_id, &rel).await?;
 
         tracing::info!(
             target: "acp::audit",
@@ -248,13 +248,13 @@ impl<S: ZanzibarStore + 'static> DocumentACP for ZanzibarDocumentACP<S> {
         &self,
         requestor: &Did,
         target: &Did,
-        _policy_id: &str,
+        policy_id: &str,
         collection_id: &str,
         doc_id: &str,
         relation: &str,
         _managing_relations: &[String],
     ) -> Result<bool> {
-        self.ensure_policy(collection_id, collection_id).await?;
+        self.ensure_policy(policy_id, collection_id).await?;
 
         if relation == OWNER_RELATION {
             return Err(Error::InvalidRelation(
@@ -264,7 +264,7 @@ impl<S: ZanzibarStore + 'static> DocumentACP for ZanzibarDocumentACP<S> {
 
         self.check_manage_relation(
             requestor,
-            collection_id,
+            policy_id,
             collection_id,
             doc_id,
             relation,
@@ -273,7 +273,7 @@ impl<S: ZanzibarStore + 'static> DocumentACP for ZanzibarDocumentACP<S> {
         .await?;
 
         let rel = Relationship::with_entity(collection_id, doc_id, relation, target.clone());
-        let deleted = self.store.delete_relationship(collection_id, &rel).await?;
+        let deleted = self.store.delete_relationship(policy_id, &rel).await?;
 
         if deleted {
             tracing::info!(

--- a/crates/acp/tests/zanzibar_acp_tests.rs
+++ b/crates/acp/tests/zanzibar_acp_tests.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use acp::{
+    policy_yaml::{build_policy, parse_policy_yaml, validate_policy_expressions},
     DocumentACP, DocumentPermission, Error, Identity, MemoryZanzibarStore, ZanzibarDocumentACP,
+    ZanzibarStore,
 };
 use identity::Did;
 
@@ -17,6 +19,25 @@ fn test_did2() -> Did {
 
 fn test_did3() -> Did {
     Did::new("did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi").unwrap()
+}
+
+fn test_did4() -> Did {
+    Did::new("did:key:z6Mkm6dQZfJ4rK5QJc1t8u8yKpWq2F6f4gL3r1m9u2Yt7n8Q").unwrap()
+}
+
+async fn create_custom_policy_acp(
+    yaml: &str,
+) -> (ZanzibarDocumentACP<MemoryZanzibarStore>, String) {
+    let parsed = parse_policy_yaml(yaml).unwrap();
+    validate_policy_expressions(&parsed).unwrap();
+
+    let policy = build_policy(&parsed, 1).unwrap();
+    let policy_id = policy.id.clone();
+
+    let store = Arc::new(MemoryZanzibarStore::new());
+    store.store_policy(&policy).await.unwrap();
+
+    (ZanzibarDocumentACP::new(store), policy_id)
 }
 
 #[tokio::test]
@@ -712,4 +733,259 @@ async fn test_revoking_admin_removes_management_capability() {
         )
         .await;
     assert!(matches!(result, Err(Error::NotManager { .. })));
+}
+
+#[tokio::test]
+async fn test_difference_policy_with_generated_id_evaluates_at_check_time() {
+    let yaml = r#"
+name: public_except_blocked
+resources:
+- name: document
+  permissions:
+  - name: read
+    expr: reader - blocked
+  - name: update
+    expr: writer - blocked
+  - name: delete
+    expr: admin
+  relations:
+  - name: reader
+    types: [actor]
+  - name: writer
+    types: [actor]
+  - name: blocked
+    types: [actor]
+  - name: admin
+    manages: [reader, writer, blocked]
+    types: [actor]
+"#;
+
+    let (acp, policy_id) = create_custom_policy_acp(yaml).await;
+    assert_ne!(policy_id, "document");
+
+    let owner = test_did();
+    let bob = test_did2();
+    let mallory = test_did3();
+    let stranger = test_did4();
+
+    acp.register_doc_object(&owner, &policy_id, "document", "employee_handbook")
+        .await
+        .unwrap();
+
+    acp.add_actor_relationship(
+        &owner,
+        &bob,
+        &policy_id,
+        "document",
+        "employee_handbook",
+        "reader",
+        &[],
+    )
+    .await
+    .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &mallory,
+        &policy_id,
+        "document",
+        "employee_handbook",
+        "reader",
+        &[],
+    )
+    .await
+    .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &mallory,
+        &policy_id,
+        "document",
+        "employee_handbook",
+        "blocked",
+        &[],
+    )
+    .await
+    .unwrap();
+
+    assert!(acp
+        .check_doc_access(
+            &Identity::Authenticated(bob.clone()),
+            DocumentPermission::Read,
+            &policy_id,
+            "document",
+            "employee_handbook"
+        )
+        .await
+        .unwrap());
+    assert!(!acp
+        .check_doc_access(
+            &Identity::Authenticated(mallory.clone()),
+            DocumentPermission::Read,
+            &policy_id,
+            "document",
+            "employee_handbook"
+        )
+        .await
+        .unwrap());
+    assert!(!acp
+        .check_doc_access(
+            &Identity::Authenticated(stranger),
+            DocumentPermission::Read,
+            &policy_id,
+            "document",
+            "employee_handbook"
+        )
+        .await
+        .unwrap());
+
+    acp.add_actor_relationship(
+        &owner,
+        &owner,
+        &policy_id,
+        "document",
+        "employee_handbook",
+        "blocked",
+        &[],
+    )
+    .await
+    .unwrap();
+    assert!(acp
+        .check_doc_access(
+            &Identity::Authenticated(owner.clone()),
+            DocumentPermission::Read,
+            &policy_id,
+            "document",
+            "employee_handbook"
+        )
+        .await
+        .unwrap());
+
+    assert!(acp
+        .delete_actor_relationship(
+            &owner,
+            &bob,
+            &policy_id,
+            "document",
+            "employee_handbook",
+            "reader",
+            &[],
+        )
+        .await
+        .unwrap());
+    assert!(!acp
+        .check_doc_access(
+            &Identity::Authenticated(bob),
+            DocumentPermission::Read,
+            &policy_id,
+            "document",
+            "employee_handbook"
+        )
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn test_nested_difference_policy_with_generated_id_handles_union_and_blocklist() {
+    let yaml = r#"
+name: nested_difference
+resources:
+- name: document
+  permissions:
+  - name: read
+    expr: (reader + writer) - blocked
+  - name: update
+    expr: writer - blocked
+  - name: delete
+    expr: admin
+  relations:
+  - name: reader
+    types: [actor]
+  - name: writer
+    types: [actor]
+  - name: blocked
+    types: [actor]
+  - name: admin
+    types: [actor]
+"#;
+
+    let (acp, policy_id) = create_custom_policy_acp(yaml).await;
+    assert_ne!(policy_id, "document");
+
+    let owner = test_did();
+    let reader = test_did2();
+    let writer = test_did3();
+    let blocked_writer = test_did4();
+
+    acp.register_doc_object(&owner, &policy_id, "document", "doc1")
+        .await
+        .unwrap();
+
+    for (target, relation) in [
+        (&reader, "reader"),
+        (&writer, "writer"),
+        (&blocked_writer, "writer"),
+        (&blocked_writer, "blocked"),
+    ] {
+        acp.add_actor_relationship(
+            &owner,
+            target,
+            &policy_id,
+            "document",
+            "doc1",
+            relation,
+            &[],
+        )
+        .await
+        .unwrap();
+    }
+
+    assert!(acp
+        .check_doc_access(
+            &Identity::Authenticated(reader),
+            DocumentPermission::Read,
+            &policy_id,
+            "document",
+            "doc1"
+        )
+        .await
+        .unwrap());
+    assert!(acp
+        .check_doc_access(
+            &Identity::Authenticated(writer.clone()),
+            DocumentPermission::Read,
+            &policy_id,
+            "document",
+            "doc1"
+        )
+        .await
+        .unwrap());
+    assert!(acp
+        .check_doc_access(
+            &Identity::Authenticated(writer),
+            DocumentPermission::Update,
+            &policy_id,
+            "document",
+            "doc1"
+        )
+        .await
+        .unwrap());
+    assert!(!acp
+        .check_doc_access(
+            &Identity::Authenticated(blocked_writer.clone()),
+            DocumentPermission::Read,
+            &policy_id,
+            "document",
+            "doc1"
+        )
+        .await
+        .unwrap());
+    assert!(!acp
+        .check_doc_access(
+            &Identity::Authenticated(blocked_writer),
+            DocumentPermission::Update,
+            &policy_id,
+            "document",
+            "doc1"
+        )
+        .await
+        .unwrap());
 }

--- a/crates/db/src/commits_fetcher/conversion.rs
+++ b/crates/db/src/commits_fetcher/conversion.rs
@@ -191,7 +191,6 @@ impl<S: Store> CommitsFetcher<S> {
                         defra_core::block::SignatureType::ES256 => "ES256",
                         defra_core::block::SignatureType::EdDSA => "EdDSA",
                         defra_core::block::SignatureType::BLS => "BLS",
-                        _ => "Unknown",
                     };
                     let sig_json = json!({
                         "type": sig_type,

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -88,7 +88,6 @@ impl From<RestError> for HttpError {
             // Use Unauthorized (401) for permission denied to match Go DefraDB behavior
             RestError::PermissionDenied(msg) => HttpError::Unauthorized(msg),
             RestError::Internal(msg) => HttpError::Internal(msg),
-            _ => HttpError::Internal("unexpected error variant".to_string()),
         }
     }
 }

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -23,6 +23,7 @@ use super::commits_numeric::{
 use super::{DocFetcher, QueryRunner};
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -655,9 +655,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             if let Some(deferred_acp_mutations) =
                                 crate::txn::current_deferred_acp_mutations()
                             {
-                                let request_bearer_token = defra_core::signing::get_request_bearer_token(
-                                    identity_did.as_str(),
-                                );
+                                let request_bearer_token =
+                                    defra_core::signing::get_request_bearer_token(
+                                        identity_did.as_str(),
+                                    );
                                 deferred_acp_mutations
                                     .schedule_register_doc_object(
                                         acp.clone(),

--- a/crates/query/src/runner/query/nested.rs
+++ b/crates/query/src/runner/query/nested.rs
@@ -338,10 +338,12 @@ mod tests {
     use crate::fetcher::FetchByIdsResult;
     use crate::planner::Planner;
 
+    type ScoreMap = HashMap<(String, String, String), HashMap<String, f64>>;
+
     #[derive(Default)]
     struct FullTextTestFetcher {
         docs: Mutex<HashMap<String, Vec<Document>>>,
-        scores: Mutex<HashMap<(String, String, String), HashMap<String, f64>>>,
+        scores: Mutex<ScoreMap>,
     }
 
     impl FullTextTestFetcher {

--- a/crates/query/src/txn/context.rs
+++ b/crates/query/src/txn/context.rs
@@ -109,9 +109,7 @@ impl DeferredAcpMutations {
         resource_name: &str,
         doc_id: &str,
     ) -> AcpResult<Option<ProjectedDocRegistration>> {
-        let state = self
-            .lock_state()
-            .map_err(AcpError::Storage)?;
+        let state = self.lock_state().map_err(AcpError::Storage)?;
         Ok(state
             .projected_registrations
             .get(&Self::doc_key(policy_id, resource_name, doc_id))
@@ -217,9 +215,7 @@ impl DeferredAcpMutations {
 
         for hook in hooks {
             let description = hook.description;
-            let result = AssertUnwindSafe((hook.callback)())
-                .catch_unwind()
-                .await;
+            let result = AssertUnwindSafe((hook.callback)()).catch_unwind().await;
             match result {
                 Ok(Ok(())) => {}
                 Ok(Err(err)) => {
@@ -314,13 +310,18 @@ pub async fn is_doc_registered_with_overlay(
     doc_id: &str,
 ) -> AcpResult<bool> {
     if let Some(mutations) = current_deferred_acp_mutations() {
-        if let Some(projected) = mutations.projected_registration(policy_id, resource_name, doc_id)?
+        if let Some(projected) =
+            mutations.projected_registration(policy_id, resource_name, doc_id)?
         {
-            return Ok(matches!(projected, ProjectedDocRegistration::Registered { .. }));
+            return Ok(matches!(
+                projected,
+                ProjectedDocRegistration::Registered { .. }
+            ));
         }
     }
 
-    acp.is_doc_registered(policy_id, resource_name, doc_id).await
+    acp.is_doc_registered(policy_id, resource_name, doc_id)
+        .await
 }
 
 /// Check document access while honoring any ACP mutations buffered in the current txn.
@@ -333,7 +334,8 @@ pub async fn check_doc_access_with_overlay(
     doc_id: &str,
 ) -> AcpResult<bool> {
     if let Some(mutations) = current_deferred_acp_mutations() {
-        if let Some(projected) = mutations.projected_registration(policy_id, resource_name, doc_id)?
+        if let Some(projected) =
+            mutations.projected_registration(policy_id, resource_name, doc_id)?
         {
             return Ok(match projected {
                 ProjectedDocRegistration::Unregistered => true,

--- a/tools/integration-test/tests/acp/transaction_rollback.rs
+++ b/tools/integration-test/tests/acp/transaction_rollback.rs
@@ -138,11 +138,18 @@ async fn acp_transaction_rollback_test(cluster: TestCluster) {
         .query_with_identity(read_query, &bob.private_key_hex)
         .expect("Bob query before transaction");
     let bob_before_docs = bob_before["User"].as_array().expect("Bob User array");
-    assert_eq!(bob_before_docs.len(), 1, "Bob should see the shared document");
+    assert_eq!(
+        bob_before_docs.len(),
+        1,
+        "Bob should see the shared document"
+    );
     assert_eq!(bob_before_docs[0]["_docID"], doc_id);
 
     let tx_id = tx_create(&http, &api_url).await;
-    let delete_query = format!(r#"mutation {{ delete_User(docID: "{}") {{ _docID }} }}"#, doc_id);
+    let delete_query = format!(
+        r#"mutation {{ delete_User(docID: "{}") {{ _docID }} }}"#,
+        doc_id
+    );
     let delete_result = graphql_query(
         &http,
         &api_url,
@@ -154,7 +161,11 @@ async fn acp_transaction_rollback_test(cluster: TestCluster) {
     let deleted_docs = delete_result["delete_User"]
         .as_array()
         .expect("delete_User should be an array");
-    assert_eq!(deleted_docs.len(), 1, "delete in txn should affect one document");
+    assert_eq!(
+        deleted_docs.len(),
+        1,
+        "delete in txn should affect one document"
+    );
     assert_eq!(deleted_docs[0]["_docID"], doc_id);
 
     let inside_tx = graphql_query(
@@ -178,7 +189,11 @@ async fn acp_transaction_rollback_test(cluster: TestCluster) {
         .query_with_identity(read_query, &alice.private_key_hex)
         .expect("Alice query after rollback");
     let alice_after_docs = alice_after["User"].as_array().expect("Alice User array");
-    assert_eq!(alice_after_docs.len(), 1, "Alice should still see the document");
+    assert_eq!(
+        alice_after_docs.len(),
+        1,
+        "Alice should still see the document"
+    );
     assert_eq!(alice_after_docs[0]["_docID"], doc_id);
 
     let bob_after = node

--- a/tools/integration-test/tests/p2p/resilience.rs
+++ b/tools/integration-test/tests/p2p/resilience.rs
@@ -115,7 +115,7 @@ async fn car_bomb_protection_test(cluster: TestCluster) {
 
     // All burst docs must arrive on node1 — neither node may crash
     poll_until(
-        || count_docs(&cluster, 1, "Packet") >= BURST_SIZE + 1,
+        || count_docs(&cluster, 1, "Packet") > BURST_SIZE,
         Duration::from_secs(60),
         Duration::from_millis(500),
         "burst docs did not all replicate to node1",
@@ -342,7 +342,7 @@ async fn dag_semaphore_exhaustion_test(cluster: TestCluster) {
 
     // All flood docs must also eventually arrive on node0
     poll_until(
-        || count_docs(&cluster, 0, "Block") >= FLOOD_COUNT + 1,
+        || count_docs(&cluster, 0, "Block") > FLOOD_COUNT,
         Duration::from_secs(60),
         Duration::from_millis(500),
         "not all flood docs reached node0",

--- a/tools/integration-test/tests/p2p_iroh/acp/mod.rs
+++ b/tools/integration-test/tests/p2p_iroh/acp/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_inception)]
+
 mod acp;
 mod dac;
 mod nac;

--- a/tools/integration-test/tests/p2p_iroh/connection/mod.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_inception)]
+
 mod connection;
 mod management;
 mod signature;

--- a/tools/integration-test/tests/p2p_iroh/replication/mod.rs
+++ b/tools/integration-test/tests/p2p_iroh/replication/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_inception)]
+
 mod collection_sub;
 mod document;
 mod document_sub;

--- a/tools/integration-test/tests/p2p_iroh/sync/mod.rs
+++ b/tools/integration-test/tests/p2p_iroh/sync/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::module_inception)]
+
 mod branchable;
 mod doc;
 mod sync;

--- a/tools/integration-test/tests/query/commits_aggregate.rs
+++ b/tools/integration-test/tests/query/commits_aggregate.rs
@@ -13,7 +13,7 @@ fn extract_doc_id(data: &Value, mutation_name: &str) -> String {
         .to_string()
 }
 
-fn extract_commits<'a>(data: &'a Value) -> &'a [Value] {
+fn extract_commits(data: &Value) -> &[Value] {
     data["_commits"]
         .as_array()
         .unwrap_or_else(|| {

--- a/tools/integration-test/tests/query/commits_height_filter.rs
+++ b/tools/integration-test/tests/query/commits_height_filter.rs
@@ -13,7 +13,7 @@ fn extract_doc_id(data: &Value, mutation_name: &str) -> String {
         .to_string()
 }
 
-fn extract_commits<'a>(data: &'a Value) -> &'a [Value] {
+fn extract_commits(data: &Value) -> &[Value] {
     data["_commits"]
         .as_array()
         .unwrap_or_else(|| {

--- a/tools/integration-test/tests/query/continuous_rollup.rs
+++ b/tools/integration-test/tests/query/continuous_rollup.rs
@@ -256,6 +256,7 @@ fn recompute_rollups(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn assert_rollup_row(
     row: &Value,
     source_doc_id: &str,

--- a/tools/integration-test/tests/query/downsample.rs
+++ b/tools/integration-test/tests/query/downsample.rs
@@ -136,6 +136,7 @@ fn query_metric(client: &integration_test::DefraClient, doc_id: &str) -> Value {
     rows[0].clone()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn assert_rollup_row(
     row: &Value,
     source_doc_id: &str,
@@ -160,6 +161,7 @@ fn assert_rollup_row(
     assert_eq!(row["max"].as_i64(), Some(expected_max));
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn wait_for_rollup(
     client: &integration_test::DefraClient,
     collection: &str,

--- a/tools/integration-test/tests/query/downsample_gc.rs
+++ b/tools/integration-test/tests/query/downsample_gc.rs
@@ -161,6 +161,7 @@ fn aggregate_commit_field(
     rows[0].clone()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn assert_rollup_row(
     row: &Value,
     source_doc_id: &str,
@@ -185,6 +186,7 @@ fn assert_rollup_row(
     assert_eq!(row["max"].as_i64(), Some(expected_max));
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn wait_for_rollup(
     client: &integration_test::DefraClient,
     collection: &str,

--- a/tools/integration-test/tests/sourcehub/acp_tuning.rs
+++ b/tools/integration-test/tests/sourcehub/acp_tuning.rs
@@ -288,7 +288,7 @@ async fn rust_access_cache_grant_revoke_invalidation() {
     for i in 0..5 {
         let result = node
             .query_with_identity("query { User { _docID name } }", &bob.private_key_hex)
-            .expect(&format!("Bob cached denial iteration {}", i));
+            .unwrap_or_else(|_| panic!("Bob cached denial iteration {}", i));
         assert_eq!(
             result["User"].as_array().unwrap().len(),
             0,
@@ -315,7 +315,7 @@ async fn rust_access_cache_grant_revoke_invalidation() {
     for i in 0..5 {
         let result = node
             .query_with_identity("query { User { _docID name } }", &bob.private_key_hex)
-            .expect(&format!("Bob cached grant iteration {}", i));
+            .unwrap_or_else(|_| panic!("Bob cached grant iteration {}", i));
         assert_eq!(
             result["User"].as_array().unwrap().len(),
             1,

--- a/tools/integration-test/tests/sourcehub/resilience.rs
+++ b/tools/integration-test/tests/sourcehub/resilience.rs
@@ -139,7 +139,7 @@ async fn rust_policy_cache_ttl_expiry() {
     for i in 0..5 {
         let result = node
             .query_with_identity("query { User { _docID name } }", &alice.private_key_hex)
-            .expect(&format!("Alice query iteration {}", i));
+            .unwrap_or_else(|_| panic!("Alice query iteration {}", i));
         assert_eq!(
             result["User"].as_array().unwrap().len(),
             1,
@@ -258,7 +258,7 @@ async fn go_policy_cache_ttl_expiry() {
     for i in 0..5 {
         let result = node
             .query_with_identity("query { User { _docID name } }", &alice.private_key_hex)
-            .expect(&format!("query iteration {}", i));
+            .unwrap_or_else(|_| panic!("query iteration {}", i));
         assert_eq!(result["User"].as_array().unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- namespace Zanzibar document ACP actor relationship mutations and lookups by `policy_id` instead of `collection_id`
- add regressions for generated policy IDs, `reader - blocked`, owner precedence, revocation, and nested `(reader + writer) - blocked`
- clean up existing workspace clippy blockers uncovered during verification

## Root cause
Policies built from YAML use generated policy IDs. Document ACP relationship add/delete paths were storing and checking tuples under the collection name instead of the policy ID, so relation tuples like `reader` and `blocked` were invisible to runtime permission checks even though the policy loaded correctly.

## Testing
- `cargo test -p zanzibar`
- `cargo test -p acp`
- `cargo test -p db`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` *(fails only in `tools/integration-test/tests/hubrs.rs` because the external hub.rs provider is not healthy in this environment: RPC `account not found` / cluster health timeout)*