### PR TITLE
refactor(acp): centralize implies-read logic via DocumentPermission helpers

### DIFF
--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -21,9 +21,7 @@ use crate::dac::DocumentACP;
 use crate::error::{Error, Result};
 use crate::identity::Identity;
 use crate::permission::DocumentPermission;
-use crate::relation::{
-    RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION,
-};
+use crate::relation::{RelationTuple, OWNER_RELATION};
 use crate::store::AcpStore;
 
 // Relation validation is done at the FFI/caller layer against the policy definition.
@@ -73,6 +71,35 @@ impl LocalDocumentACP {
         // Check wildcard relationship (target="*" means all actors)
         let wildcard_tuple = RelationTuple::new(Did::wildcard(), relation, collection_id, doc_id);
         self.store.has_tuple(&wildcard_tuple).await
+    }
+
+    /// Check whether `subject` has any relation that grants `permission`.
+    ///
+    /// For a `Read` permission, this fans out to check all relations in
+    /// `DocumentPermission::implies_read_permissions()` (reader, updater,
+    /// deleter) — matches Go's `ImplyDocumentReadPerm` semantics. For
+    /// `Update` / `Delete`, checks only the single corresponding relation.
+    async fn check_any_implies_read_relation(
+        &self,
+        subject: &Did,
+        collection_id: &str,
+        doc_id: &str,
+        permission: DocumentPermission,
+    ) -> Result<bool> {
+        if permission == DocumentPermission::Read {
+            for perm in DocumentPermission::implies_read_permissions() {
+                if self
+                    .has_relation(subject, collection_id, doc_id, perm.relation_name())
+                    .await?
+                {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        } else {
+            self.has_relation(subject, collection_id, doc_id, permission.relation_name())
+                .await
+        }
     }
 }
 
@@ -171,30 +198,10 @@ impl DocumentACP for LocalDocumentACP {
             Identity::Authenticated(did) => did,
             Identity::Anonymous => {
                 // Check if wildcard grants exist for the requested permission.
-                // Go DefraDB defines four document relations: owner, reader, updater, deleter.
                 let wildcard = Did::wildcard();
-                let granted = match permission {
-                    DocumentPermission::Read => {
-                        // Any write permission implies read (matches Go's
-                        // ImplyDocumentReadPerm in acp/types/types.go).
-                        self.has_relation(&wildcard, &ns_collection, doc_id, READER_RELATION)
-                            .await?
-                            || self
-                                .has_relation(&wildcard, &ns_collection, doc_id, UPDATER_RELATION)
-                                .await?
-                            || self
-                                .has_relation(&wildcard, &ns_collection, doc_id, DELETER_RELATION)
-                                .await?
-                    }
-                    DocumentPermission::Update => {
-                        self.has_relation(&wildcard, &ns_collection, doc_id, UPDATER_RELATION)
-                            .await?
-                    }
-                    DocumentPermission::Delete => {
-                        self.has_relation(&wildcard, &ns_collection, doc_id, DELETER_RELATION)
-                            .await?
-                    }
-                };
+                let granted = self
+                    .check_any_implies_read_relation(&wildcard, &ns_collection, doc_id, permission)
+                    .await?;
                 return Ok(granted);
             }
         };
@@ -205,28 +212,9 @@ impl DocumentACP for LocalDocumentACP {
         }
 
         // Check specific relations based on permission.
-        // Go DefraDB defines four document relations: owner, reader, updater, deleter.
-        // Any write permission implies read access (matches Go's ImplyDocumentReadPerm).
-        let granted = match permission {
-            DocumentPermission::Read => {
-                self.has_relation(did, &ns_collection, doc_id, READER_RELATION)
-                    .await?
-                    || self
-                        .has_relation(did, &ns_collection, doc_id, UPDATER_RELATION)
-                        .await?
-                    || self
-                        .has_relation(did, &ns_collection, doc_id, DELETER_RELATION)
-                        .await?
-            }
-            DocumentPermission::Update => {
-                self.has_relation(did, &ns_collection, doc_id, UPDATER_RELATION)
-                    .await?
-            }
-            DocumentPermission::Delete => {
-                self.has_relation(did, &ns_collection, doc_id, DELETER_RELATION)
-                    .await?
-            }
-        };
+        let granted = self
+            .check_any_implies_read_relation(did, &ns_collection, doc_id, permission)
+            .await?;
 
         if granted {
             tracing::debug!(

--- a/crates/acp/src/permission.rs
+++ b/crates/acp/src/permission.rs
@@ -30,10 +30,42 @@ impl DocumentPermission {
         }
     }
 
-    /// Check if this permission implies read access
+    /// Returns the canonical relation name for this permission in
+    /// document ACP policies (`reader` / `updater` / `deleter`). This
+    /// is the noun form used in the `relations:` block, vs `as_str()`
+    /// which returns the verb form used in permission expressions.
+    pub fn relation_name(&self) -> &'static str {
+        match self {
+            DocumentPermission::Read => "reader",
+            DocumentPermission::Update => "updater",
+            DocumentPermission::Delete => "deleter",
+        }
+    }
+
+    /// Check if this permission implies read access.
+    ///
+    /// All three document permissions (Read, Update, Delete) imply read
+    /// access — matches Go's `ImplyDocumentReadPerm` in
+    /// `acp/types/types.go`. Use `implies_read_permissions()` to iterate
+    /// over the full set.
     pub fn implies_read(&self) -> bool {
-        // All permissions imply read
-        true
+        matches!(
+            self,
+            DocumentPermission::Read | DocumentPermission::Update | DocumentPermission::Delete
+        )
+    }
+
+    /// Returns the set of permissions that imply read access.
+    ///
+    /// Matches Go's `ImplyDocumentReadPerm = []DocumentResourcePermission{Read, Update, Delete}`
+    /// in `acp/types/types.go`. When checking read access, backends iterate
+    /// this list and grant read if the caller has any of them.
+    pub const fn implies_read_permissions() -> &'static [DocumentPermission] {
+        &[
+            DocumentPermission::Read,
+            DocumentPermission::Update,
+            DocumentPermission::Delete,
+        ]
     }
 }
 
@@ -73,6 +105,25 @@ mod tests {
         assert!(DocumentPermission::Read.implies_read());
         assert!(DocumentPermission::Update.implies_read());
         assert!(DocumentPermission::Delete.implies_read());
+    }
+
+    #[test]
+    fn test_implies_read_permissions_matches_go() {
+        let perms = DocumentPermission::implies_read_permissions();
+        assert_eq!(perms.len(), 3);
+        assert_eq!(perms[0], DocumentPermission::Read);
+        assert_eq!(perms[1], DocumentPermission::Update);
+        assert_eq!(perms[2], DocumentPermission::Delete);
+        for p in perms {
+            assert!(p.implies_read());
+        }
+    }
+
+    #[test]
+    fn test_relation_name() {
+        assert_eq!(DocumentPermission::Read.relation_name(), "reader");
+        assert_eq!(DocumentPermission::Update.relation_name(), "updater");
+        assert_eq!(DocumentPermission::Delete.relation_name(), "deleter");
     }
 
     #[test]

--- a/crates/acp/src/zanzibar/acp/document_acp.rs
+++ b/crates/acp/src/zanzibar/acp/document_acp.rs
@@ -125,11 +125,13 @@ impl<S: ZanzibarStore + ?Sized + 'static> DocumentACP for ZanzibarDocumentACP<S>
         self.ensure_policy(policy_id, resource_name).await?;
 
         let granted = if permission == DocumentPermission::Read {
+            // Read access is granted if the caller has any of the
+            // implies-read permissions — matches Go's ImplyDocumentReadPerm.
             let engine = self.engine.read().await;
             let mut result = false;
-            for perm_name in &["read", "update", "delete"] {
+            for perm in DocumentPermission::implies_read_permissions() {
                 match engine
-                    .check(policy_id, resource_name, doc_id, perm_name, did)
+                    .check(policy_id, resource_name, doc_id, perm.as_str(), did)
                     .await
                 {
                     Ok(true) => {


### PR DESCRIPTION
## Summary

Closes #741. Part of the ACP audit completion roadmap (PR B of 4).

\`DocumentPermission::implies_read()\` was defined and unit-tested at [crates/acp/src/permission.rs:34](crates/acp/src/permission.rs#L34) but had no production caller. Both ACP backends had their own inline copies of the fan-out logic, with hardcoded relation names and duplicated iteration. If a new permission is ever added, a contributor would need to remember to update three places in lockstep.

## Changes

**Permission helper (\`crates/acp/src/permission.rs\`)**:
- Fix \`implies_read()\` to actually check membership (\`matches!(self, Read | Update | Delete)\`) instead of unconditionally returning \`true\`
- Add \`implies_read_permissions() -> &'static [DocumentPermission]\` — a const slice mirroring Go's \`ImplyDocumentReadPerm\` in \`acp/types/types.go\`
- Add \`relation_name()\` — returns \`reader\` / \`updater\` / \`deleter\` for each permission (the noun form used in policy \`relations:\` blocks; \`as_str()\` returns the verb form used in permission expressions)
- Two new unit tests: \`test_implies_read_permissions_matches_go\`, \`test_relation_name\`

**\`LocalDocumentACP\` (\`crates/acp/src/local.rs\`)**:
- Add private helper \`check_any_implies_read_relation\` that fans out via \`DocumentPermission::implies_read_permissions()\` for Read, single-relation check otherwise
- Collapse the two duplicated match arms (wildcard + authenticated) into calls to the new helper
- Drop unused \`READER_RELATION\` / \`UPDATER_RELATION\` / \`DELETER_RELATION\` imports — those names now come from \`DocumentPermission::relation_name()\`

**\`ZanzibarDocumentACP\` (\`crates/acp/src/zanzibar/acp/document_acp.rs\`)**:
- Replace hardcoded \`[\"read\", \"update\", \"delete\"]\` slice with \`DocumentPermission::implies_read_permissions()\` iteration

## No behavior change

Pure refactor. The canonical unit test \`test_all_permissions_imply_read\` and every integration test in \`tools/integration-test/tests/acp/\` exercises the semantics.

## Test plan

- [x] \`cargo test -p acp\` → 32/32 pass (including 2 new helper tests)
- [x] \`cargo test -p integration-test --test acp -- --skip ::go_\` → 43/43 pass
- [x] \`cargo clippy --all -- -D warnings\` → clean
- [x] \`cargo fmt --all\` → applied

## Related

- Issue #741 filed during Phase 1 of the ACP audit
- PR A of the completion roadmap: #753 (housekeeping)
- Next: PR C (#744 explicit owner relation), PR D (#746 DRI/DPI validation)