### PR TITLE
Tighten Windows file keyring permissions

### DIFF
--- a/crates/keyring/src/file.rs
+++ b/crates/keyring/src/file.rs
@@ -52,6 +52,18 @@ impl FileKeyring {
             fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))?;
         }
 
+        #[cfg(windows)]
+        {
+            restrict_owner_access(&dir, WindowsObjectKind::Directory)?;
+
+            for entry in fs::read_dir(&dir)? {
+                let entry = entry?;
+                if entry.file_type()?.is_file() {
+                    restrict_owner_access(&entry.path(), WindowsObjectKind::File)?;
+                }
+            }
+        }
+
         Ok(Self {
             dir,
             password: Zeroizing::new(password.into()),
@@ -115,6 +127,9 @@ impl Keyring for FileKeyring {
         #[cfg(not(unix))]
         {
             fs::write(&path, cipher)?;
+
+            #[cfg(windows)]
+            restrict_owner_access(&path, WindowsObjectKind::File)?;
         }
 
         Ok(())
@@ -166,5 +181,39 @@ impl Keyring for FileKeyring {
             }
         }
         Ok(keys)
+    }
+}
+
+#[cfg(windows)]
+#[derive(Clone, Copy)]
+enum WindowsObjectKind {
+    Directory,
+    File,
+}
+
+#[cfg(windows)]
+fn restrict_owner_access(path: &Path, kind: WindowsObjectKind) -> Result<()> {
+    use std::process::Command;
+
+    let mut grant = String::from("*S-1-3-4:");
+    grant.push_str(match kind {
+        WindowsObjectKind::Directory => "(OI)(CI)F",
+        WindowsObjectKind::File => "F",
+    });
+
+    let status = Command::new("icacls")
+        .arg(path)
+        .arg("/inheritance:r")
+        .arg("/grant:r")
+        .arg(&grant)
+        .status()?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(Error::Io(std::io::Error::other(format!(
+            "failed to restrict ACLs with icacls for {}",
+            path.display()
+        ))))
     }
 }

--- a/crates/keyring/tests/integration_tests.rs
+++ b/crates/keyring/tests/integration_tests.rs
@@ -411,3 +411,74 @@ fn test_file_keyring_key_file_permissions() {
         mode
     );
 }
+
+#[cfg(windows)]
+fn read_acl(path: &std::path::Path) -> String {
+    let output = std::process::Command::new("icacls")
+        .arg(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "icacls failed for {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[cfg(windows)]
+fn assert_owner_rights_only(path: &std::path::Path, expect_container_flags: bool) {
+    let acl = read_acl(path);
+    assert!(
+        acl.contains("OWNER RIGHTS:") || acl.contains("S-1-3-4:"),
+        "expected owner-rights ACE in ACL for {}:\n{}",
+        path.display(),
+        acl
+    );
+
+    if expect_container_flags {
+        assert!(
+            acl.contains("(OI)(CI)(F)") || acl.contains("(OI)(CI)"),
+            "expected inheritable full-control ACE in ACL for {}:\n{}",
+            path.display(),
+            acl
+        );
+    } else {
+        assert!(
+            acl.contains("(F)"),
+            "expected full-control ACE in ACL for {}:\n{}",
+            path.display(),
+            acl
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn test_file_keyring_windows_directory_and_file_permissions() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let keyring_path = temp_dir.path().join("secure_keyring");
+
+    let keyring = FileKeyring::open(&keyring_path, b"permissions-test").unwrap();
+    keyring.set("secure_key", b"secret-data").unwrap();
+
+    assert_owner_rights_only(&keyring_path, true);
+    assert_owner_rights_only(&keyring_path.join("secure_key"), false);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_file_keyring_windows_migrates_existing_files_on_open() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let keyring_path = temp_dir.path().join("secure_keyring");
+    std::fs::create_dir_all(&keyring_path).unwrap();
+
+    let existing_key = keyring_path.join("existing_key");
+    std::fs::write(&existing_key, b"preexisting").unwrap();
+
+    let _keyring = FileKeyring::open(&keyring_path, b"permissions-test").unwrap();
+
+    assert_owner_rights_only(&keyring_path, true);
+    assert_owner_rights_only(&existing_key, false);
+}


### PR DESCRIPTION
Fixes #665.

## What changed
- validated that `main` still restricts Unix permissions in `crates/keyring/src/file.rs` but leaves the Windows/non-Unix path on default filesystem permissions
- added a Windows-only `icacls` helper that removes inherited ACEs and grants owner rights full control for the keyring directory and key files
- tightened existing files on `FileKeyring::open` so pre-existing Windows key files are migrated on first access
- added Windows-gated integration coverage for new file creation and first-open migration
- left Unix `0o700`/`0o600` behavior untouched

## Validated locally
- `cargo test -p keyring@0.5.0`
- `cargo check -p keyring@0.5.0 --all-targets`
- confirmed on current `main` before changes that Unix permission handling existed and Windows handling did not

## Still needs Windows confirmation
- run the new Windows-gated ACL tests on a real Windows runner/runtime
- verify `icacls` output denies access to non-owner users as intended
- optional: confirm there are no environment-specific issues around `icacls` availability or ACL string formatting on CI

## Notes
- I attempted cross-target Windows `cargo check`, but this environment lacks the Windows OpenSSL setup required by transitive dependencies, so the build failed before it could validate the new Windows-only code path.
