### PR TITLE
fix: isolate transaction-scoped lens visibility

### DIFF
--- a/crates/db/src/lensed_fetcher/mod.rs
+++ b/crates/db/src/lensed_fetcher/mod.rs
@@ -81,6 +81,10 @@ impl<S: Store> LensedDocFetcher<S> {
     pub(crate) fn shared_txn(&self) -> Arc<TokioMutex<Option<DbTxn<S>>>> {
         self.txn.clone()
     }
+
+    pub(crate) fn lens_store(&self) -> Arc<dyn TransformStore> {
+        self.lens_store.clone()
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -96,6 +96,7 @@ pub mod schema_loader;
 pub(crate) mod se;
 pub mod txn;
 pub(crate) mod txn_context;
+pub(crate) mod txn_lens_store;
 pub(crate) mod txn_registry;
 pub(crate) mod versioned_fetcher;
 pub(crate) mod view_ops;

--- a/crates/db/src/migration/set_migration.rs
+++ b/crates/db/src/migration/set_migration.rs
@@ -12,6 +12,11 @@ use crate::error::{Error, Result};
 use crate::txn::DbTxn;
 use crate::DB;
 
+pub(crate) struct SetMigrationInTxnOutcome {
+    pub(crate) transform_id: TransformId,
+    pub(crate) updated_destination: schema::CollectionVersion,
+}
+
 impl<S: Store> DB<S> {
     /// Set a migration between two schema versions.
     ///
@@ -220,6 +225,21 @@ impl<S: Store> DB<S> {
         txn: &DbTxn<S>,
         config: LensConfig,
     ) -> Result<TransformId> {
+        self.set_migration_in_txn_with_store(txn, self.lens_store.clone(), config)
+            .await
+            .map(|outcome| outcome.transform_id)
+    }
+
+    #[instrument(skip(self, txn, lens_store, config), fields(
+        source = %config.source_schema_version_id,
+        dest = %config.destination_schema_version_id
+    ))]
+    pub(crate) async fn set_migration_in_txn_with_store(
+        &self,
+        txn: &DbTxn<S>,
+        lens_store: std::sync::Arc<dyn lens::TransformStore>,
+        config: LensConfig,
+    ) -> Result<SetMigrationInTxnOutcome> {
         let dest_version_id = config.destination_schema_version_id.clone();
         let source_version_id = config.source_schema_version_id.clone();
         let config_for_persistence = config.clone();
@@ -300,11 +320,7 @@ impl<S: Store> DB<S> {
             }
         }
 
-        let transform_id = self
-            .lens_store
-            .add(config)
-            .await
-            .map_err(|e| Error::Lens(e.to_string()))?;
+        let transform_id = lens_store.add(config).await.map_err(Error::from)?;
 
         dst_col.previous_version = Some(CollectionSource {
             source_collection_id: source_col.version_id.clone(),
@@ -319,7 +335,6 @@ impl<S: Store> DB<S> {
             "set_migration_in_txn: storing destination version with transform"
         );
 
-        let collection_name = dst_col.name.clone();
         let dst_key = CollectionKey::new(&dest_version_id);
         let dst_data = serde_json::to_vec(&dst_col).map_err(|e| {
             Error::Serialization(format!(
@@ -362,21 +377,9 @@ impl<S: Store> DB<S> {
                 .map_err(Error::Storage)?;
         }
 
-        if !collection_name.is_empty() {
-            let mut cache = self.collections.write().map_err(|e| {
-                tracing::error!(error = ?e, "Collection cache lock poisoned during set_migration_in_txn");
-                Error::LockPoisoned(
-                    "collection cache lock poisoned during set_migration_in_txn".into(),
-                )
-            })?;
-
-            if let Some(cached) = cache.get(&collection_name) {
-                if cached.schema().version_id == dest_version_id {
-                    cache.insert(collection_name.clone(), Collection::new(dst_col));
-                }
-            }
-        }
-
-        Ok(transform_id)
+        Ok(SetMigrationInTxnOutcome {
+            transform_id,
+            updated_destination: dst_col,
+        })
     }
 }

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -95,6 +95,10 @@ impl<S: Store + 'static> DbTransactionContext<S> {
     pub(crate) fn fetcher_shared_txn(&self) -> Arc<async_lock::Mutex<Option<DbTxn<S>>>> {
         self.fetcher.shared_txn()
     }
+
+    pub(crate) fn lens_store(&self) -> Arc<dyn lens::TransformStore> {
+        self.fetcher.lens_store()
+    }
 }
 
 impl<S: Store + 'static> TransactionContext for DbTransactionContext<S> {

--- a/crates/db/src/txn_lens_store.rs
+++ b/crates/db/src/txn_lens_store.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+#[cfg(not(feature = "native"))]
+use lens::MemoryTransformStore;
+#[cfg(feature = "native")]
+use lens::WasmTransformStore;
+use lens::{LensConfig, LensDocResultStream, LensDocStream, TransformId, TransformStore};
+
+use crate::{Error, Result};
+
+/// Transaction-local transform store overlay.
+///
+/// Reads fall back to the committed global store, while writes remain isolated to
+/// the transaction-local store until commit promotion runs.
+pub(crate) struct TxnLensStore {
+    base: Arc<dyn TransformStore>,
+    local: Arc<dyn TransformStore>,
+}
+
+impl TxnLensStore {
+    pub(crate) fn new(base: Arc<dyn TransformStore>) -> Result<Self> {
+        Ok(Self {
+            base,
+            local: Self::create_local_store()?,
+        })
+    }
+
+    #[cfg(feature = "native")]
+    fn create_local_store() -> Result<Arc<dyn TransformStore>> {
+        let store = WasmTransformStore::with_sandbox(Some(lens::WasmSandboxConfig::restrictive()))
+            .map_err(|e| Error::Lens(format!("failed to create transaction lens store: {}", e)))?;
+        Ok(Arc::new(store))
+    }
+
+    #[cfg(not(feature = "native"))]
+    fn create_local_store() -> Result<Arc<dyn TransformStore>> {
+        Ok(Arc::new(MemoryTransformStore::new()))
+    }
+}
+
+#[async_trait]
+impl TransformStore for TxnLensStore {
+    async fn add(&self, config: LensConfig) -> lens::Result<TransformId> {
+        self.local.add(config).await
+    }
+
+    async fn add_with_id(&self, id: TransformId, config: LensConfig) -> lens::Result<()> {
+        self.local.add_with_id(id, config).await
+    }
+
+    async fn list(&self) -> lens::Result<HashMap<String, lens::LensModule>> {
+        let mut result = self.base.list().await?;
+        result.extend(self.local.list().await?);
+        Ok(result)
+    }
+
+    fn transform(
+        &self,
+        id: &TransformId,
+        docs: LensDocStream,
+    ) -> lens::Result<LensDocResultStream> {
+        if self.local.has_transform(id) {
+            self.local.transform(id, docs)
+        } else {
+            self.base.transform(id, docs)
+        }
+    }
+
+    fn inverse(&self, id: &TransformId, docs: LensDocStream) -> lens::Result<LensDocResultStream> {
+        if self.local.has_transform(id) {
+            self.local.inverse(id, docs)
+        } else {
+            self.base.inverse(id, docs)
+        }
+    }
+
+    fn has_transform(&self, id: &TransformId) -> bool {
+        self.local.has_transform(id) || self.base.has_transform(id)
+    }
+
+    async fn remove(&self, id: &TransformId) -> lens::Result<()> {
+        if self.local.has_transform(id) {
+            self.local.remove(id).await
+        } else {
+            self.base.remove(id).await
+        }
+    }
+}

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -33,6 +33,7 @@ use crate::database::DB;
 use crate::error::{Error, Result};
 use crate::lensed_fetcher::LensedDocFetcher;
 use crate::txn_context::DbTransactionContext;
+use crate::txn_lens_store::TxnLensStore;
 
 /// Result of a stale transaction cleanup operation.
 ///
@@ -79,7 +80,6 @@ impl CleanupResult {
 pub struct DbTransactionRegistry<S: Store> {
     db: Arc<DB<S>>,
     transactions: RwLock<HashMap<String, Arc<DbTransactionContext<S>>>>,
-    pending_lenses: RwLock<HashMap<String, HashMap<String, LensConfig>>>,
     id_counter: AtomicU64,
 }
 
@@ -91,7 +91,6 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         Self {
             db,
             transactions: RwLock::new(HashMap::new()),
-            pending_lenses: RwLock::new(HashMap::new()),
             id_counter: AtomicU64::new(0),
         }
     }
@@ -308,11 +307,70 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
 
         // Get the shared transaction from the fetcher
         let shared_txn = ctx.fetcher_shared_txn();
-        let txn_guard = shared_txn.lock().await;
-        let txn = txn_guard.as_ref().ok_or(Error::TxnNotActive)?;
+        let mut txn_guard = shared_txn.lock().await;
+        let txn = txn_guard.as_mut().ok_or(Error::TxnNotActive)?;
+        let txn_lens_store = ctx.lens_store();
 
-        // Call the database's transaction-aware set_migration
-        self.db.set_migration_in_txn(txn, config).await
+        let outcome = self
+            .db
+            .set_migration_in_txn_with_store(txn, txn_lens_store.clone(), config.clone())
+            .await?;
+        let transform_id = outcome.transform_id.clone();
+        let updated_destination = outcome.updated_destination.clone();
+
+        let db = self.db.clone();
+        let transform_id_for_commit = transform_id.clone();
+        let destination_version_id = updated_destination.version_id.clone();
+        txn.on_success_async(Box::new(move || {
+            let db = db.clone();
+            let config = config.clone();
+            let transform_id = transform_id_for_commit.clone();
+            let updated_destination = updated_destination.clone();
+            let destination_version_id = destination_version_id.clone();
+            Box::pin(async move {
+                if let Err(error) = db
+                    .lens_store()
+                    .add_with_id(transform_id.clone(), config)
+                    .await
+                {
+                    tracing::warn!(
+                        transform_id = %transform_id,
+                        error = %error,
+                        "failed to promote committed transaction migration lens"
+                    );
+                }
+
+                if !updated_destination.name.is_empty() {
+                    if let Ok(mut cache) = db.collections.write() {
+                        if let Some(cached) = cache.get(&updated_destination.name) {
+                            if cached.schema().version_id == destination_version_id {
+                                cache.insert(
+                                    updated_destination.name.clone(),
+                                    Collection::new(updated_destination.clone()),
+                                );
+                            }
+                        }
+                    }
+
+                    if let Err(error) = db
+                        .maybe_reindex_after_migration(
+                            &updated_destination.name,
+                            &updated_destination.version_id,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            collection = %updated_destination.name,
+                            version_id = %updated_destination.version_id,
+                            error = %error,
+                            "failed to reindex committed transaction migration"
+                        );
+                    }
+                }
+            })
+        }))?;
+
+        Ok(transform_id)
     }
 
     /// Add a schema within an existing transaction.
@@ -378,26 +436,16 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let shared_txn = ctx.fetcher_shared_txn();
         let mut txn_guard = shared_txn.lock().await;
         let txn = txn_guard.as_mut().ok_or(Error::TxnNotActive)?;
+        let txn_lens_store = ctx.lens_store();
 
         let transform_id = Self::compute_lens_transform_id(&config).await?;
-        let transform_id_str = transform_id.to_string();
-
-        {
-            let pending = self.pending_lenses.read().map_err(|_| {
-                Error::LockPoisoned("failed to acquire pending lens read lock".into())
-            })?;
-            if pending
-                .get(txn_id)
-                .and_then(|m| m.get(&transform_id_str))
-                .is_some()
-            {
-                return Ok(transform_id);
-            }
+        if txn_lens_store.has_transform(&transform_id) {
+            return Ok(transform_id);
         }
 
         let db = self.db.clone();
         let config_for_commit = config.clone();
-        let transform_id_for_log = transform_id_str.clone();
+        let transform_id_for_log = transform_id.to_string();
         txn.on_success_async(Box::new(move || {
             let db = db.clone();
             Box::pin(async move {
@@ -411,14 +459,10 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
             })
         }))?;
 
-        let mut pending = self
-            .pending_lenses
-            .write()
-            .map_err(|_| Error::LockPoisoned("failed to acquire pending lens write lock".into()))?;
-        pending
-            .entry(txn_id.to_string())
-            .or_default()
-            .insert(transform_id_str, config);
+        txn_lens_store
+            .add_with_id(transform_id.clone(), config)
+            .await
+            .map_err(Error::from)?;
 
         Ok(transform_id)
     }
@@ -459,29 +503,14 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         &self,
         txn_id: &str,
     ) -> Result<std::collections::HashMap<String, LensModule>> {
-        self.get_ctx(txn_id)?
+        let ctx = self
+            .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
 
-        let mut lenses = self
-            .db
-            .lens_store()
+        ctx.lens_store()
             .list()
             .await
-            .map_err(|e| Error::Lens(e.to_string()))?;
-
-        let pending = self
-            .pending_lenses
-            .read()
-            .map_err(|_| Error::LockPoisoned("failed to acquire pending lens read lock".into()))?;
-        if let Some(txn_lenses) = pending.get(txn_id) {
-            for (id, config) in txn_lenses {
-                if let Some(module) = config.lens().cloned() {
-                    lenses.insert(id.clone(), module);
-                }
-            }
-        }
-
-        Ok(lenses)
+            .map_err(|e| Error::Lens(e.to_string()))
     }
 
     /// Get all collection versions visible within a transaction.
@@ -557,7 +586,14 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
         // from the SystemStore on first access within the transaction. Once loaded,
         // the collection metadata is cached for the transaction's duration.
         // Use LensedDocFetcher to support lens migrations within transactions.
-        let lens_store = self.db.lens_store().clone();
+        let lens_store = Arc::new(TxnLensStore::new(self.db.lens_store().clone()).map_err(
+            |e| {
+                TransactionError::execution(format!(
+                    "failed to create transaction lens store: {}",
+                    e
+                ))
+            },
+        )?);
         let fetcher = Arc::new(LensedDocFetcher::new(db_txn, lens_store));
         let ctx = Arc::new(DbTransactionContext::new(
             self.db.clone(),
@@ -610,11 +646,6 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
                 TransactionError::not_found(format!("transaction '{}' not found", handle))
             })?;
 
-        let _ = self
-            .pending_lenses
-            .write()
-            .map(|mut guard| guard.remove(handle.as_str()));
-
         let txn = ctx.take_txn().await.ok_or_else(|| {
             TransactionError::already_finalized(format!(
                 "transaction '{}' was already consumed (double commit/rollback?)",
@@ -644,11 +675,6 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .ok_or_else(|| {
                 TransactionError::not_found(format!("transaction '{}' not found", handle))
             })?;
-
-        let _ = self
-            .pending_lenses
-            .write()
-            .map(|mut guard| guard.remove(handle.as_str()));
 
         let txn = ctx.take_txn().await.ok_or_else(|| {
             TransactionError::already_finalized(format!(

--- a/crates/db/src/txn_registry_tests.rs
+++ b/crates/db/src/txn_registry_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use document::NormalValue;
+use lens::{LensConfig, LensModule};
 use schema::{CollectionVersion, FieldDescription, FieldKind};
 use storage::backends::MemoryStore;
 
@@ -23,6 +24,10 @@ async fn test_db_with_collections() -> Arc<DB<MemoryStore>> {
         db.create_collection(schema).await.unwrap();
     }
     db
+}
+
+fn empty_wasm_module() -> LensModule {
+    LensModule::from_bytes(vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00])
 }
 
 #[tokio::test]
@@ -195,6 +200,62 @@ async fn test_get_returns_not_found_after_rollback() {
         registry.get(&txn_id),
         GetTransactionResult::NotFound
     ));
+}
+
+#[tokio::test]
+async fn test_set_migration_in_txn_is_only_visible_inside_transaction() {
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
+
+    let txn_id = registry.begin(false).await.unwrap();
+    let config = LensConfig::new("users-v1", "users-v2", empty_wasm_module());
+
+    let transform_id = registry
+        .set_migration_in_txn(&txn_id, config)
+        .await
+        .unwrap();
+
+    let global_lenses = db.lens_store().list().await.unwrap();
+    assert!(
+        !global_lenses.contains_key(&transform_id.to_string()),
+        "uncommitted migration leaked into global lens list"
+    );
+
+    let txn_lenses = registry.list_lenses_in_txn(&txn_id).await.unwrap();
+    assert!(
+        txn_lenses.contains_key(&transform_id.to_string()),
+        "transaction-local migration should be visible inside the transaction"
+    );
+
+    registry.rollback(&txn_id).await.unwrap();
+
+    let global_after_rollback = db.lens_store().list().await.unwrap();
+    assert!(
+        !global_after_rollback.contains_key(&transform_id.to_string()),
+        "rolled back migration leaked into global lens list"
+    );
+}
+
+#[tokio::test]
+async fn test_set_migration_in_txn_promotes_transform_on_commit() {
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db.clone());
+
+    let txn_id = registry.begin(false).await.unwrap();
+    let config = LensConfig::new("users-v1", "users-v2", empty_wasm_module());
+
+    let transform_id = registry
+        .set_migration_in_txn(&txn_id, config)
+        .await
+        .unwrap();
+
+    registry.commit(&txn_id).await.unwrap();
+
+    let global_lenses = db.lens_store().list().await.unwrap();
+    assert!(
+        global_lenses.contains_key(&transform_id.to_string()),
+        "committed migration should be promoted into the global lens store"
+    );
 }
 
 #[tokio::test]

--- a/crates/lens/src/lib.rs
+++ b/crates/lens/src/lib.rs
@@ -19,6 +19,8 @@ pub use doc::{LensDoc, DELETED_FIELD, DOC_ID_FIELD};
 pub use error::{Error, Result};
 pub use history::{build_targeted_history, CollectionHistoryLink, TargetedHistoryLink};
 pub use pipeline::{Lens, LensInput};
-pub use store::{MemoryTransformStore, TransformId, TransformStore};
+pub use store::{
+    LensDocResultStream, LensDocStream, MemoryTransformStore, TransformId, TransformStore,
+};
 #[cfg(feature = "wasmtime-runtime")]
 pub use wasm::{WasmSandboxConfig, WasmTransformStore};


### PR DESCRIPTION
## Summary
- isolate uncommitted transaction lenses in a transaction-local overlay store
- promote committed migration lenses into the global store only after commit
- add regression tests for rollback visibility leakage and commit promotion

## Problem
`set_migration_in_txn` was registering transforms in the global lens store before commit. That violated the transaction-scoped API contract and let rolled-back migrations leak into normal lens listing.

## Fix
Transactions now get a lens-store overlay that resolves committed transforms from the global store and keeps uncommitted transforms locally. Transaction-scoped migration setup writes to that overlay, while commit promotes the transform into the global store and updates cache/reindex side effects after commit.

## Tests
- `cargo test -p db test_set_migration_in_txn_is_only_visible_inside_transaction -- --nocapture`
- `cargo test -p db test_set_migration_in_txn_promotes_transform_on_commit -- --nocapture`

Closes #645
