### PR TITLE
refactor(p2p): bundle SyncCoordinator shared state

### DIFF
--- a/crates/p2p/src/sync/coordinator/access.rs
+++ b/crates/p2p/src/sync/coordinator/access.rs
@@ -35,11 +35,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         peer_id_str: &str,
         collection_id: &str,
     ) -> Result<()> {
-        if self.access_mode.is_open() {
+        if self.access.access_mode.is_open() {
             return Ok(());
         }
 
-        if self.replicators.is_replicator(collection_id, peer_id_str) {
+        if self
+            .access
+            .replicators
+            .is_replicator(collection_id, peer_id_str)
+        {
             return Ok(());
         }
 
@@ -48,7 +52,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         // controls what WE push; it should not gate what we ACCEPT from
         // authenticated peers. This matches Go DefraDB where the replicator
         // target accepts push-logs without explicit subscription.
-        if self.peer_state.is_connected(peer_id_str) {
+        if self.access.peer_state.is_connected(peer_id_str) {
             return Ok(());
         }
 
@@ -66,7 +70,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Returns true only when the peer is explicitly registered as a
     /// replicator for the collection.
     pub(super) fn is_registered_replicator(&self, peer_id_str: &str, collection_id: &str) -> bool {
-        self.replicators.is_replicator(collection_id, peer_id_str)
+        self.access
+            .replicators
+            .is_replicator(collection_id, peer_id_str)
     }
 
     /// Check if a peer is authorized as a replicator for any collection.
@@ -75,15 +81,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// In Open mode, all peers are allowed. In Controlled mode, the peer
     /// must be a connected peer or a replicator for at least one collection.
     pub(super) fn check_peer_is_replicator(&self, peer_id: &PeerId) -> Result<()> {
-        if self.access_mode.is_open() {
+        if self.access.access_mode.is_open() {
             return Ok(());
         }
 
-        if self.replicators.is_any_replicator(peer_id.as_str()) {
+        if self.access.replicators.is_any_replicator(peer_id.as_str()) {
             return Ok(());
         }
 
-        if self.peer_state.is_connected(peer_id.as_str()) {
+        if self.access.peer_state.is_connected(peer_id.as_str()) {
             return Ok(());
         }
 
@@ -99,6 +105,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Get the current access mode.
     pub fn access_mode(&self) -> AccessMode {
-        self.access_mode
+        self.access.access_mode
     }
 }

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -26,7 +26,8 @@ use crate::sync::rate_limiter::PeerRateLimiter;
 use crate::transport::{PeerId, ResponseToken, TransportEvent};
 
 use super::{
-    SyncCoordinator, DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+    SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState,
+    DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
 };
 
 type TestBlockstore = DefraBlockstore<MemoryStore>;
@@ -49,26 +50,32 @@ fn create_test_coordinator(
     let (manager, events) = SyncManager::new(blockstore, peer_state.clone(), SyncConfig::default());
 
     let coordinator = SyncCoordinator {
-        transport,
-        broadcaster,
+        runtime: SyncRuntime {
+            transport,
+            broadcaster,
+            failure_tx: None,
+            dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
+            )),
+            push_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+            )),
+            rate_limiter: Arc::new(PeerRateLimiter::default()),
+        },
         manager,
-        peer_state,
-        local_peer_id,
-        access_mode,
-        replicators,
-        subscribed_collections: Arc::new(
-            tokio::sync::RwLock::new(std::collections::HashSet::new()),
-        ),
-        collection_store: Arc::new(NoOpCollectionStorage),
-        head_provider: Arc::new(NoOpHeadProvider),
-        failure_tx: None,
-        dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(
-            DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
-        )),
-        push_semaphore: Arc::new(tokio::sync::Semaphore::new(
-            DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
-        )),
-        rate_limiter: Arc::new(PeerRateLimiter::default()),
+        access: SyncAccessState {
+            peer_state,
+            local_peer_id,
+            access_mode,
+            replicators,
+        },
+        subscriptions: SyncSubscriptionState {
+            subscribed_collections: Arc::new(tokio::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
+            collection_store: Arc::new(NoOpCollectionStorage),
+            head_provider: Arc::new(NoOpHeadProvider),
+        },
     };
 
     (coordinator, events)

--- a/crates/p2p/src/sync/coordinator/accessors.rs
+++ b/crates/p2p/src/sync/coordinator/accessors.rs
@@ -14,7 +14,7 @@ use crate::transport::P2PTransport;
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Get the replicator registry.
     pub fn replicators(&self) -> &Arc<ReplicatorRegistry> {
-        &self.replicators
+        &self.access.replicators
     }
 
     /// Get the blockstore reference.
@@ -24,22 +24,22 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Get the broadcaster reference.
     pub fn broadcaster(&self) -> &Broadcaster<T> {
-        &self.broadcaster
+        &self.runtime.broadcaster
     }
 
     /// Get the local peer ID.
     pub fn local_peer_id(&self) -> &str {
-        &self.local_peer_id
+        &self.access.local_peer_id
     }
 
     /// Get the peer state tracker reference.
     pub fn peer_state(&self) -> &PeerStateTracker {
-        &self.peer_state
+        &self.access.peer_state
     }
 
     /// Get the transport reference.
     pub fn transport(&self) -> &T {
-        &self.transport
+        &self.runtime.transport
     }
 
     /// Get the sync manager reference.

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -40,10 +40,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collection_id: &str,
         creator_override: Option<&str>,
     ) -> Result<BroadcastResult> {
-        let creator = creator_override.unwrap_or(&self.local_peer_id);
+        let creator = creator_override.unwrap_or(&self.access.local_peer_id);
         let broadcast =
             Broadcaster::<T>::create_broadcast(cid, block, doc_id, collection_id, creator);
-        self.broadcaster.broadcast_update(&broadcast).await
+        self.runtime.broadcaster.broadcast_update(&broadcast).await
     }
 
     /// Push a full document DAG to replicator peers.
@@ -67,8 +67,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collection_id: &str,
         creator_override: Option<&str>,
     ) {
-        let creator = creator_override.unwrap_or(&self.local_peer_id);
-        let replicators = match self.transport.list_replicators().await {
+        let creator = creator_override.unwrap_or(&self.access.local_peer_id);
+        let replicators = match self.runtime.transport.list_replicators().await {
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(error = %e, "Failed to get replicators for push");
@@ -115,18 +115,18 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     creator.to_string(),
                     block_data.clone(),
                 );
-                if sign_with_transport(&self.transport, &mut req).is_ok() {
+                if sign_with_transport(&self.runtime.transport, &mut req).is_ok() {
                     requests.push((*block_cid, req));
                 }
             }
 
             // Spawn a task per peer, bounded by push_semaphore to prevent
             // resource exhaustion during document creation bursts.
-            let transport = self.transport.clone();
-            let failure_tx = self.failure_tx.clone();
+            let transport = self.runtime.transport.clone();
+            let failure_tx = self.runtime.failure_tx.clone();
             let doc_id_owned = doc_id.to_string();
             let collection_id_owned = collection_id.to_string();
-            let semaphore = self.push_semaphore.clone();
+            let semaphore = self.runtime.push_semaphore.clone();
             tokio::spawn(async move {
                 let _permit = semaphore.acquire().await;
                 let any_failed =
@@ -165,8 +165,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collection_id: &str,
         creator_override: Option<&str>,
     ) {
-        let creator = creator_override.unwrap_or(&self.local_peer_id);
-        let replicators = match self.transport.list_replicators().await {
+        let creator = creator_override.unwrap_or(&self.access.local_peer_id);
+        let replicators = match self.runtime.transport.list_replicators().await {
             Ok(r) => r,
             Err(e) => {
                 tracing::warn!(error = %e, "Failed to get replicators for push");
@@ -194,17 +194,17 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 Bytes::copy_from_slice(block),
             );
 
-            if let Err(e) = sign_with_transport(&self.transport, &mut request) {
+            if let Err(e) = sign_with_transport(&self.runtime.transport, &mut request) {
                 tracing::debug!(error = %e, "Failed to sign PushLog request");
                 continue;
             }
 
-            let transport = self.transport.clone();
+            let transport = self.runtime.transport.clone();
             let cid_clone = *cid;
-            let failure_tx = self.failure_tx.clone();
+            let failure_tx = self.runtime.failure_tx.clone();
             let doc_id_owned = doc_id.to_string();
             let collection_id_owned = collection_id.to_string();
-            let semaphore = self.push_semaphore.clone();
+            let semaphore = self.runtime.push_semaphore.clone();
             let peer_id_clone = peer_id.clone();
             tokio::spawn(async move {
                 let _permit = semaphore.acquire().await;

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -15,6 +15,31 @@ use crate::sync::BroadcastResult;
 use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    async fn list_replicators_for_push(&self) -> Option<Vec<crate::replicator::ReplicatorInfo>> {
+        match self.runtime.transport.list_replicators().await {
+            Ok(replicators) => Some(replicators),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to get replicators for push");
+                None
+            }
+        }
+    }
+
+    fn report_push_failure(
+        failure_tx: &Option<tokio::sync::mpsc::Sender<super::PushFailure>>,
+        peer_id: &PeerId,
+        doc_id: String,
+        collection_id: String,
+    ) {
+        if let Some(tx) = failure_tx {
+            let _ = tx.try_send(super::PushFailure {
+                peer_id: peer_id.to_string(),
+                doc_id,
+                collection_id,
+            });
+        }
+    }
+
     /// Broadcast a local update to the network.
     pub async fn broadcast_local_update(
         &self,
@@ -68,12 +93,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         creator_override: Option<&str>,
     ) {
         let creator = creator_override.unwrap_or(&self.access.local_peer_id);
-        let replicators = match self.runtime.transport.list_replicators().await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to get replicators for push");
-                return;
-            }
+        let Some(replicators) = self.list_replicators_for_push().await else {
+            return;
         };
 
         if replicators.is_empty() {
@@ -132,13 +153,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 let any_failed =
                     Self::send_ordered_pushlogs_via_transport(&transport, &peer_id, requests).await;
                 if any_failed {
-                    if let Some(tx) = failure_tx {
-                        let _ = tx.try_send(super::PushFailure {
-                            peer_id: peer_id.to_string(),
-                            doc_id: doc_id_owned,
-                            collection_id: collection_id_owned,
-                        });
-                    }
+                    Self::report_push_failure(
+                        &failure_tx,
+                        &peer_id,
+                        doc_id_owned,
+                        collection_id_owned,
+                    );
                 }
             });
         }
@@ -166,12 +186,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         creator_override: Option<&str>,
     ) {
         let creator = creator_override.unwrap_or(&self.access.local_peer_id);
-        let replicators = match self.runtime.transport.list_replicators().await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!(error = %e, "Failed to get replicators for push");
-                return;
-            }
+        let Some(replicators) = self.list_replicators_for_push().await else {
+            return;
         };
 
         for rep in &replicators {
@@ -218,13 +234,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         error = %e,
                         "PushLog to replicator failed"
                     );
-                    if let Some(tx) = failure_tx {
-                        let _ = tx.try_send(super::PushFailure {
-                            peer_id: peer_id_clone.to_string(),
-                            doc_id: doc_id_owned,
-                            collection_id: collection_id_owned,
-                        });
-                    }
+                    Self::report_push_failure(
+                        &failure_tx,
+                        &peer_id_clone,
+                        doc_id_owned,
+                        collection_id_owned,
+                    );
                 }
             });
         }

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use blockstore::Blockstore;
 use tokio::sync::mpsc;
 
-use super::SyncCoordinator;
+use super::{SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState};
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Result;
 use crate::sync::broadcaster::Broadcaster;
@@ -103,22 +103,28 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         Ok((
             Self {
-                transport,
-                broadcaster,
+                runtime: SyncRuntime {
+                    transport,
+                    broadcaster,
+                    failure_tx: None,
+                    dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(max_dag_fetches)),
+                    push_semaphore: Arc::new(tokio::sync::Semaphore::new(max_push_tasks)),
+                    rate_limiter: Arc::new(PeerRateLimiter::new(rate_limit_burst, rate_limit_rate)),
+                },
                 manager,
-                peer_state,
-                local_peer_id,
-                access_mode,
-                replicators,
-                subscribed_collections: Arc::new(tokio::sync::RwLock::new(
-                    std::collections::HashSet::new(),
-                )),
-                collection_store,
-                head_provider,
-                failure_tx: None,
-                dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(max_dag_fetches)),
-                push_semaphore: Arc::new(tokio::sync::Semaphore::new(max_push_tasks)),
-                rate_limiter: Arc::new(PeerRateLimiter::new(rate_limit_burst, rate_limit_rate)),
+                access: SyncAccessState {
+                    peer_state,
+                    local_peer_id,
+                    access_mode,
+                    replicators,
+                },
+                subscriptions: SyncSubscriptionState {
+                    subscribed_collections: Arc::new(tokio::sync::RwLock::new(
+                        std::collections::HashSet::new(),
+                    )),
+                    collection_store,
+                    head_provider,
+                },
             },
             events,
         ))
@@ -126,6 +132,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Set the failure channel for reporting push failures to the FFI layer.
     pub fn set_failure_channel(&mut self, tx: tokio::sync::mpsc::Sender<super::PushFailure>) {
-        self.failure_tx = Some(tx);
+        self.runtime.failure_tx = Some(tx);
     }
 }

--- a/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
@@ -87,6 +87,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     let missing = self.manager.pending_dag_missing(&root_cid);
                     if !missing.is_empty() {
                         let mut providers: Vec<PeerId> = self
+                            .access
                             .peer_state
                             .connected_peers()
                             .into_iter()
@@ -99,6 +100,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                             }
                         }
                         if let Err(e) = self
+                            .runtime
                             .transport
                             .sync_blocks(root_cid, providers, missing)
                             .await

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -11,6 +11,37 @@ use crate::signing::sign_with_transport;
 use crate::transport::{P2PTransport, PeerId, ResponseToken};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    async fn send_branchable_sync_reply(
+        &self,
+        peer_id: &PeerId,
+        token: Option<ResponseToken>,
+        mut reply: BranchableSyncReply,
+    ) -> Result<()> {
+        sign_with_transport(&self.runtime.transport, &mut reply)?;
+
+        let send_result = if let Some(token) = token {
+            self.runtime
+                .transport
+                .send_branchable_sync_response_token(token, reply)
+                .await
+        } else {
+            self.runtime
+                .transport
+                .send_branchable_sync_response(peer_id, reply)
+                .await
+        };
+
+        if let Err(e) = send_result {
+            tracing::warn!(
+                peer_id = %peer_id,
+                error = %e,
+                "Failed to send BranchableSync response"
+            );
+        }
+
+        Ok(())
+    }
+
     pub(super) async fn handle_branchable_sync_request(
         &self,
         peer_id: PeerId,
@@ -50,14 +81,19 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             }
         };
 
-        let mut reply = BranchableSyncReply::success(
-            &request.metadata.message_id,
-            &request.collection_id,
-            heads,
-        );
-
-        if let Err(e) = sign_with_transport(&self.runtime.transport, &mut reply) {
-            tracing::error!(
+        if let Err(e) = self
+            .send_branchable_sync_reply(
+                &peer_id,
+                token,
+                BranchableSyncReply::success(
+                    &request.metadata.message_id,
+                    &request.collection_id,
+                    heads,
+                ),
+            )
+            .await
+        {
+            tracing::warn!(
                 peer_id = %peer_id,
                 error = %e,
                 "Failed to sign BranchableSync response"
@@ -65,24 +101,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             return Err(e);
         }
 
-        let send_result = if let Some(token) = token {
-            self.runtime
-                .transport
-                .send_branchable_sync_response_token(token, reply)
-                .await
-        } else {
-            self.runtime
-                .transport
-                .send_branchable_sync_response(&peer_id, reply)
-                .await
-        };
-        if let Err(e) = send_result {
-            tracing::warn!(
-                peer_id = %peer_id,
-                error = %e,
-                "Failed to send BranchableSync response"
-            );
-        }
         Ok(())
     }
 

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -27,6 +27,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         );
 
         let heads = match self
+            .subscriptions
             .head_provider
             .get_collection_heads(&request.collection_id)
             .await
@@ -55,7 +56,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             heads,
         );
 
-        if let Err(e) = sign_with_transport(&self.transport, &mut reply) {
+        if let Err(e) = sign_with_transport(&self.runtime.transport, &mut reply) {
             tracing::error!(
                 peer_id = %peer_id,
                 error = %e,
@@ -65,11 +66,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         let send_result = if let Some(token) = token {
-            self.transport
+            self.runtime
+                .transport
                 .send_branchable_sync_response_token(token, reply)
                 .await
         } else {
-            self.transport
+            self.runtime
+                .transport
                 .send_branchable_sync_response(&peer_id, reply)
                 .await
         };
@@ -135,10 +138,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 "Spawning poll-based DAG fetchers for collection blocks"
             );
 
-            let transport = self.transport.clone();
+            let transport = self.runtime.transport.clone();
             let blockstore = self.manager.blockstore().clone();
             let event_tx = self.manager.event_sender();
-            let semaphore = self.dag_fetch_semaphore.clone();
+            let semaphore = self.runtime.dag_fetch_semaphore.clone();
 
             for root_cid in cids_to_fetch {
                 let transport = transport.clone();

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -73,11 +73,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         if let Some(token) = token {
-            self.transport
+            self.runtime
+                .transport
                 .send_car_response_token(token, car_data)
                 .await?;
         } else {
-            self.transport.send_car_response(&peer_id, car_data).await?;
+            self.runtime
+                .transport
+                .send_car_response(&peer_id, car_data)
+                .await?;
         }
         Ok(())
     }

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -11,6 +11,39 @@ use crate::signing::sign_with_transport;
 use crate::transport::{P2PTransport, PeerId, ResponseToken};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    async fn send_doc_sync_reply(
+        &self,
+        peer_id: &PeerId,
+        token: Option<ResponseToken>,
+        mut reply: DocSyncReply,
+    ) -> Result<()> {
+        sign_with_transport(&self.runtime.transport, &mut reply)?;
+
+        let send_result = if let Some(token) = token {
+            self.runtime
+                .transport
+                .send_doc_sync_response_token(token, reply)
+                .await
+        } else {
+            self.runtime
+                .transport
+                .send_doc_sync_response(peer_id, reply)
+                .await
+        };
+
+        if let Err(e) = send_result {
+            tracing::warn!(
+                peer_id = %peer_id,
+                error = %e,
+                "Failed to send DocSync response"
+            );
+        } else {
+            tracing::debug!(peer_id = %peer_id, "Sent DocSync response");
+        }
+
+        Ok(())
+    }
+
     pub(super) async fn handle_doc_sync_request(
         &self,
         peer_id: PeerId,
@@ -78,10 +111,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             "Sending DocSync response"
         );
 
-        let mut reply = DocSyncReply::success(&request.metadata.message_id, results);
-
-        if let Err(e) = sign_with_transport(&self.runtime.transport, &mut reply) {
-            tracing::error!(
+        if let Err(e) = self
+            .send_doc_sync_reply(
+                &peer_id,
+                token,
+                DocSyncReply::success(&request.metadata.message_id, results),
+            )
+            .await
+        {
+            tracing::debug!(
                 peer_id = %peer_id,
                 error = %e,
                 "Failed to sign DocSync response"
@@ -89,29 +127,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             return Err(e);
         }
 
-        let send_result = if let Some(token) = token {
-            self.runtime
-                .transport
-                .send_doc_sync_response_token(token, reply)
-                .await
-        } else {
-            self.runtime
-                .transport
-                .send_doc_sync_response(&peer_id, reply)
-                .await
-        };
-        if let Err(e) = send_result {
-            tracing::warn!(
-                peer_id = %peer_id,
-                error = %e,
-                "Failed to send DocSync response"
-            );
-        } else {
-            tracing::debug!(
-                peer_id = %peer_id,
-                "Sent DocSync response"
-            );
-        }
         Ok(())
     }
 

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -43,7 +43,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let mut results: Vec<DocSyncItem> = Vec::new();
         for doc_id in &request.doc_ids {
             tracing::trace!(doc_id = %doc_id, "Looking up heads for document");
-            match self.head_provider.get_document_heads(doc_id).await {
+            match self
+                .subscriptions
+                .head_provider
+                .get_document_heads(doc_id)
+                .await
+            {
                 Ok(heads) => {
                     tracing::debug!(
                         doc_id = %doc_id,
@@ -75,7 +80,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         let mut reply = DocSyncReply::success(&request.metadata.message_id, results);
 
-        if let Err(e) = sign_with_transport(&self.transport, &mut reply) {
+        if let Err(e) = sign_with_transport(&self.runtime.transport, &mut reply) {
             tracing::error!(
                 peer_id = %peer_id,
                 error = %e,
@@ -85,11 +90,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         let send_result = if let Some(token) = token {
-            self.transport
+            self.runtime
+                .transport
                 .send_doc_sync_response_token(token, reply)
                 .await
         } else {
-            self.transport.send_doc_sync_response(&peer_id, reply).await
+            self.runtime
+                .transport
+                .send_doc_sync_response(&peer_id, reply)
+                .await
         };
         if let Err(e) = send_result {
             tracing::warn!(
@@ -229,10 +238,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 "Spawning poll-based DAG fetchers for DocSync blocks"
             );
 
-            let transport = self.transport.clone();
+            let transport = self.runtime.transport.clone();
             let blockstore = self.manager.blockstore().clone();
             let event_tx = self.manager.event_sender();
-            let semaphore = self.dag_fetch_semaphore.clone();
+            let semaphore = self.runtime.dag_fetch_semaphore.clone();
 
             for (root_cid, doc_id) in cids_to_fetch {
                 tracing::debug!(

--- a/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
@@ -40,7 +40,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         // Parse CID
         match Cid::try_from(message.cid.as_ref()) {
             Ok(cid) => {
-                self.peer_state
+                self.access
+                    .peer_state
                     .peer_has_cid(propagation_source.as_str(), cid);
             }
             Err(e) => {

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -13,11 +13,136 @@ use super::SyncCoordinator;
 use crate::error::{Error, Result};
 use crate::message::{BranchableSyncReply, DocSyncReply, PushLogReply};
 use crate::signing::sign_with_transport;
-use crate::transport::{P2PTransport, TransportEvent};
+use crate::transport::{P2PTransport, PeerId, ResponseToken, TransportEvent};
 
 const RATE_LIMITED_MSG: &str = "rate limited: too many requests, retry later";
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    fn rate_limited_error(peer_id: &PeerId) -> Error {
+        Error::AccessDenied {
+            peer_id: peer_id.to_string(),
+            collection_id: "rate-limited".into(),
+        }
+    }
+
+    async fn reject_rate_limited_pushlog(
+        &self,
+        peer_id: &PeerId,
+        message_id: &str,
+        token: ResponseToken,
+    ) -> Error {
+        tracing::debug!(
+            peer_id = %peer_id,
+            "Rate limit exceeded for PushLogRequest, sending backpressure reply"
+        );
+        let reply = PushLogReply::error(message_id, RATE_LIMITED_MSG);
+        let _ = self
+            .runtime
+            .transport
+            .send_pushlog_response(token, reply)
+            .await;
+        Self::rate_limited_error(peer_id)
+    }
+
+    async fn reject_rate_limited_two_stream(
+        &self,
+        peer_id: &PeerId,
+        message_id: &str,
+        token: Option<ResponseToken>,
+    ) -> Error {
+        tracing::debug!(
+            peer_id = %peer_id,
+            "Rate limit exceeded for TwoStreamRequest, sending backpressure reply"
+        );
+        let mut reply = PushLogReply::error(message_id, RATE_LIMITED_MSG);
+        let _ = sign_with_transport(&self.runtime.transport, &mut reply);
+        self.send_two_stream_reply(peer_id, reply, token).await;
+        Self::rate_limited_error(peer_id)
+    }
+
+    async fn reject_rate_limited_doc_sync(
+        &self,
+        peer_id: &PeerId,
+        message_id: &str,
+        token: Option<ResponseToken>,
+    ) -> Error {
+        tracing::debug!(
+            peer_id = %peer_id,
+            "Rate limit exceeded for DocSyncRequest, sending backpressure reply"
+        );
+        let reply = DocSyncReply::error(message_id, RATE_LIMITED_MSG);
+        if let Some(token) = token {
+            let _ = self
+                .runtime
+                .transport
+                .send_doc_sync_response_token(token, reply)
+                .await;
+        } else {
+            let _ = self
+                .runtime
+                .transport
+                .send_doc_sync_response(peer_id, reply)
+                .await;
+        }
+        Self::rate_limited_error(peer_id)
+    }
+
+    async fn reject_rate_limited_branchable_sync(
+        &self,
+        peer_id: &PeerId,
+        message_id: &str,
+        collection_id: &str,
+        token: Option<ResponseToken>,
+    ) -> Error {
+        tracing::debug!(
+            peer_id = %peer_id,
+            "Rate limit exceeded for BranchableSyncRequest, sending backpressure reply"
+        );
+        let reply = BranchableSyncReply::error(message_id, collection_id, RATE_LIMITED_MSG);
+        if let Some(token) = token {
+            let _ = self
+                .runtime
+                .transport
+                .send_branchable_sync_response_token(token, reply)
+                .await;
+        } else {
+            let _ = self
+                .runtime
+                .transport
+                .send_branchable_sync_response(peer_id, reply)
+                .await;
+        }
+        Self::rate_limited_error(peer_id)
+    }
+
+    async fn reject_rate_limited_car_fetch(
+        &self,
+        peer_id: &PeerId,
+        token: Option<ResponseToken>,
+    ) -> Error {
+        tracing::debug!(
+            peer_id = %peer_id,
+            "Rate limit exceeded for CarFetchRequest, sending empty backpressure reply"
+        );
+        // CAR has no error reply type — send empty response so the
+        // sender sees an explicit (parseable) rejection rather than
+        // a hung stream / timeout.
+        if let Some(token) = token {
+            let _ = self
+                .runtime
+                .transport
+                .send_car_response_token(token, Vec::new())
+                .await;
+        } else {
+            let _ = self
+                .runtime
+                .transport
+                .send_car_response(peer_id, Vec::new())
+                .await;
+        }
+        Self::rate_limited_error(peer_id)
+    }
+
     /// Handle an event from the transport layer.
     ///
     /// This should be called from the event loop that processes TransportEvents.
@@ -55,10 +180,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         peer_id = %propagation_source,
                         "Rate limit exceeded for GossipMessage, dropping"
                     );
-                    return Err(Error::AccessDenied {
-                        peer_id: propagation_source.to_string(),
-                        collection_id: "rate-limited".into(),
-                    });
+                    return Err(Self::rate_limited_error(&propagation_source));
                 }
                 self.handle_gossip_message(propagation_source, message, topic)
                     .await?;
@@ -69,20 +191,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 token,
             } => {
                 if !self.runtime.rate_limiter.check(&peer_id) {
-                    tracing::debug!(
-                        peer_id = %peer_id,
-                        "Rate limit exceeded for PushLogRequest, sending backpressure reply"
-                    );
-                    let reply = PushLogReply::error(&request.metadata.message_id, RATE_LIMITED_MSG);
-                    let _ = self
-                        .runtime
-                        .transport
-                        .send_pushlog_response(token, reply)
-                        .await;
-                    return Err(Error::AccessDenied {
-                        peer_id: peer_id.to_string(),
-                        collection_id: "rate-limited".into(),
-                    });
+                    return Err(self
+                        .reject_rate_limited_pushlog(&peer_id, &request.metadata.message_id, token)
+                        .await);
                 }
                 self.handle_pushlog_request(peer_id, request, token).await?;
             }
@@ -94,18 +205,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 explicit_replay_authorization,
             } => {
                 if !self.runtime.rate_limiter.check(&peer_id) {
-                    tracing::debug!(
-                        peer_id = %peer_id,
-                        "Rate limit exceeded for TwoStreamRequest, sending backpressure reply"
-                    );
-                    let mut reply =
-                        PushLogReply::error(&request.metadata.message_id, RATE_LIMITED_MSG);
-                    let _ = sign_with_transport(&self.runtime.transport, &mut reply);
-                    self.send_two_stream_reply(&peer_id, reply, token).await;
-                    return Err(Error::AccessDenied {
-                        peer_id: peer_id.to_string(),
-                        collection_id: "rate-limited".into(),
-                    });
+                    return Err(self
+                        .reject_rate_limited_two_stream(
+                            &peer_id,
+                            &request.metadata.message_id,
+                            token,
+                        )
+                        .await);
                 }
                 self.handle_two_stream_request(
                     peer_id,
@@ -138,28 +244,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 token,
             } => {
                 if !self.runtime.rate_limiter.check(&peer_id) {
-                    tracing::debug!(
-                        peer_id = %peer_id,
-                        "Rate limit exceeded for DocSyncRequest, sending backpressure reply"
-                    );
-                    let reply = DocSyncReply::error(&request.metadata.message_id, RATE_LIMITED_MSG);
-                    if let Some(token) = token {
-                        let _ = self
-                            .runtime
-                            .transport
-                            .send_doc_sync_response_token(token, reply)
-                            .await;
-                    } else {
-                        let _ = self
-                            .runtime
-                            .transport
-                            .send_doc_sync_response(&peer_id, reply)
-                            .await;
-                    }
-                    return Err(Error::AccessDenied {
-                        peer_id: peer_id.to_string(),
-                        collection_id: "rate-limited".into(),
-                    });
+                    return Err(self
+                        .reject_rate_limited_doc_sync(&peer_id, &request.metadata.message_id, token)
+                        .await);
                 }
                 self.handle_doc_sync_request(peer_id, request, token)
                     .await?;
@@ -173,32 +260,14 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 token,
             } => {
                 if !self.runtime.rate_limiter.check(&peer_id) {
-                    tracing::debug!(
-                        peer_id = %peer_id,
-                        "Rate limit exceeded for BranchableSyncRequest, sending backpressure reply"
-                    );
-                    let reply = BranchableSyncReply::error(
-                        &request.metadata.message_id,
-                        &request.collection_id,
-                        RATE_LIMITED_MSG,
-                    );
-                    if let Some(token) = token {
-                        let _ = self
-                            .runtime
-                            .transport
-                            .send_branchable_sync_response_token(token, reply)
-                            .await;
-                    } else {
-                        let _ = self
-                            .runtime
-                            .transport
-                            .send_branchable_sync_response(&peer_id, reply)
-                            .await;
-                    }
-                    return Err(Error::AccessDenied {
-                        peer_id: peer_id.to_string(),
-                        collection_id: "rate-limited".into(),
-                    });
+                    return Err(self
+                        .reject_rate_limited_branchable_sync(
+                            &peer_id,
+                            &request.metadata.message_id,
+                            &request.collection_id,
+                            token,
+                        )
+                        .await);
                 }
                 self.handle_branchable_sync_request(peer_id, request, token)
                     .await?;
@@ -212,30 +281,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 token,
             } => {
                 if !self.runtime.rate_limiter.check(&peer_id) {
-                    tracing::debug!(
-                        peer_id = %peer_id,
-                        "Rate limit exceeded for CarFetchRequest, sending empty backpressure reply"
-                    );
-                    // CAR has no error reply type — send empty response so the
-                    // sender sees an explicit (parseable) rejection rather than
-                    // a hung stream / timeout.
-                    if let Some(token) = token {
-                        let _ = self
-                            .runtime
-                            .transport
-                            .send_car_response_token(token, Vec::new())
-                            .await;
-                    } else {
-                        let _ = self
-                            .runtime
-                            .transport
-                            .send_car_response(&peer_id, Vec::new())
-                            .await;
-                    }
-                    return Err(Error::AccessDenied {
-                        peer_id: peer_id.to_string(),
-                        collection_id: "rate-limited".into(),
-                    });
+                    return Err(self.reject_rate_limited_car_fetch(&peer_id, token).await);
                 }
                 self.handle_car_fetch_request(peer_id, request, token)
                     .await?;

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -25,20 +25,24 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         match event {
             TransportEvent::PeerConnected(peer_id) => {
                 tracing::debug!(peer_id = %peer_id, "Peer connected");
-                self.peer_state.peer_connected(peer_id.as_str());
+                self.access.peer_state.peer_connected(peer_id.as_str());
             }
             TransportEvent::PeerDisconnected(peer_id) => {
                 tracing::debug!(peer_id = %peer_id, "Peer disconnected");
-                self.peer_state.peer_disconnected(peer_id.as_str());
-                self.rate_limiter.remove_peer(&peer_id);
+                self.access.peer_state.peer_disconnected(peer_id.as_str());
+                self.runtime.rate_limiter.remove_peer(&peer_id);
             }
             TransportEvent::PeerSubscribed { peer_id, topic } => {
                 tracing::debug!(peer_id = %peer_id, topic = %topic, "Peer subscribed to topic");
-                self.peer_state.peer_subscribed(peer_id.as_str(), topic);
+                self.access
+                    .peer_state
+                    .peer_subscribed(peer_id.as_str(), topic);
             }
             TransportEvent::PeerUnsubscribed { peer_id, topic } => {
                 tracing::debug!(peer_id = %peer_id, topic = %topic, "Peer unsubscribed from topic");
-                self.peer_state.peer_unsubscribed(peer_id.as_str(), &topic);
+                self.access
+                    .peer_state
+                    .peer_unsubscribed(peer_id.as_str(), &topic);
             }
             TransportEvent::GossipMessage {
                 propagation_source,
@@ -46,7 +50,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 topic,
                 ..
             } => {
-                if !self.rate_limiter.check(&propagation_source) {
+                if !self.runtime.rate_limiter.check(&propagation_source) {
                     tracing::debug!(
                         peer_id = %propagation_source,
                         "Rate limit exceeded for GossipMessage, dropping"
@@ -64,13 +68,17 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if !self.rate_limiter.check(&peer_id) {
+                if !self.runtime.rate_limiter.check(&peer_id) {
                     tracing::debug!(
                         peer_id = %peer_id,
                         "Rate limit exceeded for PushLogRequest, sending backpressure reply"
                     );
                     let reply = PushLogReply::error(&request.metadata.message_id, RATE_LIMITED_MSG);
-                    let _ = self.transport.send_pushlog_response(token, reply).await;
+                    let _ = self
+                        .runtime
+                        .transport
+                        .send_pushlog_response(token, reply)
+                        .await;
                     return Err(Error::AccessDenied {
                         peer_id: peer_id.to_string(),
                         collection_id: "rate-limited".into(),
@@ -85,14 +93,14 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 is_explicit_replicator,
                 explicit_replay_authorization,
             } => {
-                if !self.rate_limiter.check(&peer_id) {
+                if !self.runtime.rate_limiter.check(&peer_id) {
                     tracing::debug!(
                         peer_id = %peer_id,
                         "Rate limit exceeded for TwoStreamRequest, sending backpressure reply"
                     );
                     let mut reply =
                         PushLogReply::error(&request.metadata.message_id, RATE_LIMITED_MSG);
-                    let _ = sign_with_transport(&self.transport, &mut reply);
+                    let _ = sign_with_transport(&self.runtime.transport, &mut reply);
                     self.send_two_stream_reply(&peer_id, reply, token).await;
                     return Err(Error::AccessDenied {
                         peer_id: peer_id.to_string(),
@@ -129,7 +137,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if !self.rate_limiter.check(&peer_id) {
+                if !self.runtime.rate_limiter.check(&peer_id) {
                     tracing::debug!(
                         peer_id = %peer_id,
                         "Rate limit exceeded for DocSyncRequest, sending backpressure reply"
@@ -137,11 +145,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     let reply = DocSyncReply::error(&request.metadata.message_id, RATE_LIMITED_MSG);
                     if let Some(token) = token {
                         let _ = self
+                            .runtime
                             .transport
                             .send_doc_sync_response_token(token, reply)
                             .await;
                     } else {
-                        let _ = self.transport.send_doc_sync_response(&peer_id, reply).await;
+                        let _ = self
+                            .runtime
+                            .transport
+                            .send_doc_sync_response(&peer_id, reply)
+                            .await;
                     }
                     return Err(Error::AccessDenied {
                         peer_id: peer_id.to_string(),
@@ -159,7 +172,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if !self.rate_limiter.check(&peer_id) {
+                if !self.runtime.rate_limiter.check(&peer_id) {
                     tracing::debug!(
                         peer_id = %peer_id,
                         "Rate limit exceeded for BranchableSyncRequest, sending backpressure reply"
@@ -171,11 +184,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     );
                     if let Some(token) = token {
                         let _ = self
+                            .runtime
                             .transport
                             .send_branchable_sync_response_token(token, reply)
                             .await;
                     } else {
                         let _ = self
+                            .runtime
                             .transport
                             .send_branchable_sync_response(&peer_id, reply)
                             .await;
@@ -196,7 +211,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if !self.rate_limiter.check(&peer_id) {
+                if !self.runtime.rate_limiter.check(&peer_id) {
                     tracing::debug!(
                         peer_id = %peer_id,
                         "Rate limit exceeded for CarFetchRequest, sending empty backpressure reply"
@@ -206,11 +221,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     // a hung stream / timeout.
                     if let Some(token) = token {
                         let _ = self
+                            .runtime
                             .transport
                             .send_car_response_token(token, Vec::new())
                             .await;
                     } else {
-                        let _ = self.transport.send_car_response(&peer_id, Vec::new()).await;
+                        let _ = self
+                            .runtime
+                            .transport
+                            .send_car_response(&peer_id, Vec::new())
+                            .await;
                     }
                     return Err(Error::AccessDenied {
                         peer_id: peer_id.to_string(),

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -18,6 +18,31 @@ use crate::transport::{P2PTransport, PeerId, ResponseToken, TransportEvent};
 const RATE_LIMITED_MSG: &str = "rate limited: too many requests, retry later";
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    fn handle_peer_connected(&self, peer_id: PeerId) {
+        tracing::debug!(peer_id = %peer_id, "Peer connected");
+        self.access.peer_state.peer_connected(peer_id.as_str());
+    }
+
+    fn handle_peer_disconnected(&self, peer_id: PeerId) {
+        tracing::debug!(peer_id = %peer_id, "Peer disconnected");
+        self.access.peer_state.peer_disconnected(peer_id.as_str());
+        self.runtime.rate_limiter.remove_peer(&peer_id);
+    }
+
+    fn handle_peer_subscribed(&self, peer_id: PeerId, topic: String) {
+        tracing::debug!(peer_id = %peer_id, topic = %topic, "Peer subscribed to topic");
+        self.access
+            .peer_state
+            .peer_subscribed(peer_id.as_str(), topic);
+    }
+
+    fn handle_peer_unsubscribed(&self, peer_id: PeerId, topic: String) {
+        tracing::debug!(peer_id = %peer_id, topic = %topic, "Peer unsubscribed from topic");
+        self.access
+            .peer_state
+            .peer_unsubscribed(peer_id.as_str(), &topic);
+    }
+
     fn rate_limited_error(peer_id: &PeerId) -> Error {
         Error::AccessDenied {
             peer_id: peer_id.to_string(),
@@ -149,25 +174,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     pub async fn handle_transport_event(&self, event: TransportEvent) -> Result<()> {
         match event {
             TransportEvent::PeerConnected(peer_id) => {
-                tracing::debug!(peer_id = %peer_id, "Peer connected");
-                self.access.peer_state.peer_connected(peer_id.as_str());
+                self.handle_peer_connected(peer_id);
             }
             TransportEvent::PeerDisconnected(peer_id) => {
-                tracing::debug!(peer_id = %peer_id, "Peer disconnected");
-                self.access.peer_state.peer_disconnected(peer_id.as_str());
-                self.runtime.rate_limiter.remove_peer(&peer_id);
+                self.handle_peer_disconnected(peer_id);
             }
             TransportEvent::PeerSubscribed { peer_id, topic } => {
-                tracing::debug!(peer_id = %peer_id, topic = %topic, "Peer subscribed to topic");
-                self.access
-                    .peer_state
-                    .peer_subscribed(peer_id.as_str(), topic);
+                self.handle_peer_subscribed(peer_id, topic);
             }
             TransportEvent::PeerUnsubscribed { peer_id, topic } => {
-                tracing::debug!(peer_id = %peer_id, topic = %topic, "Peer unsubscribed from topic");
-                self.access
-                    .peer_state
-                    .peer_unsubscribed(peer_id.as_str(), &topic);
+                self.handle_peer_unsubscribed(peer_id, topic);
             }
             TransportEvent::GossipMessage {
                 propagation_source,

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -42,7 +42,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     request.collection_id
                 ),
             );
-            if let Err(send_err) = self.transport.send_pushlog_response(token, reply).await {
+            if let Err(send_err) = self
+                .runtime
+                .transport
+                .send_pushlog_response(token, reply)
+                .await
+            {
                 tracing::warn!(
                     peer_id = %peer_id,
                     error = %send_err,
@@ -58,7 +63,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         // Parse CID - if invalid, send error response
         let cid = match Cid::try_from(request.cid.as_ref()) {
             Ok(cid) => {
-                self.peer_state.peer_has_cid(peer_id.as_str(), cid);
+                self.access.peer_state.peer_has_cid(peer_id.as_str(), cid);
                 cid
             }
             Err(e) => {
@@ -70,7 +75,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     "Failed to parse CID from PushLog request - sending error response"
                 );
                 let reply = PushLogReply::error(&request.metadata.message_id, &error_msg);
-                if let Err(send_err) = self.transport.send_pushlog_response(token, reply).await {
+                if let Err(send_err) = self
+                    .runtime
+                    .transport
+                    .send_pushlog_response(token, reply)
+                    .await
+                {
                     tracing::warn!(
                         peer_id = %peer_id,
                         error = %send_err,
@@ -110,7 +120,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             Err(e) => PushLogReply::error(&request.metadata.message_id, &e.to_string()),
         };
 
-        if let Err(e) = self.transport.send_pushlog_response(token, reply).await {
+        if let Err(e) = self
+            .runtime
+            .transport
+            .send_pushlog_response(token, reply)
+            .await
+        {
             tracing::warn!(
                 peer_id = %peer_id,
                 doc_id = %request.doc_id,
@@ -162,7 +177,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     request.collection_id
                 ),
             );
-            if let Err(sign_err) = sign_with_transport(&self.transport, &mut reply) {
+            if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
                 tracing::error!(error = %sign_err, "Failed to sign access denied response");
             }
             self.send_two_stream_reply(&peer_id, reply, token).await;
@@ -172,7 +187,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         // Parse CID
         let cid = match Cid::try_from(request.cid.as_ref()) {
             Ok(cid) => {
-                self.peer_state.peer_has_cid(peer_id.as_str(), cid);
+                self.access.peer_state.peer_has_cid(peer_id.as_str(), cid);
                 cid
             }
             Err(e) => {
@@ -184,7 +199,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     "Failed to parse CID from two-stream request - sending error response"
                 );
                 let mut reply = PushLogReply::error(&request.metadata.message_id, &error_msg);
-                if let Err(sign_err) = sign_with_transport(&self.transport, &mut reply) {
+                if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
                     tracing::error!(error = %sign_err, "Failed to sign invalid CID response");
                 }
                 self.send_two_stream_reply(&peer_id, reply, token).await;
@@ -210,7 +225,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             Err(e) => PushLogReply::error(&request.metadata.message_id, &e.to_string()),
         };
 
-        if let Err(e) = sign_with_transport(&self.transport, &mut reply) {
+        if let Err(e) = sign_with_transport(&self.runtime.transport, &mut reply) {
             tracing::error!(
                 peer_id = %peer_id,
                 error = %e,
@@ -233,7 +248,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         token: Option<ResponseToken>,
     ) {
         if let Some(token) = token {
-            if let Err(e) = self.transport.send_pushlog_response(token, reply).await {
+            if let Err(e) = self
+                .runtime
+                .transport
+                .send_pushlog_response(token, reply)
+                .await
+            {
                 tracing::warn!(
                     peer_id = %peer_id,
                     error = %e,
@@ -241,6 +261,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 );
             }
         } else if let Err(e) = self
+            .runtime
             .transport
             .send_two_stream_response(peer_id, reply)
             .await

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -83,40 +83,13 @@ pub struct PushFailure {
     pub collection_id: String,
 }
 
-/// Coordinator for P2P synchronization.
-///
-/// This is the main integration point between the P2P layer and the database.
-/// Generic over `T: P2PTransport` to support different transport backends.
-pub struct SyncCoordinator<B: Blockstore, T: P2PTransport> {
-    /// Transport for sending responses and managing connections
+/// Runtime services and async limits used by coordinator handlers.
+pub(super) struct SyncRuntime<T: P2PTransport> {
+    /// Transport for sending responses and managing connections.
     pub(super) transport: T,
 
-    /// Broadcaster for publishing updates
+    /// Broadcaster for publishing updates.
     pub(super) broadcaster: Broadcaster<T>,
-
-    /// Sync manager for block storage
-    pub(super) manager: SyncManager<B>,
-
-    /// Peer state tracker
-    pub(super) peer_state: Arc<PeerStateTracker>,
-
-    /// Local peer ID (for creator field in broadcasts)
-    pub(super) local_peer_id: String,
-
-    /// Access control mode
-    pub(super) access_mode: AccessMode,
-
-    /// Replicator registry for access control checks
-    pub(super) replicators: Arc<ReplicatorRegistry>,
-
-    /// Set of subscribed collection IDs for P2P sync (in-memory cache)
-    pub(super) subscribed_collections: Arc<tokio::sync::RwLock<std::collections::HashSet<String>>>,
-
-    /// Persistent storage for P2P collection subscriptions
-    pub(super) collection_store: Arc<dyn P2PCollectionStorage>,
-
-    /// Document head provider for DocSync responses
-    pub(super) head_provider: Arc<dyn DocumentHeadProvider>,
 
     /// Channel for reporting push failures to the FFI layer for retry tracking.
     pub(super) failure_tx: Option<tokio::sync::mpsc::Sender<PushFailure>>,
@@ -129,6 +102,51 @@ pub struct SyncCoordinator<B: Blockstore, T: P2PTransport> {
 
     /// Per-peer rate limiter applied at event dispatch to throttle abusive peers.
     pub(super) rate_limiter: Arc<PeerRateLimiter>,
+}
+
+/// Access control and peer identity state for the coordinator.
+pub(super) struct SyncAccessState {
+    /// Peer state tracker.
+    pub(super) peer_state: Arc<PeerStateTracker>,
+
+    /// Local peer ID (for creator field in broadcasts).
+    pub(super) local_peer_id: String,
+
+    /// Access control mode.
+    pub(super) access_mode: AccessMode,
+
+    /// Replicator registry for access control checks.
+    pub(super) replicators: Arc<ReplicatorRegistry>,
+}
+
+/// Subscription and document head support state for the coordinator.
+pub(super) struct SyncSubscriptionState {
+    /// Set of subscribed collection IDs for P2P sync (in-memory cache).
+    pub(super) subscribed_collections: Arc<tokio::sync::RwLock<std::collections::HashSet<String>>>,
+
+    /// Persistent storage for P2P collection subscriptions.
+    pub(super) collection_store: Arc<dyn P2PCollectionStorage>,
+
+    /// Document head provider for DocSync responses.
+    pub(super) head_provider: Arc<dyn DocumentHeadProvider>,
+}
+
+/// Coordinator for P2P synchronization.
+///
+/// This is the main integration point between the P2P layer and the database.
+/// Generic over `T: P2PTransport` to support different transport backends.
+pub struct SyncCoordinator<B: Blockstore, T: P2PTransport> {
+    /// Runtime services and async coordination primitives.
+    pub(super) runtime: SyncRuntime<T>,
+
+    /// Sync manager for block storage.
+    pub(super) manager: SyncManager<B>,
+
+    /// Access control and peer identity state.
+    pub(super) access: SyncAccessState,
+
+    /// Subscription and doc-sync support state.
+    pub(super) subscriptions: SyncSubscriptionState,
 }
 
 /// Type alias for SyncCoordinator using the libp2p transport.

--- a/crates/p2p/src/sync/coordinator/replicators.rs
+++ b/crates/p2p/src/sync/coordinator/replicators.rs
@@ -16,7 +16,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collections: Vec<String>,
         auto_subscribe: bool,
     ) -> Result<CreateReplicatorResult> {
-        self.transport
+        self.runtime
+            .transport
             .create_replicator(peer_id, collections.clone())
             .await?;
 
@@ -65,12 +66,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Delete a replicator.
     pub async fn delete_replicator(&self, peer_id: &PeerId) -> Result<()> {
-        let removed_collections = match self.transport.get_replicator(peer_id).await? {
+        let removed_collections = match self.runtime.transport.get_replicator(peer_id).await? {
             Some(info) => info.collections,
             None => Vec::new(),
         };
 
-        self.transport.delete_replicator(peer_id).await?;
+        self.runtime.transport.delete_replicator(peer_id).await?;
         tracing::info!(peer_id = %peer_id, "Deleted replicator");
 
         self.unsubscribe_orphaned_collections(&removed_collections)
@@ -86,12 +87,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collections: Vec<String>,
     ) -> Result<bool> {
         if collections.is_empty() {
-            let removed_collections = match self.transport.get_replicator(peer_id).await? {
+            let removed_collections = match self.runtime.transport.get_replicator(peer_id).await? {
                 Some(info) => info.collections,
                 None => Vec::new(),
             };
 
-            self.transport.delete_replicator(peer_id).await?;
+            self.runtime.transport.delete_replicator(peer_id).await?;
             tracing::info!(peer_id = %peer_id, "Deleted replicator (empty collections = delete all)");
 
             self.unsubscribe_orphaned_collections(&removed_collections)
@@ -101,6 +102,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         let fully_deleted = self
+            .runtime
             .transport
             .remove_replicator_collections(peer_id, collections.clone())
             .await?;
@@ -127,7 +129,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Unsubscribe from collection topics that no longer have any replicators.
     async fn unsubscribe_orphaned_collections(&self, collections: &[String]) {
         for collection_id in collections {
-            let remaining = match self.transport.list_replicators().await {
+            let remaining = match self.runtime.transport.list_replicators().await {
                 Ok(reps) => reps.iter().any(|r| r.collections.contains(collection_id)),
                 Err(e) => {
                     tracing::warn!(
@@ -154,12 +156,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Get all registered replicators.
     pub async fn list_replicators(&self) -> Result<Vec<ReplicatorInfo>> {
-        self.transport.list_replicators().await
+        self.runtime.transport.list_replicators().await
     }
 
     /// Get replicator info for a specific peer.
     pub async fn get_replicator(&self, peer_id: &PeerId) -> Result<Option<ReplicatorInfo>> {
-        self.transport.get_replicator(peer_id).await
+        self.runtime.transport.get_replicator(peer_id).await
     }
 
     /// Load replicators from stored ReplicatorInfo records.

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -13,15 +13,22 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Uses a write lock for the entire operation to prevent concurrent
     /// subscribe calls from racing past the contains-check.
     pub async fn subscribe_collection(&self, collection_id: &str) -> Result<bool> {
-        let mut subscribed_collections = self.subscribed_collections.write().await;
+        let mut subscribed_collections = self.subscriptions.subscribed_collections.write().await;
 
         if subscribed_collections.contains(collection_id) {
             return Ok(false);
         }
 
-        self.collection_store.add_collection(collection_id).await?;
+        self.subscriptions
+            .collection_store
+            .add_collection(collection_id)
+            .await?;
 
-        let result = self.broadcaster.subscribe_collection(collection_id).await;
+        let result = self
+            .runtime
+            .broadcaster
+            .subscribe_collection(collection_id)
+            .await;
 
         match result {
             Ok(subscribed) => {
@@ -33,8 +40,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 Ok(subscribed)
             }
             Err(e) => {
-                if let Err(remove_err) =
-                    self.collection_store.remove_collection(collection_id).await
+                if let Err(remove_err) = self
+                    .subscriptions
+                    .collection_store
+                    .remove_collection(collection_id)
+                    .await
                 {
                     tracing::error!(
                         collection_id = %collection_id,
@@ -50,21 +60,24 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Subscribe to a specific document for sync.
     pub async fn subscribe_document(&self, doc_id: &str) -> Result<bool> {
-        self.broadcaster.subscribe_document(doc_id).await
+        self.runtime.broadcaster.subscribe_document(doc_id).await
     }
 
     /// Unsubscribe from a collection.
     pub async fn unsubscribe_collection(&self, collection_id: &str) -> Result<bool> {
         let result = self
+            .runtime
             .broadcaster
             .unsubscribe_collection(collection_id)
             .await?;
         if result {
-            self.collection_store
+            self.subscriptions
+                .collection_store
                 .remove_collection(collection_id)
                 .await?;
 
-            self.subscribed_collections
+            self.subscriptions
+                .subscribed_collections
                 .write()
                 .await
                 .remove(collection_id);
@@ -76,18 +89,22 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Unsubscribe from a document.
     pub async fn unsubscribe_document(&self, doc_id: &str) -> Result<bool> {
-        self.broadcaster.unsubscribe_document(doc_id).await
+        self.runtime.broadcaster.unsubscribe_document(doc_id).await
     }
 
     /// Get the list of subscribed collection IDs.
     pub async fn get_subscribed_collections(&self) -> Result<Vec<String>> {
-        let collections = self.subscribed_collections.read().await;
+        let collections = self.subscriptions.subscribed_collections.read().await;
         Ok(collections.iter().cloned().collect())
     }
 
     /// Load and subscribe to all persisted P2P collections.
     pub async fn load_p2p_collections(&self) -> Result<usize> {
-        let collections = self.collection_store.get_all_collections().await?;
+        let collections = self
+            .subscriptions
+            .collection_store
+            .get_all_collections()
+            .await?;
         let count = collections.len();
 
         if count == 0 {
@@ -99,9 +116,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         let mut loaded = 0;
         for collection_id in collections {
-            match self.broadcaster.subscribe_collection(&collection_id).await {
+            match self
+                .runtime
+                .broadcaster
+                .subscribe_collection(&collection_id)
+                .await
+            {
                 Ok(true) => {
-                    self.subscribed_collections
+                    self.subscriptions
+                        .subscribed_collections
                         .write()
                         .await
                         .insert(collection_id.clone());
@@ -109,7 +132,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     tracing::debug!(collection_id = %collection_id, "Loaded P2P collection subscription");
                 }
                 Ok(false) => {
-                    self.subscribed_collections
+                    self.subscriptions
+                        .subscribed_collections
                         .write()
                         .await
                         .insert(collection_id.clone());


### PR DESCRIPTION
## Summary
- extract `SyncRuntime`, `SyncAccessState`, and `SyncSubscriptionState` from `SyncCoordinator`
- keep `SyncManager` separate while shrinking the coordinator's top-level field surface
- rewire coordinator handlers, subscriptions, replicator management, and tests to the bundled state
- extract repeated coordinator helper paths in smaller follow-up slices:
  - rate-limit reply helpers
  - peer event helpers
  - sync reply send helpers
  - broadcast push helpers

## Testing
- `cargo test -p p2p sync::coordinator::access_tests -- --nocapture`
- `cargo test -p p2p sync::coordinator -- --nocapture`

## Follow-up
This PR gets issue #671 to a reasonable reviewable point without drifting into a broader architectural rewrite.

If someone wants to continue after this lands, the remaining likely follow-ups are:
- consolidate the repeated DAG-fetch spawn setup shared by `DocSync` and `BranchableSync`
- decide whether more transport/reply plumbing should move behind an internal runtime API instead of remaining as coordinator methods

Those are intentionally left out here because they are less obviously small and would benefit from a fresh review pass before further refactoring.

Refs #671
