### PR TITLE
Use Filter explain serialization for _docID stripping

### DIFF
--- a/crates/query/src/mapper/filter/filter_impl.rs
+++ b/crates/query/src/mapper/filter/filter_impl.rs
@@ -57,6 +57,24 @@ impl Filter {
         &self.conditions
     }
 
+    /// Convert this filter to explain JSON using the existing raw filter shape.
+    pub fn to_explain_json(&self) -> JsonValue {
+        if self.conditions.is_empty() {
+            JsonValue::Null
+        } else {
+            JsonValue::Object(self.conditions.clone())
+        }
+    }
+
+    /// Convert this filter to explain JSON while stripping `_docID` conditions.
+    ///
+    /// Explain output represents docID lookups separately, so `_docID` should not
+    /// appear in the rendered filter value. The returned JSON preserves the same
+    /// object/array shape used elsewhere in explain output.
+    pub fn to_explain_json_without_docid(&self) -> JsonValue {
+        Self::strip_docid_for_explain(&self.to_explain_json())
+    }
+
     /// Evaluate the filter against document fields
     #[instrument(level = "trace", skip(self, fields, mapping))]
     pub fn matches(&self, fields: &[Option<JsonValue>], mapping: &DocumentMapping) -> Result<bool> {
@@ -259,5 +277,65 @@ impl Filter {
             }
         }
         Ok(true)
+    }
+
+    fn strip_docid_for_explain(value: &JsonValue) -> JsonValue {
+        match value {
+            JsonValue::Object(map) => {
+                let mut result = Map::new();
+
+                for (key, val) in map {
+                    if key == "_docID" {
+                        continue;
+                    }
+
+                    match FilterOp::parse(key) {
+                        Some(FilterOp::And | FilterOp::Or) => {
+                            if let JsonValue::Array(arr) = val {
+                                let filtered: Vec<JsonValue> = arr
+                                    .iter()
+                                    .map(Self::strip_docid_for_explain)
+                                    .filter(|item| {
+                                        !item.is_null()
+                                            && !item
+                                                .as_object()
+                                                .map(|object| object.is_empty())
+                                                .unwrap_or(false)
+                                    })
+                                    .collect();
+
+                                match filtered.len() {
+                                    0 => {}
+                                    1 => {
+                                        if let Some(JsonValue::Object(inner)) =
+                                            filtered.into_iter().next()
+                                        {
+                                            for (inner_key, inner_value) in inner {
+                                                result.insert(inner_key, inner_value);
+                                            }
+                                        }
+                                    }
+                                    _ => {
+                                        result.insert(key.clone(), JsonValue::Array(filtered));
+                                    }
+                                }
+                            } else {
+                                result.insert(key.clone(), val.clone());
+                            }
+                        }
+                        _ => {
+                            result.insert(key.clone(), val.clone());
+                        }
+                    }
+                }
+
+                if result.is_empty() {
+                    JsonValue::Null
+                } else {
+                    JsonValue::Object(result)
+                }
+            }
+            _ => value.clone(),
+        }
     }
 }

--- a/crates/query/src/mapper/filter/filter_tests.rs
+++ b/crates/query/src/mapper/filter/filter_tests.rs
@@ -1124,3 +1124,37 @@ fn test_filter_op_is_array_element_op() {
     assert!(!FilterOp::Eq.is_array_element_op());
     assert!(!FilterOp::Contains.is_array_element_op());
 }
+
+#[test]
+fn test_to_explain_json_without_docid_preserves_shape() {
+    let filter = Filter::from_conditions(map([(
+        "_and".to_string(),
+        json!([
+            {"_docID": {"_eq": "doc-1"}},
+            {
+                "_or": [
+                    {"_docID": {"_eq": "doc-2"}},
+                    {"name": {"_eq": "Alice"}}
+                ]
+            }
+        ]),
+    )]));
+
+    assert_eq!(
+        filter.to_explain_json_without_docid(),
+        json!({"name": {"_eq": "Alice"}})
+    );
+}
+
+#[test]
+fn test_to_explain_json_without_docid_returns_null_when_only_docid_remains() {
+    let filter = Filter::from_conditions(map([(
+        "_and".to_string(),
+        json!([
+            {"_docID": {"_eq": "doc-1"}},
+            {"_or": [{"_docID": {"_eq": "doc-2"}}]}
+        ]),
+    )]));
+
+    assert_eq!(filter.to_explain_json_without_docid(), JsonValue::Null);
+}

--- a/crates/query/src/plan/mod.rs
+++ b/crates/query/src/plan/mod.rs
@@ -21,6 +21,7 @@ mod type_join;
 pub mod view;
 pub mod view_cache;
 
+use crate::mapper::Filter;
 pub use aggregate::{
     AverageNode, AvgSourceMeta, CountNode, CountSourceMeta, MaxNode, MaxSourceMeta, MinNode,
     MinSourceMeta, SumNode, SumSourceMeta,
@@ -53,59 +54,6 @@ pub use view::ViewNode;
 /// Strip `_docID` conditions from filter for explain output.
 /// Go handles docIDs as prefix scans and strips them from filter display.
 /// This handles `_docID` at any nesting level within `_and`/`_or` arrays.
-pub(crate) fn strip_docid_from_conditions(
-    conditions: &serde_json::Map<String, serde_json::Value>,
-) -> serde_json::Value {
-    strip_docid_value(&serde_json::json!(conditions))
-}
-
-fn strip_docid_value(value: &serde_json::Value) -> serde_json::Value {
-    match value {
-        serde_json::Value::Object(map) => {
-            let mut result = serde_json::Map::new();
-            for (key, val) in map {
-                if key == "_docID" {
-                    continue;
-                }
-                if key == "_and" || key == "_or" {
-                    if let serde_json::Value::Array(arr) = val {
-                        let filtered: Vec<serde_json::Value> = arr
-                            .iter()
-                            .map(strip_docid_value)
-                            .filter(|item| {
-                                !item.is_null()
-                                    && !item.as_object().map(|o| o.is_empty()).unwrap_or(false)
-                            })
-                            .collect();
-                        match filtered.len() {
-                            0 => {} // Drop empty logical operator
-                            1 => {
-                                // Unwrap single-element _and/_or
-                                if let Some(serde_json::Value::Object(inner)) =
-                                    filtered.into_iter().next()
-                                {
-                                    for (k, v) in inner {
-                                        result.insert(k, v);
-                                    }
-                                }
-                            }
-                            _ => {
-                                result.insert(key.clone(), serde_json::Value::Array(filtered));
-                            }
-                        }
-                    } else {
-                        result.insert(key.clone(), val.clone());
-                    }
-                } else {
-                    result.insert(key.clone(), val.clone());
-                }
-            }
-            if result.is_empty() {
-                serde_json::Value::Null
-            } else {
-                serde_json::Value::Object(result)
-            }
-        }
-        _ => value.clone(),
-    }
+pub(crate) fn strip_docid_from_filter(filter: &Filter) -> serde_json::Value {
+    filter.to_explain_json_without_docid()
 }

--- a/crates/query/src/plan/scan.rs
+++ b/crates/query/src/plan/scan.rs
@@ -270,15 +270,11 @@ impl PlanNode for ScanNode {
         // (Go converts those to prefix scans). When _docID is a regular filter condition,
         // keep it in the filter output.
         if let Some(ref filter) = self.filter {
-            let conditions = filter.conditions();
             if self.doc_ids.is_some() {
                 // doc_ids provided → strip _docID (it's shown in prefixes)
-                let stripped = super::strip_docid_from_conditions(conditions);
-                obj.insert("filter".to_string(), stripped);
-            } else if conditions.is_empty() {
-                obj.insert("filter".to_string(), serde_json::Value::Null);
+                obj.insert("filter".to_string(), super::strip_docid_from_filter(filter));
             } else {
-                obj.insert("filter".to_string(), serde_json::json!(conditions));
+                obj.insert("filter".to_string(), filter.to_explain_json());
             }
         } else {
             obj.insert("filter".to_string(), serde_json::Value::Null);
@@ -340,5 +336,74 @@ impl PlanNode for ScanNode {
         );
 
         serde_json::Value::Object(obj)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use serde_json::json;
+
+    use super::ScanNode;
+    use crate::document::DocumentMapping;
+    use crate::mapper::Filter;
+    use crate::planner::PlanNode;
+
+    fn make_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "users",
+            "v1",
+            "users-v1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+            ],
+        )
+    }
+
+    fn make_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping
+    }
+
+    #[test]
+    fn explain_keeps_docid_filter_without_doc_id_prefix_scan() {
+        let filter = Filter::from_conditions(serde_json::Map::from_iter([
+            ("_docID".to_string(), json!({"_eq": "doc-1"})),
+            ("name".to_string(), json!({"_eq": "Alice"})),
+        ]));
+
+        let explain = ScanNode::new(make_collection(), make_mapping())
+            .with_filter(filter)
+            .explain();
+
+        assert_eq!(
+            explain["scanNode"]["filter"],
+            json!({
+                "_docID": {"_eq": "doc-1"},
+                "name": {"_eq": "Alice"},
+            })
+        );
+    }
+
+    #[test]
+    fn explain_strips_docid_filter_when_doc_id_prefix_scan_is_present() {
+        let filter = Filter::from_conditions(serde_json::Map::from_iter([
+            ("_docID".to_string(), json!({"_eq": "doc-1"})),
+            ("name".to_string(), json!({"_eq": "Alice"})),
+        ]));
+
+        let explain = ScanNode::new(make_collection(), make_mapping())
+            .with_filter(filter)
+            .with_doc_ids(vec!["doc-1".to_string()])
+            .explain();
+
+        assert_eq!(
+            explain["scanNode"]["filter"],
+            json!({"name": {"_eq": "Alice"}})
+        );
+        assert!(explain["scanNode"]["prefixes"].is_array());
     }
 }

--- a/crates/query/src/plan/select.rs
+++ b/crates/query/src/plan/select.rs
@@ -336,9 +336,7 @@ impl PlanNode for SelectNode {
         // Use explain_filter as fallback when no real filter is set (for relation filter display).
         let display_filter = self.filter.as_ref().or(self.explain_filter.as_ref());
         if let Some(filter) = display_filter {
-            let conditions = filter.conditions();
-            let stripped = super::strip_docid_from_conditions(conditions);
-            obj.insert("filter".to_string(), stripped);
+            obj.insert("filter".to_string(), super::strip_docid_from_filter(filter));
         } else {
             obj.insert("filter".to_string(), serde_json::Value::Null);
         }
@@ -427,5 +425,96 @@ impl PlanNode for SelectNode {
         }
 
         serde_json::Value::Object(obj)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    use super::SelectNode;
+    use crate::document::DocumentMapping;
+    use crate::error::Result;
+    use crate::mapper::Filter;
+    use crate::planner::{Doc, PlanNode};
+
+    struct MockScanNode {
+        mapping: DocumentMapping,
+        current: Doc,
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl PlanNode for MockScanNode {
+        async fn init(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn start(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn next(&mut self) -> Result<bool> {
+            Ok(false)
+        }
+
+        fn value(&self) -> &Doc {
+            &self.current
+        }
+
+        async fn close(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn source(&self) -> Option<&dyn PlanNode> {
+            None
+        }
+
+        fn document_map(&self) -> &DocumentMapping {
+            &self.mapping
+        }
+
+        fn kind(&self) -> &'static str {
+            "scanNode"
+        }
+    }
+
+    fn make_mapping() -> DocumentMapping {
+        let mut mapping = DocumentMapping::new();
+        mapping.add(0, "_docID");
+        mapping.add(1, "name");
+        mapping
+    }
+
+    #[test]
+    fn explain_preserves_select_node_shape_while_stripping_docid_filter() {
+        let filter = Filter::from_conditions(serde_json::Map::from_iter([
+            ("_docID".to_string(), json!({"_eq": "doc-1"})),
+            ("name".to_string(), json!({"_eq": "Alice"})),
+        ]));
+
+        let source: Box<dyn PlanNode> = Box::new(MockScanNode {
+            mapping: make_mapping(),
+            current: Doc::default(),
+        });
+
+        let explain = SelectNode::new(source, make_mapping())
+            .with_filter(filter)
+            .with_doc_ids(vec!["doc-1".to_string()])
+            .explain();
+
+        assert_eq!(
+            explain,
+            json!({
+                "selectNode": {
+                    "docID": ["doc-1"],
+                    "filter": {
+                        "name": {"_eq": "Alice"}
+                    },
+                    "scanNode": {}
+                }
+            })
+        );
     }
 }


### PR DESCRIPTION
Closes #690

## Summary
- move explain-time filter rendering behind `mapper::Filter` so `plan/mod.rs` and its call sites stop manipulating raw condition maps directly
- keep the existing Go-compatible explain JSON shape by having the typed `Filter` path serialize back to the same raw object/array structure
- add focused tests for nested `_docID` stripping plus `scanNode`/`selectNode` explain output shape

## Notes
- this stays local to explain-time rendering and does not broaden into planner or explain schema redesign
- the typed path maps back to the same output format through `Filter::to_explain_json()` and `Filter::to_explain_json_without_docid()`