### PR TITLE
Remove dead catch_unwind handling from transaction callbacks

### DIFF
--- a/crates/datastore/src/txn.rs
+++ b/crates/datastore/src/txn.rs
@@ -6,7 +6,6 @@
 /// - Lifecycle callbacks (on_success, on_error, on_discard)
 use crate::error::{Error, Result};
 use crate::multistore::{NamespaceView, RootView, SharedTxn};
-use futures::FutureExt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -157,10 +156,9 @@ impl BasicTxn {
     ///
     /// # Callback Panic Handling
     ///
-    /// Callback panics are caught and logged but do not affect the return value.
-    /// If a callback panics, remaining callbacks still execute, and `commit()`
-    /// returns `Ok(())` if the database commit succeeded. Check error logs for
-    /// callback panic details.
+    /// Callback panics are not recovered here. In dev/test profiles the panic
+    /// unwinds through `commit()`. In release builds this workspace uses
+    /// `panic = "abort"`, so a panicking callback aborts the process.
     pub async fn commit(mut self) -> Result<()> {
         if self.state != TxnState::Active {
             return Err(match self.state {
@@ -189,32 +187,14 @@ impl BasicTxn {
             (self.error_fns, self.error_async_fns)
         };
 
-        // Execute async callbacks sequentially with panic protection (matches storage backend)
-        for (i, callback) in async_fns.into_iter().enumerate() {
-            let callback_result = std::panic::AssertUnwindSafe(callback())
-                .catch_unwind()
-                .await;
-            if let Err(e) = callback_result {
-                tracing::error!(
-                    txn_id = self.id,
-                    callback_index = i,
-                    error = ?e,
-                    "Transaction async callback panicked - continuing with remaining callbacks"
-                );
-            }
+        // Callbacks run directly so the runtime's panic strategy stays explicit:
+        // unwind propagates in dev/test, and release aborts the process.
+        for callback in async_fns {
+            callback().await;
         }
 
-        // Execute sync callbacks with panic protection
-        for (i, callback) in sync_fns.into_iter().enumerate() {
-            let callback_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback));
-            if let Err(e) = callback_result {
-                tracing::error!(
-                    txn_id = self.id,
-                    callback_index = i,
-                    error = ?e,
-                    "Transaction sync callback panicked - continuing with remaining callbacks"
-                );
-            }
+        for callback in sync_fns {
+            callback();
         }
 
         result.map_err(Error::Storage)
@@ -227,8 +207,9 @@ impl BasicTxn {
     ///
     /// # Callback Panic Handling
     ///
-    /// Callback panics are caught and logged but do not affect the return value.
-    /// If a callback panics, remaining callbacks still execute.
+    /// Callback panics are not recovered here. In dev/test profiles the panic
+    /// unwinds through `discard()`. In release builds this workspace uses
+    /// `panic = "abort"`, so a panicking callback aborts the process.
     ///
     /// # Async Callback Warning
     ///
@@ -252,7 +233,8 @@ impl BasicTxn {
 
         self.state = TxnState::Discarded;
 
-        // Execute async callbacks concurrently with panic protection (fire-and-forget for discard)
+        // Async discard callbacks are spawned and run directly. On native
+        // targets a panic in the task follows the runtime panic strategy.
         let txn_id = self.id;
         if !self.discard_async_fns.is_empty() {
             let callback_count = self.discard_async_fns.len();
@@ -261,42 +243,23 @@ impl BasicTxn {
                 count = callback_count,
                 "Spawning async discard callbacks in background"
             );
-            for (i, callback) in self.discard_async_fns.into_iter().enumerate() {
+            for callback in self.discard_async_fns {
                 #[cfg(not(target_arch = "wasm32"))]
                 tokio::spawn(async move {
-                    let result = std::panic::AssertUnwindSafe(callback())
-                        .catch_unwind()
-                        .await;
-                    if let Err(e) = result {
-                        tracing::error!(
-                            txn_id = txn_id,
-                            callback_index = i,
-                            error = ?e,
-                            "Transaction discard async callback panicked"
-                        );
-                    }
+                    callback().await;
                 });
                 // On wasm32, async callbacks cannot be spawned or awaited from
                 // a sync context. Since discard callbacks are fire-and-forget,
                 // we drop them. Use sync callbacks for critical cleanup on wasm32.
                 #[cfg(target_arch = "wasm32")]
                 {
-                    let _ = (callback, i);
+                    let _ = callback;
                 }
             }
         }
 
-        // Execute sync callbacks with panic protection
-        for (i, callback) in self.discard_fns.into_iter().enumerate() {
-            let callback_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback));
-            if let Err(e) = callback_result {
-                tracing::error!(
-                    txn_id = self.id,
-                    callback_index = i,
-                    error = ?e,
-                    "Transaction discard sync callback panicked - continuing with remaining callbacks"
-                );
-            }
+        for callback in self.discard_fns {
+            callback();
         }
 
         Ok(())

--- a/crates/datastore/tests/txn_tests.rs
+++ b/crates/datastore/tests/txn_tests.rs
@@ -1,6 +1,7 @@
 //! Integration tests for BasicTxn.
 
 use datastore::BasicTxn;
+use futures::FutureExt;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use storage::backends::MemoryStore;
@@ -331,4 +332,92 @@ async fn test_basic_txn_async_discard_callback() {
         .await
         .expect("Timeout waiting for async callback")
         .expect("Failed to receive from callback");
+}
+
+#[tokio::test]
+async fn test_basic_txn_success_callback_panic_propagates() {
+    let store = MemoryStore::new();
+    let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+    let counter = Arc::new(AtomicU32::new(0));
+    let counter_clone = counter.clone();
+    txn.on_success(Box::new(move || {
+        counter_clone.fetch_add(1, Ordering::SeqCst);
+    }));
+    txn.on_success(Box::new(|| {
+        panic!("success callback panic");
+    }));
+    let counter_clone = counter.clone();
+    txn.on_success(Box::new(move || {
+        counter_clone.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    let panic = std::panic::AssertUnwindSafe(async move {
+        txn.commit().await.unwrap();
+    })
+    .catch_unwind()
+    .await;
+
+    assert!(panic.is_err());
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_basic_txn_async_success_callback_panic_propagates() {
+    let store = MemoryStore::new();
+    let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+    let counter = Arc::new(AtomicU32::new(0));
+    let counter_clone = counter.clone();
+    txn.on_success_async(Box::new(move || {
+        Box::pin(async move {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+        })
+    }));
+    txn.on_success_async(Box::new(|| {
+        Box::pin(async {
+            panic!("async success callback panic");
+        })
+    }));
+    let counter_clone = counter.clone();
+    txn.on_success_async(Box::new(move || {
+        Box::pin(async move {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+        })
+    }));
+
+    let panic = std::panic::AssertUnwindSafe(async move {
+        txn.commit().await.unwrap();
+    })
+    .catch_unwind()
+    .await;
+
+    assert!(panic.is_err());
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn test_basic_txn_discard_callback_panic_propagates() {
+    let store = MemoryStore::new();
+    let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+    let counter = Arc::new(AtomicU32::new(0));
+    let counter_clone = counter.clone();
+    txn.on_discard(Box::new(move || {
+        counter_clone.fetch_add(1, Ordering::SeqCst);
+    }));
+    txn.on_discard(Box::new(|| {
+        panic!("discard callback panic");
+    }));
+    let counter_clone = counter.clone();
+    txn.on_discard(Box::new(move || {
+        counter_clone.fetch_add(1, Ordering::SeqCst);
+    }));
+
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        txn.discard().unwrap();
+    }));
+
+    assert!(panic.is_err());
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
 }

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -120,34 +120,17 @@ impl CallbackManager {
 
     // Static execution methods
 
-    /// Execute sync callbacks with panic protection.
+    /// Execute sync callbacks directly.
     pub(crate) fn execute_callbacks(callbacks: Vec<TxnCallback>) {
-        for (i, callback) in callbacks.into_iter().enumerate() {
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback));
-            if let Err(panic_info) = result {
-                tracing::error!(
-                    callback_index = i,
-                    panic = ?panic_info,
-                    "Transaction callback panicked - continuing with remaining callbacks"
-                );
-            }
+        for callback in callbacks {
+            callback();
         }
     }
 
-    /// Execute async callbacks with panic protection.
+    /// Execute async callbacks directly.
     pub(crate) async fn execute_async_callbacks(callbacks: Vec<AsyncTxnCallback>) {
-        use futures::FutureExt;
-
-        for (i, callback) in callbacks.into_iter().enumerate() {
-            let future = callback();
-            let result = std::panic::AssertUnwindSafe(future).catch_unwind().await;
-            if let Err(panic_info) = result {
-                tracing::error!(
-                    callback_index = i,
-                    panic = ?panic_info,
-                    "Async callback panicked during execution - continuing with remaining callbacks"
-                );
-            }
+        for callback in callbacks {
+            callback().await;
         }
     }
 }

--- a/crates/storage/src/backends/test_suite/callbacks.rs
+++ b/crates/storage/src/backends/test_suite/callbacks.rs
@@ -1,4 +1,5 @@
 use crate::corekv::Store;
+use futures::FutureExt;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -80,8 +81,8 @@ pub async fn test_async_success_callback<S: Store>(store: &S) {
     );
 }
 
-/// Test that one callback panic doesn't stop others
-pub async fn test_callback_panic_safety<S: Store>(store: &S) {
+/// Test that sync callback panic propagates to the caller.
+pub async fn test_callback_panic_propagates<S: Store>(store: &S) {
     let mut txn = store.new_txn(false).await.unwrap();
 
     let count = Arc::new(AtomicUsize::new(0));
@@ -97,24 +98,32 @@ pub async fn test_callback_panic_safety<S: Store>(store: &S) {
         panic!("Intentional panic in test");
     }));
 
-    // Third callback - should still run
+    // Third callback - should not run once panic propagation begins
     let count3 = count.clone();
     txn.on_success(Box::new(move || {
         count3.fetch_add(1, Ordering::SeqCst);
     }));
 
     txn.set(b"key", b"value").await.unwrap();
-    txn.commit().await.unwrap();
+    let panic = std::panic::AssertUnwindSafe(async move {
+        txn.commit().await.unwrap();
+    })
+    .catch_unwind()
+    .await;
 
+    assert!(
+        panic.is_err(),
+        "Callback panic should propagate from commit"
+    );
     assert_eq!(
         count.load(Ordering::SeqCst),
-        2,
-        "Both non-panicking callbacks should execute despite middle callback panic"
+        1,
+        "Callbacks after the panic should not execute"
     );
 }
 
-/// Test async callback panic safety
-pub async fn test_async_callback_panic_safety<S: Store>(store: &S) {
+/// Test that async callback panic propagates to the caller.
+pub async fn test_async_callback_panic_propagates<S: Store>(store: &S) {
     let mut txn = store.new_txn(false).await.unwrap();
 
     let count = Arc::new(AtomicUsize::new(0));
@@ -142,13 +151,21 @@ pub async fn test_async_callback_panic_safety<S: Store>(store: &S) {
     }));
 
     txn.set(b"key", b"value").await.unwrap();
-    txn.commit().await.unwrap();
+    let panic = std::panic::AssertUnwindSafe(async move {
+        txn.commit().await.unwrap();
+    })
+    .catch_unwind()
+    .await;
 
-    assert_eq!(count.load(Ordering::SeqCst), 2);
+    assert!(
+        panic.is_err(),
+        "Async callback panic should propagate from commit"
+    );
+    assert_eq!(count.load(Ordering::SeqCst), 1);
 }
 
-/// Test discard callback panic safety
-pub async fn test_discard_callback_panic_safety<S: Store>(store: &S) {
+/// Test that discard callback panic propagates to the caller.
+pub async fn test_discard_callback_panic_propagates<S: Store>(store: &S) {
     let mut txn = store.new_txn(false).await.unwrap();
 
     let count = Arc::new(AtomicUsize::new(0));
@@ -168,7 +185,10 @@ pub async fn test_discard_callback_panic_safety<S: Store>(store: &S) {
     }));
 
     txn.set(b"key", b"value").await.unwrap();
-    txn.discard();
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        txn.discard();
+    }));
 
-    assert_eq!(count.load(Ordering::SeqCst), 2);
+    assert!(panic.is_err(), "Discard callback panic should propagate");
+    assert_eq!(count.load(Ordering::SeqCst), 1);
 }

--- a/crates/storage/src/backends/test_suite/macros.rs
+++ b/crates/storage/src/backends/test_suite/macros.rs
@@ -71,21 +71,21 @@ macro_rules! generate_backend_tests {
         }
 
         #[tokio::test]
-        async fn shared_test_callback_panic_safety() {
+        async fn shared_test_callback_panic_propagates() {
             let store = $store_fn().await;
-            test_suite::test_callback_panic_safety(&store).await;
+            test_suite::test_callback_panic_propagates(&store).await;
         }
 
         #[tokio::test]
-        async fn shared_test_async_callback_panic_safety() {
+        async fn shared_test_async_callback_panic_propagates() {
             let store = $store_fn().await;
-            test_suite::test_async_callback_panic_safety(&store).await;
+            test_suite::test_async_callback_panic_propagates(&store).await;
         }
 
         #[tokio::test]
-        async fn shared_test_discard_callback_panic_safety() {
+        async fn shared_test_discard_callback_panic_propagates() {
             let store = $store_fn().await;
-            test_suite::test_discard_callback_panic_safety(&store).await;
+            test_suite::test_discard_callback_panic_propagates(&store).await;
         }
 
         #[tokio::test]

--- a/crates/storage/src/corekv/traits.rs
+++ b/crates/storage/src/corekv/traits.rs
@@ -263,20 +263,9 @@ pub trait Dropable: Store + private::Sealed {
 ///
 /// # Callback Panic Handling
 ///
-/// All callbacks (sync and async) are wrapped in `std::panic::catch_unwind` to
-/// prevent callback panics from crashing the application. If a callback panics:
-///
-/// - The panic is caught and logged via `tracing::error`
-/// - Remaining callbacks continue to execute
-/// - The return value of `commit()` or `discard()` reflects only the database
-///   operation result, not callback execution
-///
-/// This design ensures that:
-/// 1. A buggy callback cannot prevent transaction completion
-/// 2. All registered callbacks get a chance to run
-/// 3. Panic details are preserved in logs for debugging
-///
-/// Check error logs for callback panic details if callbacks don't appear to execute.
+/// Transaction callbacks run directly. In dev/test profiles, a callback panic
+/// unwinds through the transaction API. In release builds this workspace uses
+/// `panic = "abort"`, so a panicking callback aborts the process.
 ///
 /// # Example
 ///
@@ -305,10 +294,9 @@ pub trait Txn: ReaderWriter + private::Sealed {
     ///
     /// # Callback Panic Handling
     ///
-    /// Callback panics are caught and logged but do not affect the return value.
-    /// If a callback panics, remaining callbacks still execute, and `commit()`
-    /// returns `Ok(())` if the database commit succeeded. Check error logs for
-    /// callback panic details.
+    /// Callback panics are not recovered here. In dev/test profiles the panic
+    /// unwinds through `commit()`. In release builds this workspace uses
+    /// `panic = "abort"`, so a panicking callback aborts the process.
     ///
     /// # Note
     ///
@@ -322,8 +310,9 @@ pub trait Txn: ReaderWriter + private::Sealed {
     ///
     /// # Callback Panic Handling
     ///
-    /// Callback panics are caught and logged but do not prevent discard completion.
-    /// If a callback panics, remaining callbacks still execute.
+    /// Callback panics are not recovered here. In dev/test profiles the panic
+    /// unwinds through `discard()`. In release builds this workspace uses
+    /// `panic = "abort"`, so a panicking callback aborts the process.
     ///
     /// # Note
     ///
@@ -332,38 +321,38 @@ pub trait Txn: ReaderWriter + private::Sealed {
 
     /// Register a synchronous callback to be called on successful commit.
     ///
-    /// Multiple callbacks can be registered and will be executed in order.
-    /// Panics in callbacks are caught and logged; remaining callbacks still execute.
+    /// Multiple callbacks can be registered and will be executed in order until
+    /// one panics or the list completes.
     fn on_success(&mut self, callback: TxnCallback);
 
     /// Register an asynchronous callback to be called on successful commit.
     ///
-    /// Multiple callbacks can be registered and will be executed sequentially in registration order.
-    /// Panics in callbacks are caught and logged; remaining callbacks still execute.
+    /// Multiple callbacks can be registered and will be executed sequentially
+    /// in registration order until one panics or the list completes.
     fn on_success_async(&mut self, callback: AsyncTxnCallback);
 
     /// Register a synchronous callback to be called on commit error.
     ///
-    /// Multiple callbacks can be registered and will be executed in order.
-    /// Panics in callbacks are caught and logged; remaining callbacks still execute.
+    /// Multiple callbacks can be registered and will be executed in order until
+    /// one panics or the list completes.
     fn on_error(&mut self, callback: TxnCallback);
 
     /// Register an asynchronous callback to be called on commit error.
     ///
-    /// Multiple callbacks can be registered and will be executed sequentially in registration order.
-    /// Panics in callbacks are caught and logged; remaining callbacks still execute.
+    /// Multiple callbacks can be registered and will be executed sequentially
+    /// in registration order until one panics or the list completes.
     fn on_error_async(&mut self, callback: AsyncTxnCallback);
 
     /// Register a synchronous callback to be called on discard.
     ///
-    /// Multiple callbacks can be registered and will be executed in order.
-    /// Panics in callbacks are caught and logged; remaining callbacks still execute.
+    /// Multiple callbacks can be registered and will be executed in order until
+    /// one panics or the list completes.
     fn on_discard(&mut self, callback: TxnCallback);
 
     /// Register an asynchronous callback to be called on discard.
     ///
-    /// Multiple callbacks can be registered and will be executed sequentially in registration order.
-    /// Panics in callbacks are caught and logged; remaining callbacks still execute.
+    /// Multiple callbacks can be registered and will be executed sequentially
+    /// in registration order until one panics or the list completes.
     ///
     /// # Fire-and-Forget Warning
     ///


### PR DESCRIPTION
## Summary
- validates issue #659 against current `main`: `Cargo.toml` still sets `[profile.release] panic = "abort"` and the datastore/storage transaction callback paths were still using `catch_unwind`
- takes the smaller coherent fix and removes dead callback recovery instead of changing the workspace release panic strategy
- updates transaction docs/tests so callback panic behavior is explicit: unwind propagates in dev/test, release aborts the process

Closes #659.

## Validation
- confirmed `Cargo.toml:150` still has `panic = "abort"`
- confirmed `crates/datastore/src/txn.rs` and `crates/storage/src/backends/shared.rs` were still wrapping callbacks in `catch_unwind`
- no storage/datastore tests were asserting a release-time recovery contract; existing panic tests only exercised unwind-mode behavior

## Changes
- remove `catch_unwind` / `AssertUnwindSafe` from `BasicTxn` callback execution in `crates/datastore/src/txn.rs`
- remove shared storage callback recovery in `crates/storage/src/backends/shared.rs`, which covers the transaction implementations that use `CallbackManager`
- rewrite transaction trait/docs in `crates/storage/src/corekv/traits.rs` to document the actual panic behavior
- update storage callback tests to assert panic propagation in unwind builds
- add matching `BasicTxn` integration coverage in `crates/datastore/tests/txn_tests.rs`

## Tests
- `cargo test -p storage callback -- --nocapture`
- `cargo test -p datastore --test txn_tests -- --nocapture`
