### PR TITLE
refactor: narrow typed defra-core error redesign

### DIFF
--- a/crates/acp/src/error.rs
+++ b/crates/acp/src/error.rs
@@ -10,7 +10,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     /// JSON serialization/deserialization errors
-    #[error("json error: {0}")]
+    #[error("serialization error: {0}")]
     Json(#[from] serde_json::Error),
 
     /// Permission denied for the requested operation
@@ -194,5 +194,6 @@ mod tests {
         let err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
         let error: Error = err.into();
         assert!(matches!(error, Error::Json(_)));
+        assert!(error.to_string().starts_with("serialization error: "));
     }
 }

--- a/crates/acp/src/error.rs
+++ b/crates/acp/src/error.rs
@@ -9,6 +9,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
+    /// JSON serialization/deserialization errors
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
     /// Permission denied for the requested operation
     #[error("permission denied: {0}")]
     PermissionDenied(String),
@@ -106,12 +110,6 @@ pub enum Error {
     },
 }
 
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Self {
-        Error::Serialization(err.to_string())
-    }
-}
-
 impl From<zanzibar::error::Error> for Error {
     fn from(e: zanzibar::error::Error) -> Self {
         match e {
@@ -184,5 +182,17 @@ impl Error {
             operation: operation.into(),
             details: err.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn json_errors_preserve_their_type() {
+        let err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+        let error: Error = err.into();
+        assert!(matches!(error, Error::Json(_)));
     }
 }

--- a/crates/acp/src/persistent.rs
+++ b/crates/acp/src/persistent.rs
@@ -168,7 +168,7 @@ impl<S: Store + Send + Sync> AcpStore for PersistentAcpStore<S> {
             .map_err(|e| Error::storage_txn("put_tuple:begin", e))?;
 
         let key = tuple.storage_key();
-        let value = serde_json::to_vec(tuple).map_err(|e| Error::Serialization(e.to_string()))?;
+        let value = serde_json::to_vec(tuple)?;
 
         txn.set(key.as_bytes(), &value)
             .await
@@ -245,8 +245,7 @@ impl<S: Store + Send + Sync> AcpStore for PersistentAcpStore<S> {
             .await
             .map_err(|e| Error::storage_iter("get_doc_tuples:next", e))?
         {
-            let tuple: RelationTuple = serde_json::from_slice(&kv.value)
-                .map_err(|e| Error::Serialization(e.to_string()))?;
+            let tuple: RelationTuple = serde_json::from_slice(&kv.value)?;
             tuples.push(tuple);
         }
 
@@ -284,8 +283,7 @@ impl<S: Store + Send + Sync> AcpStore for PersistentAcpStore<S> {
             .await
             .map_err(|e| Error::storage_iter("get_relation_subjects:next", e))?
         {
-            let tuple: RelationTuple = serde_json::from_slice(&kv.value)
-                .map_err(|e| Error::Serialization(e.to_string()))?;
+            let tuple: RelationTuple = serde_json::from_slice(&kv.value)?;
             subjects.push(tuple.subject().clone());
         }
 
@@ -323,8 +321,7 @@ impl<S: Store + Send + Sync> AcpStore for PersistentAcpStore<S> {
             .await
             .map_err(|e| Error::storage_iter("get_subject_relations:next", e))?
         {
-            let tuple: RelationTuple = serde_json::from_slice(&kv.value)
-                .map_err(|e| Error::Serialization(e.to_string()))?;
+            let tuple: RelationTuple = serde_json::from_slice(&kv.value)?;
             if tuple.subject() == subject {
                 relations.push(tuple.relation().to_string());
             }
@@ -438,7 +435,7 @@ impl<S: Store + Send + Sync> AcpStore for PersistentAcpStore<S> {
 
         let tuple = RelationTuple::owner(owner.clone(), collection_id, doc_id);
         let key = tuple.storage_key();
-        let value = serde_json::to_vec(&tuple).map_err(|e| Error::Serialization(e.to_string()))?;
+        let value = serde_json::to_vec(&tuple)?;
 
         txn.set(key.as_bytes(), &value)
             .await

--- a/crates/crypto/src/merkle_proof/proof.rs
+++ b/crates/crypto/src/merkle_proof/proof.rs
@@ -123,12 +123,12 @@ impl MerkleProof {
 
     /// Serialize the proof to DAG-CBOR
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
-        serde_ipld_dagcbor::to_vec(self).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::to_vec(self)?)
     }
 
     /// Deserialize the proof from DAG-CBOR
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
-        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::from_slice(bytes)?)
     }
 
     /// Get the proof path length

--- a/crates/crypto/src/merkle_proof/signed_proof.rs
+++ b/crates/crypto/src/merkle_proof/signed_proof.rs
@@ -120,12 +120,12 @@ impl SignedMerkleProof {
 
     /// Serialize to DAG-CBOR
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
-        serde_ipld_dagcbor::to_vec(self).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::to_vec(self)?)
     }
 
     /// Deserialize from DAG-CBOR
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
-        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::from_slice(bytes)?)
     }
 }
 

--- a/crates/db/src/collection/crud.rs
+++ b/crates/db/src/collection/crud.rs
@@ -28,9 +28,7 @@ impl Collection {
         }
 
         // Serialize document to CBOR
-        let data = doc
-            .to_cbor()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
+        let data = doc.to_cbor()?;
 
         // Store document
         datastore.set(&key, &data).await.map_err(Error::Storage)?;
@@ -51,8 +49,7 @@ impl Collection {
 
         match data {
             Some(bytes) => {
-                let mut doc =
-                    Document::from_cbor(&bytes).map_err(|e| Error::Serialization(e.to_string()))?;
+                let mut doc = Document::from_cbor(&bytes)?;
                 // Set the document ID (stored as part of the key, not in the serialized document)
                 doc.set_id(doc_id.clone());
 
@@ -86,9 +83,7 @@ impl Collection {
         }
 
         // Serialize and store
-        let data = doc
-            .to_cbor()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
+        let data = doc.to_cbor()?;
 
         let datastore = txn.datastore()?;
         datastore.set(&key, &data).await.map_err(Error::Storage)?;
@@ -141,9 +136,7 @@ impl Collection {
         let key = self.doc_key(&doc_id);
 
         // Serialize and store (upsert)
-        let data = doc
-            .to_cbor()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
+        let data = doc.to_cbor()?;
 
         txn.datastore()?
             .set(&key, &data)

--- a/crates/db/src/collection/crud.rs
+++ b/crates/db/src/collection/crud.rs
@@ -162,13 +162,8 @@ impl Collection {
             .map_err(Error::Storage)?;
 
         while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
-            let mut doc = Document::from_cbor(&pair.value).map_err(|e| {
-                Error::Serialization(format!(
-                    "failed to deserialize document at key {:?}: {}",
-                    String::from_utf8_lossy(&pair.key),
-                    e
-                ))
-            })?;
+            let mut doc = Document::from_cbor(&pair.value)
+                .map_err(|e| Error::document_at_key(&pair.key, e))?;
 
             // Extract doc_id from key (format: /d/<collection_id>/<doc_id>)
             // Find the last '/' and extract the doc_id string after it

--- a/crates/db/src/collection/crud_datastore.rs
+++ b/crates/db/src/collection/crud_datastore.rs
@@ -95,13 +95,8 @@ impl Collection {
                 continue;
             }
 
-            let mut doc = Document::from_cbor(&pair.value).map_err(|e| {
-                Error::Serialization(format!(
-                    "failed to deserialize document at key {:?}: {}",
-                    String::from_utf8_lossy(&pair.key),
-                    e
-                ))
-            })?;
+            let mut doc = Document::from_cbor(&pair.value)
+                .map_err(|e| Error::document_at_key(&pair.key, e))?;
 
             // Extract doc_id from key (format: /d/<collection_id>/<doc_id>)
             // Find the last '/' and extract the doc_id string after it

--- a/crates/db/src/collection/crud_datastore.rs
+++ b/crates/db/src/collection/crud_datastore.rs
@@ -37,8 +37,7 @@ impl Collection {
 
         match data {
             Some(bytes) => {
-                let mut doc =
-                    Document::from_cbor(&bytes).map_err(|e| Error::Serialization(e.to_string()))?;
+                let mut doc = Document::from_cbor(&bytes)?;
                 // Set the document ID (stored as part of the key, not in the serialized document)
                 doc.set_id(doc_id.clone());
 
@@ -162,9 +161,7 @@ impl Collection {
         }
 
         // Serialize document to CBOR
-        let data = doc
-            .to_cbor()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
+        let data = doc.to_cbor()?;
 
         // Store document
         datastore.set(&key, &data).await.map_err(Error::Storage)?;
@@ -199,9 +196,7 @@ impl Collection {
         }
 
         // Serialize and store
-        let data = doc
-            .to_cbor()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
+        let data = doc.to_cbor()?;
 
         datastore.set(&key, &data).await.map_err(Error::Storage)?;
 
@@ -291,9 +286,7 @@ impl Collection {
         let key = self.doc_key(&doc_id);
 
         // Serialize and store (upsert)
-        let data = doc
-            .to_cbor()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
+        let data = doc.to_cbor()?;
 
         datastore.set(&key, &data).await.map_err(Error::Storage)?;
 

--- a/crates/db/src/collection/index_ops.rs
+++ b/crates/db/src/collection/index_ops.rs
@@ -32,9 +32,7 @@ impl Collection {
         }
 
         // Serialize document to CBOR
-        let data = doc
-            .to_cbor()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
+        let data = doc.to_cbor()?;
 
         // Store document
         datastore.set(&key, &data).await.map_err(Error::Storage)?;
@@ -77,8 +75,7 @@ impl Collection {
         // Get old document for index update
         let old_doc = match datastore.get(&key).await.map_err(Error::Storage)? {
             Some(bytes) => {
-                let mut d =
-                    Document::from_cbor(&bytes).map_err(|e| Error::Serialization(e.to_string()))?;
+                let mut d = Document::from_cbor(&bytes)?;
                 d.set_id(doc_id.clone());
                 d
             }
@@ -86,9 +83,7 @@ impl Collection {
         };
 
         // Serialize and store
-        let data = doc
-            .to_cbor()
-            .map_err(|e| Error::Serialization(e.to_string()))?;
+        let data = doc.to_cbor()?;
 
         datastore.set(&key, &data).await.map_err(Error::Storage)?;
 
@@ -125,8 +120,7 @@ impl Collection {
         // Get the document for index cleanup
         let doc = match datastore.get(&key).await.map_err(Error::Storage)? {
             Some(bytes) => {
-                let mut d =
-                    Document::from_cbor(&bytes).map_err(|e| Error::Serialization(e.to_string()))?;
+                let mut d = Document::from_cbor(&bytes)?;
                 d.set_id(doc_id.clone());
                 d
             }

--- a/crates/db/src/collection/mod.rs
+++ b/crates/db/src/collection/mod.rs
@@ -254,9 +254,8 @@ impl Collection {
 
         match datastore.get(&key).await.map_err(Error::Storage)? {
             Some(bytes) => {
-                let version = String::from_utf8(bytes).map_err(|e| {
-                    Error::Serialization(format!("Invalid version encoding: {}", e))
-                })?;
+                let version = String::from_utf8(bytes)
+                    .map_err(|e| Error::text_decode("invalid version encoding", e))?;
                 Ok(Some(version))
             }
             None => Ok(None),

--- a/crates/db/src/collection_ops/create.rs
+++ b/crates/db/src/collection_ops/create.rs
@@ -131,10 +131,10 @@ impl<S: Store> crate::database::DB<S> {
         // 1. Store full schema at /collection/id/{version_id}
         let collection_key = CollectionKey::new(version_id.as_str());
         let data = serde_json::to_vec(&schema).map_err(|e| {
-            Error::Serialization(format!(
-                "failed to serialize schema for collection '{}': {}",
-                name, e
-            ))
+            Error::collection_schema_json(
+                format!("failed to serialize schema for collection '{}'", name),
+                e,
+            )
         })?;
         systemstore
             .set(&collection_key.bytes(), &data)
@@ -354,10 +354,10 @@ impl<S: Store> crate::database::DB<S> {
                 if changed {
                     let collection_key = CollectionKey::new(&schema.version_id);
                     let data = serde_json::to_vec(&schema).map_err(|e| {
-                        Error::Serialization(format!(
-                            "failed to re-serialize schema for '{}': {}",
-                            schema.name, e
-                        ))
+                        Error::collection_schema_json(
+                            format!("failed to re-serialize schema for '{}'", schema.name),
+                            e,
+                        )
                     })?;
                     systemstore
                         .set(&collection_key.bytes(), &data)

--- a/crates/db/src/collection_ops/mod.rs
+++ b/crates/db/src/collection_ops/mod.rs
@@ -80,7 +80,7 @@ impl<S: Store> crate::database::DB<S> {
                         key_bytes = ?&pair.key[..pair.key.len().min(50)],
                         "Collection key contains invalid UTF-8"
                     );
-                    Error::Serialization(format!("collection key contains invalid UTF-8: {}", e))
+                    Error::text_decode("collection key contains invalid UTF-8", e)
                 })?;
 
                 let prefix_str = String::from_utf8(prefix.clone()).map_err(|e| {
@@ -114,10 +114,13 @@ impl<S: Store> crate::database::DB<S> {
                         collection_name = %name,
                         "Collection version ID contains invalid UTF-8"
                     );
-                    Error::Serialization(format!(
-                        "collection version ID for '{}' contains invalid UTF-8: {}",
-                        name, e
-                    ))
+                    Error::text_decode(
+                        format!(
+                            "collection version ID for '{}' contains invalid UTF-8",
+                            name
+                        ),
+                        e,
+                    )
                 })?;
 
                 // Look up the full collection definition from /collection/id/{version_id}

--- a/crates/db/src/collection_ops/mod.rs
+++ b/crates/db/src/collection_ops/mod.rs
@@ -155,10 +155,10 @@ impl<S: Store> crate::database::DB<S> {
                             json_preview = %String::from_utf8_lossy(&collection_json[..collection_json.len().min(200)]),
                             "Failed to deserialize collection schema"
                         );
-                        Error::Serialization(format!(
-                            "failed to deserialize schema for collection '{}': {}",
-                            name, e
-                        ))
+                        Error::collection_schema_json(
+                            format!("failed to deserialize schema for collection '{}'", name),
+                            e,
+                        )
                     })?;
 
                 populate_collection_root_id(&systemstore, &mut schema).await?;

--- a/crates/db/src/collection_ops/version.rs
+++ b/crates/db/src/collection_ops/version.rs
@@ -36,10 +36,13 @@ impl<S: Store> crate::database::DB<S> {
 
             let mut target_schema: CollectionVersion = serde_json::from_slice(&target_bytes)
                 .map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to deserialize schema for version_id '{}': {}",
-                        version_id, e
-                    ))
+                    Error::collection_schema_json(
+                        format!(
+                            "failed to deserialize schema for version_id '{}'",
+                            version_id
+                        ),
+                        e,
+                    )
                 })?;
             crate::collection::populate_collection_root_id(&systemstore, &mut target_schema)
                 .await?;
@@ -52,10 +55,10 @@ impl<S: Store> crate::database::DB<S> {
 
             // Store the updated target schema
             let target_data = serde_json::to_vec(&target_schema).map_err(|e| {
-                Error::Serialization(format!(
-                    "failed to serialize schema for version_id '{}': {}",
-                    version_id, e
-                ))
+                Error::collection_schema_json(
+                    format!("failed to serialize schema for version_id '{}'", version_id),
+                    e,
+                )
             })?;
             systemstore
                 .set(&collection_key.bytes(), &target_data)
@@ -238,10 +241,10 @@ impl<S: Store> crate::database::DB<S> {
                 .ok_or(Error::CollectionVersionNotFound(version_id.to_string()))?;
             let mut schema =
                 serde_json::from_slice::<CollectionVersion>(&target_bytes).map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to deserialize version '{}': {}",
-                        version_id, e
-                    ))
+                    Error::collection_schema_json(
+                        format!("failed to deserialize version '{}'", version_id),
+                        e,
+                    )
                 })?;
 
             crate::collection::populate_collection_root_id(&systemstore, &mut schema).await?;

--- a/crates/db/src/commits_fetcher/conversion.rs
+++ b/crates/db/src/commits_fetcher/conversion.rs
@@ -27,7 +27,8 @@ impl<S: Store> CommitsFetcher<S> {
                 Error::Serialization("cid either does not exist or belong to document".to_string())
             })?;
 
-        let block = Block::from_dag_cbor(&data)?;
+        let block = Block::from_dag_cbor(&data)
+            .map_err(|e| Error::Serialization(format!("Failed to decode block: {}", e)))?;
         tracing::debug!(
             cid = %cid,
             data_len = data.len(),
@@ -52,7 +53,8 @@ impl<S: Store> CommitsFetcher<S> {
             .map_err(Error::Storage)?
             .ok_or_else(|| Error::Serialization("signature block not found".to_string()))?;
 
-        Ok(Signature::from_dag_cbor(&data)?)
+        Signature::from_dag_cbor(&data)
+            .map_err(|e| Error::Serialization(format!("Failed to decode signature block: {}", e)))
     }
 
     /// Convert a block to a commit document.

--- a/crates/db/src/commits_fetcher/conversion.rs
+++ b/crates/db/src/commits_fetcher/conversion.rs
@@ -27,8 +27,7 @@ impl<S: Store> CommitsFetcher<S> {
                 Error::Serialization("cid either does not exist or belong to document".to_string())
             })?;
 
-        let block = Block::from_dag_cbor(&data)
-            .map_err(|e| Error::Serialization(format!("Failed to decode block: {}", e)))?;
+        let block = Block::from_dag_cbor(&data)?;
         tracing::debug!(
             cid = %cid,
             data_len = data.len(),
@@ -53,8 +52,7 @@ impl<S: Store> CommitsFetcher<S> {
             .map_err(Error::Storage)?
             .ok_or_else(|| Error::Serialization("signature block not found".to_string()))?;
 
-        Signature::from_dag_cbor(&data)
-            .map_err(|e| Error::Serialization(format!("Failed to decode signature block: {}", e)))
+        Ok(Signature::from_dag_cbor(&data)?)
     }
 
     /// Convert a block to a commit document.
@@ -211,8 +209,7 @@ impl<S: Store> CommitsFetcher<S> {
         };
         map.insert("signature".to_string(), sig_value);
 
-        Document::from_map(map)
-            .map_err(|e| Error::Serialization(format!("Failed to create document: {}", e)))
+        Ok(Document::from_map(map)?)
     }
 
     /// Build simple links array (without recursive nesting) for nested queries.

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -61,6 +61,12 @@ pub enum Error {
     #[error("serialization error: {0}")]
     Serialization(String),
 
+    #[error("{context}: {source}")]
+    CollectionSchemaJson {
+        context: String,
+        source: serde_json::Error,
+    },
+
     #[error("query error: {0}")]
     Query(#[from] query::error::QueryError),
 
@@ -107,6 +113,13 @@ impl Error {
     pub fn document_at_key(key: &[u8], source: document::Error) -> Self {
         Self::DocumentAtKey {
             key: String::from_utf8_lossy(key).into_owned(),
+            source,
+        }
+    }
+
+    pub fn collection_schema_json(context: impl Into<String>, source: serde_json::Error) -> Self {
+        Self::CollectionSchemaJson {
+            context: context.into(),
             source,
         }
     }

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -184,11 +184,9 @@ mod tests {
         );
 
         assert!(matches!(error, Error::CollectionSchemaJson { .. }));
-        assert!(
-            error
-                .to_string()
-                .starts_with("failed to deserialize schema for collection 'users': ")
-        );
+        assert!(error
+            .to_string()
+            .starts_with("failed to deserialize schema for collection 'users': "));
     }
 
     #[test]
@@ -197,11 +195,9 @@ mod tests {
         let error = Error::lens_config_json("failed to serialize lens config", source);
 
         assert!(matches!(error, Error::LensConfigJson { .. }));
-        assert!(
-            error
-                .to_string()
-                .starts_with("failed to serialize lens config: ")
-        );
+        assert!(error
+            .to_string()
+            .starts_with("failed to serialize lens config: "));
     }
 
     #[test]
@@ -210,8 +206,6 @@ mod tests {
         let error = Error::text_decode("invalid version encoding", source);
 
         assert!(matches!(error, Error::TextDecode { .. }));
-        assert!(error
-            .to_string()
-            .starts_with("invalid version encoding: "));
+        assert!(error.to_string().starts_with("invalid version encoding: "));
     }
 }

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -67,6 +67,12 @@ pub enum Error {
         source: serde_json::Error,
     },
 
+    #[error("{context}: {source}")]
+    TextDecode {
+        context: String,
+        source: std::string::FromUtf8Error,
+    },
+
     #[error("query error: {0}")]
     Query(#[from] query::error::QueryError),
 
@@ -119,6 +125,13 @@ impl Error {
 
     pub fn collection_schema_json(context: impl Into<String>, source: serde_json::Error) -> Self {
         Self::CollectionSchemaJson {
+            context: context.into(),
+            source,
+        }
+    }
+
+    pub fn text_decode(context: impl Into<String>, source: std::string::FromUtf8Error) -> Self {
+        Self::TextDecode {
             context: context.into(),
             source,
         }

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -156,3 +156,62 @@ impl Error {
 
 /// Result type for database operations.
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn document_at_key_preserves_display_message() {
+        let error = Error::document_at_key(
+            b"doc-key",
+            document::Error::CborDecode("bad cbor".to_string()),
+        );
+
+        assert!(matches!(error, Error::DocumentAtKey { .. }));
+        assert_eq!(
+            error.to_string(),
+            "failed to deserialize document at key \"doc-key\": CBOR decode error: bad cbor"
+        );
+    }
+
+    #[test]
+    fn collection_schema_json_preserves_display_message() {
+        let source = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+        let error = Error::collection_schema_json(
+            "failed to deserialize schema for collection 'users'",
+            source,
+        );
+
+        assert!(matches!(error, Error::CollectionSchemaJson { .. }));
+        assert!(
+            error
+                .to_string()
+                .starts_with("failed to deserialize schema for collection 'users': ")
+        );
+    }
+
+    #[test]
+    fn lens_config_json_preserves_display_message() {
+        let source = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+        let error = Error::lens_config_json("failed to serialize lens config", source);
+
+        assert!(matches!(error, Error::LensConfigJson { .. }));
+        assert!(
+            error
+                .to_string()
+                .starts_with("failed to serialize lens config: ")
+        );
+    }
+
+    #[test]
+    fn text_decode_preserves_display_message() {
+        let source = String::from_utf8(vec![0x80]).unwrap_err();
+        let error = Error::text_decode("invalid version encoding", source);
+
+        assert!(matches!(error, Error::TextDecode { .. }));
+        assert!(error
+            .to_string()
+            .starts_with("invalid version encoding: "));
+    }
+}

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
     #[error("document error: {0}")]
     Document(#[from] document::Error),
 
+    #[error("failed to deserialize document at key {key:?}: {source}")]
+    DocumentAtKey {
+        key: String,
+        source: document::Error,
+    },
+
     #[error("collection '{0}' not found")]
     CollectionNotFound(String),
 
@@ -94,6 +100,15 @@ impl From<acp::Error> for Error {
 impl From<lens::Error> for Error {
     fn from(err: lens::Error) -> Self {
         Error::Lens(err.to_string())
+    }
+}
+
+impl Error {
+    pub fn document_at_key(key: &[u8], source: document::Error) -> Self {
+        Self::DocumentAtKey {
+            key: String::from_utf8_lossy(key).into_owned(),
+            source,
+        }
     }
 }
 

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -71,6 +71,12 @@ pub enum Error {
     },
 
     #[error("{context}: {source}")]
+    LensConfigJson {
+        context: String,
+        source: serde_json::Error,
+    },
+
+    #[error("{context}: {source}")]
     TextDecode {
         context: String,
         source: std::string::FromUtf8Error,
@@ -135,6 +141,13 @@ impl Error {
 
     pub fn text_decode(context: impl Into<String>, source: std::string::FromUtf8Error) -> Self {
         Self::TextDecode {
+            context: context.into(),
+            source,
+        }
+    }
+
+    pub fn lens_config_json(context: impl Into<String>, source: serde_json::Error) -> Self {
+        Self::LensConfigJson {
             context: context.into(),
             source,
         }

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
     #[error("document error: {0}")]
     Document(#[from] document::Error),
 
+    #[error("core error: {0}")]
+    Core(#[from] defra_core::Error),
+
     #[error("failed to deserialize document at key {key:?}: {source}")]
     DocumentAtKey {
         key: String,

--- a/crates/db/src/migration/mod.rs
+++ b/crates/db/src/migration/mod.rs
@@ -81,9 +81,8 @@ impl<S: Store> DB<S> {
 
             let systemstore = txn.systemstore()?;
             let lens_key = LensConfigKey::new(config_cid.to_string());
-            let lens_data = serde_json::to_vec(&config_for_persistence).map_err(|e| {
-                Error::Serialization(format!("failed to serialize lens config: {}", e))
-            })?;
+            let lens_data = serde_json::to_vec(&config_for_persistence)
+                .map_err(|e| Error::lens_config_json("failed to serialize lens config", e))?;
             systemstore
                 .set(&lens_key.bytes(), &lens_data)
                 .await

--- a/crates/db/src/migration/set_migration.rs
+++ b/crates/db/src/migration/set_migration.rs
@@ -51,10 +51,13 @@ impl<S: Store> DB<S> {
                 .map_err(Error::Storage)?;
             let mut source_col: schema::CollectionVersion = match src_data {
                 Some(data) => serde_json::from_slice(&data).map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to deserialize source schema '{}': {}",
-                        source_version_id, e
-                    ))
+                    Error::collection_schema_json(
+                        format!(
+                            "failed to deserialize source schema '{}'",
+                            source_version_id
+                        ),
+                        e,
+                    )
                 })?,
                 None => {
                     let mut placeholder = create_orphan_placeholder(&source_version_id, "", "");
@@ -64,10 +67,13 @@ impl<S: Store> DB<S> {
                     )
                     .await?;
                     let data = serde_json::to_vec(&placeholder).map_err(|e| {
-                        Error::Serialization(format!(
-                            "failed to serialize source placeholder '{}': {}",
-                            source_version_id, e
-                        ))
+                        Error::collection_schema_json(
+                            format!(
+                                "failed to serialize source placeholder '{}'",
+                                source_version_id
+                            ),
+                            e,
+                        )
                     })?;
                     systemstore
                         .set(&src_key.bytes(), &data)
@@ -84,10 +90,13 @@ impl<S: Store> DB<S> {
                 .map_err(Error::Storage)?;
             let mut dst_col: schema::CollectionVersion = match dst_data {
                 Some(data) => serde_json::from_slice(&data).map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to deserialize destination schema '{}': {}",
-                        dest_version_id, e
-                    ))
+                    Error::collection_schema_json(
+                        format!(
+                            "failed to deserialize destination schema '{}'",
+                            dest_version_id
+                        ),
+                        e,
+                    )
                 })?,
                 None => {
                     let mut placeholder = create_placeholder_with_source(
@@ -101,10 +110,13 @@ impl<S: Store> DB<S> {
                     )
                     .await?;
                     let data = serde_json::to_vec(&placeholder).map_err(|e| {
-                        Error::Serialization(format!(
-                            "failed to serialize destination placeholder '{}': {}",
-                            dest_version_id, e
-                        ))
+                        Error::collection_schema_json(
+                            format!(
+                                "failed to serialize destination placeholder '{}'",
+                                dest_version_id
+                            ),
+                            e,
+                        )
                     })?;
                     systemstore
                         .set(&dst_key.bytes(), &data)
@@ -164,10 +176,13 @@ impl<S: Store> DB<S> {
         let collection_name = dst_col.name.clone();
         let dst_key = CollectionKey::new(&dest_version_id);
         let dst_data = serde_json::to_vec(&dst_col).map_err(|e| {
-            Error::Serialization(format!(
-                "failed to serialize destination schema '{}': {}",
-                dest_version_id, e
-            ))
+            Error::collection_schema_json(
+                format!(
+                    "failed to serialize destination schema '{}'",
+                    dest_version_id
+                ),
+                e,
+            )
         })?;
 
         {
@@ -279,10 +294,13 @@ impl<S: Store> DB<S> {
                 .map_err(Error::Storage)?;
             let mut source_col: schema::CollectionVersion = match src_data {
                 Some(data) => serde_json::from_slice(&data).map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to deserialize source schema '{}': {}",
-                        source_version_id, e
-                    ))
+                    Error::collection_schema_json(
+                        format!(
+                            "failed to deserialize source schema '{}'",
+                            source_version_id
+                        ),
+                        e,
+                    )
                 })?,
                 None => {
                     let mut placeholder = create_orphan_placeholder(&source_version_id, "", "");
@@ -292,10 +310,13 @@ impl<S: Store> DB<S> {
                     )
                     .await?;
                     let data = serde_json::to_vec(&placeholder).map_err(|e| {
-                        Error::Serialization(format!(
-                            "failed to serialize source placeholder '{}': {}",
-                            source_version_id, e
-                        ))
+                        Error::collection_schema_json(
+                            format!(
+                                "failed to serialize source placeholder '{}'",
+                                source_version_id
+                            ),
+                            e,
+                        )
                     })?;
                     systemstore
                         .set(&src_key.bytes(), &data)
@@ -312,10 +333,13 @@ impl<S: Store> DB<S> {
                 .map_err(Error::Storage)?;
             let mut dst_col: schema::CollectionVersion = match dst_data {
                 Some(data) => serde_json::from_slice(&data).map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to deserialize destination schema '{}': {}",
-                        dest_version_id, e
-                    ))
+                    Error::collection_schema_json(
+                        format!(
+                            "failed to deserialize destination schema '{}'",
+                            dest_version_id
+                        ),
+                        e,
+                    )
                 })?,
                 None => {
                     let mut placeholder = create_placeholder_with_source(
@@ -329,10 +353,13 @@ impl<S: Store> DB<S> {
                     )
                     .await?;
                     let data = serde_json::to_vec(&placeholder).map_err(|e| {
-                        Error::Serialization(format!(
-                            "failed to serialize destination placeholder '{}': {}",
-                            dest_version_id, e
-                        ))
+                        Error::collection_schema_json(
+                            format!(
+                                "failed to serialize destination placeholder '{}'",
+                                dest_version_id
+                            ),
+                            e,
+                        )
                     })?;
                     systemstore
                         .set(&dst_key.bytes(), &data)
@@ -387,10 +414,13 @@ impl<S: Store> DB<S> {
 
         let dst_key = CollectionKey::new(&dest_version_id);
         let dst_data = serde_json::to_vec(&dst_col).map_err(|e| {
-            Error::Serialization(format!(
-                "failed to serialize destination schema '{}': {}",
-                dest_version_id, e
-            ))
+            Error::collection_schema_json(
+                format!(
+                    "failed to serialize destination schema '{}'",
+                    dest_version_id
+                ),
+                e,
+            )
         })?;
 
         {

--- a/crates/db/src/migration/set_migration.rs
+++ b/crates/db/src/migration/set_migration.rs
@@ -210,9 +210,8 @@ impl<S: Store> DB<S> {
             }
 
             let lens_key = LensConfigKey::new(transform_id.to_string());
-            let lens_data = serde_json::to_vec(&config_for_persistence).map_err(|e| {
-                Error::Serialization(format!("failed to serialize lens config: {}", e))
-            })?;
+            let lens_data = serde_json::to_vec(&config_for_persistence)
+                .map_err(|e| Error::lens_config_json("failed to serialize lens config", e))?;
             systemstore
                 .set(&lens_key.bytes(), &lens_data)
                 .await
@@ -448,9 +447,8 @@ impl<S: Store> DB<S> {
             }
 
             let lens_key = LensConfigKey::new(transform_id.to_string());
-            let lens_data = serde_json::to_vec(&config_for_persistence).map_err(|e| {
-                Error::Serialization(format!("failed to serialize lens config: {}", e))
-            })?;
+            let lens_data = serde_json::to_vec(&config_for_persistence)
+                .map_err(|e| Error::lens_config_json("failed to serialize lens config", e))?;
             systemstore
                 .set(&lens_key.bytes(), &lens_data)
                 .await

--- a/crates/db/src/patch/mod.rs
+++ b/crates/db/src/patch/mod.rs
@@ -97,9 +97,8 @@ impl<S: Store> crate::database::DB<S> {
             .collect();
 
         // Apply the patch to the schema JSON
-        let mut schema_json = serde_json::to_value(&old_schema).map_err(|e| {
-            Error::Serialization(format!("failed to serialize schema to JSON: {}", e))
-        })?;
+        let mut schema_json = serde_json::to_value(&old_schema)
+            .map_err(|e| Error::collection_schema_json("failed to serialize schema to JSON", e))?;
 
         // Normalize JSON to match Go's serialization format before applying patches.
         // Go always serializes struct fields (null for nil pointers, [] for nil slices),
@@ -225,10 +224,13 @@ impl<S: Store> crate::database::DB<S> {
                 let systemstore = txn.systemstore()?;
                 let key = CollectionKey::new(&old_version_id);
                 let data = serde_json::to_vec(&new_schema).map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to serialize updated schema version '{}': {}",
-                        old_version_id, e
-                    ))
+                    Error::collection_schema_json(
+                        format!(
+                            "failed to serialize updated schema version '{}'",
+                            old_version_id
+                        ),
+                        e,
+                    )
                 })?;
                 systemstore
                     .set(&key.bytes(), &data)

--- a/crates/db/src/patch/store.rs
+++ b/crates/db/src/patch/store.rs
@@ -204,10 +204,10 @@ impl<S: Store> crate::database::DB<S> {
                 Some(data) => {
                     let placeholder: CollectionVersion =
                         serde_json::from_slice(&data).map_err(|e| {
-                            Error::Serialization(format!(
-                                "failed to deserialize placeholder version: {}",
-                                e
-                            ))
+                            Error::collection_schema_json(
+                                "failed to deserialize placeholder version",
+                                e,
+                            )
                         })?;
                     tracing::debug!(
                         new_version_id = %new_version_id,
@@ -292,17 +292,23 @@ impl<S: Store> crate::database::DB<S> {
         // Prepare serialized data before getting systemstore reference
         let old_version_key = CollectionKey::new(old_version_id);
         let old_version_data = serde_json::to_vec(&old_schema_inactive).map_err(|e| {
-            Error::Serialization(format!(
-                "failed to serialize old schema version '{}': {}",
-                old_version_id, e
-            ))
+            Error::collection_schema_json(
+                format!(
+                    "failed to serialize old schema version '{}'",
+                    old_version_id
+                ),
+                e,
+            )
         })?;
         let new_version_key = CollectionKey::new(&new_version_id);
         let new_version_data = serde_json::to_vec(&new_schema).map_err(|e| {
-            Error::Serialization(format!(
-                "failed to serialize new schema version '{}': {}",
-                new_version_id, e
-            ))
+            Error::collection_schema_json(
+                format!(
+                    "failed to serialize new schema version '{}'",
+                    new_version_id
+                ),
+                e,
+            )
         })?;
         let name_key = CollectionNameKey::new(actual_name);
         let version_index_key = CollectionVersionKey::new(collection_id, &new_version_id);
@@ -564,10 +570,13 @@ impl<S: Store> crate::database::DB<S> {
                 let txn = self.new_txn(false).await?;
                 let key = CollectionKey::new(&updated_schema.version_id);
                 let data = serde_json::to_vec(&updated_schema).map_err(|e| {
-                    Error::Serialization(format!(
-                        "failed to serialize updated schema '{}': {}",
-                        updated_schema.version_id, e
-                    ))
+                    Error::collection_schema_json(
+                        format!(
+                            "failed to serialize updated schema '{}'",
+                            updated_schema.version_id
+                        ),
+                        e,
+                    )
                 })?;
                 {
                     let systemstore = txn.systemstore()?;

--- a/crates/db/src/schema_loader.rs
+++ b/crates/db/src/schema_loader.rs
@@ -221,13 +221,14 @@ pub async fn get_collections_by_collection_id(
         let collection_key = CollectionKey::new(version_id);
         match systemstore.get(&collection_key.bytes()).await {
             Ok(Some(json)) => {
-                let mut collection: CollectionVersion =
-                    serde_json::from_slice(&json).map_err(|e| {
-                        Error::Other(format!(
-                            "Failed to deserialize collection version {}: {}",
-                            version_id, e
-                        ))
-                    })?;
+                let mut collection: CollectionVersion = serde_json::from_slice(&json).map_err(
+                    |e| {
+                        Error::collection_schema_json(
+                            format!("failed to deserialize collection version '{}'", version_id),
+                            e,
+                        )
+                    },
+                )?;
                 crate::collection::populate_collection_root_id(systemstore, &mut collection)
                     .await?;
 
@@ -284,10 +285,10 @@ pub async fn get_collection_by_version_id(
     match systemstore.get(&collection_key.bytes()).await {
         Ok(Some(json)) => {
             let mut collection: CollectionVersion = serde_json::from_slice(&json).map_err(|e| {
-                Error::Other(format!(
-                    "Failed to deserialize collection version {}: {}",
-                    version_id, e
-                ))
+                Error::collection_schema_json(
+                    format!("failed to deserialize collection version '{}'", version_id),
+                    e,
+                )
             })?;
             crate::collection::populate_collection_root_id(systemstore, &mut collection).await?;
             Ok(Some(collection))

--- a/crates/db/src/schema_loader.rs
+++ b/crates/db/src/schema_loader.rs
@@ -221,14 +221,13 @@ pub async fn get_collections_by_collection_id(
         let collection_key = CollectionKey::new(version_id);
         match systemstore.get(&collection_key.bytes()).await {
             Ok(Some(json)) => {
-                let mut collection: CollectionVersion = serde_json::from_slice(&json).map_err(
-                    |e| {
+                let mut collection: CollectionVersion =
+                    serde_json::from_slice(&json).map_err(|e| {
                         Error::collection_schema_json(
                             format!("failed to deserialize collection version '{}'", version_id),
                             e,
                         )
-                    },
-                )?;
+                    })?;
                 crate::collection::populate_collection_root_id(systemstore, &mut collection)
                     .await?;
 

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -258,10 +258,13 @@ impl<S: Store> DbTxn<S> {
                                     collection_name = %name,
                                     "Failed to deserialize schema for collection"
                                 );
-                                Error::Serialization(format!(
-                                    "failed to deserialize schema for collection '{}': {}",
-                                    name, e
-                                ))
+                                Error::collection_schema_json(
+                                    format!(
+                                        "failed to deserialize schema for collection '{}'",
+                                        name
+                                    ),
+                                    e,
+                                )
                             })?;
                         populate_collection_root_id(&systemstore, &mut schema).await?;
                         self.collection_cache.add(Collection::new(schema));
@@ -288,10 +291,10 @@ impl<S: Store> DbTxn<S> {
                     version_id = %version_id,
                     "Failed to deserialize schema for collection"
                 );
-                Error::Serialization(format!(
-                    "failed to deserialize schema for collection '{}': {}",
-                    name, e
-                ))
+                Error::collection_schema_json(
+                    format!("failed to deserialize schema for collection '{}'", name),
+                    e,
+                )
             })?;
             populate_collection_root_id(&systemstore, &mut schema).await?;
             self.collection_cache.add(Collection::new(schema));
@@ -345,7 +348,7 @@ impl<S: Store> DbTxn<S> {
                     key_bytes = ?&pair.key[..pair.key.len().min(50)],
                     "Collection key contains invalid UTF-8"
                 );
-                Error::Serialization(format!("collection key contains invalid UTF-8: {}", e))
+                Error::text_decode("collection key contains invalid UTF-8", e)
             })?;
 
             let prefix_str = String::from_utf8(prefix.clone()).map_err(|e| {
@@ -373,20 +376,20 @@ impl<S: Store> DbTxn<S> {
             }
 
             // Old format: value is full JSON
-            let mut schema: CollectionVersion =
-                serde_json::from_slice(&pair.value).map_err(|e| {
-                    tracing::error!(
-                        error = ?e,
-                        collection_name = %name,
-                        "Failed to deserialize schema for collection '{}': {}",
-                        name,
-                        e
-                    );
-                    Error::Serialization(format!(
-                        "failed to deserialize schema for collection '{}': {}",
-                        name, e
-                    ))
-                })?;
+            let schema: CollectionVersion = serde_json::from_slice(&pair.value).map_err(|e| {
+                tracing::error!(
+                    error = ?e,
+                    collection_name = %name,
+                    "Failed to deserialize schema for collection '{}': {}",
+                    name,
+                    e
+                );
+                Error::collection_schema_json(
+                    format!("failed to deserialize schema for collection '{}'", name),
+                    e,
+                )
+            })?;
+            let mut schema = schema;
             populate_collection_root_id(&systemstore, &mut schema).await?;
 
             collections.push(Collection::new(schema));
@@ -402,19 +405,19 @@ impl<S: Store> DbTxn<S> {
             let collection_key = CollectionKey::new(&version_id);
             match systemstore.get(&collection_key.bytes()).await {
                 Ok(Some(data)) => {
-                    let mut schema: CollectionVersion =
-                        serde_json::from_slice(&data).map_err(|e| {
-                            tracing::error!(
-                                error = ?e,
-                                collection_name = %name,
-                                version_id = %version_id,
-                                "Failed to deserialize schema"
-                            );
-                            Error::Serialization(format!(
-                                "failed to deserialize schema for collection '{}': {}",
-                                name, e
-                            ))
-                        })?;
+                    let schema: CollectionVersion = serde_json::from_slice(&data).map_err(|e| {
+                        tracing::error!(
+                            error = ?e,
+                            collection_name = %name,
+                            version_id = %version_id,
+                            "Failed to deserialize schema"
+                        );
+                        Error::collection_schema_json(
+                            format!("failed to deserialize schema for collection '{}'", name),
+                            e,
+                        )
+                    })?;
+                    let mut schema = schema;
                     populate_collection_root_id(&systemstore, &mut schema).await?;
                     collections.push(Collection::new(schema));
                 }

--- a/crates/db/src/versioned_fetcher.rs
+++ b/crates/db/src/versioned_fetcher.rs
@@ -304,8 +304,7 @@ impl<S: Store> VersionedFetcher<S> {
                 )
             })?;
 
-        Block::from_dag_cbor(&data)
-            .map_err(|e| Error::Serialization(format!("Failed to decode block: {}", e)))
+        Ok(Block::from_dag_cbor(&data)?)
     }
 
     /// Replay CRDT deltas to reconstruct document state.

--- a/crates/db/src/versioned_fetcher.rs
+++ b/crates/db/src/versioned_fetcher.rs
@@ -304,7 +304,8 @@ impl<S: Store> VersionedFetcher<S> {
                 )
             })?;
 
-        Ok(Block::from_dag_cbor(&data)?)
+        Block::from_dag_cbor(&data)
+            .map_err(|e| Error::Serialization(format!("Failed to decode block: {}", e)))
     }
 
     /// Replay CRDT deltas to reconstruct document state.

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -120,12 +120,12 @@ impl Block {
 
     /// Serialize to DAG-CBOR bytes
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
-        serde_ipld_dagcbor::to_vec(self).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::to_vec(self)?)
     }
 
     /// Deserialize from DAG-CBOR bytes
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
-        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::from_slice(bytes)?)
     }
 
     /// Generate CID from block content

--- a/crates/defra-core/src/block_signature.rs
+++ b/crates/defra-core/src/block_signature.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use cid::Cid;
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, Result};
+use crate::Result;
 
 use super::block::generate_cid_from_bytes;
 
@@ -50,12 +50,12 @@ impl Encryption {
 
     /// Serialize to DAG-CBOR bytes
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
-        serde_ipld_dagcbor::to_vec(self).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::to_vec(self)?)
     }
 
     /// Deserialize from DAG-CBOR bytes
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
-        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::from_slice(bytes)?)
     }
 
     /// Generate CID for this encryption block
@@ -86,12 +86,12 @@ impl Signature {
 
     /// Serialize to DAG-CBOR bytes
     pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
-        serde_ipld_dagcbor::to_vec(self).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::to_vec(self)?)
     }
 
     /// Deserialize from DAG-CBOR bytes
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
-        serde_ipld_dagcbor::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))
+        Ok(serde_ipld_dagcbor::from_slice(bytes)?)
     }
 
     /// Generate CID for this signature block

--- a/crates/defra-core/src/error.rs
+++ b/crates/defra-core/src/error.rs
@@ -12,7 +12,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     /// Standard IO errors
-    #[error("io error: {0}")]
+    #[error("storage error: {0}")]
     Io(#[from] std::io::Error),
 
     /// Storage-related errors
@@ -20,15 +20,15 @@ pub enum Error {
     Storage(String),
 
     /// JSON serialization/deserialization errors
-    #[error("json error: {0}")]
+    #[error("serialization error: {0}")]
     Json(#[from] serde_json::Error),
 
     /// DAG-CBOR encoding errors
-    #[error("dag-cbor encode error: {0}")]
+    #[error("serialization error: {0}")]
     DagCborEncode(#[from] serde_ipld_dagcbor::EncodeError<TryReserveError>),
 
     /// DAG-CBOR decoding errors
-    #[error("dag-cbor decode error: {0}")]
+    #[error("serialization error: {0}")]
     DagCborDecode(#[from] serde_ipld_dagcbor::DecodeError<Infallible>),
 
     /// Serialization/deserialization errors
@@ -56,7 +56,7 @@ pub enum Error {
     InvalidCID(String),
 
     /// CID parsing/decoding errors
-    #[error("cid error: {0}")]
+    #[error("invalid CID: {0}")]
     Cid(#[from] cid::Error),
 
     /// CRDT merge errors
@@ -105,6 +105,7 @@ mod tests {
         let err = std::io::Error::other("boom");
         let error: Error = err.into();
         assert!(matches!(error, Error::Io(_)));
+        assert_eq!(error.to_string(), "storage error: boom");
     }
 
     #[test]
@@ -112,5 +113,14 @@ mod tests {
         let err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
         let error: Error = err.into();
         assert!(matches!(error, Error::Json(_)));
+        assert!(error.to_string().starts_with("serialization error: "));
+    }
+
+    #[test]
+    fn cid_errors_preserve_stable_display_message() {
+        let err = cid::Cid::try_from("not-a-cid").unwrap_err();
+        let error: Error = err.into();
+        assert!(matches!(error, Error::Cid(_)));
+        assert!(error.to_string().starts_with("invalid CID: "));
     }
 }

--- a/crates/defra-core/src/error.rs
+++ b/crates/defra-core/src/error.rs
@@ -1,5 +1,7 @@
 //! Error types for DefraDB
 
+use std::{collections::TryReserveError, convert::Infallible};
+
 use thiserror::Error;
 
 /// Result type alias using DefraDB's Error type
@@ -9,9 +11,25 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
+    /// Standard IO errors
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
     /// Storage-related errors
     #[error("storage error: {0}")]
     Storage(String),
+
+    /// JSON serialization/deserialization errors
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// DAG-CBOR encoding errors
+    #[error("dag-cbor encode error: {0}")]
+    DagCborEncode(#[from] serde_ipld_dagcbor::EncodeError<TryReserveError>),
+
+    /// DAG-CBOR decoding errors
+    #[error("dag-cbor decode error: {0}")]
+    DagCborDecode(#[from] serde_ipld_dagcbor::DecodeError<Infallible>),
 
     /// Serialization/deserialization errors
     #[error("serialization error: {0}")]
@@ -36,6 +54,10 @@ pub enum Error {
     /// Invalid CID
     #[error("invalid CID: {0}")]
     InvalidCID(String),
+
+    /// CID parsing/decoding errors
+    #[error("cid error: {0}")]
+    Cid(#[from] cid::Error),
 
     /// CRDT merge errors
     #[error("merge error: {0}")]
@@ -74,14 +96,21 @@ pub enum Error {
     Other(String),
 }
 
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Self {
-        Error::Storage(err.to_string())
-    }
-}
+#[cfg(test)]
+mod tests {
+    use super::Error;
 
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Self {
-        Error::Serialization(err.to_string())
+    #[test]
+    fn io_errors_preserve_their_type() {
+        let err = std::io::Error::other("boom");
+        let error: Error = err.into();
+        assert!(matches!(error, Error::Io(_)));
+    }
+
+    #[test]
+    fn json_errors_preserve_their_type() {
+        let err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+        let error: Error = err.into();
+        assert!(matches!(error, Error::Json(_)));
     }
 }

--- a/crates/defra-core/src/types.rs
+++ b/crates/defra-core/src/types.rs
@@ -166,7 +166,7 @@ pub struct CID(cid::Cid);
 impl CID {
     /// Create a CID from bytes with validation
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let c = cid::Cid::try_from(bytes).map_err(|e| Error::InvalidCID(e.to_string()))?;
+        let c = cid::Cid::try_from(bytes)?;
 
         // Validate version
         match c.version() {
@@ -188,7 +188,7 @@ impl CID {
 
     /// Create a CID from a string
     pub fn from_string(s: &str) -> Result<Self> {
-        let c = cid::Cid::try_from(s).map_err(|e| Error::InvalidCID(e.to_string()))?;
+        let c = cid::Cid::try_from(s)?;
 
         // Validate version
         match c.version() {

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -1015,7 +1015,6 @@ mod tests {
         defra_core::encryption::EncryptionConfig {
             encrypt_doc: true,
             encrypt_fields: vec![],
-            encryption_key: vec![0xAB; 32],
         }
     }
 

--- a/crates/wasm/src/error.rs
+++ b/crates/wasm/src/error.rs
@@ -54,7 +54,18 @@ impl From<document::Error> for WasmError {
 
 impl From<defra_core::Error> for WasmError {
     fn from(err: defra_core::Error) -> Self {
-        WasmError::Verification(err.to_string())
+        match err {
+            defra_core::Error::Io(_)
+            | defra_core::Error::Json(_)
+            | defra_core::Error::DagCborEncode(_)
+            | defra_core::Error::DagCborDecode(_)
+            | defra_core::Error::Serialization(_)
+            | defra_core::Error::IpldError(_) => WasmError::Serialization(err.to_string()),
+            defra_core::Error::Cid(_) | defra_core::Error::InvalidCID(_) => {
+                WasmError::InvalidArgument(err.to_string())
+            }
+            _ => WasmError::Verification(err.to_string()),
+        }
     }
 }
 
@@ -67,5 +78,24 @@ impl From<serde_json::Error> for WasmError {
 impl From<serde_wasm_bindgen::Error> for WasmError {
     fn from(err: serde_wasm_bindgen::Error) -> Self {
         WasmError::Serialization(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WasmError;
+
+    #[test]
+    fn defra_core_json_errors_map_to_serialization() {
+        let err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+        let wasm_err = WasmError::from(defra_core::Error::from(err));
+        assert!(matches!(wasm_err, WasmError::Serialization(_)));
+    }
+
+    #[test]
+    fn defra_core_cid_errors_map_to_invalid_argument() {
+        let err = cid::Cid::try_from("not-a-cid").unwrap_err();
+        let wasm_err = WasmError::from(defra_core::Error::from(err));
+        assert!(matches!(wasm_err, WasmError::InvalidArgument(_)));
     }
 }

--- a/crates/wasm/src/verification.rs
+++ b/crates/wasm/src/verification.rs
@@ -37,8 +37,7 @@ pub fn verify_merkle_proof(proof_json: &str) -> std::result::Result<bool, JsValu
 
 fn verify_merkle_proof_impl(proof_json: &str) -> Result<bool> {
     // Parse the proof from JSON
-    let proof: MerkleProof =
-        serde_json::from_str(proof_json).map_err(|e| WasmError::Serialization(e.to_string()))?;
+    let proof: MerkleProof = serde_json::from_str(proof_json)?;
 
     proof.verify().map_err(WasmError::from)
 }
@@ -94,14 +93,14 @@ pub fn verify_ed25519_signature(
 
 fn verify_ed25519_impl(public_key_hex: &str, message: &[u8], signature_hex: &str) -> Result<bool> {
     let public_key = public_key_from_string(crypto::KeyType::Ed25519, public_key_hex)
-        .map_err(|e| WasmError::Verification(e.to_string()))?;
+        .map_err(WasmError::from)?;
 
     let signature = hex::decode(signature_hex)
         .map_err(|e: hex::FromHexError| WasmError::InvalidArgument(e.to_string()))?;
 
     public_key
         .verify(message, &signature)
-        .map_err(|e| WasmError::Verification(e.to_string()))
+        .map_err(WasmError::from)
 }
 
 /// Verify a secp256k1 signature.
@@ -125,14 +124,14 @@ fn verify_secp256k1_impl(
     signature_hex: &str,
 ) -> Result<bool> {
     let public_key = public_key_from_string(crypto::KeyType::Secp256k1, public_key_hex)
-        .map_err(|e| WasmError::Verification(e.to_string()))?;
+        .map_err(WasmError::from)?;
 
     let signature = hex::decode(signature_hex)
         .map_err(|e: hex::FromHexError| WasmError::InvalidArgument(e.to_string()))?;
 
     public_key
         .verify(message, &signature)
-        .map_err(|e| WasmError::Verification(e.to_string()))
+        .map_err(WasmError::from)
 }
 
 /// Compute SHA-256 hash of data.
@@ -177,7 +176,7 @@ pub fn generate_ed25519_keypair() -> std::result::Result<JsValue, JsValue> {
 }
 
 fn generate_ed25519_impl() -> Result<JsValue> {
-    let private_key = generate_ed25519().map_err(|e| WasmError::Verification(e.to_string()))?;
+    let private_key = generate_ed25519().map_err(WasmError::from)?;
     let public_key = private_key.public_key();
 
     let result = serde_json::json!({
@@ -199,7 +198,7 @@ pub fn generate_secp256k1_keypair() -> std::result::Result<JsValue, JsValue> {
 }
 
 fn generate_secp256k1_impl() -> Result<JsValue> {
-    let private_key = generate_secp256k1().map_err(|e| WasmError::Verification(e.to_string()))?;
+    let private_key = generate_secp256k1().map_err(WasmError::from)?;
     let public_key = private_key.public_key();
 
     let result = serde_json::json!({

--- a/crates/zanzibar/src/error.rs
+++ b/crates/zanzibar/src/error.rs
@@ -5,7 +5,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("json error: {0}")]
+    #[error("serialization error: {0}")]
     Json(#[from] serde_json::Error),
 
     #[error("invalid DID: {0}")]
@@ -61,5 +61,6 @@ mod tests {
         let err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
         let error: Error = err.into();
         assert!(matches!(error, Error::Json(_)));
+        assert!(error.to_string().starts_with("serialization error: "));
     }
 }

--- a/crates/zanzibar/src/error.rs
+++ b/crates/zanzibar/src/error.rs
@@ -5,6 +5,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
     #[error("invalid DID: {0}")]
     InvalidDid(String),
 
@@ -49,8 +52,14 @@ pub enum Error {
     Serialization(String),
 }
 
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Self {
-        Error::Serialization(err.to_string())
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn json_errors_preserve_their_type() {
+        let err = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+        let error: Error = err.into();
+        assert!(matches!(error, Error::Json(_)));
     }
 }


### PR DESCRIPTION
## Summary

Narrowed `#655` to a dependency-safe typed error foundation in `defra-core`, then carried that through only the direct consumers that needed adjustment.

This does **not** attempt a repo-wide error-system rewrite. The scope stays limited to preserving typed context where `defra-core` can own it safely, updating immediate downstream consumers, and preserving user-facing message stability where those conversions changed display text.

## What Changed

- added foundational typed `defra_core::Error` variants for:
  - `std::io::Error`
  - `serde_json::Error`
  - `serde_ipld_dagcbor` encode/decode errors
  - `cid::Error`
- converted direct `defra-core` DAG-CBOR / CID call sites to preserve typed errors instead of stringifying them
- updated direct consumers in `db`, `wasm`, `acp`, and `zanzibar`
- added DB-local typed/contextual variants where preserving source error types is useful without creating dependency cycles:
  - document decode at key
  - collection schema JSON context
  - lens config JSON context
  - UTF-8 text decode context
- restored stable display strings where the typed conversions would otherwise change externally visible messages
- rebased the branch onto current `main`

## Why This Slice

`defra-core` sits below higher-level crates like `db`, `query`, and `storage`, so it cannot depend on their error types without creating cycles. This PR keeps typed context only for errors `defra-core` can safely own, and leaves broader crate-boundary cleanup for later work.

## Validation

- `cargo fmt --check`
- `cargo test -p defra-core --lib`
- `cargo test -p defra-core --lib error::tests`
- `cargo test -p acp -p zanzibar --lib`
- `cargo test -p acp --lib error::tests`
- `cargo test -p zanzibar --lib error::tests`
- `cargo test -p db --lib error::tests`

Closes #655
