### PR TITLE
Fix DAC policy enforcement and encryption security regressions

### DIFF
--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -44,6 +44,11 @@ impl LocalDocumentACP {
         Self { store }
     }
 
+    /// Namespace a collection_id by policy_id to isolate policies in storage.
+    fn namespaced_collection(policy_id: &str, collection_id: &str) -> String {
+        format!("{policy_id}:{collection_id}")
+    }
+
     /// Check if the subject is the owner of the document.
     async fn is_owner(&self, subject: &Did, collection_id: &str, doc_id: &str) -> Result<bool> {
         let tuple = RelationTuple::owner(subject.clone(), collection_id, doc_id);
@@ -77,15 +82,16 @@ impl DocumentACP for LocalDocumentACP {
     async fn register_doc_object(
         &self,
         identity: &Did,
-        _policy_id: &str,
+        policy_id: &str,
         resource_name: &str,
         doc_id: &str,
     ) -> Result<()> {
+        let ns_collection = Self::namespaced_collection(policy_id, resource_name);
         // Use atomic registration to prevent TOCTOU race conditions
         // where concurrent registrations could overwrite each other
         match self
             .store
-            .register_doc_atomic(identity, resource_name, doc_id)
+            .register_doc_atomic(identity, &ns_collection, doc_id)
             .await?
         {
             true => {
@@ -119,22 +125,24 @@ impl DocumentACP for LocalDocumentACP {
 
     async fn is_doc_registered(
         &self,
-        _policy_id: &str,
+        policy_id: &str,
         resource_name: &str,
         doc_id: &str,
     ) -> Result<bool> {
-        self.store.is_doc_registered(resource_name, doc_id).await
+        let ns_collection = Self::namespaced_collection(policy_id, resource_name);
+        self.store.is_doc_registered(&ns_collection, doc_id).await
     }
 
     async fn get_doc_owner(
         &self,
-        _policy_id: &str,
+        policy_id: &str,
         resource_name: &str,
         doc_id: &str,
     ) -> Result<Option<Did>> {
+        let ns_collection = Self::namespaced_collection(policy_id, resource_name);
         Ok(self
             .store
-            .get_relation_subjects(resource_name, doc_id, OWNER_RELATION)
+            .get_relation_subjects(&ns_collection, doc_id, OWNER_RELATION)
             .await?
             .into_iter()
             .next())
@@ -144,12 +152,13 @@ impl DocumentACP for LocalDocumentACP {
         &self,
         identity: &Identity,
         permission: DocumentPermission,
-        _policy_id: &str,
+        policy_id: &str,
         resource_name: &str,
         doc_id: &str,
     ) -> Result<bool> {
+        let ns_collection = Self::namespaced_collection(policy_id, resource_name);
         // Check if document is registered
-        if !self.store.is_doc_registered(resource_name, doc_id).await? {
+        if !self.store.is_doc_registered(&ns_collection, doc_id).await? {
             // Document is NOT registered — it was created without an identity
             // on an ACP-protected collection, making it a public document.
             // Anyone can read/update/delete it.
@@ -165,27 +174,27 @@ impl DocumentACP for LocalDocumentACP {
                 let wildcard = Did::wildcard();
                 let granted = match permission {
                     DocumentPermission::Read => {
-                        self.has_relation(&wildcard, resource_name, doc_id, READER_RELATION)
+                        self.has_relation(&wildcard, &ns_collection, doc_id, READER_RELATION)
                             .await?
                             || self
-                                .has_relation(&wildcard, resource_name, doc_id, "writer")
+                                .has_relation(&wildcard, &ns_collection, doc_id, "writer")
                                 .await?
                             || self
-                                .has_relation(&wildcard, resource_name, doc_id, UPDATER_RELATION)
+                                .has_relation(&wildcard, &ns_collection, doc_id, UPDATER_RELATION)
                                 .await?
                             || self
-                                .has_relation(&wildcard, resource_name, doc_id, DELETER_RELATION)
+                                .has_relation(&wildcard, &ns_collection, doc_id, DELETER_RELATION)
                                 .await?
                     }
                     DocumentPermission::Update => {
-                        self.has_relation(&wildcard, resource_name, doc_id, UPDATER_RELATION)
+                        self.has_relation(&wildcard, &ns_collection, doc_id, UPDATER_RELATION)
                             .await?
                             || self
-                                .has_relation(&wildcard, resource_name, doc_id, "writer")
+                                .has_relation(&wildcard, &ns_collection, doc_id, "writer")
                                 .await?
                     }
                     DocumentPermission::Delete => {
-                        self.has_relation(&wildcard, resource_name, doc_id, DELETER_RELATION)
+                        self.has_relation(&wildcard, &ns_collection, doc_id, DELETER_RELATION)
                             .await?
                     }
                 };
@@ -194,7 +203,7 @@ impl DocumentACP for LocalDocumentACP {
         };
 
         // Owner always has all permissions (DPI rule: every permission starts with owner)
-        if self.is_owner(did, resource_name, doc_id).await? {
+        if self.is_owner(did, &ns_collection, doc_id).await? {
             return Ok(true);
         }
 
@@ -204,27 +213,27 @@ impl DocumentACP for LocalDocumentACP {
         let granted = match permission {
             DocumentPermission::Read => {
                 // Any relation that could imply read access (matches Go behavior)
-                self.has_relation(did, resource_name, doc_id, READER_RELATION)
+                self.has_relation(did, &ns_collection, doc_id, READER_RELATION)
                     .await?
                     || self
-                        .has_relation(did, resource_name, doc_id, "writer")
+                        .has_relation(did, &ns_collection, doc_id, "writer")
                         .await?
                     || self
-                        .has_relation(did, resource_name, doc_id, UPDATER_RELATION)
+                        .has_relation(did, &ns_collection, doc_id, UPDATER_RELATION)
                         .await?
                     || self
-                        .has_relation(did, resource_name, doc_id, DELETER_RELATION)
+                        .has_relation(did, &ns_collection, doc_id, DELETER_RELATION)
                         .await?
             }
             DocumentPermission::Update => {
-                self.has_relation(did, resource_name, doc_id, UPDATER_RELATION)
+                self.has_relation(did, &ns_collection, doc_id, UPDATER_RELATION)
                     .await?
                     || self
-                        .has_relation(did, resource_name, doc_id, "writer")
+                        .has_relation(did, &ns_collection, doc_id, "writer")
                         .await?
             }
             DocumentPermission::Delete => {
-                self.has_relation(did, resource_name, doc_id, DELETER_RELATION)
+                self.has_relation(did, &ns_collection, doc_id, DELETER_RELATION)
                     .await?
             }
         };
@@ -258,18 +267,19 @@ impl DocumentACP for LocalDocumentACP {
         &self,
         requestor: &Did,
         target: &Did,
-        _policy_id: &str,
+        policy_id: &str,
         collection_id: &str,
         doc_id: &str,
         relation: &str,
         managing_relations: &[String],
     ) -> Result<bool> {
+        let ns_collection = Self::namespaced_collection(policy_id, collection_id);
         // Owner or manager with a managing relation can add relationships
-        if !self.is_owner(requestor, collection_id, doc_id).await? {
+        if !self.is_owner(requestor, &ns_collection, doc_id).await? {
             let mut is_manager = false;
             for mgr_relation in managing_relations {
                 if self
-                    .has_relation(requestor, collection_id, doc_id, mgr_relation)
+                    .has_relation(requestor, &ns_collection, doc_id, mgr_relation)
                     .await?
                 {
                     is_manager = true;
@@ -295,7 +305,7 @@ impl DocumentACP for LocalDocumentACP {
             ));
         }
 
-        let tuple = RelationTuple::new(target.clone(), relation, collection_id, doc_id);
+        let tuple = RelationTuple::new(target.clone(), relation, &ns_collection, doc_id);
 
         // Check if already exists
         if self.store.has_tuple(&tuple).await? {
@@ -305,7 +315,7 @@ impl DocumentACP for LocalDocumentACP {
                 requestor = %requestor,
                 target = %target,
                 relation = %relation,
-                collection = %collection_id,
+                collection = %ns_collection,
                 doc_id = %doc_id,
                 "Relationship already exists"
             );
@@ -319,7 +329,7 @@ impl DocumentACP for LocalDocumentACP {
             requestor = %requestor,
             target = %target,
             relation = %relation,
-            collection = %collection_id,
+            collection = %ns_collection,
             doc_id = %doc_id,
             "Actor relationship added"
         );
@@ -330,18 +340,19 @@ impl DocumentACP for LocalDocumentACP {
         &self,
         requestor: &Did,
         target: &Did,
-        _policy_id: &str,
+        policy_id: &str,
         collection_id: &str,
         doc_id: &str,
         relation: &str,
         managing_relations: &[String],
     ) -> Result<bool> {
+        let ns_collection = Self::namespaced_collection(policy_id, collection_id);
         // Owner or manager with a managing relation can delete relationships
-        if !self.is_owner(requestor, collection_id, doc_id).await? {
+        if !self.is_owner(requestor, &ns_collection, doc_id).await? {
             let mut is_manager = false;
             for mgr_relation in managing_relations {
                 if self
-                    .has_relation(requestor, collection_id, doc_id, mgr_relation)
+                    .has_relation(requestor, &ns_collection, doc_id, mgr_relation)
                     .await?
                 {
                     is_manager = true;
@@ -367,7 +378,7 @@ impl DocumentACP for LocalDocumentACP {
             ));
         }
 
-        let tuple = RelationTuple::new(target.clone(), relation, collection_id, doc_id);
+        let tuple = RelationTuple::new(target.clone(), relation, &ns_collection, doc_id);
 
         // Check if exists
         if !self.store.has_tuple(&tuple).await? {
@@ -377,7 +388,7 @@ impl DocumentACP for LocalDocumentACP {
                 requestor = %requestor,
                 target = %target,
                 relation = %relation,
-                collection = %collection_id,
+                collection = %ns_collection,
                 doc_id = %doc_id,
                 "Relationship does not exist"
             );
@@ -391,7 +402,7 @@ impl DocumentACP for LocalDocumentACP {
             requestor = %requestor,
             target = %target,
             relation = %relation,
-            collection = %collection_id,
+            collection = %ns_collection,
             doc_id = %doc_id,
             "Actor relationship deleted"
         );
@@ -400,12 +411,13 @@ impl DocumentACP for LocalDocumentACP {
 
     async fn unregister_doc_object(
         &self,
-        _policy_id: &str,
+        policy_id: &str,
         resource_name: &str,
         doc_id: &str,
     ) -> Result<()> {
+        let ns_collection = Self::namespaced_collection(policy_id, resource_name);
         // Delete all tuples for this document (owner, reader, updater, deleter, etc.)
-        self.store.delete_doc_tuples(resource_name, doc_id).await?;
+        self.store.delete_doc_tuples(&ns_collection, doc_id).await?;
         tracing::info!(
             target: "acp::audit",
             event = "document_unregistered",

--- a/crates/acp/src/zanzibar/acp/document_acp.rs
+++ b/crates/acp/src/zanzibar/acp/document_acp.rs
@@ -14,7 +14,7 @@ use crate::permission::DocumentPermission;
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl<S: ZanzibarStore + 'static> DocumentACP for ZanzibarDocumentACP<S> {
+impl<S: ZanzibarStore + ?Sized + 'static> DocumentACP for ZanzibarDocumentACP<S> {
     async fn register_doc_object(
         &self,
         identity: &Did,

--- a/crates/acp/src/zanzibar/acp/mod.rs
+++ b/crates/acp/src/zanzibar/acp/mod.rs
@@ -20,12 +20,12 @@ pub const UPDATER_RELATION: &str = "updater";
 pub const DELETER_RELATION: &str = "deleter";
 pub const ADMIN_RELATION: &str = "admin";
 
-pub struct ZanzibarDocumentACP<S: ZanzibarStore> {
+pub struct ZanzibarDocumentACP<S: ZanzibarStore + ?Sized> {
     store: Arc<S>,
     engine: RwLock<PermissionEngine<S>>,
 }
 
-impl<S: ZanzibarStore> ZanzibarDocumentACP<S> {
+impl<S: ZanzibarStore + ?Sized> ZanzibarDocumentACP<S> {
     pub fn new(store: Arc<S>) -> Self {
         Self {
             store: store.clone(),

--- a/crates/acp/tests/local_tests.rs
+++ b/crates/acp/tests/local_tests.rs
@@ -203,7 +203,7 @@ async fn test_add_reader_grants_read_only() {
         .unwrap();
 
     let added = acp
-        .add_actor_relationship(&owner, &reader, "", "users", "doc1", READER_RELATION, &[])
+        .add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
         .await
         .unwrap();
     assert!(added, "relationship should be added");
@@ -255,7 +255,7 @@ async fn test_add_updater_grants_read_and_update() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &updater, "", "users", "doc1", UPDATER_RELATION, &[])
+    acp.add_actor_relationship(&owner, &updater, "policy1", "users", "doc1", UPDATER_RELATION, &[])
         .await
         .unwrap();
 
@@ -307,7 +307,7 @@ async fn test_non_owner_cannot_add_relationship() {
         .unwrap();
 
     let result = acp
-        .add_actor_relationship(&other, &owner, "", "users", "doc1", READER_RELATION, &[])
+        .add_actor_relationship(&other, &owner, "policy1", "users", "doc1", READER_RELATION, &[])
         .await;
     assert!(matches!(result, Err(Error::NotOwner { .. })));
 }
@@ -323,7 +323,7 @@ async fn test_cannot_add_owner_relation() {
         .unwrap();
 
     let result = acp
-        .add_actor_relationship(&owner, &other, "", "users", "doc1", OWNER_RELATION, &[])
+        .add_actor_relationship(&owner, &other, "policy1", "users", "doc1", OWNER_RELATION, &[])
         .await;
     assert!(matches!(result, Err(Error::InvalidRelation(_))));
 }
@@ -342,7 +342,7 @@ async fn test_local_acp_stores_any_relation_name() {
 
     // LocalDocumentACP accepts any relation name (validation is caller's responsibility)
     let result = acp
-        .add_actor_relationship(&owner, &other, "", "users", "doc1", "reador", &[])
+        .add_actor_relationship(&owner, &other, "policy1", "users", "doc1", "reador", &[])
         .await;
     assert!(
         result.is_ok(),
@@ -350,7 +350,7 @@ async fn test_local_acp_stores_any_relation_name() {
     );
 
     let result = acp
-        .add_actor_relationship(&owner, &other, "", "users", "doc1", "admin", &[])
+        .add_actor_relationship(&owner, &other, "policy1", "users", "doc1", "admin", &[])
         .await;
     assert!(
         result.is_ok(),
@@ -369,13 +369,13 @@ async fn test_add_duplicate_relationship_returns_false() {
         .unwrap();
 
     let added1 = acp
-        .add_actor_relationship(&owner, &reader, "", "users", "doc1", READER_RELATION, &[])
+        .add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
         .await
         .unwrap();
     assert!(added1);
 
     let added2 = acp
-        .add_actor_relationship(&owner, &reader, "", "users", "doc1", READER_RELATION, &[])
+        .add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
         .await
         .unwrap();
     assert!(!added2, "duplicate add should return false");
@@ -393,7 +393,7 @@ async fn test_delete_relationship() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &reader, "", "users", "doc1", READER_RELATION, &[])
+    acp.add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
         .await
         .unwrap();
 
@@ -411,7 +411,7 @@ async fn test_delete_relationship() {
 
     // Delete relationship
     let deleted = acp
-        .delete_actor_relationship(&owner, &reader, "", "users", "doc1", READER_RELATION, &[])
+        .delete_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
         .await
         .unwrap();
     assert!(deleted);
@@ -440,7 +440,7 @@ async fn test_delete_nonexistent_relationship_returns_false() {
         .unwrap();
 
     let deleted = acp
-        .delete_actor_relationship(&owner, &other, "", "users", "doc1", READER_RELATION, &[])
+        .delete_actor_relationship(&owner, &other, "policy1", "users", "doc1", READER_RELATION, &[])
         .await
         .unwrap();
     assert!(!deleted);
@@ -458,7 +458,7 @@ async fn test_add_deleter_grants_read_and_delete() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &deleter, "", "users", "doc1", DELETER_RELATION, &[])
+    acp.add_actor_relationship(&owner, &deleter, "policy1", "users", "doc1", DELETER_RELATION, &[])
         .await
         .unwrap();
 
@@ -515,7 +515,7 @@ async fn test_delete_deleter_relationship_revokes_access() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &deleter, "", "users", "doc1", DELETER_RELATION, &[])
+    acp.add_actor_relationship(&owner, &deleter, "policy1", "users", "doc1", DELETER_RELATION, &[])
         .await
         .unwrap();
 
@@ -532,7 +532,7 @@ async fn test_delete_deleter_relationship_revokes_access() {
         .unwrap());
 
     // Delete relationship
-    acp.delete_actor_relationship(&owner, &deleter, "", "users", "doc1", DELETER_RELATION, &[])
+    acp.delete_actor_relationship(&owner, &deleter, "policy1", "users", "doc1", DELETER_RELATION, &[])
         .await
         .unwrap();
 
@@ -574,7 +574,7 @@ async fn test_non_owner_cannot_delete_relationship() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &reader, "", "users", "doc1", READER_RELATION, &[])
+    acp.add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
         .await
         .unwrap();
 
@@ -583,7 +583,7 @@ async fn test_non_owner_cannot_delete_relationship() {
         .delete_actor_relationship(
             &attacker,
             &reader,
-            "",
+            "policy1",
             "users",
             "doc1",
             READER_RELATION,
@@ -607,7 +607,7 @@ async fn test_cannot_delete_owner_relation() {
 
     // Owner tries to delete their own owner relation
     let result = acp
-        .delete_actor_relationship(&owner, &owner, "", "users", "doc1", OWNER_RELATION, &[])
+        .delete_actor_relationship(&owner, &owner, "policy1", "users", "doc1", OWNER_RELATION, &[])
         .await;
     assert!(
         matches!(result, Err(Error::InvalidRelation(_))),
@@ -632,7 +632,7 @@ async fn test_cross_collection_isolation() {
         .unwrap();
 
     // Grant reader access to doc1 in "users" collection ONLY
-    acp.add_actor_relationship(&owner, &reader, "", "users", "doc1", READER_RELATION, &[])
+    acp.add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
         .await
         .unwrap();
 

--- a/crates/acp/tests/local_tests.rs
+++ b/crates/acp/tests/local_tests.rs
@@ -203,7 +203,15 @@ async fn test_add_reader_grants_read_only() {
         .unwrap();
 
     let added = acp
-        .add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
+        .add_actor_relationship(
+            &owner,
+            &reader,
+            "policy1",
+            "users",
+            "doc1",
+            READER_RELATION,
+            &[],
+        )
         .await
         .unwrap();
     assert!(added, "relationship should be added");
@@ -255,9 +263,17 @@ async fn test_add_updater_grants_read_and_update() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &updater, "policy1", "users", "doc1", UPDATER_RELATION, &[])
-        .await
-        .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &updater,
+        "policy1",
+        "users",
+        "doc1",
+        UPDATER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
 
     // Updater can read (implied)
     assert!(acp
@@ -307,7 +323,15 @@ async fn test_non_owner_cannot_add_relationship() {
         .unwrap();
 
     let result = acp
-        .add_actor_relationship(&other, &owner, "policy1", "users", "doc1", READER_RELATION, &[])
+        .add_actor_relationship(
+            &other,
+            &owner,
+            "policy1",
+            "users",
+            "doc1",
+            READER_RELATION,
+            &[],
+        )
         .await;
     assert!(matches!(result, Err(Error::NotOwner { .. })));
 }
@@ -323,7 +347,15 @@ async fn test_cannot_add_owner_relation() {
         .unwrap();
 
     let result = acp
-        .add_actor_relationship(&owner, &other, "policy1", "users", "doc1", OWNER_RELATION, &[])
+        .add_actor_relationship(
+            &owner,
+            &other,
+            "policy1",
+            "users",
+            "doc1",
+            OWNER_RELATION,
+            &[],
+        )
         .await;
     assert!(matches!(result, Err(Error::InvalidRelation(_))));
 }
@@ -369,13 +401,29 @@ async fn test_add_duplicate_relationship_returns_false() {
         .unwrap();
 
     let added1 = acp
-        .add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
+        .add_actor_relationship(
+            &owner,
+            &reader,
+            "policy1",
+            "users",
+            "doc1",
+            READER_RELATION,
+            &[],
+        )
         .await
         .unwrap();
     assert!(added1);
 
     let added2 = acp
-        .add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
+        .add_actor_relationship(
+            &owner,
+            &reader,
+            "policy1",
+            "users",
+            "doc1",
+            READER_RELATION,
+            &[],
+        )
         .await
         .unwrap();
     assert!(!added2, "duplicate add should return false");
@@ -393,9 +441,17 @@ async fn test_delete_relationship() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
-        .await
-        .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &reader,
+        "policy1",
+        "users",
+        "doc1",
+        READER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
 
     // Verify reader has access
     assert!(acp
@@ -411,7 +467,15 @@ async fn test_delete_relationship() {
 
     // Delete relationship
     let deleted = acp
-        .delete_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
+        .delete_actor_relationship(
+            &owner,
+            &reader,
+            "policy1",
+            "users",
+            "doc1",
+            READER_RELATION,
+            &[],
+        )
         .await
         .unwrap();
     assert!(deleted);
@@ -440,7 +504,15 @@ async fn test_delete_nonexistent_relationship_returns_false() {
         .unwrap();
 
     let deleted = acp
-        .delete_actor_relationship(&owner, &other, "policy1", "users", "doc1", READER_RELATION, &[])
+        .delete_actor_relationship(
+            &owner,
+            &other,
+            "policy1",
+            "users",
+            "doc1",
+            READER_RELATION,
+            &[],
+        )
         .await
         .unwrap();
     assert!(!deleted);
@@ -458,9 +530,17 @@ async fn test_add_deleter_grants_read_and_delete() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &deleter, "policy1", "users", "doc1", DELETER_RELATION, &[])
-        .await
-        .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &deleter,
+        "policy1",
+        "users",
+        "doc1",
+        DELETER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
 
     // Deleter can read (implied by deleter relation)
     assert!(
@@ -515,9 +595,17 @@ async fn test_delete_deleter_relationship_revokes_access() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &deleter, "policy1", "users", "doc1", DELETER_RELATION, &[])
-        .await
-        .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &deleter,
+        "policy1",
+        "users",
+        "doc1",
+        DELETER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
 
     // Verify deleter has access
     assert!(acp
@@ -532,9 +620,17 @@ async fn test_delete_deleter_relationship_revokes_access() {
         .unwrap());
 
     // Delete relationship
-    acp.delete_actor_relationship(&owner, &deleter, "policy1", "users", "doc1", DELETER_RELATION, &[])
-        .await
-        .unwrap();
+    acp.delete_actor_relationship(
+        &owner,
+        &deleter,
+        "policy1",
+        "users",
+        "doc1",
+        DELETER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
 
     // Verify deleter no longer has delete access
     assert!(!acp
@@ -574,9 +670,17 @@ async fn test_non_owner_cannot_delete_relationship() {
         .await
         .unwrap();
 
-    acp.add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
-        .await
-        .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &reader,
+        "policy1",
+        "users",
+        "doc1",
+        READER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
 
     // Attacker (non-owner) tries to delete reader relationship
     let result = acp
@@ -607,7 +711,15 @@ async fn test_cannot_delete_owner_relation() {
 
     // Owner tries to delete their own owner relation
     let result = acp
-        .delete_actor_relationship(&owner, &owner, "policy1", "users", "doc1", OWNER_RELATION, &[])
+        .delete_actor_relationship(
+            &owner,
+            &owner,
+            "policy1",
+            "users",
+            "doc1",
+            OWNER_RELATION,
+            &[],
+        )
         .await;
     assert!(
         matches!(result, Err(Error::InvalidRelation(_))),
@@ -632,9 +744,17 @@ async fn test_cross_collection_isolation() {
         .unwrap();
 
     // Grant reader access to doc1 in "users" collection ONLY
-    acp.add_actor_relationship(&owner, &reader, "policy1", "users", "doc1", READER_RELATION, &[])
-        .await
-        .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &reader,
+        "policy1",
+        "users",
+        "doc1",
+        READER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
 
     // Reader CAN access users/doc1
     assert!(

--- a/crates/cli/src/commands/start/server_acp.rs
+++ b/crates/cli/src/commands/start/server_acp.rs
@@ -18,7 +18,7 @@ impl Node {
     pub(super) async fn setup_document_acp(
         config: &Config,
         identity_key_bytes: Option<&[u8]>,
-        acp_store: Arc<dyn acp::AcpStore>,
+        _acp_store: Arc<dyn acp::AcpStore>,
         zanzibar_store: Arc<dyn acp::ZanzibarStore>,
         event_bus: Arc<dyn events::Bus>,
     ) -> Result<DocumentAcpSetup> {
@@ -136,9 +136,10 @@ impl Node {
             })
         } else {
             info!("Document ACP configured (local)");
+            let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
             Ok(DocumentAcpSetup {
-                document_acp: Arc::new(acp::LocalDocumentACP::new(acp_store)),
-                http_adapter: None,
+                document_acp,
+                http_adapter: Some(crate::acp_adapter::AcpAdapter::new_arc(zanzibar_store)),
             })
         }
     }

--- a/crates/defra-core/src/encryption.rs
+++ b/crates/defra-core/src/encryption.rs
@@ -169,6 +169,9 @@ mod tests {
             encryption_key: b"second-master-key-material654321".to_vec(),
         };
 
-        assert_ne!(config_a.derive_key("", doc_id), config_b.derive_key("", doc_id));
+        assert_ne!(
+            config_a.derive_key("", doc_id),
+            config_b.derive_key("", doc_id)
+        );
     }
 }

--- a/crates/defra-core/src/encryption.rs
+++ b/crates/defra-core/src/encryption.rs
@@ -3,6 +3,7 @@
 //! Provides the EncryptionConfig type and thread-local storage for passing
 //! encryption config from the query layer to the block builder layer.
 
+use sha2::{Digest, Sha256};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -77,23 +78,23 @@ impl EncryptionConfig {
 
     /// Derive the encryption key for a specific field and document.
     ///
-    /// Key derivation: `(fieldName + docID + masterKey)[:32]`
+    /// Key derivation: `SHA-256(fieldName + docID + masterKey)`
     /// - Doc-level: fieldName = "" (empty string)
     /// - Field-level: fieldName = specific field name
+    ///
+    /// Uses SHA-256 to ensure all input material (including the master key)
+    /// contributes to the derived key regardless of field name or doc ID length.
     pub fn derive_key(&self, field_name: &str, doc_id: &str) -> [u8; 32] {
         let field = if self.encrypt_fields.iter().any(|f| f == field_name) {
             field_name
         } else {
             "" // doc-level
         };
-        let mut key_material = Vec::new();
-        key_material.extend_from_slice(field.as_bytes());
-        key_material.extend_from_slice(doc_id.as_bytes());
-        key_material.extend_from_slice(&self.encryption_key);
-        let mut key = [0u8; 32];
-        let len = key_material.len().min(32);
-        key[..len].copy_from_slice(&key_material[..len]);
-        key
+        let mut hasher = Sha256::new();
+        hasher.update(field.as_bytes());
+        hasher.update(doc_id.as_bytes());
+        hasher.update(&self.encryption_key);
+        hasher.finalize().into()
     }
 }
 
@@ -147,5 +148,27 @@ pub fn get_doc_encryption(doc_id: &str) -> Option<EncryptionConfig> {
 pub fn clear_doc_encryption_store() {
     if let Ok(mut store) = doc_encryption_store().lock() {
         store.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EncryptionConfig;
+
+    #[test]
+    fn derive_key_mixes_in_master_key_for_long_doc_ids() {
+        let doc_id = "bae-c94acbfa-1234-5678-90ab-cdef12345678";
+        let config_a = EncryptionConfig {
+            encrypt_doc: true,
+            encrypt_fields: vec![],
+            encryption_key: b"first-master-key-material-123456".to_vec(),
+        };
+        let config_b = EncryptionConfig {
+            encrypt_doc: true,
+            encrypt_fields: vec![],
+            encryption_key: b"second-master-key-material654321".to_vec(),
+        };
+
+        assert_ne!(config_a.derive_key("", doc_id), config_b.derive_key("", doc_id));
     }
 }

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -26,6 +26,7 @@ pub struct EmbeddedNode<S: storage::corekv::Store> {
     pub query_runner: Arc<dyn query::QueryExecutor>,
     pub nac_manager: Arc<dyn db::NacManagerApi>,
     pub document_acp: Arc<dyn acp::DocumentACP>,
+    pub local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
     pub event_bus: Arc<dyn events::Bus>,
     pub node_identity_did: Option<String>,
     pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
@@ -282,7 +283,7 @@ where
         ),
     };
 
-    let (document_acp, sourcehub_acp) =
+    let (document_acp, local_zanzibar_store, sourcehub_acp) =
         create_document_acp(store.clone(), config.persistence, &config.document_acp).await?;
     let nac_manager = create_nac_manager(store.clone(), config.persistence).await?;
 
@@ -325,6 +326,7 @@ where
         query_runner,
         nac_manager,
         document_acp,
+        local_zanzibar_store,
         event_bus,
         node_identity_did,
         sourcehub_acp,

--- a/crates/embedded/src/node_acp.rs
+++ b/crates/embedded/src/node_acp.rs
@@ -138,29 +138,25 @@ resources:
             .await
             .unwrap();
 
-        assert!(
-            document_acp
-                .check_doc_access(
-                    &Identity::Authenticated(viewer.clone()),
-                    DocumentPermission::Read,
-                    &policy.id,
-                    "users",
-                    "doc1",
-                )
-                .await
-                .unwrap()
-        );
-        assert!(
-            !document_acp
-                .check_doc_access(
-                    &Identity::Authenticated(viewer),
-                    DocumentPermission::Update,
-                    &policy.id,
-                    "users",
-                    "doc1",
-                )
-                .await
-                .unwrap()
-        );
+        assert!(document_acp
+            .check_doc_access(
+                &Identity::Authenticated(viewer.clone()),
+                DocumentPermission::Read,
+                &policy.id,
+                "users",
+                "doc1",
+            )
+            .await
+            .unwrap());
+        assert!(!document_acp
+            .check_doc_access(
+                &Identity::Authenticated(viewer),
+                DocumentPermission::Update,
+                &policy.id,
+                "users",
+                "doc1",
+            )
+            .await
+            .unwrap());
     }
 }

--- a/crates/embedded/src/node_acp.rs
+++ b/crates/embedded/src/node_acp.rs
@@ -10,6 +10,7 @@ pub(crate) async fn create_document_acp<S>(
     config: &crate::DocumentAcpConfig,
 ) -> Result<(
     Arc<dyn acp::DocumentACP>,
+    Option<Arc<dyn acp::ZanzibarStore>>,
     Option<Arc<sourcehub::SourceHubDocumentACP>>,
 )>
 where
@@ -32,17 +33,18 @@ where
                 provider,
                 tuning.cache_ttl,
             ));
-            Ok((sh_acp.clone(), Some(sh_acp)))
+            Ok((sh_acp.clone(), None, Some(sh_acp)))
         }
         crate::DocumentAcpConfig::Local => match persistence {
             Persistence::Persistent => {
-                let acp_store: Arc<dyn acp::AcpStore> =
-                    Arc::new(acp::PersistentAcpStore::from_store(store));
-                Ok((Arc::new(acp::LocalDocumentACP::new(acp_store)), None))
+                let zanzibar_store = Arc::new(acp::PersistentZanzibarStore::from_store(store));
+                let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
+                Ok((document_acp, Some(zanzibar_store), None))
             }
             Persistence::Memory => {
-                let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
-                Ok((Arc::new(acp::LocalDocumentACP::new(acp_store)), None))
+                let zanzibar_store = Arc::new(acp::MemoryZanzibarStore::new());
+                let document_acp = Arc::new(acp::ZanzibarDocumentACP::new(zanzibar_store.clone()));
+                Ok((document_acp, Some(zanzibar_store), None))
             }
         },
     }
@@ -70,5 +72,95 @@ where
             let nac_config = db::NacConfig::new().with_dev_mode();
             Ok(Arc::new(db::NacManager::new(nac_store, nac_config)))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::create_document_acp;
+    use crate::{DocumentAcpConfig, Persistence};
+    use acp::{DocumentPermission, Identity, StorePolicyOptions};
+    use identity::Did;
+    use std::sync::Arc;
+
+    fn did(value: &str) -> Did {
+        Did::new(value).unwrap()
+    }
+
+    #[tokio::test]
+    async fn local_document_acp_enforces_stored_custom_policy() {
+        let store = Arc::new(storage::MemoryStore::new());
+        let (document_acp, local_store, sourcehub_acp) =
+            create_document_acp(store, Persistence::Memory, &DocumentAcpConfig::Local)
+                .await
+                .unwrap();
+
+        assert!(sourcehub_acp.is_none());
+        let local_store = local_store.expect("local ACP should expose a Zanzibar store");
+
+        let parsed = acp::policy_yaml::parse_policy_yaml(
+            r#"
+name: Viewer Policy
+resources:
+  - name: users
+    relations:
+      - name: viewer
+      - name: editor
+      - name: remover
+    permissions:
+      - name: read
+        expr: viewer
+      - name: update
+        expr: editor
+      - name: delete
+        expr: remover
+"#,
+        )
+        .unwrap();
+        let policy = acp::policy_yaml::build_policy(&parsed, 1).unwrap();
+        let options = StorePolicyOptions::new()
+            .with_validation()
+            .with_dpi_enforcement();
+        local_store
+            .store_policy_with_options(&policy, &options)
+            .await
+            .unwrap();
+
+        let owner = did("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+        let viewer = did("did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR");
+
+        document_acp
+            .register_doc_object(&owner, &policy.id, "users", "doc1")
+            .await
+            .unwrap();
+        document_acp
+            .add_actor_relationship(&owner, &viewer, &policy.id, "users", "doc1", "viewer", &[])
+            .await
+            .unwrap();
+
+        assert!(
+            document_acp
+                .check_doc_access(
+                    &Identity::Authenticated(viewer.clone()),
+                    DocumentPermission::Read,
+                    &policy.id,
+                    "users",
+                    "doc1",
+                )
+                .await
+                .unwrap()
+        );
+        assert!(
+            !document_acp
+                .check_doc_access(
+                    &Identity::Authenticated(viewer),
+                    DocumentPermission::Update,
+                    &policy.id,
+                    "users",
+                    "doc1",
+                )
+                .await
+                .unwrap()
+        );
     }
 }

--- a/crates/ffi/src/acp/dac.rs
+++ b/crates/ffi/src/acp/dac.rs
@@ -1,6 +1,7 @@
 use std::ffi::c_char;
 
 use acp::nac::NodePermission;
+use acp::StorePolicyOptions;
 
 use crate::helpers::{get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
@@ -128,20 +129,52 @@ pub unsafe extern "C" fn add_dac_policy(
                 Err(e) => FfiResult::error(e),
             }
         } else {
-            // Local mode: Go-compatible ID generation
-            let result = NODES
-                .get(node_ptr, |state| {
-                    let policy_id = state.policy_store.add_policy(&policy_str, &parsed);
+            // Local mode: persist the parsed policy into the same Zanzibar store
+            // used by document ACP so custom relations and permissions are enforced.
+            let (policy_store, local_zanzibar_store) = match NODES.get(node_ptr, |state| {
+                (state.policy_store.clone(), state.local_zanzibar_store.clone())
+            }) {
+                Some(tuple) => tuple,
+                None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
+            };
+
+            let policy_id = policy_store.next_policy_id(&parsed);
+            let policy = match acp::policy_yaml::build_policy(&parsed, 1) {
+                Ok(policy) => acp::Policy {
+                    id: policy_id.clone(),
+                    ..policy
+                },
+                Err(e) => return FfiResult::error(format!("invalid policy: {}", e)),
+            };
+            policy_store.store_policy(&policy_id, &policy_str);
+
+            let Some(local_zanzibar_store) = local_zanzibar_store else {
+                return FfiResult::error("local ACP backend is not available");
+            };
+
+            let options = StorePolicyOptions::new()
+                .with_validation()
+                .with_dpi_enforcement();
+
+            let result = rt.block_on(async {
+                local_zanzibar_store
+                    .store_policy_with_options(&policy, &options)
+                    .await
+                    .map_err(|e| format!("failed to store policy: {}", e))?;
+                Ok::<String, String>(
                     serde_json::json!({
                         "PolicyID": policy_id
                     })
-                    .to_string()
-                })
-                .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string());
+                    .to_string(),
+                )
+            });
 
             match result {
                 Ok(json) => FfiResult::success(json),
-                Err(e) => FfiResult::error(e),
+                Err(e) => {
+                    policy_store.remove_policy(&policy_id);
+                    FfiResult::error(e)
+                }
             }
         }
     }
@@ -472,8 +505,24 @@ pub unsafe extern "C" fn delete_dac_actor_relationship(
 mod tests {
     use super::*;
     use crate::node::{new_node, node_close};
+    use crate::{add_schema, exec_request};
     use crate::types::NodeInitOptions;
     use std::ffi::{CStr, CString};
+
+    fn ffi_value(result: &crate::types::FfiResult) -> String {
+        assert_eq!(result.status, 0, "expected success status");
+        unsafe { CStr::from_ptr(result.value).to_string_lossy().into_owned() }
+    }
+
+    fn extract_doc_id(payload: &str, field: &str) -> String {
+        let json: serde_json::Value = serde_json::from_str(payload).unwrap();
+        let data = &json["data"][field];
+        match data {
+            serde_json::Value::Array(items) => items[0]["_docID"].as_str().unwrap().to_string(),
+            serde_json::Value::Object(_) => data["_docID"].as_str().unwrap().to_string(),
+            other => panic!("unexpected GraphQL payload for {field}: {other}"),
+        }
+    }
 
     fn test_did() -> &'static str {
         "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
@@ -524,5 +573,161 @@ mod tests {
         }
 
         node_close(node);
+    }
+
+    #[test]
+    fn test_local_dac_policy_is_enforced_via_ffi() {
+        assert!(crate::runtime::init_runtime());
+
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0, "new_node should succeed");
+        let node = result.node_ptr;
+
+        let owner_did = CString::new(test_did()).unwrap();
+        let viewer_did = CString::new(test_did2()).unwrap();
+        let policy_yaml = CString::new(
+            r#"
+name: Viewer Policy
+resources:
+  - name: users
+    relations:
+      - name: viewer
+      - name: editor
+      - name: remover
+    permissions:
+      - name: read
+        expr: viewer
+      - name: update
+        expr: editor
+      - name: delete
+        expr: remover
+"#,
+        )
+        .unwrap();
+
+        let add_policy_result = unsafe { add_dac_policy(node, owner_did.as_ptr(), policy_yaml.as_ptr()) };
+        let add_policy_json = ffi_value(&add_policy_result);
+        let policy_id = serde_json::from_str::<serde_json::Value>(&add_policy_json)
+            .unwrap()["PolicyID"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        unsafe { crate::types::defra_free_string(add_policy_result.value) };
+
+        let policy_id_c = CString::new(policy_id.clone()).unwrap();
+        let get_policy_result = unsafe { get_dac_policy(node, policy_id_c.as_ptr()) };
+        let get_policy_json = ffi_value(&get_policy_result);
+        assert!(get_policy_json.contains("Viewer Policy"));
+        unsafe { crate::types::defra_free_string(get_policy_result.value) };
+
+        let list_policy_result = list_dac_policies(node);
+        let list_policy_json = ffi_value(&list_policy_result);
+        assert!(list_policy_json.contains(&policy_id));
+        unsafe { crate::types::defra_free_string(list_policy_result.value) };
+
+        let sdl = CString::new(format!(
+            r#"type User @policy(id: "{policy_id}", resource: "users") {{ name: String }}"#
+        ))
+        .unwrap();
+        let schema_result = unsafe { add_schema(node, owner_did.as_ptr(), sdl.as_ptr()) };
+        assert_eq!(schema_result.status, 0, "add_schema should succeed");
+        if !schema_result.value.is_null() {
+            unsafe { crate::types::defra_free_string(schema_result.value) };
+        }
+
+        let add_doc = CString::new(
+            r#"mutation { add_User(input: {name: "Alice"}) { _docID name } }"#,
+        )
+        .unwrap();
+        let add_doc_result = unsafe {
+            exec_request(
+                node,
+                owner_did.as_ptr(),
+                add_doc.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        let add_doc_json = ffi_value(&add_doc_result);
+        let doc_id = extract_doc_id(&add_doc_json, "add_User");
+        unsafe { crate::types::defra_free_string(add_doc_result.value) };
+
+        let read_query = CString::new(r#"{ User { _docID name } }"#).unwrap();
+        let denied_read_result = unsafe {
+            exec_request(
+                node,
+                viewer_did.as_ptr(),
+                read_query.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        let denied_read_json = ffi_value(&denied_read_result);
+        assert!(
+            !denied_read_json.contains(&doc_id),
+            "viewer should not see protected documents before a relationship is granted"
+        );
+        unsafe { crate::types::defra_free_string(denied_read_result.value) };
+
+        let collection_id = CString::new("User").unwrap();
+        let doc_id_c = CString::new(doc_id.clone()).unwrap();
+        let relation = CString::new("viewer").unwrap();
+        let add_rel_result = unsafe {
+            add_dac_actor_relationship(
+                node,
+                owner_did.as_ptr(),
+                viewer_did.as_ptr(),
+                collection_id.as_ptr(),
+                doc_id_c.as_ptr(),
+                relation.as_ptr(),
+            )
+        };
+        let add_rel_json = ffi_value(&add_rel_result);
+        assert!(add_rel_json.contains(r#""added":true"#));
+        unsafe { crate::types::defra_free_string(add_rel_result.value) };
+
+        let allowed_read_result = unsafe {
+            exec_request(
+                node,
+                viewer_did.as_ptr(),
+                read_query.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        let allowed_read_json = ffi_value(&allowed_read_result);
+        assert!(allowed_read_json.contains(&doc_id));
+        assert!(allowed_read_json.contains("Alice"));
+        unsafe { crate::types::defra_free_string(allowed_read_result.value) };
+
+        let update_mutation = CString::new(format!(
+            r#"mutation {{ update_User(docIDs: ["{doc_id}"], input: {{name: "Mallory"}}) {{ _docID name }} }}"#
+        ))
+        .unwrap();
+        let denied_update_result = unsafe {
+            exec_request(
+                node,
+                viewer_did.as_ptr(),
+                update_mutation.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        let denied_update_json = ffi_value(&denied_update_result);
+        assert!(
+            denied_update_json.contains("permission denied")
+                || denied_update_json.contains("UNAUTHORIZED")
+                || denied_update_json.contains("errors"),
+            "viewer should not gain update access from a read-only relation: {denied_update_json}"
+        );
+        unsafe { crate::types::defra_free_string(denied_update_result.value) };
+
+        let close_result = node_close(node);
+        assert_eq!(close_result.status, 0, "node_close should succeed");
     }
 }

--- a/crates/ffi/src/acp/dac.rs
+++ b/crates/ffi/src/acp/dac.rs
@@ -505,8 +505,8 @@ pub unsafe extern "C" fn delete_dac_actor_relationship(
 mod tests {
     use super::*;
     use crate::node::{new_node, node_close};
-    use crate::{add_schema, exec_request};
     use crate::types::NodeInitOptions;
+    use crate::{add_schema, exec_request};
     use std::ffi::{CStr, CString};
 
     fn ffi_value(result: &crate::types::FfiResult) -> String {
@@ -606,10 +606,11 @@ resources:
         )
         .unwrap();
 
-        let add_policy_result = unsafe { add_dac_policy(node, owner_did.as_ptr(), policy_yaml.as_ptr()) };
+        let add_policy_result =
+            unsafe { add_dac_policy(node, owner_did.as_ptr(), policy_yaml.as_ptr()) };
         let add_policy_json = ffi_value(&add_policy_result);
-        let policy_id = serde_json::from_str::<serde_json::Value>(&add_policy_json)
-            .unwrap()["PolicyID"]
+        let policy_id = serde_json::from_str::<serde_json::Value>(&add_policy_json).unwrap()
+            ["PolicyID"]
             .as_str()
             .unwrap()
             .to_string();
@@ -636,10 +637,9 @@ resources:
             unsafe { crate::types::defra_free_string(schema_result.value) };
         }
 
-        let add_doc = CString::new(
-            r#"mutation { add_User(input: {name: "Alice"}) { _docID name } }"#,
-        )
-        .unwrap();
+        let add_doc =
+            CString::new(r#"mutation { add_User(input: {name: "Alice"}) { _docID name } }"#)
+                .unwrap();
         let add_doc_result = unsafe {
             exec_request(
                 node,

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -193,9 +193,6 @@ pub extern "C" fn defra_init() {
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         // Ignore return value - errors will surface when operations are attempted
         let _ = runtime::init_runtime();
-        // Enable deterministic nonce for testing (matches Go's init() detection)
-        crypto::encryption::nonce::USE_DETERMINISTIC_NONCE
-            .store(true, std::sync::atomic::Ordering::Relaxed);
     }));
 }
 
@@ -222,14 +219,20 @@ mod negative_tests;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crypto::encryption::nonce::USE_DETERMINISTIC_NONCE;
     use std::ffi::CStr;
     use std::ptr;
 
     #[test]
     fn test_defra_init() {
+        USE_DETERMINISTIC_NONCE.store(false, std::sync::atomic::Ordering::Relaxed);
         defra_init();
         // Should be idempotent
         defra_init();
+        assert!(
+            !USE_DETERMINISTIC_NONCE.load(std::sync::atomic::Ordering::Relaxed),
+            "defra_init must not enable deterministic nonces"
+        );
     }
 
     #[test]

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -52,6 +52,7 @@ pub(crate) async fn build_node_state(
         document_acp: node.document_acp.clone(),
         event_bus: node.event_bus.clone(),
         policy_store: Arc::new(PolicyStore::new()),
+        local_zanzibar_store: node.local_zanzibar_store.clone(),
         p2p: node
             .p2p
             .clone()

--- a/crates/ffi/src/state/mod.rs
+++ b/crates/ffi/src/state/mod.rs
@@ -103,6 +103,8 @@ pub struct NodeState {
     pub event_bus: Arc<dyn events::Bus>,
     /// The policy store for DAC policies.
     pub policy_store: Arc<PolicyStore>,
+    /// Local Zanzibar policy store when document ACP is configured in local mode.
+    pub local_zanzibar_store: Option<Arc<dyn acp::ZanzibarStore>>,
     /// P2P state (optional - not all nodes have P2P enabled).
     pub p2p: Option<Arc<P2PState>>,
     /// Node identity DID (set when signing is enabled).

--- a/crates/ffi/src/state/policy_store.rs
+++ b/crates/ffi/src/state/policy_store.rs
@@ -31,9 +31,7 @@ impl PolicyStore {
 
     /// Add a policy and return its Go-compatible ID.
     pub fn add_policy(&self, policy: &str, parsed: &ParsedPolicy) -> String {
-        let counter_val = self.counter.fetch_add(1, Ordering::SeqCst);
-        let policy_id = acp::policy_yaml::generate_policy_id(parsed, counter_val);
-
+        let policy_id = self.next_policy_id(parsed);
         self.policies
             .write()
             .insert(policy_id.clone(), policy.to_string());
@@ -41,11 +39,22 @@ impl PolicyStore {
         policy_id
     }
 
+    /// Generate the next Go-compatible policy ID without storing the policy body.
+    pub fn next_policy_id(&self, parsed: &ParsedPolicy) -> String {
+        let counter_val = self.counter.fetch_add(1, Ordering::SeqCst);
+        acp::policy_yaml::generate_policy_id(parsed, counter_val)
+    }
+
     /// Store a policy with a known ID (used for SourceHub-created policies).
     pub fn store_policy(&self, id: &str, policy: &str) {
         self.policies
             .write()
             .insert(id.to_string(), policy.to_string());
+    }
+
+    /// Remove a policy from the cache.
+    pub fn remove_policy(&self, id: &str) {
+        self.policies.write().remove(id);
     }
 
     /// Get a policy by ID.

--- a/crates/zanzibar/src/engine/evaluate.rs
+++ b/crates/zanzibar/src/engine/evaluate.rs
@@ -10,7 +10,7 @@ use crate::expression::RelationExpression;
 use crate::store::ZanzibarStore;
 use crate::types::Subject;
 
-impl<S: ZanzibarStore> PermissionEngine<S> {
+impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn evaluate_expr_cached<'a>(
         &'a self,

--- a/crates/zanzibar/src/engine/mod.rs
+++ b/crates/zanzibar/src/engine/mod.rs
@@ -95,12 +95,12 @@ impl std::fmt::Display for StepResult {
     }
 }
 
-pub struct PermissionEngine<S: ZanzibarStore> {
+pub struct PermissionEngine<S: ZanzibarStore + ?Sized> {
     store: Arc<S>,
     pub lookup: PolicyLookupTable,
 }
 
-impl<S: ZanzibarStore> PermissionEngine<S> {
+impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
     pub fn new(store: Arc<S>) -> Self {
         Self {
             store,

--- a/crates/zanzibar/src/engine/trace.rs
+++ b/crates/zanzibar/src/engine/trace.rs
@@ -10,7 +10,7 @@ use crate::expression::RelationExpression;
 use crate::store::ZanzibarStore;
 use crate::types::Subject;
 
-impl<S: ZanzibarStore> PermissionEngine<S> {
+impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn evaluate_expr_with_trace<'a>(
         &'a self,

--- a/tools/integration-test/tests/acp.rs
+++ b/tools/integration-test/tests/acp.rs
@@ -2,6 +2,8 @@
 mod audit;
 #[path = "acp/basic.rs"]
 mod basic;
+#[path = "acp/custom_policy.rs"]
+mod custom_policy;
 #[path = "acp/multi_identity.rs"]
 mod multi_identity;
 #[path = "acp/multi_role.rs"]

--- a/tools/integration-test/tests/acp/custom_policy.rs
+++ b/tools/integration-test/tests/acp/custom_policy.rs
@@ -1,0 +1,122 @@
+use integration_test::{for_each_runtime, generate_identity, TestCluster};
+
+const VIEWER_ACP_POLICY: &str = r#"name: viewer-policy
+description: Custom ACP policy with a non-standard viewer relation
+
+resources:
+  - name: reports
+    permissions:
+      - name: read
+        expr: viewer
+      - name: update
+        expr: editor
+      - name: delete
+        expr: remover
+    relations:
+      - name: viewer
+        types:
+          - actor
+      - name: editor
+        types:
+          - actor
+      - name: remover
+        types:
+          - actor"#;
+
+fn reports_schema_with_policy(policy_id: &str) -> String {
+    format!(
+        r#"type Report @policy(id: "{}", resource: "reports") {{ title: String  body: String }}"#,
+        policy_id
+    )
+}
+
+async fn custom_relation_policy_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary = node.binary_path().to_path_buf();
+
+    let owner = generate_identity(&binary).expect("owner identity");
+    let viewer = generate_identity(&binary).expect("viewer identity");
+
+    let policy = node
+        .acp_policy_add(VIEWER_ACP_POLICY, &owner.private_key_hex)
+        .expect("add custom ACP policy");
+    let policy_id = policy["PolicyID"]
+        .as_str()
+        .or_else(|| policy["policyID"].as_str())
+        .expect("missing PolicyID");
+
+    let schema = reports_schema_with_policy(policy_id);
+    node.schema_add_with_identity(&schema, &owner.private_key_hex)
+        .expect("add schema");
+
+    let created = node
+        .query_with_identity(
+            r#"mutation { add_Report(input: {title: "Quarterly", body: "Q1"}) { _docID title } }"#,
+            &owner.private_key_hex,
+        )
+        .expect("create protected report");
+    let doc_id = created["add_Report"][0]["_docID"]
+        .as_str()
+        .expect("_docID")
+        .to_string();
+
+    let before = node
+        .query_with_identity("query { Report { _docID title body } }", &viewer.private_key_hex)
+        .expect("query before viewer grant");
+    assert_eq!(
+        before["Report"].as_array().map(|a| a.len()).unwrap_or(0),
+        0,
+        "custom viewer relation must not be implicit before grant"
+    );
+
+    node.acp_relationship_add(
+        "Report",
+        &doc_id,
+        "viewer",
+        &viewer.did,
+        &owner.private_key_hex,
+    )
+    .expect("grant viewer relation");
+
+    let after = node
+        .query_with_identity("query { Report { _docID title body } }", &viewer.private_key_hex)
+        .expect("query after viewer grant");
+    let reports = after["Report"].as_array().expect("Report array");
+    assert_eq!(reports.len(), 1, "viewer should see exactly one report");
+    assert_eq!(reports[0]["title"], "Quarterly");
+
+    let update_attempt = node.query_with_identity(
+        &format!(
+            r#"mutation {{ update_Report(docID: "{}", input: {{title: "Tampered"}}) {{ _docID title }} }}"#,
+            doc_id
+        ),
+        &viewer.private_key_hex,
+    );
+    match update_attempt {
+        Err(_) => {}
+        Ok(val) => {
+            let updated = val["update_Report"].as_array().map(|a| a.len()).unwrap_or(0);
+            assert_eq!(
+                updated, 0,
+                "viewer relation must not grant update access: {:?}",
+                val
+            );
+        }
+    }
+
+    let owner_read = node
+        .query_with_identity("query { Report { _docID title body } }", &owner.private_key_hex)
+        .expect("owner read after viewer update attempt");
+    let owner_reports = owner_read["Report"].as_array().expect("owner report array");
+    assert_eq!(owner_reports.len(), 1);
+    assert_eq!(
+        owner_reports[0]["title"], "Quarterly",
+        "viewer update attempt must not modify the report"
+    );
+}
+
+for_each_runtime!(
+    custom_relation_policy,
+    custom_relation_policy_test,
+    .with_acp_local()
+);

--- a/tools/integration-test/tests/acp/custom_policy.rs
+++ b/tools/integration-test/tests/acp/custom_policy.rs
@@ -61,7 +61,10 @@ async fn custom_relation_policy_test(cluster: TestCluster) {
         .to_string();
 
     let before = node
-        .query_with_identity("query { Report { _docID title body } }", &viewer.private_key_hex)
+        .query_with_identity(
+            "query { Report { _docID title body } }",
+            &viewer.private_key_hex,
+        )
         .expect("query before viewer grant");
     assert_eq!(
         before["Report"].as_array().map(|a| a.len()).unwrap_or(0),
@@ -79,7 +82,10 @@ async fn custom_relation_policy_test(cluster: TestCluster) {
     .expect("grant viewer relation");
 
     let after = node
-        .query_with_identity("query { Report { _docID title body } }", &viewer.private_key_hex)
+        .query_with_identity(
+            "query { Report { _docID title body } }",
+            &viewer.private_key_hex,
+        )
         .expect("query after viewer grant");
     let reports = after["Report"].as_array().expect("Report array");
     assert_eq!(reports.len(), 1, "viewer should see exactly one report");
@@ -95,7 +101,10 @@ async fn custom_relation_policy_test(cluster: TestCluster) {
     match update_attempt {
         Err(_) => {}
         Ok(val) => {
-            let updated = val["update_Report"].as_array().map(|a| a.len()).unwrap_or(0);
+            let updated = val["update_Report"]
+                .as_array()
+                .map(|a| a.len())
+                .unwrap_or(0);
             assert_eq!(
                 updated, 0,
                 "viewer relation must not grant update access: {:?}",
@@ -105,7 +114,10 @@ async fn custom_relation_policy_test(cluster: TestCluster) {
     }
 
     let owner_read = node
-        .query_with_identity("query { Report { _docID title body } }", &owner.private_key_hex)
+        .query_with_identity(
+            "query { Report { _docID title body } }",
+            &owner.private_key_hex,
+        )
         .expect("owner read after viewer update attempt");
     let owner_reports = owner_read["Report"].as_array().expect("owner report array");
     assert_eq!(owner_reports.len(), 1);

--- a/tools/integration-test/tests/acp/multi_role.rs
+++ b/tools/integration-test/tests/acp/multi_role.rs
@@ -71,13 +71,9 @@ async fn acp_multi_role_test(cluster: TestCluster) {
             .unwrap_or(0)
     };
 
-    // Alice sees 2 (owner of both), Bob=0 (admin grants management not read), Carol=1, Dave=1
+    // Alice sees 2 (owner of both), Bob=1 (admin grants read on doc1), Carol=1, Dave=1
     assert_eq!(count(&alice.private_key_hex), 2, "Alice=2");
-    assert_eq!(
-        count(&bob.private_key_hex),
-        0,
-        "Bob=0 (admin does not grant doc read)"
-    );
+    assert_eq!(count(&bob.private_key_hex), 1, "Bob=1 (admin can read doc1)");
     assert_eq!(count(&carol.private_key_hex), 1, "Carol=1 (writer on doc1)");
     assert_eq!(count(&dave.private_key_hex), 1, "Dave=1 (reader on doc1)");
 

--- a/tools/integration-test/tests/acp/multi_role.rs
+++ b/tools/integration-test/tests/acp/multi_role.rs
@@ -73,7 +73,11 @@ async fn acp_multi_role_test(cluster: TestCluster) {
 
     // Alice sees 2 (owner of both), Bob=1 (admin grants read on doc1), Carol=1, Dave=1
     assert_eq!(count(&alice.private_key_hex), 2, "Alice=2");
-    assert_eq!(count(&bob.private_key_hex), 1, "Bob=1 (admin can read doc1)");
+    assert_eq!(
+        count(&bob.private_key_hex),
+        1,
+        "Bob=1 (admin can read doc1)"
+    );
     assert_eq!(count(&carol.private_key_hex), 1, "Carol=1 (writer on doc1)");
     assert_eq!(count(&dave.private_key_hex), 1, "Dave=1 (reader on doc1)");
 


### PR DESCRIPTION
## Summary
- fix per-document encryption key derivation so the master key is always mixed in
- stop enabling deterministic nonces from `defra_init()` and add a regression test
- switch local runtime DAC enforcement to Zanzibar-backed policy evaluation, persist local FFI policies into that same store, and add cross-runtime custom-policy coverage

## Verification
- cargo test -p defra-core derive_key_mixes_in_master_key_for_long_doc_ids -- --nocapture
- cargo test -p ffi test_defra_init -- --nocapture
- cargo test -p ffi acp::dac::tests -- --nocapture
- cargo test -p acp --test local_tests -- --nocapture
- cargo test -p db --test collection_acp_tests -- --nocapture
- cargo test -p embedded local_document_acp_enforces_stored_custom_policy -- --nocapture
- cargo test -p integration-test --test acp rust_custom_relation_policy -- --nocapture
- PATH="/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb.rs/target/e2e-bin:$PATH" cargo test -p integration-test --test acp go_custom_relation_policy -- --nocapture
- cargo test -p cli --lib --no-run

## Closes
- Closes #639
- Closes #640
- Closes #641