### PR TITLE
Handle closed replication worker semaphore

### DIFF
--- a/crates/p2p/src/sync/replication/loop_runner.rs
+++ b/crates/p2p/src/sync/replication/loop_runner.rs
@@ -137,7 +137,7 @@ impl ReplicationLoop {
     /// (e.g., publishing events to an event bus).
     pub async fn run_parallel<B, T, H, F>(
         coordinator: Arc<SyncCoordinator<B, T>>,
-        mut events: mpsc::Receiver<SyncEvent>,
+        events: mpsc::Receiver<SyncEvent>,
         handler: Arc<H>,
         config: ReplicationConfig,
         on_result: F,
@@ -153,6 +153,31 @@ impl ReplicationLoop {
         );
 
         let semaphore = Arc::new(Semaphore::new(config.max_workers));
+        Self::run_parallel_with_semaphore(
+            coordinator,
+            events,
+            handler,
+            config,
+            on_result,
+            semaphore,
+        )
+        .await;
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(super) async fn run_parallel_with_semaphore<B, T, H, F>(
+        coordinator: Arc<SyncCoordinator<B, T>>,
+        mut events: mpsc::Receiver<SyncEvent>,
+        handler: Arc<H>,
+        config: ReplicationConfig,
+        on_result: F,
+        semaphore: Arc<Semaphore>,
+    ) where
+        B: Blockstore + 'static,
+        T: P2PTransport,
+        H: MergeHandler + 'static,
+        F: Fn(ReplicationResult) + Send + Sync + 'static,
+    {
         let on_result = Arc::new(on_result);
         let config = Arc::new(config);
 
@@ -165,7 +190,13 @@ impl ReplicationLoop {
                 }
             };
 
-            let permit = semaphore.clone().acquire_owned().await.unwrap();
+            let permit = match semaphore.clone().acquire_owned().await {
+                Ok(permit) => permit,
+                Err(_) => {
+                    tracing::info!("Worker semaphore closed, stopping parallel replication loop");
+                    break;
+                }
+            };
             let coord = coordinator.clone();
             let h = handler.clone();
             let c = config.clone();

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -53,7 +53,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use storage::backends::MemoryStore;
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, Semaphore};
 
     fn test_cid() -> Cid {
         Cid::from_str("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi").unwrap()
@@ -655,6 +655,66 @@ mod tests {
             }
             _ => panic!("Expected MergedButBroadcastFailed"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_run_parallel_exits_cleanly_when_worker_semaphore_closed() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore,
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+
+        let (tx, rx) = mpsc::channel(1);
+        tx.send(SyncEvent::BlockReceived {
+            cid: test_cid(),
+            doc_id: "doc1".to_string(),
+            collection_id: "col1".to_string(),
+            creator: "peer1".to_string(),
+            sender_peer: None,
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+        })
+        .await
+        .unwrap();
+        drop(tx);
+
+        let semaphore = Arc::new(Semaphore::new(1));
+        semaphore.close();
+
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_clone = callback_count.clone();
+        let handler = Arc::new(TestMergeHandler::new(true, false));
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            ReplicationLoop::run_parallel_with_semaphore(
+                Arc::new(coordinator),
+                rx,
+                handler,
+                ReplicationConfig::default(),
+                move |_| {
+                    callback_count_clone.fetch_add(1, Ordering::SeqCst);
+                },
+                semaphore,
+            ),
+        )
+        .await
+        .expect("parallel replication loop should exit when semaphore is closed");
+
+        assert_eq!(
+            callback_count.load(Ordering::SeqCst),
+            0,
+            "closed semaphore should stop the loop before any worker starts"
+        );
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- stop the parallel replication loop cleanly when the worker semaphore is closed instead of panicking
- factor the loop body through a semaphore-aware helper so shutdown behavior can be tested directly
- add a regression test that injects a closed semaphore and verifies no worker callback runs

Closes #664

## Testing
- cargo fmt --all
- cargo test -p p2p sync::replication -- --nocapture