### PR TITLE
Consolidate DocId validation around the canonical parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,6 +3611,7 @@ dependencies = [
  "cid 0.10.1",
  "criterion 0.5.1",
  "libipld",
+ "multibase",
  "multihash 0.18.1",
  "serde",
  "serde_bytes",
@@ -3619,6 +3620,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4023,6 +4025,7 @@ dependencies = [
  "ciborium",
  "cid 0.10.1",
  "crypto",
+ "defra-core",
  "multibase",
  "multihash 0.18.1",
  "pretty_assertions",

--- a/crates/crdt/benches/merge.rs
+++ b/crates/crdt/benches/merge.rs
@@ -13,7 +13,7 @@ fn runtime() -> &'static tokio::runtime::Runtime {
 
 fn make_context() -> Context {
     Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     }

--- a/crates/crdt/src/traits.rs
+++ b/crates/crdt/src/traits.rs
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn test_context_creation() {
         let ctx = Context {
-            doc_id: DocId::new("bae-test"),
+            doc_id: DocId::new_unchecked("bae-test"),
             schema_version: "v1".to_string(),
             is_create: false,
         };

--- a/crates/crdt/tests/composite_tests.rs
+++ b/crates/crdt/tests/composite_tests.rs
@@ -16,14 +16,14 @@ use storage::{MemoryStore, Store};
 #[tokio::test]
 async fn test_composite_multiple_fields() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
 
     // Register fields
     composite.register_lww_field("name".to_string());
     composite.register_counter_field("count".to_string(), true, NumericKind::Int64);
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -71,13 +71,13 @@ async fn test_composite_multiple_fields() {
 #[tokio::test]
 async fn test_composite_field_type_mismatch_lww_to_counter() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
 
     // Register field as LWW
     composite.register_lww_field("value".to_string());
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -107,13 +107,13 @@ async fn test_composite_field_type_mismatch_lww_to_counter() {
 #[tokio::test]
 async fn test_composite_field_type_mismatch_counter_to_lww() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
 
     // Register field as Counter
     composite.register_counter_field("count".to_string(), true, NumericKind::Int64);
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -142,12 +142,12 @@ async fn test_composite_field_type_mismatch_counter_to_lww() {
 #[tokio::test]
 async fn test_composite_unknown_field() {
     let store = MemoryStore::new();
-    let composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
 
     // Don't register any fields
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -173,13 +173,13 @@ async fn test_composite_unknown_field() {
 #[tokio::test]
 async fn test_composite_schema_evolution_type_change() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
 
     // Register field as LWW in schema v1
     composite.register_lww_field("score".to_string());
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -226,12 +226,12 @@ async fn test_composite_schema_evolution_type_change() {
 #[tokio::test]
 async fn test_composite_doc_id_mismatch() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
 
     composite.register_lww_field("name".to_string());
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -260,12 +260,12 @@ async fn test_composite_doc_id_mismatch() {
 #[tokio::test]
 async fn test_composite_schema_version_mismatch() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
 
     composite.register_lww_field("name".to_string());
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };

--- a/crates/crdt/tests/counter_tests.rs
+++ b/crates/crdt/tests/counter_tests.rs
@@ -25,7 +25,7 @@ async fn test_counter_increment() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -77,7 +77,7 @@ async fn test_counter_idempotency() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -119,7 +119,7 @@ async fn test_counter_decrement_not_allowed() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -154,7 +154,7 @@ async fn test_counter_overflow_wrapping() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -207,7 +207,7 @@ async fn test_counter_field_name_mismatch() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -246,7 +246,7 @@ async fn test_counter_schema_version_mismatch() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -330,7 +330,7 @@ async fn test_counter_float64_overflow() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -378,7 +378,7 @@ async fn test_counter_float64_basic() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -430,7 +430,7 @@ async fn test_counter_merge_result_applied() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -464,7 +464,7 @@ async fn test_counter_merge_result_skipped_already_applied() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -506,7 +506,7 @@ async fn test_counter_wrong_delta_type() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -544,7 +544,7 @@ async fn test_counter_numeric_kind_mismatch() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };

--- a/crates/crdt/tests/lww_tests.rs
+++ b/crates/crdt/tests/lww_tests.rs
@@ -17,7 +17,7 @@ async fn test_lww_higher_priority_wins() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -57,7 +57,7 @@ async fn test_lww_lower_priority_ignored() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -96,7 +96,7 @@ async fn test_lww_same_priority_lexicographic() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -136,7 +136,7 @@ async fn test_lww_deletion() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -177,7 +177,7 @@ async fn test_lww_empty_data_tie_breaking() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -234,7 +234,7 @@ async fn test_lww_deletion_resurrection_with_priority() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -368,7 +368,7 @@ async fn test_lww_wrong_delta_type() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -399,7 +399,7 @@ async fn test_lww_merge_result_applied() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -424,7 +424,7 @@ async fn test_lww_merge_result_rejected_lower_priority() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -468,7 +468,7 @@ async fn test_lww_merge_result_rejected_tie_break() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -507,7 +507,7 @@ async fn test_lww_priority_zero() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -548,7 +548,7 @@ async fn test_lww_priority_max() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -588,7 +588,7 @@ async fn test_lww_field_name_mismatch() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -618,7 +618,7 @@ async fn test_lww_schema_version_mismatch() {
     let lww = Lww::new("v1".to_string(), b"doc1", "name".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -676,7 +676,7 @@ async fn test_lww_large_payload() {
     let lww = Lww::new("v1".to_string(), b"doc1", "content".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -733,7 +733,7 @@ async fn test_lww_large_payload_priority_rejected() {
     let lww = Lww::new("v1".to_string(), b"doc1", "content".to_string()).unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };

--- a/crates/crdt/tests/property_tests.rs
+++ b/crates/crdt/tests/property_tests.rs
@@ -26,7 +26,7 @@ mod lww_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -79,7 +79,7 @@ mod lww_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -113,7 +113,7 @@ mod lww_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -154,7 +154,7 @@ mod lww_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -183,7 +183,7 @@ mod lww_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -215,7 +215,7 @@ mod lww_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -269,7 +269,7 @@ mod lww_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -328,7 +328,7 @@ mod lww_properties {
     #[tokio::test]
     async fn test_lww_priority_ordering_exhaustive() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
@@ -367,7 +367,7 @@ mod lww_properties {
     #[tokio::test]
     async fn test_lww_tie_breaking_lexicographic() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
@@ -406,7 +406,7 @@ mod lww_properties {
     #[tokio::test]
     async fn test_lww_empty_value_handling() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
@@ -435,7 +435,7 @@ mod lww_properties {
     #[tokio::test]
     async fn test_lww_large_payload() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
@@ -481,7 +481,7 @@ mod counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -530,7 +530,7 @@ mod counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -563,7 +563,7 @@ mod counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -604,7 +604,7 @@ mod counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -652,7 +652,7 @@ mod counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -720,7 +720,7 @@ mod counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -773,7 +773,7 @@ mod counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -835,7 +835,7 @@ mod counter_properties {
     #[tokio::test]
     async fn test_counter_multiple_nonces() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
@@ -872,7 +872,7 @@ mod counter_properties {
     #[tokio::test]
     async fn test_counter_nonce_replay_protection() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
@@ -910,7 +910,7 @@ mod counter_properties {
     #[tokio::test]
     async fn test_counter_decrement_not_allowed() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
@@ -963,7 +963,7 @@ mod float64_counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -1014,7 +1014,7 @@ mod float64_counter_properties {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let ctx = Context {
-                    doc_id: DocId::new("doc1"),
+                    doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
                     is_create: false,
                 };
@@ -1046,7 +1046,7 @@ mod float64_counter_properties {
     #[tokio::test]
     async fn test_float64_counter_basic() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
@@ -1103,13 +1103,13 @@ mod composite_tests {
     #[tokio::test]
     async fn test_composite_multi_field_atomicity() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
 
         let store = MemoryStore::new();
-        let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+        let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
         composite.register_lww_field("name".to_string());
         composite.register_counter_field("count".to_string(), true, NumericKind::Int64);
         let mut txn = store.new_txn(false).await.unwrap();
@@ -1140,13 +1140,13 @@ mod composite_tests {
     #[tokio::test]
     async fn test_composite_doc_id_mismatch() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
 
         let store = MemoryStore::new();
-        let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+        let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
         composite.register_lww_field("name".to_string());
         let mut txn = store.new_txn(false).await.unwrap();
 
@@ -1163,13 +1163,13 @@ mod composite_tests {
     #[tokio::test]
     async fn test_composite_schema_version_mismatch() {
         let ctx = Context {
-            doc_id: DocId::new("doc1"),
+            doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
             is_create: false,
         };
 
         let store = MemoryStore::new();
-        let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+        let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
         composite.register_lww_field("name".to_string());
         let mut txn = store.new_txn(false).await.unwrap();
 

--- a/crates/db/src/merge_handler/counter.rs
+++ b/crates/db/src/merge_handler/counter.rs
@@ -100,7 +100,8 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             }
 
             let ctx = Context {
-                doc_id: DocId::new(&doc_id_str),
+                doc_id: DocId::new(&doc_id_str)
+                    .map_err(|e| MergeError::MergeFailed(e.to_string()))?,
                 schema_version: payload.schema_version_id.clone(),
                 is_create: payload.priority == 1 && !doc_exists,
             };
@@ -232,7 +233,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         // Create the CounterDelta from payload
         let delta = self.create_counter_delta(payload, numeric_kind)?;
         let ctx = Context {
-            doc_id: DocId::new(&doc_id_str),
+            doc_id: DocId::new(&doc_id_str).map_err(|e| MergeError::MergeFailed(e.to_string()))?,
             schema_version: payload.schema_version_id.clone(),
             is_create: payload.priority == 1 && !doc_exists,
         };

--- a/crates/db/src/merge_handler/lww.rs
+++ b/crates/db/src/merge_handler/lww.rs
@@ -92,7 +92,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
 
         let seed_ctx = Context {
-            doc_id: DocId::new(doc_id_str),
+            doc_id: DocId::new(doc_id_str).map_err(|e| MergeError::MergeFailed(e.to_string()))?,
             schema_version: payload.schema_version_id.clone(),
             is_create: true,
         };
@@ -157,7 +157,8 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 )
                 .await?;
             let ctx = Context {
-                doc_id: DocId::new(&doc_id_str),
+                doc_id: DocId::new(&doc_id_str)
+                    .map_err(|e| MergeError::MergeFailed(e.to_string()))?,
                 schema_version: payload.schema_version_id.clone(),
                 is_create: payload.priority == 1 && !doc_exists,
             };
@@ -271,7 +272,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             )
             .await?;
         let ctx = Context {
-            doc_id: DocId::new(&doc_id_str),
+            doc_id: DocId::new(&doc_id_str).map_err(|e| MergeError::MergeFailed(e.to_string()))?,
             schema_version: payload.schema_version_id.clone(),
             is_create: payload.priority == 1 && !doc_exists,
         };

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -15,6 +15,8 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_bytes.workspace = true
+uuid.workspace = true
+multibase = "0.9"
 
 # IPLD
 cid.workspace = true

--- a/crates/defra-core/src/doc_id.rs
+++ b/crates/defra-core/src/doc_id.rs
@@ -1,0 +1,209 @@
+use std::fmt;
+
+use uuid::Uuid;
+
+/// DocID version constant (matches Go's DocIDV0).
+pub const DOC_ID_V0: u16 = 0x01;
+
+/// Parsed DocID components shared across crates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ParsedDocId {
+    version: u16,
+    uuid: Uuid,
+}
+
+impl ParsedDocId {
+    pub fn new(version: u16, uuid: Uuid) -> Result<Self, DocIdFormatError> {
+        if version != DOC_ID_V0 {
+            return Err(DocIdFormatError::InvalidVersion(version));
+        }
+
+        Ok(Self { version, uuid })
+    }
+
+    /// Parse a DocID from its string representation.
+    ///
+    /// Format: `{base32(version)}-{uuid}`
+    pub fn from_string(s: &str) -> Result<Self, DocIdFormatError> {
+        let parts: Vec<&str> = s.splitn(2, '-').collect();
+        if parts.len() != 2 {
+            return Err(DocIdFormatError::Malformed);
+        }
+
+        let version_str = parts[0];
+        let uuid_str = parts[1];
+
+        let (_, version_bytes) = multibase::decode(version_str)?;
+        if version_bytes.is_empty() {
+            return Err(DocIdFormatError::Malformed);
+        }
+
+        let version = read_uvarint(&version_bytes).ok_or(DocIdFormatError::Malformed)?;
+        if version != DOC_ID_V0 as u64 {
+            return Err(DocIdFormatError::InvalidVersion(version as u16));
+        }
+
+        let uuid = Uuid::parse_str(uuid_str)?;
+
+        Ok(Self {
+            version: version as u16,
+            uuid,
+        })
+    }
+
+    /// Parse a DocID from its binary form.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, DocIdFormatError> {
+        if bytes.len() < 17 {
+            return Err(DocIdFormatError::Malformed);
+        }
+
+        let version = read_uvarint(bytes).ok_or(DocIdFormatError::Malformed)?;
+        if version != DOC_ID_V0 as u64 {
+            return Err(DocIdFormatError::InvalidVersion(version as u16));
+        }
+
+        let uuid_start = varint_size(version);
+        if bytes.len() < uuid_start + 16 {
+            return Err(DocIdFormatError::Malformed);
+        }
+
+        let uuid_bytes: [u8; 16] = bytes[uuid_start..uuid_start + 16]
+            .try_into()
+            .map_err(|_| DocIdFormatError::Malformed)?;
+        let uuid = Uuid::from_bytes(uuid_bytes);
+
+        Ok(Self {
+            version: version as u16,
+            uuid,
+        })
+    }
+
+    pub fn version(&self) -> u16 {
+        self.version
+    }
+
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(18);
+        write_uvarint(&mut buf, self.version as u64);
+        buf.extend_from_slice(self.uuid.as_bytes());
+        buf
+    }
+}
+
+impl fmt::Display for ParsedDocId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let size = varint_size(self.version as u64);
+        let mut version_buf = vec![0_u8; size];
+        write_uvarint_to_slice(&mut version_buf, self.version as u64);
+        let version_str = multibase::encode(multibase::Base::Base32Lower, &version_buf);
+
+        write!(f, "{}-{}", version_str, self.uuid)
+    }
+}
+
+pub fn validate_doc_id_str(s: &str) -> Result<(), DocIdFormatError> {
+    ParsedDocId::from_string(s).map(|_| ())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DocIdFormatError {
+    #[error("malformed document ID")]
+    Malformed,
+
+    #[error("invalid document ID version: {0}")]
+    InvalidVersion(u16),
+
+    #[error("multibase decode error: {0}")]
+    Multibase(#[from] multibase::Error),
+
+    #[error("UUID parse error: {0}")]
+    Uuid(#[from] uuid::Error),
+}
+
+fn read_uvarint(buf: &[u8]) -> Option<u64> {
+    let mut x: u64 = 0;
+    let mut s: u32 = 0;
+    for (i, &b) in buf.iter().enumerate() {
+        if i == 10 {
+            return None;
+        }
+        if b < 0x80 {
+            if i == 9 && b > 1 {
+                return None;
+            }
+            return Some(x | (b as u64) << s);
+        }
+        x |= ((b & 0x7f) as u64) << s;
+        s += 7;
+    }
+    None
+}
+
+fn write_uvarint(buf: &mut Vec<u8>, mut x: u64) {
+    while x >= 0x80 {
+        buf.push((x as u8) | 0x80);
+        x >>= 7;
+    }
+    buf.push(x as u8);
+}
+
+fn write_uvarint_to_slice(buf: &mut [u8], mut x: u64) -> usize {
+    debug_assert!(
+        buf.len() >= varint_size(x),
+        "buffer too small for varint: need {} bytes, got {}",
+        varint_size(x),
+        buf.len()
+    );
+
+    let mut i = 0;
+    while x >= 0x80 && i < buf.len() {
+        buf[i] = (x as u8) | 0x80;
+        x >>= 7;
+        i += 1;
+    }
+    if i < buf.len() {
+        buf[i] = x as u8;
+        i += 1;
+    }
+    i
+}
+
+fn varint_size(x: u64) -> usize {
+    if x == 0 {
+        return 1;
+    }
+
+    let mut size = 0;
+    let mut v = x;
+    while v > 0 {
+        size += 1;
+        v >>= 7;
+    }
+    size
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_doc_id() {
+        let parsed = ParsedDocId::from_string("bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc").unwrap();
+
+        assert_eq!(parsed.version(), DOC_ID_V0);
+        assert_eq!(
+            parsed.to_string(),
+            "bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc"
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_doc_id() {
+        assert!(ParsedDocId::from_string("bae-not-a-uuid").is_err());
+        assert!(ParsedDocId::from_string("nodash").is_err());
+    }
+}

--- a/crates/defra-core/src/document.rs
+++ b/crates/defra-core/src/document.rs
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn test_document_serialization() {
         let mut doc = Document::new();
-        doc.id = Some(DocId::new("bae-test"));
+        doc.id = Some(DocId::new("bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc").unwrap());
         doc.set_field("name", json!("Bob"));
 
         let serialized = serde_json::to_string(&doc).unwrap();

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod block_delta;
 pub mod block_signature;
 pub mod collection;
 pub mod dac_bypass;
+pub mod doc_id;
 pub mod document;
 pub mod encryption;
 pub mod error;

--- a/crates/defra-core/src/types.rs
+++ b/crates/defra-core/src/types.rs
@@ -1,17 +1,27 @@
 //! Core type definitions for DefraDB
 
+use crate::doc_id::validate_doc_id_str;
 use crate::{Error, Result};
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
-/// Document identifier - unique identifier for a document
-/// Format: "bae-<base32-encoded-bytes>"
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Document identifier.
+///
+/// Canonical format: `{base32(version)}-{uuid}`
+/// Example: `bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DocId(String);
 
 impl DocId {
-    /// Create a new DocId from a string
-    pub fn new(id: impl Into<String>) -> Self {
+    /// Create a new DocId from a string, validating the canonical format.
+    pub fn new(id: impl Into<String>) -> Result<Self> {
+        let id = id.into();
+        validate_doc_id_str(&id).map_err(|err| Error::InvalidDocumentId(err.to_string()))?;
+        Ok(Self(id))
+    }
+
+    /// Create a DocId without validating the string format.
+    pub fn new_unchecked(id: impl Into<String>) -> Self {
         Self(id.into())
     }
 
@@ -24,6 +34,33 @@ impl DocId {
 impl fmt::Display for DocId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl std::str::FromStr for DocId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::new(s)
+    }
+}
+
+impl Serialize for DocId {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for DocId {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(de::Error::custom)
     }
 }
 
@@ -193,8 +230,20 @@ mod tests {
 
     #[test]
     fn test_docid_creation() {
-        let id = DocId::new("bae-test123");
+        let id = DocId::new_unchecked("bae-test123");
         assert_eq!(id.as_str(), "bae-test123");
+    }
+
+    #[test]
+    fn test_docid_validation() {
+        assert!(DocId::new("bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc").is_ok());
+        assert!(DocId::new("doc1").is_err());
+    }
+
+    #[test]
+    fn test_docid_deserialization_rejects_invalid_values() {
+        let err = serde_json::from_str::<DocId>("\"doc1\"").unwrap_err();
+        assert!(err.to_string().contains("invalid document ID"));
     }
 
     #[test]

--- a/crates/document/Cargo.toml
+++ b/crates/document/Cargo.toml
@@ -12,6 +12,7 @@ description = "Runtime document types for DefraDB"
 # Internal dependencies
 schema = { path = "../schema" }
 crypto = { path = "../crypto" }
+defra-core = { path = "../defra-core" }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/document/src/doc_id.rs
+++ b/crates/document/src/doc_id.rs
@@ -1,6 +1,7 @@
 //! Document ID type with content-addressed generation
 
 use cid::Cid;
+use defra_core::doc_id::ParsedDocId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -62,34 +63,11 @@ impl DocID {
     ///
     /// Format: `{base32(version)}-{uuid}`
     pub fn from_string(s: &str) -> Result<Self> {
-        let parts: Vec<&str> = s.splitn(2, '-').collect();
-        if parts.len() != 2 {
-            return Err(Error::MalformedDocID);
-        }
-
-        let version_str = parts[0];
-        let uuid_str = parts[1];
-
-        // Decode the version from base32
-        let (_, version_bytes) = multibase::decode(version_str)?;
-        if version_bytes.is_empty() {
-            return Err(Error::MalformedDocID);
-        }
-
-        // Read version as varint (but for v0 it's just a single byte)
-        let version = read_uvarint(&version_bytes).ok_or(Error::MalformedDocID)?;
-
-        // Validate version
-        if version != DOC_ID_V0 as u64 {
-            return Err(Error::InvalidDocIDVersion(version as u16));
-        }
-
-        // Parse UUID
-        let uuid = Uuid::parse_str(uuid_str)?;
+        let parsed = ParsedDocId::from_string(s)?;
 
         Ok(Self {
-            version: version as u16,
-            uuid,
+            version: parsed.version(),
+            uuid: parsed.uuid(),
             cid: None, // CID is not recoverable from string representation
         })
     }
@@ -114,38 +92,18 @@ impl DocID {
     /// Convert to byte representation.
     /// Format: version (varint) + uuid bytes
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(18); // 2 bytes version + 16 bytes uuid
-        write_uvarint(&mut buf, self.version as u64);
-        buf.extend_from_slice(self.uuid.as_bytes());
-        buf
+        ParsedDocId::new(self.version, self.uuid)
+            .expect("DocID instances always carry a valid version")
+            .to_bytes()
     }
 
     /// Parse from byte representation.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() < 17 {
-            // At least 1 byte version + 16 bytes uuid
-            return Err(Error::MalformedDocID);
-        }
-
-        let version = read_uvarint(bytes).ok_or(Error::MalformedDocID)?;
-        if version != DOC_ID_V0 as u64 {
-            return Err(Error::InvalidDocIDVersion(version as u16));
-        }
-
-        // UUID starts after the varint (for v0, varint is 1 byte)
-        let uuid_start = varint_size(version);
-        if bytes.len() < uuid_start + 16 {
-            return Err(Error::MalformedDocID);
-        }
-
-        let uuid_bytes: [u8; 16] = bytes[uuid_start..uuid_start + 16]
-            .try_into()
-            .map_err(|_| Error::MalformedDocID)?;
-        let uuid = Uuid::from_bytes(uuid_bytes);
+        let parsed = ParsedDocId::from_bytes(bytes)?;
 
         Ok(Self {
-            version: version as u16,
-            uuid,
+            version: parsed.version(),
+            uuid: parsed.uuid(),
             cid: None,
         })
     }
@@ -153,13 +111,8 @@ impl DocID {
 
 impl std::fmt::Display for DocID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Use dynamic buffer sizing based on actual varint requirements
-        let size = varint_size(self.version as u64);
-        let mut version_buf = vec![0u8; size];
-        write_uvarint_to_slice(&mut version_buf, self.version as u64);
-        let version_str = multibase::encode(multibase::Base::Base32Lower, &version_buf);
-
-        write!(f, "{}-{}", version_str, self.uuid)
+        let parsed = ParsedDocId::new(self.version, self.uuid).map_err(|_| std::fmt::Error)?;
+        write!(f, "{}", parsed)
     }
 }
 
@@ -180,68 +133,4 @@ impl std::str::FromStr for DocID {
     fn from_str(s: &str) -> Result<Self> {
         Self::from_string(s)
     }
-}
-
-// === Varint helpers (matching Go's binary.Uvarint) ===
-
-fn read_uvarint(buf: &[u8]) -> Option<u64> {
-    let mut x: u64 = 0;
-    let mut s: u32 = 0;
-    for (i, &b) in buf.iter().enumerate() {
-        if i == 10 {
-            // Overflow
-            return None;
-        }
-        if b < 0x80 {
-            if i == 9 && b > 1 {
-                // Overflow
-                return None;
-            }
-            return Some(x | (b as u64) << s);
-        }
-        x |= ((b & 0x7f) as u64) << s;
-        s += 7;
-    }
-    None // Buffer too small
-}
-
-fn write_uvarint(buf: &mut Vec<u8>, mut x: u64) {
-    while x >= 0x80 {
-        buf.push((x as u8) | 0x80);
-        x >>= 7;
-    }
-    buf.push(x as u8);
-}
-
-fn write_uvarint_to_slice(buf: &mut [u8], mut x: u64) -> usize {
-    debug_assert!(
-        buf.len() >= varint_size(x),
-        "buffer too small for varint: need {} bytes, got {}",
-        varint_size(x),
-        buf.len()
-    );
-    let mut i = 0;
-    while x >= 0x80 && i < buf.len() {
-        buf[i] = (x as u8) | 0x80;
-        x >>= 7;
-        i += 1;
-    }
-    if i < buf.len() {
-        buf[i] = x as u8;
-        i += 1;
-    }
-    i
-}
-
-fn varint_size(x: u64) -> usize {
-    if x == 0 {
-        return 1;
-    }
-    let mut size = 0;
-    let mut v = x;
-    while v > 0 {
-        size += 1;
-        v >>= 7;
-    }
-    size
 }

--- a/crates/document/src/error.rs
+++ b/crates/document/src/error.rs
@@ -62,4 +62,7 @@ pub enum Error {
 
     #[error("schema error: {0}")]
     Schema(#[from] schema::SchemaError),
+
+    #[error("{0}")]
+    CoreDocID(#[from] defra_core::doc_id::DocIdFormatError),
 }

--- a/crates/http/src/validation.rs
+++ b/crates/http/src/validation.rs
@@ -1,6 +1,7 @@
 //! Input validation utilities for HTTP handlers.
 
 use crate::error::HttpError;
+use defra_core::types::DocId;
 
 /// Validate that a string is a valid identifier (collection name, field name, etc.)
 ///
@@ -58,8 +59,7 @@ pub fn validate_multiaddr(address: &str) -> Result<(), HttpError> {
 
 /// Validate a document ID format.
 ///
-/// DefraDB document IDs have the format "bae-" followed by a UUID-like string.
-/// This performs basic validation; full validation happens in the document layer.
+/// DefraDB document IDs use the canonical DocID parser shared with the document layer.
 pub fn validate_doc_id(doc_id: &str) -> Result<(), HttpError> {
     if doc_id.trim().is_empty() {
         return Err(HttpError::BadRequest(
@@ -67,33 +67,9 @@ pub fn validate_doc_id(doc_id: &str) -> Result<(), HttpError> {
         ));
     }
 
-    // DefraDB doc IDs start with "bae-"
-    if !doc_id.starts_with("bae-") {
-        return Err(HttpError::BadRequest(format!(
-            "invalid document ID '{}': must start with 'bae-'",
-            doc_id
-        )));
-    }
-
-    // Basic format check: bae- followed by alphanumeric and dashes
-    let suffix = &doc_id[4..];
-    if suffix.is_empty() {
-        return Err(HttpError::BadRequest(format!(
-            "invalid document ID '{}': missing ID after 'bae-' prefix",
-            doc_id
-        )));
-    }
-
-    // Validate the suffix contains only valid characters (hex digits and dashes)
-    let valid = suffix.chars().all(|c| c.is_ascii_hexdigit() || c == '-');
-    if !valid {
-        return Err(HttpError::BadRequest(format!(
-            "invalid document ID '{}': ID suffix must contain only hex digits and dashes",
-            doc_id
-        )));
-    }
-
-    Ok(())
+    DocId::new(doc_id)
+        .map(|_| ())
+        .map_err(|e| HttpError::BadRequest(format!("invalid document ID '{}': {}", doc_id, e)))
 }
 
 #[cfg(test)]
@@ -199,8 +175,7 @@ mod tests {
     #[test]
     fn test_validate_doc_id_valid() {
         assert!(validate_doc_id("bae-3fc941b7-505c-5ce2-91a0-b180930ec8a9").is_ok());
-        assert!(validate_doc_id("bae-abcd1234").is_ok());
-        assert!(validate_doc_id("bae-0123456789abcdef").is_ok());
+        assert!(validate_doc_id("bae-c94acbfa-dd53-40d0-97f3-29ce16c333fc").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extract canonical DocID parsing/format validation into a shared `defra-core` module
- make `defra-core::DocId` validated by default, with explicit `new_unchecked()` for tests and internal fake IDs
- update `document::DocID` and HTTP validation to use the shared parser rules

## Testing
- cargo test -p defra-core
- cargo test -p document doc_id
- cargo test -p defra-http validation
- cargo test -p crdt
- cargo check -p db

Closes #685