### PR TITLE
fix(http): add /api/v0/acp/status to route permissions table

### DIFF
--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -170,6 +170,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         // =====================================================================
         // ACP (Document Access Control)
         // =====================================================================
+        "/api/v0/acp/status" => RoutePermission::Required(NodePermission::DacStatus),
         "/api/v0/acp/policy" => match *method {
             Method::POST => RoutePermission::Required(NodePermission::DacPolicyAdd),
             Method::GET => RoutePermission::Required(NodePermission::DacStatus),
@@ -471,6 +472,11 @@ mod tests {
                 RoutePermission::Required(NodePermission::P2pSyncDocuments),
             ),
             // ACP
+            (
+                "/api/v0/acp/status",
+                Method::GET,
+                RoutePermission::Required(NodePermission::DacStatus),
+            ),
             (
                 "/api/v0/acp/policy",
                 Method::POST,

--- a/crates/http/src/route_permissions_tests.rs
+++ b/crates/http/src/route_permissions_tests.rs
@@ -156,6 +156,17 @@ mod tests {
     }
 
     #[test]
+    fn acp_status_route_uses_dac_status_permission() {
+        // Regression test for #758: the route was missing from the
+        // permission table and falling through to DocumentRead, which
+        // over-restricted callers that only had DacStatus.
+        assert_eq!(
+            route_permission("/api/v0/acp/status", &Method::GET),
+            RoutePermission::Required(NodePermission::DacStatus)
+        );
+    }
+
+    #[test]
     fn unknown_route_gets_safe_default() {
         assert_eq!(
             route_permission("/api/v0/unknown", &Method::GET),
@@ -346,6 +357,11 @@ mod tests {
                 RoutePermission::Required(NodePermission::P2pSyncDocuments),
             ),
             // ACP
+            (
+                "/api/v0/acp/status",
+                Method::GET,
+                RoutePermission::Required(NodePermission::DacStatus),
+            ),
             (
                 "/api/v0/acp/policy",
                 Method::POST,


### PR DESCRIPTION
## Summary

Closes #758. Small fix discovered during the post-#756 ACP audit completion sweep.

The route \`/api/v0/acp/status\` is registered in [routes.rs:143](crates/http/src/router/routes.rs#L143) but was missing from the explicit match in [route_permissions.rs](crates/http/src/route_permissions.rs). It fell through to the safe default (\`DocumentRead\`) and emitted a \`tracing::warn!\` on every request. The handler at [handlers/acp.rs:111](crates/http/src/handlers/acp.rs#L111) independently calls \`require_permission(DacStatus)\`, so the net effect was that callers needed **both** \`DocumentRead\` AND \`DacStatus\` to access the endpoint — more restrictive than Go and over-restrictive vs the intended permission model.

## Why it's a bug, not a security hole

- A legitimate \`DacStatus\` admin without document read rights got 403 on a status endpoint they should have access to
- Every status request spammed the \`Route not in permission table\` warning at WARN level
- Maintenance signal: a route was added to \`routes.rs\` without updating the permission table

## Changes

- [crates/http/src/route_permissions.rs](crates/http/src/route_permissions.rs) — add \`\"/api/v0/acp/status\" => Required(DacStatus)\` to the match arm and to the in-file exhaustiveness fixture
- [crates/http/src/route_permissions_tests.rs](crates/http/src/route_permissions_tests.rs) — add the entry to the external fixture, plus a new focused test \`acp_status_route_uses_dac_status_permission\` as a regression guard

## Test plan

- [x] \`cargo test -p defra-http route_permissions\` → 11/11 pass (10 existing + 1 new)
- [x] \`cargo fmt -p defra-http\`
- [x] \`cargo clippy -p defra-http --tests -- -D warnings\`