### PR TITLE
Make response tokens transport-typed

### DIFF
--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -714,22 +714,6 @@ impl P2PHostHandle {
         Ok(host_addrs)
     }
 
-    /// Create a test handle with a dummy channel (for unit tests only).
-    #[cfg(test)]
-    pub(crate) fn test_handle() -> Self {
-        let keypair = Keypair::generate_ed25519();
-        let local_peer_id = keypair.public().to_peer_id();
-        let public_key_proto = keypair.public().encode_protobuf();
-        let (command_tx, _rx) = mpsc::channel(1);
-        Self {
-            command_tx,
-            local_public_key_proto: public_key_proto,
-            local_peer_id,
-            keypair,
-            explicit_replay_capabilities: Arc::new(RwLock::new(HashMap::new())),
-        }
-    }
-
     /// Get connected peers with their full multiaddrs (Go-compatible ActivePeers).
     pub async fn peer_addresses(&self) -> Result<Vec<String>> {
         let (response_tx, response_rx) = oneshot::channel();

--- a/crates/p2p/src/host/libp2p_transport.rs
+++ b/crates/p2p/src/host/libp2p_transport.rs
@@ -16,7 +16,7 @@ use crate::message::{
 };
 use crate::replicator::ReplicatorInfo;
 use crate::topics::DefraTopic;
-use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, ResponseToken, TransportEvent};
+use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, TransportEvent};
 use crate::QueryId;
 
 /// Libp2p-backed P2P transport.
@@ -64,6 +64,8 @@ fn parse_multiaddr(addr: &PeerAddr) -> Result<libp2p::Multiaddr> {
 
 #[async_trait]
 impl P2PTransport for Libp2pTransport {
+    type ResponseToken = ResponseChannel;
+
     fn local_peer_id(&self) -> &PeerId {
         &self.local_peer_id
     }
@@ -133,11 +135,12 @@ impl P2PTransport for Libp2pTransport {
             .collect())
     }
 
-    async fn send_pushlog_response(&self, token: ResponseToken, reply: PushLogReply) -> Result<()> {
-        let channel: ResponseChannel = token
-            .downcast::<ResponseChannel>()
-            .ok_or_else(|| Error::ResponseSend("invalid response token type".to_string()))?;
-        self.handle.send_pushlog_response(channel, reply).await
+    async fn send_pushlog_response(
+        &self,
+        token: Self::ResponseToken,
+        reply: PushLogReply,
+    ) -> Result<()> {
+        self.handle.send_pushlog_response(token, reply).await
     }
 
     async fn send_two_stream_request(
@@ -194,7 +197,7 @@ impl P2PTransport for Libp2pTransport {
 
     async fn send_car_response_token(
         &self,
-        _token: ResponseToken,
+        _token: Self::ResponseToken,
         _car_data: Vec<u8>,
     ) -> Result<()> {
         Err(Error::ResponseSend(
@@ -204,7 +207,7 @@ impl P2PTransport for Libp2pTransport {
 
     async fn send_doc_sync_response_token(
         &self,
-        _token: ResponseToken,
+        _token: Self::ResponseToken,
         _reply: DocSyncReply,
     ) -> Result<()> {
         Err(Error::ResponseSend(
@@ -214,7 +217,7 @@ impl P2PTransport for Libp2pTransport {
 
     async fn send_branchable_sync_response_token(
         &self,
-        _token: ResponseToken,
+        _token: Self::ResponseToken,
         _reply: BranchableSyncReply,
     ) -> Result<()> {
         Err(Error::ResponseSend(
@@ -282,7 +285,7 @@ impl P2PTransport for Libp2pTransport {
 }
 
 /// Convert a `HostEvent` into a `TransportEvent`.
-pub fn convert_host_event(event: crate::host::HostEvent) -> TransportEvent {
+pub fn convert_host_event(event: crate::host::HostEvent) -> TransportEvent<ResponseChannel> {
     use crate::host::HostEvent;
 
     match event {
@@ -295,7 +298,7 @@ pub fn convert_host_event(event: crate::host::HostEvent) -> TransportEvent {
         } => TransportEvent::PushLogRequest {
             peer_id: PeerId::from(peer_id),
             request,
-            token: ResponseToken::new(channel),
+            token: channel,
         },
         HostEvent::Listening(addr) => TransportEvent::Listening(PeerAddr::from(addr)),
         HostEvent::GossipMessage {

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use iroh::{Endpoint, EndpointId, SecretKey};
+use iroh::{Endpoint, EndpointId};
 use iroh_gossip::net::Gossip;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -44,7 +44,7 @@ pub async fn spawn_endpoint(
     config: IrohEndpointConfig,
 ) -> crate::error::Result<(
     mpsc::Sender<IrohCommand>,
-    mpsc::Receiver<TransportEvent>,
+    mpsc::Receiver<TransportEvent<iroh::endpoint::SendStream>>,
     JoinHandle<()>,
 )> {
     let mut alpns: Vec<Vec<u8>> = protocols::ALL_ALPNS.iter().map(|a| a.to_vec()).collect();
@@ -65,7 +65,7 @@ pub async fn spawn_endpoint(
     let gossip = Gossip::builder().spawn(endpoint.clone());
 
     let (command_tx, command_rx) = mpsc::channel::<IrohCommand>(256);
-    let (event_tx, event_rx) = mpsc::channel::<TransportEvent>(256);
+    let (event_tx, event_rx) = mpsc::channel::<TransportEvent<iroh::endpoint::SendStream>>(256);
 
     let task = tokio::spawn(run_event_loop(endpoint, gossip, command_rx, event_tx));
 
@@ -77,7 +77,7 @@ async fn run_event_loop(
     endpoint: Endpoint,
     gossip: Gossip,
     mut command_rx: mpsc::Receiver<IrohCommand>,
-    event_tx: mpsc::Sender<TransportEvent>,
+    event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) {
     let peer_map = Arc::new(parking_lot::Mutex::new(PeerMap::new()));
     let mut subscriptions: HashMap<String, TopicSubscription> = HashMap::new();

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -37,7 +37,7 @@ pub(super) async fn handle_command(
     replicators: &mut HashMap<String, ReplicatorInfo>,
     active_syncs: &mut HashMap<u64, ActiveSync>,
     next_query_id: &mut u64,
-    event_tx: &mpsc::Sender<TransportEvent>,
+    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> bool {
     match cmd {
         IrohCommand::Dial {
@@ -402,7 +402,7 @@ async fn handle_dial(
     subscriptions: &HashMap<String, TopicSubscription>,
     peer_id: &PeerId,
     addrs: Vec<PeerAddr>,
-    event_tx: &mpsc::Sender<TransportEvent>,
+    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> crate::error::Result<()> {
     let endpoint_id = parse_endpoint_id(peer_id)?;
     let endpoint_addr = endpoint_addr_from_parts(peer_id, &addrs)?;
@@ -463,7 +463,7 @@ pub(super) async fn handle_subscribe(
     subscriptions: &mut HashMap<String, TopicSubscription>,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
     topic: crate::topics::DefraTopic,
-    event_tx: &mpsc::Sender<TransportEvent>,
+    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> crate::error::Result<bool> {
     use futures::StreamExt;
 
@@ -572,7 +572,7 @@ async fn handle_publish(
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
     topic: crate::topics::DefraTopic,
     msg: &crate::message::PushLogBroadcast,
-    event_tx: &mpsc::Sender<TransportEvent>,
+    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> crate::error::Result<MessageId> {
     let topic_str = topic.to_string();
 

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -118,7 +118,7 @@ pub(super) async fn try_fetch_from_provider(
     provider: &PeerId,
     request: CarFetchRequest,
     direct_addr: Option<std::net::SocketAddr>,
-    event_tx: &mpsc::Sender<TransportEvent>,
+    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> bool {
     let endpoint_id = match parse_endpoint_id(provider) {
         Ok(id) => id,
@@ -236,7 +236,7 @@ pub(super) async fn handle_block_sync(
     root: cid::Cid,
     providers: Vec<PeerId>,
     missing: Vec<cid::Cid>,
-    event_tx: mpsc::Sender<TransportEvent>,
+    event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) {
     use tokio::task::JoinHandle;
 

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -21,7 +21,7 @@ pub(super) async fn handle_incoming(
     gossip: &Gossip,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
     subscriptions: &HashMap<String, TopicSubscription>,
-    event_tx: &mpsc::Sender<TransportEvent>,
+    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) {
     let remote_addr = match incoming.remote_addr() {
         iroh::endpoint::IncomingAddr::Ip(addr) => Some(addr),
@@ -89,7 +89,7 @@ async fn handle_connection_streams(
     connection: Connection,
     remote_id: EndpointId,
     alpn: Vec<u8>,
-    event_tx: mpsc::Sender<TransportEvent>,
+    event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     peer_map: Arc<parking_lot::Mutex<PeerMap>>,
 ) {
     let peer_id = endpoint_id_to_peer_id(&remote_id);
@@ -123,7 +123,7 @@ pub(super) async fn handle_connection_streams_from_dial(
     connection: Connection,
     remote_id: EndpointId,
     alpn: Vec<u8>,
-    event_tx: mpsc::Sender<TransportEvent>,
+    event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     peer_map: Arc<parking_lot::Mutex<PeerMap>>,
 ) {
     handle_connection_streams(connection, remote_id, alpn, event_tx, peer_map).await;
@@ -135,18 +135,17 @@ async fn dispatch_stream(
     peer_id: &PeerId,
     send: iroh::endpoint::SendStream,
     recv: &mut iroh::endpoint::RecvStream,
-    event_tx: &mpsc::Sender<TransportEvent>,
+    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> crate::error::Result<()> {
     match alpn {
         x if x == protocols::ALPN_PUSHLOG => {
             let request: crate::message::PushLogRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
-            let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::PushLogRequest {
                     peer_id: peer_id.clone(),
                     request,
-                    token,
+                    token: send,
                 })
                 .await
                 .is_err()
@@ -157,12 +156,11 @@ async fn dispatch_stream(
         x if x == protocols::ALPN_TWOSTREAM => {
             let request: crate::message::PushLogRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
-            let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::TwoStreamRequest {
                     peer_id: peer_id.clone(),
                     request,
-                    token: Some(token),
+                    token: Some(send),
                     is_explicit_replicator: false,
                     explicit_replay_authorization: None,
                 })
@@ -175,12 +173,11 @@ async fn dispatch_stream(
         x if x == protocols::ALPN_DOCSYNC => {
             let request: crate::message::DocSyncRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
-            let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::DocSyncRequest {
                     peer_id: peer_id.clone(),
                     request,
-                    token: Some(token),
+                    token: Some(send),
                 })
                 .await
                 .is_err()
@@ -191,12 +188,11 @@ async fn dispatch_stream(
         x if x == protocols::ALPN_BRANCHABLE => {
             let request: crate::message::BranchableSyncRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
-            let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::BranchableSyncRequest {
                     peer_id: peer_id.clone(),
                     request,
-                    token: Some(token),
+                    token: Some(send),
                 })
                 .await
                 .is_err()
@@ -215,12 +211,11 @@ async fn dispatch_stream(
                 requested_count = request.wanted_cids.len(),
                 "CAR dispatch: emitting CarFetchRequest"
             );
-            let token = crate::transport::ResponseToken::new(send);
             if event_tx
                 .send(TransportEvent::CarFetchRequest {
                     peer_id: peer_id.clone(),
                     request,
-                    token: Some(token),
+                    token: Some(send),
                 })
                 .await
                 .is_err()

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -18,7 +18,7 @@ use crate::message::{
 };
 use crate::replicator::ReplicatorInfo;
 use crate::topics::DefraTopic;
-use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, ResponseToken};
+use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
 use crate::QueryId;
 
 use super::command::IrohCommand;
@@ -73,6 +73,8 @@ impl IrohTransport {
 
 #[async_trait]
 impl P2PTransport for IrohTransport {
+    type ResponseToken = iroh::endpoint::SendStream;
+
     fn local_peer_id(&self) -> &PeerId {
         &self.local_peer_id
     }
@@ -150,11 +152,11 @@ impl P2PTransport for IrohTransport {
             .await
     }
 
-    async fn send_pushlog_response(&self, token: ResponseToken, reply: PushLogReply) -> Result<()> {
-        let send_stream: iroh::endpoint::SendStream = token
-            .downcast::<iroh::endpoint::SendStream>()
-            .ok_or_else(|| Error::ResponseSend("invalid response token type".to_string()))?;
-
+    async fn send_pushlog_response(
+        &self,
+        send_stream: Self::ResponseToken,
+        reply: PushLogReply,
+    ) -> Result<()> {
         self.send_command(|r| IrohCommand::SendPushLogResponse {
             send_stream,
             reply_msg: reply,
@@ -249,13 +251,9 @@ impl P2PTransport for IrohTransport {
 
     async fn send_doc_sync_response_token(
         &self,
-        token: ResponseToken,
+        send_stream: Self::ResponseToken,
         reply: DocSyncReply,
     ) -> Result<()> {
-        let send_stream: iroh::endpoint::SendStream = token
-            .downcast::<iroh::endpoint::SendStream>()
-            .ok_or_else(|| Error::ResponseSend("invalid response token type".to_string()))?;
-
         self.send_command(|r| IrohCommand::SendDocSyncResponseToken {
             send_stream,
             reply_msg: reply,
@@ -266,13 +264,9 @@ impl P2PTransport for IrohTransport {
 
     async fn send_branchable_sync_response_token(
         &self,
-        token: ResponseToken,
+        send_stream: Self::ResponseToken,
         reply: BranchableSyncReply,
     ) -> Result<()> {
-        let send_stream: iroh::endpoint::SendStream = token
-            .downcast::<iroh::endpoint::SendStream>()
-            .ok_or_else(|| Error::ResponseSend("invalid response token type".to_string()))?;
-
         self.send_command(|r| IrohCommand::SendBranchableSyncResponseToken {
             send_stream,
             reply_msg: reply,
@@ -281,11 +275,11 @@ impl P2PTransport for IrohTransport {
         .await
     }
 
-    async fn send_car_response_token(&self, token: ResponseToken, car_data: Vec<u8>) -> Result<()> {
-        let mut send_stream: iroh::endpoint::SendStream = token
-            .downcast::<iroh::endpoint::SendStream>()
-            .ok_or_else(|| Error::ResponseSend("invalid response token type".to_string()))?;
-
+    async fn send_car_response_token(
+        &self,
+        mut send_stream: Self::ResponseToken,
+        car_data: Vec<u8>,
+    ) -> Result<()> {
         send_stream
             .write_all(&car_data)
             .await

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -14,8 +14,6 @@ use tokio::time::timeout;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Error;
-use crate::host::libp2p_transport::Libp2pTransport;
-use crate::host::P2PHostHandle;
 use crate::message::{BranchableSyncRequest, DocSyncRequest, MetaData, PushLogRequest};
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
@@ -23,7 +21,11 @@ use crate::sync::head_provider::NoOpHeadProvider;
 use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager};
 use crate::sync::peer_state::PeerStateTracker;
 use crate::sync::rate_limiter::PeerRateLimiter;
-use crate::transport::{PeerId, ResponseToken, TransportEvent};
+use crate::topics::DefraTopic;
+use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, TransportEvent};
+use crate::QueryId;
+use crate::ReplicatorInfo;
+use async_trait::async_trait;
 
 use super::{
     SyncCoordinator, DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
@@ -37,12 +39,11 @@ fn create_test_coordinator(
     replicators: Arc<ReplicatorRegistry>,
     peer_state: Arc<PeerStateTracker>,
 ) -> (
-    SyncCoordinator<TestBlockstore, Libp2pTransport>,
+    SyncCoordinator<TestBlockstore, NoopTransport>,
     tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
 ) {
-    let host = P2PHostHandle::test_handle();
-    let local_peer_id = host.local_peer_id_cached().to_string();
-    let transport = Libp2pTransport::new(host);
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
     let broadcaster = Broadcaster::new(transport.clone());
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, true));
@@ -74,7 +75,228 @@ fn create_test_coordinator(
     (coordinator, events)
 }
 
-fn doc_sync_event(peer_id: PeerId) -> TransportEvent {
+#[derive(Clone)]
+struct NoopTransport {
+    peer_id: PeerId,
+    pubkey: Vec<u8>,
+}
+
+impl NoopTransport {
+    fn new() -> Self {
+        Self {
+            peer_id: PeerId::new("local-peer".to_string()),
+            pubkey: vec![1, 2, 3],
+        }
+    }
+}
+
+#[async_trait]
+impl P2PTransport for NoopTransport {
+    type ResponseToken = ();
+
+    fn local_peer_id(&self) -> &PeerId {
+        &self.peer_id
+    }
+
+    fn local_public_key_proto(&self) -> &[u8] {
+        &self.pubkey
+    }
+
+    fn sign(&self, _data: &[u8]) -> crate::Result<Vec<u8>> {
+        Ok(vec![0])
+    }
+
+    async fn dial(&self, _peer_id: &PeerId, _addrs: Vec<PeerAddr>) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn listen(&self, _addr: PeerAddr) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn connected_peers(&self) -> crate::Result<Vec<PeerId>> {
+        Ok(Vec::new())
+    }
+
+    async fn listen_addresses(&self) -> crate::Result<Vec<PeerAddr>> {
+        Ok(Vec::new())
+    }
+
+    async fn poll_until_connected(
+        &self,
+        _peer_id: &PeerId,
+        _timeout: Duration,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn peer_addresses(&self) -> crate::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+
+    async fn subscribe(&self, _topic: DefraTopic) -> crate::Result<bool> {
+        Ok(true)
+    }
+
+    async fn unsubscribe(&self, _topic: DefraTopic) -> crate::Result<bool> {
+        Ok(true)
+    }
+
+    async fn publish(
+        &self,
+        _topic: DefraTopic,
+        _msg: crate::message::PushLogBroadcast,
+    ) -> crate::Result<MessageId> {
+        Ok(MessageId::new("noop".to_string()))
+    }
+
+    async fn topic_peers(&self, _topic: DefraTopic) -> crate::Result<Vec<PeerId>> {
+        Ok(Vec::new())
+    }
+
+    async fn send_pushlog_response(
+        &self,
+        _token: Self::ResponseToken,
+        _reply: crate::message::PushLogReply,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_two_stream_request(
+        &self,
+        _peer_id: &PeerId,
+        _req: PushLogRequest,
+    ) -> crate::Result<crate::message::PushLogReply> {
+        Ok(crate::message::PushLogReply::success("noop"))
+    }
+
+    async fn send_two_stream_response(
+        &self,
+        _peer_id: &PeerId,
+        _reply: crate::message::PushLogReply,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_doc_sync_request(
+        &self,
+        _peer_id: &PeerId,
+        _req: DocSyncRequest,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_doc_sync_response(
+        &self,
+        _peer_id: &PeerId,
+        _reply: crate::message::DocSyncReply,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_branchable_sync_request(
+        &self,
+        _peer_id: &PeerId,
+        _req: BranchableSyncRequest,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_branchable_sync_response(
+        &self,
+        _peer_id: &PeerId,
+        _reply: crate::message::BranchableSyncReply,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_car_request(&self, _peer_id: &PeerId, _root_cid: Cid) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_car_response(&self, _peer_id: &PeerId, _car_data: Vec<u8>) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_car_response_token(
+        &self,
+        _token: Self::ResponseToken,
+        _car_data: Vec<u8>,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_doc_sync_response_token(
+        &self,
+        _token: Self::ResponseToken,
+        _reply: crate::message::DocSyncReply,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_branchable_sync_response_token(
+        &self,
+        _token: Self::ResponseToken,
+        _reply: crate::message::BranchableSyncReply,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn send_se_artifacts(
+        &self,
+        _peer_id: &PeerId,
+        _req: crate::message::PushSEArtifactsRequest,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn sync_blocks(
+        &self,
+        _root: Cid,
+        _providers: Vec<PeerId>,
+        _missing: Vec<Cid>,
+    ) -> crate::Result<QueryId> {
+        Ok(QueryId(1))
+    }
+
+    async fn cancel_sync(&self, _query_id: QueryId) -> crate::Result<bool> {
+        Ok(true)
+    }
+
+    async fn create_replicator(
+        &self,
+        _peer_id: &PeerId,
+        _collections: Vec<String>,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn delete_replicator(&self, _peer_id: &PeerId) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn list_replicators(&self) -> crate::Result<Vec<ReplicatorInfo>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_replicator(&self, _peer_id: &PeerId) -> crate::Result<Option<ReplicatorInfo>> {
+        Ok(None)
+    }
+
+    async fn remove_replicator_collections(
+        &self,
+        _peer_id: &PeerId,
+        _collections: Vec<String>,
+    ) -> crate::Result<bool> {
+        Ok(false)
+    }
+
+    async fn shutdown(&self) -> crate::Result<()> {
+        Ok(())
+    }
+}
+
+fn doc_sync_event(peer_id: PeerId) -> TransportEvent<()> {
     TransportEvent::DocSyncRequest {
         peer_id,
         request: DocSyncRequest {
@@ -85,7 +307,7 @@ fn doc_sync_event(peer_id: PeerId) -> TransportEvent {
     }
 }
 
-fn branchable_sync_event(peer_id: PeerId, collection_id: &str) -> TransportEvent {
+fn branchable_sync_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
     TransportEvent::BranchableSyncRequest {
         peer_id,
         request: BranchableSyncRequest {
@@ -116,11 +338,11 @@ fn pushlog_request(collection_id: &str) -> PushLogRequest {
     )
 }
 
-fn pushlog_event(peer_id: PeerId, collection_id: &str) -> TransportEvent {
+fn pushlog_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
     TransportEvent::PushLogRequest {
         peer_id,
         request: pushlog_request(collection_id),
-        token: ResponseToken::new(()),
+        token: (),
     }
 }
 
@@ -128,7 +350,7 @@ fn two_stream_event(
     peer_id: PeerId,
     collection_id: &str,
     is_explicit_replicator: bool,
-) -> TransportEvent {
+) -> TransportEvent<()> {
     TransportEvent::TwoStreamRequest {
         peer_id,
         request: pushlog_request(collection_id),

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -245,7 +245,7 @@ mod tests {
     };
     use crate::sync::manager::SyncEvent;
     use crate::topics::DefraTopic;
-    use crate::transport::{MessageId, PeerAddr, ResponseToken};
+    use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
     use crate::{QueryId, ReplicatorInfo};
     use async_trait::async_trait;
     use blockstore::{Blockstore, DefraBlockstore};
@@ -309,6 +309,8 @@ mod tests {
 
     #[async_trait]
     impl P2PTransport for TestTransport {
+        type ResponseToken = ();
+
         fn local_peer_id(&self) -> &PeerId {
             &self.peer_id
         }
@@ -371,7 +373,7 @@ mod tests {
 
         async fn send_pushlog_response(
             &self,
-            _token: ResponseToken,
+            _token: Self::ResponseToken,
             _reply: PushLogReply,
         ) -> P2PResult<()> {
             Ok(())
@@ -441,7 +443,7 @@ mod tests {
 
         async fn send_car_response_token(
             &self,
-            _token: ResponseToken,
+            _token: Self::ResponseToken,
             _car_data: Vec<u8>,
         ) -> P2PResult<()> {
             Ok(())
@@ -449,7 +451,7 @@ mod tests {
 
         async fn send_doc_sync_response_token(
             &self,
-            _token: ResponseToken,
+            _token: Self::ResponseToken,
             _reply: DocSyncReply,
         ) -> P2PResult<()> {
             Ok(())
@@ -457,7 +459,7 @@ mod tests {
 
         async fn send_branchable_sync_response_token(
             &self,
-            _token: ResponseToken,
+            _token: Self::ResponseToken,
             _reply: BranchableSyncReply,
         ) -> P2PResult<()> {
             Ok(())

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -8,14 +8,14 @@ use super::super::SyncCoordinator;
 use crate::error::Result;
 use crate::message::BranchableSyncReply;
 use crate::signing::sign_with_transport;
-use crate::transport::{P2PTransport, PeerId, ResponseToken};
+use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     pub(super) async fn handle_branchable_sync_request(
         &self,
         peer_id: PeerId,
         request: crate::message::BranchableSyncRequest,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) -> Result<()> {
         self.check_access_str(peer_id.as_str(), &request.collection_id)
             .await?;

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -7,7 +7,7 @@ use crate::error::Result;
 use crate::message::CarFetchRequest;
 use crate::sync::car::{collect_dag_blocks, collect_exact_blocks, decode_car, encode_car};
 use crate::sync::coordinator::SyncCoordinator;
-use crate::transport::{P2PTransport, PeerId, ResponseToken};
+use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Handle an inbound CAR fetch request: collect the DAG and send CARv1 response.
@@ -15,7 +15,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: PeerId,
         request: CarFetchRequest,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) -> Result<()> {
         self.check_peer_is_replicator(&peer_id)?;
 

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -8,14 +8,14 @@ use super::super::SyncCoordinator;
 use crate::error::{Error, Result};
 use crate::message::{DocSyncItem, DocSyncReply, MAX_DOC_IDS};
 use crate::signing::sign_with_transport;
-use crate::transport::{P2PTransport, PeerId, ResponseToken};
+use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     pub(super) async fn handle_doc_sync_request(
         &self,
         peer_id: PeerId,
         request: crate::message::DocSyncRequest,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) -> Result<()> {
         self.check_peer_is_replicator(&peer_id)?;
 

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -21,7 +21,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Handle an event from the transport layer.
     ///
     /// This should be called from the event loop that processes TransportEvents.
-    pub async fn handle_transport_event(&self, event: TransportEvent) -> Result<()> {
+    pub async fn handle_transport_event(
+        &self,
+        event: TransportEvent<T::ResponseToken>,
+    ) -> Result<()> {
         match event {
             TransportEvent::PeerConnected(peer_id) => {
                 tracing::debug!(peer_id = %peer_id, "Peer connected");
@@ -229,7 +232,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     .await?;
             }
             other => {
-                tracing::trace!(event = ?other, "Ignoring non-sync transport event");
+                let _ = other;
+                tracing::trace!("Ignoring non-sync transport event");
             }
         }
         Ok(())

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -7,7 +7,7 @@ use super::super::SyncCoordinator;
 use crate::error::Result;
 use crate::message::{PushLogBroadcast, PushLogReply};
 use crate::signing::sign_with_transport;
-use crate::transport::{P2PTransport, PeerId, ResponseToken};
+use crate::transport::{P2PTransport, PeerId};
 use crate::ExplicitReplayAuthorization;
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
@@ -15,7 +15,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: PeerId,
         request: crate::message::PushLogRequest,
-        token: ResponseToken,
+        token: T::ResponseToken,
     ) -> Result<()> {
         tracing::debug!(
             peer_id = %peer_id,
@@ -132,7 +132,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: PeerId,
         request: crate::message::PushLogRequest,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
         is_explicit_replicator: bool,
         explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
     ) -> Result<()> {
@@ -230,7 +230,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: &PeerId,
         reply: PushLogReply,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) {
         if let Some(token) = token {
             if let Err(e) = self.transport.send_pushlog_response(token, reply).await {

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -42,7 +42,7 @@ mod tests {
     use crate::sync::manager::SyncEvent;
     use crate::sync::merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
     use crate::topics::DefraTopic;
-    use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, ResponseToken};
+    use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
     use crate::QueryId;
     use crate::ReplicatorInfo;
     use async_trait::async_trait;
@@ -115,6 +115,8 @@ mod tests {
 
     #[async_trait]
     impl P2PTransport for NoopTransport {
+        type ResponseToken = ();
+
         fn local_peer_id(&self) -> &PeerId {
             &self.peer_id
         }
@@ -177,7 +179,7 @@ mod tests {
 
         async fn send_pushlog_response(
             &self,
-            _token: ResponseToken,
+            _token: Self::ResponseToken,
             _reply: PushLogReply,
         ) -> P2PResult<()> {
             Ok(())
@@ -241,7 +243,7 @@ mod tests {
 
         async fn send_car_response_token(
             &self,
-            _token: ResponseToken,
+            _token: Self::ResponseToken,
             _car_data: Vec<u8>,
         ) -> P2PResult<()> {
             Ok(())
@@ -249,7 +251,7 @@ mod tests {
 
         async fn send_doc_sync_response_token(
             &self,
-            _token: ResponseToken,
+            _token: Self::ResponseToken,
             _reply: DocSyncReply,
         ) -> P2PResult<()> {
             Ok(())
@@ -257,7 +259,7 @@ mod tests {
 
         async fn send_branchable_sync_response_token(
             &self,
-            _token: ResponseToken,
+            _token: Self::ResponseToken,
             _reply: BranchableSyncReply,
         ) -> P2PResult<()> {
             Ok(())

--- a/crates/p2p/src/transport.rs
+++ b/crates/p2p/src/transport.rs
@@ -4,7 +4,6 @@
 //! from the concrete libp2p transport, enabling alternative implementations
 //! (e.g., iroh) without modifying the coordinator.
 
-use std::any::Any;
 use std::fmt;
 use std::time::Duration;
 
@@ -114,34 +113,12 @@ impl From<libp2p::gossipsub::MessageId> for MessageId {
     }
 }
 
-/// Opaque token for sending a response to a request.
-///
-/// For libp2p, this wraps a `ResponseChannel`. Other transports may
-/// wrap their own response correlation types.
-pub struct ResponseToken(Box<dyn Any + Send>);
-
-impl ResponseToken {
-    pub fn new<T: Any + Send + 'static>(inner: T) -> Self {
-        Self(Box::new(inner))
-    }
-
-    pub fn downcast<T: Any + Send + 'static>(self) -> Option<T> {
-        self.0.downcast::<T>().ok().map(|b| *b)
-    }
-}
-
-impl fmt::Debug for ResponseToken {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ResponseToken").finish()
-    }
-}
-
 /// Events from the transport layer, consumed by the sync coordinator.
 ///
 /// This mirrors `HostEvent` but uses transport-agnostic types.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum TransportEvent {
+pub enum TransportEvent<ResponseToken> {
     PeerConnected(PeerId),
     PeerDisconnected(PeerId),
     PushLogRequest {
@@ -225,6 +202,8 @@ pub enum TransportEvent {
 /// implementations (libp2p, iroh) without modifying coordinator logic.
 #[async_trait]
 pub trait P2PTransport: Clone + Send + Sync + 'static {
+    type ResponseToken: Send + 'static;
+
     // ---- Identity ----
 
     fn local_peer_id(&self) -> &PeerId;
@@ -260,7 +239,11 @@ pub trait P2PTransport: Clone + Send + Sync + 'static {
 
     // ---- Messaging ----
 
-    async fn send_pushlog_response(&self, token: ResponseToken, reply: PushLogReply) -> Result<()>;
+    async fn send_pushlog_response(
+        &self,
+        token: Self::ResponseToken,
+        reply: PushLogReply,
+    ) -> Result<()>;
 
     async fn send_two_stream_request(
         &self,
@@ -290,17 +273,21 @@ pub trait P2PTransport: Clone + Send + Sync + 'static {
 
     async fn send_car_response(&self, peer_id: &PeerId, car_data: Vec<u8>) -> Result<()>;
 
-    async fn send_car_response_token(&self, token: ResponseToken, car_data: Vec<u8>) -> Result<()>;
+    async fn send_car_response_token(
+        &self,
+        token: Self::ResponseToken,
+        car_data: Vec<u8>,
+    ) -> Result<()>;
 
     async fn send_doc_sync_response_token(
         &self,
-        token: ResponseToken,
+        token: Self::ResponseToken,
         reply: DocSyncReply,
     ) -> Result<()>;
 
     async fn send_branchable_sync_response_token(
         &self,
-        token: ResponseToken,
+        token: Self::ResponseToken,
         reply: BranchableSyncReply,
     ) -> Result<()>;
 


### PR DESCRIPTION
## Summary
- replace the erased `ResponseToken` wrapper with a transport-owned associated `ResponseToken` type on `P2PTransport`
- thread `TransportEvent<T::ResponseToken>` through the coordinator and both transport implementations so mismatched tokens fail at compile time
- move access/coordinator tests to a test transport with `type ResponseToken = ()` and keep iroh/libp2p builds green

## Verification
- cargo check -p p2p
- cargo check -p p2p --features iroh-transport
- cargo test -p p2p access_tests --lib
- cargo test -p p2p dag_fetcher --lib

Closes #691