### PR TITLE
Fix fulltext index name collisions

### DIFF
--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -448,7 +448,7 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
         let (_collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
 
-        let idx_name = format!("{}_fulltext", field_name);
+        let idx_name = crate::index_manager::fulltext_index_name(field_name);
         let ft_index = index_manager
             .get_index(&idx_name)
             .and_then(|idx| idx.as_fulltext())

--- a/crates/db/src/index_manager/mod.rs
+++ b/crates/db/src/index_manager/mod.rs
@@ -63,6 +63,15 @@ fn is_valid_index_name(name: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+/// Generate the internal map key used for full-text indexes.
+///
+/// This key is intentionally invalid for public index creation APIs because
+/// full-text indexes are synthesized from `@fulltext` schema directives and do
+/// not share the same namespace as user-defined secondary indexes.
+pub(crate) fn fulltext_index_name(field_name: &str) -> String {
+    format!("__fulltext__:{field_name}")
+}
+
 /// Manages indexes for a collection.
 ///
 /// Provides operations for creating, dropping, and maintaining secondary indexes.
@@ -106,7 +115,7 @@ impl IndexManager {
         // with regular indexes (which use the IndexIDSequenceKey mechanism).
         // The high-bit (0x8000_0000) separates the namespace from regular index IDs.
         for ft_desc in &schema.fulltext_indexes {
-            let idx_name = format!("{}_fulltext", ft_desc.field_name);
+            let idx_name = fulltext_index_name(&ft_desc.field_name);
             let idx_id = {
                 // FNV-1a: stable across Rust versions unlike DefaultHasher
                 let mut h: u32 = 2166136261;

--- a/crates/db/src/lensed_auto_commit_fetcher/mod.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/mod.rs
@@ -145,7 +145,7 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
                     ))
                 })?;
 
-        let idx_name = format!("{}_fulltext", field_name);
+        let idx_name = crate::index_manager::fulltext_index_name(field_name);
         let ft_index = index_manager
             .get_index(&idx_name)
             .and_then(|idx| idx.as_fulltext())

--- a/crates/db/src/lensed_fetcher/mod.rs
+++ b/crates/db/src/lensed_fetcher/mod.rs
@@ -143,7 +143,7 @@ impl<S: Store + 'static> DocFetcher for LensedDocFetcher<S> {
                 ))
             })?;
 
-        let idx_name = format!("{}_fulltext", field_name);
+        let idx_name = crate::index_manager::fulltext_index_name(field_name);
         let ft_index = index_manager
             .get_index(&idx_name)
             .and_then(|idx| idx.as_fulltext())

--- a/crates/db/tests/index_manager_tests.rs
+++ b/crates/db/tests/index_manager_tests.rs
@@ -5,10 +5,13 @@ use db::index_manager::IndexManager;
 use db::Error;
 use document::{Document, NormalValue};
 use schema::{
-    CollectionVersion, FieldDescription, FieldKind, IndexDescription, IndexedFieldDescription,
+    CollectionVersion, FieldDescription, FieldKind, FullTextIndexDescription, IndexDescription,
+    IndexedFieldDescription,
 };
 use storage::backends::MemoryStore;
 use storage::index::IndexIterator;
+
+const RESERVED_FULLTEXT_INDEX_NAME_FOR_NAME: &str = "__fulltext__:name";
 
 fn test_schema() -> CollectionVersion {
     CollectionVersion::new(
@@ -277,6 +280,49 @@ async fn test_from_collection_with_indexes() {
     assert_eq!(manager.index_count(), 2);
     assert!(manager.has_index("idx_name"));
     assert!(manager.has_index("idx_email"));
+}
+
+#[tokio::test]
+async fn test_fulltext_indexes_use_reserved_internal_names() {
+    let mut schema = test_schema();
+    schema.fulltext_indexes = vec![FullTextIndexDescription::new("name")];
+
+    let manager = IndexManager::from_collection(1, &schema).unwrap();
+
+    assert!(manager.has_index(RESERVED_FULLTEXT_INDEX_NAME_FOR_NAME));
+    assert!(!manager.has_index("name_fulltext"));
+}
+
+#[tokio::test]
+async fn test_regular_index_named_field_fulltext_does_not_collide_with_fulltext_index() {
+    let store = MemoryStore::new();
+    let db = DB::new(store).unwrap();
+    let txn = db.new_txn(false).await.unwrap();
+    let datastore = txn.datastore().unwrap();
+
+    let mut schema = test_schema();
+    schema.fulltext_indexes = vec![FullTextIndexDescription::new("name")];
+
+    let mut manager = IndexManager::from_collection(1, &schema).unwrap();
+
+    let desc = manager
+        .create_index(
+            &datastore,
+            "users",
+            "name_fulltext".to_string(),
+            vec![IndexedFieldDescription {
+                name: "email".to_string(),
+                descending: false,
+            }],
+            false,
+            &schema.fields,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(desc.name, "name_fulltext");
+    assert!(manager.has_index("name_fulltext"));
+    assert!(manager.has_index(RESERVED_FULLTEXT_INDEX_NAME_FOR_NAME));
 }
 
 #[tokio::test]

--- a/tools/integration-test/tests/fts/edge_cases.rs
+++ b/tools/integration-test/tests/fts/edge_cases.rs
@@ -117,3 +117,40 @@ async fn bm25_empty_field_does_not_crash() {
         "Doc with content should score positive"
     );
 }
+
+#[tokio::test]
+async fn bm25_works_with_user_index_named_like_legacy_fulltext_key() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    let client = cluster.client(0);
+    client.schema_add(SCHEMA).unwrap();
+
+    client
+        .index_create("Article", &["category"], Some("title_fulltext"), false)
+        .expect("create regular index using legacy fulltext-style name");
+
+    client
+        .query(r#"mutation { add_Article(input: {title: "Rust Search", body: "Searching rust content", category: "tech"}) { _docID } }"#)
+        .unwrap();
+    client
+        .query(r#"mutation { add_Article(input: {title: "Gardening Notes", body: "Soil and seeds", category: "home"}) { _docID } }"#)
+        .unwrap();
+
+    let data = client
+        .query(
+            r#"query { Article(order: {_alias: {BM25: DESC}}) { title BM25(query: "rust", fields: ["title"]) } }"#,
+        )
+        .unwrap();
+
+    let articles = data["Article"].as_array().unwrap();
+    assert_eq!(articles.len(), 2);
+    assert_eq!(articles[0]["title"].as_str(), Some("Rust Search"));
+    assert!(
+        articles[0]["BM25"].as_f64().unwrap_or(0.0) > 0.0,
+        "BM25 should still resolve the full-text index after creating title_fulltext"
+    );
+    assert_eq!(
+        articles[1]["BM25"].as_f64().unwrap_or(0.0),
+        0.0,
+        "Non-matching document should still receive zero score"
+    );
+}


### PR DESCRIPTION
## Summary
- reserve an internal-only key format for synthesized full-text indexes
- update BM25 lookup paths to use the shared internal key helper
- add regression tests showing a normal index named  no longer collides with a  index on 

## Validation
- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 129 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s


running 1 test
test test_fulltext_indexes_use_reserved_internal_names ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 29 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.00s
- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 129 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s


running 1 test
test test_regular_index_named_field_fulltext_does_not_collide_with_fulltext_index ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 29 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 17 filtered out; finished in 0.00s

Closes #646