### PR TITLE
fix: zeroize derived ECIES key material

### DIFF
--- a/crates/crdt/tests/composite_tests.rs
+++ b/crates/crdt/tests/composite_tests.rs
@@ -261,11 +261,11 @@ async fn test_composite_doc_id_mismatch() {
 #[tokio::test]
 async fn test_composite_float64_counter_overflow_becomes_positive_infinity() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new("doc1").unwrap(), "v1".to_string());
     composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new("doc1").unwrap(),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -310,11 +310,11 @@ async fn test_composite_float64_counter_overflow_becomes_positive_infinity() {
 #[tokio::test]
 async fn test_composite_float64_counter_nan_increment_propagates_nan() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new("doc1").unwrap(), "v1".to_string());
     composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new("doc1").unwrap(),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -345,11 +345,11 @@ async fn test_composite_float64_counter_nan_increment_propagates_nan() {
 #[tokio::test]
 async fn test_composite_float64_counter_negative_zero_normalizes_to_positive_zero() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new("doc1").unwrap(), "v1".to_string());
     composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new("doc1").unwrap(),
         schema_version: "v1".to_string(),
         is_create: false,
     };

--- a/crates/crdt/tests/composite_tests.rs
+++ b/crates/crdt/tests/composite_tests.rs
@@ -261,11 +261,11 @@ async fn test_composite_doc_id_mismatch() {
 #[tokio::test]
 async fn test_composite_float64_counter_overflow_becomes_positive_infinity() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1").unwrap(), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
     composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
 
     let ctx = Context {
-        doc_id: DocId::new("doc1").unwrap(),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -310,11 +310,11 @@ async fn test_composite_float64_counter_overflow_becomes_positive_infinity() {
 #[tokio::test]
 async fn test_composite_float64_counter_nan_increment_propagates_nan() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1").unwrap(), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
     composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
 
     let ctx = Context {
-        doc_id: DocId::new("doc1").unwrap(),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -345,11 +345,11 @@ async fn test_composite_float64_counter_nan_increment_propagates_nan() {
 #[tokio::test]
 async fn test_composite_float64_counter_negative_zero_normalizes_to_positive_zero() {
     let store = MemoryStore::new();
-    let mut composite = CompositeDAG::new(DocId::new("doc1").unwrap(), "v1".to_string());
+    let mut composite = CompositeDAG::new(DocId::new_unchecked("doc1"), "v1".to_string());
     composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
 
     let ctx = Context {
-        doc_id: DocId::new("doc1").unwrap(),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };

--- a/crates/crdt/tests/counter_tests.rs
+++ b/crates/crdt/tests/counter_tests.rs
@@ -375,7 +375,7 @@ async fn test_counter_float64_nan_increment_propagates_nan() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new("doc1").unwrap(),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -412,7 +412,7 @@ async fn test_counter_float64_negative_zero_normalizes_to_positive_zero() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1"),
+        doc_id: DocId::new("doc1").unwrap(),
         schema_version: "v1".to_string(),
         is_create: false,
     };

--- a/crates/crdt/tests/counter_tests.rs
+++ b/crates/crdt/tests/counter_tests.rs
@@ -375,7 +375,7 @@ async fn test_counter_float64_nan_increment_propagates_nan() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1").unwrap(),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };
@@ -412,7 +412,7 @@ async fn test_counter_float64_negative_zero_normalizes_to_positive_zero() {
     .unwrap();
 
     let ctx = Context {
-        doc_id: DocId::new("doc1").unwrap(),
+        doc_id: DocId::new_unchecked("doc1"),
         schema_version: "v1".to_string(),
         is_create: false,
     };

--- a/crates/crypto/src/encryption/ecies.rs
+++ b/crates/crypto/src/encryption/ecies.rs
@@ -10,6 +10,7 @@ use hkdf::Hkdf;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::Zeroizing;
 
 use defra_core::Result;
 
@@ -18,6 +19,29 @@ use crate::error::{
     crypto_error, failed_to_parse_ephemeral_public_key, verification_with_hmac_failed,
 };
 use crate::types::{AES_KEY_SIZE, HMAC_SIZE, X25519_PUBLIC_KEY_SIZE};
+
+fn derive_ecies_keys(
+    shared_secret: &[u8],
+) -> Result<(Zeroizing<[u8; AES_KEY_SIZE]>, Zeroizing<[u8; HMAC_SIZE]>)> {
+    let hkdf = Hkdf::<Sha256>::new(None, shared_secret);
+
+    let mut keys = Zeroizing::new([0u8; AES_KEY_SIZE + HMAC_SIZE]);
+    hkdf.expand(&[], &mut *keys)
+        .map_err(|e| crypto_error(format!("HKDF expansion failed: {}", e)))?;
+
+    let aes_key = Zeroizing::new(
+        keys[..AES_KEY_SIZE]
+            .try_into()
+            .map_err(|_| crypto_error("failed to derive AES key from HKDF output"))?,
+    );
+    let hmac_key = Zeroizing::new(
+        keys[AES_KEY_SIZE..]
+            .try_into()
+            .map_err(|_| crypto_error("failed to derive HMAC key from HKDF output"))?,
+    );
+
+    Ok((aes_key, hmac_key))
+}
 
 /// Options for ECIES encryption/decryption
 #[derive(Default)]
@@ -125,14 +149,7 @@ pub fn encrypt_ecies(
     // We expand 64 bytes and split: first 32 for AES, next 32 for HMAC.
     // This matches Go's sequential hkdf.Read() calls for P2P compatibility.
     // Empty salt and info parameters match the Go implementation.
-    let hkdf = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
-
-    let mut keys = [0u8; AES_KEY_SIZE + AES_KEY_SIZE];
-    hkdf.expand(&[], &mut keys)
-        .map_err(|e| crypto_error(format!("HKDF expansion failed: {}", e)))?;
-
-    let aes_key: [u8; AES_KEY_SIZE] = keys[..AES_KEY_SIZE].try_into().unwrap();
-    let hmac_key: [u8; AES_KEY_SIZE] = keys[AES_KEY_SIZE..].try_into().unwrap();
+    let (aes_key, hmac_key) = derive_ecies_keys(shared_secret.as_bytes())?;
 
     // 4. Build AAD: ephemeral public key + optional additional data
     let mut aad = ephemeral_public.as_bytes().to_vec();
@@ -141,10 +158,10 @@ pub fn encrypt_ecies(
     }
 
     // 5. Encrypt with AES-GCM (nonce prepended to ciphertext)
-    let (encrypted_data, _nonce) = encrypt_aes(plaintext, &aes_key, &aad, true)?;
+    let (encrypted_data, _nonce) = encrypt_aes(plaintext, aes_key.as_ref(), &aad, true)?;
 
     // 6. HMAC over the encrypted data
-    let mut mac = Hmac::<Sha256>::new_from_slice(&hmac_key)
+    let mut mac = Hmac::<Sha256>::new_from_slice(hmac_key.as_ref())
         .map_err(|e| crypto_error(format!("failed to create HMAC: {:?}", e)))?;
     mac.update(&encrypted_data);
     let mac_tag = mac.finalize().into_bytes();
@@ -229,17 +246,10 @@ pub fn decrypt_ecies(
     // 4. HKDF-SHA256: derive AES and HMAC keys (RFC 5869)
     // We expand 64 bytes and split: first 32 for AES, next 32 for HMAC.
     // This matches Go's sequential hkdf.Read() calls for P2P compatibility.
-    let hkdf = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
-
-    let mut keys = [0u8; AES_KEY_SIZE + AES_KEY_SIZE];
-    hkdf.expand(&[], &mut keys)
-        .map_err(|e| crypto_error(format!("HKDF expansion failed: {}", e)))?;
-
-    let aes_key: [u8; AES_KEY_SIZE] = keys[..AES_KEY_SIZE].try_into().unwrap();
-    let hmac_key: [u8; AES_KEY_SIZE] = keys[AES_KEY_SIZE..].try_into().unwrap();
+    let (aes_key, hmac_key) = derive_ecies_keys(shared_secret.as_bytes())?;
 
     // 5. Verify HMAC
-    let mut mac = Hmac::<Sha256>::new_from_slice(&hmac_key)
+    let mut mac = Hmac::<Sha256>::new_from_slice(hmac_key.as_ref())
         .map_err(|e| crypto_error(format!("failed to create HMAC: {:?}", e)))?;
     mac.update(encrypted_data);
     mac.verify_slice(received_mac)
@@ -252,7 +262,7 @@ pub fn decrypt_ecies(
     }
 
     // 7. Decrypt with AES-GCM (nonce is prepended in encrypted_data)
-    let plaintext = decrypt_aes(None, encrypted_data, &aes_key, &aad)?;
+    let plaintext = decrypt_aes(None, encrypted_data, aes_key.as_ref(), &aad)?;
 
     Ok(plaintext)
 }

--- a/crates/crypto/src/encryption/ecies.rs
+++ b/crates/crypto/src/encryption/ecies.rs
@@ -20,9 +20,9 @@ use crate::error::{
 };
 use crate::types::{AES_KEY_SIZE, HMAC_SIZE, X25519_PUBLIC_KEY_SIZE};
 
-fn derive_ecies_keys(
-    shared_secret: &[u8],
-) -> Result<(Zeroizing<[u8; AES_KEY_SIZE]>, Zeroizing<[u8; HMAC_SIZE]>)> {
+type DerivedKeys = (Zeroizing<[u8; AES_KEY_SIZE]>, Zeroizing<[u8; HMAC_SIZE]>);
+
+fn derive_ecies_keys(shared_secret: &[u8]) -> Result<DerivedKeys> {
     let hkdf = Hkdf::<Sha256>::new(None, shared_secret);
 
     let mut keys = Zeroizing::new([0u8; AES_KEY_SIZE + HMAC_SIZE]);


### PR DESCRIPTION
## Summary

Closes #666.

Wrap ECIES HKDF-derived key material in `zeroize::Zeroizing` so the temporary key buffer and both derived AES/HMAC keys are cleared on drop.

## What Changed

- added a small helper to derive ECIES keys from HKDF into `Zeroizing` buffers
- applied the same zeroization behavior in both `encrypt_ecies` and `decrypt_ecies`
- corrected the HKDF output split to use `HMAC_SIZE` for the HMAC half
- replaced the previous `try_into().unwrap()` conversions with error propagation

## Testing

- `cargo test -p crypto --test ecies_tests -- --nocapture`
- `cargo test -p crypto --test go_compat_encryption -- --nocapture`
