### PR TITLE
Fix implicit GraphQL query snapshot consistency

### DIFF
--- a/crates/db/src/lensed_fetcher/index_scan.rs
+++ b/crates/db/src/lensed_fetcher/index_scan.rs
@@ -1,0 +1,228 @@
+//! Index scan implementation for LensedDocFetcher.
+
+use std::collections::HashSet;
+
+use defra_core::thread_bounds::MaybeBoxFuture;
+use query::planner::index_selection::{IndexScanParams, IndexScanType};
+use storage::corekv::Store;
+use storage::index::IndexIterator;
+
+use crate::collection::collection_short_id;
+use crate::collection_loader::get_collection_with_lazy_load;
+use crate::index_manager::IndexManager;
+
+use super::LensedDocFetcher;
+
+impl<S: Store + 'static> LensedDocFetcher<S> {
+    pub(super) fn get_by_index_scan_impl<'a>(
+        &'a self,
+        collection_name: &'a str,
+        params: &'a IndexScanParams,
+    ) -> MaybeBoxFuture<'a, query::error::Result<query::fetcher::IndexScanResult>> {
+        Box::pin(self.get_by_index_scan_inner(collection_name, params))
+    }
+
+    async fn get_by_index_scan_inner(
+        &self,
+        collection_name: &str,
+        params: &IndexScanParams,
+    ) -> query::error::Result<query::fetcher::IndexScanResult> {
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
+
+        let short_id = collection_short_id(collection.collection_id());
+        let index_manager =
+            IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to create index manager for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
+
+        let index = index_manager.get_index(&params.index_name).ok_or_else(|| {
+            query::error::QueryError::execution(format!(
+                "index '{}' not found on collection '{}'",
+                params.index_name, collection_name
+            ))
+        })?;
+
+        let limit = params.limit;
+        let offset = params.offset;
+
+        async fn collect_with_limit<I: IndexIterator>(
+            iter: &mut I,
+            limit: Option<u64>,
+            offset: u64,
+            value_filter: Option<&query::planner::index_selection::ScanValueFilter>,
+        ) -> Result<(Vec<String>, u64), query::error::QueryError> {
+            let mut entries = Vec::new();
+            let mut skipped = 0u64;
+            let mut total_iterated = 0u64;
+
+            while let Some(entry) = iter.next().await.map_err(|e| {
+                query::error::QueryError::execution(format!("index iteration error: {}", e))
+            })? {
+                total_iterated += 1;
+
+                if let Some(filter) = value_filter {
+                    if let Some(first_value) = entry.values.first() {
+                        if !filter.matches_value(first_value) {
+                            continue;
+                        }
+                    }
+                }
+
+                if skipped < offset {
+                    skipped += 1;
+                    continue;
+                }
+
+                entries.push(entry.doc_id);
+
+                if let Some(lim) = limit {
+                    if entries.len() >= lim as usize {
+                        break;
+                    }
+                }
+            }
+
+            Ok((entries, total_iterated))
+        }
+
+        let vf = params.value_filter.as_ref();
+        let (raw_doc_ids, raw_fetches): (Vec<String>, u64) = match &params.scan_type {
+            IndexScanType::ExactMatch { values } => {
+                let mut iter = index.get(&datastore, values).await.map_err(|e| {
+                    query::error::QueryError::execution(format!("index error: {}", e))
+                })?;
+                collect_with_limit(&mut iter, limit, offset, vf).await?
+            }
+            IndexScanType::InScan {
+                values,
+                suffix_values,
+            } => {
+                let is_composite = index.description().fields.len() > 1;
+                let has_full_key = !suffix_values.is_empty()
+                    && suffix_values.len() == index.description().fields.len() - 1;
+                let mut all_doc_ids = Vec::new();
+                for value in values {
+                    if has_full_key {
+                        let mut key_values = vec![value.clone()];
+                        key_values.extend(suffix_values.iter().cloned());
+                        let mut iter = index.get(&datastore, &key_values).await.map_err(|e| {
+                            query::error::QueryError::execution(format!("index error: {}", e))
+                        })?;
+                        let entries = iter.collect_all().await.map_err(|e| {
+                            query::error::QueryError::execution(format!(
+                                "index iteration error: {}",
+                                e
+                            ))
+                        })?;
+                        all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
+                    } else if is_composite {
+                        let mut iter = index
+                            .scan_prefix(&datastore, std::slice::from_ref(value), false)
+                            .await
+                            .map_err(|e| {
+                                query::error::QueryError::execution(format!("index error: {}", e))
+                            })?;
+                        let entries = iter.collect_all().await.map_err(|e| {
+                            query::error::QueryError::execution(format!(
+                                "index iteration error: {}",
+                                e
+                            ))
+                        })?;
+                        all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
+                    } else {
+                        let mut iter = index
+                            .get(&datastore, std::slice::from_ref(value))
+                            .await
+                            .map_err(|e| {
+                                query::error::QueryError::execution(format!("index error: {}", e))
+                            })?;
+                        let entries = iter.collect_all().await.map_err(|e| {
+                            query::error::QueryError::execution(format!(
+                                "index iteration error: {}",
+                                e
+                            ))
+                        })?;
+                        all_doc_ids.extend(entries.into_iter().map(|e| e.doc_id));
+                    }
+                }
+                let count = all_doc_ids.len() as u64;
+                (all_doc_ids, count)
+            }
+            IndexScanType::PrefixScan {
+                prefix_values,
+                reverse,
+            } => {
+                let mut iter = index
+                    .scan_prefix(&datastore, prefix_values, *reverse)
+                    .await
+                    .map_err(|e| {
+                        query::error::QueryError::execution(format!("index error: {}", e))
+                    })?;
+                collect_with_limit(&mut iter, limit, offset, vf).await?
+            }
+            IndexScanType::RangeScan {
+                prefix_values,
+                lower,
+                upper,
+                reverse,
+            } => {
+                let mut iter = index
+                    .scan_range(
+                        &datastore,
+                        prefix_values,
+                        lower.clone(),
+                        upper.clone(),
+                        *reverse,
+                    )
+                    .await
+                    .map_err(|e| {
+                        query::error::QueryError::execution(format!("index error: {}", e))
+                    })?;
+                collect_with_limit(&mut iter, limit, offset, vf).await?
+            }
+            IndexScanType::OrScan { branches } => {
+                let mut all_doc_ids = Vec::new();
+                let mut total_raw_fetches = 0u64;
+                for branch in branches {
+                    let branch_params = IndexScanParams {
+                        index_name: params.index_name.clone(),
+                        scan_type: branch.clone(),
+                        limit: None,
+                        offset: 0,
+                        value_filter: None,
+                    };
+                    let branch_result = self
+                        .get_by_index_scan_impl(collection_name, &branch_params)
+                        .await?;
+                    total_raw_fetches += branch_result.raw_fetches();
+                    all_doc_ids.extend(branch_result.doc_ids().iter().cloned());
+                }
+                let mut seen = HashSet::new();
+                let doc_ids: Vec<String> = all_doc_ids
+                    .into_iter()
+                    .filter(|id| seen.insert(id.clone()))
+                    .collect();
+                return Ok(query::fetcher::IndexScanResult::with_raw_count(
+                    doc_ids,
+                    total_raw_fetches,
+                ));
+            }
+            _ => unreachable!(),
+        };
+
+        let mut seen = HashSet::new();
+        let doc_ids: Vec<String> = raw_doc_ids
+            .into_iter()
+            .filter(|id| seen.insert(id.clone()))
+            .collect();
+
+        Ok(query::fetcher::IndexScanResult::with_raw_count(
+            doc_ids,
+            raw_fetches,
+        ))
+    }
+}

--- a/crates/db/src/lensed_fetcher/mod.rs
+++ b/crates/db/src/lensed_fetcher/mod.rs
@@ -171,6 +171,34 @@ impl<S: Store + 'static> DocFetcher for LensedDocFetcher<S> {
         true
     }
 
+    async fn get_document_at_cid(
+        &self,
+        cid: &str,
+        expected_doc_id: Option<&str>,
+    ) -> query::error::Result<Document> {
+        use crate::versioned_fetcher::VersionedFetcher;
+
+        let versioned_fetcher = VersionedFetcher::new(self.txn.clone());
+        versioned_fetcher
+            .get_document_at_cid(cid, expected_doc_id)
+            .await
+            .map_err(|e| query::error::QueryError::execution(e.to_string()))
+    }
+
+    async fn get_documents_at_cid(
+        &self,
+        cid: &str,
+        expected_doc_id: Option<&str>,
+    ) -> query::error::Result<Vec<Document>> {
+        use crate::versioned_fetcher::VersionedFetcher;
+
+        let versioned_fetcher = VersionedFetcher::new(self.txn.clone());
+        versioned_fetcher
+            .get_documents_at_cid(cid, expected_doc_id)
+            .await
+            .map_err(|e| query::error::QueryError::execution(e.to_string()))
+    }
+
     async fn get_view_cache_items(&self, collection_id: u32) -> query::error::Result<Vec<Vec<u8>>> {
         self.get_view_cache_items_impl(collection_id).await
     }

--- a/crates/db/src/lensed_fetcher/mod.rs
+++ b/crates/db/src/lensed_fetcher/mod.rs
@@ -18,6 +18,7 @@
 //! The migrated values and new version are cached in the datastore.
 
 mod fetcher;
+mod index_scan;
 mod migration;
 
 #[cfg(test)]
@@ -130,11 +131,7 @@ impl<S: Store + 'static> DocFetcher for LensedDocFetcher<S> {
         let (collection, datastore) =
             get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
-        let short_id = if collection.schema().root_id > 0 {
-            collection.schema().root_id
-        } else {
-            collection_short_id(collection.collection_id())
-        };
+        let short_id = collection_short_id(collection.collection_id());
         let index_manager =
             IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
                 query::error::QueryError::execution(format!(
@@ -160,6 +157,18 @@ impl<S: Store + 'static> DocFetcher for LensedDocFetcher<S> {
             .map_err(|e| {
                 query::error::QueryError::execution(format!("fulltext search error: {}", e))
             })
+    }
+
+    async fn get_by_index_scan(
+        &self,
+        collection_name: &str,
+        params: &query::planner::index_selection::IndexScanParams,
+    ) -> query::error::Result<query::fetcher::IndexScanResult> {
+        self.get_by_index_scan_impl(collection_name, params).await
+    }
+
+    fn supports_index_queries(&self) -> bool {
+        true
     }
 
     async fn get_view_cache_items(&self, collection_id: u32) -> query::error::Result<Vec<Vec<u8>>> {

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -14,7 +14,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     async fn send_branchable_sync_reply(
         &self,
         peer_id: &PeerId,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
         mut reply: BranchableSyncReply,
     ) -> Result<()> {
         sign_with_transport(&self.runtime.transport, &mut reply)?;

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -14,7 +14,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     async fn send_doc_sync_reply(
         &self,
         peer_id: &PeerId,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
         mut reply: DocSyncReply,
     ) -> Result<()> {
         sign_with_transport(&self.runtime.transport, &mut reply)?;

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -13,7 +13,7 @@ use super::SyncCoordinator;
 use crate::error::{Error, Result};
 use crate::message::{BranchableSyncReply, DocSyncReply, PushLogReply};
 use crate::signing::sign_with_transport;
-use crate::transport::{P2PTransport, PeerId, ResponseToken, TransportEvent};
+use crate::transport::{P2PTransport, PeerId, TransportEvent};
 
 const RATE_LIMITED_MSG: &str = "rate limited: too many requests, retry later";
 
@@ -54,7 +54,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: &PeerId,
         message_id: &str,
-        token: ResponseToken,
+        token: T::ResponseToken,
     ) -> Error {
         tracing::debug!(
             peer_id = %peer_id,
@@ -73,7 +73,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: &PeerId,
         message_id: &str,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) -> Error {
         tracing::debug!(
             peer_id = %peer_id,
@@ -89,7 +89,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: &PeerId,
         message_id: &str,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) -> Error {
         tracing::debug!(
             peer_id = %peer_id,
@@ -117,7 +117,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         peer_id: &PeerId,
         message_id: &str,
         collection_id: &str,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) -> Error {
         tracing::debug!(
             peer_id = %peer_id,
@@ -143,7 +143,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     async fn reject_rate_limited_car_fetch(
         &self,
         peer_id: &PeerId,
-        token: Option<ResponseToken>,
+        token: Option<T::ResponseToken>,
     ) -> Error {
         tracing::debug!(
             peer_id = %peer_id,

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::future::Future;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use acp::nac::NodePermission;
 use identity::Did;
@@ -130,6 +130,29 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                 };
             }
         };
+
+        if matches!(&parsed, ParsedOperation::Query { .. }) {
+            match self.registry.begin(true).await {
+                Ok(handle) => {
+                    let response = self.execute_in_txn(request.clone(), &handle).await;
+                    if let Err(error) = self.registry.rollback(&handle).await {
+                        warn!(
+                            txn_id = %handle,
+                            error = %error,
+                            "Failed to close implicit read-only transaction after query execution"
+                        );
+                    }
+                    return response;
+                }
+                Err(TransactionError::NotSupported(_)) => {}
+                Err(error) => {
+                    return QueryResponse::error(format!(
+                        "failed to create implicit read-only transaction: {}",
+                        error
+                    ));
+                }
+            }
+        }
 
         // Validate that all referenced collections exist before execution
         if let Err(e) = validate_parsed_operation(&parsed, self.effective_provider().as_ref()).await
@@ -498,5 +521,106 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
             schema_str.push_str("}\n\n");
         }
         Ok(schema_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use document::Document;
+    use serde_json::json;
+
+    use crate::fetcher::{DocFetcher, FetchByIdsResult};
+    use crate::test_utils::{MockFetcher, MockTxnRegistry};
+
+    struct ChangingFetcher {
+        call_count: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ChangingFetcher {
+        fn new() -> Self {
+            Self {
+                call_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn make_doc(&self, name: String) -> Document {
+            let mut doc = Document::new();
+            doc.generate_and_set_doc_id().expect("doc id");
+            doc.set("name", serde_json::Value::String(name));
+            doc
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl DocFetcher for ChangingFetcher {
+        async fn get_all(&self, _collection_name: &str) -> Result<Vec<Document>> {
+            let call = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                + 1;
+            Ok(vec![self.make_doc(format!("auto-{call}"))])
+        }
+
+        async fn get_by_ids(
+            &self,
+            collection_name: &str,
+            _doc_ids: &[String],
+        ) -> Result<FetchByIdsResult> {
+            let docs = self.get_all(collection_name).await?;
+            Ok(FetchByIdsResult::all_found(docs))
+        }
+
+        async fn get_by_field_value(
+            &self,
+            collection_name: &str,
+            _field_name: &str,
+            _value: &str,
+        ) -> Result<Vec<Document>> {
+            self.get_all(collection_name).await
+        }
+    }
+
+    fn make_users_doc(name: &str) -> Document {
+        let mut doc = Document::new();
+        doc.generate_and_set_doc_id().expect("doc id");
+        doc.set("name", serde_json::Value::String(name.to_string()));
+        doc
+    }
+
+    #[tokio::test]
+    async fn execute_uses_implicit_read_txn_when_registry_is_available() {
+        let collections = crate::parse_sdl("type Users { name: String }").expect("schema");
+
+        let txn_fetcher = MockFetcher::new();
+        txn_fetcher.add_doc("Users", make_users_doc("txn-snapshot"));
+
+        let runner = QueryRunner::with_registry(
+            ChangingFetcher::new(),
+            collections,
+            MockTxnRegistry::new(txn_fetcher),
+        );
+
+        let response = runner
+            .execute(QueryRequest::new(
+                "{ first: Users { name } second: Users { name } }",
+            ))
+            .await;
+
+        assert!(
+            !response.has_errors(),
+            "unexpected errors: {:?}",
+            response.errors
+        );
+        assert_eq!(
+            response.data,
+            Some(json!({
+                "first": [{"name": "txn-snapshot"}],
+                "second": [{"name": "txn-snapshot"}],
+            }))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- execute regular GraphQL query requests inside an implicit read-only transaction when a transaction registry is available
- fall back to the existing auto-commit fetcher path only when transactions are not supported
- add a regression test proving a single GraphQL request now sees one transaction-scoped snapshot instead of per-fetch snapshots

## Testing
- cargo test -p query execute_uses_implicit_read_txn_when_registry_is_available
- cargo test -p query test_query_response_success

Closes #649