### PR TITLE
Use persisted root IDs instead of legacy collection short IDs

### DIFF
--- a/crates/cli/src/index_adapter.rs
+++ b/crates/cli/src/index_adapter.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use db::collection::collection_short_id;
 use db::IndexManager;
 use defra_http::router::{IndexFieldInfo, IndexInfo, IndexOperations};
 use schema::IndexedFieldDescription;
@@ -41,11 +40,7 @@ impl<S: Store + 'static> IndexOperations for IndexAdapter<S> {
             .map_err(|e| format!("{}", e))?;
 
         let schema = col.schema().clone();
-        let short_id = if schema.root_id > 0 {
-            schema.root_id
-        } else {
-            collection_short_id(col.collection_id())
-        };
+        let short_id = schema.resolved_root_id();
 
         let mut index_manager =
             IndexManager::from_collection(short_id, &schema).map_err(|e| format!("{}", e))?;
@@ -177,11 +172,7 @@ impl<S: Store + 'static> IndexOperations for IndexAdapter<S> {
             .map_err(|e| format!("{}", e))?;
 
         let schema = col.schema().clone();
-        let short_id = if schema.root_id > 0 {
-            schema.root_id
-        } else {
-            collection_short_id(col.collection_id())
-        };
+        let short_id = schema.resolved_root_id();
 
         let mut index_manager =
             IndexManager::from_collection(short_id, &schema).map_err(|e| format!("{}", e))?;

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -48,22 +48,6 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
         }
     }
 
-    pub fn with_full_context_arc(
-        transport: IrohTransport,
-        coordinator: Arc<IrohSyncCoordinator<B>>,
-        doc_pusher: Arc<dyn TransportDocPusher>,
-        event_bus: Arc<dyn events::Bus>,
-        version_syncer: Option<Arc<dyn TransportVersionSyncer>>,
-    ) -> Arc<dyn P2POperations> {
-        Arc::new(Self::with_full_context(
-            transport,
-            coordinator,
-            doc_pusher,
-            event_bus,
-            version_syncer,
-        ))
-    }
-
     pub fn set_initial_tracked_documents(&self, docs: HashSet<String>) {
         if let Ok(mut tracked) = self.tracked_documents.write() {
             *tracked = docs;

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -12,7 +12,6 @@ use storage::corekv::Store;
 use tracing::warn;
 
 use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
-use crate::collection::collection_short_id;
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
 use crate::txn::DbTxn;
@@ -193,7 +192,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
                 }
             })?;
 
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id();
         let enc_config = get_encryption_config();
         let sign_config = get_signing_config();
@@ -335,7 +334,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
                 }
             })?;
 
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id();
         let enc_config = get_encryption_config()
             .or_else(|| doc.id().and_then(|id| get_doc_encryption(&id.to_string())));
@@ -436,7 +435,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))?;
 
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id();
         let sign_config = get_signing_config();
 

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -50,7 +50,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             })?;
 
             // Create an IndexManager for unique constraint enforcement
-            let short_id = collection_short_id(collection.collection_id());
+            let short_id = collection.resolved_root_id();
             let index_manager = IndexManager::from_collection(short_id, collection.schema())
                 .map_err(|e| {
                     query::error::QueryError::execution(format!(
@@ -137,7 +137,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                             // For branchable collections, create a collection-level block
                             let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
                             if collection.schema().is_branchable {
-                                let short_id = collection_short_id(collection.collection_id());
+                                let short_id = collection.resolved_root_id();
                                 match write_collection_block(
                                     &blockstore,
                                     &headstore,

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -24,7 +24,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
         let collection = self.get_collection_or_err(collection_name)?;
 
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id().to_string();
         let sign_config = get_signing_config();
         let enc_config = get_encryption_config();

--- a/crates/db/src/auto_commit_mutator/delete.rs
+++ b/crates/db/src/auto_commit_mutator/delete.rs
@@ -23,7 +23,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             })?;
 
             // Create an IndexManager for index maintenance
-            let short_id = collection_short_id(collection.collection_id());
+            let short_id = collection.resolved_root_id();
             let index_manager = IndexManager::from_collection(short_id, collection.schema())
                 .map_err(|e| {
                     query::error::QueryError::execution(format!(
@@ -75,7 +75,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
                             // For branchable collections, also create a collection-level block
                             if collection.schema().is_branchable {
-                                let short_id = collection_short_id(collection.collection_id());
+                                let short_id = collection.resolved_root_id();
                                 if let Err(e) = write_collection_block(
                                     &blockstore,
                                     &headstore,

--- a/crates/db/src/auto_commit_mutator/delete_many.rs
+++ b/crates/db/src/auto_commit_mutator/delete_many.rs
@@ -24,7 +24,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         }
 
         let collection = self.get_collection_or_err(collection_name)?;
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id().to_string();
         let sign_config = get_signing_config();
 

--- a/crates/db/src/auto_commit_mutator/mod.rs
+++ b/crates/db/src/auto_commit_mutator/mod.rs
@@ -24,7 +24,6 @@ use storage::corekv::Store;
 use tracing::warn;
 
 use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
-use crate::collection::collection_short_id;
 use crate::database::DB;
 use crate::index_manager::IndexManager;
 use crate::lensed_fetcher::LensedDocFetcher;

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -44,7 +44,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             })?;
 
             // Create an IndexManager for index maintenance
-            let short_id = collection_short_id(collection.collection_id());
+            let short_id = collection.resolved_root_id();
             let index_manager = IndexManager::from_collection(short_id, collection.schema())
                 .map_err(|e| {
                     query::error::QueryError::execution(format!(
@@ -134,7 +134,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                             // For branchable collections, create a collection-level block
                             let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
                             if collection.schema().is_branchable {
-                                let short_id = collection_short_id(collection.collection_id());
+                                let short_id = collection.resolved_root_id();
                                 match write_collection_block(
                                     &blockstore,
                                     &headstore,

--- a/crates/db/src/collection/mod.rs
+++ b/crates/db/src/collection/mod.rs
@@ -25,7 +25,7 @@ use schema::{
     ScalarKind,
 };
 use storage::corekv::{IterOptions, Key, Store};
-use storage::keys::systemstore::CollectionID;
+use storage::keys::systemstore::{CollectionID, CollectionIDSequenceKey};
 
 /// Derive the legacy short ID from a collection_id string.
 ///
@@ -70,6 +70,38 @@ pub async fn require_persisted_collection_short_id(
                 collection_id
             ))
         })
+}
+
+/// Load the persisted root ID for a collection, allocating one if it does not exist yet.
+pub async fn ensure_persisted_collection_short_id(
+    systemstore: &NamespaceView,
+    collection_id: &str,
+) -> Result<u32> {
+    if let Some(short_id) = load_persisted_collection_short_id(systemstore, collection_id).await? {
+        return Ok(short_id);
+    }
+
+    let seq_key = CollectionIDSequenceKey;
+    let key_bytes = seq_key.bytes();
+    let current: u32 = match systemstore.get(&key_bytes).await.map_err(Error::Storage)? {
+        Some(bytes) if bytes.len() == 4 => {
+            u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
+        }
+        _ => 0,
+    };
+    let next = current + 1;
+    systemstore
+        .set(&key_bytes, &next.to_be_bytes())
+        .await
+        .map_err(Error::Storage)?;
+
+    let short_id_key = CollectionID::new(collection_id);
+    systemstore
+        .set(&short_id_key.bytes(), next.to_string().as_bytes())
+        .await
+        .map_err(Error::Storage)?;
+
+    Ok(next)
 }
 
 /// Populate a deserialized collection schema with its persisted root ID.

--- a/crates/db/src/collection/mod.rs
+++ b/crates/db/src/collection/mod.rs
@@ -29,8 +29,9 @@ use storage::keys::systemstore::CollectionID;
 
 /// Derive the legacy short ID from a collection_id string.
 ///
-/// New code should prefer `CollectionVersion::resolved_root_id()` or `Collection::resolved_root_id()`
-/// so persisted root IDs win whenever they are available.
+/// This is retained only for compatibility with older metadata and tests. Store-backed code
+/// should resolve or require the persisted `root_id` instead.
+#[deprecated(note = "use persisted collection root IDs instead")]
 pub fn collection_short_id(collection_id: &str) -> u32 {
     legacy_collection_short_id(collection_id)
 }
@@ -54,6 +55,33 @@ pub async fn load_persisted_collection_short_id(
     };
 
     Ok(short_id_str.parse::<u32>().ok())
+}
+
+/// Load the persisted root ID for a collection, returning an error if the mapping is missing.
+pub async fn require_persisted_collection_short_id(
+    systemstore: &NamespaceView,
+    collection_id: &str,
+) -> Result<u32> {
+    load_persisted_collection_short_id(systemstore, collection_id)
+        .await?
+        .ok_or_else(|| {
+            Error::Other(format!(
+                "missing persisted collection root_id for collection_id '{}'",
+                collection_id
+            ))
+        })
+}
+
+/// Populate a deserialized collection schema with its persisted root ID.
+pub async fn populate_collection_root_id(
+    systemstore: &NamespaceView,
+    schema: &mut CollectionVersion,
+) -> Result<()> {
+    if schema.root_id == 0 {
+        schema.root_id =
+            require_persisted_collection_short_id(systemstore, &schema.collection_id).await?;
+    }
+    Ok(())
 }
 
 /// Key prefix for document data in datastore.

--- a/crates/db/src/collection/mod.rs
+++ b/crates/db/src/collection/mod.rs
@@ -15,22 +15,45 @@ mod crud_datastore;
 mod index_ops;
 mod validation;
 
-use std::hash::{Hash, Hasher};
-
 use crate::error::{Error, Result};
 use crate::index_manager::IndexManager;
 use crate::txn::DbTxn;
 use datastore::NamespaceView;
 use document::{DocID, Document, NormalValue};
-use schema::{CollectionVersion, FieldKind, IndexDescription, ScalarArrayKind, ScalarKind};
-use storage::corekv::{IterOptions, Store};
+use schema::{
+    legacy_collection_short_id, CollectionVersion, FieldKind, IndexDescription, ScalarArrayKind,
+    ScalarKind,
+};
+use storage::corekv::{IterOptions, Key, Store};
+use storage::keys::systemstore::CollectionID;
 
-/// Derive a short u32 ID from a collection_id string.
-/// Uses a simple hash to ensure determinism and uniqueness.
+/// Derive the legacy short ID from a collection_id string.
+///
+/// New code should prefer `CollectionVersion::resolved_root_id()` or `Collection::resolved_root_id()`
+/// so persisted root IDs win whenever they are available.
 pub fn collection_short_id(collection_id: &str) -> u32 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    collection_id.hash(&mut hasher);
-    hasher.finish() as u32
+    legacy_collection_short_id(collection_id)
+}
+
+/// Load the persisted short ID for a collection if one exists.
+pub async fn load_persisted_collection_short_id(
+    systemstore: &NamespaceView,
+    collection_id: &str,
+) -> Result<Option<u32>> {
+    let short_id_key = CollectionID::new(collection_id);
+    let Some(short_id_bytes) = systemstore
+        .get(&short_id_key.bytes())
+        .await
+        .map_err(Error::Storage)?
+    else {
+        return Ok(None);
+    };
+
+    let Ok(short_id_str) = String::from_utf8(short_id_bytes.to_vec()) else {
+        return Ok(None);
+    };
+
+    Ok(short_id_str.parse::<u32>().ok())
 }
 
 /// Key prefix for document data in datastore.
@@ -76,6 +99,11 @@ impl Collection {
     /// Get the collection schema.
     pub fn schema(&self) -> &CollectionVersion {
         &self.def
+    }
+
+    /// Get the storage prefix ID used for indexes, heads, and view cache keys.
+    pub fn resolved_root_id(&self) -> u32 {
+        self.def.resolved_root_id()
     }
 
     /// Get all indexes defined on this collection.

--- a/crates/db/src/collection/mod.rs
+++ b/crates/db/src/collection/mod.rs
@@ -19,7 +19,6 @@ use crate::error::{Error, Result};
 use crate::index_manager::IndexManager;
 use crate::txn::DbTxn;
 use datastore::NamespaceView;
-pub use defra_core::collection_short_id;
 use document::{DocID, Document, NormalValue};
 use schema::{
     legacy_collection_short_id, CollectionVersion, FieldKind, IndexDescription, ScalarArrayKind,

--- a/crates/db/src/collection_loader.rs
+++ b/crates/db/src/collection_loader.rs
@@ -9,10 +9,10 @@ use async_lock::Mutex as TokioMutex;
 use datastore::NamespaceView;
 use schema::CollectionVersion;
 use storage::corekv::{Key, Store};
-use storage::keys::systemstore::{CollectionID, CollectionKey, CollectionNameKey};
+use storage::keys::systemstore::{CollectionKey, CollectionNameKey};
 use tracing::{error, warn};
 
-use crate::collection::Collection;
+use crate::collection::{populate_collection_root_id, Collection};
 use crate::index_manager::IndexManager;
 use crate::txn::DbTxn;
 
@@ -85,13 +85,14 @@ pub(crate) async fn load_collection_from_systemstore(
                 ))
             })?;
 
-            // Load sequential short ID from /collection/shortID/{collection_id}
-            let short_id_key = CollectionID::new(&schema.collection_id);
-            if let Ok(Some(short_id_bytes)) = systemstore.get(&short_id_key.bytes()).await {
-                if let Ok(short_id_str) = String::from_utf8(short_id_bytes) {
-                    schema.root_id = short_id_str.parse::<u32>().unwrap_or(0);
-                }
-            }
+            populate_collection_root_id(systemstore, &mut schema)
+                .await
+                .map_err(|e| {
+                    query::error::QueryError::execution(format!(
+                        "failed to load persisted root_id for collection '{}': {}",
+                        name, e
+                    ))
+                })?;
 
             Ok(Some(Collection::new(schema)))
         }

--- a/crates/db/src/collection_loader.rs
+++ b/crates/db/src/collection_loader.rs
@@ -12,7 +12,7 @@ use storage::corekv::{Key, Store};
 use storage::keys::systemstore::{CollectionID, CollectionKey, CollectionNameKey};
 use tracing::{error, warn};
 
-use crate::collection::{collection_short_id, Collection};
+use crate::collection::Collection;
 use crate::index_manager::IndexManager;
 use crate::txn::DbTxn;
 
@@ -183,13 +183,8 @@ pub(crate) async fn get_collection_with_index_manager<S: Store + 'static>(
 ) -> query::error::Result<(Collection, NamespaceView, IndexManager)> {
     let (collection, datastore) = get_collection_with_lazy_load(txn, collection_name).await?;
 
-    // Create an IndexManager from the collection schema
-    // Use sequential root_id if available, fall back to hash-based short_id
-    let short_id = if collection.schema().root_id > 0 {
-        collection.schema().root_id
-    } else {
-        collection_short_id(collection.collection_id())
-    };
+    // Create an IndexManager from the collection schema.
+    let short_id = collection.resolved_root_id();
     let index_manager =
         IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
             query::error::QueryError::execution(format!(

--- a/crates/db/src/collection_ops/create.rs
+++ b/crates/db/src/collection_ops/create.rs
@@ -125,8 +125,7 @@ impl<S: Store> crate::database::DB<S> {
         // Go assigns them via IndexManager.next_index_id() which uses a per-collection
         // sequence key. We replicate that here so IDs match Go exactly.
         if !schema.indexes.is_empty() {
-            let col_short_id = crate::collection::collection_short_id(collection_id.as_str());
-            let seq_key = IndexIDSequenceKey::new(format!("{}", col_short_id));
+            let seq_key = IndexIDSequenceKey::new(format!("{}", short_id));
             let key_bytes = seq_key.bytes();
             let mut current: u32 =
                 match systemstore.get(&key_bytes).await.map_err(Error::Storage)? {

--- a/crates/db/src/collection_ops/create.rs
+++ b/crates/db/src/collection_ops/create.rs
@@ -1,28 +1,6 @@
 use super::*;
 
 impl<S: Store> crate::database::DB<S> {
-    /// Get the next collection short ID from the sequence key.
-    pub(crate) async fn next_collection_short_id(systemstore: &NamespaceView) -> Result<u32> {
-        let seq_key = CollectionIDSequenceKey;
-        let key_bytes = seq_key.bytes();
-        let current: u32 = match systemstore.get(&key_bytes).await.map_err(Error::Storage)? {
-            Some(bytes) => {
-                if bytes.len() == 4 {
-                    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
-                } else {
-                    0
-                }
-            }
-            None => 0,
-        };
-        let next = current + 1;
-        systemstore
-            .set(&key_bytes, &next.to_be_bytes())
-            .await
-            .map_err(Error::Storage)?;
-        Ok(next)
-    }
-
     /// Create a collection within an existing transaction.
     ///
     /// This method validates the collection schema, assigns a unique short ID,
@@ -117,7 +95,9 @@ impl<S: Store> crate::database::DB<S> {
         let systemstore = txn.systemstore()?;
 
         // Assign sequential short ID (matches Go's monotonic counter)
-        let short_id = Self::next_collection_short_id(&systemstore).await?;
+        let short_id =
+            crate::collection::ensure_persisted_collection_short_id(&systemstore, collection_id)
+                .await?;
         schema.root_id = short_id;
 
         // Re-assign index IDs from the persistent sequence so they start at 1.
@@ -147,13 +127,6 @@ impl<S: Store> crate::database::DB<S> {
                 .await
                 .map_err(Error::Storage)?;
         }
-
-        // Store short ID mapping at /collection/shortID/{collection_id}
-        let short_id_key = CollectionID::new(collection_id.as_str());
-        systemstore
-            .set(&short_id_key.bytes(), short_id.to_string().as_bytes())
-            .await
-            .map_err(Error::Storage)?;
 
         // 1. Store full schema at /collection/id/{version_id}
         let collection_key = CollectionKey::new(version_id.as_str());

--- a/crates/db/src/collection_ops/delete.rs
+++ b/crates/db/src/collection_ops/delete.rs
@@ -105,7 +105,7 @@ impl<S: Store> crate::database::DB<S> {
             .ok_or_else(|| Error::CollectionNotFound(name.to_string()))?;
 
         let collection_id = collection.collection_id().to_string();
-        let short_id = crate::collection::collection_short_id(&collection_id);
+        let short_id = collection.resolved_root_id();
 
         // Phase 1: Collect all doc_ids in a read-only txn
         let doc_ids = self.collect_doc_ids(&collection_id).await?;

--- a/crates/db/src/collection_ops/mod.rs
+++ b/crates/db/src/collection_ops/mod.rs
@@ -12,7 +12,7 @@ mod lookup;
 mod resolve;
 mod version;
 
-use crate::collection::Collection;
+use crate::collection::{populate_collection_root_id, Collection};
 use crate::collection_name::CollectionName;
 use crate::collection_snapshot::CollectionSnapshot;
 use crate::error::{Error, Result};
@@ -162,22 +162,7 @@ impl<S: Store> crate::database::DB<S> {
                         ))
                     })?;
 
-                // If the collection doesn't have a root_id yet (existing data from before root_id
-                // was added), look it up from the short ID mapping
-                if schema.root_id == 0 {
-                    let short_id_key = CollectionID::new(&schema.collection_id);
-                    if let Some(short_id_bytes) = systemstore
-                        .get(&short_id_key.bytes())
-                        .await
-                        .map_err(Error::Storage)?
-                    {
-                        if let Ok(short_id_str) = String::from_utf8(short_id_bytes.to_vec()) {
-                            if let Ok(short_id) = short_id_str.parse::<u32>() {
-                                schema.root_id = short_id;
-                            }
-                        }
-                    }
-                }
+                populate_collection_root_id(&systemstore, &mut schema).await?;
 
                 // Store in map with collection name for relation finalization later
                 schemas.insert(name.clone(), schema);

--- a/crates/db/src/collection_ops/mod.rs
+++ b/crates/db/src/collection_ops/mod.rs
@@ -21,8 +21,7 @@ use datastore::NamespaceView;
 use schema::CollectionVersion;
 use storage::corekv::{IterOptions, Key, Store};
 use storage::keys::systemstore::{
-    CollectionID, CollectionIDSequenceKey, CollectionKey, CollectionNameKey, CollectionVersionKey,
-    IndexIDSequenceKey,
+    CollectionKey, CollectionNameKey, CollectionVersionKey, IndexIDSequenceKey,
 };
 use tracing::instrument;
 

--- a/crates/db/src/collection_ops/version.rs
+++ b/crates/db/src/collection_ops/version.rs
@@ -41,6 +41,8 @@ impl<S: Store> crate::database::DB<S> {
                         version_id, e
                     ))
                 })?;
+            crate::collection::populate_collection_root_id(&systemstore, &mut target_schema)
+                .await?;
 
             let name = target_schema.name.clone();
             let collection_id = target_schema.collection_id.clone();
@@ -186,7 +188,11 @@ impl<S: Store> crate::database::DB<S> {
 
             while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
                 match serde_json::from_slice::<CollectionVersion>(&pair.value) {
-                    Ok(col) => versions.push(col),
+                    Ok(mut col) => {
+                        crate::collection::populate_collection_root_id(&systemstore, &mut col)
+                            .await?;
+                        versions.push(col);
+                    }
                     Err(e) => {
                         tracing::warn!(
                             error = %e,
@@ -238,21 +244,7 @@ impl<S: Store> crate::database::DB<S> {
                     ))
                 })?;
 
-            // Populate root_id from store (skipped during deserialization)
-            if schema.root_id == 0 {
-                let short_id_key = CollectionID::new(&schema.collection_id);
-                if let Some(short_id_bytes) = systemstore
-                    .get(&short_id_key.bytes())
-                    .await
-                    .map_err(Error::Storage)?
-                {
-                    if let Ok(short_id_str) = String::from_utf8(short_id_bytes.to_vec()) {
-                        if let Ok(short_id) = short_id_str.parse::<u32>() {
-                            schema.root_id = short_id;
-                        }
-                    }
-                }
-            }
+            crate::collection::populate_collection_root_id(&systemstore, &mut schema).await?;
 
             schema
         };

--- a/crates/db/src/collection_provider.rs
+++ b/crates/db/src/collection_provider.rs
@@ -16,6 +16,7 @@ use schema::CollectionVersion;
 use std::sync::Arc;
 use storage::corekv::{Key, Store};
 
+use crate::collection;
 use crate::database::DB;
 use crate::txn::DbTxn;
 
@@ -93,7 +94,10 @@ impl<S: Store + 'static> CollectionProvider for TxnCollectionProvider<S> {
                 let version_id = match String::from_utf8(data.clone()) {
                     Ok(vid) if !vid.starts_with('{') => vid,
                     _ => {
-                        let schema: CollectionVersion = serde_json::from_slice(&data)
+                        let mut schema: CollectionVersion = serde_json::from_slice(&data)
+                            .map_err(|e| QueryError::execution(e.to_string()))?;
+                        collection::populate_collection_root_id(&systemstore, &mut schema)
+                            .await
                             .map_err(|e| QueryError::execution(e.to_string()))?;
                         return Ok(Some(Arc::new(schema)));
                     }
@@ -105,7 +109,10 @@ impl<S: Store + 'static> CollectionProvider for TxnCollectionProvider<S> {
                     .await
                     .map_err(|e| QueryError::execution(e.to_string()))?
                 {
-                    let schema: CollectionVersion = serde_json::from_slice(&data)
+                    let mut schema: CollectionVersion = serde_json::from_slice(&data)
+                        .map_err(|e| QueryError::execution(e.to_string()))?;
+                    collection::populate_collection_root_id(&systemstore, &mut schema)
+                        .await
                         .map_err(|e| QueryError::execution(e.to_string()))?;
                     return Ok(Some(Arc::new(schema)));
                 }

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -9,7 +9,6 @@ use storage::corekv::Store;
 use tracing::warn;
 
 use crate::block_builder::{write_collection_block, write_document_blocks};
-use crate::collection::collection_short_id;
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
 use crate::txn::DbTxn;
@@ -164,7 +163,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                     }
 
                     if collection.schema().is_branchable {
-                        let short_id = collection_short_id(collection.collection_id());
+                        let short_id = collection.resolved_root_id();
                         if let Err(error) = write_collection_block(
                             &blockstore,
                             &headstore,

--- a/crates/db/src/head_provider.rs
+++ b/crates/db/src/head_provider.rs
@@ -15,7 +15,7 @@ use storage::keys::headstore::{HeadstoreColKey, HeadstoreDocKey, HeadstorePriori
 
 use p2p::sync::DocumentHeadProvider;
 
-use crate::collection::{collection_short_id, load_persisted_collection_short_id};
+use crate::collection::require_persisted_collection_short_id;
 use crate::database::DB;
 
 /// Database-backed document head provider.
@@ -203,12 +203,11 @@ impl<S: Store + 'static> DocumentHeadProvider for DbHeadProvider<S> {
             p2p::error::Error::HeadProvider(format!("failed to get headstore: {}", e))
         })?;
 
-        let short_id = load_persisted_collection_short_id(&systemstore, collection_id)
+        let short_id = require_persisted_collection_short_id(&systemstore, collection_id)
             .await
             .map_err(|e| {
                 p2p::error::Error::HeadProvider(format!("failed to load short id: {}", e))
-            })?
-            .unwrap_or_else(|| collection_short_id(collection_id));
+            })?;
         let prefix = HeadstoreColKey::collection_prefix(short_id);
         let opts = IterOptions::new().with_prefix(prefix);
 

--- a/crates/db/src/head_provider.rs
+++ b/crates/db/src/head_provider.rs
@@ -15,7 +15,7 @@ use storage::keys::headstore::{HeadstoreColKey, HeadstoreDocKey, HeadstorePriori
 
 use p2p::sync::DocumentHeadProvider;
 
-use crate::collection::collection_short_id;
+use crate::collection::{collection_short_id, load_persisted_collection_short_id};
 use crate::database::DB;
 
 /// Database-backed document head provider.
@@ -196,12 +196,19 @@ impl<S: Store + 'static> DocumentHeadProvider for DbHeadProvider<S> {
             p2p::error::Error::HeadProvider(format!("failed to create transaction: {}", e))
         })?;
 
+        let systemstore = txn.systemstore().map_err(|e| {
+            p2p::error::Error::HeadProvider(format!("failed to get systemstore: {}", e))
+        })?;
         let headstore = txn.headstore().map_err(|e| {
             p2p::error::Error::HeadProvider(format!("failed to get headstore: {}", e))
         })?;
 
-        // Derive short ID from collection_id string and query prefix /c/{short_id}/
-        let short_id = collection_short_id(collection_id);
+        let short_id = load_persisted_collection_short_id(&systemstore, collection_id)
+            .await
+            .map_err(|e| {
+                p2p::error::Error::HeadProvider(format!("failed to load short id: {}", e))
+            })?
+            .unwrap_or_else(|| collection_short_id(collection_id));
         let prefix = HeadstoreColKey::collection_prefix(short_id);
         let opts = IterOptions::new().with_prefix(prefix);
 

--- a/crates/db/src/lensed_auto_commit_fetcher/index_scan.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/index_scan.rs
@@ -7,7 +7,6 @@ use query::planner::index_selection::{IndexScanParams, IndexScanType};
 use storage::corekv::Store;
 use storage::index::IndexIterator;
 
-use crate::collection::collection_short_id;
 use crate::index_manager::IndexManager;
 
 use super::LensedAutoCommitFetcher;
@@ -40,7 +39,7 @@ impl<S: Store + 'static> LensedAutoCommitFetcher<S> {
             query::error::QueryError::execution(format!("failed to get datastore: {}", e))
         })?;
 
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let index_manager =
             IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
                 query::error::QueryError::execution(format!(

--- a/crates/db/src/lensed_auto_commit_fetcher/mod.rs
+++ b/crates/db/src/lensed_auto_commit_fetcher/mod.rs
@@ -135,7 +135,7 @@ impl<S: Store + 'static> DocFetcher for LensedAutoCommitFetcher<S> {
             query::error::QueryError::execution(format!("failed to get datastore: {}", e))
         })?;
 
-        let short_id = crate::collection::collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let index_manager =
             crate::index_manager::IndexManager::from_collection(short_id, collection.schema())
                 .map_err(|e| {

--- a/crates/db/src/lensed_fetcher/index_scan.rs
+++ b/crates/db/src/lensed_fetcher/index_scan.rs
@@ -7,7 +7,6 @@ use query::planner::index_selection::{IndexScanParams, IndexScanType};
 use storage::corekv::Store;
 use storage::index::IndexIterator;
 
-use crate::collection::collection_short_id;
 use crate::collection_loader::get_collection_with_lazy_load;
 use crate::index_manager::IndexManager;
 
@@ -30,7 +29,7 @@ impl<S: Store + 'static> LensedDocFetcher<S> {
         let (collection, datastore) =
             get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let index_manager =
             IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
                 query::error::QueryError::execution(format!(

--- a/crates/db/src/lensed_fetcher/mod.rs
+++ b/crates/db/src/lensed_fetcher/mod.rs
@@ -130,7 +130,7 @@ impl<S: Store + 'static> DocFetcher for LensedDocFetcher<S> {
         let (collection, datastore) =
             get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         let index_manager =
             IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
                 query::error::QueryError::execution(format!(

--- a/crates/db/src/lensed_fetcher/mod.rs
+++ b/crates/db/src/lensed_fetcher/mod.rs
@@ -123,18 +123,13 @@ impl<S: Store + 'static> DocFetcher for LensedDocFetcher<S> {
         field_name: &str,
         query: &str,
     ) -> query::error::Result<std::collections::HashMap<String, f64>> {
-        use crate::collection::collection_short_id;
         use crate::collection_loader::get_collection_with_lazy_load;
         use crate::index_manager::IndexManager;
 
         let (collection, datastore) =
             get_collection_with_lazy_load(&self.txn, collection_name).await?;
 
-        let short_id = if collection.schema().root_id > 0 {
-            collection.schema().root_id
-        } else {
-            collection_short_id(collection.collection_id())
-        };
+        let short_id = collection.resolved_root_id();
         let index_manager =
             IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
                 query::error::QueryError::execution(format!(

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -110,6 +110,7 @@ pub use block_builder::build_block_from_document;
 pub use block_builder::{build_blocks_from_document, BlockResult};
 #[cfg(feature = "p2p")]
 pub use broadcast_mutator::BroadcastMutator;
+#[allow(deprecated)]
 pub use collection::{collection_short_id, Collection};
 pub use collection_acp::{
     block_unsafe_policy_transition, check_doc_permission, check_policy_transition,

--- a/crates/db/src/merge_handler/collection.rs
+++ b/crates/db/src/merge_handler/collection.rs
@@ -244,11 +244,12 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let txn = self.db.new_txn(false).await?;
         let collection_id = metadata.collection_id.unwrap_or(&payload.schema_version_id);
         let short_id = if let Ok(systemstore) = txn.systemstore() {
-            crate::collection::load_persisted_collection_short_id(&systemstore, collection_id)
+            crate::collection::require_persisted_collection_short_id(&systemstore, collection_id)
                 .await?
-                .unwrap_or_else(|| collection_short_id(collection_id))
         } else {
-            collection_short_id(collection_id)
+            return Err(MergeError::Database(crate::error::Error::Other(
+                "failed to access systemstore while resolving collection root_id".to_string(),
+            )));
         };
         if let Ok(headstore) = txn.headstore() {
             // Remove only the heads that this block supersedes (its parents).
@@ -500,11 +501,15 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let short_id = {
             let txn = self.db.new_txn(true).await?;
             let short_id = if let Ok(systemstore) = txn.systemstore() {
-                crate::collection::load_persisted_collection_short_id(&systemstore, collection_id)
-                    .await?
-                    .unwrap_or_else(|| collection_short_id(collection_id))
+                crate::collection::require_persisted_collection_short_id(
+                    &systemstore,
+                    collection_id,
+                )
+                .await?
             } else {
-                collection_short_id(collection_id)
+                return Err(MergeError::Database(crate::error::Error::Other(
+                    "failed to access systemstore while resolving collection root_id".to_string(),
+                )));
             };
             let _ = txn.discard();
             short_id

--- a/crates/db/src/merge_handler/collection.rs
+++ b/crates/db/src/merge_handler/collection.rs
@@ -241,10 +241,15 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         // Update collection headstore using proper head merging.
         // Only remove heads that this block explicitly supersedes (listed in block.heads),
         // preserving concurrent branches for later merge via write_collection_block.
-        let collection_id = metadata.collection_id.unwrap_or(&payload.schema_version_id);
-        let short_id = collection_short_id(collection_id);
-
         let txn = self.db.new_txn(false).await?;
+        let collection_id = metadata.collection_id.unwrap_or(&payload.schema_version_id);
+        let short_id = if let Ok(systemstore) = txn.systemstore() {
+            crate::collection::load_persisted_collection_short_id(&systemstore, collection_id)
+                .await?
+                .unwrap_or_else(|| collection_short_id(collection_id))
+        } else {
+            collection_short_id(collection_id)
+        };
         if let Ok(headstore) = txn.headstore() {
             // Remove only the heads that this block supersedes (its parents).
             // This preserves concurrent branches in the headstore.
@@ -492,7 +497,18 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
 
         // Update collection headstore using the shared headstore view
         let collection_id = metadata.collection_id.unwrap_or(&payload.schema_version_id);
-        let short_id = collection_short_id(collection_id);
+        let short_id = {
+            let txn = self.db.new_txn(true).await?;
+            let short_id = if let Ok(systemstore) = txn.systemstore() {
+                crate::collection::load_persisted_collection_short_id(&systemstore, collection_id)
+                    .await?
+                    .unwrap_or_else(|| collection_short_id(collection_id))
+            } else {
+                collection_short_id(collection_id)
+            };
+            let _ = txn.discard();
+            short_id
+        };
 
         {
             let mut batch_merged_guard = batch_merged_collections.lock().unwrap_or_else(|e| {

--- a/crates/db/src/merge_handler/composite_persist.rs
+++ b/crates/db/src/merge_handler/composite_persist.rs
@@ -78,7 +78,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             .await
             .map_err(MergeError::Database)?;
 
-        let short_id = collection_short_id(collection.collection_id());
+        let short_id = collection.resolved_root_id();
         if let Ok(index_manager) = IndexManager::from_collection(short_id, collection.schema()) {
             let index_result = match &old_doc {
                 Some(old_doc) => {
@@ -147,7 +147,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
     ) -> std::result::Result<(), MergeError> {
         if let Ok(doc_id) = DocID::from_string(context.doc_id_str) {
             if let Ok(Some(old_doc)) = collection.get_with_datastore(datastore, &doc_id).await {
-                let short_id = collection_short_id(collection.collection_id());
+                let short_id = collection.resolved_root_id();
                 if let Ok(index_manager) =
                     IndexManager::from_collection(short_id, collection.schema())
                 {

--- a/crates/db/src/merge_handler/definition.rs
+++ b/crates/db/src/merge_handler/definition.rs
@@ -138,6 +138,12 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let txn = self.db.new_txn(false).await.map_err(MergeError::Database)?;
         {
             let systemstore = txn.systemstore().map_err(MergeError::Database)?;
+            schema.root_id = crate::collection::ensure_persisted_collection_short_id(
+                &systemstore,
+                &collection_id,
+            )
+            .await
+            .map_err(MergeError::Database)?;
 
             // 1. Store full schema at /collection/id/{version_id}
             let collection_key = CollectionKey::new(&version_id);

--- a/crates/db/src/merge_handler/mod.rs
+++ b/crates/db/src/merge_handler/mod.rs
@@ -484,11 +484,14 @@ mod tests {
     use blockstore::{Blockstore as _, DefraBlockstore};
     use crypto::PrivateKey as _;
     use defra_core::block::{
-        Block, CrdtDelta, LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
+        Block, CollectionDefinitionDeltaPayload, CrdtDelta, LwwDeltaPayload, Signature,
+        SignatureHeader, SignatureType,
     };
     use events::{Bus, ChannelBus, EventName};
     use schema::{CollectionVersion, FieldDescription, FieldKind};
     use storage::backends::MemoryStore;
+    use storage::corekv::Key;
+    use storage::keys::systemstore::CollectionID;
     use tokio::time::{timeout, Duration};
 
     fn make_handler() -> (
@@ -963,6 +966,45 @@ mod tests {
         assert!(
             subscription.try_recv().is_err(),
             "batch merge should publish exactly the queued update events"
+        );
+    }
+
+    #[tokio::test]
+    async fn synced_collection_definition_persists_short_id_mapping() {
+        let (handler, _blockstore) = make_handler();
+
+        let payload = CollectionDefinitionDeltaPayload::new(1).with_name("Users");
+        let block = Block {
+            delta: CrdtDelta::CollectionDefinition(payload.clone()),
+            heads: None,
+            links: None,
+            encryption: None,
+            signature: None,
+        };
+        let cid = block.generate_cid().unwrap();
+
+        let outcome = handler
+            .process_collection_definition_delta(
+                &cid,
+                &block,
+                &payload,
+                &BlockMetadata::schema_sync(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(outcome, MergeOutcome::Merged);
+
+        let txn = handler.db.new_txn(true).await.unwrap();
+        let systemstore = txn.systemstore().unwrap();
+        let mapping = systemstore
+            .get(&CollectionID::new(cid.to_string()).bytes())
+            .await
+            .unwrap();
+        let _ = txn.discard();
+
+        assert!(
+            mapping.is_some(),
+            "expected synced schema to persist a root_id mapping"
         );
     }
 }

--- a/crates/db/src/merge_handler/mod.rs
+++ b/crates/db/src/merge_handler/mod.rs
@@ -45,7 +45,7 @@ use storage::corekv::{Key, Store};
 use storage::keys::systemstore::{CollectionKey, CollectionVersionKey};
 use zeroize::Zeroizing;
 
-use crate::collection::{collection_short_id, Collection};
+use crate::collection::Collection;
 use crate::database::DB;
 use crate::index_manager::IndexManager;
 use hook::CompositeMergeHook;

--- a/crates/db/src/migration/reindex.rs
+++ b/crates/db/src/migration/reindex.rs
@@ -7,7 +7,6 @@ use storage::corekv::Store;
 use tracing::instrument;
 
 use super::helpers::json_to_native_value;
-use crate::collection::collection_short_id;
 use crate::error::{Error, Result};
 use crate::index_manager::IndexManager;
 use crate::schema_loader::get_collections_by_collection_id;
@@ -107,7 +106,7 @@ impl<S: Store> DB<S> {
 
         let collection_id = collection.collection_id().to_string();
         let target_version_id = collection.version_id().to_string();
-        let short_id = collection_short_id(&collection_id);
+        let short_id = collection.resolved_root_id();
 
         let read_txn = self.new_txn(true).await?;
         let systemstore = read_txn.systemstore()?;

--- a/crates/db/src/migration/set_migration.rs
+++ b/crates/db/src/migration/set_migration.rs
@@ -44,7 +44,7 @@ impl<S: Store> DB<S> {
                 .get(&src_key.bytes())
                 .await
                 .map_err(Error::Storage)?;
-            let source_col: schema::CollectionVersion = match src_data {
+            let mut source_col: schema::CollectionVersion = match src_data {
                 Some(data) => serde_json::from_slice(&data).map_err(|e| {
                     Error::Serialization(format!(
                         "failed to deserialize source schema '{}': {}",
@@ -52,7 +52,12 @@ impl<S: Store> DB<S> {
                     ))
                 })?,
                 None => {
-                    let placeholder = create_orphan_placeholder(&source_version_id, "", "");
+                    let mut placeholder = create_orphan_placeholder(&source_version_id, "", "");
+                    placeholder.root_id = crate::collection::ensure_persisted_collection_short_id(
+                        &systemstore,
+                        &placeholder.collection_id,
+                    )
+                    .await?;
                     let data = serde_json::to_vec(&placeholder).map_err(|e| {
                         Error::Serialization(format!(
                             "failed to serialize source placeholder '{}': {}",
@@ -72,7 +77,7 @@ impl<S: Store> DB<S> {
                 .get(&dst_key.bytes())
                 .await
                 .map_err(Error::Storage)?;
-            let dst_col: schema::CollectionVersion = match dst_data {
+            let mut dst_col: schema::CollectionVersion = match dst_data {
                 Some(data) => serde_json::from_slice(&data).map_err(|e| {
                     Error::Serialization(format!(
                         "failed to deserialize destination schema '{}': {}",
@@ -80,11 +85,16 @@ impl<S: Store> DB<S> {
                     ))
                 })?,
                 None => {
-                    let placeholder = create_placeholder_with_source(
+                    let mut placeholder = create_placeholder_with_source(
                         &dest_version_id,
                         &source_col.name,
                         &source_col.collection_id,
                     );
+                    placeholder.root_id = crate::collection::ensure_persisted_collection_short_id(
+                        &systemstore,
+                        &placeholder.collection_id,
+                    )
+                    .await?;
                     let data = serde_json::to_vec(&placeholder).map_err(|e| {
                         Error::Serialization(format!(
                             "failed to serialize destination placeholder '{}': {}",
@@ -98,6 +108,21 @@ impl<S: Store> DB<S> {
                     placeholder
                 }
             };
+
+            if !source_col.collection_id.is_empty() {
+                source_col.root_id = crate::collection::ensure_persisted_collection_short_id(
+                    &systemstore,
+                    &source_col.collection_id,
+                )
+                .await?;
+            }
+            if !dst_col.collection_id.is_empty() {
+                dst_col.root_id = crate::collection::ensure_persisted_collection_short_id(
+                    &systemstore,
+                    &dst_col.collection_id,
+                )
+                .await?;
+            }
 
             (source_col, dst_col)
         };
@@ -232,7 +257,7 @@ impl<S: Store> DB<S> {
                 .get(&src_key.bytes())
                 .await
                 .map_err(Error::Storage)?;
-            let source_col: schema::CollectionVersion = match src_data {
+            let mut source_col: schema::CollectionVersion = match src_data {
                 Some(data) => serde_json::from_slice(&data).map_err(|e| {
                     Error::Serialization(format!(
                         "failed to deserialize source schema '{}': {}",
@@ -240,7 +265,12 @@ impl<S: Store> DB<S> {
                     ))
                 })?,
                 None => {
-                    let placeholder = create_orphan_placeholder(&source_version_id, "", "");
+                    let mut placeholder = create_orphan_placeholder(&source_version_id, "", "");
+                    placeholder.root_id = crate::collection::ensure_persisted_collection_short_id(
+                        &systemstore,
+                        &placeholder.collection_id,
+                    )
+                    .await?;
                     let data = serde_json::to_vec(&placeholder).map_err(|e| {
                         Error::Serialization(format!(
                             "failed to serialize source placeholder '{}': {}",
@@ -260,7 +290,7 @@ impl<S: Store> DB<S> {
                 .get(&dst_key.bytes())
                 .await
                 .map_err(Error::Storage)?;
-            let dst_col: schema::CollectionVersion = match dst_data {
+            let mut dst_col: schema::CollectionVersion = match dst_data {
                 Some(data) => serde_json::from_slice(&data).map_err(|e| {
                     Error::Serialization(format!(
                         "failed to deserialize destination schema '{}': {}",
@@ -268,11 +298,16 @@ impl<S: Store> DB<S> {
                     ))
                 })?,
                 None => {
-                    let placeholder = create_placeholder_with_source(
+                    let mut placeholder = create_placeholder_with_source(
                         &dest_version_id,
                         &source_col.name,
                         &source_col.collection_id,
                     );
+                    placeholder.root_id = crate::collection::ensure_persisted_collection_short_id(
+                        &systemstore,
+                        &placeholder.collection_id,
+                    )
+                    .await?;
                     let data = serde_json::to_vec(&placeholder).map_err(|e| {
                         Error::Serialization(format!(
                             "failed to serialize destination placeholder '{}': {}",
@@ -286,6 +321,21 @@ impl<S: Store> DB<S> {
                     placeholder
                 }
             };
+
+            if !source_col.collection_id.is_empty() {
+                source_col.root_id = crate::collection::ensure_persisted_collection_short_id(
+                    &systemstore,
+                    &source_col.collection_id,
+                )
+                .await?;
+            }
+            if !dst_col.collection_id.is_empty() {
+                dst_col.root_id = crate::collection::ensure_persisted_collection_short_id(
+                    &systemstore,
+                    &dst_col.collection_id,
+                )
+                .await?;
+            }
 
             (source_col, dst_col)
         };

--- a/crates/db/src/schema_loader.rs
+++ b/crates/db/src/schema_loader.rs
@@ -82,7 +82,14 @@ pub async fn load_active_collections<S: Store>(db: &DB<S>) -> Result<Vec<Collect
 
                 // Deserialize the collection
                 match serde_json::from_slice::<CollectionVersion>(&collection_json) {
-                    Ok(collection) => collections.push(collection),
+                    Ok(mut collection) => {
+                        crate::collection::populate_collection_root_id(
+                            &systemstore,
+                            &mut collection,
+                        )
+                        .await?;
+                        collections.push(collection);
+                    }
                     Err(e) => {
                         load_error = Some(Error::Other(format!(
                             "Failed to deserialize collection {}: {}",
@@ -214,12 +221,15 @@ pub async fn get_collections_by_collection_id(
         let collection_key = CollectionKey::new(version_id);
         match systemstore.get(&collection_key.bytes()).await {
             Ok(Some(json)) => {
-                let collection: CollectionVersion = serde_json::from_slice(&json).map_err(|e| {
-                    Error::Other(format!(
-                        "Failed to deserialize collection version {}: {}",
-                        version_id, e
-                    ))
-                })?;
+                let mut collection: CollectionVersion =
+                    serde_json::from_slice(&json).map_err(|e| {
+                        Error::Other(format!(
+                            "Failed to deserialize collection version {}: {}",
+                            version_id, e
+                        ))
+                    })?;
+                crate::collection::populate_collection_root_id(systemstore, &mut collection)
+                    .await?;
 
                 // Log the version with transform information
                 tracing::debug!(
@@ -273,12 +283,13 @@ pub async fn get_collection_by_version_id(
     let collection_key = CollectionKey::new(version_id);
     match systemstore.get(&collection_key.bytes()).await {
         Ok(Some(json)) => {
-            let collection: CollectionVersion = serde_json::from_slice(&json).map_err(|e| {
+            let mut collection: CollectionVersion = serde_json::from_slice(&json).map_err(|e| {
                 Error::Other(format!(
                     "Failed to deserialize collection version {}: {}",
                     version_id, e
                 ))
             })?;
+            crate::collection::populate_collection_root_id(systemstore, &mut collection).await?;
             Ok(Some(collection))
         }
         Ok(None) => Ok(None),

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -4,7 +4,7 @@
 /// - Explicit/implicit transaction handling
 /// - Transaction-scoped collection cache (lazy loading)
 /// - Reference to the database for collection operations
-use crate::collection::Collection;
+use crate::collection::{populate_collection_root_id, Collection};
 use crate::collection_cache::CollectionCache;
 use crate::error::{Error, Result};
 use datastore::{AsyncCallback, BasicTxn, NamespaceView, RootView, TxnCallback};
@@ -252,7 +252,7 @@ impl<S: Store> DbTxn<S> {
                     _ => {
                         // Fallback: Old format where full JSON is stored at name key
                         // This handles backward compatibility during migration
-                        let schema: CollectionVersion =
+                        let mut schema: CollectionVersion =
                             serde_json::from_slice(&data).map_err(|e| {
                                 tracing::error!(
                                     error = ?e,
@@ -264,6 +264,7 @@ impl<S: Store> DbTxn<S> {
                                     name, e
                                 ))
                             })?;
+                        populate_collection_root_id(&systemstore, &mut schema).await?;
                         self.collection_cache.add(Collection::new(schema));
                         return Ok(self.collection_cache.get(name));
                     }
@@ -281,7 +282,7 @@ impl<S: Store> DbTxn<S> {
 
         // Process result and update cache
         if let Some(data) = maybe_data {
-            let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
+            let mut schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
                 tracing::error!(
                     error = ?e,
                     collection_name = %name,
@@ -293,6 +294,7 @@ impl<S: Store> DbTxn<S> {
                     name, e
                 ))
             })?;
+            populate_collection_root_id(&systemstore, &mut schema).await?;
             self.collection_cache.add(Collection::new(schema));
             return Ok(self.collection_cache.get(name));
         }
@@ -372,19 +374,21 @@ impl<S: Store> DbTxn<S> {
             }
 
             // Old format: value is full JSON
-            let schema: CollectionVersion = serde_json::from_slice(&pair.value).map_err(|e| {
-                tracing::error!(
-                    error = ?e,
-                    collection_name = %name,
-                    "Failed to deserialize schema for collection '{}': {}",
-                    name,
-                    e
-                );
-                Error::Serialization(format!(
-                    "failed to deserialize schema for collection '{}': {}",
-                    name, e
-                ))
-            })?;
+            let mut schema: CollectionVersion =
+                serde_json::from_slice(&pair.value).map_err(|e| {
+                    tracing::error!(
+                        error = ?e,
+                        collection_name = %name,
+                        "Failed to deserialize schema for collection '{}': {}",
+                        name,
+                        e
+                    );
+                    Error::Serialization(format!(
+                        "failed to deserialize schema for collection '{}': {}",
+                        name, e
+                    ))
+                })?;
+            populate_collection_root_id(&systemstore, &mut schema).await?;
 
             collections.push(Collection::new(schema));
         }
@@ -399,18 +403,20 @@ impl<S: Store> DbTxn<S> {
             let collection_key = CollectionKey::new(&version_id);
             match systemstore.get(&collection_key.bytes()).await {
                 Ok(Some(data)) => {
-                    let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
-                        tracing::error!(
-                            error = ?e,
-                            collection_name = %name,
-                            version_id = %version_id,
-                            "Failed to deserialize schema"
-                        );
-                        Error::Serialization(format!(
-                            "failed to deserialize schema for collection '{}': {}",
-                            name, e
-                        ))
-                    })?;
+                    let mut schema: CollectionVersion =
+                        serde_json::from_slice(&data).map_err(|e| {
+                            tracing::error!(
+                                error = ?e,
+                                collection_name = %name,
+                                version_id = %version_id,
+                                "Failed to deserialize schema"
+                            );
+                            Error::Serialization(format!(
+                                "failed to deserialize schema for collection '{}': {}",
+                                name, e
+                            ))
+                        })?;
+                    populate_collection_root_id(&systemstore, &mut schema).await?;
                     collections.push(Collection::new(schema));
                 }
                 Ok(None) => {

--- a/crates/db/tests/schema_loader_tests.rs
+++ b/crates/db/tests/schema_loader_tests.rs
@@ -148,7 +148,7 @@ async fn test_load_collection_requires_short_id_mapping() {
 
     {
         let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-        let txn = DbTxn::new(basic_txn, store.clone());
+        let txn = DbTxn::new(basic_txn);
 
         txn.systemstore()
             .unwrap()
@@ -279,7 +279,7 @@ async fn test_set_migration_placeholder_persists_short_id_mapping() {
     assert_eq!(versions.len(), 2);
 
     let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn, store.clone());
+    let txn = DbTxn::new(basic_txn);
     let systemstore = txn.systemstore().unwrap();
     let short_id = systemstore
         .get(&CollectionID::new(ORPHAN_COLLECTION_ID).bytes())

--- a/crates/db/tests/schema_loader_tests.rs
+++ b/crates/db/tests/schema_loader_tests.rs
@@ -9,7 +9,7 @@ use db::txn::DbTxn;
 use schema::CollectionVersion;
 use storage::backends::MemoryStore;
 use storage::corekv::Key;
-use storage::keys::systemstore::{CollectionKey, CollectionNameKey};
+use storage::keys::systemstore::{CollectionID, CollectionKey, CollectionNameKey};
 
 #[tokio::test]
 async fn test_load_empty_database() {
@@ -29,12 +29,14 @@ async fn test_load_single_collection() {
     let db = DB::new((*store).clone()).unwrap();
 
     // Manually insert a collection into systemstore
-    let collection = CollectionVersion::new("users", "bafytest123", "bafytest123", vec![]);
+    let mut collection = CollectionVersion::new("users", "bafytest123", "bafytest123", vec![]);
+    collection.root_id = 1;
 
     // Store collection definition
     let collection_json = serde_json::to_vec(&collection).unwrap();
     let collection_key = CollectionKey::new(&collection.version_id);
     let name_key = CollectionNameKey::new(&collection.name);
+    let short_id_key = CollectionID::new(&collection.collection_id);
 
     {
         let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
@@ -51,6 +53,11 @@ async fn test_load_single_collection() {
         txn.systemstore()
             .unwrap()
             .set(&name_key.bytes(), collection.version_id.as_bytes())
+            .await
+            .unwrap();
+        txn.systemstore()
+            .unwrap()
+            .set(&short_id_key.bytes(), b"1")
             .await
             .unwrap();
 
@@ -80,11 +87,19 @@ async fn test_load_multiple_collections() {
         let txn = DbTxn::new(basic_txn, store.clone());
 
         for (name, id) in &collections {
-            let collection = CollectionVersion::new(*name, *id, *id, vec![]);
+            let mut collection = CollectionVersion::new(*name, *id, *id, vec![]);
+            let root_id = match *name {
+                "users" => 1,
+                "posts" => 2,
+                "comments" => 3,
+                _ => unreachable!(),
+            };
+            collection.root_id = root_id;
 
             let collection_json = serde_json::to_vec(&collection).unwrap();
             let collection_key = CollectionKey::new(*id);
             let name_key = CollectionNameKey::new(*name);
+            let short_id_key = CollectionID::new(*id);
 
             txn.systemstore()
                 .unwrap()
@@ -94,6 +109,11 @@ async fn test_load_multiple_collections() {
             txn.systemstore()
                 .unwrap()
                 .set(&name_key.bytes(), id.as_bytes())
+                .await
+                .unwrap();
+            txn.systemstore()
+                .unwrap()
+                .set(&short_id_key.bytes(), root_id.to_string().as_bytes())
                 .await
                 .unwrap();
         }
@@ -109,6 +129,38 @@ async fn test_load_multiple_collections() {
     assert!(names.contains(&"users"));
     assert!(names.contains(&"posts"));
     assert!(names.contains(&"comments"));
+}
+
+#[tokio::test]
+async fn test_load_collection_requires_short_id_mapping() {
+    let store = Arc::new(MemoryStore::new());
+    let db = DB::new((*store).clone()).unwrap();
+
+    let collection = CollectionVersion::new("users", "bafytest123", "bafytest123", vec![]);
+    let collection_json = serde_json::to_vec(&collection).unwrap();
+    let collection_key = CollectionKey::new(&collection.version_id);
+    let name_key = CollectionNameKey::new(&collection.name);
+
+    {
+        let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
+        let txn = DbTxn::new(basic_txn, store.clone());
+
+        txn.systemstore()
+            .unwrap()
+            .set(&collection_key.bytes(), &collection_json)
+            .await
+            .unwrap();
+        txn.systemstore()
+            .unwrap()
+            .set(&name_key.bytes(), collection.version_id.as_bytes())
+            .await
+            .unwrap();
+
+        txn.commit().await.unwrap();
+    }
+
+    let err = load_active_collections(&db).await.unwrap_err().to_string();
+    assert!(err.contains("missing persisted collection root_id"));
 }
 
 #[tokio::test]

--- a/crates/db/tests/schema_loader_tests.rs
+++ b/crates/db/tests/schema_loader_tests.rs
@@ -13,7 +13,7 @@ use storage::corekv::Key;
 use storage::keys::systemstore::{CollectionID, CollectionKey, CollectionNameKey};
 
 fn new_txn(basic_txn: BasicTxn) -> DbTxn<MemoryStore> {
-    DbTxn::new(basic_txn)
+    DbTxn::<MemoryStore>::new(basic_txn)
 }
 
 #[tokio::test]
@@ -148,7 +148,7 @@ async fn test_load_collection_requires_short_id_mapping() {
 
     {
         let basic_txn = BasicTxn::new(&*store, 1, false).await.unwrap();
-        let txn = DbTxn::new(basic_txn);
+        let txn = DbTxn::<MemoryStore>::new(basic_txn);
 
         txn.systemstore()
             .unwrap()
@@ -279,7 +279,7 @@ async fn test_set_migration_placeholder_persists_short_id_mapping() {
     assert_eq!(versions.len(), 2);
 
     let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
-    let txn = DbTxn::new(basic_txn);
+    let txn = DbTxn::<MemoryStore>::new(basic_txn);
     let systemstore = txn.systemstore().unwrap();
     let short_id = systemstore
         .get(&CollectionID::new(ORPHAN_COLLECTION_ID).bytes())

--- a/crates/db/tests/schema_loader_tests.rs
+++ b/crates/db/tests/schema_loader_tests.rs
@@ -6,7 +6,8 @@ use datastore::BasicTxn;
 use db::database::DB;
 use db::schema_loader::load_active_collections;
 use db::txn::DbTxn;
-use schema::CollectionVersion;
+use lens::{LensConfig, LensModule};
+use schema::{CollectionVersion, ORPHAN_COLLECTION_ID};
 use storage::backends::MemoryStore;
 use storage::corekv::Key;
 use storage::keys::systemstore::{CollectionID, CollectionKey, CollectionNameKey};
@@ -255,5 +256,35 @@ async fn test_load_invalid_json_collection_returns_error() {
         err_msg.contains("deserialize"),
         "Error should mention 'deserialize', got: {}",
         err_msg
+    );
+}
+
+#[tokio::test]
+async fn test_set_migration_placeholder_persists_short_id_mapping() {
+    let store = Arc::new(MemoryStore::new());
+    let db = DB::new((*store).clone()).unwrap();
+
+    let config = LensConfig::new(
+        "missing-src",
+        "missing-dst",
+        LensModule::from_bytes(b"\0asm\x01\0\0\0".to_vec()),
+    );
+    db.set_migration(config).await.unwrap();
+
+    let versions = db.get_all_collection_versions().await.unwrap();
+    assert_eq!(versions.len(), 2);
+
+    let basic_txn = BasicTxn::new(&*store, 2, true).await.unwrap();
+    let txn = DbTxn::new(basic_txn, store.clone());
+    let systemstore = txn.systemstore().unwrap();
+    let short_id = systemstore
+        .get(&CollectionID::new(ORPHAN_COLLECTION_ID).bytes())
+        .await
+        .unwrap();
+    let _ = txn.discard();
+
+    assert!(
+        short_id.is_some(),
+        "expected placeholder root_id mapping to exist"
     );
 }

--- a/crates/db/tests/txn_tests.rs
+++ b/crates/db/tests/txn_tests.rs
@@ -11,7 +11,7 @@ use storage::corekv::Key;
 use storage::keys::systemstore::{CollectionID, CollectionIDSequenceKey};
 
 fn new_txn(basic_txn: BasicTxn) -> DbTxn<MemoryStore> {
-    DbTxn::new(basic_txn)
+    DbTxn::<MemoryStore>::new(basic_txn)
 }
 
 fn new_explicit_txn(basic_txn: BasicTxn) -> DbTxn<MemoryStore> {
@@ -255,10 +255,10 @@ async fn test_db_txn_id_increments() {
 async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_duplicating() {
     let store = Arc::new(MemoryStore::new());
 
-    let txn1 = DbTxn::new(
+    let txn1 = DbTxn::<MemoryStore>::new(
         BasicTxn::new(&*store, 1, false).await.unwrap(),
     );
-    let txn2 = DbTxn::new(
+    let txn2 = DbTxn::<MemoryStore>::new(
         BasicTxn::new(&*store, 2, false).await.unwrap(),
     );
 
@@ -292,7 +292,7 @@ async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_dupli
         "expected write-write conflict, got: {err}"
     );
 
-    let retry_txn = DbTxn::new(
+    let retry_txn = DbTxn::<MemoryStore>::new(
         BasicTxn::new(&*store, 3, false).await.unwrap(),
     );
     let retried_short_id = {
@@ -304,7 +304,7 @@ async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_dupli
     assert_eq!(retried_short_id, 2);
     retry_txn.commit().await.unwrap();
 
-    let read_txn = DbTxn::new(
+    let read_txn = DbTxn::<MemoryStore>::new(
         BasicTxn::new(&*store, 4, true).await.unwrap(),
     );
     let (collection_a_short_id, collection_b_short_id, sequence_value) = {

--- a/crates/db/tests/txn_tests.rs
+++ b/crates/db/tests/txn_tests.rs
@@ -255,12 +255,8 @@ async fn test_db_txn_id_increments() {
 async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_duplicating() {
     let store = Arc::new(MemoryStore::new());
 
-    let txn1 = DbTxn::<MemoryStore>::new(
-        BasicTxn::new(&*store, 1, false).await.unwrap(),
-    );
-    let txn2 = DbTxn::<MemoryStore>::new(
-        BasicTxn::new(&*store, 2, false).await.unwrap(),
-    );
+    let txn1 = DbTxn::<MemoryStore>::new(BasicTxn::new(&*store, 1, false).await.unwrap());
+    let txn2 = DbTxn::<MemoryStore>::new(BasicTxn::new(&*store, 2, false).await.unwrap());
 
     let short_id_1 = {
         let systemstore1 = txn1.systemstore().unwrap();
@@ -292,9 +288,7 @@ async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_dupli
         "expected write-write conflict, got: {err}"
     );
 
-    let retry_txn = DbTxn::<MemoryStore>::new(
-        BasicTxn::new(&*store, 3, false).await.unwrap(),
-    );
+    let retry_txn = DbTxn::<MemoryStore>::new(BasicTxn::new(&*store, 3, false).await.unwrap());
     let retried_short_id = {
         let retry_systemstore = retry_txn.systemstore().unwrap();
         ensure_persisted_collection_short_id(&retry_systemstore, "collection-b")
@@ -304,9 +298,7 @@ async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_dupli
     assert_eq!(retried_short_id, 2);
     retry_txn.commit().await.unwrap();
 
-    let read_txn = DbTxn::<MemoryStore>::new(
-        BasicTxn::new(&*store, 4, true).await.unwrap(),
-    );
+    let read_txn = DbTxn::<MemoryStore>::new(BasicTxn::new(&*store, 4, true).await.unwrap());
     let (collection_a_short_id, collection_b_short_id, sequence_value) = {
         let read_systemstore = read_txn.systemstore().unwrap();
         let sequence_key = CollectionIDSequenceKey;

--- a/crates/db/tests/txn_tests.rs
+++ b/crates/db/tests/txn_tests.rs
@@ -3,9 +3,12 @@
 use std::sync::Arc;
 
 use datastore::BasicTxn;
+use db::collection::ensure_persisted_collection_short_id;
 use db::txn::DbTxn;
 use db::Error;
 use storage::backends::MemoryStore;
+use storage::corekv::Key;
+use storage::keys::systemstore::{CollectionID, CollectionIDSequenceKey};
 
 #[tokio::test]
 async fn test_db_txn_basic() {
@@ -238,6 +241,86 @@ async fn test_db_txn_id_increments() {
     let basic_txn3 = BasicTxn::new(&*store, 100, false).await.unwrap();
     let txn3 = DbTxn::new(basic_txn3, store.clone());
     assert_eq!(txn3.id().unwrap(), 100);
+}
+
+#[tokio::test]
+async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_duplicating() {
+    let store = Arc::new(MemoryStore::new());
+
+    let txn1 = DbTxn::new(
+        BasicTxn::new(&*store, 1, false).await.unwrap(),
+        store.clone(),
+    );
+    let txn2 = DbTxn::new(
+        BasicTxn::new(&*store, 2, false).await.unwrap(),
+        store.clone(),
+    );
+
+    let short_id_1 = {
+        let systemstore1 = txn1.systemstore().unwrap();
+        ensure_persisted_collection_short_id(&systemstore1, "collection-a")
+            .await
+            .unwrap()
+    };
+    let short_id_2 = {
+        let systemstore2 = txn2.systemstore().unwrap();
+        ensure_persisted_collection_short_id(&systemstore2, "collection-b")
+            .await
+            .unwrap()
+    };
+
+    assert_eq!(short_id_1, 1);
+    assert_eq!(
+        short_id_2, 1,
+        "concurrent snapshots may tentatively pick the same next ID"
+    );
+
+    txn1.commit().await.unwrap();
+
+    let err = txn2.commit().await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            Error::Datastore(datastore::Error::Storage(storage::Error::TxnConflict))
+        ),
+        "expected write-write conflict, got: {err}"
+    );
+
+    let retry_txn = DbTxn::new(
+        BasicTxn::new(&*store, 3, false).await.unwrap(),
+        store.clone(),
+    );
+    let retried_short_id = {
+        let retry_systemstore = retry_txn.systemstore().unwrap();
+        ensure_persisted_collection_short_id(&retry_systemstore, "collection-b")
+            .await
+            .unwrap()
+    };
+    assert_eq!(retried_short_id, 2);
+    retry_txn.commit().await.unwrap();
+
+    let read_txn = DbTxn::new(
+        BasicTxn::new(&*store, 4, true).await.unwrap(),
+        store.clone(),
+    );
+    let (collection_a_short_id, collection_b_short_id, sequence_value) = {
+        let read_systemstore = read_txn.systemstore().unwrap();
+        let sequence_key = CollectionIDSequenceKey;
+        let collection_a_short_id = read_systemstore
+            .get(&CollectionID::new("collection-a").bytes())
+            .await
+            .unwrap();
+        let collection_b_short_id = read_systemstore
+            .get(&CollectionID::new("collection-b").bytes())
+            .await
+            .unwrap();
+        let sequence_value = read_systemstore.get(&sequence_key.bytes()).await.unwrap();
+        (collection_a_short_id, collection_b_short_id, sequence_value)
+    };
+
+    assert_eq!(collection_a_short_id, Some(b"1".to_vec()));
+    assert_eq!(collection_b_short_id, Some(b"2".to_vec()));
+    assert_eq!(sequence_value, Some(2u32.to_be_bytes().to_vec()));
 }
 
 #[tokio::test]

--- a/crates/db/tests/txn_tests.rs
+++ b/crates/db/tests/txn_tests.rs
@@ -257,11 +257,9 @@ async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_dupli
 
     let txn1 = DbTxn::new(
         BasicTxn::new(&*store, 1, false).await.unwrap(),
-        store.clone(),
     );
     let txn2 = DbTxn::new(
         BasicTxn::new(&*store, 2, false).await.unwrap(),
-        store.clone(),
     );
 
     let short_id_1 = {
@@ -296,7 +294,6 @@ async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_dupli
 
     let retry_txn = DbTxn::new(
         BasicTxn::new(&*store, 3, false).await.unwrap(),
-        store.clone(),
     );
     let retried_short_id = {
         let retry_systemstore = retry_txn.systemstore().unwrap();
@@ -309,7 +306,6 @@ async fn test_persisted_collection_root_id_allocation_conflicts_instead_of_dupli
 
     let read_txn = DbTxn::new(
         BasicTxn::new(&*store, 4, true).await.unwrap(),
-        store.clone(),
     );
     let (collection_a_short_id, collection_b_short_id, sequence_value) = {
         let read_systemstore = read_txn.systemstore().unwrap();

--- a/crates/ffi/src/index/create.rs
+++ b/crates/ffi/src/index/create.rs
@@ -1,7 +1,6 @@
 use std::ffi::c_char;
 
 use acp::nac::NodePermission;
-use db::collection_short_id;
 use storage::corekv::Key;
 
 use crate::helpers::{get_node_database, get_rt, require_c_str};
@@ -96,7 +95,7 @@ pub unsafe extern "C" fn create_index(
 
                 // Create the index manager
                 let mut index_manager = db::index_manager::IndexManager::from_collection(
-                    collection_short_id(collection.schema().collection_id.as_str()),
+                    collection.schema().resolved_root_id(),
                     collection.schema(),
                 )
                 .map_err(|e| format!("failed to create index manager: {}", e))?;

--- a/crates/ffi/src/index/manage.rs
+++ b/crates/ffi/src/index/manage.rs
@@ -1,7 +1,6 @@
 use std::ffi::c_char;
 
 use acp::nac::NodePermission;
-use db::collection_short_id;
 use storage::corekv::Key;
 
 use crate::helpers::{get_node_database, get_rt, require_c_str};
@@ -105,7 +104,7 @@ pub unsafe extern "C" fn delete_index(
 
                 // Create the index manager
                 let mut index_manager = db::index_manager::IndexManager::from_collection(
-                    collection_short_id(collection.schema().collection_id.as_str()),
+                    collection.schema().resolved_root_id(),
                     collection.schema(),
                 )
                 .map_err(|e| format!("failed to create index manager: {}", e))?;

--- a/crates/query/src/plan/scan.rs
+++ b/crates/query/src/plan/scan.rs
@@ -3,7 +3,6 @@
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use defra_core::collection_short_id;
 use schema::CollectionVersion;
 
 use tracing::debug;

--- a/crates/query/src/plan/scan.rs
+++ b/crates/query/src/plan/scan.rs
@@ -1,7 +1,6 @@
 //! ScanNode for scanning collection documents
 
 use async_trait::async_trait;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use schema::CollectionVersion;
@@ -13,14 +12,6 @@ use crate::error::Result;
 use crate::fetcher::DocFetcher;
 use crate::mapper::Filter;
 use crate::planner::{Doc, ExecInfo, PlanNode};
-
-/// Derive a short u32 ID from a collection_id string.
-/// Uses the same hash as db::collection_short_id for consistency.
-fn collection_short_id(collection_id: &str) -> u32 {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    collection_id.hash(&mut hasher);
-    hasher.finish() as u32
-}
 
 /// ScanNode scans documents from a collection.
 ///
@@ -143,15 +134,8 @@ impl ScanNode {
     }
 
     /// Get the storage prefix for this collection.
-    ///
-    /// Uses the sequential root_id if available (assigned during collection creation),
-    /// falling back to hash-based short_id for backwards compatibility.
     fn collection_prefix(&self) -> u32 {
-        if self.collection.root_id > 0 {
-            self.collection.root_id
-        } else {
-            collection_short_id(&self.collection.collection_id)
-        }
+        self.collection.resolved_root_id()
     }
 }
 

--- a/crates/schema/src/collection.rs
+++ b/crates/schema/src/collection.rs
@@ -7,9 +7,19 @@ use crate::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
 
 /// Sentinel collection ID for placeholder versions whose real collection is unknown.
 pub const ORPHAN_COLLECTION_ID: &str = "OrphanCollectionID";
+
+/// Legacy short-ID derivation used before collections persisted a unique root ID.
+///
+/// This remains the compatibility fallback for older metadata that has no `root_id`.
+pub fn legacy_collection_short_id(collection_id: &str) -> u32 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    collection_id.hash(&mut hasher);
+    hasher.finish() as u32
+}
 
 /// Helper to deserialize `null` as an empty Vec (Go serializes empty slices as null).
 fn deserialize_null_as_empty_vec<'de, D, T>(
@@ -174,6 +184,18 @@ fn default_active() -> bool {
 }
 
 impl CollectionVersion {
+    /// Returns the collection storage prefix ID used for indexes, heads, and view cache keys.
+    ///
+    /// New collections persist a unique sequential `root_id`. Older metadata may not have it, so
+    /// we fall back to the legacy hash to preserve backwards compatibility.
+    pub fn resolved_root_id(&self) -> u32 {
+        if self.root_id > 0 {
+            self.root_id
+        } else {
+            legacy_collection_short_id(&self.collection_id)
+        }
+    }
+
     /// Create a new collection version with default values for optional fields.
     pub fn new(
         name: impl Into<String>,
@@ -485,5 +507,36 @@ impl CollectionBuilder {
             field.name.hash(&mut hasher);
         }
         format!("v{:x}", hasher.finish())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{legacy_collection_short_id, CollectionVersion};
+
+    #[test]
+    fn legacy_short_id_collision_exists_for_known_pair() {
+        let left = "coll_test_000029de";
+        let right = "coll_test_0000b4ed";
+
+        assert_eq!(
+            legacy_collection_short_id(left),
+            legacy_collection_short_id(right)
+        );
+    }
+
+    #[test]
+    fn resolved_root_id_prefers_persisted_root_id() {
+        let mut left = CollectionVersion::new("left", "v1", "coll_test_000029de", Vec::new());
+        let mut right = CollectionVersion::new("right", "v2", "coll_test_0000b4ed", Vec::new());
+
+        assert_eq!(left.resolved_root_id(), right.resolved_root_id());
+
+        left.root_id = 101;
+        right.root_id = 202;
+
+        assert_eq!(left.resolved_root_id(), 101);
+        assert_eq!(right.resolved_root_id(), 202);
+        assert_ne!(left.resolved_root_id(), right.resolved_root_id());
     }
 }

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -26,7 +26,9 @@ pub use cid::{
     generate_collection_set_cid, generate_field_block_with_priority_and_heads, generate_field_cid,
     generate_field_cid_with_priority, generate_field_cid_with_priority_and_heads, BlockWithCid,
 };
-pub use collection::{CollectionBuilder, CollectionVersion, ORPHAN_COLLECTION_ID};
+pub use collection::{
+    legacy_collection_short_id, CollectionBuilder, CollectionVersion, ORPHAN_COLLECTION_ID,
+};
 pub use ctype::CType;
 pub use embedding::VectorEmbeddingDescription;
 pub use error::{Result, SchemaError};


### PR DESCRIPTION
## Summary
- switch live db/query/cli/ffi storage namespace usage over to persisted sequential `root_id` values
- require persisted collection root-ID mappings in store-backed collection loading, version loading, transaction caches, and P2P collection-head resolution instead of silently falling back to the legacy 32-bit hash
- keep the legacy hash only as a deprecated compatibility helper for transient/manual schemas and add regression coverage with a known colliding pair

## Testing
- cargo test -p schema
- cargo check -p db
- cargo test -p db --test schema_loader_tests
- cargo check -p cli
- cargo check -p ffi

Closes #647
Resolves #678