### PR TITLE
refactor(db): share auto-commit mutation lifecycle

### DIFF
--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -9,14 +9,16 @@ use query::mutator::{
 use std::collections::HashSet;
 use std::sync::Arc;
 use storage::corekv::Store;
-use tracing::warn;
 
-use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
-use crate::collection::collection_short_id;
+use super::helpers::{
+    blockstore_for_txn, commit_txn, create_result_from_commit, delete_result_from_commit,
+    headstore_for_txn, map_create_error, map_delete_error, map_update_error,
+    update_result_from_commit, write_delete_commit_result, write_document_commit_result,
+};
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
 use crate::txn::DbTxn;
-use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
+use defra_core::encryption::{get_doc_encryption, get_encryption_config};
 use defra_core::signing::get_signing_config;
 
 struct PendingUpdateEvent {
@@ -46,9 +48,7 @@ impl<S: Store> BatchMutator<S> {
         let txn = txn.as_ref().ok_or_else(|| {
             query::error::QueryError::execution("mutation batch transaction is no longer active")
         })?;
-        txn.blockstore().map_err(|e| {
-            query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
-        })
+        blockstore_for_txn(txn)
     }
 
     async fn headstore(&self) -> query::error::Result<datastore::NamespaceView> {
@@ -56,9 +56,7 @@ impl<S: Store> BatchMutator<S> {
         let txn = txn.as_ref().ok_or_else(|| {
             query::error::QueryError::execution("mutation batch transaction is no longer active")
         })?;
-        txn.headstore().map_err(|e| {
-            query::error::QueryError::execution(format!("failed to get headstore: {}", e))
-        })
+        headstore_for_txn(txn)
     }
 
     async fn take_txn(&self) -> query::error::Result<DbTxn<S>> {
@@ -115,12 +113,9 @@ impl<S: Store + 'static> MutationBatchController for BatchMutator<S> {
     async fn commit(&self) -> query::error::Result<()> {
         let txn = self.take_txn().await?;
 
-        if let Err(e) = txn.commit().await {
+        if let Err(e) = commit_txn(txn, "mutation batch", "batch commit").await {
             self.pending_events.lock().await.clear();
-            return Err(query::error::QueryError::execution(format!(
-                "commit error: {}",
-                e
-            )));
+            return Err(e);
         }
 
         let pending_events = std::mem::take(&mut *self.pending_events.lock().await);
@@ -182,19 +177,8 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         collection
             .create_with_indexes(&datastore, &doc, &index_manager, id_was_generated)
             .await
-            .map_err(|e| {
-                let msg = e.to_string();
-                if msg.contains("can not index a doc's field(s) that violates unique index") {
-                    query::error::QueryError::execution(
-                        "can not index a doc's field(s) that violates unique index.".to_string(),
-                    )
-                } else {
-                    query::error::QueryError::execution(format!("create error: {}", e))
-                }
-            })?;
+            .map_err(map_create_error)?;
 
-        let short_id = collection_short_id(collection.collection_id());
-        let schema_version_id = collection.version_id();
         let enc_config = get_encryption_config();
         let sign_config = get_signing_config();
 
@@ -202,58 +186,19 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             let blockstore = self.blockstore().await?;
             let headstore = self.headstore().await?;
 
-            match write_document_blocks(
+            write_document_commit_result(
+                collection_name,
+                "create",
+                &collection,
                 &blockstore,
                 &headstore,
                 &doc,
-                schema_version_id,
                 None,
                 enc_config.as_ref(),
                 sign_config.as_ref(),
+                true,
             )
             .await
-            {
-                Ok(block_result) => {
-                    if let Some(ref config) = enc_config {
-                        store_doc_encryption(&doc_id.to_string(), config.clone());
-                    }
-
-                    let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                    if collection.schema().is_branchable {
-                        match write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            block_result.cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        {
-                            Ok((col_cid, col_bytes)) => {
-                                col_block_data = Some((col_cid, col_bytes));
-                            }
-                            Err(e) => {
-                                warn!(
-                                    collection = %collection_name,
-                                    error = %e,
-                                    "Failed to write collection block for branchable create"
-                                );
-                            }
-                        }
-                    }
-
-                    Some((block_result.cid, block_result.block, col_block_data))
-                }
-                Err(e) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to write document blocks - commits queries may not work"
-                    );
-                    None
-                }
-            }
         };
 
         let cid = commit_result
@@ -268,17 +213,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         )
         .await;
 
-        match commit_result {
-            Some((cid, block, col_data)) => {
-                let mut result = CreateResult::with_commit(doc_id, doc, cid, block);
-                if let Some((col_cid, col_bytes)) = col_data {
-                    result.broadcast_cid = Some(col_cid);
-                    result.broadcast_block = Some(col_bytes);
-                }
-                Ok(result)
-            }
-            None => Ok(CreateResult::new(doc_id, doc)),
-        }
+        Ok(create_result_from_commit(doc_id, doc, commit_result))
     }
 
     async fn update(
@@ -318,25 +253,8 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         collection
             .update_with_indexes(&datastore, &doc, &index_manager)
             .await
-            .map_err(|e| match e {
-                crate::error::Error::DocumentNotFound(id) => {
-                    query::error::QueryError::document_not_found(id)
-                }
-                other => {
-                    let msg = other.to_string();
-                    if msg.contains("can not index a doc's field(s) that violates unique index") {
-                        query::error::QueryError::execution(
-                            "can not index a doc's field(s) that violates unique index."
-                                .to_string(),
-                        )
-                    } else {
-                        query::error::QueryError::execution(format!("update error: {}", other))
-                    }
-                }
-            })?;
+            .map_err(map_update_error)?;
 
-        let short_id = collection_short_id(collection.collection_id());
-        let schema_version_id = collection.version_id();
         let enc_config = get_encryption_config()
             .or_else(|| doc.id().and_then(|id| get_doc_encryption(&id.to_string())));
         let sign_config = get_signing_config();
@@ -345,54 +263,19 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             let blockstore = self.blockstore().await?;
             let headstore = self.headstore().await?;
 
-            match write_document_blocks(
+            write_document_commit_result(
+                collection_name,
+                "update",
+                &collection,
                 &blockstore,
                 &headstore,
                 &doc,
-                schema_version_id,
                 Some(&modified_fields),
                 enc_config.as_ref(),
                 sign_config.as_ref(),
+                false,
             )
             .await
-            {
-                Ok(block_result) => {
-                    let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                    if collection.schema().is_branchable {
-                        match write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            block_result.cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        {
-                            Ok((col_cid, col_bytes)) => {
-                                col_block_data = Some((col_cid, col_bytes));
-                            }
-                            Err(e) => {
-                                warn!(
-                                    collection = %collection_name,
-                                    error = %e,
-                                    "Failed to write collection block for branchable update"
-                                );
-                            }
-                        }
-                    }
-
-                    Some((block_result.cid, block_result.block, col_block_data))
-                }
-                Err(e) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to write document blocks - commits queries may not work"
-                    );
-                    None
-                }
-            }
         };
 
         if let Some(doc_id) = doc.id() {
@@ -410,17 +293,11 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         }
 
         let fields_modified = doc.values().len();
-        match commit_result {
-            Some((cid, block, col_data)) => {
-                let mut result = UpdateResult::with_commit(doc, fields_modified, cid, block);
-                if let Some((col_cid, col_bytes)) = col_data {
-                    result.broadcast_cid = Some(col_cid);
-                    result.broadcast_block = Some(col_bytes);
-                }
-                Ok(result)
-            }
-            None => Ok(UpdateResult::new(doc, fields_modified)),
-        }
+        Ok(update_result_from_commit(
+            doc,
+            fields_modified,
+            commit_result,
+        ))
     }
 
     async fn delete(
@@ -434,59 +311,24 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         let existed = collection
             .delete_with_indexes(&datastore, doc_id, &index_manager)
             .await
-            .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))?;
+            .map_err(map_delete_error)?;
 
-        let short_id = collection_short_id(collection.collection_id());
-        let schema_version_id = collection.version_id();
         let sign_config = get_signing_config();
 
         let commit_result: Option<(Cid, Vec<u8>)> = {
             let blockstore = self.blockstore().await?;
             let headstore = self.headstore().await?;
 
-            match write_delete_block(
+            write_delete_commit_result(
+                collection_name,
+                "delete",
+                &collection,
                 &blockstore,
                 &headstore,
-                &doc_id.to_string(),
-                schema_version_id,
+                doc_id,
                 sign_config.as_ref(),
             )
             .await
-            {
-                Ok(block_result) => {
-                    let composite_cid = block_result.cid;
-
-                    if collection.schema().is_branchable {
-                        if let Err(e) = write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            composite_cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        .map(|_| ())
-                        {
-                            warn!(
-                                collection = %collection_name,
-                                error = %e,
-                                "Failed to write collection block for branchable delete"
-                            );
-                        }
-                    }
-
-                    Some((composite_cid, block_result.block))
-                }
-                Err(e) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to write delete block - commits queries may not work"
-                    );
-                    None
-                }
-            }
         };
 
         let cid = commit_result
@@ -501,15 +343,11 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         )
         .await;
 
-        match commit_result {
-            Some((cid, block)) => Ok(DeleteResult::with_commit(
-                doc_id.clone(),
-                existed,
-                cid,
-                block,
-            )),
-            None => Ok(DeleteResult::new(doc_id.clone(), existed)),
-        }
+        Ok(delete_result_from_commit(
+            doc_id.clone(),
+            existed,
+            commit_result,
+        ))
     }
 
     async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -1,3 +1,7 @@
+use super::helpers::{
+    blockstore_for_txn, commit_txn, create_result_from_commit, discard_txn, headstore_for_txn,
+    map_create_error, write_document_commit_result,
+};
 use super::*;
 
 #[allow(clippy::type_complexity)]
@@ -10,9 +14,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         let collection = self.get_collection_or_err(collection_name)?;
 
         // Create a write transaction
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_write_txn().await?;
 
         // Generate embeddings before doc ID (embedding values affect content hash)
         let embedding_config = self.db.options().embedding_config();
@@ -42,22 +44,10 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
         // Execute the mutation in a block to drop datastore before commit
         let result = {
-            let datastore = txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
+            let datastore = self.datastore_for_collection(&txn, collection_name)?;
 
             // Create an IndexManager for unique constraint enforcement
-            let short_id = collection_short_id(collection.collection_id());
-            let index_manager = IndexManager::from_collection(short_id, collection.schema())
-                .map_err(|e| {
-                    query::error::QueryError::execution(format!(
-                        "failed to create index manager for collection '{}': {}",
-                        collection_name, e
-                    ))
-                })?;
+            let index_manager = self.index_manager_for_collection(&collection, collection_name)?;
 
             self.db
                 .validate_downsample_write(&datastore, collection.schema(), &doc, None)
@@ -69,18 +59,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             collection
                 .create_with_indexes(&datastore, &doc, &index_manager, id_was_generated)
                 .await
-                .map_err(|e| {
-                    let msg = e.to_string();
-                    // If this is a unique constraint violation, return the core message without wrapping
-                    if msg.contains("can not index a doc's field(s) that violates unique index") {
-                        query::error::QueryError::execution(
-                            "can not index a doc's field(s) that violates unique index."
-                                .to_string(),
-                        )
-                    } else {
-                        query::error::QueryError::execution(format!("create error: {}", e))
-                    }
-                })
+                .map_err(map_create_error)
         };
 
         match result {
@@ -90,21 +69,8 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 // The stores must be dropped before commit, so scope them
                 // (composite_cid, composite_bytes, optional (collection_cid, collection_bytes))
                 let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = {
-                    let blockstore = txn.blockstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get blockstore: {}",
-                            e
-                        ))
-                    })?;
-                    let headstore = txn.headstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get headstore: {}",
-                            e
-                        ))
-                    })?;
-
-                    // Use version_id for collectionVersionID (matches Go's VersionID())
-                    let schema_version_id = collection.version_id();
+                    let blockstore = blockstore_for_txn(&txn)?;
+                    let headstore = headstore_for_txn(&txn)?;
 
                     // Get encryption config from thread-local (set by plan nodes)
                     let enc_config = get_encryption_config();
@@ -117,77 +83,23 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     );
 
                     // For create operations, all fields are new - pass None for modified_fields
-                    match write_document_blocks(
+                    write_document_commit_result(
+                        collection_name,
+                        "create",
+                        &collection,
                         &blockstore,
                         &headstore,
                         &doc,
-                        schema_version_id,
                         None,
                         enc_config.as_ref(),
                         sign_config.as_ref(),
+                        true,
                     )
                     .await
-                    {
-                        Ok(block_result) => {
-                            // Store encryption config per-document so updates re-apply it
-                            if let Some(ref config) = enc_config {
-                                store_doc_encryption(&doc_id.to_string(), config.clone());
-                            }
-
-                            // For branchable collections, create a collection-level block
-                            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                            if collection.schema().is_branchable {
-                                let short_id = collection_short_id(collection.collection_id());
-                                match write_collection_block(
-                                    &blockstore,
-                                    &headstore,
-                                    short_id,
-                                    schema_version_id,
-                                    block_result.cid,
-                                    sign_config.as_ref(),
-                                )
-                                .await
-                                {
-                                    Ok((col_cid, col_bytes)) => {
-                                        col_block_data = Some((col_cid, col_bytes));
-                                    }
-                                    Err(e) => {
-                                        warn!(
-                                            collection = %collection_name,
-                                            error = %e,
-                                            "Failed to write collection block for branchable create"
-                                        );
-                                    }
-                                }
-                            }
-
-                            Some((block_result.cid, block_result.block, col_block_data))
-                        }
-                        Err(e) => {
-                            warn!(
-                                collection = %collection_name,
-                                error = %e,
-                                "Failed to write document blocks - commits queries may not work"
-                            );
-                            // Don't fail the mutation, just log the warning
-                            // The document was stored successfully, blocks are for commit history
-                            None
-                        }
-                    }
                 }; // blockstore and headstore dropped here
 
                 // Commit the transaction (all store references now dropped)
-                if let Err(e) = txn.commit().await {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to commit transaction after create"
-                    );
-                    return Err(query::error::QueryError::execution(format!(
-                        "commit error: {}",
-                        e
-                    )));
-                }
+                commit_txn(txn, collection_name, "create").await?;
 
                 // Emit update event for subscriptions
                 let cid = commit_result
@@ -197,27 +109,11 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 self.emit_update_events(&collection, &doc_id.to_string(), cid);
 
                 // Return result with commit CID and block if available
-                match commit_result {
-                    Some((cid, block, col_data)) => {
-                        let mut result = CreateResult::with_commit(doc_id, doc, cid, block);
-                        if let Some((col_cid, col_bytes)) = col_data {
-                            result.broadcast_cid = Some(col_cid);
-                            result.broadcast_block = Some(col_bytes);
-                        }
-                        Ok(result)
-                    }
-                    None => Ok(CreateResult::new(doc_id, doc)),
-                }
+                Ok(create_result_from_commit(doc_id, doc, commit_result))
             }
             Err(e) => {
                 // Discard the transaction on error
-                if let Err(discard_err) = txn.discard() {
-                    warn!(
-                        collection = %collection_name,
-                        error = %discard_err,
-                        "Failed to discard transaction after create error"
-                    );
-                }
+                discard_txn(txn, collection_name, "create");
                 Err(e)
             }
         }

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -1,3 +1,6 @@
+use super::helpers::{
+    blockstore_for_txn, commit_txn, create_result_from_commit, headstore_for_txn, map_create_error,
+};
 use super::*;
 
 use crate::block_builder::{compute_document_blocks, insert_computed_blocks, ComputedBlocks};
@@ -30,13 +33,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         let enc_config = get_encryption_config();
 
         // Build IndexManager once for the entire batch (schema is identical for all docs)
-        let index_manager =
-            IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to create index manager for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
+        let index_manager = self.index_manager_for_collection(&collection, collection_name)?;
 
         // === Phase 1: Prepare documents (sequential — embeddings are async/external) ===
         let mut prepared_docs: Vec<(Document, bool)> = Vec::with_capacity(docs.len());
@@ -116,9 +113,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .collect();
 
         // === Phase 3: Transaction — sequential writes ===
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_write_txn().await?;
 
         let mut results: Vec<(
             DocID,
@@ -135,12 +130,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
             // Datastore + index writes
             {
-                let datastore = txn.datastore().map_err(|e| {
-                    query::error::QueryError::execution(format!(
-                        "failed to get datastore for collection '{}': {}",
-                        collection_name, e
-                    ))
-                })?;
+                let datastore = self.datastore_for_collection(&txn, collection_name)?;
 
                 self.db
                     .validate_downsample_write(&datastore, collection.schema(), &doc, None)
@@ -150,35 +140,14 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 collection
                     .create_with_indexes(&datastore, &doc, &index_manager, id_was_generated)
                     .await
-                    .map_err(|e| {
-                        let msg = e.to_string();
-                        if msg.contains("can not index a doc's field(s) that violates unique index")
-                        {
-                            query::error::QueryError::execution(
-                                "can not index a doc's field(s) that violates unique index."
-                                    .to_string(),
-                            )
-                        } else {
-                            query::error::QueryError::execution(format!("create error: {}", e))
-                        }
-                    })?;
+                    .map_err(map_create_error)?;
             } // datastore dropped
 
             // Insert pre-computed blocks + collection blocks
             let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = match blocks {
                 Some(computed) => {
-                    let blockstore = txn.blockstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get blockstore: {}",
-                            e
-                        ))
-                    })?;
-                    let headstore = txn.headstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get headstore: {}",
-                            e
-                        ))
-                    })?;
+                    let blockstore = blockstore_for_txn(&txn)?;
+                    let headstore = headstore_for_txn(&txn)?;
 
                     match insert_computed_blocks(&blockstore, &headstore, &computed).await {
                         Ok(()) => {
@@ -234,17 +203,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         }
 
         // Commit ONCE for the entire batch
-        if let Err(e) = txn.commit().await {
-            warn!(
-                collection = %collection_name,
-                error = %e,
-                "Failed to commit batch transaction"
-            );
-            return Err(query::error::QueryError::execution(format!(
-                "commit error: {}",
-                e
-            )));
-        }
+        commit_txn(txn, collection_name, "batch").await?;
 
         // Emit events and build results
         let mut create_results = Vec::with_capacity(results.len());
@@ -255,19 +214,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 .unwrap_or_default();
             self.emit_update_events(&collection, &doc_id.to_string(), cid);
 
-            match commit_result {
-                Some((cid, block, col_data)) => {
-                    let mut result = CreateResult::with_commit(doc_id, doc, cid, block);
-                    if let Some((col_cid, col_bytes)) = col_data {
-                        result.broadcast_cid = Some(col_cid);
-                        result.broadcast_block = Some(col_bytes);
-                    }
-                    create_results.push(result);
-                }
-                None => {
-                    create_results.push(CreateResult::new(doc_id, doc));
-                }
-            }
+            create_results.push(create_result_from_commit(doc_id, doc, commit_result));
         }
 
         Ok(create_results)

--- a/crates/db/src/auto_commit_mutator/delete.rs
+++ b/crates/db/src/auto_commit_mutator/delete.rs
@@ -1,3 +1,7 @@
+use super::helpers::{
+    blockstore_for_txn, commit_txn, delete_result_from_commit, discard_txn, headstore_for_txn,
+    map_delete_error, write_delete_commit_result,
+};
 use super::*;
 
 impl<S: Store + 'static> AutoCommitMutator<S> {
@@ -9,141 +13,59 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         let collection = self.get_collection_or_err(collection_name)?;
 
         // Create a write transaction
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_write_txn().await?;
 
         // Execute the mutation in a block to drop datastore before commit
         let result = {
-            let datastore = txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
+            let datastore = self.datastore_for_collection(&txn, collection_name)?;
 
             // Create an IndexManager for index maintenance
-            let short_id = collection_short_id(collection.collection_id());
-            let index_manager = IndexManager::from_collection(short_id, collection.schema())
-                .map_err(|e| {
-                    query::error::QueryError::execution(format!(
-                        "failed to create index manager for collection '{}': {}",
-                        collection_name, e
-                    ))
-                })?;
+            let index_manager = self.index_manager_for_collection(&collection, collection_name)?;
 
             // Use delete_with_indexes to maintain index consistency
             collection
                 .delete_with_indexes(&datastore, doc_id, &index_manager)
                 .await
-                .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))
+                .map_err(map_delete_error)
         };
 
         match result {
             Ok(existed) => {
                 // Build delete block (composite with status=2) in a scoped block
                 let commit_result: Option<(Cid, Vec<u8>)> = {
-                    let blockstore = txn.blockstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get blockstore: {}",
-                            e
-                        ))
-                    })?;
-                    let headstore = txn.headstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get headstore: {}",
-                            e
-                        ))
-                    })?;
-
-                    let schema_version_id = collection.version_id();
-                    let doc_id_str = doc_id.to_string();
+                    let blockstore = blockstore_for_txn(&txn)?;
+                    let headstore = headstore_for_txn(&txn)?;
                     // Get signing config from thread-local (set by FFI exec_request)
                     let sign_config = get_signing_config();
 
-                    match write_delete_block(
+                    write_delete_commit_result(
+                        collection_name,
+                        "delete",
+                        &collection,
                         &blockstore,
                         &headstore,
-                        &doc_id_str,
-                        schema_version_id,
+                        doc_id,
                         sign_config.as_ref(),
                     )
                     .await
-                    {
-                        Ok(block_result) => {
-                            let composite_cid = block_result.cid;
-
-                            // For branchable collections, also create a collection-level block
-                            if collection.schema().is_branchable {
-                                let short_id = collection_short_id(collection.collection_id());
-                                if let Err(e) = write_collection_block(
-                                    &blockstore,
-                                    &headstore,
-                                    short_id,
-                                    schema_version_id,
-                                    composite_cid,
-                                    sign_config.as_ref(),
-                                )
-                                .await
-                                .map(|_| ())
-                                {
-                                    warn!(
-                                        collection = %collection_name,
-                                        error = %e,
-                                        "Failed to write collection block for branchable delete"
-                                    );
-                                }
-                            }
-
-                            Some((composite_cid, block_result.block))
-                        }
-                        Err(e) => {
-                            warn!(
-                                collection = %collection_name,
-                                error = %e,
-                                "Failed to write delete block - commits queries may not work"
-                            );
-                            None
-                        }
-                    }
                 }; // blockstore and headstore dropped here
 
                 // Commit the transaction (datastore reference is now dropped)
-                if let Err(e) = txn.commit().await {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to commit transaction after delete"
-                    );
-                    return Err(query::error::QueryError::execution(format!(
-                        "commit error: {}",
-                        e
-                    )));
-                }
+                commit_txn(txn, collection_name, "delete").await?;
 
                 // Emit update event for subscriptions (deletes are also "updates")
                 let cid = commit_result.as_ref().map(|(c, _)| *c).unwrap_or_default();
                 self.emit_update_events(&collection, &doc_id.to_string(), cid);
 
-                match commit_result {
-                    Some((cid, block)) => Ok(DeleteResult::with_commit(
-                        doc_id.clone(),
-                        existed,
-                        cid,
-                        block,
-                    )),
-                    None => Ok(DeleteResult::new(doc_id.clone(), existed)),
-                }
+                Ok(delete_result_from_commit(
+                    doc_id.clone(),
+                    existed,
+                    commit_result,
+                ))
             }
             Err(e) => {
                 // Discard the transaction on error
-                if let Err(discard_err) = txn.discard() {
-                    warn!(
-                        collection = %collection_name,
-                        error = %discard_err,
-                        "Failed to discard transaction after delete error"
-                    );
-                }
+                discard_txn(txn, collection_name, "delete");
                 Err(e)
             }
         }

--- a/crates/db/src/auto_commit_mutator/delete_many.rs
+++ b/crates/db/src/auto_commit_mutator/delete_many.rs
@@ -1,3 +1,6 @@
+use super::helpers::{
+    blockstore_for_txn, commit_txn, headstore_for_txn, map_delete_error, write_delete_commit_result,
+};
 use super::*;
 
 impl<S: Store + 'static> AutoCommitMutator<S> {
@@ -24,34 +27,19 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         }
 
         let collection = self.get_collection_or_err(collection_name)?;
-        let short_id = collection_short_id(collection.collection_id());
-        let schema_version_id = collection.version_id().to_string();
         let sign_config = get_signing_config();
 
-        let index_manager =
-            IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to create index manager for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
+        let index_manager = self.index_manager_for_collection(&collection, collection_name)?;
 
         // Single transaction for all deletes
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_write_txn().await?;
 
         let mut results: Vec<(DocID, bool, Option<Cid>)> = Vec::with_capacity(doc_ids.len());
 
         for doc_id in doc_ids {
             // Delete from datastore + indexes
             let existed = {
-                let datastore = txn.datastore().map_err(|e| {
-                    query::error::QueryError::execution(format!(
-                        "failed to get datastore for collection '{}': {}",
-                        collection_name, e
-                    ))
-                })?;
+                let datastore = self.datastore_for_collection(&txn, collection_name)?;
 
                 match collection
                     .delete_with_indexes(&datastore, doc_id, &index_manager)
@@ -59,10 +47,11 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 {
                     Ok(existed) => existed,
                     Err(e) => {
+                        let mapped_error = map_delete_error(e);
                         warn!(
                             collection = %collection_name,
                             doc_id = %doc_id,
-                            error = %e,
+                            error = %mapped_error,
                             "Failed to delete document in batch"
                         );
                         results.push((doc_id.clone(), false, None));
@@ -73,55 +62,22 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
             // Write delete block (composite with status=2)
             let commit_cid = {
-                let blockstore = txn.blockstore().map_err(|e| {
-                    query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
-                })?;
-                let headstore = txn.headstore().map_err(|e| {
-                    query::error::QueryError::execution(format!("failed to get headstore: {}", e))
-                })?;
+                let blockstore = blockstore_for_txn(&txn)?;
+                let headstore = headstore_for_txn(&txn)?;
 
-                match write_delete_block(
+                match write_delete_commit_result(
+                    collection_name,
+                    "delete",
+                    &collection,
                     &blockstore,
                     &headstore,
-                    &doc_id.to_string(),
-                    &schema_version_id,
+                    doc_id,
                     sign_config.as_ref(),
                 )
                 .await
                 {
-                    Ok(block_result) => {
-                        let composite_cid = block_result.cid;
-
-                        if collection.schema().is_branchable {
-                            if let Err(e) = write_collection_block(
-                                &blockstore,
-                                &headstore,
-                                short_id,
-                                &schema_version_id,
-                                composite_cid,
-                                sign_config.as_ref(),
-                            )
-                            .await
-                            {
-                                warn!(
-                                    collection = %collection_name,
-                                    error = %e,
-                                    "Failed to write collection block for branchable delete"
-                                );
-                            }
-                        }
-
-                        Some(composite_cid)
-                    }
-                    Err(e) => {
-                        warn!(
-                            collection = %collection_name,
-                            doc_id = %doc_id,
-                            error = %e,
-                            "Failed to write delete block in batch"
-                        );
-                        None
-                    }
+                    Some((composite_cid, _)) => Some(composite_cid),
+                    None => None,
                 }
             };
 
@@ -129,17 +85,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         }
 
         // Single commit for entire batch
-        if let Err(e) = txn.commit().await {
-            warn!(
-                collection = %collection_name,
-                error = %e,
-                "Failed to commit batch delete transaction"
-            );
-            return Err(query::error::QueryError::execution(format!(
-                "commit error: {}",
-                e
-            )));
-        }
+        commit_txn(txn, collection_name, "batch delete").await?;
 
         // Emit events after commit
         let mut delete_results = Vec::with_capacity(results.len());

--- a/crates/db/src/auto_commit_mutator/helpers.rs
+++ b/crates/db/src/auto_commit_mutator/helpers.rs
@@ -1,6 +1,264 @@
 use super::*;
 
 use crate::collection::Collection;
+use crate::database::DB;
+use crate::index_manager::IndexManager;
+use crate::txn::DbTxn;
+use datastore::NamespaceView;
+use defra_core::encryption::{store_doc_encryption, EncryptionConfig};
+use defra_core::signing::SigningConfig;
+use std::collections::HashSet;
+
+pub(super) type DocumentCommitResult = (Cid, Vec<u8>, Option<(Cid, Vec<u8>)>);
+pub(super) type DeleteCommitResult = (Cid, Vec<u8>);
+
+pub(super) fn map_create_error(error: crate::error::Error) -> query::error::QueryError {
+    let msg = error.to_string();
+    if msg.contains("can not index a doc's field(s) that violates unique index") {
+        query::error::QueryError::execution(
+            "can not index a doc's field(s) that violates unique index.".to_string(),
+        )
+    } else {
+        query::error::QueryError::execution(format!("create error: {}", error))
+    }
+}
+
+pub(super) fn map_update_error(error: crate::error::Error) -> query::error::QueryError {
+    match error {
+        crate::error::Error::DocumentNotFound(id) => {
+            query::error::QueryError::document_not_found(id)
+        }
+        other => {
+            let msg = other.to_string();
+            if msg.contains("can not index a doc's field(s) that violates unique index") {
+                query::error::QueryError::execution(
+                    "can not index a doc's field(s) that violates unique index.".to_string(),
+                )
+            } else {
+                query::error::QueryError::execution(format!("update error: {}", other))
+            }
+        }
+    }
+}
+
+pub(super) fn map_delete_error(error: crate::error::Error) -> query::error::QueryError {
+    query::error::QueryError::execution(format!("delete error: {}", error))
+}
+
+pub(super) async fn commit_txn<S: Store>(
+    txn: DbTxn<S>,
+    collection_name: &str,
+    operation: &str,
+) -> query::error::Result<()> {
+    if let Err(error) = txn.commit().await {
+        warn!(
+            collection = %collection_name,
+            error = %error,
+            "Failed to commit transaction after {}",
+            operation
+        );
+        return Err(query::error::QueryError::execution(format!(
+            "commit error: {}",
+            error
+        )));
+    }
+
+    Ok(())
+}
+
+pub(super) fn discard_txn<S: Store>(txn: DbTxn<S>, collection_name: &str, operation: &str) {
+    if let Err(error) = txn.discard() {
+        warn!(
+            collection = %collection_name,
+            error = %error,
+            "Failed to discard transaction after {} error",
+            operation
+        );
+    }
+}
+
+pub(super) fn blockstore_for_txn<S: Store>(txn: &DbTxn<S>) -> query::error::Result<NamespaceView> {
+    txn.blockstore().map_err(|e| {
+        query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
+    })
+}
+
+pub(super) fn headstore_for_txn<S: Store>(txn: &DbTxn<S>) -> query::error::Result<NamespaceView> {
+    txn.headstore()
+        .map_err(|e| query::error::QueryError::execution(format!("failed to get headstore: {}", e)))
+}
+
+pub(super) async fn write_document_commit_result(
+    collection_name: &str,
+    operation: &str,
+    collection: &Collection,
+    blockstore: &NamespaceView,
+    headstore: &NamespaceView,
+    doc: &Document,
+    modified_fields: Option<&HashSet<String>>,
+    enc_config: Option<&EncryptionConfig>,
+    sign_config: Option<&SigningConfig>,
+    should_store_doc_encryption: bool,
+) -> Option<DocumentCommitResult> {
+    match write_document_blocks(
+        blockstore,
+        headstore,
+        doc,
+        collection.version_id(),
+        modified_fields,
+        enc_config,
+        sign_config,
+    )
+    .await
+    {
+        Ok(block_result) => {
+            if should_store_doc_encryption {
+                if let (Some(config), Some(doc_id)) = (enc_config, doc.id()) {
+                    store_doc_encryption(&doc_id.to_string(), config.clone());
+                }
+            }
+
+            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+            if collection.schema().is_branchable {
+                let short_id = collection_short_id(collection.collection_id());
+                match write_collection_block(
+                    blockstore,
+                    headstore,
+                    short_id,
+                    collection.version_id(),
+                    block_result.cid,
+                    sign_config,
+                )
+                .await
+                {
+                    Ok((col_cid, col_bytes)) => {
+                        col_block_data = Some((col_cid, col_bytes));
+                    }
+                    Err(error) => {
+                        warn!(
+                            collection = %collection_name,
+                            error = %error,
+                            "Failed to write collection block for branchable {}",
+                            operation
+                        );
+                    }
+                }
+            }
+
+            Some((block_result.cid, block_result.block, col_block_data))
+        }
+        Err(error) => {
+            warn!(
+                collection = %collection_name,
+                error = %error,
+                "Failed to write document blocks - commits queries may not work"
+            );
+            None
+        }
+    }
+}
+
+pub(super) async fn write_delete_commit_result(
+    collection_name: &str,
+    operation: &str,
+    collection: &Collection,
+    blockstore: &NamespaceView,
+    headstore: &NamespaceView,
+    doc_id: &DocID,
+    sign_config: Option<&SigningConfig>,
+) -> Option<DeleteCommitResult> {
+    match write_delete_block(
+        blockstore,
+        headstore,
+        &doc_id.to_string(),
+        collection.version_id(),
+        sign_config,
+    )
+    .await
+    {
+        Ok(block_result) => {
+            let composite_cid = block_result.cid;
+
+            if collection.schema().is_branchable {
+                if let Err(error) = write_collection_block(
+                    blockstore,
+                    headstore,
+                    collection_short_id(collection.collection_id()),
+                    collection.version_id(),
+                    composite_cid,
+                    sign_config,
+                )
+                .await
+                .map(|_| ())
+                {
+                    warn!(
+                        collection = %collection_name,
+                        error = %error,
+                        "Failed to write collection block for branchable {}",
+                        operation
+                    );
+                }
+            }
+
+            Some((composite_cid, block_result.block))
+        }
+        Err(error) => {
+            warn!(
+                collection = %collection_name,
+                error = %error,
+                "Failed to write delete block - commits queries may not work"
+            );
+            None
+        }
+    }
+}
+
+pub(super) fn create_result_from_commit(
+    doc_id: DocID,
+    doc: Document,
+    commit_result: Option<DocumentCommitResult>,
+) -> CreateResult {
+    match commit_result {
+        Some((cid, block, col_data)) => {
+            let mut result = CreateResult::with_commit(doc_id, doc, cid, block);
+            if let Some((col_cid, col_bytes)) = col_data {
+                result.broadcast_cid = Some(col_cid);
+                result.broadcast_block = Some(col_bytes);
+            }
+            result
+        }
+        None => CreateResult::new(doc_id, doc),
+    }
+}
+
+pub(super) fn update_result_from_commit(
+    doc: Document,
+    fields_modified: usize,
+    commit_result: Option<DocumentCommitResult>,
+) -> UpdateResult {
+    match commit_result {
+        Some((cid, block, col_data)) => {
+            let mut result = UpdateResult::with_commit(doc, fields_modified, cid, block);
+            if let Some((col_cid, col_bytes)) = col_data {
+                result.broadcast_cid = Some(col_cid);
+                result.broadcast_block = Some(col_bytes);
+            }
+            result
+        }
+        None => UpdateResult::new(doc, fields_modified),
+    }
+}
+
+pub(super) fn delete_result_from_commit(
+    doc_id: DocID,
+    existed: bool,
+    commit_result: Option<DeleteCommitResult>,
+) -> DeleteResult {
+    match commit_result {
+        Some((cid, block)) => DeleteResult::with_commit(doc_id, existed, cid, block),
+        None => DeleteResult::new(doc_id, existed),
+    }
+}
 
 impl<S: Store + 'static> AutoCommitMutator<S> {
     /// Get collection from DB cache or return a not-found error.
@@ -12,6 +270,43 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .get_collection(collection_name)
             .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))
+    }
+
+    pub(super) async fn new_write_txn(&self) -> query::error::Result<DbTxn<S>> {
+        Self::new_write_txn_for_db(&self.db).await
+    }
+
+    pub(super) async fn new_write_txn_for_db(db: &DB<S>) -> query::error::Result<DbTxn<S>> {
+        db.new_txn(false).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })
+    }
+
+    pub(super) fn datastore_for_collection(
+        &self,
+        txn: &DbTxn<S>,
+        collection_name: &str,
+    ) -> query::error::Result<NamespaceView> {
+        txn.datastore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get datastore for collection '{}': {}",
+                collection_name, e
+            ))
+        })
+    }
+
+    pub(super) fn index_manager_for_collection(
+        &self,
+        collection: &Collection,
+        collection_name: &str,
+    ) -> query::error::Result<IndexManager> {
+        let short_id = collection_short_id(collection.collection_id());
+        IndexManager::from_collection(short_id, collection.schema()).map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to create index manager for collection '{}': {}",
+                collection_name, e
+            ))
+        })
     }
 
     /// Emit update events for subscriptions.

--- a/crates/db/src/auto_commit_mutator/mod.rs
+++ b/crates/db/src/auto_commit_mutator/mod.rs
@@ -26,7 +26,6 @@ use tracing::warn;
 use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
 use crate::collection::collection_short_id;
 use crate::database::DB;
-use crate::index_manager::IndexManager;
 use crate::lensed_fetcher::LensedDocFetcher;
 use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
 use defra_core::signing::get_signing_config;

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -1,3 +1,7 @@
+use super::helpers::{
+    blockstore_for_txn, commit_txn, discard_txn, headstore_for_txn, map_update_error,
+    update_result_from_commit, write_document_commit_result,
+};
 use super::*;
 
 #[allow(clippy::type_complexity)]
@@ -30,28 +34,14 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         }
 
         // Create a write transaction
-        let txn = self.db.new_txn(false).await.map_err(|e| {
-            query::error::QueryError::execution(format!("failed to create txn: {}", e))
-        })?;
+        let txn = self.new_write_txn().await?;
 
         // Execute the mutation in a block to drop datastore before commit
         let result = {
-            let datastore = txn.datastore().map_err(|e| {
-                query::error::QueryError::execution(format!(
-                    "failed to get datastore for collection '{}': {}",
-                    collection_name, e
-                ))
-            })?;
+            let datastore = self.datastore_for_collection(&txn, collection_name)?;
 
             // Create an IndexManager for index maintenance
-            let short_id = collection_short_id(collection.collection_id());
-            let index_manager = IndexManager::from_collection(short_id, collection.schema())
-                .map_err(|e| {
-                    query::error::QueryError::execution(format!(
-                        "failed to create index manager for collection '{}': {}",
-                        collection_name, e
-                    ))
-                })?;
+            let index_manager = self.index_manager_for_collection(&collection, collection_name)?;
 
             self.db
                 .validate_downsample_write(
@@ -67,24 +57,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             collection
                 .update_with_indexes(&datastore, &doc, &index_manager)
                 .await
-                .map_err(|e| match e {
-                    crate::error::Error::DocumentNotFound(id) => {
-                        query::error::QueryError::document_not_found(id)
-                    }
-                    other => {
-                        let msg = other.to_string();
-                        // If this is a unique constraint violation, return the core message without wrapping
-                        if msg.contains("can not index a doc's field(s) that violates unique index")
-                        {
-                            query::error::QueryError::execution(
-                                "can not index a doc's field(s) that violates unique index."
-                                    .to_string(),
-                            )
-                        } else {
-                            query::error::QueryError::execution(format!("update error: {}", other))
-                        }
-                    }
-                })
+                .map_err(map_update_error)
         };
 
         match result {
@@ -93,21 +66,8 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 // This enables _commits queries to find the document's version history
                 // (composite_cid, composite_bytes, optional (collection_cid, collection_bytes))
                 let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = {
-                    let blockstore = txn.blockstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get blockstore: {}",
-                            e
-                        ))
-                    })?;
-                    let headstore = txn.headstore().map_err(|e| {
-                        query::error::QueryError::execution(format!(
-                            "failed to get headstore: {}",
-                            e
-                        ))
-                    })?;
-
-                    // Use version_id for collectionVersionID (matches Go's VersionID())
-                    let schema_version_id = collection.version_id();
+                    let blockstore = blockstore_for_txn(&txn)?;
+                    let headstore = headstore_for_txn(&txn)?;
 
                     // Get encryption config: first try thread-local (explicit in mutation),
                     // then fall back to per-document stored config (from create with encryption).
@@ -119,70 +79,23 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
                     // For update operations, pass the modified fields to only create blocks
                     // for the fields that actually changed
-                    match write_document_blocks(
+                    write_document_commit_result(
+                        collection_name,
+                        "update",
+                        &collection,
                         &blockstore,
                         &headstore,
                         &doc,
-                        schema_version_id,
                         Some(&modified_fields),
                         enc_config.as_ref(),
                         sign_config.as_ref(),
+                        false,
                     )
                     .await
-                    {
-                        Ok(block_result) => {
-                            // For branchable collections, create a collection-level block
-                            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                            if collection.schema().is_branchable {
-                                let short_id = collection_short_id(collection.collection_id());
-                                match write_collection_block(
-                                    &blockstore,
-                                    &headstore,
-                                    short_id,
-                                    schema_version_id,
-                                    block_result.cid,
-                                    sign_config.as_ref(),
-                                )
-                                .await
-                                {
-                                    Ok((col_cid, col_bytes)) => {
-                                        col_block_data = Some((col_cid, col_bytes));
-                                    }
-                                    Err(e) => {
-                                        warn!(
-                                            collection = %collection_name,
-                                            error = %e,
-                                            "Failed to write collection block for branchable update"
-                                        );
-                                    }
-                                }
-                            }
-                            Some((block_result.cid, block_result.block, col_block_data))
-                        }
-                        Err(e) => {
-                            warn!(
-                                collection = %collection_name,
-                                error = %e,
-                                "Failed to write document blocks - commits queries may not work"
-                            );
-                            // Don't fail the mutation, just log the warning
-                            None
-                        }
-                    }
                 }; // blockstore and headstore dropped here
 
                 // Commit the transaction (all store references now dropped)
-                if let Err(e) = txn.commit().await {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to commit transaction after update"
-                    );
-                    return Err(query::error::QueryError::execution(format!(
-                        "commit error: {}",
-                        e
-                    )));
-                }
+                commit_txn(txn, collection_name, "update").await?;
 
                 // Emit update event for subscriptions
                 if let Some(doc_id) = doc.id() {
@@ -195,28 +108,15 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
                 // Count modified fields
                 let fields_modified = doc.values().len();
-                match commit_result {
-                    Some((cid, block, col_data)) => {
-                        let mut result =
-                            UpdateResult::with_commit(doc, fields_modified, cid, block);
-                        if let Some((col_cid, col_bytes)) = col_data {
-                            result.broadcast_cid = Some(col_cid);
-                            result.broadcast_block = Some(col_bytes);
-                        }
-                        Ok(result)
-                    }
-                    None => Ok(UpdateResult::new(doc, fields_modified)),
-                }
+                Ok(update_result_from_commit(
+                    doc,
+                    fields_modified,
+                    commit_result,
+                ))
             }
             Err(e) => {
                 // Discard the transaction on error
-                if let Err(discard_err) = txn.discard() {
-                    warn!(
-                        collection = %collection_name,
-                        error = %discard_err,
-                        "Failed to discard transaction after update error"
-                    );
-                }
+                discard_txn(txn, collection_name, "update");
                 Err(e)
             }
         }


### PR DESCRIPTION
## Summary
- extract shared auto-commit mutation helpers for txn setup, commit/discard handling, block writing, and result shaping
- reuse those helpers across single-doc, batch, and multi-doc auto-commit mutators
- preserve the existing per-operation mutation logic and event semantics while removing duplicated transaction ceremony

## Testing
- cargo check -p db
- cargo test -p db
