### PR TITLE
fix(crypto): tighten merkle_proof verification semantics (#732, #733)

### DIFF
--- a/crates/crypto/src/merkle_proof/extraction.rs
+++ b/crates/crypto/src/merkle_proof/extraction.rs
@@ -8,9 +8,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use super::proof::MerkleProof;
 use super::proof_node::ProofNode;
 
-/// Maximum nodes to visit during BFS traversal to prevent DoS via large DAGs
-const MAX_TRAVERSAL_NODES: usize = 10_000;
-
 /// Blockstore trait for proof extraction
 ///
 /// This trait abstracts block retrieval to allow proof extraction from
@@ -74,16 +71,10 @@ pub async fn extract_proof<B: ProofBlockstore>(
     visited.insert(leaf_cid);
     queue.push_back(leaf_cid);
 
-    // BFS traversal following heads references
+    // BFS traversal following heads references.
+    // DoS protection: bounded by the size of the blockstore (caller's responsibility),
+    // not by a hardcoded limit here. Go has no equivalent cap on chain depth.
     while let Some(current_cid) = queue.pop_front() {
-        // Check traversal limit to prevent DoS via large DAGs
-        if visited.len() > MAX_TRAVERSAL_NODES {
-            return Err(Error::BlockError(format!(
-                "BFS traversal exceeded maximum nodes ({})",
-                MAX_TRAVERSAL_NODES
-            )));
-        }
-
         // Get the current block data
         let block_data = if let Some(data) = block_cache.get(&current_cid) {
             data.clone()

--- a/crates/crypto/src/merkle_proof/proof.rs
+++ b/crates/crypto/src/merkle_proof/proof.rs
@@ -6,9 +6,6 @@ use serde::{Deserialize, Serialize};
 
 use super::proof_node::ProofNode;
 
-/// Maximum allowed proof path length to prevent DoS via large proofs
-const MAX_PROOF_PATH_LENGTH: usize = 1000;
-
 /// Merkle proof demonstrating a path from leaf to root
 ///
 /// The proof contains an ordered sequence of blocks from the leaf (index 0)
@@ -41,48 +38,50 @@ impl MerkleProof {
     /// Verify this proof is valid
     ///
     /// Checks:
-    /// 1. Path length is within limits
-    /// 2. Path is non-empty
-    /// 3. First node CID matches leaf_cid
-    /// 4. Last node CID matches root_cid
-    /// 5. Each node's CID matches its content hash
-    /// 6. Each node's heads contains the next node's CID (child -> parent chain)
+    /// 1. Path is non-empty (Err)
+    /// 2. First node CID matches leaf_cid (Err — wrong input)
+    /// 3. Last node CID matches root_cid (Err — wrong input)
+    /// 4. Each node's CID matches its content hash (Ok(false) — cryptographic failure)
+    /// 5. Each node's heads contains the next node's CID (Ok(false) — broken chain)
     ///
-    /// The chain structure is: leaf (newest) -> ... -> root (oldest)
+    /// The chain structure is: leaf (newest) -> ... -> root (oldest).
     /// Each node points to its parent(s) via the `heads` field.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` — proof verifies
+    /// - `Ok(false)` — proof is structurally valid but cryptographically incorrect
+    ///   (content hash mismatch, broken chain link)
+    /// - `Err(_)` — caller supplied structurally invalid input (empty path, anchor mismatch)
     pub fn verify(&self) -> Result<bool> {
-        // Check path length to prevent DoS
-        if self.path.len() > MAX_PROOF_PATH_LENGTH {
-            return Err(Error::BlockError(format!(
-                "Proof path exceeds maximum length: {} > {}",
-                self.path.len(),
-                MAX_PROOF_PATH_LENGTH
-            )));
-        }
-
+        // Anchor/structural failures are caller errors — return Err so they can't be
+        // silently ignored. Match Go's convention where "nothing to verify" is an error.
         if self.path.is_empty() {
-            return Ok(false);
+            return Err(Error::BlockError("proof path is empty".to_string()));
         }
 
-        // Verify leaf CID matches
         if self.path[0].cid != self.leaf_cid {
-            return Ok(false);
+            return Err(Error::BlockError(
+                "proof leaf CID does not match first path node".to_string(),
+            ));
         }
 
-        // Verify root CID matches
         if self.path[self.path.len() - 1].cid != self.root_cid {
-            return Ok(false);
+            return Err(Error::BlockError(
+                "proof root CID does not match last path node".to_string(),
+            ));
         }
 
-        // Verify each node's CID matches its content
+        // Verify each node's CID matches its content.
+        // A hash mismatch is a legitimate cryptographic "no" — return Ok(false).
         for node in &self.path {
             if !node.verify_cid()? {
                 return Ok(false);
             }
         }
 
-        // Verify chain integrity: each node's heads should contain the next node's CID
-        // This is because in a child -> parent chain, child.heads points to parent
+        // Verify chain integrity: each node's heads should contain the next node's CID.
+        // A broken chain link is a legitimate cryptographic "no" — return Ok(false).
         for i in 0..self.path.len() - 1 {
             let current_block = self.path[i].decode_block()?;
             let next_cid = &self.path[i + 1].cid;

--- a/crates/crypto/src/merkle_proof/signed_proof.rs
+++ b/crates/crypto/src/merkle_proof/signed_proof.rs
@@ -75,17 +75,24 @@ impl SignedMerkleProof {
             )));
         }
 
-        // Verify the identity in the signature matches the provided key
-        // Identity is stored as hex-encoded public key string bytes
+        // Verify the identity in the signature matches the provided key.
+        // Identity is stored as hex-encoded public key string bytes.
+        // An identity mismatch means the caller provided the wrong key —
+        // this is a configuration error, not a cryptographic "no", so return Err.
         let expected_identity = public_key.to_hex_string().into_bytes();
         if self.signature.header.identity != expected_identity {
-            return Ok(false);
+            return Err(Error::Crypto(
+                "proof identity does not match expected public key".to_string(),
+            ));
         }
 
-        // Verify the signature
+        // Verify the signature. A failed signature check is a security event —
+        // return Err to match Go's verifySignature convention.
         let proof_bytes = self.proof.to_dag_cbor()?;
         if !public_key.verify(&proof_bytes, &self.signature.value)? {
-            return Ok(false);
+            return Err(Error::Crypto(
+                "proof signature verification failed".to_string(),
+            ));
         }
 
         // Verify the proof itself
@@ -98,10 +105,13 @@ impl SignedMerkleProof {
     pub fn verify_with_embedded_key(&self) -> Result<bool> {
         let public_key = extract_public_key_from_signature(&self.signature)?;
 
-        // Verify the signature
+        // Verify the signature. A failed signature check is a security event —
+        // return Err to match Go's verifySignature convention.
         let proof_bytes = self.proof.to_dag_cbor()?;
         if !public_key.verify(&proof_bytes, &self.signature.value)? {
-            return Ok(false);
+            return Err(Error::Crypto(
+                "proof signature verification failed".to_string(),
+            ));
         }
 
         // Verify the proof itself

--- a/crates/crypto/tests/merkle_proof_tests.rs
+++ b/crates/crypto/tests/merkle_proof_tests.rs
@@ -97,21 +97,28 @@ async fn test_two_block_chain_proof() {
 
 #[tokio::test]
 async fn test_proof_wrong_root_fails() {
+    // Wrong root CID is a structural anchor mismatch — returns Err.
     let block = Block::new(create_test_delta("doc1", "name"), vec![], vec![]);
     let cid = block.generate_cid().unwrap();
     let node = ProofNode::from_block(&block).unwrap();
 
-    // Create a different block for wrong root CID
     let other_block = Block::new(create_test_delta("doc2", "age"), vec![], vec![]);
     let wrong_root = other_block.generate_cid().unwrap();
 
     let proof = MerkleProof::new(cid, wrong_root, vec![node]);
-    assert!(!proof.verify().unwrap());
+    let result = proof.verify();
+    assert!(result.is_err(), "wrong root CID should return Err");
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("root CID does not match"));
 }
 
 #[tokio::test]
 async fn test_proof_missing_link_fails() {
-    // Create two unrelated blocks
+    // Missing chain link is a legitimate cryptographic "no" — returns Ok(false).
+    // Create two unrelated blocks; their CIDs become the anchors so the structural
+    // checks pass, but the heads chain between them is broken.
     let block1 = Block::new(create_test_delta("doc1", "name"), vec![], vec![]);
     let cid1 = block1.generate_cid().unwrap();
     let node1 = ProofNode::from_block(&block1).unwrap();
@@ -120,15 +127,20 @@ async fn test_proof_missing_link_fails() {
     let cid2 = block2.generate_cid().unwrap();
     let node2 = ProofNode::from_block(&block2).unwrap();
 
-    // Try to create proof between unrelated blocks
     let proof = MerkleProof::new(cid1, cid2, vec![node1, node2]);
-    assert!(!proof.verify().unwrap());
+    assert!(
+        !proof.verify().unwrap(),
+        "broken chain link should return Ok(false)"
+    );
 }
 
 #[tokio::test]
 async fn test_empty_proof_fails() {
+    // Empty path is a structural input error — returns Err.
     let proof = MerkleProof::new(Cid::default(), Cid::default(), vec![]);
-    assert!(!proof.verify().unwrap());
+    let result = proof.verify();
+    assert!(result.is_err(), "empty proof should return Err");
+    assert!(result.unwrap_err().to_string().contains("empty"));
 }
 
 #[tokio::test]
@@ -247,6 +259,8 @@ async fn test_signed_proof_secp256k1() {
 
 #[tokio::test]
 async fn test_signed_proof_wrong_key_fails() {
+    // Identity mismatch — the caller provided a key that isn't the signer.
+    // This is a configuration error; return Err to match Go's convention.
     let private_key1 = generate_ed25519().unwrap();
     let private_key2 = generate_ed25519().unwrap();
     let wrong_public_key = private_key2.public_key();
@@ -258,12 +272,21 @@ async fn test_signed_proof_wrong_key_fails() {
 
     let signed = SignedMerkleProof::sign(proof, &private_key1 as &dyn PrivateKey).unwrap();
 
-    // Verification with wrong key should fail
-    assert!(!signed.verify(wrong_public_key.as_ref()).unwrap());
+    let result = signed.verify(wrong_public_key.as_ref());
+    assert!(
+        result.is_err(),
+        "wrong key should return Err, not Ok(false)"
+    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("identity does not match"));
 }
 
 #[tokio::test]
 async fn test_signed_proof_tampered_proof_fails() {
+    // Signature verification failure — the signed bytes changed, so the signature
+    // no longer matches. Cryptographic security event; return Err.
     let private_key = generate_ed25519().unwrap();
 
     let block = Block::new(create_test_delta("doc1", "name"), vec![], vec![]);
@@ -273,13 +296,19 @@ async fn test_signed_proof_tampered_proof_fails() {
 
     let mut signed = SignedMerkleProof::sign(proof, &private_key as &dyn PrivateKey).unwrap();
 
-    // Tamper with the proof
     let other_block = Block::new(create_test_delta("doc2", "other"), vec![], vec![]);
     let other_cid = other_block.generate_cid().unwrap();
     signed.proof.root_cid = other_cid;
 
-    // Verification should fail due to signature mismatch
-    assert!(!signed.verify_with_embedded_key().unwrap());
+    let result = signed.verify_with_embedded_key();
+    assert!(
+        result.is_err(),
+        "tampered proof should return Err, not Ok(false)"
+    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("signature verification failed"));
 }
 
 #[tokio::test]
@@ -531,6 +560,7 @@ fn test_verify_cid_unsupported_codec() {
 
 #[tokio::test]
 async fn test_signed_proof_corrupted_signature_fails() {
+    // Corrupted signature bytes — cryptographic verification failure, return Err.
     let private_key = generate_ed25519().unwrap();
 
     let block = Block::new(create_test_delta("doc1", "name"), vec![], vec![]);
@@ -540,16 +570,19 @@ async fn test_signed_proof_corrupted_signature_fails() {
 
     let mut signed = SignedMerkleProof::sign(proof, &private_key as &dyn PrivateKey).unwrap();
 
-    // Corrupt the signature value by flipping bits
     if !signed.signature.value.is_empty() {
         signed.signature.value[0] ^= 0xFF;
     }
 
-    // Verification should fail (return false, not error)
+    let result = signed.verify_with_embedded_key();
     assert!(
-        !signed.verify_with_embedded_key().unwrap(),
-        "Corrupted signature should fail verification"
+        result.is_err(),
+        "corrupted signature should return Err, not Ok(false)"
     );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("signature verification failed"));
 }
 
 #[tokio::test]
@@ -598,20 +631,21 @@ fn test_merkle_proof_from_dag_cbor_invalid_bytes_fails() {
 
 #[test]
 fn test_proof_wrong_leaf_cid_fails() {
+    // Wrong leaf CID is a structural anchor mismatch — returns Err.
     let block = Block::new(create_test_delta("doc1", "name"), vec![], vec![]);
     let cid = block.generate_cid().unwrap();
     let node = ProofNode::from_block(&block).unwrap();
 
-    // Create a different block for wrong leaf CID
     let other_block = Block::new(create_test_delta("doc2", "age"), vec![], vec![]);
     let wrong_leaf = other_block.generate_cid().unwrap();
 
-    // Wrong leaf CID doesn't match path[0].cid
     let proof = MerkleProof::new(wrong_leaf, cid, vec![node]);
-    assert!(
-        !proof.verify().unwrap(),
-        "Proof with wrong leaf CID should fail"
-    );
+    let result = proof.verify();
+    assert!(result.is_err(), "wrong leaf CID should return Err");
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("leaf CID does not match"));
 }
 
 #[tokio::test]
@@ -680,4 +714,205 @@ fn test_merkle_proof_from_dag_cbor_wrong_schema_fails() {
         result.is_err(),
         "Wrong schema should return deserialization error"
     );
+}
+
+// =========================================================================
+// Go parity tests for verification semantics
+//
+// These tests lock in the Rust behavior to match Go's conventions:
+// - Cryptographic signature failures return Err (match Go's ErrSignatureVerification)
+// - Caller-supplied anchor mismatches return Err (configuration error)
+// - Hash/chain mismatches during verification return Ok(false) (legitimate "no")
+// - No hardcoded path length limit (Go has none)
+// =========================================================================
+
+/// Build a chain of `count` blocks where each block's heads points to the previous block.
+/// Returns (blocks, cids) in leaf-to-root order (leaf at index 0, root at last index).
+fn build_linear_chain(count: usize) -> (Vec<Block>, Vec<Cid>) {
+    assert!(count > 0, "chain must have at least one block");
+    let mut blocks = Vec::with_capacity(count);
+    let mut cids = Vec::with_capacity(count);
+
+    // Root (index count-1) is the oldest block — no heads.
+    // Each successive block (going toward the leaf at index 0) points to the previous CID
+    // via its heads field. We build from root to leaf.
+    let mut chain = Vec::with_capacity(count);
+    let root = Block::new(create_test_delta("doc-chain", "f0"), vec![], vec![]);
+    let mut prev_cid = root.generate_cid().unwrap();
+    chain.push((root, prev_cid));
+
+    for i in 1..count {
+        let field = format!("f{}", i);
+        let block = Block::new(
+            create_test_delta("doc-chain", &field),
+            vec![prev_cid],
+            vec![],
+        );
+        let cid = block.generate_cid().unwrap();
+        chain.push((block, cid));
+        prev_cid = cid;
+    }
+
+    // chain is now [root, ..., leaf]. Reverse to get [leaf, ..., root] (proof path order).
+    chain.reverse();
+    for (b, c) in chain {
+        blocks.push(b);
+        cids.push(c);
+    }
+    (blocks, cids)
+}
+
+#[tokio::test]
+async fn test_large_chain_proof_verifies_without_limit() {
+    // Regression for #732: MAX_PROOF_PATH_LENGTH used to reject proofs > 1000 nodes.
+    // Go has no such limit. A legitimate 1500-node chain must verify successfully.
+    let count = 1500;
+    let (blocks, cids) = build_linear_chain(count);
+
+    let path: Vec<ProofNode> = blocks
+        .iter()
+        .map(|b| ProofNode::from_block(b).unwrap())
+        .collect();
+
+    let leaf_cid = cids[0];
+    let root_cid = cids[count - 1];
+    let proof = MerkleProof::new(leaf_cid, root_cid, path);
+
+    assert!(
+        proof.verify().unwrap(),
+        "1500-node chain proof should verify without hitting any hardcoded limit"
+    );
+}
+
+#[tokio::test]
+async fn test_verify_err_vs_ok_false_semantics() {
+    // Parity test documenting the Err vs Ok(false) contract:
+    //
+    // - Empty path, wrong leaf anchor, wrong root anchor: Err (caller mistake)
+    // - Content hash mismatch, broken chain link: Ok(false) (cryptographic "no")
+
+    // 1. Empty path → Err
+    let empty = MerkleProof::new(Cid::default(), Cid::default(), vec![]);
+    assert!(empty.verify().is_err());
+
+    // 2. Wrong leaf anchor → Err
+    let block_a = Block::new(create_test_delta("doc", "a"), vec![], vec![]);
+    let cid_a = block_a.generate_cid().unwrap();
+    let node_a = ProofNode::from_block(&block_a).unwrap();
+    let block_b = Block::new(create_test_delta("doc", "b"), vec![], vec![]);
+    let cid_b = block_b.generate_cid().unwrap();
+    let wrong_leaf = MerkleProof::new(cid_b, cid_a, vec![node_a.clone()]);
+    assert!(wrong_leaf.verify().is_err());
+
+    // 3. Wrong root anchor → Err
+    let wrong_root = MerkleProof::new(cid_a, cid_b, vec![node_a.clone()]);
+    assert!(wrong_root.verify().is_err());
+
+    // 4. Broken chain link → Ok(false) (cids match the path, but block_a.heads doesn't contain cid_b)
+    let node_b = ProofNode::from_block(&block_b).unwrap();
+    let broken = MerkleProof::new(cid_a, cid_b, vec![node_a, node_b]);
+    let result = broken.verify();
+    assert!(result.is_ok(), "broken chain link should be Ok, not Err");
+    assert!(!result.unwrap(), "broken chain link should return false");
+}
+
+#[tokio::test]
+async fn test_signed_proof_signature_failure_returns_err() {
+    // Parity test: cryptographic signature verification failure must return Err,
+    // matching Go's verifySignature returning ErrSignatureVerification.
+    let private_key = generate_ed25519().unwrap();
+
+    let block = Block::new(create_test_delta("doc1", "name"), vec![], vec![]);
+    let cid = block.generate_cid().unwrap();
+    let node = ProofNode::from_block(&block).unwrap();
+    let proof = MerkleProof::new(cid, cid, vec![node]);
+
+    let mut signed = SignedMerkleProof::sign(proof, &private_key as &dyn PrivateKey).unwrap();
+
+    // Flip all bytes in the signature
+    for byte in signed.signature.value.iter_mut() {
+        *byte = !*byte;
+    }
+
+    // Direct verify() path
+    let pub_key = private_key.public_key();
+    let result_verify = signed.verify(pub_key.as_ref());
+    assert!(
+        result_verify.is_err(),
+        "verify() must return Err on signature failure, got {:?}",
+        result_verify
+    );
+
+    // verify_with_embedded_key() path
+    let result_embedded = signed.verify_with_embedded_key();
+    assert!(
+        result_embedded.is_err(),
+        "verify_with_embedded_key() must return Err on signature failure, got {:?}",
+        result_embedded
+    );
+
+    // Standalone verify_signed_proof helper path
+    let result_helper = verify_signed_proof(&signed);
+    assert!(
+        result_helper.is_err(),
+        "verify_signed_proof() must return Err on signature failure, got {:?}",
+        result_helper
+    );
+}
+
+#[tokio::test]
+async fn test_signed_proof_identity_mismatch_returns_err() {
+    // Parity test: identity mismatch is a caller error (wrong key provided),
+    // must return Err. This distinguishes "I don't have the right key" from
+    // "the signature is cryptographically invalid".
+    let signer_key = generate_ed25519().unwrap();
+    let other_key = generate_secp256k1().unwrap();
+
+    let block = Block::new(create_test_delta("doc1", "name"), vec![], vec![]);
+    let cid = block.generate_cid().unwrap();
+    let node = ProofNode::from_block(&block).unwrap();
+    let proof = MerkleProof::new(cid, cid, vec![node]);
+
+    let signed = SignedMerkleProof::sign(proof, &signer_key as &dyn PrivateKey).unwrap();
+
+    // Using a key of a different curve type — hits the key_type check first.
+    let other_pub = other_key.public_key();
+    let result_type = signed.verify(other_pub.as_ref());
+    assert!(result_type.is_err(), "key type mismatch should return Err");
+
+    // Using a different ed25519 key — hits the identity check.
+    let wrong_ed = generate_ed25519().unwrap();
+    let wrong_pub = wrong_ed.public_key();
+    let result_identity = signed.verify(wrong_pub.as_ref());
+    assert!(
+        result_identity.is_err(),
+        "identity mismatch should return Err, got {:?}",
+        result_identity
+    );
+    assert!(result_identity
+        .unwrap_err()
+        .to_string()
+        .contains("identity does not match"));
+}
+
+#[tokio::test]
+async fn test_valid_signed_proof_still_returns_ok_true() {
+    // Sanity check that the happy path still returns Ok(true) — we haven't
+    // accidentally made valid proofs fail after tightening the error semantics.
+    let private_key = generate_ed25519().unwrap();
+
+    let block0 = Block::new(create_test_delta("doc", "g"), vec![], vec![]);
+    let cid0 = block0.generate_cid().unwrap();
+    let node0 = ProofNode::from_block(&block0).unwrap();
+
+    let block1 = Block::new(create_test_delta("doc", "u1"), vec![cid0], vec![]);
+    let cid1 = block1.generate_cid().unwrap();
+    let node1 = ProofNode::from_block(&block1).unwrap();
+
+    let proof = MerkleProof::new(cid1, cid0, vec![node1, node0]);
+    let signed = SignedMerkleProof::sign(proof, &private_key as &dyn PrivateKey).unwrap();
+
+    let pub_key = private_key.public_key();
+    assert!(signed.verify(pub_key.as_ref()).unwrap());
+    assert!(signed.verify_with_embedded_key().unwrap());
 }


### PR DESCRIPTION
## Summary

Fixes two correctness issues in `crates/crypto/src/merkle_proof/` that diverged from Go's conventions, and adds Go parity tests that lock in the verification semantics.

Closes #732, #733.

## Problem

### #733 — Cryptographic failures silently returned `Ok(false)`

Six call sites across `proof.rs` and `signed_proof.rs` returned `Ok(false)` for verification failures, including cryptographic signature check failures. Go's `verifySignature` in `internal/core/block/signature.go` always returns `ErrSignatureVerification`. Callers that forget to check the returned bool silently pass invalid proofs through — a security-adjacent bug.

### #732 — `MAX_PROOF_PATH_LENGTH` rejected valid Go proofs

`proof.rs` enforced a hardcoded 1000-node path length limit. Go has no equivalent ceiling on chain depth. A document with more than 1000 sequential updates would produce a valid proof in Go and fail verification in Rust. Also: `extraction.rs` had a separate `MAX_TRAVERSAL_NODES = 10_000` cap, so proofs of size 1001-10000 could be extracted but not verified.

## Fix

### Err vs Ok(false) contract

The new contract distinguishes three failure modes:

| Condition | Return | Rationale |
|---|---|---|
| Empty path | `Err` | Nothing to verify — caller mistake |
| Leaf/root anchor mismatch | `Err` | Caller provided wrong leaf_cid/root_cid |
| Signed proof identity mismatch | `Err` | Caller provided wrong public key |
| Signed proof signature verification failure | `Err` | Cryptographic security event |
| Content hash mismatch (CID doesn't match data) | `Ok(false)` | Legitimate "this proof does not verify" |
| Broken chain link (heads doesn't contain next CID) | `Ok(false)` | Legitimate "this proof does not verify" |

The split matches Go's convention: _caller errors_ and _security events_ are `Err`, while _cryptographic "no"_ is a bool result.

### Path length limits removed

Both `MAX_PROOF_PATH_LENGTH` (1000 in proof.rs) and `MAX_TRAVERSAL_NODES` (10,000 in extraction.rs) are removed. DoS protection belongs at the serialization input-size layer (the caller's responsibility) and at the bounded blockstore — not at hardcoded verification limits that diverge from Go.

## What changed

- `crates/crypto/src/merkle_proof/proof.rs` — removed `MAX_PROOF_PATH_LENGTH`, converted three `Ok(false)` returns to `Err`, documented the contract in the `verify` doc comment
- `crates/crypto/src/merkle_proof/signed_proof.rs` — converted identity mismatch and signature verification failures (in both `verify` and `verify_with_embedded_key`) to `Err`
- `crates/crypto/src/merkle_proof/extraction.rs` — removed `MAX_TRAVERSAL_NODES`
- `crates/crypto/tests/merkle_proof_tests.rs` — updated 6 existing tests to reflect new `Err` semantics, added 5 new tests

### New tests

- `test_large_chain_proof_verifies_without_limit` — 1500-node chain regression guard for #732
- `test_verify_err_vs_ok_false_semantics` — parity test locking in the Err/Ok(false) contract
- `test_signed_proof_signature_failure_returns_err` — exercises all three verification paths (`verify`, `verify_with_embedded_key`, `verify_signed_proof`)
- `test_signed_proof_identity_mismatch_returns_err` — both key-type mismatch and identity mismatch paths
- `test_valid_signed_proof_still_returns_ok_true` — happy path sanity check

## Separate concern (flagged, not addressed in this PR)

**No Go compat tests exist for merkle proof verification.** None of the `crates/crypto/tests/go_compat_*.rs` files exercise merkle proofs. Rust/Go agreement on proof verification has never been validated with byte-for-byte test vectors generated from the Go implementation. The parity tests in this PR lock in the Rust semantics against the Go _convention_, but full byte-level cross-implementation testing should be a follow-up issue.

## Test plan

- [x] `cargo test -p crypto --test merkle_proof_tests` — 37/37 pass
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test` — all pass
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean

## Breaking change?

**API signature unchanged** (`verify() -> Result<bool>`), but callers that previously saw `Ok(false)` for identity mismatch or signature failure will now see `Err`. The WASM/FFI callers use `?` propagation and map errors to `JsValue`/C error codes, so the change is transparent at those boundaries. Any Rust caller that was explicitly matching `Ok(false)` to mean "signature invalid" would need to also handle `Err(Error::Crypto(_))` — but this was arguably always the correct thing to do.
