### PR TITLE
fix(acp): wire NAC bypass-dac and node-identity shortcuts into mutation path (#738, #739, #740)

### DIFF
--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -170,15 +170,15 @@ impl DocumentACP for LocalDocumentACP {
         let did = match identity {
             Identity::Authenticated(did) => did,
             Identity::Anonymous => {
-                // Check if wildcard grants exist for the requested permission
+                // Check if wildcard grants exist for the requested permission.
+                // Go DefraDB defines four document relations: owner, reader, updater, deleter.
                 let wildcard = Did::wildcard();
                 let granted = match permission {
                     DocumentPermission::Read => {
+                        // Any write permission implies read (matches Go's
+                        // ImplyDocumentReadPerm in acp/types/types.go).
                         self.has_relation(&wildcard, &ns_collection, doc_id, READER_RELATION)
                             .await?
-                            || self
-                                .has_relation(&wildcard, &ns_collection, doc_id, "writer")
-                                .await?
                             || self
                                 .has_relation(&wildcard, &ns_collection, doc_id, UPDATER_RELATION)
                                 .await?
@@ -189,9 +189,6 @@ impl DocumentACP for LocalDocumentACP {
                     DocumentPermission::Update => {
                         self.has_relation(&wildcard, &ns_collection, doc_id, UPDATER_RELATION)
                             .await?
-                            || self
-                                .has_relation(&wildcard, &ns_collection, doc_id, "writer")
-                                .await?
                     }
                     DocumentPermission::Delete => {
                         self.has_relation(&wildcard, &ns_collection, doc_id, DELETER_RELATION)
@@ -208,16 +205,12 @@ impl DocumentACP for LocalDocumentACP {
         }
 
         // Check specific relations based on permission.
-        // Go DefraDB: any write permission implies read access.
-        // Relations checked: reader, writer, updater, deleter, admin.
+        // Go DefraDB defines four document relations: owner, reader, updater, deleter.
+        // Any write permission implies read access (matches Go's ImplyDocumentReadPerm).
         let granted = match permission {
             DocumentPermission::Read => {
-                // Any relation that could imply read access (matches Go behavior)
                 self.has_relation(did, &ns_collection, doc_id, READER_RELATION)
                     .await?
-                    || self
-                        .has_relation(did, &ns_collection, doc_id, "writer")
-                        .await?
                     || self
                         .has_relation(did, &ns_collection, doc_id, UPDATER_RELATION)
                         .await?
@@ -228,9 +221,6 @@ impl DocumentACP for LocalDocumentACP {
             DocumentPermission::Update => {
                 self.has_relation(did, &ns_collection, doc_id, UPDATER_RELATION)
                     .await?
-                    || self
-                        .has_relation(did, &ns_collection, doc_id, "writer")
-                        .await?
             }
             DocumentPermission::Delete => {
                 self.has_relation(did, &ns_collection, doc_id, DELETER_RELATION)

--- a/crates/db/src/block_verify.rs
+++ b/crates/db/src/block_verify.rs
@@ -117,12 +117,14 @@ async fn verify_block_signature_with_blockstore<S: Store>(
             .get_collection_by_version_id(schema_version_id)
             .map_err(|e| format!("failed to get collection: {}", e))?
         {
+            let node_did = database.node_did();
             let has_permission = crate::check_doc_permission(
                 document_acp,
                 caller_identity,
                 acp::DocumentPermission::Read,
                 collection.schema(),
                 &doc_id,
+                node_did.as_ref(),
             )
             .await
             .map_err(|e| format!("ACP check failed: {}", e))?;

--- a/crates/db/src/collection_acp.rs
+++ b/crates/db/src/collection_acp.rs
@@ -33,22 +33,45 @@ use schema::CollectionVersion;
 
 /// Check if identity has permission for a document operation.
 ///
-/// Returns true if:
+/// Returns true if any of the following holds:
 /// 1. Collection has no policy (ACP not enforced)
-/// 2. Document is unregistered (public)
-/// 3. Identity has the required permission
+/// 2. The thread-local DAC bypass flag is set (NAC admin with `bypass-dac`,
+///    resolved at the HTTP/FFI entry point via `should_bypass_dac()`)
+/// 3. The request identity equals the configured `node_identity` (the
+///    process owner gets full access — matches Go DefraDB's
+///    `internal/db/collection_acp.go:60-62`)
+/// 4. Document is unregistered (public) — handled inside the backend
+/// 5. Identity has the required relation/permission — handled by the backend
 pub async fn check_doc_permission(
     acp: &dyn DocumentACP,
     identity: &Identity,
     permission: DocumentPermission,
     collection: &CollectionVersion,
     doc_id: &str,
+    node_identity: Option<&Did>,
 ) -> acp::Result<bool> {
     // If collection has no policy, ACP is not enforced
     let policy = match &collection.policy {
         Some(p) => p,
         None => return Ok(true),
     };
+
+    // DAC bypass via thread-local flag (set by HTTP/FFI entry points after
+    // resolving NAC `bypass-dac` permission via `acp::nac::should_bypass_dac`).
+    // Mirrors how the query path honors the bypass via `permission_filter`.
+    if defra_core::dac_bypass::get_dac_bypass() {
+        return Ok(true);
+    }
+
+    // Node-identity full-access shortcut (matches Go's
+    // `internal/db/collection_acp.go:60-62`). The process owner is granted
+    // full access to all documents regardless of DAC, which is required for
+    // background tasks, backup, GC, and admin operations.
+    if let (Some(node_did), Identity::Authenticated(req_did)) = (node_identity, identity) {
+        if node_did == req_did {
+            return Ok(true);
+        }
+    }
 
     acp.check_doc_access(
         identity,
@@ -114,27 +137,40 @@ pub async fn unregister_doc_if_needed(
 
 /// ACP context for mutation operations.
 ///
-/// This wraps the DocumentACP and identity for convenient access
-/// during collection mutations.
+/// This wraps the DocumentACP, request identity, and the node identity for
+/// convenient access during collection mutations. The node identity is used
+/// for the full-access shortcut (matches Go DefraDB's behavior — the process
+/// owner gets full access to all documents).
 #[derive(Clone)]
 pub struct AcpContext {
     /// Document ACP for permission checks
     pub acp: Arc<dyn DocumentACP>,
     /// Identity making the request
     pub identity: Identity,
+    /// Node identity (process owner) — granted full access if equal to `identity`
+    pub node_identity: Option<Did>,
 }
 
 impl AcpContext {
     /// Create a new ACP context.
-    pub fn new(acp: Arc<dyn DocumentACP>, identity: Identity) -> Self {
-        Self { acp, identity }
+    pub fn new(acp: Arc<dyn DocumentACP>, identity: Identity, node_identity: Option<Did>) -> Self {
+        Self {
+            acp,
+            identity,
+            node_identity,
+        }
     }
 
     /// Create from an optional DID for backward compatibility.
-    pub fn from_optional_did(acp: Arc<dyn DocumentACP>, did: Option<Did>) -> Self {
+    pub fn from_optional_did(
+        acp: Arc<dyn DocumentACP>,
+        did: Option<Did>,
+        node_identity: Option<Did>,
+    ) -> Self {
         Self {
             acp,
             identity: Identity::from(did),
+            node_identity,
         }
     }
 
@@ -151,6 +187,7 @@ impl AcpContext {
             permission,
             collection,
             doc_id,
+            self.node_identity.as_ref(),
         )
         .await
     }

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -414,6 +414,18 @@ impl<S: Store> DB<S> {
         self.options.node_identity.is_some()
     }
 
+    /// Returns the node identity's DID, if configured and derivable.
+    ///
+    /// Used by ACP checks to apply the node-identity full-access shortcut.
+    /// Returns `None` if the node identity is not configured or its public
+    /// key cannot be converted into a DID.
+    pub fn node_did(&self) -> Option<identity::Did> {
+        self.options
+            .node_identity
+            .as_ref()
+            .and_then(|id| id.did().ok())
+    }
+
     /// Create the appropriate lens transform store for the current platform.
     #[cfg(feature = "native")]
     fn create_lens_store() -> Result<Arc<dyn TransformStore>> {

--- a/crates/db/tests/collection_acp_tests.rs
+++ b/crates/db/tests/collection_acp_tests.rs
@@ -56,6 +56,7 @@ async fn test_no_policy_allows_all() {
         DocumentPermission::Read,
         &collection,
         "doc1",
+        None,
     )
     .await
     .unwrap();
@@ -123,6 +124,7 @@ async fn test_owner_has_update_permission() {
         DocumentPermission::Update,
         &collection,
         "doc1",
+        None,
     )
     .await
     .unwrap();
@@ -149,6 +151,7 @@ async fn test_non_owner_denied_update_permission() {
         DocumentPermission::Update,
         &collection,
         "doc1",
+        None,
     )
     .await
     .unwrap();
@@ -162,7 +165,7 @@ async fn test_acp_context() {
     let collection = collection_with_policy();
     let owner = test_did();
 
-    let ctx = AcpContext::new(acp, Identity::Authenticated(owner));
+    let ctx = AcpContext::new(acp, Identity::Authenticated(owner), None);
 
     // Register document using context
     ctx.register_doc(&collection, "doc1").await.unwrap();
@@ -347,6 +350,7 @@ async fn test_policy_change_mid_transaction_permission_check() {
         DocumentPermission::Read,
         &collection_v1,
         "doc1",
+        None,
     )
     .await
     .unwrap();
@@ -359,6 +363,7 @@ async fn test_policy_change_mid_transaction_permission_check() {
         DocumentPermission::Read,
         &collection_v1,
         "doc1",
+        None,
     )
     .await
     .unwrap();
@@ -377,6 +382,7 @@ async fn test_policy_change_mid_transaction_permission_check() {
         DocumentPermission::Read,
         &collection_v2,
         "doc1",
+        None,
     )
     .await
     .unwrap();
@@ -405,6 +411,7 @@ async fn test_policy_removal_mid_transaction_makes_docs_public() {
         DocumentPermission::Update,
         &collection_with_pol,
         "doc1",
+        None,
     )
     .await
     .unwrap();
@@ -420,6 +427,7 @@ async fn test_policy_removal_mid_transaction_makes_docs_public() {
         DocumentPermission::Update,
         &collection_no_pol,
         "doc1",
+        None,
     )
     .await
     .unwrap();
@@ -433,8 +441,271 @@ async fn test_policy_removal_mid_transaction_makes_docs_public() {
         DocumentPermission::Update,
         &collection_no_pol,
         "doc1",
+        None,
     )
     .await
     .unwrap();
     assert!(allowed);
+}
+
+// =========================================================================
+// Bypass tests for #738 (DAC bypass thread-local) and #739 (node identity)
+// =========================================================================
+
+#[tokio::test]
+async fn test_node_identity_bypass_grants_full_access() {
+    // A request from the node identity should be granted full access to a
+    // protected document owned by a different identity.
+    // Matches Go's `internal/db/collection_acp.go:60-62`.
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = collection_with_policy();
+    let owner = test_did();
+    let node_identity = test_did2();
+
+    // Register the document with `owner` as the owner.
+    register_doc_if_needed(&acp, Some(&owner), &collection, "doc1")
+        .await
+        .unwrap();
+
+    // The node identity is a different DID — it has no document-level grants.
+    // Without the bypass, this would be denied.
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(node_identity.clone()),
+        DocumentPermission::Read,
+        &collection,
+        "doc1",
+        Some(&node_identity),
+    )
+    .await
+    .unwrap();
+    assert!(allowed, "node identity must be granted full access");
+
+    // Same for Update.
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(node_identity.clone()),
+        DocumentPermission::Update,
+        &collection,
+        "doc1",
+        Some(&node_identity),
+    )
+    .await
+    .unwrap();
+    assert!(allowed, "node identity must be granted Update access");
+
+    // Same for Delete.
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(node_identity.clone()),
+        DocumentPermission::Delete,
+        &collection,
+        "doc1",
+        Some(&node_identity),
+    )
+    .await
+    .unwrap();
+    assert!(allowed, "node identity must be granted Delete access");
+}
+
+#[tokio::test]
+async fn test_non_node_identity_still_denied() {
+    // Sanity check: with a configured node_identity, a different identity
+    // must still be subject to the normal DAC checks.
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = collection_with_policy();
+    let owner = test_did();
+    let node_identity = test_did2();
+    let stranger = Did::new("did:key:z6MkpZqHJYYwK7gP9eVUuLAMz3jJW4Wc8nN6F2VQ8RJ7Wn1V").unwrap();
+
+    register_doc_if_needed(&acp, Some(&owner), &collection, "doc1")
+        .await
+        .unwrap();
+
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(stranger),
+        DocumentPermission::Read,
+        &collection,
+        "doc1",
+        Some(&node_identity),
+    )
+    .await
+    .unwrap();
+    assert!(
+        !allowed,
+        "stranger must still be denied even with node_identity configured"
+    );
+}
+
+#[tokio::test]
+async fn test_node_identity_none_falls_through() {
+    // When node_identity is None, the bypass shortcut is skipped and DAC
+    // applies normally.
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = collection_with_policy();
+    let owner = test_did();
+    let stranger = test_did2();
+
+    register_doc_if_needed(&acp, Some(&owner), &collection, "doc1")
+        .await
+        .unwrap();
+
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(stranger),
+        DocumentPermission::Read,
+        &collection,
+        "doc1",
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(
+        !allowed,
+        "stranger must be denied when no node_identity is set"
+    );
+}
+
+#[tokio::test]
+async fn test_dac_bypass_thread_local_grants_full_access() {
+    // The thread-local `dac_bypass` flag (set by HTTP/FFI entry points after
+    // resolving NAC `bypass-dac` permission via `should_bypass_dac`) must
+    // grant access on the mutation path too.
+    // This covers #738 — the previous gap was that the mutation path
+    // (`check_doc_permission`) ignored this flag.
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = collection_with_policy();
+    let owner = test_did();
+    let admin = test_did2();
+
+    register_doc_if_needed(&acp, Some(&owner), &collection, "doc1")
+        .await
+        .unwrap();
+
+    // Without the flag, admin is denied.
+    defra_core::dac_bypass::set_dac_bypass(false);
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(admin.clone()),
+        DocumentPermission::Update,
+        &collection,
+        "doc1",
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(!allowed, "admin without bypass flag must be denied");
+
+    // With the flag set, admin is granted access regardless of DAC.
+    defra_core::dac_bypass::set_dac_bypass(true);
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(admin.clone()),
+        DocumentPermission::Update,
+        &collection,
+        "doc1",
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(allowed, "admin with dac_bypass flag must be granted access");
+
+    // Reset the thread-local so it doesn't leak into other tests.
+    defra_core::dac_bypass::set_dac_bypass(false);
+}
+
+// =========================================================================
+// Parity test for #740: "writer" must NOT be a recognized relation
+// =========================================================================
+
+#[tokio::test]
+async fn test_writer_relation_is_not_recognized() {
+    // Go DefraDB uses only owner/reader/updater/deleter relations.
+    // A "writer" relation (which used to be checked in local.rs) must not
+    // grant Update or Read access.
+    use acp::{AcpStore, RelationTuple, UPDATER_RELATION};
+
+    let store = Arc::new(MemoryAcpStore::new());
+    let acp = LocalDocumentACP::new(store.clone());
+    let collection = collection_with_policy();
+    let owner = test_did();
+    let granted_user = test_did2();
+
+    register_doc_if_needed(&acp, Some(&owner), &collection, "doc1")
+        .await
+        .unwrap();
+
+    // Manually insert a "writer" relation tuple via put_tuple.
+    let policy = collection.policy.as_ref().unwrap();
+    let ns_collection = format!("{}:{}", policy.id, policy.resource_name);
+    let tuple = RelationTuple::try_new(granted_user.clone(), "writer", &ns_collection, "doc1")
+        .expect("relation tuple");
+    store.put_tuple(&tuple).await.unwrap();
+
+    // The "writer" relation must NOT grant Update access (Go has no such relation).
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(granted_user.clone()),
+        DocumentPermission::Update,
+        &collection,
+        "doc1",
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(
+        !allowed,
+        "\"writer\" relation must not grant Update — Go DefraDB uses \"updater\""
+    );
+
+    // And it must NOT grant Read either.
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(granted_user.clone()),
+        DocumentPermission::Read,
+        &collection,
+        "doc1",
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(!allowed, "\"writer\" relation must not grant Read");
+
+    // Now grant the canonical "updater" relation and verify Read+Update work.
+    let tuple = RelationTuple::try_new(
+        granted_user.clone(),
+        UPDATER_RELATION,
+        &ns_collection,
+        "doc1",
+    )
+    .expect("relation tuple");
+    store.put_tuple(&tuple).await.unwrap();
+
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(granted_user.clone()),
+        DocumentPermission::Update,
+        &collection,
+        "doc1",
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(allowed, "canonical 'updater' relation must grant Update");
+
+    let allowed = check_doc_permission(
+        &acp,
+        &Identity::Authenticated(granted_user),
+        DocumentPermission::Read,
+        &collection,
+        "doc1",
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(
+        allowed,
+        "canonical 'updater' relation must imply Read (matches Go's ImplyDocumentReadPerm)"
+    );
 }

--- a/crates/ffi/src/query/mod.rs
+++ b/crates/ffi/src/query/mod.rs
@@ -41,22 +41,20 @@ pub(crate) fn nac_permission_for_query(query_str: &str) -> NodePermission {
     }
 }
 
-/// Check if the identity has DAC bypass permission (NAC admin/owner).
+/// Check if the identity has DAC bypass permission (NAC admin/owner) or
+/// is the node identity itself.
 ///
-/// Sets the thread-local `dac_bypass` flag to `true` if the identity has
-/// the `DacBypass` node permission (meaning they can read all documents
-/// regardless of DAC policies).
+/// Sets the thread-local `dac_bypass` flag to `true` if either:
+///
+/// - The request identity equals the configured node identity (matches Go's
+///   `internal/db/collection_acp.go:60-62` — process owner gets full access).
+/// - The identity has the `DacBypass` NAC permission.
 pub(crate) fn check_and_set_dac_bypass(
     rt: &tokio::runtime::Runtime,
     node_ptr: usize,
     identity_did: *const c_char,
 ) {
     defra_core::dac_bypass::set_dac_bypass(false);
-
-    let nac_manager = match NODES.get(node_ptr, |state| state.nac_manager.clone()) {
-        Some(m) => m,
-        None => return,
-    };
 
     // SAFETY: `identity_did` is either null or a valid C string from the FFI caller.
     let identity_str = unsafe { c_str_to_string(identity_did) };
@@ -66,6 +64,22 @@ pub(crate) fn check_and_set_dac_bypass(
             Err(_) => return,
         },
         _ => None,
+    };
+
+    // Node-identity full-access shortcut.
+    let node_did = NODES
+        .get(node_ptr, |state| state.node_identity_did.clone())
+        .flatten();
+    if let (Some(node), Some(req)) = (&node_did, &did) {
+        if node.as_str() == req.as_str() {
+            defra_core::dac_bypass::set_dac_bypass(true);
+            return;
+        }
+    }
+
+    let nac_manager = match NODES.get(node_ptr, |state| state.nac_manager.clone()) {
+        Some(m) => m,
+        None => return,
     };
 
     let status = rt.block_on(nac_manager.status());

--- a/crates/http/src/query_context.rs
+++ b/crates/http/src/query_context.rs
@@ -125,9 +125,19 @@ pub(crate) fn resolve_signing_config(
 
 /// Resolve whether DAC bypass should be enabled for this request.
 ///
-/// - If NAC is not configured or not enabled, no bypass.
-/// - If identity has `DacBypass` permission, enable bypass.
+/// - If the request identity equals the configured node identity, bypass.
+///   (Matches Go's `internal/db/collection_acp.go:60-62` — the process owner
+///   gets full access to all documents regardless of DAC.)
+/// - If NAC is configured and the identity has `DacBypass` permission, bypass.
+/// - Otherwise, no bypass.
 pub(crate) async fn resolve_dac_bypass(state: &AppState, identity: &ExtractIdentity) -> bool {
+    // Node-identity full-access shortcut.
+    if let (Some(node_did), Some(req_did)) = (&state.node_identity_did, identity.did()) {
+        if node_did.as_str() == req_did.as_str() {
+            return true;
+        }
+    }
+
     let Some(nac) = &state.nac else {
         return false;
     };


### PR DESCRIPTION
## Summary

Three related ACP correctness fixes that bring Rust DefraDB into line with Go DefraDB on the document permission check path.

Closes #738, #739, #740.

## Bugs fixed

### #738 — DAC bypass not enforced on mutations

The thread-local `dac_bypass` flag (set by HTTP/FFI entry points after resolving the NAC `bypass-dac` permission via `should_bypass_dac`) was honored on the query read path (via `permission_filter.rs`) but **ignored on the mutation path** (`check_doc_permission`). A NAC admin granted `bypass-dac` could read protected docs but not write to them.

Fix: `check_doc_permission()` now consults `defra_core::dac_bypass::get_dac_bypass()` before delegating to the DocumentACP backend.

### #739 — Missing node-identity full-access shortcut

Go's `internal/db/collection_acp.go:60-62` grants the process owner full access to all documents:

```go
if ident.HasValue() && c.db.nodeIdentity.HasValue() && ident.Value().DID() == c.db.nodeIdentity.Value().DID() {
    return true, nil
}
```

This is required for backup, GC, downsample, admin tools, and internal background tasks running as the node identity. Rust had no such shortcut anywhere in the call chain.

Fix:
- `crates/http/src/query_context.rs:resolve_dac_bypass` now returns `true` when the request identity matches the configured node identity
- `crates/ffi/src/query/mod.rs:check_and_set_dac_bypass` does the same for FFI callers
- `crates/db/src/collection_acp.rs:check_doc_permission` accepts an optional `node_identity` parameter for direct callers (e.g., `block_verify`)
- `crates/db/src/database.rs` exposes a new `node_did()` helper

### #740 — `"writer"` is not a valid DefraDB relation

`LocalDocumentACP` checked for a `"writer"` relation in four places. Go uses only `owner/reader/updater/deleter`. The DPI validator never accepts `writer` as a declared relation, so the lookup was both dead code and a wire-compatibility hazard.

Fix: Removed all four `"writer"` references from `crates/acp/src/local.rs`.

## What changed

| File | Change |
|---|---|
| `crates/db/src/collection_acp.rs` | `check_doc_permission` now consults the dac_bypass thread-local and optional node_identity |
| `crates/db/src/database.rs` | New `node_did()` helper |
| `crates/db/src/block_verify.rs` | Passes node DID to check_doc_permission |
| `crates/http/src/query_context.rs` | `resolve_dac_bypass` returns true if identity == node identity |
| `crates/ffi/src/query/mod.rs` | Same shortcut for FFI callers |
| `crates/acp/src/local.rs` | Removed all `"writer"` relation references |
| `crates/db/tests/collection_acp_tests.rs` | 4 new tests + updated existing tests for new param |

## Tests

4 new tests in `crates/db/tests/collection_acp_tests.rs`:

- `test_node_identity_bypass_grants_full_access` — verifies the node identity shortcut works for Read/Update/Delete
- `test_non_node_identity_still_denied` — sanity check that other identities are still subject to DAC
- `test_node_identity_none_falls_through` — verifies the shortcut is skipped when node_identity is None
- `test_dac_bypass_thread_local_grants_full_access` — verifies the thread-local flag now works on the mutation path
- `test_writer_relation_is_not_recognized` — verifies the canonical `updater` relation works and `writer` is rejected

## Test plan

- [x] `cargo test -p db --test collection_acp_tests` — 24/24 pass (4 new + 20 existing)
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test` — all pass
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] `cargo test -p integration-test --test acp -- ::rust_` — all 20 Rust ACP integration tests pass
- [x] `cargo test -p integration-test --test nac -- ::rust_` — all 8 Rust NAC tests pass

## Breaking changes

`check_doc_permission()` now takes an additional `node_identity: Option<&Did>` parameter, and `AcpContext::new()` takes an additional `node_identity: Option<Did>` parameter. Both downstream callers (`block_verify.rs` and the test file) have been updated. No external API surface changes.

## Reference

- Go: `internal/db/collection_acp.go:60-62` (node identity shortcut), `internal/db/acp/check.go:106` (canDACBypass)
- Issues: #738 (DAC bypass), #739 (node identity), #740 (writer relation)
