### PR TITLE
refactor: migrate P2P surfaces to typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4212,6 +4212,7 @@ dependencies = [
  "sourcehub",
  "storage",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use blockstore::Blockstore;
 
-use defra_http::router::{P2POperations, ReplicatorInfo};
+use defra_http::router::{P2PError, P2POperations, P2PResult, ReplicatorInfo};
 use p2p::iroh::{format_public_listen_addrs, parse_public_peer_addr, IrohTransport};
 use p2p::sync::IrohSyncCoordinator;
 use p2p::topics::DefraTopic;
@@ -73,24 +73,24 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
 
 #[async_trait]
 impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
-    async fn local_peer_id(&self) -> Result<String, String> {
+    async fn local_peer_id(&self) -> P2PResult<String> {
         Ok(self.transport.local_peer_id().to_string())
     }
 
-    async fn listen_addresses(&self) -> Result<Vec<String>, String> {
+    async fn listen_addresses(&self) -> P2PResult<Vec<String>> {
         self.transport
             .listen_addresses()
             .await
             .map(|addrs| format_public_listen_addrs(self.transport.local_peer_id(), &addrs))
-            .map_err(|e| e.to_string())
+            .map_err(|e| P2PError::Transport(e.to_string()))
     }
 
-    async fn connected_peers(&self) -> Result<Vec<String>, String> {
+    async fn connected_peers(&self) -> P2PResult<Vec<String>> {
         let connected = self
             .transport
             .connected_peers()
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
 
         let mut result = Vec::new();
         for peer in &connected {
@@ -106,18 +106,19 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(result)
     }
 
-    async fn connect_peer(&self, addr: &str) -> Result<(), String> {
-        let (peer_id, direct_addrs) = parse_public_peer_addr(addr).map_err(|e| e.to_string())?;
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()> {
+        let (peer_id, direct_addrs) =
+            parse_public_peer_addr(addr).map_err(|e| P2PError::InvalidInput(e.to_string()))?;
 
         self.transport
             .dial(&peer_id, direct_addrs)
             .await
-            .map_err(|e| format!("failed to connect: {}", e))?;
+            .map_err(|e| P2PError::Transport(format!("failed to connect: {}", e)))?;
 
         self.transport
             .poll_until_connected(&peer_id, std::time::Duration::from_secs(10))
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
 
         if let Ok(mut addrs) = self.peer_addresses.write() {
             addrs.insert(peer_id.to_string(), addr.to_string());
@@ -126,12 +127,12 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String> {
+    async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         let p2p_infos = self
             .transport
             .list_replicators()
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
 
         let http_infos: Vec<ReplicatorInfo> = p2p_infos
             .into_iter()
@@ -154,16 +155,18 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         addr: Option<&str>,
         _explicit_replay_capabilities: Vec<defra_http::router::ExplicitReplayCapabilityInput>,
         _expected_authorizer_did: Option<&str>,
-    ) -> Result<(), String> {
-        let addr_str = addr.ok_or_else(|| "address is required".to_string())?;
-        let (peer_id, direct_addrs) =
-            parse_public_peer_addr(addr_str).map_err(|error| error.to_string())?;
+    ) -> P2PResult<()> {
+        let addr_str = addr.ok_or_else(|| P2PError::InvalidInput("address is required".into()))?;
+        let (peer_id, direct_addrs) = parse_public_peer_addr(addr_str)
+            .map_err(|error| P2PError::InvalidInput(error.to_string()))?;
 
         let effective_collections = if collections.is_empty() {
             if let Some(ref pusher) = self.doc_pusher {
                 pusher.list_collections()?
             } else {
-                return Err("no database context to list collections".to_string());
+                return Err(P2PError::Unsupported(
+                    "no database context to list collections".into(),
+                ));
             }
         } else {
             collections
@@ -175,7 +178,10 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 if let Some(cid) = pusher.get_collection_id(name) {
                     collection_cids.push(cid);
                 } else {
-                    return Err(format!("collection '{}' not found", name));
+                    return Err(P2PError::NotFound(format!(
+                        "collection '{}' not found",
+                        name
+                    )));
                 }
             }
         } else {
@@ -190,12 +196,12 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 coordinator
                     .get_replicator(&peer_id)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(|e| P2PError::Transport(e.to_string()))
             } else {
                 self.transport
                     .get_replicator(&peer_id)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(|e| P2PError::Transport(e.to_string()))
             };
             match result {
                 Ok(Some(info)) => info.collections.into_iter().collect(),
@@ -214,7 +220,9 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         self.transport
             .dial(&peer_id, direct_addrs)
             .await
-            .map_err(|e| format!("failed to connect to replicator peer: {}", e))?;
+            .map_err(|e| {
+                P2PError::Transport(format!("failed to connect to replicator peer: {}", e))
+            })?;
 
         if let Ok(mut addrs) = self.peer_addresses.write() {
             addrs.insert(peer_id.to_string(), addr_str.to_string());
@@ -224,12 +232,12 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             coordinator
                 .create_replicator(&peer_id, collection_cids.clone(), true)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| P2PError::Transport(e.to_string()))?;
         } else {
             self.transport
                 .create_replicator(&peer_id, collection_cids.clone())
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| P2PError::Transport(e.to_string()))?;
         }
 
         if let Some(ref pusher) = self.doc_pusher {
@@ -296,20 +304,21 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
-    ) -> Result<(), String> {
-        let addr_str = addr.ok_or_else(|| "address is required".to_string())?;
-        let (peer_id, _) = parse_public_peer_addr(addr_str).map_err(|e| e.to_string())?;
+    ) -> P2PResult<()> {
+        let addr_str = addr.ok_or_else(|| P2PError::InvalidInput("address is required".into()))?;
+        let (peer_id, _) =
+            parse_public_peer_addr(addr_str).map_err(|e| P2PError::InvalidInput(e.to_string()))?;
 
         if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .remove_replicator_collections(&peer_id, collections)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| P2PError::Transport(e.to_string()))?;
         } else {
             self.transport
                 .delete_replicator(&peer_id)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| P2PError::Transport(e.to_string()))?;
         }
 
         if let Some(ref pusher) = self.doc_pusher {
@@ -332,28 +341,28 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn get_collections(&self) -> Result<Vec<String>, String> {
+    async fn get_collections(&self) -> P2PResult<Vec<String>> {
         if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .get_subscribed_collections()
                 .await
-                .map_err(|e| e.to_string())
+                .map_err(|e| P2PError::Transport(e.to_string()))
         } else {
             Ok(Vec::new())
         }
     }
 
-    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn add_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         if let Some(ref coordinator) = self.sync_coordinator {
             for collection_name in collections {
                 let topic_id = if let Some(ref pusher) = self.doc_pusher {
                     if let Some(collection_id) = pusher.get_collection_id(&collection_name) {
                         collection_id
                     } else {
-                        return Err(format!(
+                        return Err(P2PError::NotFound(format!(
                             "collection '{}' not found - add schema before subscribing to P2P",
                             collection_name
-                        ));
+                        )));
                     }
                 } else {
                     collection_name.clone()
@@ -362,14 +371,14 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 coordinator
                     .subscribe_collection(&topic_id)
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| P2PError::Transport(e.to_string()))?;
             }
 
             if let Some(ref pusher) = self.doc_pusher {
                 let all_cols = coordinator
                     .get_subscribed_collections()
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| P2PError::Transport(e.to_string()))?;
                 if let Err(e) = pusher.persist_p2p_collections(&all_cols).await {
                     tracing::warn!(error = %e, "failed to persist P2P collections");
                 }
@@ -377,11 +386,13 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
 
             Ok(())
         } else {
-            Err("p2p collections functionality requires sync coordinator".to_string())
+            Err(P2PError::Unsupported(
+                "p2p collections functionality requires sync coordinator".into(),
+            ))
         }
     }
 
-    async fn remove_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn remove_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         if let Some(ref coordinator) = self.sync_coordinator {
             let topic_ids = collections
                 .into_iter()
@@ -400,14 +411,14 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 coordinator
                     .unsubscribe_collection(&topic_id)
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| P2PError::Transport(e.to_string()))?;
             }
 
             if let Some(ref pusher) = self.doc_pusher {
                 let all_cols = coordinator
                     .get_subscribed_collections()
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| P2PError::Transport(e.to_string()))?;
                 if let Err(e) = pusher.persist_p2p_collections(&all_cols).await {
                     tracing::warn!(error = %e, "failed to persist P2P collections after removal");
                 }
@@ -415,15 +426,17 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
 
             Ok(())
         } else {
-            Err("p2p collections functionality requires sync coordinator".to_string())
+            Err(P2PError::Unsupported(
+                "p2p collections functionality requires sync coordinator".into(),
+            ))
         }
     }
 
-    async fn get_documents(&self) -> Result<Vec<defra_http::router::P2pDocumentInfo>, String> {
+    async fn get_documents(&self) -> P2PResult<Vec<defra_http::router::P2pDocumentInfo>> {
         let docs = self
             .tracked_documents
             .read()
-            .map_err(|e| format!("failed to read tracked documents: {}", e))?;
+            .map_err(|e| P2PError::Internal(format!("failed to read tracked documents: {}", e)))?;
         let mut sorted: Vec<String> = docs.iter().cloned().collect();
         sorted.sort();
         Ok(sorted
@@ -438,11 +451,12 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
     async fn add_documents(
         &self,
         docs: Vec<defra_http::router::P2pDocumentRequest>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         let doc_ids: Vec<String> = docs.into_iter().map(|d| d.doc_id).collect();
 
-        document::validate_doc_ids(&doc_ids)
-            .map_err(|_| "malformed document ID, missing either version or cid".to_string())?;
+        document::validate_doc_ids(&doc_ids).map_err(|_| {
+            P2PError::InvalidInput("malformed document ID, missing either version or cid".into())
+        })?;
 
         for doc_id in &doc_ids {
             let topic = DefraTopic::document(doc_id);
@@ -471,11 +485,12 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
     async fn remove_documents(
         &self,
         docs: Vec<defra_http::router::P2pDocumentRequest>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         let doc_ids: Vec<String> = docs.into_iter().map(|d| d.doc_id).collect();
 
-        document::validate_doc_ids(&doc_ids)
-            .map_err(|_| "malformed document ID, missing either version or cid".to_string())?;
+        document::validate_doc_ids(&doc_ids).map_err(|_| {
+            P2PError::InvalidInput("malformed document ID, missing either version or cid".into())
+        })?;
 
         for doc_id in &doc_ids {
             let topic = DefraTopic::document(doc_id);
@@ -490,11 +505,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_documents(
-        &self,
-        collection_name: &str,
-        doc_ids: Vec<String>,
-    ) -> Result<(), String> {
+    async fn sync_documents(&self, collection_name: &str, doc_ids: Vec<String>) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
@@ -506,11 +517,10 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             .as_ref()
             .ok_or_else(|| "no event bus for sync".to_string())?;
 
-        let connected_peers = self
-            .transport
-            .connected_peers()
-            .await
-            .map_err(|e| format!("failed to get connected peers: {}", e))?;
+        let connected_peers =
+            self.transport.connected_peers().await.map_err(|e| {
+                P2PError::Transport(format!("failed to get connected peers: {}", e))
+            })?;
 
         if connected_peers.is_empty() {
             return Ok(());
@@ -533,7 +543,10 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             let mut request = p2p::message::DocSyncRequest::new(doc_ids.clone());
             if let Err(e) = p2p::signing::sign_with_transport(&self.transport, &mut request) {
                 event_bus.unsubscribe(sub.id());
-                return Err(format!("failed to sign DocSync request: {}", e));
+                return Err(P2PError::Internal(format!(
+                    "failed to sign DocSync request: {}",
+                    e
+                )));
             }
 
             let mut any_sent = false;
@@ -583,26 +596,26 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_branchable_collection(&self, collection_id: &str) -> Result<(), String> {
+    async fn sync_branchable_collection(&self, collection_id: &str) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
             .ok_or_else(|| "no database context for sync".to_string())?;
         pusher.validate_branchable_collection(collection_id)?;
 
-        let connected_peers = self
-            .transport
-            .connected_peers()
-            .await
-            .map_err(|e| format!("failed to get connected peers: {}", e))?;
+        let connected_peers =
+            self.transport.connected_peers().await.map_err(|e| {
+                P2PError::Transport(format!("failed to get connected peers: {}", e))
+            })?;
 
         if connected_peers.is_empty() {
             return Ok(());
         }
 
         let mut request = p2p::message::BranchableSyncRequest::new(collection_id.to_string());
-        p2p::signing::sign_with_transport(&self.transport, &mut request)
-            .map_err(|e| format!("failed to sign BranchableSync request: {}", e))?;
+        p2p::signing::sign_with_transport(&self.transport, &mut request).map_err(|e| {
+            P2PError::Internal(format!("failed to sign BranchableSync request: {}", e))
+        })?;
 
         for peer in &connected_peers {
             let request_clone = request.clone();
@@ -618,20 +631,20 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> Result<(), String> {
+    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> P2PResult<()> {
         if version_ids.is_empty() {
             return Ok(());
         }
 
         for vid in &version_ids {
-            cid::Cid::try_from(vid.as_str()).map_err(|e| format!("invalid cid: {}", e))?;
+            cid::Cid::try_from(vid.as_str())
+                .map_err(|e| P2PError::InvalidInput(format!("invalid cid: {}", e)))?;
         }
 
-        let connected_peers = self
-            .transport
-            .connected_peers()
-            .await
-            .map_err(|e| format!("failed to get connected peers: {}", e))?;
+        let connected_peers =
+            self.transport.connected_peers().await.map_err(|e| {
+                P2PError::Transport(format!("failed to get connected peers: {}", e))
+            })?;
 
         if connected_peers.is_empty() {
             return Ok(());

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use blockstore::Blockstore;
 
-use defra_http::router::{ExplicitReplayCapabilityInput, P2POperations, ReplicatorInfo};
+use defra_http::router::{
+    ExplicitReplayCapabilityInput, P2PError, P2POperations, P2PResult, ReplicatorInfo,
+};
 use p2p::sync::Libp2pSyncCoordinator;
 use p2p::topics::DefraTopic;
 use p2p::P2PHostHandle;
@@ -221,28 +223,28 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
 
 #[async_trait]
 impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
-    async fn local_peer_id(&self) -> Result<String, String> {
+    async fn local_peer_id(&self) -> P2PResult<String> {
         self.handle
             .local_peer_id()
             .await
             .map(|id| id.to_string())
-            .map_err(|e| e.to_string())
+            .map_err(|e| P2PError::Transport(e.to_string()))
     }
 
-    async fn listen_addresses(&self) -> Result<Vec<String>, String> {
+    async fn listen_addresses(&self) -> P2PResult<Vec<String>> {
         self.handle
             .listen_addresses()
             .await
             .map(|addrs| addrs.into_iter().map(|a| a.to_string()).collect())
-            .map_err(|e| e.to_string())
+            .map_err(|e| P2PError::Transport(e.to_string()))
     }
 
-    async fn connected_peers(&self) -> Result<Vec<String>, String> {
+    async fn connected_peers(&self) -> P2PResult<Vec<String>> {
         let connected = self
             .handle
             .connected_peers()
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
 
         let all_addrs = self
             .handle
@@ -250,23 +252,24 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 self.peer_addresses.read().ok()?.get(pid).cloned()
             })
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
 
         Ok(all_addrs)
     }
 
-    async fn connect_peer(&self, addr: &str) -> Result<(), String> {
-        let parsed = p2p::parse_multiaddr_with_peer_id(addr).map_err(|e| e.to_string())?;
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()> {
+        let parsed = p2p::parse_multiaddr_with_peer_id(addr)
+            .map_err(|e| P2PError::InvalidInput(e.to_string()))?;
 
         self.handle
             .dial(parsed.peer_id, vec![parsed.transport_addr])
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
 
         self.handle
             .poll_until_connected(parsed.peer_id, std::time::Duration::from_secs(10))
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
 
         // Cache the full multiaddr for connected_peers resolution
         if let Ok(mut addrs) = self.peer_addresses.write() {
@@ -276,12 +279,12 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String> {
+    async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         let p2p_infos = self
             .handle
             .list_replicators()
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
 
         let http_infos: Vec<ReplicatorInfo> = p2p_infos
             .into_iter()
@@ -304,16 +307,19 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         addr: Option<&str>,
         explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
         expected_authorizer_did: Option<&str>,
-    ) -> Result<(), String> {
-        let addr_str = addr.ok_or_else(|| "address is required".to_string())?;
-        let parsed = p2p::parse_multiaddr_with_peer_id(addr_str).map_err(|e| e.to_string())?;
+    ) -> P2PResult<()> {
+        let addr_str = addr.ok_or_else(|| P2PError::InvalidInput("address is required".into()))?;
+        let parsed = p2p::parse_multiaddr_with_peer_id(addr_str)
+            .map_err(|e| P2PError::InvalidInput(e.to_string()))?;
 
         // If collections empty, replicate all (matching Go behavior)
         let effective_collections = if collections.is_empty() {
             if let Some(ref pusher) = self.doc_pusher {
                 pusher.list_collections()?
             } else {
-                return Err("no database context to list collections".to_string());
+                return Err(P2PError::Unsupported(
+                    "no database context to list collections".into(),
+                ));
             }
         } else {
             collections
@@ -326,7 +332,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 if let Some(cid) = pusher.get_collection_id(name) {
                     collection_cids.push(cid);
                 } else {
-                    return Err(format!("collection '{}' not found", name));
+                    return Err(P2PError::NotFound(format!(
+                        "collection '{}' not found",
+                        name
+                    )));
                 }
             }
         } else {
@@ -341,15 +350,17 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
 
         if !explicit_replay_capabilities.is_empty() {
             let expected_authorizer_did = expected_authorizer_did.ok_or_else(|| {
-                "explicit replay capabilities require an authenticated identity".to_string()
+                P2PError::InvalidInput(
+                    "explicit replay capabilities require an authenticated identity".into(),
+                )
             })?;
 
             for capability in explicit_replay_capabilities {
                 if !requested_collections.contains(&capability.collection_id) {
-                    return Err(format!(
+                    return Err(P2PError::InvalidInput(format!(
                         "explicit replay capability collection '{}' was not requested",
                         capability.collection_id
-                    ));
+                    )));
                 }
 
                 let authorization = p2p::verify_explicit_replay_capability(
@@ -359,17 +370,17 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                     &capability.collection_id,
                 )
                 .map_err(|error| {
-                    format!(
+                    P2PError::InvalidInput(format!(
                         "invalid explicit replay capability for collection '{}': {}",
                         capability.collection_id, error
-                    )
+                    ))
                 })?;
 
                 if authorization.authorizer_did != expected_authorizer_did {
-                    return Err(format!(
+                    return Err(P2PError::InvalidInput(format!(
                         "explicit replay capability authorizer '{}' did not match authenticated identity '{}'",
                         authorization.authorizer_did, expected_authorizer_did
-                    ));
+                    )));
                 }
 
                 validated_capabilities.push((capability.collection_id, capability.capability));
@@ -411,12 +422,12 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 coordinator
                     .get_replicator(&transport_pid)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(|e| P2PError::Transport(e.to_string()))
             } else {
                 self.handle
                     .get_replicator(peer_id)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(|e| P2PError::Transport(e.to_string()))
             };
             match result {
                 Ok(Some(info)) => info.collections.into_iter().collect(),
@@ -436,7 +447,9 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         self.handle
             .dial(peer_id, vec![parsed.transport_addr])
             .await
-            .map_err(|e| format!("failed to connect to replicator peer: {}", e))?;
+            .map_err(|e| {
+                P2PError::Transport(format!("failed to connect to replicator peer: {}", e))
+            })?;
 
         // Cache peer address for connected_peers resolution
         if let Ok(mut addrs) = self.peer_addresses.write() {
@@ -449,12 +462,12 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             coordinator
                 .create_replicator(&transport_pid, collection_cids.clone(), true)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| P2PError::Transport(e.to_string()))?;
         } else {
             self.handle
                 .create_replicator(peer_id, collection_cids.clone())
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| P2PError::Transport(e.to_string()))?;
         }
 
         // Persist to peerstore (best-effort, log warning on failure)
@@ -529,9 +542,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
-    ) -> Result<(), String> {
-        let addr_str = addr.ok_or_else(|| "address is required".to_string())?;
-        let parsed = p2p::parse_multiaddr_with_peer_id(addr_str).map_err(|e| e.to_string())?;
+    ) -> P2PResult<()> {
+        let addr_str = addr.ok_or_else(|| P2PError::InvalidInput("address is required".into()))?;
+        let parsed = p2p::parse_multiaddr_with_peer_id(addr_str)
+            .map_err(|e| P2PError::InvalidInput(e.to_string()))?;
         let peer_id = parsed.peer_id;
 
         if let Some(ref coordinator) = self.sync_coordinator {
@@ -539,7 +553,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             coordinator
                 .remove_replicator_collections(&transport_pid, collections)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| P2PError::Transport(e.to_string()))?;
         } else {
             if !collections.is_empty() {
                 tracing::warn!(
@@ -551,7 +565,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             self.handle
                 .delete_replicator(peer_id)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| P2PError::Transport(e.to_string()))?;
         }
 
         // Delete from peerstore (best-effort, log warning on failure)
@@ -576,18 +590,18 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn get_collections(&self) -> Result<Vec<String>, String> {
+    async fn get_collections(&self) -> P2PResult<Vec<String>> {
         if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .get_subscribed_collections()
                 .await
-                .map_err(|e| e.to_string())
+                .map_err(|e| P2PError::Transport(e.to_string()))
         } else {
             Ok(Vec::new())
         }
     }
 
-    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn add_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         if let Some(ref coordinator) = self.sync_coordinator {
             for collection_name in collections {
                 let topic_id = if let Some(ref pusher) = self.doc_pusher {
@@ -599,10 +613,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                         );
                         collection_id
                     } else {
-                        return Err(format!(
+                        return Err(P2PError::NotFound(format!(
                             "collection '{}' not found - add schema before subscribing to P2P",
                             collection_name
-                        ));
+                        )));
                     }
                 } else {
                     tracing::warn!(
@@ -615,7 +629,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 coordinator
                     .subscribe_collection(&topic_id)
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| P2PError::Transport(e.to_string()))?;
             }
 
             // Persist all subscribed collections (best-effort)
@@ -623,7 +637,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 let all_cols = coordinator
                     .get_subscribed_collections()
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| P2PError::Transport(e.to_string()))?;
                 if let Err(e) = pusher.persist_p2p_collections(&all_cols).await {
                     tracing::warn!(error = %e, "failed to persist P2P collections");
                 }
@@ -631,11 +645,13 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
 
             Ok(())
         } else {
-            Err("p2p collections functionality requires sync coordinator".to_string())
+            Err(P2PError::Unsupported(
+                "p2p collections functionality requires sync coordinator".into(),
+            ))
         }
     }
 
-    async fn remove_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn remove_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         if let Some(ref coordinator) = self.sync_coordinator {
             let topic_ids = collections
                 .into_iter()
@@ -654,14 +670,14 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 coordinator
                     .unsubscribe_collection(&topic_id)
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| P2PError::Transport(e.to_string()))?;
             }
 
             if let Some(ref pusher) = self.doc_pusher {
                 let all_cols = coordinator
                     .get_subscribed_collections()
                     .await
-                    .map_err(|e| e.to_string())?;
+                    .map_err(|e| P2PError::Transport(e.to_string()))?;
                 if let Err(e) = pusher.persist_p2p_collections(&all_cols).await {
                     tracing::warn!(error = %e, "failed to persist P2P collections after removal");
                 }
@@ -669,15 +685,17 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
 
             Ok(())
         } else {
-            Err("p2p collections functionality requires sync coordinator".to_string())
+            Err(P2PError::Unsupported(
+                "p2p collections functionality requires sync coordinator".into(),
+            ))
         }
     }
 
-    async fn get_documents(&self) -> Result<Vec<defra_http::router::P2pDocumentInfo>, String> {
+    async fn get_documents(&self) -> P2PResult<Vec<defra_http::router::P2pDocumentInfo>> {
         let docs = self
             .tracked_documents
             .read()
-            .map_err(|e| format!("failed to read tracked documents: {}", e))?;
+            .map_err(|e| P2PError::Internal(format!("failed to read tracked documents: {}", e)))?;
         let mut sorted: Vec<String> = docs.iter().cloned().collect();
         sorted.sort();
         Ok(sorted
@@ -692,12 +710,13 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
     async fn add_documents(
         &self,
         docs: Vec<defra_http::router::P2pDocumentRequest>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         let doc_ids: Vec<String> = docs.into_iter().map(|d| d.doc_id).collect();
 
         // Validate all document IDs have valid format (atomic: all or nothing)
-        document::validate_doc_ids(&doc_ids)
-            .map_err(|_| "malformed document ID, missing either version or cid".to_string())?;
+        document::validate_doc_ids(&doc_ids).map_err(|_| {
+            P2PError::InvalidInput("malformed document ID, missing either version or cid".into())
+        })?;
 
         for doc_id in &doc_ids {
             let topic = DefraTopic::document(doc_id);
@@ -727,12 +746,13 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
     async fn remove_documents(
         &self,
         docs: Vec<defra_http::router::P2pDocumentRequest>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         let doc_ids: Vec<String> = docs.into_iter().map(|d| d.doc_id).collect();
 
         // Validate all document IDs have valid format (atomic: all or nothing)
-        document::validate_doc_ids(&doc_ids)
-            .map_err(|_| "malformed document ID, missing either version or cid".to_string())?;
+        document::validate_doc_ids(&doc_ids).map_err(|_| {
+            P2PError::InvalidInput("malformed document ID, missing either version or cid".into())
+        })?;
 
         for doc_id in &doc_ids {
             let topic = DefraTopic::document(doc_id);
@@ -747,11 +767,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_documents(
-        &self,
-        collection_name: &str,
-        doc_ids: Vec<String>,
-    ) -> Result<(), String> {
+    async fn sync_documents(&self, collection_name: &str, doc_ids: Vec<String>) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
@@ -763,11 +779,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .as_ref()
             .ok_or_else(|| "no event bus for sync".to_string())?;
 
-        let connected_peers = self
-            .handle
-            .connected_peers()
-            .await
-            .map_err(|e| format!("failed to get connected peers: {}", e))?;
+        let connected_peers =
+            self.handle.connected_peers().await.map_err(|e| {
+                P2PError::Transport(format!("failed to get connected peers: {}", e))
+            })?;
 
         if connected_peers.is_empty() {
             return Ok(());
@@ -791,7 +806,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             let mut request = p2p::message::DocSyncRequest::new(doc_ids.clone());
             if let Err(e) = p2p::signing::sign_message(self.handle.keypair(), &mut request) {
                 event_bus.unsubscribe(sub.id());
-                return Err(format!("failed to sign DocSync request: {}", e));
+                return Err(P2PError::Internal(format!(
+                    "failed to sign DocSync request: {}",
+                    e
+                )));
             }
 
             let mut any_sent = false;
@@ -838,26 +856,26 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_branchable_collection(&self, collection_id: &str) -> Result<(), String> {
+    async fn sync_branchable_collection(&self, collection_id: &str) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
             .ok_or_else(|| "no database context for sync".to_string())?;
         pusher.validate_branchable_collection(collection_id)?;
 
-        let connected_peers = self
-            .handle
-            .connected_peers()
-            .await
-            .map_err(|e| format!("failed to get connected peers: {}", e))?;
+        let connected_peers =
+            self.handle.connected_peers().await.map_err(|e| {
+                P2PError::Transport(format!("failed to get connected peers: {}", e))
+            })?;
 
         if connected_peers.is_empty() {
             return Ok(());
         }
 
         let mut request = p2p::message::BranchableSyncRequest::new(collection_id.to_string());
-        p2p::signing::sign_message(self.handle.keypair(), &mut request)
-            .map_err(|e| format!("failed to sign BranchableSync request: {}", e))?;
+        p2p::signing::sign_message(self.handle.keypair(), &mut request).map_err(|e| {
+            P2PError::Internal(format!("failed to sign BranchableSync request: {}", e))
+        })?;
 
         for peer_id in &connected_peers {
             let request_clone = request.clone();
@@ -877,21 +895,21 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> Result<(), String> {
+    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> P2PResult<()> {
         if version_ids.is_empty() {
             return Ok(());
         }
 
         // Validate all CIDs upfront before attempting sync (matches Go behavior).
         for vid in &version_ids {
-            cid::Cid::try_from(vid.as_str()).map_err(|e| format!("invalid cid: {}", e))?;
+            cid::Cid::try_from(vid.as_str())
+                .map_err(|e| P2PError::InvalidInput(format!("invalid cid: {}", e)))?;
         }
 
-        let connected_peers = self
-            .handle
-            .connected_peers()
-            .await
-            .map_err(|e| format!("failed to get connected peers: {}", e))?;
+        let connected_peers =
+            self.handle.connected_peers().await.map_err(|e| {
+                P2PError::Transport(format!("failed to get connected peers: {}", e))
+            })?;
 
         if connected_peers.is_empty() {
             return Ok(());
@@ -905,5 +923,6 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         syncer
             .sync_versions(&self.handle, version_ids, connected_peers)
             .await
+            .map_err(P2PError::from)
     }
 }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -48,6 +48,10 @@ impl HttpP2PAdapter {
     fn unsupported() -> String {
         "not supported by embedded defra-node HTTP adapter".to_string()
     }
+
+    fn p2p_error_to_http_string(error: embedded::P2PError) -> String {
+        error.to_string()
+    }
 }
 
 #[cfg(all(feature = "http", feature = "p2p"))]
@@ -65,14 +69,14 @@ impl defra_http::P2POperations for HttpP2PAdapter {
         self.inner
             .connected_peers()
             .await
-            .map_err(|e| e.to_string())
+            .map_err(Self::p2p_error_to_http_string)
     }
 
     async fn connect_peer(&self, addr: &str) -> Result<(), String> {
         self.inner
             .connect_peer(addr)
             .await
-            .map_err(|e| e.to_string())
+            .map_err(Self::p2p_error_to_http_string)
     }
 
     async fn get_replicators(&self) -> Result<Vec<defra_http::router::ReplicatorInfo>, String> {
@@ -90,7 +94,7 @@ impl defra_http::P2POperations for HttpP2PAdapter {
         self.inner
             .set_replicator(addr, collections)
             .await
-            .map_err(|e| e.to_string())
+            .map_err(Self::p2p_error_to_http_string)
     }
 
     async fn remove_replicator(
@@ -110,7 +114,7 @@ impl defra_http::P2POperations for HttpP2PAdapter {
             self.inner
                 .subscribe_collection(&collection)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(Self::p2p_error_to_http_string)?;
         }
         Ok(())
     }
@@ -160,15 +164,18 @@ impl defra_http::P2POperations for HttpP2PAdapter {
 pub trait P2POps: Send + Sync {
     async fn local_peer_id(&self) -> String;
     async fn listen_addresses(&self) -> Vec<String>;
-    async fn connected_peers(&self) -> anyhow::Result<Vec<String>>;
-    async fn connect_peer(&self, addr: &str) -> anyhow::Result<()>;
-    async fn notify_network_change(&self) -> anyhow::Result<()>;
-    async fn subscribe_collection(&self, name: &str) -> anyhow::Result<()>;
+    async fn connected_peers(&self) -> embedded::P2PResult<Vec<String>>;
+    async fn connect_peer(&self, addr: &str) -> embedded::P2PResult<()>;
+    async fn notify_network_change(&self) -> embedded::P2PResult<()>;
+    async fn subscribe_collection(&self, name: &str) -> embedded::P2PResult<()>;
     /// Set up push replication to a peer for the given collections.
     /// The peer address may be an endpoint ticket, `<node-id>@<ip>:<port>`,
     /// or just `<node-id>`.
-    async fn set_replicator(&self, peer_addr: &str, collections: Vec<String>)
-        -> anyhow::Result<()>;
+    async fn set_replicator(
+        &self,
+        peer_addr: &str,
+        collections: Vec<String>,
+    ) -> embedded::P2PResult<()>;
 }
 
 /// Type-erased schema operations so we can store DB<S> without leaking the Store generic.

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -49,38 +49,61 @@ impl HttpP2PAdapter {
         "not supported by embedded defra-node HTTP adapter".to_string()
     }
 
-    fn p2p_error_to_http_string(error: embedded::P2PError) -> String {
-        error.to_string()
+    fn map_embedded_error(error: embedded::P2PError) -> defra_http::router::P2PError {
+        match error {
+            embedded::P2PError::InvalidInput(message) => {
+                defra_http::router::P2PError::InvalidInput(message)
+            }
+            embedded::P2PError::NotFound(message) => {
+                defra_http::router::P2PError::NotFound(message)
+            }
+            embedded::P2PError::Unsupported(message) => {
+                defra_http::router::P2PError::Unsupported(message)
+            }
+            embedded::P2PError::Transport(message) => {
+                defra_http::router::P2PError::Transport(message)
+            }
+            embedded::P2PError::Persistence(message) => {
+                defra_http::router::P2PError::Internal(message)
+            }
+            embedded::P2PError::Internal(message) => {
+                defra_http::router::P2PError::Internal(message)
+            }
+        }
     }
 }
 
 #[cfg(all(feature = "http", feature = "p2p"))]
 #[async_trait::async_trait]
 impl defra_http::P2POperations for HttpP2PAdapter {
-    async fn local_peer_id(&self) -> Result<String, String> {
+    async fn local_peer_id(&self) -> defra_http::router::P2PResult<String> {
         Ok(self.inner.local_peer_id().await)
     }
 
-    async fn listen_addresses(&self) -> Result<Vec<String>, String> {
+    async fn listen_addresses(&self) -> defra_http::router::P2PResult<Vec<String>> {
         Ok(self.inner.listen_addresses().await)
     }
 
-    async fn connected_peers(&self) -> Result<Vec<String>, String> {
+    async fn connected_peers(&self) -> defra_http::router::P2PResult<Vec<String>> {
         self.inner
             .connected_peers()
             .await
-            .map_err(Self::p2p_error_to_http_string)
+            .map_err(Self::map_embedded_error)
     }
 
-    async fn connect_peer(&self, addr: &str) -> Result<(), String> {
+    async fn connect_peer(&self, addr: &str) -> defra_http::router::P2PResult<()> {
         self.inner
             .connect_peer(addr)
             .await
-            .map_err(Self::p2p_error_to_http_string)
+            .map_err(Self::map_embedded_error)
     }
 
-    async fn get_replicators(&self) -> Result<Vec<defra_http::router::ReplicatorInfo>, String> {
-        Err(Self::unsupported())
+    async fn get_replicators(
+        &self,
+    ) -> defra_http::router::P2PResult<Vec<defra_http::router::ReplicatorInfo>> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
     async fn add_replicator(
@@ -89,72 +112,103 @@ impl defra_http::P2POperations for HttpP2PAdapter {
         addr: Option<&str>,
         _explicit_replay_capabilities: Vec<defra_http::router::ExplicitReplayCapabilityInput>,
         _expected_authorizer_did: Option<&str>,
-    ) -> Result<(), String> {
-        let addr = addr.ok_or_else(|| "replicator address is required".to_string())?;
+    ) -> defra_http::router::P2PResult<()> {
+        let addr = addr.ok_or_else(|| {
+            defra_http::router::P2PError::InvalidInput("replicator address is required".into())
+        })?;
         self.inner
             .set_replicator(addr, collections)
             .await
-            .map_err(Self::p2p_error_to_http_string)
+            .map_err(Self::map_embedded_error)
     }
 
     async fn remove_replicator(
         &self,
         _collections: Vec<String>,
         _addr: Option<&str>,
-    ) -> Result<(), String> {
-        Err(Self::unsupported())
+    ) -> defra_http::router::P2PResult<()> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
-    async fn get_collections(&self) -> Result<Vec<String>, String> {
-        Err(Self::unsupported())
+    async fn get_collections(&self) -> defra_http::router::P2PResult<Vec<String>> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
-    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn add_collections(&self, collections: Vec<String>) -> defra_http::router::P2PResult<()> {
         for collection in collections {
             self.inner
                 .subscribe_collection(&collection)
                 .await
-                .map_err(Self::p2p_error_to_http_string)?;
+                .map_err(Self::map_embedded_error)?;
         }
         Ok(())
     }
 
-    async fn remove_collections(&self, _collections: Vec<String>) -> Result<(), String> {
-        Err(Self::unsupported())
+    async fn remove_collections(
+        &self,
+        _collections: Vec<String>,
+    ) -> defra_http::router::P2PResult<()> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
-    async fn get_documents(&self) -> Result<Vec<defra_http::router::P2pDocumentInfo>, String> {
-        Err(Self::unsupported())
+    async fn get_documents(
+        &self,
+    ) -> defra_http::router::P2PResult<Vec<defra_http::router::P2pDocumentInfo>> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
     async fn add_documents(
         &self,
         _docs: Vec<defra_http::router::P2pDocumentRequest>,
-    ) -> Result<(), String> {
-        Err(Self::unsupported())
+    ) -> defra_http::router::P2PResult<()> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
     async fn remove_documents(
         &self,
         _docs: Vec<defra_http::router::P2pDocumentRequest>,
-    ) -> Result<(), String> {
-        Err(Self::unsupported())
+    ) -> defra_http::router::P2PResult<()> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
     async fn sync_documents(
         &self,
         _collection_name: &str,
         _doc_ids: Vec<String>,
-    ) -> Result<(), String> {
-        Err(Self::unsupported())
+    ) -> defra_http::router::P2PResult<()> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
-    async fn sync_branchable_collection(&self, _collection_id: &str) -> Result<(), String> {
-        Err(Self::unsupported())
+    async fn sync_branchable_collection(
+        &self,
+        _collection_id: &str,
+    ) -> defra_http::router::P2PResult<()> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 
-    async fn sync_collection_versions(&self, _version_ids: Vec<String>) -> Result<(), String> {
-        Err(Self::unsupported())
+    async fn sync_collection_versions(
+        &self,
+        _version_ids: Vec<String>,
+    ) -> defra_http::router::P2PResult<()> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
     }
 }
 

--- a/crates/defra-node/src/p2p_handle.rs
+++ b/crates/defra-node/src/p2p_handle.rs
@@ -24,39 +24,41 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
         p2p::iroh::format_public_listen_addrs(self.transport.local_peer_id(), &raw_addrs)
     }
 
-    async fn connected_peers(&self) -> anyhow::Result<Vec<String>> {
+    async fn connected_peers(&self) -> embedded::P2PResult<Vec<String>> {
         self.transport
             .connected_peers()
             .await
             .map(|peers| peers.into_iter().map(|peer| peer.to_string()).collect())
-            .map_err(|e| anyhow::anyhow!("connected peers failed: {}", e))
+            .map_err(|error| {
+                embedded::P2PError::transport(format!("connected peers failed: {}", error))
+            })
     }
 
-    async fn connect_peer(&self, addr: &str) -> anyhow::Result<()> {
-        let (peer_id, addrs) = p2p::iroh::parse_public_peer_addr(addr)?;
+    async fn connect_peer(&self, addr: &str) -> embedded::P2PResult<()> {
+        let (peer_id, addrs) = p2p::iroh::parse_public_peer_addr(addr)
+            .map_err(|error| embedded::P2PError::invalid_input(error.to_string()))?;
         self.transport
             .dial(&peer_id, addrs)
             .await
-            .map_err(|e| anyhow::anyhow!("dial failed: {}", e))
+            .map_err(|error| embedded::P2PError::transport(format!("dial failed: {}", error)))
     }
 
-    async fn notify_network_change(&self) -> anyhow::Result<()> {
-        self.transport
-            .network_change()
-            .await
-            .map_err(|e| anyhow::anyhow!("network_change failed: {}", e))
+    async fn notify_network_change(&self) -> embedded::P2PResult<()> {
+        self.transport.network_change().await.map_err(|error| {
+            embedded::P2PError::transport(format!("network_change failed: {}", error))
+        })
     }
 
-    async fn subscribe_collection(&self, name: &str) -> anyhow::Result<()> {
+    async fn subscribe_collection(&self, name: &str) -> embedded::P2PResult<()> {
         // Resolve collection name -> CID (gossip topics use CIDs, not names)
         let collection_id = self
             .collection_lookup
             .get_collection_id(name)
             .ok_or_else(|| {
-                anyhow::anyhow!(
+                embedded::P2PError::not_found(format!(
                     "collection '{}' not found -- add schema before subscribing to P2P",
                     name
-                )
+                ))
             })?;
         tracing::debug!(
             collection_name = %name,
@@ -66,7 +68,9 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
         self.coordinator
             .subscribe_collection(&collection_id)
             .await
-            .map_err(|e| anyhow::anyhow!("subscribe collection failed: {}", e))?;
+            .map_err(|error| {
+                embedded::P2PError::transport(format!("subscribe collection failed: {}", error))
+            })?;
         Ok(())
     }
 
@@ -74,8 +78,9 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
         &self,
         peer_addr: &str,
         collections: Vec<String>,
-    ) -> anyhow::Result<()> {
-        let (peer_id, addrs) = p2p::iroh::parse_public_peer_addr(peer_addr)?;
+    ) -> embedded::P2PResult<()> {
+        let (peer_id, addrs) = p2p::iroh::parse_public_peer_addr(peer_addr)
+            .map_err(|error| embedded::P2PError::invalid_input(error.to_string()))?;
         if !addrs.is_empty() || p2p::iroh::is_ticket_string(peer_addr) {
             self.connect_peer(peer_addr).await?;
         }
@@ -87,7 +92,10 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
                 .collection_lookup
                 .get_collection_id(name)
                 .ok_or_else(|| {
-                    anyhow::anyhow!("collection '{}' not found for replicator setup", name)
+                    embedded::P2PError::not_found(format!(
+                        "collection '{}' not found for replicator setup",
+                        name
+                    ))
                 })?;
             tracing::debug!(
                 collection_name = %name,
@@ -100,7 +108,9 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
         self.coordinator
             .create_replicator(&peer_id, collection_cids, true)
             .await
-            .map_err(|e| anyhow::anyhow!("set replicator failed: {}", e))?;
+            .map_err(|error| {
+                embedded::P2PError::transport(format!("set replicator failed: {}", error))
+            })?;
 
         tracing::info!(
             peer_id = %peer_id,

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -33,6 +33,7 @@ serde.workspace = true
 serde_bytes.workspace = true
 serde_ipld_dagcbor.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing.workspace = true
 

--- a/crates/embedded/src/iroh_adapter.rs
+++ b/crates/embedded/src/iroh_adapter.rs
@@ -7,7 +7,8 @@ use blockstore::Blockstore;
 use crate::transport_doc_pusher::TransportDocPusher;
 use crate::transport_version_syncer::TransportVersionSyncer;
 use crate::{
-    P2POperations, P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo, ReplicatorPushOptions,
+    P2PError, P2POperations, P2PResult, P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo,
+    ReplicatorPushOptions,
 };
 
 use p2p::iroh::{format_public_listen_addrs, parse_public_peer_addr, IrohTransport};
@@ -90,24 +91,24 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
 
 #[async_trait]
 impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
-    async fn local_peer_id(&self) -> Result<String, String> {
+    async fn local_peer_id(&self) -> P2PResult<String> {
         Ok(self.transport.local_peer_id().to_string())
     }
 
-    async fn listen_addresses(&self) -> Result<Vec<String>, String> {
+    async fn listen_addresses(&self) -> P2PResult<Vec<String>> {
         self.transport
             .listen_addresses()
             .await
             .map(|addrs| format_public_listen_addrs(self.transport.local_peer_id(), &addrs))
-            .map_err(|error| error.to_string())
+            .map_err(|error| P2PError::transport(error.to_string()))
     }
 
-    async fn connected_peers(&self) -> Result<Vec<String>, String> {
+    async fn connected_peers(&self) -> P2PResult<Vec<String>> {
         let connected = self
             .transport
             .connected_peers()
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| P2PError::transport(error.to_string()))?;
 
         let mut result = Vec::new();
         for peer in &connected {
@@ -123,9 +124,9 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(result)
     }
 
-    async fn connect_peer(&self, addr: &str) -> Result<(), String> {
-        let (peer_id, direct_addrs) =
-            parse_public_peer_addr(addr).map_err(|error| error.to_string())?;
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()> {
+        let (peer_id, direct_addrs) = parse_public_peer_addr(addr)
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
         let dial_timeout = if direct_addrs.is_empty() {
             std::time::Duration::from_secs(10)
         } else {
@@ -134,12 +135,14 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
 
         tokio::time::timeout(dial_timeout, self.transport.dial(&peer_id, direct_addrs))
             .await
-            .map_err(|_| format!("failed to connect: timeout dialing {peer_id}"))?
-            .map_err(|error| format!("failed to connect: {error}"))?;
+            .map_err(|_| {
+                P2PError::transport(format!("failed to connect: timeout dialing {peer_id}"))
+            })?
+            .map_err(|error| P2PError::transport(format!("failed to connect: {error}")))?;
         self.transport
             .poll_until_connected(&peer_id, std::time::Duration::from_secs(10))
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| P2PError::transport(error.to_string()))?;
 
         if let Ok(mut addrs) = self.peer_addresses.write() {
             addrs.insert(peer_id.to_string(), addr.to_string());
@@ -149,19 +152,19 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn notify_network_change(&self) -> Result<(), String> {
+    async fn notify_network_change(&self) -> P2PResult<()> {
         self.transport
             .network_change()
             .await
-            .map_err(|error| error.to_string())
+            .map_err(|error| P2PError::transport(error.to_string()))
     }
 
-    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String> {
+    async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         let p2p_infos = self
             .transport
             .list_replicators()
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| P2PError::transport(error.to_string()))?;
 
         Ok(p2p_infos
             .into_iter()
@@ -181,16 +184,18 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         collections: Vec<String>,
         addr: Option<&str>,
         push_options: ReplicatorPushOptions,
-    ) -> Result<(), String> {
-        let addr_str = addr.ok_or_else(|| "address is required".to_string())?;
-        let (peer_id, direct_addrs) =
-            parse_public_peer_addr(addr_str).map_err(|error| error.to_string())?;
+    ) -> P2PResult<()> {
+        let addr_str = addr.ok_or_else(|| P2PError::invalid_input("address is required"))?;
+        let (peer_id, direct_addrs) = parse_public_peer_addr(addr_str)
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
 
         let effective_collections = if collections.is_empty() {
             if let Some(ref pusher) = self.doc_pusher {
-                pusher.list_collections()?
+                pusher.list_collections().map_err(P2PError::from)?
             } else {
-                return Err("no database context to list collections".to_string());
+                return Err(P2PError::unsupported(
+                    "no database context to list collections",
+                ));
             }
         } else {
             collections
@@ -202,7 +207,9 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 if let Some(cid) = pusher.get_collection_id(name) {
                     collection_cids.push(cid);
                 } else {
-                    return Err(format!("collection '{name}' not found"));
+                    return Err(P2PError::not_found(format!(
+                        "collection '{name}' not found"
+                    )));
                 }
             }
         } else {
@@ -217,12 +224,12 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 coordinator
                     .get_replicator(&peer_id)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(|error| P2PError::transport(error.to_string()))
             } else {
                 self.transport
                     .get_replicator(&peer_id)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(|error| P2PError::transport(error.to_string()))
             };
             match result {
                 Ok(Some(info)) => info.collections.into_iter().collect(),
@@ -241,7 +248,9 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         self.transport
             .dial(&peer_id, direct_addrs)
             .await
-            .map_err(|error| format!("failed to connect to replicator peer: {error}"))?;
+            .map_err(|error| {
+                P2PError::transport(format!("failed to connect to replicator peer: {error}"))
+            })?;
 
         if let Ok(mut addrs) = self.peer_addresses.write() {
             addrs.insert(peer_id.to_string(), addr_str.to_string());
@@ -251,12 +260,12 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             coordinator
                 .create_replicator(&peer_id, collection_cids.clone(), true)
                 .await
-                .map_err(|error| error.to_string())?;
+                .map_err(|error| P2PError::transport(error.to_string()))?;
         } else {
             self.transport
                 .create_replicator(&peer_id, collection_cids.clone())
                 .await
-                .map_err(|error| error.to_string())?;
+                .map_err(|error| P2PError::transport(error.to_string()))?;
         }
 
         if let Some(ref pusher) = self.doc_pusher {
@@ -324,21 +333,21 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
-    ) -> Result<(), String> {
-        let addr_str = addr.ok_or_else(|| "address is required".to_string())?;
-        let (peer_id, _direct_addrs) =
-            parse_public_peer_addr(addr_str).map_err(|error| error.to_string())?;
+    ) -> P2PResult<()> {
+        let addr_str = addr.ok_or_else(|| P2PError::invalid_input("address is required"))?;
+        let (peer_id, _direct_addrs) = parse_public_peer_addr(addr_str)
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
 
         let fully_deleted = if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .remove_replicator_collections(&peer_id, collections)
                 .await
-                .map_err(|error| error.to_string())?
+                .map_err(|error| P2PError::transport(error.to_string()))?
         } else {
             self.transport
                 .remove_replicator_collections(&peer_id, collections)
                 .await
-                .map_err(|error| error.to_string())?
+                .map_err(|error| P2PError::transport(error.to_string()))?
         };
 
         if let Some(ref pusher) = self.doc_pusher {
@@ -358,7 +367,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                     .transport
                     .get_replicator(&peer_id)
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
                 if let Some(info) = remaining {
                     if let Err(error) = pusher
                         .persist_replicator(&peer_id.to_string(), &info.collections)
@@ -381,17 +390,16 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn retry_replicators(&self, push_options: ReplicatorPushOptions) -> Result<(), String> {
+    async fn retry_replicators(&self, push_options: ReplicatorPushOptions) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
-            .ok_or_else(|| "no database context to retry replicators".to_string())?;
-        let collections = pusher.list_collections()?;
-        let replicators = self
-            .transport
-            .list_replicators()
-            .await
-            .map_err(|error| format!("failed to get replicators: {error}"))?;
+            .ok_or_else(|| P2PError::unsupported("no database context to retry replicators"))?;
+        let collections = pusher.list_collections().map_err(P2PError::from)?;
+        let replicators =
+            self.transport.list_replicators().await.map_err(|error| {
+                P2PError::transport(format!("failed to get replicators: {error}"))
+            })?;
 
         let mut push_handles = Vec::new();
         for replicator in replicators {
@@ -421,28 +429,28 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn get_collections(&self) -> Result<Vec<String>, String> {
+    async fn get_collections(&self) -> P2PResult<Vec<String>> {
         if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .get_subscribed_collections()
                 .await
-                .map_err(|error| error.to_string())
+                .map_err(|error| P2PError::transport(error.to_string()))
         } else {
             Ok(Vec::new())
         }
     }
 
-    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn add_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         if let Some(ref coordinator) = self.sync_coordinator {
             for collection_name in collections {
                 let topic_id = if let Some(ref pusher) = self.doc_pusher {
                     if let Some(collection_id) = pusher.get_collection_id(&collection_name) {
                         collection_id
                     } else {
-                        return Err(format!(
+                        return Err(P2PError::not_found(format!(
                             "collection '{}' not found - add schema before subscribing to P2P",
                             collection_name
-                        ));
+                        )));
                     }
                 } else {
                     collection_name.clone()
@@ -451,14 +459,14 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 coordinator
                     .subscribe_collection(&topic_id)
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
             }
 
             if let Some(ref pusher) = self.doc_pusher {
                 let all_cols = coordinator
                     .get_subscribed_collections()
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
                 if let Err(error) = pusher.persist_p2p_collections(&all_cols).await {
                     tracing::warn!(error = %error, "failed to persist P2P collections");
                 }
@@ -466,37 +474,42 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
 
             Ok(())
         } else {
-            Err("p2p collections functionality requires sync coordinator".to_string())
+            Err(P2PError::unsupported(
+                "p2p collections functionality requires sync coordinator",
+            ))
         }
     }
 
-    async fn remove_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn remove_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         if let Some(ref coordinator) = self.sync_coordinator {
             let topic_ids = collections
                 .into_iter()
                 .map(|collection_name| {
                     if let Some(ref pusher) = self.doc_pusher {
-                        pusher
-                            .get_collection_id(&collection_name)
-                            .ok_or_else(|| format!("collection '{}' not found", collection_name))
+                        pusher.get_collection_id(&collection_name).ok_or_else(|| {
+                            P2PError::not_found(format!(
+                                "collection '{}' not found",
+                                collection_name
+                            ))
+                        })
                     } else {
                         Ok(collection_name)
                     }
                 })
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<P2PResult<Vec<_>>>()?;
 
             for topic_id in topic_ids {
                 coordinator
                     .unsubscribe_collection(&topic_id)
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
             }
 
             if let Some(ref pusher) = self.doc_pusher {
                 let all_cols = coordinator
                     .get_subscribed_collections()
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
                 if let Err(error) = pusher.persist_p2p_collections(&all_cols).await {
                     tracing::warn!(error = %error, "failed to persist P2P collections after removal");
                 }
@@ -504,15 +517,16 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
 
             Ok(())
         } else {
-            Err("p2p collections functionality requires sync coordinator".to_string())
+            Err(P2PError::unsupported(
+                "p2p collections functionality requires sync coordinator",
+            ))
         }
     }
 
-    async fn get_documents(&self) -> Result<Vec<P2pDocumentInfo>, String> {
-        let docs = self
-            .tracked_documents
-            .read()
-            .map_err(|error| format!("failed to read tracked documents: {error}"))?;
+    async fn get_documents(&self) -> P2PResult<Vec<P2pDocumentInfo>> {
+        let docs = self.tracked_documents.read().map_err(|error| {
+            P2PError::internal(format!("failed to read tracked documents: {error}"))
+        })?;
         let mut sorted: Vec<String> = docs.iter().cloned().collect();
         sorted.sort();
         Ok(sorted
@@ -524,10 +538,11 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             .collect())
     }
 
-    async fn add_documents(&self, docs: Vec<P2pDocumentRequest>) -> Result<(), String> {
+    async fn add_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
         let doc_ids: Vec<String> = docs.into_iter().map(|doc| doc.doc_id).collect();
-        document::validate_doc_ids(&doc_ids)
-            .map_err(|_| "malformed document ID, missing either version or cid".to_string())?;
+        document::validate_doc_ids(&doc_ids).map_err(|_| {
+            P2PError::invalid_input("malformed document ID, missing either version or cid")
+        })?;
 
         for doc_id in &doc_ids {
             let topic = DefraTopic::document(doc_id);
@@ -553,10 +568,11 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> Result<(), String> {
+    async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
         let doc_ids: Vec<String> = docs.into_iter().map(|doc| doc.doc_id).collect();
-        document::validate_doc_ids(&doc_ids)
-            .map_err(|_| "malformed document ID, missing either version or cid".to_string())?;
+        document::validate_doc_ids(&doc_ids).map_err(|_| {
+            P2PError::invalid_input("malformed document ID, missing either version or cid")
+        })?;
 
         for doc_id in &doc_ids {
             let topic = DefraTopic::document(doc_id);
@@ -571,52 +587,55 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> Result<(), String> {
+    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
-            .ok_or_else(|| "no database context for republish".to_string())?;
+            .ok_or_else(|| P2PError::unsupported("no database context for republish"))?;
         let coordinator = self
             .sync_coordinator
             .as_ref()
-            .ok_or_else(|| "no sync coordinator for republish".to_string())?;
-        pusher.validate_collection_exists(collection_name)?;
-        let collection_id = pusher
-            .get_collection_id(collection_name)
-            .ok_or_else(|| format!("collection '{collection_name}' not found"))?;
-        let head_blocks = pusher.load_document_head_blocks(doc_id).await?;
+            .ok_or_else(|| P2PError::unsupported("no sync coordinator for republish"))?;
+        pusher
+            .validate_collection_exists(collection_name)
+            .map_err(P2PError::from)?;
+        let collection_id = pusher.get_collection_id(collection_name).ok_or_else(|| {
+            P2PError::not_found(format!("collection '{collection_name}' not found"))
+        })?;
+        let head_blocks = pusher
+            .load_document_head_blocks(doc_id)
+            .await
+            .map_err(P2PError::from)?;
 
         for (cid, block) in head_blocks {
             coordinator
                 .broadcast_local_update(&cid, &block, doc_id, &collection_id)
                 .await
-                .map_err(|error| format!("failed to republish document head {cid}: {error}"))?;
+                .map_err(|error| {
+                    P2PError::transport(format!("failed to republish document head {cid}: {error}"))
+                })?;
         }
 
         Ok(())
     }
 
-    async fn sync_documents(
-        &self,
-        collection_name: &str,
-        doc_ids: Vec<String>,
-    ) -> Result<(), String> {
+    async fn sync_documents(&self, collection_name: &str, doc_ids: Vec<String>) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
-            .ok_or_else(|| "no database context for sync".to_string())?;
-        pusher.validate_collection_exists(collection_name)?;
+            .ok_or_else(|| P2PError::unsupported("no database context for sync"))?;
+        pusher
+            .validate_collection_exists(collection_name)
+            .map_err(P2PError::from)?;
 
         let event_bus = self
             .event_bus
             .as_ref()
-            .ok_or_else(|| "no event bus for sync".to_string())?;
+            .ok_or_else(|| P2PError::unsupported("no event bus for sync"))?;
 
-        let connected_peers = self
-            .transport
-            .connected_peers()
-            .await
-            .map_err(|error| format!("failed to get connected peers: {error}"))?;
+        let connected_peers = self.transport.connected_peers().await.map_err(|error| {
+            P2PError::transport(format!("failed to get connected peers: {error}"))
+        })?;
         if connected_peers.is_empty() {
             return Ok(());
         }
@@ -637,7 +656,9 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             let mut request = p2p::message::DocSyncRequest::new(doc_ids.clone());
             if let Err(error) = p2p::signing::sign_with_transport(&self.transport, &mut request) {
                 event_bus.unsubscribe(sub.id());
-                return Err(format!("failed to sign DocSync request: {error}"));
+                return Err(P2PError::internal(format!(
+                    "failed to sign DocSync request: {error}"
+                )));
             }
 
             let mut any_sent = false;
@@ -683,25 +704,26 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_branchable_collection(&self, collection_id: &str) -> Result<(), String> {
+    async fn sync_branchable_collection(&self, collection_id: &str) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
-            .ok_or_else(|| "no database context for sync".to_string())?;
-        pusher.validate_branchable_collection(collection_id)?;
+            .ok_or_else(|| P2PError::unsupported("no database context for sync"))?;
+        pusher
+            .validate_branchable_collection(collection_id)
+            .map_err(P2PError::from)?;
 
-        let connected_peers = self
-            .transport
-            .connected_peers()
-            .await
-            .map_err(|error| format!("failed to get connected peers: {error}"))?;
+        let connected_peers = self.transport.connected_peers().await.map_err(|error| {
+            P2PError::transport(format!("failed to get connected peers: {error}"))
+        })?;
         if connected_peers.is_empty() {
             return Ok(());
         }
 
         let mut request = p2p::message::BranchableSyncRequest::new(collection_id.to_string());
-        p2p::signing::sign_with_transport(&self.transport, &mut request)
-            .map_err(|error| format!("failed to sign BranchableSync request: {error}"))?;
+        p2p::signing::sign_with_transport(&self.transport, &mut request).map_err(|error| {
+            P2PError::internal(format!("failed to sign BranchableSync request: {error}"))
+        })?;
 
         for peer in &connected_peers {
             let request_clone = request.clone();
@@ -720,20 +742,18 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> Result<(), String> {
+    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> P2PResult<()> {
         if version_ids.is_empty() {
             return Ok(());
         }
         for version_id in &version_ids {
             cid::Cid::try_from(version_id.as_str())
-                .map_err(|error| format!("invalid cid: {error}"))?;
+                .map_err(|error| P2PError::invalid_input(format!("invalid cid: {error}")))?;
         }
 
-        let connected_peers = self
-            .transport
-            .connected_peers()
-            .await
-            .map_err(|error| format!("failed to get connected peers: {error}"))?;
+        let connected_peers = self.transport.connected_peers().await.map_err(|error| {
+            P2PError::transport(format!("failed to get connected peers: {error}"))
+        })?;
         if connected_peers.is_empty() {
             return Ok(());
         }
@@ -741,7 +761,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         let syncer = self
             .version_syncer
             .as_ref()
-            .ok_or_else(|| "version syncer required".to_string())?
+            .ok_or_else(|| P2PError::unsupported("version syncer required"))?
             .clone();
         tokio::spawn(async move {
             if let Err(error) = syncer.sync_versions(version_ids, connected_peers).await {

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -21,6 +21,8 @@ pub use libp2p_adapter::{CollectionLookup, P2PAdapter, VersionSyncer};
 pub use libp2p_doc_pusher::{DbDocPusher, DocPusher};
 pub use node::{build_with_store, EmbeddedNode, NodeBuilder};
 pub use node_tasks::BackgroundTasks;
+mod p2p_error;
+pub use p2p_error::{P2PError, P2PResult};
 pub use transport_doc_pusher::{DbTransportDocPusher, TransportDocPusher};
 pub use transport_version_syncer::{DbTransportVersionSyncer, TransportVersionSyncer};
 pub use version_syncer::DbVersionSyncer;

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -33,38 +33,34 @@ pub use iroh_adapter::IrohP2PAdapter;
 /// Transport-agnostic P2P operations exposed by embedded nodes.
 #[async_trait]
 pub trait P2POperations: Send + Sync {
-    async fn local_peer_id(&self) -> Result<String, String>;
-    async fn listen_addresses(&self) -> Result<Vec<String>, String>;
-    async fn connected_peers(&self) -> Result<Vec<String>, String>;
-    async fn connect_peer(&self, addr: &str) -> Result<(), String>;
-    async fn notify_network_change(&self) -> Result<(), String>;
-    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String>;
+    async fn local_peer_id(&self) -> P2PResult<String>;
+    async fn listen_addresses(&self) -> P2PResult<Vec<String>>;
+    async fn connected_peers(&self) -> P2PResult<Vec<String>>;
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()>;
+    async fn notify_network_change(&self) -> P2PResult<()>;
+    async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>>;
     async fn add_replicator(
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
         push_options: ReplicatorPushOptions,
-    ) -> Result<(), String>;
+    ) -> P2PResult<()>;
     async fn remove_replicator(
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
-    ) -> Result<(), String>;
-    async fn retry_replicators(&self, push_options: ReplicatorPushOptions) -> Result<(), String>;
-    async fn get_collections(&self) -> Result<Vec<String>, String>;
-    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String>;
-    async fn remove_collections(&self, collections: Vec<String>) -> Result<(), String>;
-    async fn get_documents(&self) -> Result<Vec<P2pDocumentInfo>, String>;
-    async fn add_documents(&self, docs: Vec<P2pDocumentRequest>) -> Result<(), String>;
-    async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> Result<(), String>;
-    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> Result<(), String>;
-    async fn sync_documents(
-        &self,
-        collection_name: &str,
-        doc_ids: Vec<String>,
-    ) -> Result<(), String>;
-    async fn sync_branchable_collection(&self, collection_id: &str) -> Result<(), String>;
-    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> Result<(), String>;
+    ) -> P2PResult<()>;
+    async fn retry_replicators(&self, push_options: ReplicatorPushOptions) -> P2PResult<()>;
+    async fn get_collections(&self) -> P2PResult<Vec<String>>;
+    async fn add_collections(&self, collections: Vec<String>) -> P2PResult<()>;
+    async fn remove_collections(&self, collections: Vec<String>) -> P2PResult<()>;
+    async fn get_documents(&self) -> P2PResult<Vec<P2pDocumentInfo>>;
+    async fn add_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()>;
+    async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()>;
+    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> P2PResult<()>;
+    async fn sync_documents(&self, collection_name: &str, doc_ids: Vec<String>) -> P2PResult<()>;
+    async fn sync_branchable_collection(&self, collection_id: &str) -> P2PResult<()>;
+    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> P2PResult<()>;
 }
 
 /// Optional inputs used when pushing existing documents to replicators.

--- a/crates/embedded/src/libp2p_adapter.rs
+++ b/crates/embedded/src/libp2p_adapter.rs
@@ -27,7 +27,7 @@ pub trait VersionSyncer: Send + Sync {
         handle: &P2PHostHandle,
         version_ids: Vec<String>,
         connected_peers: Vec<libp2p::PeerId>,
-    ) -> Result<(), String>;
+    ) -> P2PResult<()>;
 }
 
 /// Adapter implementing embedded P2P operations on top of `P2PHostHandle`.

--- a/crates/embedded/src/libp2p_adapter.rs
+++ b/crates/embedded/src/libp2p_adapter.rs
@@ -6,7 +6,8 @@ use blockstore::Blockstore;
 
 use crate::libp2p_doc_pusher::DocPusher;
 use crate::{
-    P2POperations, P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo, ReplicatorPushOptions,
+    P2PError, P2POperations, P2PResult, P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo,
+    ReplicatorPushOptions,
 };
 
 use p2p::sync::Libp2pSyncCoordinator;
@@ -103,38 +104,39 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
 
 #[async_trait]
 impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
-    async fn local_peer_id(&self) -> Result<String, String> {
+    async fn local_peer_id(&self) -> P2PResult<String> {
         self.handle
             .local_peer_id()
             .await
             .map(|id| id.to_string())
-            .map_err(|error| error.to_string())
+            .map_err(|error| P2PError::transport(error.to_string()))
     }
 
-    async fn listen_addresses(&self) -> Result<Vec<String>, String> {
+    async fn listen_addresses(&self) -> P2PResult<Vec<String>> {
         self.handle
             .listen_addresses()
             .await
             .map(|addrs| addrs.into_iter().map(|addr| addr.to_string()).collect())
-            .map_err(|error| error.to_string())
+            .map_err(|error| P2PError::transport(error.to_string()))
     }
 
-    async fn connected_peers(&self) -> Result<Vec<String>, String> {
+    async fn connected_peers(&self) -> P2PResult<Vec<String>> {
         let connected = self
             .handle
             .connected_peers()
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| P2PError::transport(error.to_string()))?;
         self.handle
             .resolve_peer_addresses(&connected, |peer_id| {
                 self.peer_addresses.read().ok()?.get(peer_id).cloned()
             })
             .await
-            .map_err(|error| error.to_string())
+            .map_err(|error| P2PError::transport(error.to_string()))
     }
 
-    async fn connect_peer(&self, addr: &str) -> Result<(), String> {
-        let parsed = p2p::parse_multiaddr_with_peer_id(addr).map_err(|e| e.to_string())?;
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()> {
+        let parsed = p2p::parse_multiaddr_with_peer_id(addr)
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
         let already_connected = self
             .handle
             .connected_peers()
@@ -150,11 +152,11 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         self.handle
             .dial(parsed.peer_id, vec![parsed.transport_addr])
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| P2PError::transport(error.to_string()))?;
         self.handle
             .poll_until_connected(parsed.peer_id, std::time::Duration::from_secs(10))
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| P2PError::transport(error.to_string()))?;
         if let Ok(mut addrs) = self.peer_addresses.write() {
             addrs.insert(parsed.peer_id.to_string(), addr.to_string());
         }
@@ -162,16 +164,16 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn notify_network_change(&self) -> Result<(), String> {
+    async fn notify_network_change(&self) -> P2PResult<()> {
         Ok(())
     }
 
-    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String> {
+    async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         let p2p_infos = self
             .handle
             .list_replicators()
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| P2PError::transport(error.to_string()))?;
 
         Ok(p2p_infos
             .into_iter()
@@ -191,15 +193,18 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         collections: Vec<String>,
         addr: Option<&str>,
         push_options: ReplicatorPushOptions,
-    ) -> Result<(), String> {
-        let addr_str = addr.ok_or_else(|| "address is required".to_string())?;
-        let parsed = p2p::parse_multiaddr_with_peer_id(addr_str).map_err(|e| e.to_string())?;
+    ) -> P2PResult<()> {
+        let addr_str = addr.ok_or_else(|| P2PError::invalid_input("address is required"))?;
+        let parsed = p2p::parse_multiaddr_with_peer_id(addr_str)
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
 
         let effective_collections = if collections.is_empty() {
             if let Some(ref pusher) = self.doc_pusher {
-                pusher.list_collections()?
+                pusher.list_collections().map_err(P2PError::from)?
             } else {
-                return Err("no database context to list collections".to_string());
+                return Err(P2PError::unsupported(
+                    "no database context to list collections",
+                ));
             }
         } else {
             collections
@@ -211,7 +216,9 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 if let Some(cid) = pusher.get_collection_id(name) {
                     collection_cids.push(cid);
                 } else {
-                    return Err(format!("collection '{name}' not found"));
+                    return Err(P2PError::not_found(format!(
+                        "collection '{name}' not found"
+                    )));
                 }
             }
         } else {
@@ -229,12 +236,12 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 coordinator
                     .get_replicator(&transport_peer_id)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(|error| P2PError::transport(error.to_string()))
             } else {
                 self.handle
                     .get_replicator(peer_id)
                     .await
-                    .map_err(|e| e.to_string())
+                    .map_err(|error| P2PError::transport(error.to_string()))
             };
             match result {
                 Ok(Some(info)) => info.collections.into_iter().collect(),
@@ -253,7 +260,9 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         self.handle
             .dial(peer_id, vec![parsed.transport_addr])
             .await
-            .map_err(|error| format!("failed to connect to replicator peer: {error}"))?;
+            .map_err(|error| {
+                P2PError::transport(format!("failed to connect to replicator peer: {error}"))
+            })?;
         if let Ok(mut addrs) = self.peer_addresses.write() {
             addrs.insert(peer_id.to_string(), addr_str.to_string());
         }
@@ -263,12 +272,12 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             coordinator
                 .create_replicator(&transport_peer_id, collection_cids.clone(), true)
                 .await
-                .map_err(|error| error.to_string())?;
+                .map_err(|error| P2PError::transport(error.to_string()))?;
         } else {
             self.handle
                 .create_replicator(peer_id, collection_cids.clone())
                 .await
-                .map_err(|error| error.to_string())?;
+                .map_err(|error| P2PError::transport(error.to_string()))?;
         }
 
         if let Some(ref pusher) = self.doc_pusher {
@@ -339,13 +348,13 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
-    ) -> Result<(), String> {
-        let addr_str = addr.ok_or_else(|| "address is required".to_string())?;
+    ) -> P2PResult<()> {
+        let addr_str = addr.ok_or_else(|| P2PError::invalid_input("address is required"))?;
         let peer_id = match p2p::parse_multiaddr_with_peer_id(addr_str) {
             Ok(parsed) => parsed.peer_id,
-            Err(_) => addr_str
-                .parse::<libp2p::PeerId>()
-                .map_err(|error| format!("invalid peer ID '{}': {}", addr_str, error))?,
+            Err(_) => addr_str.parse::<libp2p::PeerId>().map_err(|error| {
+                P2PError::invalid_input(format!("invalid peer ID '{}': {}", addr_str, error))
+            })?,
         };
 
         let fully_deleted = if let Some(ref coordinator) = self.sync_coordinator {
@@ -353,12 +362,12 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             coordinator
                 .remove_replicator_collections(&transport_peer_id, collections)
                 .await
-                .map_err(|error| error.to_string())?
+                .map_err(|error| P2PError::transport(error.to_string()))?
         } else {
             self.handle
                 .remove_replicator_collections(peer_id, collections)
                 .await
-                .map_err(|error| error.to_string())?
+                .map_err(|error| P2PError::transport(error.to_string()))?
         };
 
         if let Some(ref pusher) = self.doc_pusher {
@@ -378,7 +387,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                     .handle
                     .get_replicator(peer_id)
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
                 if let Some(info) = remaining {
                     if let Err(error) = pusher
                         .persist_replicator(&peer_id.to_string(), &info.collections)
@@ -401,17 +410,16 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn retry_replicators(&self, push_options: ReplicatorPushOptions) -> Result<(), String> {
+    async fn retry_replicators(&self, push_options: ReplicatorPushOptions) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
-            .ok_or_else(|| "no database context to retry replicators".to_string())?;
-        let collections = pusher.list_collections()?;
-        let replicators = self
-            .handle
-            .list_replicators()
-            .await
-            .map_err(|error| format!("failed to get replicators: {error}"))?;
+            .ok_or_else(|| P2PError::unsupported("no database context to retry replicators"))?;
+        let collections = pusher.list_collections().map_err(P2PError::from)?;
+        let replicators =
+            self.handle.list_replicators().await.map_err(|error| {
+                P2PError::transport(format!("failed to get replicators: {error}"))
+            })?;
 
         let mut push_handles = Vec::new();
         for replicator in replicators {
@@ -451,28 +459,28 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn get_collections(&self) -> Result<Vec<String>, String> {
+    async fn get_collections(&self) -> P2PResult<Vec<String>> {
         if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .get_subscribed_collections()
                 .await
-                .map_err(|error| error.to_string())
+                .map_err(|error| P2PError::transport(error.to_string()))
         } else {
             Ok(Vec::new())
         }
     }
 
-    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn add_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         if let Some(ref coordinator) = self.sync_coordinator {
             for collection_name in collections {
                 let topic_id = if let Some(ref pusher) = self.doc_pusher {
                     if let Some(collection_id) = pusher.get_collection_id(&collection_name) {
                         collection_id
                     } else {
-                        return Err(format!(
+                        return Err(P2PError::not_found(format!(
                             "collection '{}' not found - add schema before subscribing to P2P",
                             collection_name
-                        ));
+                        )));
                     }
                 } else {
                     collection_name.clone()
@@ -481,14 +489,14 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 coordinator
                     .subscribe_collection(&topic_id)
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
             }
 
             if let Some(ref pusher) = self.doc_pusher {
                 let all_cols = coordinator
                     .get_subscribed_collections()
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
                 if let Err(error) = pusher.persist_p2p_collections(&all_cols).await {
                     tracing::warn!(error = %error, "failed to persist P2P collections");
                 }
@@ -496,37 +504,42 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
 
             Ok(())
         } else {
-            Err("p2p collections functionality requires sync coordinator".to_string())
+            Err(P2PError::unsupported(
+                "p2p collections functionality requires sync coordinator",
+            ))
         }
     }
 
-    async fn remove_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn remove_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         if let Some(ref coordinator) = self.sync_coordinator {
             let topic_ids = collections
                 .into_iter()
                 .map(|collection_name| {
                     if let Some(ref pusher) = self.doc_pusher {
-                        pusher
-                            .get_collection_id(&collection_name)
-                            .ok_or_else(|| format!("collection '{}' not found", collection_name))
+                        pusher.get_collection_id(&collection_name).ok_or_else(|| {
+                            P2PError::not_found(format!(
+                                "collection '{}' not found",
+                                collection_name
+                            ))
+                        })
                     } else {
                         Ok(collection_name)
                     }
                 })
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<P2PResult<Vec<_>>>()?;
 
             for topic_id in topic_ids {
                 coordinator
                     .unsubscribe_collection(&topic_id)
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
             }
 
             if let Some(ref pusher) = self.doc_pusher {
                 let all_cols = coordinator
                     .get_subscribed_collections()
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| P2PError::transport(error.to_string()))?;
                 if let Err(error) = pusher.persist_p2p_collections(&all_cols).await {
                     tracing::warn!(error = %error, "failed to persist P2P collections after removal");
                 }
@@ -534,15 +547,16 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
 
             Ok(())
         } else {
-            Err("p2p collections functionality requires sync coordinator".to_string())
+            Err(P2PError::unsupported(
+                "p2p collections functionality requires sync coordinator",
+            ))
         }
     }
 
-    async fn get_documents(&self) -> Result<Vec<P2pDocumentInfo>, String> {
-        let docs = self
-            .tracked_documents
-            .read()
-            .map_err(|error| format!("failed to read tracked documents: {error}"))?;
+    async fn get_documents(&self) -> P2PResult<Vec<P2pDocumentInfo>> {
+        let docs = self.tracked_documents.read().map_err(|error| {
+            P2PError::internal(format!("failed to read tracked documents: {error}"))
+        })?;
         let mut sorted: Vec<String> = docs.iter().cloned().collect();
         sorted.sort();
         Ok(sorted
@@ -554,10 +568,11 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .collect())
     }
 
-    async fn add_documents(&self, docs: Vec<P2pDocumentRequest>) -> Result<(), String> {
+    async fn add_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
         let doc_ids: Vec<String> = docs.into_iter().map(|doc| doc.doc_id).collect();
-        document::validate_doc_ids(&doc_ids)
-            .map_err(|_| "malformed document ID, missing either version or cid".to_string())?;
+        document::validate_doc_ids(&doc_ids).map_err(|_| {
+            P2PError::invalid_input("malformed document ID, missing either version or cid")
+        })?;
 
         for doc_id in &doc_ids {
             let topic = DefraTopic::document(doc_id);
@@ -583,10 +598,11 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> Result<(), String> {
+    async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
         let doc_ids: Vec<String> = docs.into_iter().map(|doc| doc.doc_id).collect();
-        document::validate_doc_ids(&doc_ids)
-            .map_err(|_| "malformed document ID, missing either version or cid".to_string())?;
+        document::validate_doc_ids(&doc_ids).map_err(|_| {
+            P2PError::invalid_input("malformed document ID, missing either version or cid")
+        })?;
 
         for doc_id in &doc_ids {
             let topic = DefraTopic::document(doc_id);
@@ -601,52 +617,55 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> Result<(), String> {
+    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
-            .ok_or_else(|| "no database context for republish".to_string())?;
+            .ok_or_else(|| P2PError::unsupported("no database context for republish"))?;
         let coordinator = self
             .sync_coordinator
             .as_ref()
-            .ok_or_else(|| "no sync coordinator for republish".to_string())?;
-        pusher.validate_collection_exists(collection_name)?;
-        let collection_id = pusher
-            .get_collection_id(collection_name)
-            .ok_or_else(|| format!("collection '{collection_name}' not found"))?;
-        let head_blocks = pusher.load_document_head_blocks(doc_id).await?;
+            .ok_or_else(|| P2PError::unsupported("no sync coordinator for republish"))?;
+        pusher
+            .validate_collection_exists(collection_name)
+            .map_err(P2PError::from)?;
+        let collection_id = pusher.get_collection_id(collection_name).ok_or_else(|| {
+            P2PError::not_found(format!("collection '{collection_name}' not found"))
+        })?;
+        let head_blocks = pusher
+            .load_document_head_blocks(doc_id)
+            .await
+            .map_err(P2PError::from)?;
 
         for (cid, block) in head_blocks {
             coordinator
                 .broadcast_local_update(&cid, &block, doc_id, &collection_id)
                 .await
-                .map_err(|error| format!("failed to republish document head {cid}: {error}"))?;
+                .map_err(|error| {
+                    P2PError::transport(format!("failed to republish document head {cid}: {error}"))
+                })?;
         }
 
         Ok(())
     }
 
-    async fn sync_documents(
-        &self,
-        collection_name: &str,
-        doc_ids: Vec<String>,
-    ) -> Result<(), String> {
+    async fn sync_documents(&self, collection_name: &str, doc_ids: Vec<String>) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
-            .ok_or_else(|| "no database context for sync".to_string())?;
-        pusher.validate_collection_exists(collection_name)?;
+            .ok_or_else(|| P2PError::unsupported("no database context for sync"))?;
+        pusher
+            .validate_collection_exists(collection_name)
+            .map_err(P2PError::from)?;
 
         let event_bus = self
             .event_bus
             .as_ref()
-            .ok_or_else(|| "no event bus for sync".to_string())?;
+            .ok_or_else(|| P2PError::unsupported("no event bus for sync"))?;
 
-        let connected_peers = self
-            .handle
-            .connected_peers()
-            .await
-            .map_err(|error| format!("failed to get connected peers: {error}"))?;
+        let connected_peers = self.handle.connected_peers().await.map_err(|error| {
+            P2PError::transport(format!("failed to get connected peers: {error}"))
+        })?;
         if connected_peers.is_empty() {
             return Ok(());
         }
@@ -667,7 +686,9 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             let mut request = p2p::message::DocSyncRequest::new(doc_ids.clone());
             if let Err(error) = p2p::signing::sign_message(self.handle.keypair(), &mut request) {
                 event_bus.unsubscribe(sub.id());
-                return Err(format!("failed to sign DocSync request: {error}"));
+                return Err(P2PError::internal(format!(
+                    "failed to sign DocSync request: {error}"
+                )));
             }
 
             for peer_id in &connected_peers {
@@ -706,25 +727,26 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_branchable_collection(&self, collection_id: &str) -> Result<(), String> {
+    async fn sync_branchable_collection(&self, collection_id: &str) -> P2PResult<()> {
         let pusher = self
             .doc_pusher
             .as_ref()
-            .ok_or_else(|| "no database context for sync".to_string())?;
-        pusher.validate_branchable_collection(collection_id)?;
+            .ok_or_else(|| P2PError::unsupported("no database context for sync"))?;
+        pusher
+            .validate_branchable_collection(collection_id)
+            .map_err(P2PError::from)?;
 
-        let connected_peers = self
-            .handle
-            .connected_peers()
-            .await
-            .map_err(|error| format!("failed to get connected peers: {error}"))?;
+        let connected_peers = self.handle.connected_peers().await.map_err(|error| {
+            P2PError::transport(format!("failed to get connected peers: {error}"))
+        })?;
         if connected_peers.is_empty() {
             return Ok(());
         }
 
         let mut request = p2p::message::BranchableSyncRequest::new(collection_id.to_string());
-        p2p::signing::sign_message(self.handle.keypair(), &mut request)
-            .map_err(|error| format!("failed to sign BranchableSync request: {error}"))?;
+        p2p::signing::sign_message(self.handle.keypair(), &mut request).map_err(|error| {
+            P2PError::internal(format!("failed to sign BranchableSync request: {error}"))
+        })?;
 
         for peer_id in &connected_peers {
             let request_clone = request.clone();
@@ -743,20 +765,18 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
-    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> Result<(), String> {
+    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> P2PResult<()> {
         if version_ids.is_empty() {
             return Ok(());
         }
         for version_id in &version_ids {
             cid::Cid::try_from(version_id.as_str())
-                .map_err(|error| format!("invalid cid: {error}"))?;
+                .map_err(|error| P2PError::invalid_input(format!("invalid cid: {error}")))?;
         }
 
-        let connected_peers = self
-            .handle
-            .connected_peers()
-            .await
-            .map_err(|error| format!("failed to get connected peers: {error}"))?;
+        let connected_peers = self.handle.connected_peers().await.map_err(|error| {
+            P2PError::transport(format!("failed to get connected peers: {error}"))
+        })?;
         if connected_peers.is_empty() {
             return Ok(());
         }
@@ -764,9 +784,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         let syncer = self
             .version_syncer
             .as_ref()
-            .ok_or_else(|| "version syncer required".to_string())?;
+            .ok_or_else(|| P2PError::unsupported("version syncer required"))?;
         syncer
             .sync_versions(&self.handle, version_ids, connected_peers)
             .await
+            .map_err(P2PError::from)
     }
 }

--- a/crates/embedded/src/libp2p_adapter.rs
+++ b/crates/embedded/src/libp2p_adapter.rs
@@ -200,7 +200,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
 
         let effective_collections = if collections.is_empty() {
             if let Some(ref pusher) = self.doc_pusher {
-                pusher.list_collections().map_err(P2PError::from)?
+                pusher.list_collections()?
             } else {
                 return Err(P2PError::unsupported(
                     "no database context to list collections",
@@ -415,7 +415,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .doc_pusher
             .as_ref()
             .ok_or_else(|| P2PError::unsupported("no database context to retry replicators"))?;
-        let collections = pusher.list_collections().map_err(P2PError::from)?;
+        let collections = pusher.list_collections()?;
         let replicators =
             self.handle.list_replicators().await.map_err(|error| {
                 P2PError::transport(format!("failed to get replicators: {error}"))
@@ -626,16 +626,11 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .sync_coordinator
             .as_ref()
             .ok_or_else(|| P2PError::unsupported("no sync coordinator for republish"))?;
-        pusher
-            .validate_collection_exists(collection_name)
-            .map_err(P2PError::from)?;
+        pusher.validate_collection_exists(collection_name)?;
         let collection_id = pusher.get_collection_id(collection_name).ok_or_else(|| {
             P2PError::not_found(format!("collection '{collection_name}' not found"))
         })?;
-        let head_blocks = pusher
-            .load_document_head_blocks(doc_id)
-            .await
-            .map_err(P2PError::from)?;
+        let head_blocks = pusher.load_document_head_blocks(doc_id).await?;
 
         for (cid, block) in head_blocks {
             coordinator
@@ -654,9 +649,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .doc_pusher
             .as_ref()
             .ok_or_else(|| P2PError::unsupported("no database context for sync"))?;
-        pusher
-            .validate_collection_exists(collection_name)
-            .map_err(P2PError::from)?;
+        pusher.validate_collection_exists(collection_name)?;
 
         let event_bus = self
             .event_bus
@@ -732,9 +725,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .doc_pusher
             .as_ref()
             .ok_or_else(|| P2PError::unsupported("no database context for sync"))?;
-        pusher
-            .validate_branchable_collection(collection_id)
-            .map_err(P2PError::from)?;
+        pusher.validate_branchable_collection(collection_id)?;
 
         let connected_peers = self.handle.connected_peers().await.map_err(|error| {
             P2PError::transport(format!("failed to get connected peers: {error}"))
@@ -788,6 +779,5 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         syncer
             .sync_versions(&self.handle, version_ids, connected_peers)
             .await
-            .map_err(P2PError::from)
     }
 }

--- a/crates/embedded/src/libp2p_doc_pusher.rs
+++ b/crates/embedded/src/libp2p_doc_pusher.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::libp2p_adapter::CollectionLookup;
+use crate::{P2PError, P2PResult};
 use async_trait::async_trait;
 use cid::Cid;
 use p2p::P2PHostHandle;
@@ -15,26 +16,25 @@ pub trait DocPusher: Send + Sync {
         collections: &[String],
         se_key: Option<&[u8]>,
         se_identity_pubkey: Option<&[u8]>,
-    ) -> Result<(), String>;
+    ) -> P2PResult<()>;
 
     fn get_collection_id(&self, name: &str) -> Option<String>;
 
-    fn list_collections(&self) -> Result<Vec<String>, String>;
+    fn list_collections(&self) -> P2PResult<Vec<String>>;
 
-    async fn persist_replicator(&self, peer_id: &str, collections: &[String])
-        -> Result<(), String>;
+    async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()>;
 
-    async fn delete_persisted_replicator(&self, peer_id: &str) -> Result<(), String>;
+    async fn delete_persisted_replicator(&self, peer_id: &str) -> P2PResult<()>;
 
-    async fn persist_p2p_documents(&self, doc_ids: &[String]) -> Result<(), String>;
+    async fn persist_p2p_documents(&self, doc_ids: &[String]) -> P2PResult<()>;
 
-    async fn load_p2p_documents(&self) -> Result<Vec<String>, String>;
+    async fn load_p2p_documents(&self) -> P2PResult<Vec<String>>;
 
-    async fn persist_p2p_collections(&self, collections: &[String]) -> Result<(), String>;
+    async fn persist_p2p_collections(&self, collections: &[String]) -> P2PResult<()>;
 
-    fn validate_collection_exists(&self, name: &str) -> Result<(), String>;
+    fn validate_collection_exists(&self, name: &str) -> P2PResult<()>;
 
-    fn validate_branchable_collection(&self, collection_id: &str) -> Result<(), String>;
+    fn validate_branchable_collection(&self, collection_id: &str) -> P2PResult<()>;
 
     async fn retry_doc(
         &self,
@@ -42,9 +42,9 @@ pub trait DocPusher: Send + Sync {
         peer_id: libp2p::PeerId,
         doc_id: &str,
         collection_id: &str,
-    ) -> Result<(), String>;
+    ) -> P2PResult<()>;
 
-    async fn load_document_head_blocks(&self, doc_id: &str) -> Result<Vec<(Cid, Vec<u8>)>, String>;
+    async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>>;
 }
 
 /// Database-backed `DocPusher` implementation.
@@ -79,7 +79,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         collections: &[String],
         se_key: Option<&[u8]>,
         se_identity_pubkey: Option<&[u8]>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         db::push_existing_docs(
             handle,
             &self.db,
@@ -90,6 +90,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             se_identity_pubkey,
         )
         .await
+        .map_err(P2PError::from)
     }
 
     fn get_collection_id(&self, name: &str) -> Option<String> {
@@ -110,81 +111,82 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         }
     }
 
-    fn list_collections(&self) -> Result<Vec<String>, String> {
+    fn list_collections(&self) -> P2PResult<Vec<String>> {
         self.db
             .list_collections()
-            .map_err(|error| format!("failed to list collections: {error}"))
+            .map_err(|error| P2PError::internal(format!("failed to list collections: {error}")))
     }
 
-    async fn persist_replicator(
-        &self,
-        peer_id: &str,
-        collections: &[String],
-    ) -> Result<(), String> {
+    async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()> {
         let parsed_peer_id: libp2p::PeerId = peer_id
             .parse()
-            .map_err(|error| format!("invalid peer ID: {error}"))?;
+            .map_err(|error| P2PError::invalid_input(format!("invalid peer ID: {error}")))?;
         let info = p2p::ReplicatorInfo::new(parsed_peer_id, collections.to_vec());
-        let bytes = info
-            .to_bytes()
-            .map_err(|error| format!("failed to serialize replicator info: {error}"))?;
+        let bytes = info.to_bytes().map_err(|error| {
+            P2PError::internal(format!("failed to serialize replicator info: {error}"))
+        })?;
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         peerstore
             .create_replicator(peer_id, &bytes)
             .await
-            .map_err(|error| format!("failed to persist replicator: {error}"))
+            .map_err(|error| {
+                P2PError::persistence(format!("failed to persist replicator: {error}"))
+            })
     }
 
-    async fn delete_persisted_replicator(&self, peer_id: &str) -> Result<(), String> {
+    async fn delete_persisted_replicator(&self, peer_id: &str) -> P2PResult<()> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
-        peerstore
-            .delete_replicator(peer_id)
-            .await
-            .map_err(|error| format!("failed to delete persisted replicator: {error}"))
+        peerstore.delete_replicator(peer_id).await.map_err(|error| {
+            P2PError::persistence(format!("failed to delete persisted replicator: {error}"))
+        })
     }
 
-    async fn persist_p2p_documents(&self, doc_ids: &[String]) -> Result<(), String> {
+    async fn persist_p2p_documents(&self, doc_ids: &[String]) -> P2PResult<()> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
-        peerstore
-            .persist_documents(doc_ids)
-            .await
-            .map_err(|error| format!("failed to persist P2P documents: {error}"))
+        peerstore.persist_documents(doc_ids).await.map_err(|error| {
+            P2PError::persistence(format!("failed to persist P2P documents: {error}"))
+        })
     }
 
-    async fn load_p2p_documents(&self) -> Result<Vec<String>, String> {
+    async fn load_p2p_documents(&self) -> P2PResult<Vec<String>> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
-        peerstore
-            .load_documents()
-            .await
-            .map_err(|error| format!("failed to load P2P documents: {error}"))
+        peerstore.load_documents().await.map_err(|error| {
+            P2PError::persistence(format!("failed to load P2P documents: {error}"))
+        })
     }
 
-    async fn persist_p2p_collections(&self, collections: &[String]) -> Result<(), String> {
+    async fn persist_p2p_collections(&self, collections: &[String]) -> P2PResult<()> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         peerstore
             .persist_collections(collections)
             .await
-            .map_err(|error| format!("failed to persist P2P collections: {error}"))
+            .map_err(|error| {
+                P2PError::persistence(format!("failed to persist P2P collections: {error}"))
+            })
     }
 
-    fn validate_collection_exists(&self, name: &str) -> Result<(), String> {
+    fn validate_collection_exists(&self, name: &str) -> P2PResult<()> {
         self.db
             .require_collection(name)
             .map(|_| ())
-            .map_err(|error| error.to_string())
+            .map_err(|error| P2PError::not_found(error.to_string()))
     }
 
-    fn validate_branchable_collection(&self, collection_id: &str) -> Result<(), String> {
+    fn validate_branchable_collection(&self, collection_id: &str) -> P2PResult<()> {
         match self.db.find_collection_by_id(collection_id) {
             Ok(Some(collection)) => {
                 if !collection.schema().is_branchable {
-                    Err("collection is not branchable".to_string())
+                    Err(P2PError::invalid_input("collection is not branchable"))
                 } else {
                     Ok(())
                 }
             }
-            Ok(None) => Err(format!("collection with ID '{collection_id}' not found")),
-            Err(error) => Err(format!("failed to find collection: {error}")),
+            Ok(None) => Err(P2PError::not_found(format!(
+                "collection with ID '{collection_id}' not found"
+            ))),
+            Err(error) => Err(P2PError::internal(format!(
+                "failed to find collection: {error}"
+            ))),
         }
     }
 
@@ -194,7 +196,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         peer_id: libp2p::PeerId,
         doc_id: &str,
         collection_id: &str,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         db::retry_doc(
             handle,
             &self.db,
@@ -204,32 +206,33 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             collection_id,
         )
         .await
+        .map_err(P2PError::from)
     }
 
-    async fn load_document_head_blocks(&self, doc_id: &str) -> Result<Vec<(Cid, Vec<u8>)>, String> {
+    async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>> {
         let provider = db::DbHeadProvider::new(self.db.clone());
         let heads = <db::DbHeadProvider<S> as p2p::sync::DocumentHeadProvider>::get_document_heads(
             &provider, doc_id,
         )
         .await
-        .map_err(|error| format!("failed to load document heads: {error}"))?;
+        .map_err(|error| P2PError::internal(format!("failed to load document heads: {error}")))?;
 
-        let txn = self
-            .db
-            .new_txn(true)
-            .await
-            .map_err(|error| format!("failed to create read transaction: {error}"))?;
+        let txn = self.db.new_txn(true).await.map_err(|error| {
+            P2PError::internal(format!("failed to create read transaction: {error}"))
+        })?;
         let blockstore = txn
             .blockstore()
-            .map_err(|error| format!("failed to get blockstore: {error}"))?;
+            .map_err(|error| P2PError::internal(format!("failed to get blockstore: {error}")))?;
 
         let mut blocks = Vec::with_capacity(heads.len());
         for cid in heads {
             let bytes = blockstore
                 .get(&cid.to_bytes())
                 .await
-                .map_err(|error| format!("failed to read head block {cid}: {error}"))?
-                .ok_or_else(|| format!("head block {cid} not found"))?;
+                .map_err(|error| {
+                    P2PError::internal(format!("failed to read head block {cid}: {error}"))
+                })?
+                .ok_or_else(|| P2PError::not_found(format!("head block {cid} not found")))?;
             blocks.push((cid, bytes));
         }
         Ok(blocks)

--- a/crates/embedded/src/p2p_error.rs
+++ b/crates/embedded/src/p2p_error.rs
@@ -1,0 +1,111 @@
+use thiserror::Error;
+
+/// Shared error categories for embedded P2P operations.
+///
+/// This is introduced as groundwork for migrating the embedded P2P surface away
+/// from `Result<_, String>` without forcing a one-shot API break across all
+/// downstream callers.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum P2PError {
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("unsupported operation: {0}")]
+    Unsupported(String),
+
+    #[error("transport error: {0}")]
+    Transport(String),
+
+    #[error("persistence error: {0}")]
+    Persistence(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+/// Convenience result alias for embedded P2P operations.
+pub type P2PResult<T> = Result<T, P2PError>;
+
+impl P2PError {
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        Self::InvalidInput(message.into())
+    }
+
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::NotFound(message.into())
+    }
+
+    pub fn unsupported(message: impl Into<String>) -> Self {
+        Self::Unsupported(message.into())
+    }
+
+    pub fn transport(message: impl Into<String>) -> Self {
+        Self::Transport(message.into())
+    }
+
+    pub fn persistence(message: impl Into<String>) -> Self {
+        Self::Persistence(message.into())
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+impl From<String> for P2PError {
+    fn from(message: String) -> Self {
+        Self::Internal(message)
+    }
+}
+
+impl From<&str> for P2PError {
+    fn from(message: &str) -> Self {
+        Self::Internal(message.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{P2PError, P2PResult};
+
+    #[test]
+    fn helpers_assign_expected_variants() {
+        assert_eq!(
+            P2PError::invalid_input("bad addr"),
+            P2PError::InvalidInput("bad addr".to_string())
+        );
+        assert_eq!(
+            P2PError::not_found("peer missing"),
+            P2PError::NotFound("peer missing".to_string())
+        );
+        assert_eq!(
+            P2PError::unsupported("not wired"),
+            P2PError::Unsupported("not wired".to_string())
+        );
+        assert_eq!(
+            P2PError::transport("dial failed"),
+            P2PError::Transport("dial failed".to_string())
+        );
+        assert_eq!(
+            P2PError::persistence("store failed"),
+            P2PError::Persistence("store failed".to_string())
+        );
+        assert_eq!(
+            P2PError::internal("unexpected"),
+            P2PError::Internal("unexpected".to_string())
+        );
+    }
+
+    #[test]
+    fn string_conversion_defaults_to_internal() {
+        let err: P2PError = "boom".into();
+        let result: P2PResult<()> = Err(String::from("bad state").into());
+
+        assert_eq!(err, P2PError::Internal("boom".to_string()));
+        assert_eq!(result, Err(P2PError::Internal("bad state".to_string())));
+    }
+}

--- a/crates/embedded/src/transport_doc_pusher.rs
+++ b/crates/embedded/src/transport_doc_pusher.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::{P2PError, P2PResult};
 use async_trait::async_trait;
 use cid::Cid;
 use p2p::transport::PeerId;
@@ -13,35 +14,30 @@ pub trait TransportDocPusher: Send + Sync {
         peer_id: &PeerId,
         collections: &[String],
         se_key: Option<&[u8]>,
-    ) -> Result<(), String>;
+    ) -> P2PResult<()>;
 
-    async fn retry_doc(
-        &self,
-        peer_id: &PeerId,
-        doc_id: &str,
-        collection_id: &str,
-    ) -> Result<(), String>;
+    async fn retry_doc(&self, peer_id: &PeerId, doc_id: &str, collection_id: &str)
+        -> P2PResult<()>;
 
-    async fn load_document_head_blocks(&self, doc_id: &str) -> Result<Vec<(Cid, Vec<u8>)>, String>;
+    async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>>;
 
     fn get_collection_id(&self, name: &str) -> Option<String>;
 
-    fn list_collections(&self) -> Result<Vec<String>, String>;
+    fn list_collections(&self) -> P2PResult<Vec<String>>;
 
-    async fn persist_replicator(&self, peer_id: &str, collections: &[String])
-        -> Result<(), String>;
+    async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()>;
 
-    async fn delete_persisted_replicator(&self, peer_id: &str) -> Result<(), String>;
+    async fn delete_persisted_replicator(&self, peer_id: &str) -> P2PResult<()>;
 
-    async fn persist_p2p_documents(&self, doc_ids: &[String]) -> Result<(), String>;
+    async fn persist_p2p_documents(&self, doc_ids: &[String]) -> P2PResult<()>;
 
-    async fn load_p2p_documents(&self) -> Result<Vec<String>, String>;
+    async fn load_p2p_documents(&self) -> P2PResult<Vec<String>>;
 
-    async fn persist_p2p_collections(&self, collections: &[String]) -> Result<(), String>;
+    async fn persist_p2p_collections(&self, collections: &[String]) -> P2PResult<()>;
 
-    fn validate_collection_exists(&self, name: &str) -> Result<(), String>;
+    fn validate_collection_exists(&self, name: &str) -> P2PResult<()>;
 
-    fn validate_branchable_collection(&self, collection_id: &str) -> Result<(), String>;
+    fn validate_branchable_collection(&self, collection_id: &str) -> P2PResult<()>;
 }
 
 /// Database-backed `TransportDocPusher` with an embedded transport.
@@ -78,7 +74,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         peer_id: &PeerId,
         collections: &[String],
         se_key: Option<&[u8]>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         db::push_existing_docs_via_transport(
             &self.transport,
             &self.db,
@@ -88,6 +84,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             se_key,
         )
         .await
+        .map_err(P2PError::from)
     }
 
     async fn retry_doc(
@@ -95,7 +92,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         peer_id: &PeerId,
         doc_id: &str,
         collection_id: &str,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         db::retry_doc_via_transport(
             &self.transport,
             &self.db,
@@ -105,32 +102,33 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             collection_id,
         )
         .await
+        .map_err(P2PError::from)
     }
 
-    async fn load_document_head_blocks(&self, doc_id: &str) -> Result<Vec<(Cid, Vec<u8>)>, String> {
+    async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>> {
         let provider = db::DbHeadProvider::new(self.db.clone());
         let heads = <db::DbHeadProvider<S> as p2p::sync::DocumentHeadProvider>::get_document_heads(
             &provider, doc_id,
         )
         .await
-        .map_err(|error| format!("failed to load document heads: {error}"))?;
+        .map_err(|error| P2PError::internal(format!("failed to load document heads: {error}")))?;
 
-        let txn = self
-            .db
-            .new_txn(true)
-            .await
-            .map_err(|error| format!("failed to create read transaction: {error}"))?;
+        let txn = self.db.new_txn(true).await.map_err(|error| {
+            P2PError::internal(format!("failed to create read transaction: {error}"))
+        })?;
         let blockstore = txn
             .blockstore()
-            .map_err(|error| format!("failed to get blockstore: {error}"))?;
+            .map_err(|error| P2PError::internal(format!("failed to get blockstore: {error}")))?;
 
         let mut blocks = Vec::with_capacity(heads.len());
         for cid in heads {
             let bytes = blockstore
                 .get(&cid.to_bytes())
                 .await
-                .map_err(|error| format!("failed to read head block {cid}: {error}"))?
-                .ok_or_else(|| format!("head block {cid} not found"))?;
+                .map_err(|error| {
+                    P2PError::internal(format!("failed to read head block {cid}: {error}"))
+                })?
+                .ok_or_else(|| P2PError::not_found(format!("head block {cid} not found")))?;
             blocks.push((cid, bytes));
         }
         Ok(blocks)
@@ -154,79 +152,80 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         }
     }
 
-    fn list_collections(&self) -> Result<Vec<String>, String> {
+    fn list_collections(&self) -> P2PResult<Vec<String>> {
         self.db
             .list_collections()
-            .map_err(|error| format!("failed to list collections: {error}"))
+            .map_err(|error| P2PError::internal(format!("failed to list collections: {error}")))
     }
 
-    async fn persist_replicator(
-        &self,
-        peer_id: &str,
-        collections: &[String],
-    ) -> Result<(), String> {
+    async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()> {
         let info =
             p2p::ReplicatorInfo::from_raw(peer_id.to_string(), collections.to_vec(), Vec::new());
-        let bytes = info
-            .to_bytes()
-            .map_err(|error| format!("failed to serialize replicator info: {error}"))?;
+        let bytes = info.to_bytes().map_err(|error| {
+            P2PError::internal(format!("failed to serialize replicator info: {error}"))
+        })?;
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         peerstore
             .create_replicator(peer_id, &bytes)
             .await
-            .map_err(|error| format!("failed to persist replicator: {error}"))
+            .map_err(|error| {
+                P2PError::persistence(format!("failed to persist replicator: {error}"))
+            })
     }
 
-    async fn delete_persisted_replicator(&self, peer_id: &str) -> Result<(), String> {
+    async fn delete_persisted_replicator(&self, peer_id: &str) -> P2PResult<()> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
-        peerstore
-            .delete_replicator(peer_id)
-            .await
-            .map_err(|error| format!("failed to delete persisted replicator: {error}"))
+        peerstore.delete_replicator(peer_id).await.map_err(|error| {
+            P2PError::persistence(format!("failed to delete persisted replicator: {error}"))
+        })
     }
 
-    async fn persist_p2p_documents(&self, doc_ids: &[String]) -> Result<(), String> {
+    async fn persist_p2p_documents(&self, doc_ids: &[String]) -> P2PResult<()> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
-        peerstore
-            .persist_documents(doc_ids)
-            .await
-            .map_err(|error| format!("failed to persist P2P documents: {error}"))
+        peerstore.persist_documents(doc_ids).await.map_err(|error| {
+            P2PError::persistence(format!("failed to persist P2P documents: {error}"))
+        })
     }
 
-    async fn load_p2p_documents(&self) -> Result<Vec<String>, String> {
+    async fn load_p2p_documents(&self) -> P2PResult<Vec<String>> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
-        peerstore
-            .load_documents()
-            .await
-            .map_err(|error| format!("failed to load P2P documents: {error}"))
+        peerstore.load_documents().await.map_err(|error| {
+            P2PError::persistence(format!("failed to load P2P documents: {error}"))
+        })
     }
 
-    async fn persist_p2p_collections(&self, collections: &[String]) -> Result<(), String> {
+    async fn persist_p2p_collections(&self, collections: &[String]) -> P2PResult<()> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         peerstore
             .persist_collections(collections)
             .await
-            .map_err(|error| format!("failed to persist P2P collections: {error}"))
+            .map_err(|error| {
+                P2PError::persistence(format!("failed to persist P2P collections: {error}"))
+            })
     }
 
-    fn validate_collection_exists(&self, name: &str) -> Result<(), String> {
+    fn validate_collection_exists(&self, name: &str) -> P2PResult<()> {
         self.db
             .require_collection(name)
             .map(|_| ())
-            .map_err(|error| error.to_string())
+            .map_err(|error| P2PError::not_found(error.to_string()))
     }
 
-    fn validate_branchable_collection(&self, collection_id: &str) -> Result<(), String> {
+    fn validate_branchable_collection(&self, collection_id: &str) -> P2PResult<()> {
         match self.db.find_collection_by_id(collection_id) {
             Ok(Some(collection)) => {
                 if !collection.schema().is_branchable {
-                    Err("collection is not branchable".to_string())
+                    Err(P2PError::invalid_input("collection is not branchable"))
                 } else {
                     Ok(())
                 }
             }
-            Ok(None) => Err(format!("collection with ID '{collection_id}' not found")),
-            Err(error) => Err(format!("failed to find collection: {error}")),
+            Ok(None) => Err(P2PError::not_found(format!(
+                "collection with ID '{collection_id}' not found"
+            ))),
+            Err(error) => Err(P2PError::internal(format!(
+                "failed to find collection: {error}"
+            ))),
         }
     }
 }

--- a/crates/embedded/src/transport_version_syncer.rs
+++ b/crates/embedded/src/transport_version_syncer.rs
@@ -6,6 +6,8 @@ use blockstore::Blockstore;
 use p2p::transport::PeerId;
 use p2p::P2PTransport;
 
+use crate::{P2PError, P2PResult};
+
 /// Trait for syncing collection versions via a generic transport.
 #[async_trait]
 pub trait TransportVersionSyncer: Send + Sync {
@@ -13,7 +15,7 @@ pub trait TransportVersionSyncer: Send + Sync {
         &self,
         version_ids: Vec<String>,
         connected_peers: Vec<PeerId>,
-    ) -> Result<(), String>;
+    ) -> P2PResult<()>;
 }
 
 /// Database-backed version syncer that fetches schema blocks via transport.
@@ -57,7 +59,7 @@ async fn fetch_block<B: Blockstore, T: P2PTransport>(
     transport: &T,
     peers: &[PeerId],
     timeout_secs: u64,
-) -> Result<bytes::Bytes, String> {
+) -> P2PResult<bytes::Bytes> {
     if let Ok(Some(data)) = blockstore.get(&target_cid).await {
         return Ok(data);
     }
@@ -65,7 +67,7 @@ async fn fetch_block<B: Blockstore, T: P2PTransport>(
     transport
         .sync_blocks(target_cid, peers.to_vec(), vec![target_cid])
         .await
-        .map_err(|error| format!("block sync for {target_cid}: {error}"))?;
+        .map_err(|error| P2PError::transport(format!("block sync for {target_cid}: {error}")))?;
 
     let timeout = std::time::Duration::from_secs(timeout_secs);
     let start = std::time::Instant::now();
@@ -76,7 +78,9 @@ async fn fetch_block<B: Blockstore, T: P2PTransport>(
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
-    Err(format!("timeout fetching block {target_cid}"))
+    Err(P2PError::transport(format!(
+        "timeout fetching block {target_cid}"
+    )))
 }
 
 async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore, T: P2PTransport>(
@@ -85,20 +89,22 @@ async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore, T: P2PTra
     transport: &T,
     db: &Arc<db::DB<S>>,
     connected_peers: &[PeerId],
-) -> Result<(), String> {
+) -> P2PResult<()> {
     use defra_core::{LensConfigBlock, LensModuleBlock, LensWasmBlock};
 
     let config_data =
         fetch_block(*transform_cid, blockstore, transport, connected_peers, 10).await?;
     let config_block: LensConfigBlock = serde_ipld_dagcbor::from_slice(&config_data)
-        .map_err(|error| format!("decode config block: {error}"))?;
+        .map_err(|error| P2PError::internal(format!("decode config block: {error}")))?;
 
     let mut lens_modules = Vec::new();
     for module_cid in &config_block.modules {
         let module_data =
             fetch_block(*module_cid, blockstore, transport, connected_peers, 10).await?;
-        let module_block: LensModuleBlock = serde_ipld_dagcbor::from_slice(&module_data)
-            .map_err(|error| format!("decode module block {module_cid}: {error}"))?;
+        let module_block: LensModuleBlock =
+            serde_ipld_dagcbor::from_slice(&module_data).map_err(|error| {
+                P2PError::internal(format!("decode module block {module_cid}: {error}"))
+            })?;
 
         let lens_data = fetch_block(
             module_block.lens,
@@ -108,8 +114,10 @@ async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore, T: P2PTra
             10,
         )
         .await?;
-        let wasm_block: LensWasmBlock = serde_ipld_dagcbor::from_slice(&lens_data)
-            .map_err(|error| format!("decode lens block {}: {error}", module_block.lens))?;
+        let wasm_block: LensWasmBlock =
+            serde_ipld_dagcbor::from_slice(&lens_data).map_err(|error| {
+                P2PError::internal(format!("decode lens block {}: {error}", module_block.lens))
+            })?;
 
         let wasm_bytes = match &wasm_block {
             LensWasmBlock::Direct { wasm_bytes } => wasm_bytes.clone(),
@@ -119,7 +127,9 @@ async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore, T: P2PTra
                     let chunk_data =
                         fetch_block(*chunk_cid, blockstore, transport, connected_peers, 10).await?;
                     let decoded: serde_bytes::ByteBuf = serde_ipld_dagcbor::from_slice(&chunk_data)
-                        .map_err(|error| format!("decode WASM chunk {chunk_cid}: {error}"))?;
+                        .map_err(|error| {
+                            P2PError::internal(format!("decode WASM chunk {chunk_cid}: {error}"))
+                        })?;
                     all_bytes.extend_from_slice(&decoded);
                 }
                 all_bytes
@@ -155,7 +165,7 @@ async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore, T: P2PTra
     db.lens_store()
         .add_with_id(transform_id, config)
         .await
-        .map_err(|error| format!("register lens: {error}"))?;
+        .map_err(|error| P2PError::internal(format!("register lens: {error}")))?;
 
     Ok(())
 }
@@ -168,12 +178,12 @@ impl<S: storage::corekv::Store + 'static, B: Blockstore + 'static, T: P2PTranspo
         &self,
         version_ids: Vec<String>,
         connected_peers: Vec<PeerId>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         use p2p::sync::MergeHandler;
 
         for version_id_str in &version_ids {
             let version_cid = cid::Cid::try_from(version_id_str.as_str())
-                .map_err(|error| format!("invalid cid: {error}"))?;
+                .map_err(|error| P2PError::invalid_input(format!("invalid cid: {error}")))?;
 
             if let Err(error) = self
                 .transport

--- a/crates/embedded/src/version_syncer.rs
+++ b/crates/embedded/src/version_syncer.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use blockstore::Blockstore;
 use p2p::P2PHostHandle;
 
-use crate::VersionSyncer;
+use crate::{P2PError, P2PResult, VersionSyncer};
 
 /// Database-backed version syncer that fetches schema blocks via Bitswap.
 pub struct DbVersionSyncer<S: storage::corekv::Store, B: Blockstore> {
@@ -42,7 +42,7 @@ async fn fetch_block<B: Blockstore>(
     handle: &P2PHostHandle,
     peers: &[libp2p::PeerId],
     timeout_secs: u64,
-) -> Result<bytes::Bytes, String> {
+) -> P2PResult<bytes::Bytes> {
     if let Ok(Some(data)) = blockstore.get(&target_cid).await {
         return Ok(data);
     }
@@ -50,7 +50,7 @@ async fn fetch_block<B: Blockstore>(
     handle
         .bitswap_sync(target_cid, peers.to_vec(), vec![target_cid])
         .await
-        .map_err(|error| format!("bitswap sync for {target_cid}: {error}"))?;
+        .map_err(|error| P2PError::transport(format!("bitswap sync for {target_cid}: {error}")))?;
 
     let timeout = std::time::Duration::from_secs(timeout_secs);
     let start = std::time::Instant::now();
@@ -61,7 +61,9 @@ async fn fetch_block<B: Blockstore>(
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
-    Err(format!("timeout fetching block {target_cid}"))
+    Err(P2PError::transport(format!(
+        "timeout fetching block {target_cid}"
+    )))
 }
 
 async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore>(
@@ -70,23 +72,27 @@ async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore>(
     handle: &P2PHostHandle,
     db: &Arc<db::DB<S>>,
     connected_peers: &[libp2p::PeerId],
-) -> Result<(), String> {
+) -> P2PResult<()> {
     use defra_core::{LensConfigBlock, LensModuleBlock, LensWasmBlock};
 
     let config_data = fetch_block(*transform_cid, blockstore, handle, connected_peers, 10).await?;
     let config_block: LensConfigBlock = serde_ipld_dagcbor::from_slice(&config_data)
-        .map_err(|error| format!("decode config block: {error}"))?;
+        .map_err(|error| P2PError::internal(format!("decode config block: {error}")))?;
 
     let mut lens_modules = Vec::new();
     for module_cid in &config_block.modules {
         let module_data = fetch_block(*module_cid, blockstore, handle, connected_peers, 10).await?;
-        let module_block: LensModuleBlock = serde_ipld_dagcbor::from_slice(&module_data)
-            .map_err(|error| format!("decode module block {module_cid}: {error}"))?;
+        let module_block: LensModuleBlock =
+            serde_ipld_dagcbor::from_slice(&module_data).map_err(|error| {
+                P2PError::internal(format!("decode module block {module_cid}: {error}"))
+            })?;
 
         let lens_data =
             fetch_block(module_block.lens, blockstore, handle, connected_peers, 10).await?;
-        let wasm_block: LensWasmBlock = serde_ipld_dagcbor::from_slice(&lens_data)
-            .map_err(|error| format!("decode lens block {}: {error}", module_block.lens))?;
+        let wasm_block: LensWasmBlock =
+            serde_ipld_dagcbor::from_slice(&lens_data).map_err(|error| {
+                P2PError::internal(format!("decode lens block {}: {error}", module_block.lens))
+            })?;
 
         let wasm_bytes = match &wasm_block {
             LensWasmBlock::Direct { wasm_bytes } => wasm_bytes.clone(),
@@ -96,7 +102,9 @@ async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore>(
                     let chunk_data =
                         fetch_block(*chunk_cid, blockstore, handle, connected_peers, 10).await?;
                     let decoded: serde_bytes::ByteBuf = serde_ipld_dagcbor::from_slice(&chunk_data)
-                        .map_err(|error| format!("decode WASM chunk {chunk_cid}: {error}"))?;
+                        .map_err(|error| {
+                            P2PError::internal(format!("decode WASM chunk {chunk_cid}: {error}"))
+                        })?;
                     all_bytes.extend_from_slice(&decoded);
                 }
                 all_bytes
@@ -133,7 +141,7 @@ async fn sync_lens<S: storage::corekv::Store + 'static, B: Blockstore>(
     db.lens_store()
         .add_with_id(transform_id, config)
         .await
-        .map_err(|error| format!("register lens: {error}"))?;
+        .map_err(|error| P2PError::internal(format!("register lens: {error}")))?;
 
     Ok(())
 }
@@ -147,12 +155,12 @@ impl<S: storage::corekv::Store + 'static, B: Blockstore + 'static> VersionSyncer
         handle: &P2PHostHandle,
         version_ids: Vec<String>,
         connected_peers: Vec<libp2p::PeerId>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         use p2p::sync::MergeHandler;
 
         for version_id_str in &version_ids {
             let version_cid = cid::Cid::try_from(version_id_str.as_str())
-                .map_err(|error| format!("invalid cid: {error}"))?;
+                .map_err(|error| P2PError::invalid_input(format!("invalid cid: {error}")))?;
 
             if let Err(error) = handle
                 .bitswap_sync(version_cid, connected_peers.clone(), vec![version_cid])

--- a/crates/ffi/src/acp/dac.rs
+++ b/crates/ffi/src/acp/dac.rs
@@ -396,6 +396,7 @@ pub unsafe extern "C" fn add_dac_actor_relationship(
                         .ops()
                         .republish_document(&collection_id_str, &doc_id_str)
                         .await
+                        .map_err(|error| error.to_string())
                     {
                         tracing::debug!(
                             error = %error,

--- a/crates/ffi/src/acp/dac.rs
+++ b/crates/ffi/src/acp/dac.rs
@@ -396,7 +396,7 @@ pub unsafe extern "C" fn add_dac_actor_relationship(
                         .ops()
                         .republish_document(&collection_id_str, &doc_id_str)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(crate::p2p::FfiP2PError::from)
                     {
                         tracing::debug!(
                             error = %error,

--- a/crates/ffi/src/p2p/collections.rs
+++ b/crates/ffi/src/p2p/collections.rs
@@ -45,7 +45,13 @@ pub unsafe extern "C" fn p2p_add_collections(
                     None => return Err("no p2p system configured".to_string()),
                 };
 
-                rt.block_on(async { p2p.system.ops().add_collections(collections).await })
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .add_collections(collections)
+                        .await
+                        .map_err(|error| error.to_string())
+                })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
             .and_then(|result| result);
@@ -91,7 +97,13 @@ pub unsafe extern "C" fn p2p_delete_collections(
                     None => return Err("no p2p system configured".to_string()),
                 };
 
-                rt.block_on(async { p2p.system.ops().remove_collections(collections).await })
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .remove_collections(collections)
+                        .await
+                        .map_err(|error| error.to_string())
+                })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
             .and_then(|result| result);
@@ -131,7 +143,8 @@ pub unsafe extern "C" fn p2p_list_collections(
                 };
 
                 rt.block_on(async {
-                    let collections = p2p.system.ops().get_collections().await?;
+                    let collections = p2p.system.ops().get_collections().await
+                        .map_err(|error| error.to_string())?;
                     serde_json::to_string(&collections)
                         .map_err(|error| format!("failed to serialize collections: {}", error))
                 })

--- a/crates/ffi/src/p2p/collections.rs
+++ b/crates/ffi/src/p2p/collections.rs
@@ -6,10 +6,10 @@ use acp::nac::NodePermission;
 use crate::helpers::{get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
 use crate::state::NODES;
+use crate::try_ffi;
 use crate::types::FfiResult;
-use crate::{try_ffi, ERR_INVALID_NODE_HANDLE};
 
-use super::parse_collections_json;
+use super::{into_ffi_ok, into_ffi_result, parse_collections_json, FfiP2PError};
 
 /// Add P2P-enabled collections to the node.
 ///
@@ -35,14 +35,14 @@ pub unsafe extern "C" fn p2p_add_collections(
         let collections_str = try_ffi!(require_c_str(collections_json, "collections_json"));
         let collections = match parse_collections_json(&collections_str) {
             Ok(collections) => collections,
-            Err(error) => return FfiResult::error(error),
+            Err(error) => return FfiResult::error(error.message),
         };
 
         let result = NODES
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
@@ -50,16 +50,13 @@ pub unsafe extern "C" fn p2p_add_collections(
                         .ops()
                         .add_collections(collections)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }
 
@@ -87,14 +84,14 @@ pub unsafe extern "C" fn p2p_delete_collections(
         let collections_str = try_ffi!(require_c_str(collections_json, "collections_json"));
         let collections = match parse_collections_json(&collections_str) {
             Ok(collections) => collections,
-            Err(error) => return FfiResult::error(error),
+            Err(error) => return FfiResult::error(error.message),
         };
 
         let result = NODES
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
@@ -102,16 +99,13 @@ pub unsafe extern "C" fn p2p_delete_collections(
                         .ops()
                         .remove_collections(collections)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }
 
@@ -139,22 +133,28 @@ pub unsafe extern "C" fn p2p_list_collections(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
-                    let collections = p2p.system.ops().get_collections().await
-                        .map_err(|error| error.to_string())?;
+                    let collections = p2p
+                        .system
+                        .ops()
+                        .get_collections()
+                        .await
+                        .map_err(FfiP2PError::from)?;
                     serde_json::to_string(&collections)
-                        .map_err(|error| format!("failed to serialize collections: {}", error))
+                        .map_err(|error| {
+                            FfiP2PError::internal(format!(
+                                "failed to serialize collections: {}",
+                                error
+                            ))
+                        })
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(json) => FfiResult::success(json),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_result(result)
     }
 }

--- a/crates/ffi/src/p2p/documents.rs
+++ b/crates/ffi/src/p2p/documents.rs
@@ -6,10 +6,10 @@ use acp::nac::NodePermission;
 use crate::helpers::{get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
 use crate::state::NODES;
+use crate::try_ffi;
 use crate::types::FfiResult;
-use crate::{try_ffi, ERR_INVALID_NODE_HANDLE};
 
-use super::parse_doc_ids_json;
+use super::{into_ffi_ok, into_ffi_result, parse_doc_ids_json, FfiP2PError};
 
 /// Add tracked P2P documents to the node.
 ///
@@ -35,7 +35,7 @@ pub unsafe extern "C" fn p2p_add_documents(
         let doc_ids_str = try_ffi!(require_c_str(doc_ids_json, "doc_ids_json"));
         let doc_ids = match parse_doc_ids_json(&doc_ids_str) {
             Ok(doc_ids) => doc_ids,
-            Err(error) => return FfiResult::error(error),
+            Err(error) => return FfiResult::error(error.message),
         };
 
         let docs = doc_ids
@@ -50,7 +50,7 @@ pub unsafe extern "C" fn p2p_add_documents(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
@@ -58,16 +58,13 @@ pub unsafe extern "C" fn p2p_add_documents(
                         .ops()
                         .add_documents(docs)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }
 
@@ -95,7 +92,7 @@ pub unsafe extern "C" fn p2p_delete_documents(
         let doc_ids_str = try_ffi!(require_c_str(doc_ids_json, "doc_ids_json"));
         let doc_ids = match parse_doc_ids_json(&doc_ids_str) {
             Ok(doc_ids) => doc_ids,
-            Err(error) => return FfiResult::error(error),
+            Err(error) => return FfiResult::error(error.message),
         };
 
         let docs = doc_ids
@@ -110,7 +107,7 @@ pub unsafe extern "C" fn p2p_delete_documents(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
@@ -118,16 +115,13 @@ pub unsafe extern "C" fn p2p_delete_documents(
                         .ops()
                         .remove_documents(docs)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }
 
@@ -155,25 +149,31 @@ pub unsafe extern "C" fn p2p_list_documents(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
-                    let documents = p2p.system.ops().get_documents().await
-                        .map_err(|error| error.to_string())?;
+                    let documents = p2p
+                        .system
+                        .ops()
+                        .get_documents()
+                        .await
+                        .map_err(FfiP2PError::from)?;
                     let mut doc_ids: Vec<String> =
                         documents.into_iter().map(|doc| doc.doc_id).collect();
                     doc_ids.sort();
                     serde_json::to_string(&doc_ids)
-                        .map_err(|error| format!("failed to serialize documents: {}", error))
+                        .map_err(|error| {
+                            FfiP2PError::internal(format!(
+                                "failed to serialize documents: {}",
+                                error
+                            ))
+                        })
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(json) => FfiResult::success(json),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_result(result)
     }
 }

--- a/crates/ffi/src/p2p/documents.rs
+++ b/crates/ffi/src/p2p/documents.rs
@@ -53,7 +53,13 @@ pub unsafe extern "C" fn p2p_add_documents(
                     None => return Err("no p2p system configured".to_string()),
                 };
 
-                rt.block_on(async { p2p.system.ops().add_documents(docs).await })
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .add_documents(docs)
+                        .await
+                        .map_err(|error| error.to_string())
+                })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
             .and_then(|result| result);
@@ -107,7 +113,13 @@ pub unsafe extern "C" fn p2p_delete_documents(
                     None => return Err("no p2p system configured".to_string()),
                 };
 
-                rt.block_on(async { p2p.system.ops().remove_documents(docs).await })
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .remove_documents(docs)
+                        .await
+                        .map_err(|error| error.to_string())
+                })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
             .and_then(|result| result);
@@ -147,7 +159,8 @@ pub unsafe extern "C" fn p2p_list_documents(
                 };
 
                 rt.block_on(async {
-                    let documents = p2p.system.ops().get_documents().await?;
+                    let documents = p2p.system.ops().get_documents().await
+                        .map_err(|error| error.to_string())?;
                     let mut doc_ids: Vec<String> =
                         documents.into_iter().map(|doc| doc.doc_id).collect();
                     doc_ids.sort();

--- a/crates/ffi/src/p2p/mod.rs
+++ b/crates/ffi/src/p2p/mod.rs
@@ -5,6 +5,8 @@
 //! - Replicator management
 //! - P2P collection management
 
+use std::fmt;
+
 mod collections;
 mod documents;
 mod node;
@@ -23,18 +25,154 @@ pub use replicator::{p2p_add_replicator, p2p_delete_replicator, p2p_list_replica
 pub use sync::{p2p_sync_branchable_collection, p2p_sync_documents};
 pub use version_sync::p2p_sync_collection_versions;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FfiP2PErrorCode {
+    InvalidInput,
+    NotFound,
+    Unsupported,
+    Transport,
+    Internal,
+}
+
+/// Internal P2P error classification for the FFI layer.
+///
+/// The public C ABI still only exposes `status + error string`, but keeping
+/// a structured error inside Rust lets us standardize the boundary now and add
+/// error codes later without re-auditing every entrypoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FfiP2PError {
+    pub(crate) code: FfiP2PErrorCode,
+    pub(crate) message: String,
+}
+
+pub(crate) type FfiP2PResult<T> = Result<T, FfiP2PError>;
+
+impl FfiP2PError {
+    pub(crate) fn invalid_input(message: impl Into<String>) -> Self {
+        Self {
+            code: FfiP2PErrorCode::InvalidInput,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            code: FfiP2PErrorCode::NotFound,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn unsupported(message: impl Into<String>) -> Self {
+        Self {
+            code: FfiP2PErrorCode::Unsupported,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn transport(message: impl Into<String>) -> Self {
+        Self {
+            code: FfiP2PErrorCode::Transport,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn internal(message: impl Into<String>) -> Self {
+        Self {
+            code: FfiP2PErrorCode::Internal,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn no_p2p_system() -> Self {
+        Self::unsupported("no p2p system configured")
+    }
+
+    pub(crate) fn invalid_node_handle() -> Self {
+        Self::invalid_input(crate::ERR_INVALID_NODE_HANDLE)
+    }
+}
+
+impl fmt::Display for FfiP2PError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl From<embedded::P2PError> for FfiP2PError {
+    fn from(error: embedded::P2PError) -> Self {
+        match error {
+            embedded::P2PError::InvalidInput(message) => Self::invalid_input(message),
+            embedded::P2PError::NotFound(message) => Self::not_found(message),
+            embedded::P2PError::Unsupported(message) => Self::unsupported(message),
+            embedded::P2PError::Transport(message) => Self::transport(message),
+            embedded::P2PError::Persistence(message) => Self::internal(message),
+            embedded::P2PError::Internal(message) => Self::internal(message),
+            _ => Self::internal(error.to_string()),
+        }
+    }
+}
+
+impl From<String> for FfiP2PError {
+    fn from(message: String) -> Self {
+        Self::internal(message)
+    }
+}
+
+impl From<&str> for FfiP2PError {
+    fn from(message: &str) -> Self {
+        Self::internal(message.to_string())
+    }
+}
+
+pub(crate) fn into_ffi_result(result: FfiP2PResult<String>) -> crate::types::FfiResult {
+    match result {
+        Ok(json) => crate::types::FfiResult::success(json),
+        Err(error) => crate::types::FfiResult::error(error.message),
+    }
+}
+
+pub(crate) fn into_ffi_ok(result: FfiP2PResult<()>) -> crate::types::FfiResult {
+    match result {
+        Ok(()) => crate::types::FfiResult::ok(),
+        Err(error) => crate::types::FfiResult::error(error.message),
+    }
+}
+
 /// Parse a JSON array of collection names.
 ///
 /// Expects format like: `["collection1", "collection2"]`
 /// Also handles JSON `null` (treated as empty array).
-pub(crate) fn parse_collections_json(json_str: &str) -> Result<Vec<String>, String> {
-    let opt: Option<Vec<String>> =
-        serde_json::from_str(json_str).map_err(|e| format!("invalid collections JSON: {}", e))?;
+pub(crate) fn parse_collections_json(json_str: &str) -> FfiP2PResult<Vec<String>> {
+    let opt: Option<Vec<String>> = serde_json::from_str(json_str)
+        .map_err(|e| FfiP2PError::invalid_input(format!("invalid collections JSON: {}", e)))?;
     Ok(opt.unwrap_or_default())
 }
 
-pub(crate) fn parse_doc_ids_json(json_str: &str) -> Result<Vec<String>, String> {
-    let opt: Option<Vec<String>> =
-        serde_json::from_str(json_str).map_err(|e| format!("invalid doc_ids JSON: {}", e))?;
+pub(crate) fn parse_doc_ids_json(json_str: &str) -> FfiP2PResult<Vec<String>> {
+    let opt: Option<Vec<String>> = serde_json::from_str(json_str)
+        .map_err(|e| FfiP2PError::invalid_input(format!("invalid doc_ids JSON: {}", e)))?;
     Ok(opt.unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_collections_json, FfiP2PError, FfiP2PErrorCode};
+
+    #[test]
+    fn maps_embedded_error_variants() {
+        let error = FfiP2PError::from(embedded::P2PError::invalid_input("bad addr"));
+        assert_eq!(error.code, FfiP2PErrorCode::InvalidInput);
+        assert_eq!(error.message, "bad addr");
+
+        let error = FfiP2PError::from(embedded::P2PError::transport("dial failed"));
+        assert_eq!(error.code, FfiP2PErrorCode::Transport);
+        assert_eq!(error.message, "dial failed");
+    }
+
+    #[test]
+    fn parses_invalid_collections_as_invalid_input() {
+        let error = parse_collections_json("{").unwrap_err();
+        assert_eq!(error.code, FfiP2PErrorCode::InvalidInput);
+        assert!(error.message.contains("invalid collections JSON"));
+    }
 }

--- a/crates/ffi/src/p2p/peer.rs
+++ b/crates/ffi/src/p2p/peer.rs
@@ -38,12 +38,14 @@ pub unsafe extern "C" fn p2p_peer_info(node_ptr: usize, identity_did: *const c_c
                         .system
                         .ops()
                         .local_peer_id()
-                        .await?;
+                        .await
+                        .map_err(|error| error.to_string())?;
                     let addresses = p2p
                         .system
                         .ops()
                         .listen_addresses()
-                        .await?;
+                        .await
+                        .map_err(|error| error.to_string())?;
 
                     let full_addrs = match p2p.system.kind() {
                         embedded::TransportKind::Libp2p => addresses
@@ -96,7 +98,13 @@ pub unsafe extern "C" fn p2p_notify_network_change(
                     None => return Err("no p2p system configured".to_string()),
                 };
 
-                rt.block_on(async { p2p.system.ops().notify_network_change().await })
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .notify_network_change()
+                        .await
+                        .map_err(|error| error.to_string())
+                })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
             .and_then(|result| result);
@@ -136,7 +144,8 @@ pub unsafe extern "C" fn p2p_active_peers(
                 };
 
                 rt.block_on(async {
-                    let peers = p2p.system.ops().connected_peers().await?;
+                    let peers = p2p.system.ops().connected_peers().await
+                        .map_err(|error| error.to_string())?;
                     serde_json::to_string(&peers)
                         .map_err(|error| format!("failed to serialize peer list: {}", error))
                 })
@@ -181,7 +190,13 @@ pub unsafe extern "C" fn p2p_connect(
                     None => return Err("no p2p system configured".to_string()),
                 };
 
-                rt.block_on(async { p2p.system.ops().connect_peer(&addr_str).await })
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .connect_peer(&addr_str)
+                        .await
+                        .map_err(|error| error.to_string())
+                })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
             .and_then(|result| result);

--- a/crates/ffi/src/p2p/peer.rs
+++ b/crates/ffi/src/p2p/peer.rs
@@ -6,8 +6,10 @@ use acp::nac::NodePermission;
 use crate::helpers::{get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
 use crate::state::NODES;
+use crate::try_ffi;
 use crate::types::FfiResult;
-use crate::{try_ffi, ERR_INVALID_NODE_HANDLE};
+
+use super::{into_ffi_ok, into_ffi_result, FfiP2PError};
 
 /// Get local P2P peer info.
 ///
@@ -39,13 +41,13 @@ pub unsafe extern "C" fn p2p_peer_info(node_ptr: usize, identity_did: *const c_c
                         .ops()
                         .local_peer_id()
                         .await
-                        .map_err(|error| error.to_string())?;
+                        .map_err(FfiP2PError::from)?;
                     let addresses = p2p
                         .system
                         .ops()
                         .listen_addresses()
                         .await
-                        .map_err(|error| error.to_string())?;
+                        .map_err(FfiP2PError::from)?;
 
                     let full_addrs = match p2p.system.kind() {
                         embedded::TransportKind::Libp2p => addresses
@@ -58,16 +60,18 @@ pub unsafe extern "C" fn p2p_peer_info(node_ptr: usize, identity_did: *const c_c
                     };
 
                     serde_json::to_string(&full_addrs)
-                        .map_err(|error| format!("failed to serialize peer info: {}", error))
+                        .map_err(|error| {
+                            FfiP2PError::internal(format!(
+                                "failed to serialize peer info: {}",
+                                error
+                            ))
+                        })
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(json) => FfiResult::success(json),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_result(result)
     }
 }
 
@@ -95,7 +99,7 @@ pub unsafe extern "C" fn p2p_notify_network_change(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
@@ -103,16 +107,13 @@ pub unsafe extern "C" fn p2p_notify_network_change(
                         .ops()
                         .notify_network_change()
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }
 
@@ -140,23 +141,29 @@ pub unsafe extern "C" fn p2p_active_peers(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
-                    let peers = p2p.system.ops().connected_peers().await
-                        .map_err(|error| error.to_string())?;
+                    let peers = p2p
+                        .system
+                        .ops()
+                        .connected_peers()
+                        .await
+                        .map_err(FfiP2PError::from)?;
                     serde_json::to_string(&peers)
-                        .map_err(|error| format!("failed to serialize peer list: {}", error))
+                        .map_err(|error| {
+                            FfiP2PError::internal(format!(
+                                "failed to serialize peer list: {}",
+                                error
+                            ))
+                        })
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(json) => FfiResult::success(json),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_result(result)
     }
 }
 
@@ -187,7 +194,7 @@ pub unsafe extern "C" fn p2p_connect(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
@@ -195,15 +202,12 @@ pub unsafe extern "C" fn p2p_connect(
                         .ops()
                         .connect_peer(&addr_str)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }

--- a/crates/ffi/src/p2p/push.rs
+++ b/crates/ffi/src/p2p/push.rs
@@ -1,8 +1,10 @@
 use crate::ffi_entry;
 use crate::helpers::get_rt;
 use crate::state::NODES;
+use crate::try_ffi;
 use crate::types::FfiResult;
-use crate::{try_ffi, ERR_INVALID_NODE_HANDLE};
+
+use super::{into_ffi_ok, FfiP2PError};
 
 /// Retry pushing existing documents to all registered replicators.
 ///
@@ -18,7 +20,7 @@ pub unsafe extern "C" fn p2p_retry_replicators(node_ptr: usize) -> FfiResult {
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
                 let push_options = embedded::ReplicatorPushOptions {
                     se_encryption_key: state.se_encryption_key.as_ref().map(|key| key.to_vec()),
@@ -33,15 +35,12 @@ pub unsafe extern "C" fn p2p_retry_replicators(node_ptr: usize) -> FfiResult {
                         .ops()
                         .retry_replicators(push_options)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }

--- a/crates/ffi/src/p2p/push.rs
+++ b/crates/ffi/src/p2p/push.rs
@@ -28,7 +28,13 @@ pub unsafe extern "C" fn p2p_retry_replicators(node_ptr: usize) -> FfiResult {
                         .map(|identity| identity.as_bytes().to_vec()),
                 };
 
-                rt.block_on(async { p2p.system.ops().retry_replicators(push_options).await })
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .retry_replicators(push_options)
+                        .await
+                        .map_err(|error| error.to_string())
+                })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
             .and_then(|result| result);

--- a/crates/ffi/src/p2p/replicator.rs
+++ b/crates/ffi/src/p2p/replicator.rs
@@ -6,10 +6,10 @@ use acp::nac::NodePermission;
 use crate::helpers::{get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
 use crate::state::NODES;
+use crate::try_ffi;
 use crate::types::{c_str_to_string, FfiResult};
-use crate::{try_ffi, ERR_INVALID_NODE_HANDLE};
 
-use super::parse_collections_json;
+use super::{into_ffi_ok, into_ffi_result, parse_collections_json, FfiP2PError};
 
 fn replicator_push_options(state: &crate::state::NodeState) -> embedded::ReplicatorPushOptions {
     embedded::ReplicatorPushOptions {
@@ -46,14 +46,14 @@ pub unsafe extern "C" fn p2p_add_replicator(
         let collections_str = try_ffi!(require_c_str(collections_json, "collections_json"));
         let collections = match parse_collections_json(&collections_str) {
             Ok(collections) => collections,
-            Err(error) => return FfiResult::error(error),
+            Err(error) => return FfiResult::error(error.message),
         };
 
         let result = NODES
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 let addr = addr_str.clone();
@@ -64,16 +64,13 @@ pub unsafe extern "C" fn p2p_add_replicator(
                         .ops()
                         .add_replicator(collections, Some(&addr), push_options)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }
 
@@ -105,7 +102,7 @@ pub unsafe extern "C" fn p2p_delete_replicator(
             match c_str_to_string(collections_json) {
                 Some(s) if !s.is_empty() => match parse_collections_json(&s) {
                     Ok(collections) => collections,
-                    Err(error) => return FfiResult::error(error),
+                    Err(error) => return FfiResult::error(error.message),
                 },
                 _ => Vec::new(),
             }
@@ -115,7 +112,7 @@ pub unsafe extern "C" fn p2p_delete_replicator(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 let peer = peer_str.clone();
@@ -125,16 +122,13 @@ pub unsafe extern "C" fn p2p_delete_replicator(
                         .ops()
                         .remove_replicator(collections, Some(&peer))
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }
 
@@ -163,22 +157,28 @@ pub unsafe extern "C" fn p2p_list_replicators(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 rt.block_on(async {
-                    let replicators = p2p.system.ops().get_replicators().await
-                        .map_err(|error| error.to_string())?;
+                    let replicators = p2p
+                        .system
+                        .ops()
+                        .get_replicators()
+                        .await
+                        .map_err(FfiP2PError::from)?;
                     serde_json::to_string(&replicators)
-                        .map_err(|error| format!("failed to serialize replicators: {}", error))
+                        .map_err(|error| {
+                            FfiP2PError::internal(format!(
+                                "failed to serialize replicators: {}",
+                                error
+                            ))
+                        })
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(json) => FfiResult::success(json),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_result(result)
     }
 }

--- a/crates/ffi/src/p2p/replicator.rs
+++ b/crates/ffi/src/p2p/replicator.rs
@@ -64,6 +64,7 @@ pub unsafe extern "C" fn p2p_add_replicator(
                         .ops()
                         .add_replicator(collections, Some(&addr), push_options)
                         .await
+                        .map_err(|error| error.to_string())
                 })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
@@ -124,6 +125,7 @@ pub unsafe extern "C" fn p2p_delete_replicator(
                         .ops()
                         .remove_replicator(collections, Some(&peer))
                         .await
+                        .map_err(|error| error.to_string())
                 })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
@@ -165,7 +167,8 @@ pub unsafe extern "C" fn p2p_list_replicators(
                 };
 
                 rt.block_on(async {
-                    let replicators = p2p.system.ops().get_replicators().await?;
+                    let replicators = p2p.system.ops().get_replicators().await
+                        .map_err(|error| error.to_string())?;
                     serde_json::to_string(&replicators)
                         .map_err(|error| format!("failed to serialize replicators: {}", error))
                 })

--- a/crates/ffi/src/p2p/sync.rs
+++ b/crates/ffi/src/p2p/sync.rs
@@ -6,10 +6,10 @@ use acp::nac::NodePermission;
 use crate::helpers::{get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
 use crate::state::NODES;
+use crate::try_ffi;
 use crate::types::FfiResult;
-use crate::{try_ffi, ERR_INVALID_NODE_HANDLE};
 
-use super::parse_doc_ids_json;
+use super::{into_ffi_ok, parse_doc_ids_json, FfiP2PError};
 
 /// Sync specific documents from peers.
 ///
@@ -36,14 +36,14 @@ pub unsafe extern "C" fn p2p_sync_documents(
         let doc_ids_str = try_ffi!(require_c_str(doc_ids_json, "doc_ids_json"));
         let doc_ids = match parse_doc_ids_json(&doc_ids_str) {
             Ok(doc_ids) => doc_ids,
-            Err(error) => return FfiResult::error(error),
+            Err(error) => return FfiResult::error(error.message),
         };
 
         let result = NODES
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 let collection_name = collection_name_str.clone();
@@ -53,16 +53,13 @@ pub unsafe extern "C" fn p2p_sync_documents(
                         .ops()
                         .sync_documents(&collection_name, doc_ids)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }
 
@@ -92,7 +89,7 @@ pub unsafe extern "C" fn p2p_sync_branchable_collection(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 let collection_id = collection_id_str.clone();
@@ -101,15 +98,12 @@ pub unsafe extern "C" fn p2p_sync_branchable_collection(
                         .ops()
                         .sync_branchable_collection(&collection_id)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }

--- a/crates/ffi/src/p2p/sync.rs
+++ b/crates/ffi/src/p2p/sync.rs
@@ -53,6 +53,7 @@ pub unsafe extern "C" fn p2p_sync_documents(
                         .ops()
                         .sync_documents(&collection_name, doc_ids)
                         .await
+                        .map_err(|error| error.to_string())
                 })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
@@ -100,6 +101,7 @@ pub unsafe extern "C" fn p2p_sync_branchable_collection(
                         .ops()
                         .sync_branchable_collection(&collection_id)
                         .await
+                        .map_err(|error| error.to_string())
                 })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())

--- a/crates/ffi/src/p2p/version_sync.rs
+++ b/crates/ffi/src/p2p/version_sync.rs
@@ -6,8 +6,10 @@ use acp::nac::NodePermission;
 use crate::helpers::{get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
 use crate::state::NODES;
+use crate::try_ffi;
 use crate::types::FfiResult;
-use crate::{try_ffi, ERR_INVALID_NODE_HANDLE};
+
+use super::{into_ffi_ok, FfiP2PError};
 
 /// Sync collection versions (schema definitions) from connected peers.
 ///
@@ -33,10 +35,13 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
         let version_ids: Vec<String> = match serde_json::from_str(&version_ids_str) {
             Ok(ids) => ids,
             Err(error) => {
-                return FfiResult::error(format!(
-                    "failed to parse version_ids_json: {}",
-                    error
-                ));
+                return FfiResult::error(
+                    FfiP2PError::invalid_input(format!(
+                        "failed to parse version_ids_json: {}",
+                        error
+                    ))
+                    .message,
+                );
             }
         };
 
@@ -48,7 +53,7 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
             .get(node_ptr, |state| {
                 let p2p = match &state.p2p {
                     Some(p2p) => p2p,
-                    None => return Err("no p2p system configured".to_string()),
+                    None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
                 let version_ids = version_ids.clone();
@@ -57,15 +62,12 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
                         .ops()
                         .sync_collection_versions(version_ids)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(FfiP2PError::from)
                 })
             })
-            .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())
+            .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);
 
-        match result {
-            Ok(()) => FfiResult::ok(),
-            Err(error) => FfiResult::error(error),
-        }
+        into_ffi_ok(result)
     }
 }

--- a/crates/ffi/src/p2p/version_sync.rs
+++ b/crates/ffi/src/p2p/version_sync.rs
@@ -57,6 +57,7 @@ pub unsafe extern "C" fn p2p_sync_collection_versions(
                         .ops()
                         .sync_collection_versions(version_ids)
                         .await
+                        .map_err(|error| error.to_string())
                 })
             })
             .ok_or_else(|| ERR_INVALID_NODE_HANDLE.to_string())

--- a/crates/http/src/handlers/p2p/collections.rs
+++ b/crates/http/src/handlers/p2p/collections.rs
@@ -2,6 +2,7 @@
 
 use axum::{extract::State, Json};
 
+use super::{map_p2p_bad_request, map_p2p_internal};
 use crate::error::HttpError;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
@@ -21,7 +22,7 @@ pub async fn list_collections(
 
     let p2p = state.require_p2p()?;
 
-    let collections = p2p.get_collections().await.map_err(HttpError::Internal)?;
+    let collections = p2p.get_collections().await.map_err(map_p2p_internal)?;
 
     Ok(Json(collections))
 }
@@ -55,7 +56,7 @@ pub async fn add_collections(
 
     p2p.add_collections(collections)
         .await
-        .map_err(HttpError::BadRequest)?;
+        .map_err(map_p2p_bad_request)?;
 
     // Go returns 200 OK with empty body
     Ok(())
@@ -90,7 +91,7 @@ pub async fn remove_collections(
 
     p2p.remove_collections(collections)
         .await
-        .map_err(HttpError::BadRequest)?;
+        .map_err(map_p2p_bad_request)?;
 
     // Go returns 200 OK with empty body
     Ok(())
@@ -119,7 +120,7 @@ pub async fn sync_branchable(
 
     p2p.sync_branchable_collection(&body.collection_id)
         .await
-        .map_err(HttpError::Internal)?;
+        .map_err(map_p2p_internal)?;
 
     Ok(Json(()))
 }
@@ -142,7 +143,7 @@ pub async fn sync_versions(
 
     p2p.sync_collection_versions(body.version_ids)
         .await
-        .map_err(HttpError::Internal)?;
+        .map_err(map_p2p_internal)?;
 
     Ok(Json(()))
 }

--- a/crates/http/src/handlers/p2p/documents.rs
+++ b/crates/http/src/handlers/p2p/documents.rs
@@ -2,6 +2,7 @@
 
 use axum::{extract::State, Json};
 
+use super::{map_p2p_bad_request, map_p2p_internal};
 use crate::error::HttpError;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
@@ -23,7 +24,7 @@ pub async fn list_documents(
 
     let p2p = state.require_p2p()?;
 
-    let docs = p2p.get_documents().await.map_err(HttpError::Internal)?;
+    let docs = p2p.get_documents().await.map_err(map_p2p_internal)?;
 
     // Convert to flat array of document IDs (Go-compatible format)
     let doc_ids: Vec<String> = docs.into_iter().map(|d| d.doc_id).collect();
@@ -68,9 +69,7 @@ pub async fn add_documents(
         })
         .collect();
 
-    p2p.add_documents(docs)
-        .await
-        .map_err(HttpError::BadRequest)?;
+    p2p.add_documents(docs).await.map_err(map_p2p_bad_request)?;
 
     // Go returns 200 OK with empty body
     Ok(())
@@ -114,7 +113,7 @@ pub async fn remove_documents(
 
     p2p.remove_documents(docs)
         .await
-        .map_err(HttpError::BadRequest)?;
+        .map_err(map_p2p_bad_request)?;
 
     // Go returns 200 OK with empty body
     Ok(())
@@ -138,7 +137,7 @@ pub async fn sync_documents(
 
     p2p.sync_documents(&body.collection_name, body.doc_ids)
         .await
-        .map_err(HttpError::Internal)?;
+        .map_err(map_p2p_internal)?;
 
     Ok(Json(()))
 }

--- a/crates/http/src/handlers/p2p/mod.rs
+++ b/crates/http/src/handlers/p2p/mod.rs
@@ -9,10 +9,20 @@
 //!
 //! All endpoints enforce NAC permissions when NAC is enabled.
 
+use crate::error::HttpError;
+
 mod collections;
 mod documents;
 mod peers;
 mod replicators;
+
+fn map_p2p_bad_request(error: String) -> HttpError {
+    HttpError::BadRequest(error)
+}
+
+fn map_p2p_internal(error: String) -> HttpError {
+    HttpError::Internal(error)
+}
 
 pub use collections::{
     add_collections, list_collections, remove_collections, sync_branchable, sync_versions,

--- a/crates/http/src/handlers/p2p/mod.rs
+++ b/crates/http/src/handlers/p2p/mod.rs
@@ -10,18 +10,31 @@
 //! All endpoints enforce NAC permissions when NAC is enabled.
 
 use crate::error::HttpError;
+use crate::router::P2PError;
 
 mod collections;
 mod documents;
 mod peers;
 mod replicators;
 
-fn map_p2p_bad_request(error: String) -> HttpError {
-    HttpError::BadRequest(error)
+fn map_p2p_bad_request(error: P2PError) -> HttpError {
+    match error {
+        P2PError::InvalidInput(message) => HttpError::BadRequest(message),
+        P2PError::NotFound(message) => HttpError::NotFound(message),
+        P2PError::Unsupported(message) => HttpError::NotImplemented(message),
+        P2PError::Transport(message) => HttpError::BadRequest(message),
+        P2PError::Internal(message) => HttpError::Internal(message),
+    }
 }
 
-fn map_p2p_internal(error: String) -> HttpError {
-    HttpError::Internal(error)
+fn map_p2p_internal(error: P2PError) -> HttpError {
+    match error {
+        P2PError::InvalidInput(message) => HttpError::BadRequest(message),
+        P2PError::NotFound(message) => HttpError::NotFound(message),
+        P2PError::Unsupported(message) => HttpError::NotImplemented(message),
+        P2PError::Transport(message) => HttpError::Internal(message),
+        P2PError::Internal(message) => HttpError::Internal(message),
+    }
 }
 
 pub use collections::{

--- a/crates/http/src/handlers/p2p/peers.rs
+++ b/crates/http/src/handlers/p2p/peers.rs
@@ -3,6 +3,7 @@
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 
+use super::{map_p2p_bad_request, map_p2p_internal};
 use crate::error::HttpError;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
@@ -45,9 +46,9 @@ pub async fn get_info(
 
     let p2p = state.require_p2p()?;
 
-    let peer_id = p2p.local_peer_id().await.map_err(HttpError::Internal)?;
+    let peer_id = p2p.local_peer_id().await.map_err(map_p2p_internal)?;
 
-    let addresses = p2p.listen_addresses().await.map_err(HttpError::Internal)?;
+    let addresses = p2p.listen_addresses().await.map_err(map_p2p_internal)?;
 
     let full_addrs: Vec<String> = addresses
         .into_iter()
@@ -76,7 +77,7 @@ pub async fn list_peers(
 
     let p2p = state.require_p2p()?;
 
-    let peers = p2p.connected_peers().await.map_err(HttpError::Internal)?;
+    let peers = p2p.connected_peers().await.map_err(map_p2p_internal)?;
 
     let peer_infos: Vec<PeerInfo> = peers
         .into_iter()
@@ -101,7 +102,7 @@ pub async fn active_peers(
 
     let p2p = state.require_p2p()?;
 
-    let peers = p2p.connected_peers().await.map_err(HttpError::Internal)?;
+    let peers = p2p.connected_peers().await.map_err(map_p2p_internal)?;
 
     Ok(Json(peers))
 }
@@ -127,7 +128,7 @@ pub async fn connect_peer(
 
     p2p.connect_peer(&request.address)
         .await
-        .map_err(HttpError::BadRequest)?;
+        .map_err(map_p2p_bad_request)?;
 
     Ok(Json(()))
 }
@@ -150,9 +151,7 @@ pub async fn connect(
 
     for addr in &addresses {
         validate_multiaddr(addr)?;
-        p2p.connect_peer(addr)
-            .await
-            .map_err(HttpError::BadRequest)?;
+        p2p.connect_peer(addr).await.map_err(map_p2p_bad_request)?;
     }
 
     Ok(())

--- a/crates/http/src/handlers/p2p/replicators.rs
+++ b/crates/http/src/handlers/p2p/replicators.rs
@@ -3,6 +3,7 @@
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 
+use super::{map_p2p_bad_request, map_p2p_internal};
 use crate::error::HttpError;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
@@ -65,7 +66,7 @@ pub async fn list_replicators(
 
     let p2p = state.require_p2p()?;
 
-    let replicators = p2p.get_replicators().await.map_err(HttpError::Internal)?;
+    let replicators = p2p.get_replicators().await.map_err(map_p2p_internal)?;
 
     let response: Vec<ReplicatorInfoResponse> = replicators
         .into_iter()
@@ -124,7 +125,7 @@ pub async fn add_replicator(
         expected_authorizer_did.as_deref(),
     )
     .await
-    .map_err(HttpError::BadRequest)?;
+    .map_err(map_p2p_bad_request)?;
 
     Ok(Json(()))
 }
@@ -162,7 +163,7 @@ pub async fn remove_replicator(
 
     p2p.remove_replicator(request.collections, addr)
         .await
-        .map_err(HttpError::BadRequest)?;
+        .map_err(map_p2p_bad_request)?;
 
     // Go returns 200 OK with empty body
     Ok(())

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -86,8 +86,8 @@ pub use router::{
     create_router, create_router_with_rest, create_router_with_state, AcpLightClientStatus,
     AcpOperations, AppState, AppStateBuilder, BackupOperations, BlockOperations,
     DocumentAcpOperations, IndexFieldInfo, IndexInfo, IndexOperations, NacStatus, NacStatusInfo,
-    NodeAcpOperations, NodePermission, P2POperations, PolicyInfo, ReplicatorInfo,
-    TransactionOperations, ViewOperations,
+    NodeAcpOperations, NodePermission, P2PError, P2POperations, P2PResult, PolicyInfo,
+    ReplicatorInfo, TransactionOperations, ViewOperations,
 };
 pub use server::{Server, ServerConfig};
 

--- a/crates/http/src/mock/p2p.rs
+++ b/crates/http/src/mock/p2p.rs
@@ -3,7 +3,9 @@
 use async_trait::async_trait;
 use std::sync::{Arc, RwLock};
 
-use crate::router::{P2POperations, P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo};
+use crate::router::{
+    P2PError, P2POperations, P2PResult, P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo,
+};
 
 /// Mock P2P operations for testing P2P handlers.
 #[derive(Debug)]
@@ -70,19 +72,19 @@ impl MockP2POperations {
 
 #[async_trait]
 impl P2POperations for MockP2POperations {
-    async fn local_peer_id(&self) -> Result<String, String> {
+    async fn local_peer_id(&self) -> P2PResult<String> {
         Ok(self.peer_id.clone())
     }
 
-    async fn listen_addresses(&self) -> Result<Vec<String>, String> {
+    async fn listen_addresses(&self) -> P2PResult<Vec<String>> {
         Ok(self.addresses.clone())
     }
 
-    async fn connected_peers(&self) -> Result<Vec<String>, String> {
+    async fn connected_peers(&self) -> P2PResult<Vec<String>> {
         Ok(self.peers.read().unwrap().clone())
     }
 
-    async fn connect_peer(&self, addr: &str) -> Result<(), String> {
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()> {
         // Extract a mock peer ID from the address
         let peer_id = if addr.contains("/p2p/") {
             addr.split("/p2p/").last().unwrap_or("unknown").to_string()
@@ -93,7 +95,7 @@ impl P2POperations for MockP2POperations {
         Ok(())
     }
 
-    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String> {
+    async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         Ok(self.replicators.read().unwrap().clone())
     }
 
@@ -103,7 +105,7 @@ impl P2POperations for MockP2POperations {
         addr: Option<&str>,
         _explicit_replay_capabilities: Vec<crate::router::ExplicitReplayCapabilityInput>,
         _expected_authorizer_did: Option<&str>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         self.replicators.write().unwrap().push(ReplicatorInfo {
             id: Some("12D3KooWNewReplicator".to_string()),
             collections,
@@ -116,17 +118,17 @@ impl P2POperations for MockP2POperations {
         &self,
         collections: Vec<String>,
         _addr: Option<&str>,
-    ) -> Result<(), String> {
+    ) -> P2PResult<()> {
         let mut replicators = self.replicators.write().unwrap();
         replicators.retain(|r| !collections.iter().all(|c| r.collections.contains(c)));
         Ok(())
     }
 
-    async fn get_collections(&self) -> Result<Vec<String>, String> {
+    async fn get_collections(&self) -> P2PResult<Vec<String>> {
         Ok(self.collections.read().unwrap().clone())
     }
 
-    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn add_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         let mut existing = self.collections.write().unwrap();
         for col in collections {
             if !existing.contains(&col) {
@@ -136,37 +138,33 @@ impl P2POperations for MockP2POperations {
         Ok(())
     }
 
-    async fn remove_collections(&self, collections: Vec<String>) -> Result<(), String> {
+    async fn remove_collections(&self, collections: Vec<String>) -> P2PResult<()> {
         let mut existing = self.collections.write().unwrap();
         existing.retain(|c| !collections.contains(c));
         Ok(())
     }
 
-    async fn get_documents(&self) -> Result<Vec<P2pDocumentInfo>, String> {
+    async fn get_documents(&self) -> P2PResult<Vec<P2pDocumentInfo>> {
         Ok(vec![])
     }
 
-    async fn add_documents(&self, _docs: Vec<P2pDocumentRequest>) -> Result<(), String> {
+    async fn add_documents(&self, _docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
         Ok(())
     }
 
-    async fn remove_documents(&self, _docs: Vec<P2pDocumentRequest>) -> Result<(), String> {
+    async fn remove_documents(&self, _docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
         Ok(())
     }
 
-    async fn sync_documents(
-        &self,
-        _collection_name: &str,
-        _doc_ids: Vec<String>,
-    ) -> Result<(), String> {
+    async fn sync_documents(&self, _collection_name: &str, _doc_ids: Vec<String>) -> P2PResult<()> {
         Ok(())
     }
 
-    async fn sync_branchable_collection(&self, _collection_id: &str) -> Result<(), String> {
+    async fn sync_branchable_collection(&self, _collection_id: &str) -> P2PResult<()> {
         Ok(())
     }
 
-    async fn sync_collection_versions(&self, _version_ids: Vec<String>) -> Result<(), String> {
+    async fn sync_collection_versions(&self, _version_ids: Vec<String>) -> P2PResult<()> {
         Ok(())
     }
 }
@@ -188,24 +186,24 @@ impl FailingMockP2POperations {
 
 #[async_trait]
 impl P2POperations for FailingMockP2POperations {
-    async fn local_peer_id(&self) -> Result<String, String> {
-        Err(self.error.clone())
+    async fn local_peer_id(&self) -> P2PResult<String> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn listen_addresses(&self) -> Result<Vec<String>, String> {
-        Err(self.error.clone())
+    async fn listen_addresses(&self) -> P2PResult<Vec<String>> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn connected_peers(&self) -> Result<Vec<String>, String> {
-        Err(self.error.clone())
+    async fn connected_peers(&self) -> P2PResult<Vec<String>> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn connect_peer(&self, _addr: &str) -> Result<(), String> {
-        Err(self.error.clone())
+    async fn connect_peer(&self, _addr: &str) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String> {
-        Err(self.error.clone())
+    async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
     async fn add_replicator(
@@ -214,55 +212,51 @@ impl P2POperations for FailingMockP2POperations {
         _addr: Option<&str>,
         _explicit_replay_capabilities: Vec<crate::router::ExplicitReplayCapabilityInput>,
         _expected_authorizer_did: Option<&str>,
-    ) -> Result<(), String> {
-        Err(self.error.clone())
+    ) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
     async fn remove_replicator(
         &self,
         _collections: Vec<String>,
         _addr: Option<&str>,
-    ) -> Result<(), String> {
-        Err(self.error.clone())
+    ) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn get_collections(&self) -> Result<Vec<String>, String> {
-        Err(self.error.clone())
+    async fn get_collections(&self) -> P2PResult<Vec<String>> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn add_collections(&self, _collections: Vec<String>) -> Result<(), String> {
-        Err(self.error.clone())
+    async fn add_collections(&self, _collections: Vec<String>) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn remove_collections(&self, _collections: Vec<String>) -> Result<(), String> {
-        Err(self.error.clone())
+    async fn remove_collections(&self, _collections: Vec<String>) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn get_documents(&self) -> Result<Vec<P2pDocumentInfo>, String> {
-        Err(self.error.clone())
+    async fn get_documents(&self) -> P2PResult<Vec<P2pDocumentInfo>> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn add_documents(&self, _docs: Vec<P2pDocumentRequest>) -> Result<(), String> {
-        Err(self.error.clone())
+    async fn add_documents(&self, _docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn remove_documents(&self, _docs: Vec<P2pDocumentRequest>) -> Result<(), String> {
-        Err(self.error.clone())
+    async fn remove_documents(&self, _docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn sync_documents(
-        &self,
-        _collection_name: &str,
-        _doc_ids: Vec<String>,
-    ) -> Result<(), String> {
-        Err(self.error.clone())
+    async fn sync_documents(&self, _collection_name: &str, _doc_ids: Vec<String>) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn sync_branchable_collection(&self, _collection_id: &str) -> Result<(), String> {
-        Err(self.error.clone())
+    async fn sync_branchable_collection(&self, _collection_id: &str) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 
-    async fn sync_collection_versions(&self, _version_ids: Vec<String>) -> Result<(), String> {
-        Err(self.error.clone())
+    async fn sync_collection_versions(&self, _version_ids: Vec<String>) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
     }
 }

--- a/crates/http/src/router/mod.rs
+++ b/crates/http/src/router/mod.rs
@@ -11,7 +11,7 @@ pub use traits::{
     CollectionManagementOperations, DocumentAcpOperations, DumpOperations, EncryptedIndexInfo,
     EncryptedIndexOperations, ExplicitReplayCapabilityInput, ImportResult, IndexFieldInfo,
     IndexInfo, IndexOperations, LensOperations, NacStatus, NacStatusInfo, NodeAcpOperations,
-    NodePermission, P2POperations, P2pDocumentInfo, P2pDocumentRequest, PolicyInfo, ReplicatorInfo,
-    SchemaOperations, SyncBranchableRequest, SyncDocumentsRequest, SyncVersionsRequest,
-    TransactionOperations, ViewOperations,
+    NodePermission, P2PError, P2POperations, P2PResult, P2pDocumentInfo, P2pDocumentRequest,
+    PolicyInfo, ReplicatorInfo, SchemaOperations, SyncBranchableRequest, SyncDocumentsRequest,
+    SyncVersionsRequest, TransactionOperations, ViewOperations,
 };

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -1,5 +1,7 @@
 //! Operation traits and supporting types for the HTTP router.
 
+use thiserror::Error;
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExplicitReplayCapabilityInput {
     #[serde(rename = "CollectionID")]
@@ -8,31 +10,60 @@ pub struct ExplicitReplayCapabilityInput {
     pub capability: String,
 }
 
+/// HTTP-facing P2P error categories.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum P2PError {
+    #[error("invalid request: {0}")]
+    InvalidInput(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("unsupported operation: {0}")]
+    Unsupported(String),
+
+    #[error("transport error: {0}")]
+    Transport(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+pub type P2PResult<T> = Result<T, P2PError>;
+
+impl From<String> for P2PError {
+    fn from(message: String) -> Self {
+        Self::Internal(message)
+    }
+}
+
+impl From<&str> for P2PError {
+    fn from(message: &str) -> Self {
+        Self::Internal(message.to_string())
+    }
+}
+
 /// Trait for P2P operations that can be accessed via HTTP.
 ///
 /// Abstracts P2P host functionality to decouple HTTP handlers from the
 /// actual P2P implementation, enabling both dependency injection and testing.
-///
-/// All methods return `Result<T, String>` where the error string should be
-/// a user-friendly message. For validation failures, use descriptive messages
-/// like "invalid address format". For internal errors, use messages like
-/// "failed to connect: <reason>".
 #[async_trait::async_trait]
 pub trait P2POperations: Send + Sync {
     /// Get the local peer ID.
-    async fn local_peer_id(&self) -> Result<String, String>;
+    async fn local_peer_id(&self) -> P2PResult<String>;
 
     /// Get listening addresses.
-    async fn listen_addresses(&self) -> Result<Vec<String>, String>;
+    async fn listen_addresses(&self) -> P2PResult<Vec<String>>;
 
     /// Get connected peers.
-    async fn connected_peers(&self) -> Result<Vec<String>, String>;
+    async fn connected_peers(&self) -> P2PResult<Vec<String>>;
 
     /// Connect to a peer at the given address.
-    async fn connect_peer(&self, addr: &str) -> Result<(), String>;
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()>;
 
     /// Get all replicators.
-    async fn get_replicators(&self) -> Result<Vec<ReplicatorInfo>, String>;
+    async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>>;
 
     /// Add a replicator for collections.
     async fn add_replicator(
@@ -41,45 +72,41 @@ pub trait P2POperations: Send + Sync {
         addr: Option<&str>,
         explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
         expected_authorizer_did: Option<&str>,
-    ) -> Result<(), String>;
+    ) -> P2PResult<()>;
 
     /// Remove a replicator for collections.
     async fn remove_replicator(
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
-    ) -> Result<(), String>;
+    ) -> P2PResult<()>;
 
     /// Get P2P collections.
-    async fn get_collections(&self) -> Result<Vec<String>, String>;
+    async fn get_collections(&self) -> P2PResult<Vec<String>>;
 
     /// Add collections to P2P.
-    async fn add_collections(&self, collections: Vec<String>) -> Result<(), String>;
+    async fn add_collections(&self, collections: Vec<String>) -> P2PResult<()>;
 
     /// Remove collections from P2P.
-    async fn remove_collections(&self, collections: Vec<String>) -> Result<(), String>;
+    async fn remove_collections(&self, collections: Vec<String>) -> P2PResult<()>;
 
     /// Get P2P documents (for document-level replication).
-    async fn get_documents(&self) -> Result<Vec<P2pDocumentInfo>, String>;
+    async fn get_documents(&self) -> P2PResult<Vec<P2pDocumentInfo>>;
 
     /// Add documents to P2P replication.
-    async fn add_documents(&self, docs: Vec<P2pDocumentRequest>) -> Result<(), String>;
+    async fn add_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()>;
 
     /// Remove documents from P2P replication.
-    async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> Result<(), String>;
+    async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()>;
 
     /// Sync specific documents from connected peers.
-    async fn sync_documents(
-        &self,
-        collection_name: &str,
-        doc_ids: Vec<String>,
-    ) -> Result<(), String>;
+    async fn sync_documents(&self, collection_name: &str, doc_ids: Vec<String>) -> P2PResult<()>;
 
     /// Sync a branchable collection from connected peers.
-    async fn sync_branchable_collection(&self, collection_id: &str) -> Result<(), String>;
+    async fn sync_branchable_collection(&self, collection_id: &str) -> P2PResult<()>;
 
     /// Sync collection versions (schema definitions) from connected peers via Bitswap.
-    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> Result<(), String>;
+    async fn sync_collection_versions(&self, version_ids: Vec<String>) -> P2PResult<()>;
 }
 
 /// Replicator information for HTTP responses.


### PR DESCRIPTION
## Summary
- add an initial `embedded::P2PError` enum and `P2PResult<T>` alias
- export the new error surface from the `embedded` crate
- add narrow unit tests for the initial typed-error groundwork

## Why this first
Issue #667 is a large cross-crate refactor. This PR intentionally starts with a non-breaking first step in `embedded` so follow-up commits can migrate the existing `Result<_, String>` P2P traits and adapters incrementally instead of attempting a one-shot API rewrite.

## Current scope
- no behavior changes yet
- no trait signatures changed yet
- no HTTP or FFI mapping changes yet

## Verification
- `cargo fmt --all`
- `cargo test -p embedded p2p_error --lib`

## Follow-ups planned in this branch
- migrate embedded P2P traits/adapters from `String` to `P2PError`
- identify the HTTP status-mapping boundary separately from the embedded error model
- decide whether FFI error-code work belongs in this PR or a dedicated follow-up

Related: #667
