### PR TITLE
Add SourceHub ACP support to defra-node builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3693,6 +3693,7 @@ dependencies = [
  "schema",
  "serde",
  "serde_json",
+ "sourcehub",
  "storage",
  "tokio",
  "tracing",

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -23,6 +23,7 @@ storage = { path = "../storage" }
 query = { path = "../query" }
 events = { path = "../events" }
 acp = { path = "../acp" }
+sourcehub = { path = "../sourcehub" }
 identity = { path = "../identity" }
 defra-core = { path = "../defra-core" }
 schema = { path = "../schema" }

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -1,5 +1,23 @@
 //! Configuration types for the embedded DefraDB node.
 
+/// Document ACP configuration.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DocumentAcpConfig {
+    #[default]
+    Local,
+    SourceHub(SourceHubConfig),
+}
+
+/// SourceHub document ACP configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceHubConfig {
+    pub grpc_address: String,
+    pub comet_rpc_address: String,
+    pub chain_id: String,
+    pub signer_key: Vec<u8>,
+}
+
 /// Configuration for the optional HTTP GraphQL server.
 #[cfg(feature = "http")]
 pub struct HttpConfig {

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -15,6 +15,7 @@ pub mod coding_search;
 pub mod config;
 mod db_impls;
 pub mod dense_search;
+mod node_acp;
 #[cfg(feature = "p2p")]
 mod p2p_handle;
 pub mod search_chunks;
@@ -26,6 +27,9 @@ use std::sync::Arc;
 #[cfg(feature = "p2p")]
 use p2p::P2PTransport;
 
+#[cfg(feature = "p2p")]
+type WireDocumentAcpCallback = Box<dyn FnOnce(Arc<dyn acp::DocumentACP>, bool)>;
+
 pub use coding_search::{
     CodingHybridSearchHit, CodingHybridSearchRequest, CodingHybridSearchResponse,
     CodingSearchTarget,
@@ -34,6 +38,7 @@ pub use coding_search::{
 pub use config::HttpConfig;
 #[cfg(feature = "p2p")]
 pub use config::P2PConfig;
+pub use config::{DocumentAcpConfig, SourceHubConfig};
 pub use dense_search::{DenseHybridSearchHit, DenseHybridSearchRequest, DenseHybridSearchResponse};
 pub use events::EventName;
 pub use query::{QueryExecutor, QueryRequest, QueryResponse};
@@ -276,6 +281,7 @@ pub struct NodeBuilder {
     embedding_url: Option<String>,
     embedding_model: Option<String>,
     embedding_api_key: Option<String>,
+    document_acp: DocumentAcpConfig,
     #[cfg(feature = "http")]
     http_config: Option<HttpConfig>,
     #[cfg(feature = "p2p")]
@@ -314,6 +320,12 @@ impl NodeBuilder {
     /// Set the resolved embedding API key value used for Authorization headers.
     pub fn with_embedding_api_key(mut self, api_key: impl Into<String>) -> Self {
         self.embedding_api_key = Some(api_key.into());
+        self
+    }
+
+    /// Configure the node to use SourceHub-backed document ACP.
+    pub fn with_sourcehub(mut self, config: SourceHubConfig) -> Self {
+        self.document_acp = DocumentAcpConfig::SourceHub(config);
         self
     }
 
@@ -375,6 +387,7 @@ impl NodeBuilder {
                     Self::build_with_store(
                         store,
                         acp_store,
+                        self.document_acp.clone(),
                         db_options.clone(),
                         event_bus,
                         #[cfg(feature = "p2p")]
@@ -395,6 +408,7 @@ impl NodeBuilder {
                     Self::build_with_store(
                         store,
                         acp_store,
+                        self.document_acp.clone(),
                         db_options.clone(),
                         event_bus,
                         #[cfg(feature = "p2p")]
@@ -417,6 +431,7 @@ impl NodeBuilder {
             Self::build_with_store(
                 store,
                 acp_store,
+                self.document_acp,
                 db_options,
                 event_bus,
                 #[cfg(feature = "p2p")]
@@ -489,6 +504,7 @@ impl NodeBuilder {
     async fn build_with_store<S: storage::corekv::Store + 'static>(
         store: Arc<S>,
         acp_store: Arc<dyn acp::AcpStore>,
+        document_acp_config: DocumentAcpConfig,
         db_options: db::DbOptions,
         event_bus: Arc<dyn events::Bus>,
         #[cfg(feature = "p2p")] p2p_config: Option<P2PConfig>,
@@ -506,7 +522,7 @@ impl NodeBuilder {
 
         // P2P setup (affects mutator choice)
         #[cfg(feature = "p2p")]
-        let p2p_result = if let Some(p2p_cfg) = p2p_config {
+        let mut p2p_result = if let Some(p2p_cfg) = p2p_config {
             Some(Self::setup_p2p(store.clone(), database.clone(), &p2p_cfg).await?)
         } else {
             None
@@ -528,8 +544,16 @@ impl NodeBuilder {
         let provider: Arc<dyn query::CollectionProvider> =
             db::DbCollectionProvider::new_arc(database.clone());
         let registry = Arc::new(db::DbTransactionRegistry::new(database.clone()));
-        let document_acp: Arc<dyn acp::DocumentACP> =
-            Arc::new(acp::LocalDocumentACP::new(acp_store));
+        let (document_acp, _strict_replicated_doc_access) =
+            node_acp::create_document_acp(acp_store, &document_acp_config).await?;
+
+        #[cfg(feature = "p2p")]
+        if let Some(wire_document_acp) = p2p_result
+            .as_mut()
+            .and_then(|result| result.wire_document_acp.take())
+        {
+            wire_document_acp(document_acp.clone(), _strict_replicated_doc_access);
+        }
 
         // Assemble query runner
         let query_runner =
@@ -615,7 +639,10 @@ impl NodeBuilder {
         }
 
         // 8. Merge handler
-        let merge_handler = Arc::new(db::DbMergeHandler::new(database.clone(), sync_blockstore));
+        let merge_handler_inner =
+            Arc::new(db::DbMergeHandler::new(database.clone(), sync_blockstore));
+        let merge_handler = Arc::new(db::AcpMergeHandler::new(merge_handler_inner));
+        let merge_handler_for_acp = merge_handler.clone();
 
         // 9. Replication loop (transport-generic)
         let coord_for_repl = coordinator.clone();
@@ -640,10 +667,12 @@ impl NodeBuilder {
         let collection_lookup: Arc<dyn CollectionLookup> = database.clone();
 
         // 12. BroadcastMutator (replaces AutoCommitMutator)
-        let mutator: Arc<dyn query::DocMutator> = Arc::new(db::BroadcastMutator::new(
+        let broadcast_mutator = Arc::new(db::BroadcastMutator::new(
             database.clone(),
             coordinator.clone(),
         ));
+        let broadcast_mutator_for_acp = broadcast_mutator.clone();
+        let mutator: Arc<dyn query::DocMutator> = broadcast_mutator;
 
         let peer_id = transport.local_peer_id().to_string();
         tracing::info!(peer_id = %peer_id, "P2P started (IROH/QUIC)");
@@ -653,7 +682,15 @@ impl NodeBuilder {
             collection_lookup,
         });
 
-        Ok(P2PSetupResult { ops, mutator })
+        Ok(P2PSetupResult {
+            ops,
+            mutator,
+            wire_document_acp: Some(Box::new(move |acp, strict| {
+                merge_handler_for_acp.set_document_acp(acp.clone());
+                merge_handler_for_acp.set_strict_replicated_doc_access(strict);
+                broadcast_mutator_for_acp.set_document_acp(acp);
+            })),
+        })
     }
 
     #[cfg(feature = "p2p")]
@@ -817,6 +854,7 @@ fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
 struct P2PSetupResult {
     ops: Arc<dyn P2POps>,
     mutator: Arc<dyn query::DocMutator>,
+    wire_document_acp: Option<WireDocumentAcpCallback>,
 }
 
 #[cfg(all(test, feature = "http"))]

--- a/crates/defra-node/src/node_acp.rs
+++ b/crates/defra-node/src/node_acp.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+
+pub(crate) async fn create_document_acp(
+    acp_store: Arc<dyn acp::AcpStore>,
+    config: &crate::DocumentAcpConfig,
+) -> Result<(Arc<dyn acp::DocumentACP>, bool)> {
+    match config {
+        crate::DocumentAcpConfig::SourceHub(sourcehub_config) => {
+            let tuning = sourcehub::AcpTuning::default();
+            let provider = Arc::new(
+                sourcehub::CosmosProvider::new(
+                    sourcehub_config.grpc_address.clone(),
+                    sourcehub_config.comet_rpc_address.clone(),
+                    &sourcehub_config.signer_key,
+                    &sourcehub_config.chain_id,
+                    &tuning,
+                )
+                .map_err(|error| anyhow!("failed to create SourceHub provider: {error}"))?,
+            );
+            let sh_acp = Arc::new(sourcehub::SourceHubDocumentACP::new(
+                provider,
+                tuning.cache_ttl,
+            ));
+            Ok((sh_acp, true))
+        }
+        crate::DocumentAcpConfig::Local => {
+            let document_acp = Arc::new(acp::LocalDocumentACP::new(acp_store));
+            Ok((document_acp, false))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SourceHub document ACP configuration types to `defra-node`
- add `NodeBuilder::with_sourcehub(...)` and thread the ACP choice through `build_with_store`
- construct SourceHub-backed `DocumentACP` for `defra-node` and wire it into query + P2P ACP paths

## Context
Issue #650 was validated against current `main`. The query layer is already ACP-provider-agnostic; the gap was that `defra-node` always constructed local document ACP and exposed no SourceHub configuration surface.

## Testing
- `cargo check -p defra-node`
