### PR TITLE
test(acp): verify explicit owner relation is rejected by both backends (#744)

### DIFF
--- a/tools/integration-test/tests/acp/policy_validation.rs
+++ b/tools/integration-test/tests/acp/policy_validation.rs
@@ -477,3 +477,60 @@ resources:
 }
 
 for_each_runtime!(acp_add_policy_extra_relations_allowed, acp_add_policy_extra_relations_allowed, .with_acp_local());
+
+// =========================================================================
+// Explicit owner relation — shared Rust/Go behavior (closes #744)
+// =========================================================================
+
+async fn acp_add_policy_explicit_owner_relation_rejected(cluster: TestCluster) {
+    // #744 originally claimed Go accepts explicit `owner` declarations
+    // while Rust rejects. Verified on defradb commit d5a5a879
+    // (2026-04-10): **both backends reject** with the same error
+    // ("owner is a reserved relation name"), because both delegate
+    // policy transformation to the same `sourcenetwork/acp_core`
+    // library. The original audit finding was incorrect — this is a
+    // shared constraint enforced by ACPCore's transformer, not a
+    // Rust-only behavior.
+    //
+    // This test locks in the shared rejection so neither side can
+    // diverge without a deliberate review.
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy = r#"
+name: test
+description: a policy with explicit owner declaration
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: updater
+      - name: delete
+        expr: deleter
+    relations:
+      - name: owner
+        types:
+          - actor
+      - name: reader
+        types:
+          - actor
+      - name: updater
+        types:
+          - actor
+      - name: deleter
+        types:
+          - actor
+"#;
+    let err = try_add_policy(&node, policy, &alice.private_key_hex)
+        .expect("explicit owner declaration must be rejected (shared Rust/Go behavior)");
+    let el = err.to_lowercase();
+    assert!(
+        el.contains("reserved relation name") || el.contains("bad_input"),
+        "expected reserved-owner error, got: {}",
+        err
+    );
+}
+
+for_each_runtime!(acp_add_policy_explicit_owner_relation_rejected, acp_add_policy_explicit_owner_relation_rejected, .with_acp_local());


### PR DESCRIPTION
## Summary

Closes **#744** as not-a-bug. Part of the ACP audit completion roadmap (PR C of 4).

### The finding

Issue #744 was filed claiming Go accepts explicit \`owner\` declarations while Rust rejects, creating a wire-compat gap for Go-authored policies. **This was wrong.**

Verified against \`defradb\` binary commit \`d5a5a879\` (2026-04-10): **both backends reject** an explicit owner declaration with the exact same error:

\`\`\`
invalid resource: 'owner' is a reserved relation name:
rename 'owner' to a different name; ... kind=BAD_INPUT
\`\`\`

The reason they produce the same error is that both Rust and Go delegate policy YAML transformation to the same \`sourcenetwork/acp_core\` Go library, whose transformer enforces \`owner\` as a reserved, auto-injected relation name. The audit reader who filed #744 saw Go's \`RequiredRegistererRelationName = \"owner\"\` constant in \`acp/types/types.go\` and assumed Go accepts declarations — but the constant is consumed by ACPCore, which rejects them.

### What this PR does

Adds one regression test that asserts both runtimes reject the policy. No code change — the parity is already correct. The test runs on both \`.with_acp_local()\` (which uses \`ZanzibarDocumentACP\` backed by ACPCore) and, via \`for_each_runtime!\`, against the Go binary. Locks in the shared behavior so neither side can diverge without a deliberate review.

### Why no code change

The plan said the fix would "remove the reject at \`validate.rs:13-20\` and dedup in \`build_policy\`". I implemented that change and tested against Go — Go then failed my test, because Go also rejects the exact same input. I reverted the code change and inverted the test direction.

This is exactly the kind of "verify before trusting the audit report" step that the user asked for: *"in cases when 100% parity with go results in bad/broken/incorrect/insecure code, look into fixing both sides if applicable."* The audit finding was based on reading the Go constant without testing the actual behavior. Since Go and Rust agree, no fix is needed.

### Test plan

- [x] \`cargo test -p integration-test --test acp -- policy_validation::rust_acp_add_policy_explicit_owner_relation_rejected\` → ✅
- [x] \`PATH=../defradb/build:$PATH DEFRA_SKIP_VERSION_CHECK=1 cargo test ... -- policy_validation::go_acp_add_policy_explicit_owner_relation_rejected\` → ✅
- [x] \`cargo fmt -p integration-test\` clean

## Related

- Phase 1 audit: #742
- PR A of the completion roadmap: #753 (housekeeping)
- PR B: #754 (#741 implies_read helper)
- Next: PR D (#746 DRI/DPI validation — the big one)