### PR TITLE
storage: replace transaction flag mutexes with atomics

### DIFF
--- a/crates/storage/src/backends/fjall/store.rs
+++ b/crates/storage/src/backends/fjall/store.rs
@@ -187,8 +187,8 @@ impl Store for FjallStore {
             snapshot,
             pending: Mutex::new(BTreeMap::new()),
             readonly,
-            discarded: Mutex::new(false),
-            committed: Mutex::new(false),
+            discarded: AtomicBool::new(false),
+            committed: AtomicBool::new(false),
             callbacks: CallbackManager::new(),
             durability: self.durability,
         }))

--- a/crates/storage/src/backends/fjall/transaction.rs
+++ b/crates/storage/src/backends/fjall/transaction.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use super::compute_range_bounds;
@@ -23,8 +23,8 @@ pub(crate) struct FjallTxn {
     /// Pending changes (Some(value) = set, None = delete)
     pub(crate) pending: Mutex<BTreeMap<Vec<u8>, Option<Vec<u8>>>>,
     pub(crate) readonly: bool,
-    pub(crate) discarded: Mutex<bool>,
-    pub(crate) committed: Mutex<bool>,
+    pub(crate) discarded: AtomicBool,
+    pub(crate) committed: AtomicBool,
     pub(crate) callbacks: CallbackManager,
     pub(crate) durability: DurabilityMode,
 }
@@ -33,8 +33,8 @@ impl Drop for FjallTxn {
     fn drop(&mut self) {
         self.active_txn_count.fetch_sub(1, Ordering::AcqRel);
 
-        let was_committed = *self.committed.lock();
-        let was_discarded = *self.discarded.lock();
+        let was_committed = self.committed.load(Ordering::Acquire);
+        let was_discarded = self.discarded.load(Ordering::Acquire);
         if !was_committed && !was_discarded {
             let has_pending = !self.pending.lock().is_empty();
             let total_skipped =
@@ -96,7 +96,7 @@ impl crate::corekv::private::Sealed for FjallTxn {}
 #[async_trait]
 impl Reader for FjallTxn {
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if key.is_empty() {
@@ -106,7 +106,7 @@ impl Reader for FjallTxn {
     }
 
     async fn has(&self, key: &[u8]) -> Result<bool> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if key.is_empty() {
@@ -116,7 +116,7 @@ impl Reader for FjallTxn {
     }
 
     async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if key.is_empty() {
@@ -126,7 +126,7 @@ impl Reader for FjallTxn {
     }
 
     async fn iterator(&self, opts: IterOptions) -> Result<Box<dyn Iterator>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -204,7 +204,7 @@ fn bound_as_ref(bound: &std::ops::Bound<Vec<u8>>) -> std::ops::Bound<&[u8]> {
 #[async_trait]
 impl Writer for FjallTxn {
     async fn set(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if self.readonly {
@@ -220,7 +220,7 @@ impl Writer for FjallTxn {
     }
 
     async fn delete(&mut self, key: &[u8]) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if self.readonly {
@@ -237,14 +237,14 @@ impl Writer for FjallTxn {
 #[async_trait]
 impl Txn for FjallTxn {
     async fn commit(self: Box<Self>) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit a discarded transaction");
             CallbackManager::execute_callbacks(self.callbacks.take_error());
             CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
             return Err(Error::DiscardedTxn);
         }
 
-        if *self.committed.lock() {
+        if self.committed.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit an already committed transaction");
             return Err(Error::Other("Transaction already committed".into()));
         }
@@ -291,7 +291,7 @@ impl Txn for FjallTxn {
             }
         }
 
-        *self.committed.lock() = true;
+        self.committed.store(true, Ordering::Release);
 
         CallbackManager::execute_callbacks(self.callbacks.take_success());
         CallbackManager::execute_async_callbacks(self.callbacks.take_success_async()).await;
@@ -300,7 +300,7 @@ impl Txn for FjallTxn {
     }
 
     fn discard(self: Box<Self>) {
-        *self.discarded.lock() = true;
+        self.discarded.store(true, Ordering::Release);
 
         CallbackManager::execute_callbacks(self.callbacks.take_discard());
 

--- a/crates/storage/src/backends/leveldb/store.rs
+++ b/crates/storage/src/backends/leveldb/store.rs
@@ -165,8 +165,8 @@ impl Store for LevelDbStore {
             snapshot,
             pending: Mutex::new(BTreeMap::new()),
             readonly,
-            discarded: Mutex::new(false),
-            committed: Mutex::new(false),
+            discarded: std::sync::atomic::AtomicBool::new(false),
+            committed: std::sync::atomic::AtomicBool::new(false),
             callbacks: CallbackManager::new(),
         }))
     }

--- a/crates/storage/src/backends/leveldb/transaction.rs
+++ b/crates/storage/src/backends/leveldb/transaction.rs
@@ -3,6 +3,7 @@ use parking_lot::Mutex;
 use rusty_leveldb::{WriteBatch, DB};
 use std::collections::BTreeMap;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::iterator::LevelDbIterator;
 use crate::backends::shared::CallbackManager;
@@ -28,10 +29,10 @@ pub(crate) struct LevelDbTxn {
     pub(crate) readonly: bool,
 
     /// Whether the transaction has been discarded
-    pub(crate) discarded: Mutex<bool>,
+    pub(crate) discarded: AtomicBool,
 
     /// Whether the transaction has been committed
-    pub(crate) committed: Mutex<bool>,
+    pub(crate) committed: AtomicBool,
 
     /// Transaction lifecycle callbacks
     pub(crate) callbacks: CallbackManager,
@@ -68,7 +69,7 @@ impl crate::corekv::private::Sealed for LevelDbTxn {}
 #[async_trait(?Send)]
 impl Reader for LevelDbTxn {
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -80,7 +81,7 @@ impl Reader for LevelDbTxn {
     }
 
     async fn has(&self, key: &[u8]) -> Result<bool> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -92,7 +93,7 @@ impl Reader for LevelDbTxn {
     }
 
     async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -104,7 +105,7 @@ impl Reader for LevelDbTxn {
     }
 
     async fn iterator(&self, opts: IterOptions) -> Result<Box<dyn Iterator>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -129,7 +130,7 @@ impl Reader for LevelDbTxn {
 #[async_trait(?Send)]
 impl Writer for LevelDbTxn {
     async fn set(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -148,7 +149,7 @@ impl Writer for LevelDbTxn {
     }
 
     async fn delete(&mut self, key: &[u8]) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -169,7 +170,7 @@ impl Writer for LevelDbTxn {
 impl Txn for LevelDbTxn {
     async fn commit(self: Box<Self>) -> Result<()> {
         // Check discarded first
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit a discarded transaction");
             CallbackManager::execute_callbacks(self.callbacks.take_error());
             CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
@@ -177,13 +178,13 @@ impl Txn for LevelDbTxn {
         }
 
         // Check if already committed
-        if *self.committed.lock() {
+        if self.committed.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit an already committed transaction");
             return Err(Error::Other("Transaction already committed".into()));
         }
 
         // Mark as committed
-        *self.committed.lock() = true;
+        self.committed.store(true, Ordering::Release);
 
         // Clone pending changes before accessing DB
         let pending = self.pending.lock().clone();
@@ -213,7 +214,7 @@ impl Txn for LevelDbTxn {
     }
 
     fn discard(self: Box<Self>) {
-        *self.discarded.lock() = true;
+        self.discarded.store(true, Ordering::Release);
 
         // Execute sync discard callbacks
         CallbackManager::execute_callbacks(self.callbacks.take_discard());

--- a/crates/storage/src/backends/memory/store.rs
+++ b/crates/storage/src/backends/memory/store.rs
@@ -65,8 +65,8 @@ impl Store for MemoryStore {
             snapshot,
             pending: Mutex::new(BTreeMap::new()),
             readonly,
-            discarded: Mutex::new(false),
-            committed: Mutex::new(false),
+            discarded: AtomicBool::new(false),
+            committed: AtomicBool::new(false),
             callbacks: CallbackManager::new(),
         }))
     }

--- a/crates/storage/src/backends/memory/transaction.rs
+++ b/crates/storage/src/backends/memory/transaction.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -35,10 +36,10 @@ pub(crate) struct MemoryTxn {
     pub(crate) readonly: bool,
 
     /// Whether the transaction has been discarded
-    pub(crate) discarded: Mutex<bool>,
+    pub(crate) discarded: AtomicBool,
 
     /// Whether the transaction has been committed
-    pub(crate) committed: Mutex<bool>,
+    pub(crate) committed: AtomicBool,
 
     /// Transaction lifecycle callbacks
     pub(crate) callbacks: CallbackManager,
@@ -75,7 +76,7 @@ impl crate::corekv::private::Sealed for MemoryTxn {}
 #[async_trait]
 impl Reader for MemoryTxn {
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -87,7 +88,7 @@ impl Reader for MemoryTxn {
     }
 
     async fn has(&self, key: &[u8]) -> Result<bool> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -99,7 +100,7 @@ impl Reader for MemoryTxn {
     }
 
     async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -111,7 +112,7 @@ impl Reader for MemoryTxn {
     }
 
     async fn iterator(&self, opts: IterOptions) -> Result<Box<dyn Iterator>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -136,7 +137,7 @@ impl Reader for MemoryTxn {
 #[async_trait]
 impl Writer for MemoryTxn {
     async fn set(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -155,7 +156,7 @@ impl Writer for MemoryTxn {
     }
 
     async fn delete(&mut self, key: &[u8]) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -176,7 +177,7 @@ impl Writer for MemoryTxn {
 impl Txn for MemoryTxn {
     async fn commit(self: Box<Self>) -> Result<()> {
         // Check discarded first (matches redb backend order)
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit a discarded transaction");
             CallbackManager::execute_callbacks(self.callbacks.take_error());
             CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
@@ -184,7 +185,7 @@ impl Txn for MemoryTxn {
         }
 
         // Check if already committed (defensive - ownership prevents this in normal usage)
-        if *self.committed.lock() {
+        if self.committed.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit an already committed transaction");
             return Err(Error::Other("Transaction already committed".into()));
         }
@@ -205,7 +206,7 @@ impl Txn for MemoryTxn {
         }
 
         // Mark as committed
-        *self.committed.lock() = true;
+        self.committed.store(true, Ordering::Release);
 
         // Apply pending changes to store
         if !pending.is_empty() {
@@ -231,7 +232,7 @@ impl Txn for MemoryTxn {
     }
 
     fn discard(self: Box<Self>) {
-        *self.discarded.lock() = true;
+        self.discarded.store(true, Ordering::Release);
 
         // Execute sync discard callbacks
         CallbackManager::execute_callbacks(self.callbacks.take_discard());

--- a/crates/storage/src/backends/rocksdb/transaction.rs
+++ b/crates/storage/src/backends/rocksdb/transaction.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::ops::Bound;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use super::iterator::RocksDbMergingIterator;
@@ -69,8 +69,8 @@ pub(crate) struct RocksDbTxn {
     /// Pending changes (Some(value) = set, None = delete)
     pub(crate) pending: Mutex<BTreeMap<Vec<u8>, Option<Vec<u8>>>>,
     pub(crate) readonly: bool,
-    pub(crate) discarded: Mutex<bool>,
-    pub(crate) committed: Mutex<bool>,
+    pub(crate) discarded: AtomicBool,
+    pub(crate) committed: AtomicBool,
     pub(crate) callbacks: CallbackManager,
     pub(crate) durability: DurabilityMode,
 }
@@ -79,8 +79,8 @@ impl Drop for RocksDbTxn {
     fn drop(&mut self) {
         self.active_txn_count.fetch_sub(1, Ordering::AcqRel);
 
-        let was_committed = *self.committed.lock();
-        let was_discarded = *self.discarded.lock();
+        let was_committed = self.committed.load(Ordering::Acquire);
+        let was_discarded = self.discarded.load(Ordering::Acquire);
         if !was_committed && !was_discarded {
             let has_pending = !self.pending.lock().is_empty();
             let total_skipped =
@@ -123,8 +123,8 @@ impl RocksDbTxn {
             read_version,
             pending: Mutex::new(BTreeMap::new()),
             readonly,
-            discarded: Mutex::new(false),
-            committed: Mutex::new(false),
+            discarded: AtomicBool::new(false),
+            committed: AtomicBool::new(false),
             callbacks: CallbackManager::new(),
             durability,
         }
@@ -163,7 +163,7 @@ impl crate::corekv::private::Sealed for RocksDbTxn {}
 #[async_trait]
 impl Reader for RocksDbTxn {
     async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if key.is_empty() {
@@ -173,7 +173,7 @@ impl Reader for RocksDbTxn {
     }
 
     async fn has(&self, key: &[u8]) -> Result<bool> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if key.is_empty() {
@@ -183,7 +183,7 @@ impl Reader for RocksDbTxn {
     }
 
     async fn get_size(&self, key: &[u8]) -> Result<Option<usize>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if key.is_empty() {
@@ -193,7 +193,7 @@ impl Reader for RocksDbTxn {
     }
 
     async fn iterator(&self, opts: IterOptions) -> Result<Box<dyn Iterator>> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
 
@@ -327,7 +327,7 @@ fn prefix_to_end_bound(prefix: &[u8]) -> Option<Vec<u8>> {
 #[async_trait]
 impl Writer for RocksDbTxn {
     async fn set(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if self.readonly {
@@ -343,7 +343,7 @@ impl Writer for RocksDbTxn {
     }
 
     async fn delete(&mut self, key: &[u8]) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             return Err(Error::DiscardedTxn);
         }
         if self.readonly {
@@ -360,14 +360,14 @@ impl Writer for RocksDbTxn {
 #[async_trait]
 impl Txn for RocksDbTxn {
     async fn commit(self: Box<Self>) -> Result<()> {
-        if *self.discarded.lock() {
+        if self.discarded.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit a discarded transaction");
             CallbackManager::execute_callbacks(self.callbacks.take_error());
             CallbackManager::execute_async_callbacks(self.callbacks.take_error_async()).await;
             return Err(Error::DiscardedTxn);
         }
 
-        if *self.committed.lock() {
+        if self.committed.load(Ordering::Acquire) {
             tracing::warn!("Attempted to commit an already committed transaction");
             return Err(Error::Other("Transaction already committed".into()));
         }
@@ -416,7 +416,7 @@ impl Txn for RocksDbTxn {
             }
         }
 
-        *self.committed.lock() = true;
+        self.committed.store(true, Ordering::Release);
 
         CallbackManager::execute_callbacks(self.callbacks.take_success());
         CallbackManager::execute_async_callbacks(self.callbacks.take_success_async()).await;
@@ -425,7 +425,7 @@ impl Txn for RocksDbTxn {
     }
 
     fn discard(self: Box<Self>) {
-        *self.discarded.lock() = true;
+        self.discarded.store(true, Ordering::Release);
 
         CallbackManager::execute_callbacks(self.callbacks.take_discard());
 


### PR DESCRIPTION
## Summary
Narrows issue #673 to a concrete storage cleanup by replacing transaction lifecycle `Mutex<bool>` flags with `AtomicBool` in the backends that still used synchronous mutexes for committed/discarded state.

## Changes
- replace `discarded` and `committed` `Mutex<bool>` fields with `AtomicBool` in memory, leveldb, fjall, and rocksdb transactions
- update the corresponding store constructors to initialize atomics
- keep transaction behavior unchanged while removing unnecessary locking on hot-path lifecycle checks

## Validation
- `cargo check -p storage`
- `cargo clippy -p storage -- -W clippy::await_holding_lock`

## Issue Context
The original issue inventory is stale and the current branch does not appear to hold sync mutex guards across `.await` in the reported paths. This PR extracts the remaining low-risk cleanup that is still justified.
