### PR TITLE
Remove unused store parameter from DbTxn constructors

### DIFF
--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -313,7 +313,7 @@ impl<S: Store> DB<S> {
         let basic_txn = BasicTxn::new(&*self.store, id, readonly)
             .await
             .map_err(Error::Storage)?;
-        Ok(DbTxn::new(basic_txn, self.store.clone()))
+        Ok(DbTxn::new(basic_txn))
     }
 
     /// Execute a function within a transaction.

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -9,7 +9,6 @@ use crate::collection_cache::CollectionCache;
 use crate::error::{Error, Result};
 use datastore::{AsyncCallback, BasicTxn, NamespaceView, RootView, TxnCallback};
 use schema::CollectionVersion;
-use std::sync::Arc;
 use storage::corekv::{IterOptions, Key, Store};
 use storage::keys::systemstore::{CollectionKey, CollectionNameKey};
 
@@ -46,7 +45,7 @@ pub struct DbTxn<S: Store> {
 
 impl<S: Store> DbTxn<S> {
     /// Create a new implicit DbTxn.
-    pub fn new(txn: BasicTxn, _store: Arc<S>) -> Self {
+    pub fn new(txn: BasicTxn) -> Self {
         Self {
             txn: Some(txn),
             explicit: false,
@@ -56,7 +55,7 @@ impl<S: Store> DbTxn<S> {
     }
 
     /// Create a new explicit DbTxn.
-    pub fn new_explicit(txn: BasicTxn, _store: Arc<S>) -> Self {
+    pub fn new_explicit(txn: BasicTxn) -> Self {
         Self {
             txn: Some(txn),
             explicit: true,

--- a/crates/db/tests/schema_loader_tests.rs
+++ b/crates/db/tests/schema_loader_tests.rs
@@ -11,6 +11,10 @@ use storage::backends::MemoryStore;
 use storage::corekv::Key;
 use storage::keys::systemstore::{CollectionKey, CollectionNameKey};
 
+fn new_txn(basic_txn: BasicTxn) -> DbTxn<MemoryStore> {
+    DbTxn::new(basic_txn)
+}
+
 #[tokio::test]
 async fn test_load_empty_database() {
     let store = MemoryStore::new();
@@ -38,7 +42,7 @@ async fn test_load_single_collection() {
 
     {
         let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-        let txn = DbTxn::new(basic_txn, store.clone());
+        let txn = new_txn(basic_txn);
 
         // Store the collection definition at /collection/id/<id>
         txn.systemstore()
@@ -77,7 +81,7 @@ async fn test_load_multiple_collections() {
 
     {
         let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-        let txn = DbTxn::new(basic_txn, store.clone());
+        let txn = new_txn(basic_txn);
 
         for (name, id) in &collections {
             let collection = CollectionVersion::new(*name, *id, *id, vec![]);
@@ -119,7 +123,7 @@ async fn test_load_missing_collection_definition_returns_error() {
     // Store only the name mapping, NOT the collection definition
     {
         let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-        let txn = DbTxn::new(basic_txn, store.clone());
+        let txn = new_txn(basic_txn);
 
         let name_key = CollectionNameKey::new("orphan_collection");
         txn.systemstore()
@@ -174,7 +178,7 @@ async fn test_load_invalid_json_collection_returns_error() {
     // Store name mapping pointing to invalid JSON
     {
         let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-        let txn = DbTxn::new(basic_txn, store.clone());
+        let txn = new_txn(basic_txn);
 
         let name_key = CollectionNameKey::new("bad_collection");
         let collection_key = CollectionKey::new("bad_id_456");

--- a/crates/db/tests/txn_tests.rs
+++ b/crates/db/tests/txn_tests.rs
@@ -7,11 +7,19 @@ use db::txn::DbTxn;
 use db::Error;
 use storage::backends::MemoryStore;
 
+fn new_txn(basic_txn: BasicTxn) -> DbTxn<MemoryStore> {
+    DbTxn::new(basic_txn)
+}
+
+fn new_explicit_txn(basic_txn: BasicTxn) -> DbTxn<MemoryStore> {
+    DbTxn::new_explicit(basic_txn)
+}
+
 #[tokio::test]
 async fn test_db_txn_basic() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
 
     assert_eq!(txn.id().unwrap(), 1);
     assert!(!txn.is_readonly().unwrap());
@@ -22,7 +30,7 @@ async fn test_db_txn_basic() {
 async fn test_db_txn_explicit() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new_explicit(basic_txn, store.clone());
+    let txn = new_explicit_txn(basic_txn);
 
     assert!(txn.is_explicit());
 }
@@ -31,7 +39,7 @@ async fn test_db_txn_explicit() {
 async fn test_db_txn_make_explicit() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let mut txn = DbTxn::new(basic_txn, store.clone());
+    let mut txn = new_txn(basic_txn);
 
     assert!(!txn.is_explicit());
     txn.make_explicit();
@@ -42,7 +50,7 @@ async fn test_db_txn_make_explicit() {
 async fn test_db_txn_write_and_commit() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
 
     // Write data
     txn.datastore()
@@ -56,7 +64,7 @@ async fn test_db_txn_write_and_commit() {
 
     // Verify data persisted
     let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     let value = txn.datastore().unwrap().get(b"key").await.unwrap();
     assert_eq!(value, Some(b"value".to_vec()));
 }
@@ -65,7 +73,7 @@ async fn test_db_txn_write_and_commit() {
 async fn test_db_txn_write_and_discard() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
 
     // Write data
     txn.datastore()
@@ -79,7 +87,7 @@ async fn test_db_txn_write_and_discard() {
 
     // Verify data NOT persisted
     let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     let value = txn.datastore().unwrap().get(b"key").await.unwrap();
     assert_eq!(value, None);
 }
@@ -88,7 +96,7 @@ async fn test_db_txn_write_and_discard() {
 async fn test_db_txn_force_commit() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new_explicit(basic_txn, store.clone());
+    let txn = new_explicit_txn(basic_txn);
 
     // Write data
     txn.datastore()
@@ -102,7 +110,7 @@ async fn test_db_txn_force_commit() {
 
     // Verify data persisted
     let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     let value = txn.datastore().unwrap().get(b"key").await.unwrap();
     assert_eq!(value, Some(b"value".to_vec()));
 }
@@ -113,7 +121,7 @@ async fn test_db_txn_force_commit() {
 async fn test_db_txn_explicit_commit_returns_error() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new_explicit(basic_txn, store.clone());
+    let txn = new_explicit_txn(basic_txn);
 
     // Commit on explicit transaction should return error
     let result = txn.commit().await;
@@ -124,7 +132,7 @@ async fn test_db_txn_explicit_commit_returns_error() {
 async fn test_db_txn_explicit_discard_returns_error() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new_explicit(basic_txn, store.clone());
+    let txn = new_explicit_txn(basic_txn);
 
     // Discard on explicit transaction should return error
     let result = txn.discard();
@@ -135,7 +143,7 @@ async fn test_db_txn_explicit_discard_returns_error() {
 async fn test_db_txn_force_discard() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new_explicit(basic_txn, store.clone());
+    let txn = new_explicit_txn(basic_txn);
 
     // Write data
     txn.datastore()
@@ -149,7 +157,7 @@ async fn test_db_txn_force_discard() {
 
     // Verify data NOT persisted
     let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     let value = txn.datastore().unwrap().get(b"key").await.unwrap();
     assert_eq!(value, None);
 }
@@ -158,7 +166,7 @@ async fn test_db_txn_force_discard() {
 async fn test_db_txn_accessor_returns_all_stores() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
 
     // All accessor methods should succeed on active transaction
     assert!(txn.blockstore().is_ok());
@@ -178,7 +186,7 @@ async fn test_db_txn_callbacks_executed_on_commit() {
 
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let mut txn = DbTxn::new(basic_txn, store.clone());
+    let mut txn = new_txn(basic_txn);
 
     let success_called = Arc::new(AtomicBool::new(false));
     let success_clone = success_called.clone();
@@ -197,7 +205,7 @@ async fn test_db_txn_callbacks_executed_on_discard() {
 
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let mut txn = DbTxn::new(basic_txn, store.clone());
+    let mut txn = new_txn(basic_txn);
 
     let discard_called = Arc::new(AtomicBool::new(false));
     let discard_clone = discard_called.clone();
@@ -214,7 +222,7 @@ async fn test_db_txn_callbacks_executed_on_discard() {
 async fn test_db_txn_readonly_cannot_write() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
 
     assert!(txn.is_readonly().unwrap());
 
@@ -228,15 +236,15 @@ async fn test_db_txn_id_increments() {
     let store = Arc::new(MemoryStore::new());
 
     let basic_txn1 = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn1 = DbTxn::new(basic_txn1, store.clone());
+    let txn1 = new_txn(basic_txn1);
     assert_eq!(txn1.id().unwrap(), 1);
 
     let basic_txn2 = BasicTxn::new(&*store, 2, false).await.unwrap();
-    let txn2 = DbTxn::new(basic_txn2, store.clone());
+    let txn2 = new_txn(basic_txn2);
     assert_eq!(txn2.id().unwrap(), 2);
 
     let basic_txn3 = BasicTxn::new(&*store, 100, false).await.unwrap();
-    let txn3 = DbTxn::new(basic_txn3, store.clone());
+    let txn3 = new_txn(basic_txn3);
     assert_eq!(txn3.id().unwrap(), 100);
 }
 
@@ -244,7 +252,7 @@ async fn test_db_txn_id_increments() {
 async fn test_db_txn_multiple_writes_single_commit() {
     let store = Arc::new(MemoryStore::new());
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
 
     // Multiple writes in single transaction
     txn.datastore()
@@ -267,7 +275,7 @@ async fn test_db_txn_multiple_writes_single_commit() {
 
     // Verify all persisted
     let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     assert_eq!(
         txn.datastore().unwrap().get(b"key1").await.unwrap(),
         Some(b"value1".to_vec())
@@ -288,7 +296,7 @@ async fn test_db_txn_overwrite_value() {
 
     // Write initial value
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     txn.datastore()
         .unwrap()
         .set(b"key", b"initial")
@@ -298,7 +306,7 @@ async fn test_db_txn_overwrite_value() {
 
     // Overwrite value
     let basic_txn = BasicTxn::new(&*store, 2, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     txn.datastore()
         .unwrap()
         .set(b"key", b"updated")
@@ -308,7 +316,7 @@ async fn test_db_txn_overwrite_value() {
 
     // Verify updated value
     let basic_txn = BasicTxn::new(&*store, 3, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     assert_eq!(
         txn.datastore().unwrap().get(b"key").await.unwrap(),
         Some(b"updated".to_vec())
@@ -321,7 +329,7 @@ async fn test_db_txn_delete_value() {
 
     // Write initial value
     let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     txn.datastore()
         .unwrap()
         .set(b"key", b"value")
@@ -331,12 +339,12 @@ async fn test_db_txn_delete_value() {
 
     // Delete value
     let basic_txn = BasicTxn::new(&*store, 2, false).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     txn.datastore().unwrap().delete(b"key").await.unwrap();
     txn.commit().await.unwrap();
 
     // Verify deleted
     let basic_txn = BasicTxn::new(&*store, 3, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = new_txn(basic_txn);
     assert_eq!(txn.datastore().unwrap().get(b"key").await.unwrap(), None);
 }


### PR DESCRIPTION
## Summary
- remove the unused `store` parameter from `DbTxn::new` and `DbTxn::new_explicit`
- update the `DB::new_txn` call site to use the simplified constructors
- keep `db` tests readable with small `MemoryStore` transaction helpers where type inference no longer has the extra argument

## Testing
- cargo test -p db

Closes #688