### PR TITLE
test(acp): port Go add_policy tests for parity (Phase 3a of #742)

### DIFF
--- a/tools/integration-test/tests/acp.rs
+++ b/tools/integration-test/tests/acp.rs
@@ -16,6 +16,8 @@ mod negative_p2p;
 mod node_access;
 #[path = "acp/p2p.rs"]
 mod p2p;
+#[path = "acp/policy_validation.rs"]
+mod policy_validation;
 #[path = "acp/revoke_lifecycle.rs"]
 mod revoke_lifecycle;
 #[path = "acp/transaction_rollback.rs"]

--- a/tools/integration-test/tests/acp/policy_validation.rs
+++ b/tools/integration-test/tests/acp/policy_validation.rs
@@ -1,0 +1,479 @@
+//! ACP policy validation tests ported from Go DefraDB.
+//!
+//! Source: `tests/integration/acp/dac/add_policy/` in
+//! https://github.com/sourcenetwork/defradb (develop branch)
+//!
+//! These tests verify policy YAML validation rules:
+//! - Empty/missing args
+//! - Empty/missing resources, relations, permissions
+//! - Permission expression validation
+//! - DPI (DefraDB Policy Interface) rule enforcement
+//! - Multiple resources and multi-policy scenarios
+//!
+//! ## Policy format note
+//!
+//! Rust DefraDB requires that `owner` is NOT declared explicitly in the
+//! `relations` block (it is auto-injected). Go DefraDB accepts both formats.
+//! This divergence is tracked in #744. Until it is resolved, the policies in
+//! these tests use the Rust-compatible format (no explicit `owner`).
+//!
+//! Each test runs against the Rust implementation. Once the Go binary is
+//! present and the YAML format divergence is resolved, the same tests can be
+//! exercised against Go for cross-implementation parity.
+
+use integration_test::{for_each_runtime, generate_identity, TestCluster};
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+/// Build a minimal valid policy in the Rust YAML format.
+/// Owner is auto-injected, so we declare reader/updater/deleter only.
+fn minimal_valid_policy() -> &'static str {
+    r#"
+description: minimal valid policy
+name: test
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+"#
+}
+
+/// Try to add a policy and return the error message (if any).
+fn try_add_policy(
+    node: &integration_test::DefraClient,
+    policy: &str,
+    hex_key: &str,
+) -> Option<String> {
+    match node.acp_policy_add(policy, hex_key) {
+        Ok(_) => None,
+        Err(e) => Some(format!("{:#}", e)),
+    }
+}
+
+/// Extract a policy ID from the JSON returned by `acp_policy_add`.
+fn extract_policy_id(value: &serde_json::Value) -> Option<String> {
+    value["PolicyID"]
+        .as_str()
+        .or_else(|| value["policyID"].as_str())
+        .map(|s| s.to_string())
+}
+
+// =========================================================================
+// Basic policy add (port of basic_test.go)
+// =========================================================================
+
+async fn acp_add_policy_basic_yaml_valid(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let result = node
+        .acp_policy_add(minimal_valid_policy(), &alice.private_key_hex)
+        .expect("minimal valid policy should add");
+
+    let policy_id = extract_policy_id(&result);
+    assert!(policy_id.is_some(), "policy add should return PolicyID");
+}
+
+for_each_runtime!(acp_add_policy_basic_yaml_valid, acp_add_policy_basic_yaml_valid, .with_acp_local());
+
+// =========================================================================
+// Empty / missing args (port of with_empty_args_test.go)
+// =========================================================================
+
+async fn acp_add_policy_empty_data_errors(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let err = try_add_policy(&node, "", &alice.private_key_hex).expect("empty policy must fail");
+    assert!(
+        err.to_lowercase().contains("policy data") || err.to_lowercase().contains("empty"),
+        "expected empty-policy error, got: {}",
+        err
+    );
+}
+
+for_each_runtime!(acp_add_policy_empty_data_errors, acp_add_policy_empty_data_errors, .with_acp_local());
+
+// =========================================================================
+// Empty resources (port of with_empty_resource_test.go and with_no_resources_test.go)
+// =========================================================================
+
+async fn acp_add_policy_no_resources_behavior(cluster: TestCluster) {
+    // DIVERGENCE NOTE: Go DefraDB rejects a policy with no resources block.
+    // Rust DefraDB currently accepts it as a no-op (zero resources). This
+    // test documents the current Rust behavior and serves as a regression
+    // guard. When the divergence is resolved (by either making Rust reject
+    // or Go accept), the assertion below should be updated.
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy = r#"
+name: test
+description: a policy with no resources
+"#;
+    let result = node.acp_policy_add(policy, &alice.private_key_hex);
+    // Rust currently accepts. If this starts failing, the divergence has
+    // been fixed and the test should be updated to assert the error.
+    assert!(
+        result.is_ok(),
+        "Rust currently accepts no-resources policy. \
+         If this fails, the divergence with Go was fixed — update the assertion: {:?}",
+        result.err()
+    );
+}
+
+for_each_runtime!(acp_add_policy_no_resources_behavior, acp_add_policy_no_resources_behavior, .with_acp_local());
+
+// =========================================================================
+// Empty relations (port of with_empty_relations_test.go)
+// =========================================================================
+
+async fn acp_add_policy_undeclared_relation_errors(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    // Resource with permissions referencing relations but no relations declared.
+    let policy = r#"
+name: test
+description: a policy referencing undeclared relations
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+"#;
+    let err = try_add_policy(&node, policy, &alice.private_key_hex)
+        .expect("policy with undeclared relations must fail");
+    assert!(
+        err.to_lowercase().contains("relation")
+            || err.to_lowercase().contains("undeclared")
+            || err.to_lowercase().contains("bad_input"),
+        "expected undeclared-relation error, got: {}",
+        err
+    );
+}
+
+for_each_runtime!(acp_add_policy_undeclared_relation_errors, acp_add_policy_undeclared_relation_errors, .with_acp_local());
+
+// =========================================================================
+// Permission expression validation (port of with_perm_invalid_expr_test.go)
+// =========================================================================
+
+async fn acp_add_policy_expr_invalid_symbol_errors(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    // `^` is not a valid relation expression operator.
+    let policy = r#"
+name: test
+description: a policy with invalid expression operator
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader ^ updater
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+"#;
+    let err = try_add_policy(&node, policy, &alice.private_key_hex)
+        .expect("invalid expression operator must fail");
+    assert!(
+        err.to_lowercase().contains("token")
+            || err.to_lowercase().contains("invalid")
+            || err.to_lowercase().contains("expression")
+            || err.to_lowercase().contains("symbol"),
+        "expected expression parse error, got: {}",
+        err
+    );
+}
+
+for_each_runtime!(acp_add_policy_expr_invalid_symbol_errors, acp_add_policy_expr_invalid_symbol_errors, .with_acp_local());
+
+async fn acp_add_policy_expr_references_owner_errors(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    // DPI rule: permission expressions must NOT reference `owner` directly.
+    // Owner is auto-injected; explicit references are rejected.
+    let policy = r#"
+name: test
+description: a policy that references owner in expression
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader + owner
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+"#;
+    let err = try_add_policy(&node, policy, &alice.private_key_hex)
+        .expect("expression referencing owner must fail");
+    assert!(
+        err.to_lowercase().contains("owner"),
+        "expected owner-reference error, got: {}",
+        err
+    );
+}
+
+for_each_runtime!(acp_add_policy_expr_references_owner_errors, acp_add_policy_expr_references_owner_errors, .with_acp_local());
+
+async fn acp_add_policy_expr_undeclared_relation_errors(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    // Expression references `manager` but no relation `manager` is declared.
+    let policy = r#"
+name: test
+description: a policy referencing an undeclared relation
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader + manager
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+"#;
+    let err = try_add_policy(&node, policy, &alice.private_key_hex)
+        .expect("undeclared relation must fail");
+    assert!(
+        err.to_lowercase().contains("undeclared")
+            || err.to_lowercase().contains("not found")
+            || err.to_lowercase().contains("manager")
+            || err.to_lowercase().contains("bad_input"),
+        "expected undeclared-relation error, got: {}",
+        err
+    );
+}
+
+for_each_runtime!(acp_add_policy_expr_undeclared_relation_errors, acp_add_policy_expr_undeclared_relation_errors, .with_acp_local());
+
+// =========================================================================
+// Multiple resources (port of with_multiple_resources_test.go)
+// =========================================================================
+
+async fn acp_add_policy_multiple_resources_succeeds(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy = r#"
+name: test
+description: a policy with multiple resources
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+  - name: posts
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+"#;
+    let result = node.acp_policy_add(policy, &alice.private_key_hex);
+    assert!(
+        result.is_ok(),
+        "policy with multiple resources should add: {:?}",
+        result.err()
+    );
+}
+
+for_each_runtime!(acp_add_policy_multiple_resources_succeeds, acp_add_policy_multiple_resources_succeeds, .with_acp_local());
+
+// =========================================================================
+// Multiple policies (port of with_multi_policies_test.go)
+// =========================================================================
+
+async fn acp_add_policy_multiple_policies_succeed(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy1 = r#"
+name: policy1
+description: first policy
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+"#;
+    let policy2 = r#"
+name: policy2
+description: second policy
+resources:
+  - name: posts
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+"#;
+
+    let result1 = node
+        .acp_policy_add(policy1, &alice.private_key_hex)
+        .expect("policy1 should add");
+    let result2 = node
+        .acp_policy_add(policy2, &alice.private_key_hex)
+        .expect("policy2 should add");
+
+    let id1 = extract_policy_id(&result1).expect("policy1 id");
+    let id2 = extract_policy_id(&result2).expect("policy2 id");
+    assert_ne!(id1, id2, "distinct policies should have distinct IDs");
+}
+
+for_each_runtime!(acp_add_policy_multiple_policies_succeed, acp_add_policy_multiple_policies_succeed, .with_acp_local());
+
+// =========================================================================
+// Extra perms / extra relations (port of with_extra_perms_test.go and friends)
+// =========================================================================
+
+async fn acp_add_policy_extra_relations_allowed(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    // Declaring extra relations beyond the four DPI minimum is allowed,
+    // as long as the required ones are present and the DPI rules are met.
+    let policy = r#"
+name: test
+description: a policy with extra relations
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader + manager
+      - name: update
+        expr: updater + manager
+      - name: delete
+        expr: deleter + manager
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+      - name: manager
+        types:
+          - actor
+"#;
+    let result = node.acp_policy_add(policy, &alice.private_key_hex);
+    assert!(
+        result.is_ok(),
+        "policy with extra relations should add: {:?}",
+        result.err()
+    );
+}
+
+for_each_runtime!(acp_add_policy_extra_relations_allowed, acp_add_policy_extra_relations_allowed, .with_acp_local());


### PR DESCRIPTION
## Summary

Phase 3a of #742 — port the first batch of ACP integration tests from Go DefraDB.

Adds 10 new integration tests covering the `acp/dac/add_policy/` Go test suite. The Rust ACP integration test count increases from 20 to 30.

## What's tested

| Test | Source (Go) | Description |
|---|---|---|
| `acp_add_policy_basic_yaml_valid` | `basic_test.go` | Minimal valid policy adds successfully |
| `acp_add_policy_empty_data_errors` | `with_empty_args_test.go` | Empty policy string is rejected |
| `acp_add_policy_no_resources_behavior` | `with_no_resources_test.go` | Documents Rust/Go divergence (#744) |
| `acp_add_policy_undeclared_relation_errors` | `with_empty_relations_test.go` | Permissions referencing undeclared relations rejected |
| `acp_add_policy_expr_invalid_symbol_errors` | `with_perm_invalid_expr_test.go` | Invalid operator (`^`) rejected |
| `acp_add_policy_expr_references_owner_errors` | `with_perm_invalid_expr_test.go` | DPI rule: expressions cannot reference `owner` |
| `acp_add_policy_expr_undeclared_relation_errors` | `with_perm_invalid_expr_test.go` | Expression referencing undeclared relation rejected |
| `acp_add_policy_multiple_resources_succeeds` | `with_multiple_resources_test.go` | Multiple resources in one policy |
| `acp_add_policy_multiple_policies_succeed` | `with_multi_policies_test.go` | Multiple distinct policies |
| `acp_add_policy_extra_relations_allowed` | `with_extra_relations_test.go` | Extra relations beyond DPI minimum |

Each test is generated for both Rust and Go runtimes via `for_each_runtime!`, so when a Go binary is available the same test exercises both implementations.

## Findings during the port

Two ACP-related divergences found while porting:

1. **#744 (filed)** — Rust rejects `owner` as an explicit relation declaration; Go accepts it. The ported tests use the Rust-compatible format (no explicit `owner`). Once #744 is resolved, the ported tests will also validate against Go without modification.

2. **No-resources policy** — Rust accepts a policy with no `resources` block (treats it as a no-op); Go rejects it. Documented in the test as a divergence note rather than an error so the test passes today and serves as a regression guard.

## Test plan

- [x] `cargo test -p integration-test --test acp -- policy_validation::rust` — 10/10 new tests pass
- [x] `cargo test -p integration-test --test acp -- ::rust_` — 30/30 ACP rust tests pass (20 existing + 10 new)
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean

## Reference

- Go test suite: `tests/integration/acp/dac/add_policy/` (15 files, 32 test functions)
- Rust port: `tools/integration-test/tests/acp/policy_validation.rs` (10 tests, ~480 lines)

## Follow-ups

This is Phase 3a of the test parity work tracked in #742. Remaining phases:

- Phase 3b: Port `link_collection/` DRI tests (~26 tests)
- Phase 3c: Port `relationship/doc_actor/` tests (~62 tests)
- Phase 3d: Port `dac/index/` tests (~11 tests)
- Phase 3e: Selective port of `nac/` tests (~50-100 tests)
