### PR TITLE
Fix ECIES HMAC key sizing constants

### DIFF
--- a/crates/crypto/src/encryption/ecies.rs
+++ b/crates/crypto/src/encryption/ecies.rs
@@ -10,7 +10,6 @@ use hkdf::Hkdf;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};
-use zeroize::Zeroizing;
 
 use defra_core::Result;
 
@@ -19,29 +18,6 @@ use crate::error::{
     crypto_error, failed_to_parse_ephemeral_public_key, verification_with_hmac_failed,
 };
 use crate::types::{AES_KEY_SIZE, HMAC_KEY_SIZE, HMAC_SIZE, X25519_PUBLIC_KEY_SIZE};
-
-type DerivedKeys = (Zeroizing<[u8; AES_KEY_SIZE]>, Zeroizing<[u8; HMAC_SIZE]>);
-
-fn derive_ecies_keys(shared_secret: &[u8]) -> Result<DerivedKeys> {
-    let hkdf = Hkdf::<Sha256>::new(None, shared_secret);
-
-    let mut keys = Zeroizing::new([0u8; AES_KEY_SIZE + HMAC_SIZE]);
-    hkdf.expand(&[], &mut *keys)
-        .map_err(|e| crypto_error(format!("HKDF expansion failed: {}", e)))?;
-
-    let aes_key = Zeroizing::new(
-        keys[..AES_KEY_SIZE]
-            .try_into()
-            .map_err(|_| crypto_error("failed to derive AES key from HKDF output"))?,
-    );
-    let hmac_key = Zeroizing::new(
-        keys[AES_KEY_SIZE..]
-            .try_into()
-            .map_err(|_| crypto_error("failed to derive HMAC key from HKDF output"))?,
-    );
-
-    Ok((aes_key, hmac_key))
-}
 
 /// Options for ECIES encryption/decryption
 #[derive(Default)]

--- a/crates/crypto/src/encryption/ecies.rs
+++ b/crates/crypto/src/encryption/ecies.rs
@@ -17,7 +17,7 @@ use crate::encryption::aes::{decrypt_aes, encrypt_aes};
 use crate::error::{
     crypto_error, failed_to_parse_ephemeral_public_key, verification_with_hmac_failed,
 };
-use crate::types::{AES_KEY_SIZE, HMAC_SIZE, X25519_PUBLIC_KEY_SIZE};
+use crate::types::{AES_KEY_SIZE, HMAC_KEY_SIZE, HMAC_SIZE, X25519_PUBLIC_KEY_SIZE};
 
 /// Options for ECIES encryption/decryption
 #[derive(Default)]
@@ -127,12 +127,12 @@ pub fn encrypt_ecies(
     // Empty salt and info parameters match the Go implementation.
     let hkdf = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
 
-    let mut keys = [0u8; AES_KEY_SIZE + AES_KEY_SIZE];
+    let mut keys = [0u8; AES_KEY_SIZE + HMAC_KEY_SIZE];
     hkdf.expand(&[], &mut keys)
         .map_err(|e| crypto_error(format!("HKDF expansion failed: {}", e)))?;
 
     let aes_key: [u8; AES_KEY_SIZE] = keys[..AES_KEY_SIZE].try_into().unwrap();
-    let hmac_key: [u8; AES_KEY_SIZE] = keys[AES_KEY_SIZE..].try_into().unwrap();
+    let hmac_key: [u8; HMAC_KEY_SIZE] = keys[AES_KEY_SIZE..].try_into().unwrap();
 
     // 4. Build AAD: ephemeral public key + optional additional data
     let mut aad = ephemeral_public.as_bytes().to_vec();
@@ -231,12 +231,12 @@ pub fn decrypt_ecies(
     // This matches Go's sequential hkdf.Read() calls for P2P compatibility.
     let hkdf = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
 
-    let mut keys = [0u8; AES_KEY_SIZE + AES_KEY_SIZE];
+    let mut keys = [0u8; AES_KEY_SIZE + HMAC_KEY_SIZE];
     hkdf.expand(&[], &mut keys)
         .map_err(|e| crypto_error(format!("HKDF expansion failed: {}", e)))?;
 
     let aes_key: [u8; AES_KEY_SIZE] = keys[..AES_KEY_SIZE].try_into().unwrap();
-    let hmac_key: [u8; AES_KEY_SIZE] = keys[AES_KEY_SIZE..].try_into().unwrap();
+    let hmac_key: [u8; HMAC_KEY_SIZE] = keys[AES_KEY_SIZE..].try_into().unwrap();
 
     // 5. Verify HMAC
     let mut mac = Hmac::<Sha256>::new_from_slice(&hmac_key)

--- a/crates/crypto/src/types.rs
+++ b/crates/crypto/src/types.rs
@@ -37,8 +37,11 @@ pub const AES_KEY_SIZE: usize = 32;
 /// X25519 public key size in bytes
 pub const X25519_PUBLIC_KEY_SIZE: usize = 32;
 
-/// HMAC-SHA256 output size in bytes
+/// HMAC-SHA256 tag size in bytes
 pub const HMAC_SIZE: usize = 32;
+
+/// ECIES HMAC-SHA256 key size in bytes
+pub const HMAC_KEY_SIZE: usize = 32;
 
 /// Ed25519 public key size in bytes
 pub const ED25519_PUBLIC_KEY_SIZE: usize = 32;
@@ -99,6 +102,7 @@ mod tests {
         assert_eq!(AES_KEY_SIZE, 32);
         assert_eq!(X25519_PUBLIC_KEY_SIZE, 32);
         assert_eq!(HMAC_SIZE, 32);
+        assert_eq!(HMAC_KEY_SIZE, 32);
         assert_eq!(ED25519_PUBLIC_KEY_SIZE, 32);
         assert_eq!(ED25519_PRIVATE_KEY_SIZE, 64);
         assert_eq!(SECP256K1_COMPRESSED_PUBLIC_KEY_SIZE, 33);

--- a/crates/crypto/tests/ecies_tests.rs
+++ b/crates/crypto/tests/ecies_tests.rs
@@ -2,7 +2,7 @@
 
 use crypto::encryption::ecies::{decrypt_ecies, encrypt_ecies, EciesOptions};
 use crypto::keys::generation::generate_x25519;
-use crypto::types::{HMAC_SIZE, X25519_PUBLIC_KEY_SIZE};
+use crypto::types::{AES_KEY_SIZE, HMAC_KEY_SIZE, HMAC_SIZE, X25519_PUBLIC_KEY_SIZE};
 use hkdf::Hkdf;
 use sha2::Sha256;
 use x25519_dalek::{PublicKey, StaticSecret};
@@ -556,15 +556,15 @@ fn test_ecies_hkdf_key_derivation() {
 
     // Derive keys using HKDF-SHA256 with empty salt and info (matches Go)
     let hkdf = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
-    let mut keys = [0u8; 64];
+    let mut keys = [0u8; AES_KEY_SIZE + HMAC_KEY_SIZE];
     hkdf.expand(&[], &mut keys).unwrap();
 
-    let aes_key = &keys[..32];
-    let hmac_key = &keys[32..];
+    let aes_key = &keys[..AES_KEY_SIZE];
+    let hmac_key = &keys[AES_KEY_SIZE..];
 
     // Verify derived keys are deterministic
-    assert_eq!(aes_key.len(), 32, "AES key should be 32 bytes");
-    assert_eq!(hmac_key.len(), 32, "HMAC key should be 32 bytes");
+    assert_eq!(aes_key.len(), AES_KEY_SIZE, "AES key should be 32 bytes");
+    assert_eq!(hmac_key.len(), HMAC_KEY_SIZE, "HMAC key should be 32 bytes");
     assert_ne!(aes_key, hmac_key, "AES and HMAC keys should be different");
 
     // Verify keys are non-trivial
@@ -579,7 +579,7 @@ fn test_ecies_hkdf_key_derivation() {
 
     // Re-derive to ensure determinism
     let hkdf2 = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
-    let mut keys2 = [0u8; 64];
+    let mut keys2 = [0u8; AES_KEY_SIZE + HMAC_KEY_SIZE];
     hkdf2.expand(&[], &mut keys2).unwrap();
 
     assert_eq!(keys, keys2, "HKDF derivation should be deterministic");

--- a/crates/crypto/tests/go_compat_encryption.rs
+++ b/crates/crypto/tests/go_compat_encryption.rs
@@ -6,6 +6,7 @@
 use crypto::encryption::aes::{decrypt_aes, encrypt_aes};
 use crypto::encryption::ecies::{decrypt_ecies, encrypt_ecies, EciesOptions};
 use crypto::encryption::nonce::USE_DETERMINISTIC_NONCE;
+use crypto::types::{AES_KEY_SIZE, HMAC_KEY_SIZE};
 use hkdf::Hkdf;
 use serial_test::serial;
 use sha2::Sha256;
@@ -110,11 +111,11 @@ fn test_hkdf_key_derivation_matches_go() {
     // Use the shared secret from Go
     let hkdf = Hkdf::<Sha256>::new(None, &X25519_SHARED_SECRET);
 
-    let mut keys = [0u8; 64];
+    let mut keys = [0u8; AES_KEY_SIZE + HMAC_KEY_SIZE];
     hkdf.expand(&[], &mut keys).unwrap();
 
-    let aes_key = &keys[..32];
-    let hmac_key = &keys[32..];
+    let aes_key = &keys[..AES_KEY_SIZE];
+    let hmac_key = &keys[AES_KEY_SIZE..];
 
     assert_eq!(
         aes_key, &HKDF_AES_KEY,

--- a/crates/crypto/tests/go_compat_encryption.rs
+++ b/crates/crypto/tests/go_compat_encryption.rs
@@ -5,7 +5,7 @@
 
 use crypto::encryption::aes::{decrypt_aes, encrypt_aes};
 use crypto::encryption::ecies::{decrypt_ecies, encrypt_ecies, EciesOptions};
-use crypto::encryption::nonce::USE_DETERMINISTIC_NONCE;
+use crypto::encryption::nonce::set_deterministic_nonce;
 use crypto::types::{AES_KEY_SIZE, HMAC_KEY_SIZE};
 use hkdf::Hkdf;
 use serial_test::serial;


### PR DESCRIPTION
## Summary
- validate issue #643 against current `main` and the Go implementation
- add an explicit `HMAC_KEY_SIZE` constant for ECIES key derivation
- use `AES_KEY_SIZE + HMAC_KEY_SIZE` in Rust ECIES HKDF expansion and update targeted tests to assert the intended split explicitly

## Validation
What is true:
- current `main` used `AES_KEY_SIZE` for the derived HMAC key buffer type and total HKDF buffer sizing in `crates/crypto/src/encryption/ecies.rs`
- this is not a runtime bug today because both sides are 32 bytes on current `main`
- Go already models the split as `AESKeySize` then `HMACSize`, so Rust had a semantic mismatch even though the derived bytes still matched

What this PR does:
- preserves the current wire format and derived key bytes
- makes the Rust code express the ECIES design directly instead of depending on `AES_KEY_SIZE == 32`
- keeps Go compatibility tests passing

## Tests
- `cargo test -p crypto --test go_compat_encryption -- --nocapture`
- `cargo test -p crypto --test ecies_tests -- --nocapture`

Closes #643.
