### PR TITLE
ci: enable 54 skipped integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,21 +141,34 @@ jobs:
           echo "$CACHE_DIR" >> "$GITHUB_PATH"
           "$CACHE_DIR/defradb" version --format json
 
+      # `basic` is serialized because its tests start rust nodes and the
+      # harness port allocator (`defra-harness::ports`) has a TOCTOU race
+      # between dropping the port guard listener and the child process
+      # binding. Under high parallelism the race triggers EADDRINUSE.
+      # Track the underlying harness fix in the backbone repo; this flag
+      # is the tactical mitigation.
+      - name: Run rust integration tests (serialized — port race)
+        if: matrix.suite == 'rust'
+        run: >-
+          cargo test -p integration-test
+          --test basic
+          -- --test-threads=1 --skip ::go_
+
       - name: Run rust integration tests
         if: matrix.suite == 'rust'
         run: >-
           cargo test -p integration-test
-          --test basic --test query --test acp --test nac
+          --test query --test acp --test nac
           --test encryption --test identity
           --test backup --test fts
-          -- ::rust_
+          -- --skip ::go_
 
       - name: Run rust P2P integration tests
         if: matrix.suite == 'rust'
         run: >-
           cargo test -p integration-test
           --test p2p
-          -- --test-threads=1 ::rust_
+          -- --test-threads=1 --skip ::go_
 
       - name: Run go-compat integration tests
         if: matrix.suite == 'go-compat'

--- a/tools/integration-test/tests/identity/keyring_lifecycle.rs
+++ b/tools/integration-test/tests/identity/keyring_lifecycle.rs
@@ -121,13 +121,13 @@ fn generate_creates_both_keys(binary: &Path) {
 
 #[test]
 
-fn generate_creates_both_keys_rust() {
+fn rust_generate_creates_both_keys() {
     generate_creates_both_keys(&defra_binary());
 }
 
 #[test]
 
-fn generate_creates_both_keys_go() {
+fn go_generate_creates_both_keys() {
     let go = go_binary().expect("Go defradb not in PATH");
     generate_creates_both_keys(&go);
 }
@@ -151,13 +151,13 @@ fn generate_no_encryption(binary: &Path) {
 
 #[test]
 
-fn generate_no_encryption_rust() {
+fn rust_generate_no_encryption() {
     generate_no_encryption(&defra_binary());
 }
 
 #[test]
 
-fn generate_no_encryption_go() {
+fn go_generate_no_encryption() {
     let go = go_binary().expect("Go defradb not in PATH");
     generate_no_encryption(&go);
 }
@@ -185,13 +185,13 @@ fn generate_no_peer_key(binary: &Path) {
 
 #[test]
 
-fn generate_no_peer_key_rust() {
+fn rust_generate_no_peer_key() {
     generate_no_peer_key(&defra_binary());
 }
 
 #[test]
 
-fn generate_no_peer_key_go() {
+fn go_generate_no_peer_key() {
     let go = go_binary().expect("Go defradb not in PATH");
     generate_no_peer_key(&go);
 }
@@ -218,13 +218,13 @@ fn generate_fails_if_exists(binary: &Path) {
 
 #[test]
 
-fn generate_fails_if_exists_rust() {
+fn rust_generate_fails_if_exists() {
     generate_fails_if_exists(&defra_binary());
 }
 
 #[test]
 
-fn generate_fails_if_exists_go() {
+fn go_generate_fails_if_exists() {
     let go = go_binary().expect("Go defradb not in PATH");
     generate_fails_if_exists(&go);
 }
@@ -242,13 +242,13 @@ fn generate_force_overwrites(binary: &Path) {
 
 #[test]
 
-fn generate_force_overwrites_rust() {
+fn rust_generate_force_overwrites() {
     generate_force_overwrites(&defra_binary());
 }
 
 #[test]
 
-fn generate_force_overwrites_go() {
+fn go_generate_force_overwrites() {
     let go = go_binary().expect("Go defradb not in PATH");
     generate_force_overwrites(&go);
 }
@@ -268,13 +268,13 @@ fn generate_silent_on_success(binary: &Path) {
 
 #[test]
 
-fn generate_silent_on_success_rust() {
+fn rust_generate_silent_on_success() {
     generate_silent_on_success(&defra_binary());
 }
 
 #[test]
 
-fn generate_silent_on_success_go() {
+fn go_generate_silent_on_success() {
     let go = go_binary().expect("Go defradb not in PATH");
     generate_silent_on_success(&go);
 }
@@ -297,13 +297,13 @@ fn export_hex_format(binary: &Path) {
 
 #[test]
 
-fn export_hex_format_rust() {
+fn rust_export_hex_format() {
     export_hex_format(&defra_binary());
 }
 
 #[test]
 
-fn export_hex_format_go() {
+fn go_export_hex_format() {
     let go = go_binary().expect("Go defradb not in PATH");
     export_hex_format(&go);
 }
@@ -340,13 +340,13 @@ fn export_roundtrip(binary: &Path) {
 
 #[test]
 
-fn export_roundtrip_rust() {
+fn rust_export_roundtrip() {
     export_roundtrip(&defra_binary());
 }
 
 #[test]
 
-fn export_roundtrip_go() {
+fn go_export_roundtrip() {
     let go = go_binary().expect("Go defradb not in PATH");
     export_roundtrip(&go);
 }
@@ -367,13 +367,13 @@ fn import_positional_hex(binary: &Path) {
 
 #[test]
 
-fn import_positional_hex_rust() {
+fn rust_import_positional_hex() {
     import_positional_hex(&defra_binary());
 }
 
 #[test]
 
-fn import_positional_hex_go() {
+fn go_import_positional_hex() {
     let go = go_binary().expect("Go defradb not in PATH");
     import_positional_hex(&go);
 }
@@ -394,13 +394,13 @@ fn import_silent_on_success(binary: &Path) {
 
 #[test]
 
-fn import_silent_on_success_rust() {
+fn rust_import_silent_on_success() {
     import_silent_on_success(&defra_binary());
 }
 
 #[test]
 
-fn import_silent_on_success_go() {
+fn go_import_silent_on_success() {
     let go = go_binary().expect("Go defradb not in PATH");
     import_silent_on_success(&go);
 }
@@ -415,13 +415,13 @@ fn import_invalid_hex_fails(binary: &Path) {
 
 #[test]
 
-fn import_invalid_hex_fails_rust() {
+fn rust_import_invalid_hex_fails() {
     import_invalid_hex_fails(&defra_binary());
 }
 
 #[test]
 
-fn import_invalid_hex_fails_go() {
+fn go_import_invalid_hex_fails() {
     let go = go_binary().expect("Go defradb not in PATH");
     import_invalid_hex_fails(&go);
 }
@@ -442,13 +442,13 @@ fn list_empty(binary: &Path) {
 
 #[test]
 
-fn list_empty_rust() {
+fn rust_list_empty() {
     list_empty(&defra_binary());
 }
 
 #[test]
 
-fn list_empty_go() {
+fn go_list_empty() {
     let go = go_binary().expect("Go defradb not in PATH");
     list_empty(&go);
 }
@@ -478,13 +478,13 @@ fn list_format(binary: &Path) {
 
 #[test]
 
-fn list_format_rust() {
+fn rust_list_format() {
     list_format(&defra_binary());
 }
 
 #[test]
 
-fn list_format_go() {
+fn go_list_format() {
     let go = go_binary().expect("Go defradb not in PATH");
     list_format(&go);
 }
@@ -495,7 +495,7 @@ fn list_format_go() {
 
 #[test]
 
-fn generate_named_key_rust() {
+fn rust_generate_named_key() {
     let tmp = tempfile::tempdir().unwrap();
     let kr = tmp.path();
     let binary = defra_binary();
@@ -518,7 +518,7 @@ fn generate_named_key_rust() {
 
 #[test]
 
-fn generate_named_key_force_rust() {
+fn rust_generate_named_key_force() {
     let tmp = tempfile::tempdir().unwrap();
     let kr = tmp.path();
     let binary = defra_binary();
@@ -538,7 +538,7 @@ fn generate_named_key_force_rust() {
 
 #[test]
 
-fn import_stdin_rust() {
+fn rust_import_stdin() {
     let tmp = tempfile::tempdir().unwrap();
     let kr = tmp.path();
     let binary = defra_binary();


### PR DESCRIPTION
## Summary

Closes #751. CI's rust integration suite used the positive filter \`-- ::rust_\` to select the Rust side of dual-backend tests, but the filter only matched prefix-style names generated by \`for_each_runtime!\`. **54 tests were silently skipped** — including the entire FTS binary.

## What was skipped

| Binary | Before | After | Delta | Reason |
|---|---|---|---|---|
| basic | 10 | 12 | +2 | \`smoke::smoke_single_rust_node\`, \`version_json_has_all_fields\` unprefixed |
| query | 16 | 19 | +3 | \`sdl_generate::*\` unprefixed |
| acp | 20 | 20 | 0 | |
| nac | 8 | 8 | 0 | |
| encryption | 5 | 5 | 0 | |
| identity | 6 | 37 | **+31** | \`keyring_lifecycle\` used \`*_rust\`/\`*_go\` suffix convention |
| backup | 6 | 6 | 0 | |
| **fts** | **0** | **18** | **+18** | Whole binary skipped — names like \`basic::bm25_basic_search\` |
| p2p | 18 | 18 | 0 | |
| **Total** | **89** | **143** | **+54 (1.6×)** | |

## Changes

**1. Rename 29 functions in \`identity/keyring_lifecycle.rs\`** from \`*_rust\` / \`*_go\` suffix to \`rust_*\` / \`go_*\` prefix convention. Brings the repo to one consistent naming style. The 3 cross-binary tests (\`import_rust_export_go\`, \`import_go_export_rust\`, \`generate_go_list_rust\`) stay as-is — they need both binaries and are neither-style by design; they already guard on \`go_binary()\` availability.

**2. Replace the CI filter** \`-- ::rust_\` with \`-- --skip ::go_\`. A negative filter runs anything that isn't a \`::go_*\` prefix test, which covers:
- prefix-style \`rust_*\` tests from \`for_each_runtime!\`
- unprefixed rust-only tests (FTS, basic smoke, query sdl_generate)
- cross-binary tests (run in both suites, skip gracefully when the other binary is absent)

The \`::go_\` substring is precise: \`keyring_lifecycle::go_generate_*\` matches; \`keyring_lifecycle::import_go_export_rust\` does NOT (the \`go_\` is mid-name, not after \`::\`).

## Test plan

- [x] \`cargo fmt -p integration-test\` clean
- [x] \`cargo clippy -p integration-test --tests -- -D warnings\` clean
- [x] \`cargo test -p integration-test --test fts -- --skip ::go_\` → 18/18 ✅ (was 0 running)
- [x] \`cargo test -p integration-test --test identity -- --skip ::go_\` → 37/37 ✅ (was 6)
- [x] \`cargo test -p integration-test --test basic --test query --test acp --test nac --test encryption --test backup -- --skip ::go_\` → 70/70 ✅
- [x] \`cargo test -p integration-test --test p2p -- --test-threads=1 --skip ::go_\` → 15/15 ✅ (3 \`#[ignore]\` unchanged)
- [x] All 140 non-ignored tests pass green locally.

## Cost

**Zero build cost.** Every added test reuses the binary that's already compiled by the integration matrix job. Runtime impact is additive only to the rust matrix job (~2-4 min on a self-hosted runner based on FTS + identity measured durations).

## Follow-up (separate PR, not this one)

Expanding the \`go-compat\` matrix job to run \`acp\` / \`nac\` / \`encryption\` / \`backup\` against the Go binary. Blocked on #745-#750 merging first so the 5 known #746 divergence guards in \`link_collection\` can be skipped explicitly.

External-infra binaries (\`sourcehub\`, \`hubrs\`) are out of scope — they need their own workflow.