### PR TITLE
fix(acp): add DRI + DPI validation to schema-add path (#746)

### DIFF
--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -36,6 +36,7 @@ mod persistent;
 pub mod policy_yaml;
 mod relation;
 mod store;
+mod validation;
 pub mod zanzibar;
 
 pub use auth_error::normalize_auth_error;
@@ -49,6 +50,7 @@ pub use relation::{
     RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION,
 };
 pub use store::AcpStore;
+pub use validation::{validate_resource_interface, REQUIRED_DOCUMENT_PERMISSIONS};
 
 // Re-export key zanzibar engine types from the standalone zanzibar crate
 pub use zanzibar::PersistentZanzibarStore;

--- a/crates/acp/src/validation.rs
+++ b/crates/acp/src/validation.rs
@@ -1,0 +1,151 @@
+//! Policy validation helpers shared across ACP backends.
+//!
+//! Matches Go's `acp/validation.go` semantics and error strings so that
+//! Rust and Go produce indistinguishable output at the schema-add boundary.
+//!
+//! The canonical entry point is [`validate_resource_interface`] which runs
+//! the full DRI → DPI chain:
+//!
+//! 1. Policy must exist in the ACP store
+//! 2. Resource must exist on the policy
+//! 3. Resource must declare all DPI-required permissions (`read`, `update`,
+//!    `delete` for document ACP)
+//!
+//! Used by both `AcpAdapter` (local ACP backend) and `SourceHubAcpAdapter`
+//! (SourceHub-backed ACP backend with a local policy cache). Go's equivalent
+//! is called by the schema-add path at `internal/db/definition_validation.go`.
+
+use crate::Policy;
+
+/// The DPI-required permissions for a document resource.
+///
+/// Matches Go's `RequiredResourcePermissionsForDocument` in `acp/types/types.go`.
+pub const REQUIRED_DOCUMENT_PERMISSIONS: &[&str] = &["read", "update", "delete"];
+
+/// Validate a policy ID + resource name pair against a retrieved policy.
+///
+/// Returns `Ok(())` if the policy has the named resource and the resource
+/// declares all DPI-required document permissions. Error strings are
+/// Go-compatible (see `acp/validation.go`).
+///
+/// `maybe_policy` is the result of querying the backend's policy store by
+/// `policy_id` — `None` means the policy doesn't exist.
+///
+/// `policy_id` and `resource_name` must be non-empty; empty-arg rejection
+/// happens upstream in the SDL directive parser.
+pub fn validate_resource_interface(
+    policy_id: &str,
+    resource_name: &str,
+    maybe_policy: Option<&Policy>,
+) -> Result<(), String> {
+    if policy_id.is_empty() {
+        return Err("policyID must not be empty".to_string());
+    }
+    if resource_name.is_empty() {
+        return Err("resource name must not be empty".to_string());
+    }
+
+    let policy = maybe_policy.ok_or_else(|| {
+        format!(
+            "policyID specified does not exist with acp. PolicyID: {}",
+            policy_id
+        )
+    })?;
+
+    let resource = policy.get_resource(resource_name).ok_or_else(|| {
+        format!(
+            "resource does not exist on the specified policy. PolicyID: {}, ResourceName: {}",
+            policy_id, resource_name
+        )
+    })?;
+
+    for required in REQUIRED_DOCUMENT_PERMISSIONS {
+        if resource.get_relation(required).is_none() {
+            return Err(format!(
+                "resource is missing required permission on policy. \
+                 PolicyID: {}, ResourceName: {}, Permission: {}",
+                policy_id, resource_name, required
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Relation, RelationExpression, Resource};
+
+    fn policy_with_perms(id: &str, resource: &str, perms: &[&str]) -> Policy {
+        let mut res = Resource::new(resource);
+        // Minimal direct relations used by computed permissions
+        res = res.with_relation(Relation::direct("owner"));
+        for p in perms {
+            res = res.with_relation(Relation::computed(
+                *p,
+                RelationExpression::computed_userset("owner"),
+            ));
+        }
+        Policy::new(id, "test").with_resource(res)
+    }
+
+    #[test]
+    fn empty_policy_id_errors() {
+        let err = validate_resource_interface("", "users", None).unwrap_err();
+        assert!(err.contains("policyID must not be empty"));
+    }
+
+    #[test]
+    fn empty_resource_errors() {
+        let err = validate_resource_interface("pid", "", None).unwrap_err();
+        assert!(err.contains("resource name must not be empty"));
+    }
+
+    #[test]
+    fn missing_policy_errors_with_go_message() {
+        let err = validate_resource_interface("pid", "users", None).unwrap_err();
+        assert!(err.contains("does not exist with acp"), "got: {}", err);
+        assert!(err.contains("pid"));
+    }
+
+    #[test]
+    fn missing_resource_errors_with_go_message() {
+        let policy = policy_with_perms("pid", "users", &["read", "update", "delete"]);
+        let err = validate_resource_interface("pid", "doesNotExist", Some(&policy)).unwrap_err();
+        assert!(
+            err.contains("resource does not exist on the specified policy"),
+            "got: {}",
+            err
+        );
+        assert!(err.contains("doesNotExist"));
+    }
+
+    #[test]
+    fn missing_read_perm_errors() {
+        let policy = policy_with_perms("pid", "users", &["update", "delete"]);
+        let err = validate_resource_interface("pid", "users", Some(&policy)).unwrap_err();
+        assert!(err.contains("missing required permission"), "got: {}", err);
+        assert!(err.contains("Permission: read"));
+    }
+
+    #[test]
+    fn missing_update_perm_errors() {
+        let policy = policy_with_perms("pid", "users", &["read", "delete"]);
+        let err = validate_resource_interface("pid", "users", Some(&policy)).unwrap_err();
+        assert!(err.contains("Permission: update"), "got: {}", err);
+    }
+
+    #[test]
+    fn missing_delete_perm_errors() {
+        let policy = policy_with_perms("pid", "users", &["read", "update"]);
+        let err = validate_resource_interface("pid", "users", Some(&policy)).unwrap_err();
+        assert!(err.contains("Permission: delete"), "got: {}", err);
+    }
+
+    #[test]
+    fn valid_policy_passes() {
+        let policy = policy_with_perms("pid", "users", &["read", "update", "delete"]);
+        validate_resource_interface("pid", "users", Some(&policy)).unwrap();
+    }
+}

--- a/crates/cli/src/acp_adapter.rs
+++ b/crates/cli/src/acp_adapter.rs
@@ -87,4 +87,18 @@ impl AcpOperations for AcpAdapter {
 
         Ok(policy.as_ref().map(policy_to_info))
     }
+
+    async fn validate_resource_interface(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+    ) -> Result<(), String> {
+        let policy = self.store.get_policy(policy_id).await.map_err(|e| {
+            format!(
+                "policy validation failed with acp: {}. PolicyID: {}",
+                e, policy_id
+            )
+        })?;
+        acp::validate_resource_interface(policy_id, resource_name, policy.as_ref())
+    }
 }

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -90,10 +90,6 @@ impl Node {
             }
         }
 
-        let schema_adapter = crate::schema_adapter::SchemaAdapter::new_arc(database.clone());
-        server = server.with_schema_arc(schema_adapter);
-        info!("Schema HTTP endpoint enabled");
-
         let lens_adapter = crate::lens_adapter::LensAdapter::new_arc(database.clone());
         server = server.with_lens_arc(lens_adapter);
         info!("Lens HTTP endpoint enabled");
@@ -106,27 +102,42 @@ impl Node {
             info!("NAC disabled (use --node-acp-enable to enable)");
         }
 
-        if config.acp.document_type != AcpDocumentType::None {
-            let acp_adapter = acp_setup
-                .http_adapter
-                .clone()
-                .unwrap_or_else(|| crate::acp_adapter::AcpAdapter::new_arc(zanzibar_store.clone()));
-            server = server.with_acp_arc(acp_adapter);
-            info!(
-                "ACP policy HTTP endpoints enabled (type: {})",
-                config.acp.document_type
-            );
+        // Build the ACP adapter first (if enabled) so SchemaAdapter can use
+        // it for schema-time DRI validation (#746).
+        let acp_adapter_for_schema: Option<Arc<dyn defra_http::router::AcpOperations>> =
+            if config.acp.document_type != AcpDocumentType::None {
+                let acp_adapter = acp_setup.http_adapter.clone().unwrap_or_else(|| {
+                    crate::acp_adapter::AcpAdapter::new_arc(zanzibar_store.clone())
+                });
+                server = server.with_acp_arc(acp_adapter.clone());
+                info!(
+                    "ACP policy HTTP endpoints enabled (type: {})",
+                    config.acp.document_type
+                );
 
-            let doc_acp_adapter = crate::doc_acp_adapter::DocumentAcpAdapter::new_arc(
+                let doc_acp_adapter = crate::doc_acp_adapter::DocumentAcpAdapter::new_arc(
+                    database.clone(),
+                    acp_setup.document_acp.clone(),
+                    zanzibar_store,
+                );
+                server = server.with_doc_acp_arc(doc_acp_adapter);
+                info!("Document ACP HTTP endpoints enabled");
+
+                Some(acp_adapter)
+            } else {
+                info!("Document ACP disabled (use --document-acp-type to enable)");
+                None
+            };
+
+        let schema_adapter = match &acp_adapter_for_schema {
+            Some(acp) => crate::schema_adapter::SchemaAdapter::new_arc_with_acp(
                 database.clone(),
-                acp_setup.document_acp.clone(),
-                zanzibar_store,
-            );
-            server = server.with_doc_acp_arc(doc_acp_adapter);
-            info!("Document ACP HTTP endpoints enabled");
-        } else {
-            info!("Document ACP disabled (use --document-acp-type to enable)");
-        }
+                acp.clone(),
+            ),
+            None => crate::schema_adapter::SchemaAdapter::new_arc(database.clone()),
+        };
+        server = server.with_schema_arc(schema_adapter);
+        info!("Schema HTTP endpoint enabled");
 
         let view_adapter = crate::view_adapter::ViewAdapter::new_arc(database.clone());
         server = server.with_view_arc(view_adapter);

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -4,19 +4,39 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use defra_http::router::SchemaOperations;
+use defra_http::router::{AcpOperations, SchemaOperations};
 use schema::CollectionVersion;
 use storage::corekv::Store;
 
 /// Adapter that implements schema operations using the database.
 pub struct SchemaAdapter<S: Store> {
     database: Arc<db::DB<S>>,
+    /// Optional ACP handle for schema-time DRI validation (#746).
+    ///
+    /// When `Some`, `add_schema` validates `@policy(id:, resource:)`
+    /// directives against the ACP store before creating collections:
+    /// the policy must exist, the resource must exist on it, and the
+    /// resource must declare the DPI-required `read`/`update`/`delete`
+    /// permissions. When `None` (legacy / tests without ACP wired in),
+    /// the validator is skipped.
+    acp: Option<Arc<dyn AcpOperations>>,
 }
 
 impl<S: Store + 'static> SchemaAdapter<S> {
     /// Create a new adapter wrapping the given database.
     pub fn new(database: Arc<db::DB<S>>) -> Self {
-        Self { database }
+        Self {
+            database,
+            acp: None,
+        }
+    }
+
+    /// Create a new adapter with ACP wired in for schema-time DRI validation.
+    pub fn new_with_acp(database: Arc<db::DB<S>>, acp: Arc<dyn AcpOperations>) -> Self {
+        Self {
+            database,
+            acp: Some(acp),
+        }
     }
 
     /// Create an Arc-wrapped adapter for HTTP schema operations.
@@ -24,7 +44,21 @@ impl<S: Store + 'static> SchemaAdapter<S> {
         Arc::new(Self::new(database))
     }
 
+    /// Create an Arc-wrapped adapter for HTTP schema operations with ACP
+    /// validation wired in.
+    pub fn new_arc_with_acp(
+        database: Arc<db::DB<S>>,
+        acp: Arc<dyn AcpOperations>,
+    ) -> Arc<dyn SchemaOperations> {
+        Arc::new(Self::new_with_acp(database, acp))
+    }
+
     /// Create an Arc-wrapped adapter for PG wire protocol schema operations.
+    ///
+    /// Note: the PG path currently does not thread ACP context through, so
+    /// schema-time DRI validation (#746) is skipped for PG users. When the
+    /// PG server gains access to `AppState.acp`, add a `_with_acp` variant
+    /// and call `new_with_acp` here too.
     pub fn new_pg_arc(database: Arc<db::DB<S>>) -> Arc<dyn pg_compat::SchemaManager> {
         Arc::new(Self::new(database))
     }
@@ -42,6 +76,21 @@ impl<S: Store + 'static> SchemaAdapter<S> {
 
         db::definition_validation::validate_new_collections(&collections)
             .map_err(|e| format!("failed to validate schema: {}", e))?;
+
+        // #746: validate every @policy directive against the ACP store
+        // before creating any collection. If any collection's DRI is
+        // invalid (policy missing, resource missing, DPI perm missing),
+        // reject the whole schema-add so we don't leave a half-created
+        // state.
+        if let Some(acp) = &self.acp {
+            for collection in &collections {
+                if let Some(policy) = &collection.policy {
+                    acp.validate_resource_interface(&policy.id, &policy.resource_name)
+                        .await
+                        .map_err(|e| format!("failed to add collection: {}", e))?;
+                }
+            }
+        }
 
         let mut created = Vec::new();
         for collection in collections {

--- a/crates/cli/src/sourcehub_acp_adapter.rs
+++ b/crates/cli/src/sourcehub_acp_adapter.rs
@@ -120,6 +120,24 @@ impl AcpOperations for SourceHubAcpAdapter {
         Ok(policy.as_ref().map(policy_to_info))
     }
 
+    async fn validate_resource_interface(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+    ) -> Result<(), String> {
+        // The SourceHub adapter caches policies in its local store after a
+        // successful on-chain `add_policy`. Query the local cache — same
+        // semantics as `get_policy` above, and matches Go's pattern of
+        // validating against the most recently observed policy state.
+        let policy = self.local_store.get_policy(policy_id).await.map_err(|e| {
+            format!(
+                "policy validation failed with acp: {}. PolicyID: {}",
+                e, policy_id
+            )
+        })?;
+        acp::validate_resource_interface(policy_id, resource_name, policy.as_ref())
+    }
+
     async fn get_light_client_status(&self) -> Result<AcpLightClientStatus, String> {
         let status = self
             .sourcehub_acp

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -186,6 +186,30 @@ pub trait AcpOperations: Send + Sync {
     /// or `Err(message)` on internal errors.
     async fn get_policy(&self, id: &str) -> Result<Option<PolicyInfo>, String>;
 
+    /// Validate a collection's `@policy(id:..., resource:...)` directive
+    /// against the ACP store. Called at schema-add time.
+    ///
+    /// Matches Go's `acp.ValidateResourceInterface` in `acp/validation.go`:
+    /// 1. The policy with `policy_id` must exist
+    /// 2. The resource with `resource_name` must exist on that policy
+    /// 3. The resource must declare the DPI-required `read`, `update`,
+    ///    and `delete` permissions (Go's `RequiredResourcePermissionsForDocument`)
+    ///
+    /// Error messages must match Go's format so the behavior is indistinguishable
+    /// from the caller's perspective.
+    ///
+    /// The default impl returns `Ok(())` (permissive) so backends that don't
+    /// query a policy store — test mocks, SourceHub light-client placeholders —
+    /// don't break. Production impls (`AcpAdapter`, `SourceHubAcpAdapter`)
+    /// override with real validation.
+    async fn validate_resource_interface(
+        &self,
+        _policy_id: &str,
+        _resource_name: &str,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Get ACP light client status when this ACP backend exposes one.
     async fn get_light_client_status(&self) -> Result<AcpLightClientStatus, String> {
         Err("ACP light client status is not available for this ACP backend".to_string())

--- a/tools/integration-test/tests/acp/link_collection.rs
+++ b/tools/integration-test/tests/acp/link_collection.rs
@@ -25,15 +25,15 @@
 //! matching with multiple alternatives and always include `"bad_input"` as a
 //! generic fallback — matching the Phase 3a `policy_validation.rs` style.
 //!
-//! ## Known divergence: DRI existence + DPI rule checks not enforced
+//! ## DRI existence + DPI rule checks
 //!
-//! Five of the rejection tests below currently assert the **Rust** behavior
-//! rather than the Go behavior, with `DIVERGENCE:` comments. Rust's schema
-//! loader does not verify that the referenced policy/resource exists or
-//! enforce the DPI rule that requires `read`/`update`/`delete` permissions
-//! on the linked resource. Tracked in issue #746. These tests are
-//! regression guards — when #746 is fixed, each flagged assertion must be
-//! flipped back to expect an error.
+//! Rust now enforces the same DRI → DPI chain Go does at schema-add time
+//! (#746 fixed). When a `@policy(id:, resource:)` directive references:
+//! - a policy that doesn't exist → `"policyID specified does not exist with acp"`
+//! - a resource name not on the policy → `"resource does not exist on the specified policy"`
+//! - a resource missing `read`/`update`/`delete` permission → `"resource is missing required permission on policy"`
+//! Error strings are Go-compatible so mixed Rust/Go deployments produce
+//! identical user-facing output.
 
 use integration_test::{for_each_runtime, generate_identity, TestCluster};
 
@@ -503,14 +503,10 @@ for_each_runtime!(
 
 // Port of reject_missing_dri_test.go (both cases).
 //
-// DIVERGENCE (#746): Go DefraDB rejects at schema-add time with
-// "policyID specified does not exist with acp". Rust's
-// `parse_policy_directive` validates arg types and emptiness but never
-// consults ACP to verify the policy exists, so Rust accepts the schema
-// and registers the type. The DRI existence check is missing at the
-// schema-build path ([crates/query/src/sdl_parse/builder.rs:784]).
-// Regression guard — flip the asserts back to expect an error once #746
-// is fixed.
+// Before #746 was fixed Rust silently accepted a schema with a
+// nonexistent policy id. After the fix, Rust rejects with the same
+// Go-compatible error string as Go does: "policyID specified does not
+// exist with acp".
 async fn acp_link_collection_nonexistent_policy_reject(cluster: TestCluster) {
     let node = cluster.client(0);
     let alice = generate_identity(node.binary_path()).expect("alice identity");
@@ -522,14 +518,14 @@ async fn acp_link_collection_nonexistent_policy_reject(cluster: TestCluster) {
         r#"type UsersA @policy(id: "{}", resource: "users") {{ name: String age: Int }}"#,
         nonexistent_policy_id
     );
-    let result = try_add_schema(&node, &sdl, &alice.private_key_hex);
+    let err = try_add_schema(&node, &sdl, &alice.private_key_hex)
+        .expect("schema with nonexistent policy id must be rejected");
     assert!(
-        result.is_none(),
-        "Rust currently silently accepts a schema referencing a nonexistent \
-         policy id — Go rejects it. If this fails, the divergence has been \
-         fixed and the test must assert the error instead. Actual: {:?}",
-        result
+        err.to_lowercase().contains("does not exist with acp"),
+        "expected Go-compatible nonexistent-policy error, got: {}",
+        err
     );
+    assert!(!type_exists(&node, "UsersA"));
 
     // Case 2: a different policy exists but the referenced one does not.
     let _ = add_users_policy(&node, users_policy(), &alice.private_key_hex);
@@ -537,13 +533,15 @@ async fn acp_link_collection_nonexistent_policy_reject(cluster: TestCluster) {
         r#"type UsersB @policy(id: "{}", resource: "users") {{ name: String age: Int }}"#,
         nonexistent_policy_id
     );
-    let result = try_add_schema(&node, &sdl_b, &alice.private_key_hex);
-    assert!(
-        result.is_none(),
-        "Rust currently silently accepts (with unrelated policy present). \
-         If this fails, the divergence has been fixed. Actual: {:?}",
-        result
+    let err = try_add_schema(&node, &sdl_b, &alice.private_key_hex).expect(
+        "schema with nonexistent policy id must still be rejected (unrelated policy present)",
     );
+    assert!(
+        err.to_lowercase().contains("does not exist with acp"),
+        "expected Go-compatible nonexistent-policy error (with unrelated policy present), got: {}",
+        err
+    );
+    assert!(!type_exists(&node, "UsersB"));
 }
 
 for_each_runtime!(
@@ -554,10 +552,8 @@ for_each_runtime!(
 
 // Port of reject_missing_resource_on_dri_test.go.
 //
-// DIVERGENCE (#746): Go rejects with "resource does not exist on the
-// specified policy". Rust accepts — same root cause as
-// `acp_link_collection_nonexistent_policy_reject`: no DRI validation at
-// schema-build time. Regression guard.
+// After #746 fix: Rust rejects with "resource does not exist on the
+// specified policy" — Go-compatible error string.
 async fn acp_link_collection_nonexistent_resource_reject(cluster: TestCluster) {
     let node = cluster.client(0);
     let alice = generate_identity(node.binary_path()).expect("alice identity");
@@ -567,14 +563,15 @@ async fn acp_link_collection_nonexistent_resource_reject(cluster: TestCluster) {
         r#"type Users @policy(id: "{}", resource: "doesNotExist") {{ name: String age: Int }}"#,
         policy_id
     );
-    let result = try_add_schema(&node, &sdl, &alice.private_key_hex);
+    let err = try_add_schema(&node, &sdl, &alice.private_key_hex)
+        .expect("schema with nonexistent resource must be rejected");
     assert!(
-        result.is_none(),
-        "Rust currently silently accepts a schema with a nonexistent \
-         resource name on a valid policy — Go rejects it. If this fails, \
-         the divergence has been fixed. Actual: {:?}",
-        result
+        err.to_lowercase()
+            .contains("resource does not exist on the specified policy"),
+        "expected Go-compatible nonexistent-resource error, got: {}",
+        err
     );
+    assert!(!type_exists(&node, "Users"));
 }
 
 for_each_runtime!(
@@ -589,38 +586,42 @@ for_each_runtime!(
 
 // Port of reject_invalid_owner_read_perm_on_dri_test.go.
 //
-// DIVERGENCE (#746): Go enforces the DPI rule that a resource bound via
-// `@policy` must define the `read`, `update`, and `delete` permissions
-// and rejects with "resource is missing required permission on policy".
-// Rust enforces neither at policy-add time nor at schema-link time.
-// Regression guard for the current silent-accept behavior.
+// After #746 fix: Rust rejects with "resource is missing required
+// permission on policy. ... Permission: read". The DPI rule requires
+// documents to declare read/update/delete on the linked resource.
 async fn acp_link_collection_missing_read_perm_reject(cluster: TestCluster) {
     let node = cluster.client(0);
     let alice = generate_identity(node.binary_path()).expect("alice identity");
 
     let policy_result = node.acp_policy_add(users_policy_missing_read(), &alice.private_key_hex);
+    // The policy itself doesn't enforce DPI rules at add time — the
+    // check happens at schema-link time. If the store pre-validates the
+    // policy and rejects here, also accept that (Go parity).
     let policy_id = match policy_result {
-        Ok(v) => extract_policy_id(&v),
-        Err(_) => {
-            // Policy add failed = DPI enforced at policy-add time. Rust fixed.
+        Ok(v) => extract_policy_id(&v).expect("policy id"),
+        Err(e) => {
+            let el = format!("{:#}", e).to_lowercase();
+            assert!(
+                el.contains("read") || el.contains("permission") || el.contains("required"),
+                "policy-add-time DPI rejection must mention read/permission, got: {}",
+                e
+            );
             return;
         }
-    };
-    let Some(policy_id) = policy_id else {
-        return;
     };
     let sdl = format!(
         r#"type Users @policy(id: "{}", resource: "users") {{ name: String age: Int }}"#,
         policy_id
     );
-    let result = try_add_schema(&node, &sdl, &alice.private_key_hex);
+    let err = try_add_schema(&node, &sdl, &alice.private_key_hex)
+        .expect("schema with missing-read DRI must be rejected");
+    let el = err.to_lowercase();
     assert!(
-        result.is_none(),
-        "Rust currently silently accepts a schema whose DRI is missing \
-         the `read` permission — Go rejects it. If this fails, the \
-         divergence has been fixed. Actual: {:?}",
-        result
+        el.contains("missing required permission") && el.contains("read"),
+        "expected Go-compatible missing-read-perm error, got: {}",
+        err
     );
+    assert!(!type_exists(&node, "Users"));
 }
 
 for_each_runtime!(
@@ -630,31 +631,37 @@ for_each_runtime!(
 );
 
 // Port of reject_invalid_owner_update_perm_on_dri_test.go.
-// See `acp_link_collection_missing_read_perm_reject` for the divergence note.
+// After #746 fix: Rust rejects with the Go-compatible error string.
 async fn acp_link_collection_missing_update_perm_reject(cluster: TestCluster) {
     let node = cluster.client(0);
     let alice = generate_identity(node.binary_path()).expect("alice identity");
 
     let policy_result = node.acp_policy_add(users_policy_missing_update(), &alice.private_key_hex);
     let policy_id = match policy_result {
-        Ok(v) => extract_policy_id(&v),
-        Err(_) => return,
-    };
-    let Some(policy_id) = policy_id else {
-        return;
+        Ok(v) => extract_policy_id(&v).expect("policy id"),
+        Err(e) => {
+            let el = format!("{:#}", e).to_lowercase();
+            assert!(
+                el.contains("update") || el.contains("permission") || el.contains("required"),
+                "policy-add-time DPI rejection must mention update/permission, got: {}",
+                e
+            );
+            return;
+        }
     };
     let sdl = format!(
         r#"type Users @policy(id: "{}", resource: "users") {{ name: String age: Int }}"#,
         policy_id
     );
-    let result = try_add_schema(&node, &sdl, &alice.private_key_hex);
+    let err = try_add_schema(&node, &sdl, &alice.private_key_hex)
+        .expect("schema with missing-update DRI must be rejected");
+    let el = err.to_lowercase();
     assert!(
-        result.is_none(),
-        "Rust currently silently accepts a schema whose DRI is missing \
-         the `update` permission — Go rejects it. If this fails, the \
-         divergence has been fixed. Actual: {:?}",
-        result
+        el.contains("missing required permission") && el.contains("update"),
+        "expected Go-compatible missing-update-perm error, got: {}",
+        err
     );
+    assert!(!type_exists(&node, "Users"));
 }
 
 for_each_runtime!(
@@ -664,31 +671,37 @@ for_each_runtime!(
 );
 
 // Port of reject_invalid_owner_delete_perm_on_dri_test.go.
-// See `acp_link_collection_missing_read_perm_reject` for the divergence note.
+// After #746 fix: Rust rejects with the Go-compatible error string.
 async fn acp_link_collection_missing_delete_perm_reject(cluster: TestCluster) {
     let node = cluster.client(0);
     let alice = generate_identity(node.binary_path()).expect("alice identity");
 
     let policy_result = node.acp_policy_add(users_policy_missing_delete(), &alice.private_key_hex);
     let policy_id = match policy_result {
-        Ok(v) => extract_policy_id(&v),
-        Err(_) => return,
-    };
-    let Some(policy_id) = policy_id else {
-        return;
+        Ok(v) => extract_policy_id(&v).expect("policy id"),
+        Err(e) => {
+            let el = format!("{:#}", e).to_lowercase();
+            assert!(
+                el.contains("delete") || el.contains("permission") || el.contains("required"),
+                "policy-add-time DPI rejection must mention delete/permission, got: {}",
+                e
+            );
+            return;
+        }
     };
     let sdl = format!(
         r#"type Users @policy(id: "{}", resource: "users") {{ name: String age: Int }}"#,
         policy_id
     );
-    let result = try_add_schema(&node, &sdl, &alice.private_key_hex);
+    let err = try_add_schema(&node, &sdl, &alice.private_key_hex)
+        .expect("schema with missing-delete DRI must be rejected");
+    let el = err.to_lowercase();
     assert!(
-        result.is_none(),
-        "Rust currently silently accepts a schema whose DRI is missing \
-         the `delete` permission — Go rejects it. If this fails, the \
-         divergence has been fixed. Actual: {:?}",
-        result
+        el.contains("missing required permission") && el.contains("delete"),
+        "expected Go-compatible missing-delete-perm error, got: {}",
+        err
     );
+    assert!(!type_exists(&node, "Users"));
 }
 
 for_each_runtime!(


### PR DESCRIPTION
## Summary

Closes **#746**. The headline bug from the Phase 1 ACP audit — Rust's schema loader silently accepted \`@policy(id:..., resource:...)\` directives without verifying that the policy, resource, or DPI-required permissions actually exist. Part of the ACP audit completion roadmap (PR D of 4).

Go DefraDB rejects all three at schema-add time via [\`acp.ValidateResourceInterface\`](https://github.com/sourcenetwork/defradb/blob/develop/acp/validation.go), called from \`internal/db/definition_validation.go\`. Rust now does the same thing with identical error strings.

## Why this matters

Before this fix a collection could be registered against:
- a nonexistent policy ID — silently accepted, document ACP would behave unpredictably
- a resource name not present on the policy — same problem
- a resource missing \`read\`/\`update\`/\`delete\` permissions — DPI violation silently ignored

Any of the above would produce a schema that **Go would refuse to load**, breaking wire compatibility on replication or recovery. A determined caller could also use the gap to confuse ACP enforcement on subsequent document operations.

## What changes

**New code:**
- [crates/acp/src/validation.rs](crates/acp/src/validation.rs) — \`validate_resource_interface(policy_id, resource_name, &Policy)\` helper that mirrors Go's \`ValidateResourceInterface\`. 8 unit tests covering empty args, missing policy, missing resource, and each of the three missing-permission paths.
- [crates/http/src/router/traits.rs](crates/http/src/router/traits.rs) — \`AcpOperations::validate_resource_interface\` trait method with a default permissive impl so test mocks don't break.

**Production impls:**
- [crates/cli/src/acp_adapter.rs](crates/cli/src/acp_adapter.rs) — Local ACP backend queries its \`ZanzibarStore\` and delegates to the shared helper.
- [crates/cli/src/sourcehub_acp_adapter.rs](crates/cli/src/sourcehub_acp_adapter.rs) — SourceHub backend queries its local policy cache (same store SourceHub's \`add_policy\` writes to after on-chain confirmation).

**Plumbing:**
- [crates/cli/src/schema_adapter.rs](crates/cli/src/schema_adapter.rs) — \`SchemaAdapter\` gains an optional \`acp: Option<Arc<dyn AcpOperations>>\` field and a \`new_with_acp\` constructor. \`add_schema_inner\` iterates parsed collections and calls \`acp.validate_resource_interface\` for each \`@policy\` directive before any \`create_collection\` runs, so an invalid DRI aborts the entire schema-add transaction.
- [crates/cli/src/commands/start/server_http.rs](crates/cli/src/commands/start/server_http.rs) — reorders adapter construction so \`acp_adapter\` is built first, then passed into \`SchemaAdapter::new_arc_with_acp\`.

**Test flips (all previously documented as \`DIVERGENCE (#746)\` regression guards):**
- \`acp_link_collection_nonexistent_policy_reject\` → now asserts \`\"does not exist with acp\"\`
- \`acp_link_collection_nonexistent_resource_reject\` → now asserts \`\"resource does not exist on the specified policy\"\`
- \`acp_link_collection_missing_{read,update,delete}_perm_reject\` → now assert \`\"missing required permission\"\` + the specific missing permission name

The file-level \`## Known divergence\` comment at the top of \`link_collection.rs\` has been updated to document the now-fixed parity.

## Verification

**Unit tests:**
- \`cargo test -p acp\` → 40 pass (32 existing + 8 new validation tests)

**Rust-side integration:**
- \`cargo test -p integration-test --test acp -- link_collection::rust_ --test-threads=1\` → **13/13 pass**
- \`cargo test -p integration-test --test acp -- --skip ::go_\` → **43/43 pass**

**Go-side integration (cross-implementation parity, against defradb binary commit \`d5a5a879\`):**
- \`PATH=../defradb/build:$PATH DEFRA_SKIP_VERSION_CHECK=1 cargo test ... link_collection::go_ --test-threads=1\` → **13/13 pass** (was 8/13 before — the 5 divergence guards were explicitly known to fail on both sides asymmetrically; they now produce the same category of error and both pass the shared assertion)

**Workspace:**
- \`cargo test --workspace --exclude integration-test --exclude ffi-test\` → all green
- \`cargo clippy --all -- -D warnings\` → clean
- \`cargo fmt --all\` → applied

## Out of scope

- **PG wire protocol schema-add path** currently does not thread ACP context, so DRI validation is skipped for PG users. Left as a follow-up comment in \`schema_adapter.rs\` — when \`build_pg_server\` gains access to \`AppState.acp\`, add a \`new_pg_arc_with_acp\` variant and wire it.
- **DB crate direct callers** (downsample, backup import, FFI purge) bypass the HTTP layer and therefore don't run the new validator. These are trusted internal operations that run as the node identity, so no ACP context is needed; they rely on the node-identity bypass from PR #743. Tracked separately as #633 (DB-layer NAC enforcement) if/when defense-in-depth is added.

## Related

- Phase 1 audit issue filed during initial ACP review
- PR A #753 (housekeeping)
- PR B #754 (#741 implies_read helper)  
- PR C #755 (#744 explicit owner — verified-parity)
- **PR D this one — the big one**, closes the last remaining ACP correctness bug