### PR TITLE
Match float counter behavior with Go

### DIFF
--- a/crates/crdt/src/composite.rs
+++ b/crates/crdt/src/composite.rs
@@ -364,12 +364,6 @@ impl CompositeDAG {
                                 field_name, data.len()
                             ))
                         })?);
-                        if !increment.is_finite() {
-                            return Err(Error::MergeError(format!(
-                                "invalid float64 increment for field '{}': {}",
-                                field_name, increment
-                            )));
-                        }
                         if !allow_decrement && increment < 0.0 {
                             return Err(Error::MergeError("decrement not allowed".into()));
                         }
@@ -398,20 +392,7 @@ impl CompositeDAG {
                                 None => 0.0,
                             }
                         };
-                        if !current.is_finite() {
-                            return Err(Error::MergeError(format!(
-                                "invalid float64 current value for field '{}': {}",
-                                field_name, current
-                            )));
-                        }
-                        let result = current + increment;
-                        if !result.is_finite() {
-                            return Err(Error::MergeError(format!(
-                                "float64 overflow for field '{}': {} + {} = {}",
-                                field_name, current, increment, result
-                            )));
-                        }
-                        result.to_be_bytes()
+                        (current + increment).to_be_bytes()
                     }
                 };
 

--- a/crates/crdt/src/counter.rs
+++ b/crates/crdt/src/counter.rs
@@ -2,7 +2,7 @@
 //!
 //! Supports increment and decrement operations with nonce-based idempotent delivery.
 //! Uses commutative addition with wrapping on overflow for Int64 (matching Go DefraDB),
-//! and error on overflow for Float64. This is not a traditional PN-Counter (which uses
+//! and IEEE-754 addition for Float64. This is not a traditional PN-Counter (which uses
 //! separate per-replica counters); instead it uses a single value with nonce tracking.
 
 use crate::traits::{Context, Delta, MergeResult, ReplicatedData, ValueReader};
@@ -96,12 +96,6 @@ impl CounterDelta {
             return Err(Error::MergeError(
                 "schema_version_id cannot be empty".into(),
             ));
-        }
-        if !increment.is_finite() {
-            return Err(Error::MergeError(format!(
-                "float64 increment must be finite, got: {}",
-                increment
-            )));
         }
         Ok(Self {
             doc_id,
@@ -408,15 +402,6 @@ impl Counter {
             }
             NumericKind::Float64 => {
                 let increment = delta.decode_float64()?;
-
-                // Validate increment (reject NaN and infinities)
-                if !increment.is_finite() {
-                    return Err(Error::MergeError(format!(
-                        "invalid float64 increment: {}",
-                        increment
-                    )));
-                }
-
                 if !self.allow_decrement && increment < 0.0 {
                     return Err(Error::MergeError("decrement not allowed".into()));
                 }
@@ -426,28 +411,7 @@ impl Counter {
                 } else {
                     self.get_float64(rw).await?
                 };
-
-                // Validate current value
-                if !current.is_finite() {
-                    return Err(Error::MergeError(format!(
-                        "invalid float64 current value: {}",
-                        current
-                    )));
-                }
-
-                // Float64: Reject overflow to infinity (different from int64 saturation)
-                // Rationale: NaN/infinity breaks CRDT convergence properties
-                let result = current + increment;
-
-                // Validate result (check for overflow to infinity)
-                if !result.is_finite() {
-                    return Err(Error::MergeError(format!(
-                        "float64 overflow: {} + {} = {}",
-                        current, increment, result
-                    )));
-                }
-
-                NewValue::Float64(result)
+                NewValue::Float64(current + increment)
             }
         };
 

--- a/crates/crdt/tests/composite_tests.rs
+++ b/crates/crdt/tests/composite_tests.rs
@@ -11,6 +11,7 @@ use crdt::counter::NumericKind;
 use crdt::traits::{Context, ReplicatedData};
 use defra_core::types::DocId;
 use std::collections::HashMap;
+use std::f64;
 use storage::{MemoryStore, Store};
 
 #[tokio::test]
@@ -255,6 +256,125 @@ async fn test_composite_doc_id_mismatch() {
         .unwrap_err()
         .to_string()
         .contains("document ID mismatch"));
+}
+
+#[tokio::test]
+async fn test_composite_float64_counter_overflow_becomes_positive_infinity() {
+    let store = MemoryStore::new();
+    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
+
+    let ctx = Context {
+        doc_id: DocId::new("doc1"),
+        schema_version: "v1".to_string(),
+        is_create: false,
+    };
+
+    let mut delta1 = CompositeDelta::new(b"doc1".to_vec(), "v1".to_string(), 10).unwrap();
+    delta1
+        .add_field_delta(
+            "count".to_string(),
+            FieldDelta::Counter {
+                priority: 10,
+                nonce: 1,
+                data: f64::MAX.to_be_bytes().to_vec(),
+            },
+        )
+        .unwrap();
+
+    let mut delta2 = CompositeDelta::new(b"doc1".to_vec(), "v1".to_string(), 20).unwrap();
+    delta2
+        .add_field_delta(
+            "count".to_string(),
+            FieldDelta::Counter {
+                priority: 20,
+                nonce: 2,
+                data: f64::MAX.to_be_bytes().to_vec(),
+            },
+        )
+        .unwrap();
+
+    let mut txn = store.new_txn(false).await.unwrap();
+    composite.merge(&mut *txn, &ctx, &delta1).await.unwrap();
+    composite.merge(&mut *txn, &ctx, &delta2).await.unwrap();
+    txn.commit().await.unwrap();
+
+    let txn = store.new_txn(true).await.unwrap();
+    let count_key = b"/data/v1/doc1/count".to_vec();
+    let count_bytes = txn.get(&count_key).await.unwrap().unwrap();
+    let count = f64::from_be_bytes(count_bytes.try_into().unwrap());
+    assert!(count.is_infinite());
+    assert!(count.is_sign_positive());
+}
+
+#[tokio::test]
+async fn test_composite_float64_counter_nan_increment_propagates_nan() {
+    let store = MemoryStore::new();
+    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
+
+    let ctx = Context {
+        doc_id: DocId::new("doc1"),
+        schema_version: "v1".to_string(),
+        is_create: false,
+    };
+
+    let mut delta = CompositeDelta::new(b"doc1".to_vec(), "v1".to_string(), 10).unwrap();
+    delta
+        .add_field_delta(
+            "count".to_string(),
+            FieldDelta::Counter {
+                priority: 10,
+                nonce: 1,
+                data: f64::NAN.to_be_bytes().to_vec(),
+            },
+        )
+        .unwrap();
+
+    let mut txn = store.new_txn(false).await.unwrap();
+    composite.merge(&mut *txn, &ctx, &delta).await.unwrap();
+    txn.commit().await.unwrap();
+
+    let txn = store.new_txn(true).await.unwrap();
+    let count_key = b"/data/v1/doc1/count".to_vec();
+    let count_bytes = txn.get(&count_key).await.unwrap().unwrap();
+    let count = f64::from_be_bytes(count_bytes.try_into().unwrap());
+    assert!(count.is_nan());
+}
+
+#[tokio::test]
+async fn test_composite_float64_counter_negative_zero_normalizes_to_positive_zero() {
+    let store = MemoryStore::new();
+    let mut composite = CompositeDAG::new(DocId::new("doc1"), "v1".to_string());
+    composite.register_counter_field("count".to_string(), true, NumericKind::Float64);
+
+    let ctx = Context {
+        doc_id: DocId::new("doc1"),
+        schema_version: "v1".to_string(),
+        is_create: false,
+    };
+
+    let mut delta = CompositeDelta::new(b"doc1".to_vec(), "v1".to_string(), 10).unwrap();
+    delta
+        .add_field_delta(
+            "count".to_string(),
+            FieldDelta::Counter {
+                priority: 10,
+                nonce: 1,
+                data: (-0.0f64).to_be_bytes().to_vec(),
+            },
+        )
+        .unwrap();
+
+    let mut txn = store.new_txn(false).await.unwrap();
+    composite.merge(&mut *txn, &ctx, &delta).await.unwrap();
+    txn.commit().await.unwrap();
+
+    let txn = store.new_txn(true).await.unwrap();
+    let count_key = b"/data/v1/doc1/count".to_vec();
+    let count_bytes = txn.get(&count_key).await.unwrap().unwrap();
+    let count = f64::from_be_bytes(count_bytes.try_into().unwrap());
+    assert_eq!(count.to_bits(), 0.0f64.to_bits());
 }
 
 #[tokio::test]

--- a/crates/crdt/tests/counter_tests.rs
+++ b/crates/crdt/tests/counter_tests.rs
@@ -272,9 +272,8 @@ async fn test_counter_schema_version_mismatch() {
         .contains("schema version mismatch"));
 }
 
-#[tokio::test]
-async fn test_counter_float64_nan_rejected_by_constructor() {
-    // NaN is rejected during delta construction (new_float64 validates)
+#[test]
+fn test_counter_float64_constructor_accepts_nan() {
     let result = CounterDelta::new_float64(
         b"doc1".to_vec(),
         "count".to_string(),
@@ -283,13 +282,11 @@ async fn test_counter_float64_nan_rejected_by_constructor() {
         "v1".to_string(),
         f64::NAN,
     );
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("must be finite"));
+    assert!(result.is_ok());
 }
 
 #[test]
-fn test_counter_float64_positive_infinity() {
-    // new_float64 validates, so we test via the constructor validation
+fn test_counter_float64_constructor_accepts_positive_infinity() {
     let result = CounterDelta::new_float64(
         b"doc1".to_vec(),
         "count".to_string(),
@@ -298,13 +295,11 @@ fn test_counter_float64_positive_infinity() {
         "v1".to_string(),
         f64::INFINITY,
     );
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("must be finite"));
+    assert!(result.is_ok());
 }
 
 #[test]
-fn test_counter_float64_negative_infinity() {
-    // new_float64 validates, so we test via the constructor validation
+fn test_counter_float64_constructor_accepts_negative_infinity() {
     let result = CounterDelta::new_float64(
         b"doc1".to_vec(),
         "count".to_string(),
@@ -313,12 +308,11 @@ fn test_counter_float64_negative_infinity() {
         "v1".to_string(),
         f64::NEG_INFINITY,
     );
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("must be finite"));
+    assert!(result.is_ok());
 }
 
 #[tokio::test]
-async fn test_counter_float64_overflow() {
+async fn test_counter_float64_overflow_becomes_positive_infinity() {
     let store = MemoryStore::new();
     let counter = Counter::new(
         "v1".to_string(),
@@ -360,9 +354,86 @@ async fn test_counter_float64_overflow() {
     )
     .unwrap();
 
-    let result = counter.merge(&mut *txn, &ctx, &delta2).await;
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("float64 overflow"));
+    counter.merge(&mut *txn, &ctx, &delta2).await.unwrap();
+
+    let value_bytes = counter.value(&*txn).await.unwrap();
+    let value = f64::from_be_bytes(value_bytes.try_into().unwrap());
+    assert!(value.is_infinite());
+    assert!(value.is_sign_positive());
+}
+
+#[tokio::test]
+async fn test_counter_float64_nan_increment_propagates_nan() {
+    let store = MemoryStore::new();
+    let counter = Counter::new(
+        "v1".to_string(),
+        b"doc1",
+        "count".to_string(),
+        true,
+        NumericKind::Float64,
+    )
+    .unwrap();
+
+    let ctx = Context {
+        doc_id: DocId::new("doc1"),
+        schema_version: "v1".to_string(),
+        is_create: false,
+    };
+
+    let mut txn = store.new_txn(false).await.unwrap();
+
+    let delta = CounterDelta::new_float64(
+        b"doc1".to_vec(),
+        "count".to_string(),
+        10,
+        1,
+        "v1".to_string(),
+        f64::NAN,
+    )
+    .unwrap();
+
+    counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
+
+    let value_bytes = counter.value(&*txn).await.unwrap();
+    let value = f64::from_be_bytes(value_bytes.try_into().unwrap());
+    assert!(value.is_nan());
+}
+
+#[tokio::test]
+async fn test_counter_float64_negative_zero_normalizes_to_positive_zero() {
+    let store = MemoryStore::new();
+    let counter = Counter::new(
+        "v1".to_string(),
+        b"doc1",
+        "count".to_string(),
+        true,
+        NumericKind::Float64,
+    )
+    .unwrap();
+
+    let ctx = Context {
+        doc_id: DocId::new("doc1"),
+        schema_version: "v1".to_string(),
+        is_create: false,
+    };
+
+    let mut txn = store.new_txn(false).await.unwrap();
+
+    let delta = CounterDelta::new_float64(
+        b"doc1".to_vec(),
+        "count".to_string(),
+        10,
+        1,
+        "v1".to_string(),
+        -0.0,
+    )
+    .unwrap();
+
+    counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
+
+    let value_bytes = counter.value(&*txn).await.unwrap();
+    let value = f64::from_be_bytes(value_bytes.try_into().unwrap());
+    assert_eq!(value.to_bits(), 0.0f64.to_bits());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- align Rust float counter merge behavior with the current Go implementation
- remove Rust-only finite-value rejection for float counters in both standalone and composite CRDT paths
- add tests covering Go parity cases for `+Inf`, `-Inf`, `NaN`, and `-0.0`

## Why
Rust and Go currently diverge on float counter edge cases. Go accepts IEEE-754 outcomes from counter addition, while Rust rejected non-finite increments and overflow results during merge. That breaks cross-language convergence for replicated counters.

This PR makes Rust match the behavior already documented by Go's counter tests so both implementations converge on the same bytes/state.

## Reviewer Notes
- This change is intentionally preserving Go parity, not tightening float semantics.
- After this change, Rust float counters can persist `NaN`, `+Inf`, and `-Inf` if those values arise from replicated deltas, matching Go.
- The same behavior is applied to composite counter fields so Rust stays internally consistent across CRDT surfaces.

## Testing
- `cargo test -p crdt`

Closes #662
