### PR TITLE
Deduplicate collection_short_id helper

### DIFF
--- a/crates/db/src/collection/mod.rs
+++ b/crates/db/src/collection/mod.rs
@@ -15,23 +15,14 @@ mod crud_datastore;
 mod index_ops;
 mod validation;
 
-use std::hash::{Hash, Hasher};
-
 use crate::error::{Error, Result};
 use crate::index_manager::IndexManager;
 use crate::txn::DbTxn;
 use datastore::NamespaceView;
+pub use defra_core::collection_short_id;
 use document::{DocID, Document, NormalValue};
 use schema::{CollectionVersion, FieldKind, IndexDescription, ScalarArrayKind, ScalarKind};
 use storage::corekv::{IterOptions, Store};
-
-/// Derive a short u32 ID from a collection_id string.
-/// Uses a simple hash to ensure determinism and uniqueness.
-pub fn collection_short_id(collection_id: &str) -> u32 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    collection_id.hash(&mut hasher);
-    hasher.finish() as u32
-}
 
 /// Key prefix for document data in datastore.
 pub(super) const DOC_KEY_PREFIX: &[u8] = b"/d/";

--- a/crates/defra-core/src/collection.rs
+++ b/crates/defra-core/src/collection.rs
@@ -1,6 +1,15 @@
 //! Collection types and operations
 
+use std::hash::{Hash, Hasher};
+
 use crate::types::CollectionId;
+
+/// Derive a short u32 ID from a collection_id string.
+pub fn collection_short_id(collection_id: &str) -> u32 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    collection_id.hash(&mut hasher);
+    hasher.finish() as u32
+}
 
 /// A collection in DefraDB - similar to a table in SQL
 #[derive(Debug, Clone)]
@@ -23,5 +32,19 @@ impl Collection {
             name: name.into(),
             version,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collection_short_id;
+
+    #[test]
+    fn collection_short_id_is_stable() {
+        assert_eq!(collection_short_id("users"), 3731571252);
+        assert_eq!(
+            collection_short_id("bafyreihszin3nr7ja7ig3zpvxypv6h2pvf2kk2ul6w67qnx6n7fgslha6e"),
+            2751466997
+        );
     }
 }

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -26,6 +26,7 @@ pub use block::{
     FieldDefinitionDeltaPayload, LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
     DAG_CBOR_CODEC, SHA2_256_CODE,
 };
+pub use collection::collection_short_id;
 pub use encryption::EncryptionKey;
 pub use error::{Error, Result};
 pub use ipld::{collect_block_links, extract_links, walk_ipld, IpldVisitor};

--- a/crates/query/src/plan/scan.rs
+++ b/crates/query/src/plan/scan.rs
@@ -1,9 +1,9 @@
 //! ScanNode for scanning collection documents
 
 use async_trait::async_trait;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+use defra_core::collection_short_id;
 use schema::CollectionVersion;
 
 use tracing::debug;
@@ -13,14 +13,6 @@ use crate::error::Result;
 use crate::fetcher::DocFetcher;
 use crate::mapper::Filter;
 use crate::planner::{Doc, ExecInfo, PlanNode};
-
-/// Derive a short u32 ID from a collection_id string.
-/// Uses the same hash as db::collection_short_id for consistency.
-fn collection_short_id(collection_id: &str) -> u32 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    collection_id.hash(&mut hasher);
-    hasher.finish() as u32
-}
 
 /// ScanNode scans documents from a collection.
 ///


### PR DESCRIPTION
## Summary
- validated #678 against current `origin/main`; both duplicate `collection_short_id` implementations were still present in `query` and `db`, so the issue remains valid
- moved the shared hash helper into `defra-core` and re-exported it for reuse
- updated `query` and `db` to use the shared implementation without changing behavior
- added a focused regression test in `defra-core` to lock current hash outputs

## Validation
- `cargo test -p defra-core collection_short_id_is_stable -- --nocapture`
- `cargo check -p query`
- `cargo check -p db`

Closes #678