### PR TITLE
chore: add conservative rustfmt and clippy config

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+# Pin Clippy's current default complexity thresholds so they do not drift with toolchain updates.
+cognitive-complexity-threshold = 25
+type-complexity-threshold = 250

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# Matches the formatting already present across the workspace.
+max_width = 100


### PR DESCRIPTION
## Summary
- add a conservative `rustfmt.toml` that pins `max_width = 100`, which already matches the current workspace formatting and produced no code diff when validated against `main`
- add a conservative `clippy.toml` that pins the current default complexity thresholds (`cognitive-complexity-threshold = 25`, `type-complexity-threshold = 250`) to avoid toolchain drift without introducing stricter style churn
- leave CI unchanged because `main` already enforces `cargo fmt --all -- --check` and `cargo clippy --all -- -D warnings`

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`

## Deferred
- `imports_granularity` is intentionally not set here. I tested both `Module` and `Crate` against current `main`, and each option would rewrite a large number of existing imports across the workspace. That turns this from a low-risk consistency config into a repo-wide style change.

Refs #683
