### PR TITLE
Investigate CID sort allocation overhead

### DIFF
--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -7,6 +7,7 @@ use cid::Cid;
 use multihash::MultihashGeneric;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::sync::OnceLock;
 
 use crate::{Error, Result};
 
@@ -87,7 +88,7 @@ impl Block {
 
         // Sort and normalize links
         let mut sorted_links = links;
-        sorted_links.sort_by_cached_key(|link| link.link.to_string());
+        sorted_links.sort();
         let links = if sorted_links.is_empty() {
             None
         } else {
@@ -187,13 +188,16 @@ impl Block {
 ///
 /// Matches Go's `internal/core/block/block.go:DAGLink`.
 /// The name is typically a field name or "_head" for composite head links.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DAGLink {
     /// Field name or "_head" for composite head
     pub name: String,
 
     /// CID of the linked block
     pub link: Cid,
+
+    #[serde(skip)]
+    sort_key: OnceLock<String>,
 }
 
 impl DAGLink {
@@ -202,9 +206,22 @@ impl DAGLink {
         Self {
             name: name.into(),
             link,
+            sort_key: OnceLock::new(),
         }
     }
+
+    fn sort_key(&self) -> &str {
+        self.sort_key.get_or_init(|| self.link.to_string())
+    }
 }
+
+impl PartialEq for DAGLink {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.link == other.link
+    }
+}
+
+impl Eq for DAGLink {}
 
 impl PartialOrd for DAGLink {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -215,7 +232,7 @@ impl PartialOrd for DAGLink {
 impl Ord for DAGLink {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // Sort by link CID multibase string (matching Go's strings.Compare)
-        self.link.to_string().cmp(&other.link.to_string())
+        self.sort_key().cmp(other.sort_key())
     }
 }
 

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -78,7 +78,7 @@ impl Block {
     pub fn new(delta: CrdtDelta, heads: Vec<Cid>, links: Vec<DAGLink>) -> Self {
         // Sort and normalize heads
         let mut sorted_heads = heads;
-        sorted_heads.sort_by_key(|a| a.to_string());
+        sorted_heads.sort_by_cached_key(|a| a.to_string());
         let heads = if sorted_heads.is_empty() {
             None
         } else {
@@ -87,7 +87,7 @@ impl Block {
 
         // Sort and normalize links
         let mut sorted_links = links;
-        sorted_links.sort();
+        sorted_links.sort_by_cached_key(|link| link.link.to_string());
         let links = if sorted_links.is_empty() {
             None
         } else {

--- a/crates/defra-core/src/ipld/from_ipld.rs
+++ b/crates/defra-core/src/ipld/from_ipld.rs
@@ -99,7 +99,7 @@ impl TryFrom<&Ipld> for DAGLink {
             None => return Err(Error::IpldError("Missing 'link' in DAGLink".to_string())),
         };
 
-        Ok(DAGLink { name, link })
+        Ok(DAGLink::new(name, link))
     }
 }
 

--- a/crates/defra-core/tests/block_tests.rs
+++ b/crates/defra-core/tests/block_tests.rs
@@ -381,6 +381,18 @@ fn test_dag_link_ordering() {
 }
 
 #[test]
+fn test_block_new_sorts_links_by_cid_string() {
+    let link_a = DAGLink::new("z-name", test_cid());
+    let link_b = DAGLink::new("a-name", test_cid2());
+
+    let block = Block::new(test_lww_delta(), vec![], vec![link_a, link_b]);
+    let links = block.links.unwrap();
+
+    assert_eq!(links[0].link, test_cid2());
+    assert_eq!(links[1].link, test_cid());
+}
+
+#[test]
 fn test_encryption_roundtrip() {
     let enc = Encryption::new(b"doc1".to_vec(), b"key123".to_vec());
 

--- a/crates/defra-core/tests/block_tests.rs
+++ b/crates/defra-core/tests/block_tests.rs
@@ -393,6 +393,15 @@ fn test_block_new_sorts_links_by_cid_string() {
 }
 
 #[test]
+fn test_dag_link_equality_ignores_sort_cache_state() {
+    let link = DAGLink::new("field", test_cid());
+    let mut sorted = [link.clone()];
+    sorted.sort();
+
+    assert_eq!(sorted[0], link);
+}
+
+#[test]
 fn test_encryption_roundtrip() {
     let enc = Encryption::new(b"doc1".to_vec(), b"key123".to_vec());
 


### PR DESCRIPTION
## Summary
Create an isolated worktree/branch to investigate allocation overhead in CID sort comparators.

## Status
Draft setup PR for issue triage and implementation.

Refs #672