### PR TITLE
fix(query): RAII guards for mutation thread-locals (#757)

### DIFF
--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -16,6 +16,42 @@ use crate::txn::TransactionRegistry;
 
 use super::{DocFetcher, QueryRunner};
 
+/// RAII guard that clears the `encryption_config` thread-local on Drop.
+///
+/// `mutation.rs` sets the thread-local during execution. Without this
+/// guard, an early-return via `?` (or a panic unwind) leaves stale
+/// state on the blocking-pool worker thread, which the next
+/// `spawn_blocking` closure inherits — silent encryption-key confusion
+/// across requests. See #757.
+///
+/// Always clears to None on Drop, regardless of entry state. The
+/// function "owns" the mutation context for the duration of the call
+/// and leaves the worker thread in a clean state on exit (happy path,
+/// early-return via `?`, or panic unwind). This also self-heals against
+/// any previous task that may have leaked state.
+struct EncryptionConfigGuard;
+
+impl Drop for EncryptionConfigGuard {
+    fn drop(&mut self) {
+        defra_core::encryption::set_encryption_config(None);
+    }
+}
+
+/// RAII guard that clears the `broadcast_creator_did` thread-local on Drop.
+///
+/// Critical for P2P identity correctness — without this, a panicking
+/// mutation can leave the previous caller's DID on the blocking-pool
+/// worker, and the next anonymous mutation would silently broadcast
+/// with someone else's identity (registered as that identity on the
+/// receiving peer via `acp_merge_handler`). See #757.
+struct BroadcastCreatorDidGuard;
+
+impl Drop for BroadcastCreatorDidGuard {
+    fn drop(&mut self) {
+        defra_core::signing::set_broadcast_creator_did(None);
+    }
+}
+
 impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Execute a GraphQL mutation and return JSON results.
     ///
@@ -352,6 +388,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             }
         }
 
+        // Bind a RAII guard so the thread-local is cleared on every exit
+        // path (including `?`, panic unwind, and the happy path). See #757.
+        let _encryption_config_guard = EncryptionConfigGuard;
+
         // Set encryption config for this mutation (thread-local, read by AutoCommitMutator)
         if mutation.encrypt_doc || !mutation.encrypt_fields.is_empty() {
             if let Some(ref key) = self.encryption_key {
@@ -366,6 +406,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         } else {
             defra_core::encryption::set_encryption_config(None);
         }
+
+        // Bind a RAII guard for broadcast_creator_did. Critical for P2P
+        // identity correctness — without this, a panicking mutation can
+        // leave the previous caller's DID on the blocking-pool worker,
+        // and the next anonymous mutation would silently broadcast with
+        // someone else's identity. See #757.
+        let _broadcast_creator_did_guard = BroadcastCreatorDidGuard;
 
         // Set broadcast identity for P2P: PushLog Creator field will carry this
         // DID instead of the node PeerId, enabling ACP owner registration on the
@@ -607,8 +654,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         plan.close().await.map_err(&map_doc_not_found)?;
 
-        // Clear encryption config after plan execution
-        defra_core::encryption::set_encryption_config(None);
+        // Note: encryption_config and broadcast_creator_did are cleared
+        // automatically by the RAII guards declared above when this
+        // function returns. The bearer token store stays alive — the
+        // ACP registration block below needs it for hub.rs auth.
 
         let plan_execution_elapsed = plan_execution_start.elapsed();
         for doc_id in &result_doc_ids {
@@ -618,10 +667,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 "Mutation plan execution completed"
             );
         }
-
-        // Clear broadcast identity after plan execution (but keep request bearer
-        // token alive -- ACP registration below needs it for hub.rs auth).
-        defra_core::signing::set_broadcast_creator_did(None);
 
         // For CREATE/UPSERT operations with caller_identity: register created docs with ACP
         if matches!(
@@ -957,6 +1002,115 @@ mod tests {
         ) -> Result<Option<Document>> {
             Ok(None)
         }
+    }
+
+    // =========================================================================
+    // RAII guard tests for #757
+    //
+    // These tests verify that the EncryptionConfigGuard and
+    // BroadcastCreatorDidGuard always clear their respective thread-locals
+    // on Drop, regardless of how the owning function exits. They are NOT
+    // #[tokio::test] because the entire point is to exercise thread-local
+    // semantics on a single thread synchronously.
+    // =========================================================================
+
+    fn make_test_encryption_config() -> defra_core::encryption::EncryptionConfig {
+        defra_core::encryption::EncryptionConfig {
+            encrypt_doc: true,
+            encrypt_fields: vec![],
+            encryption_key: vec![0xAB; 32],
+        }
+    }
+
+    #[test]
+    fn encryption_config_guard_clears_on_normal_drop() {
+        // Pre-condition: ensure clean state
+        defra_core::encryption::set_encryption_config(None);
+
+        // Set state and bind guard
+        defra_core::encryption::set_encryption_config(Some(make_test_encryption_config()));
+        assert!(defra_core::encryption::get_encryption_config().is_some());
+
+        {
+            let _guard = EncryptionConfigGuard;
+            // Inside the guard scope the state is still set.
+            assert!(defra_core::encryption::get_encryption_config().is_some());
+            // Guard drops at end of scope.
+        }
+
+        // After guard drop the thread-local is cleared.
+        assert!(defra_core::encryption::get_encryption_config().is_none());
+    }
+
+    #[test]
+    fn encryption_config_guard_clears_on_panic_unwind() {
+        defra_core::encryption::set_encryption_config(None);
+        defra_core::encryption::set_encryption_config(Some(make_test_encryption_config()));
+
+        // Drive the guard's drop via a panic in a catch_unwind boundary,
+        // simulating an early-return from a panicking mutation.
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = EncryptionConfigGuard;
+            panic!("simulated mutation panic");
+        });
+
+        // Even after a panic unwind, the guard cleared the thread-local.
+        assert!(defra_core::encryption::get_encryption_config().is_none());
+    }
+
+    #[test]
+    fn encryption_config_guard_self_heals_from_leaked_state() {
+        // Simulate a previous task that leaked stale state on this thread.
+        defra_core::encryption::set_encryption_config(Some(make_test_encryption_config()));
+        assert!(defra_core::encryption::get_encryption_config().is_some());
+
+        // Even if the guard is bound without us setting fresh state, on
+        // Drop it clears the thread-local — self-healing.
+        {
+            let _guard = EncryptionConfigGuard;
+        }
+
+        assert!(defra_core::encryption::get_encryption_config().is_none());
+    }
+
+    #[test]
+    fn broadcast_creator_did_guard_clears_on_normal_drop() {
+        defra_core::signing::set_broadcast_creator_did(None);
+        defra_core::signing::set_broadcast_creator_did(Some("did:key:test".to_string()));
+        assert!(defra_core::signing::get_broadcast_creator_did().is_some());
+
+        {
+            let _guard = BroadcastCreatorDidGuard;
+            assert!(defra_core::signing::get_broadcast_creator_did().is_some());
+        }
+
+        assert!(defra_core::signing::get_broadcast_creator_did().is_none());
+    }
+
+    #[test]
+    fn broadcast_creator_did_guard_clears_on_panic_unwind() {
+        defra_core::signing::set_broadcast_creator_did(None);
+        defra_core::signing::set_broadcast_creator_did(Some("did:key:alice".to_string()));
+
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = BroadcastCreatorDidGuard;
+            panic!("simulated mutation panic");
+        });
+
+        // Critical: a panicking mutation must NOT leave Alice's DID on
+        // this thread for the next anonymous mutation to broadcast as.
+        assert!(defra_core::signing::get_broadcast_creator_did().is_none());
+    }
+
+    #[test]
+    fn broadcast_creator_did_guard_self_heals_from_leaked_state() {
+        defra_core::signing::set_broadcast_creator_did(Some("did:key:leaked".to_string()));
+
+        {
+            let _guard = BroadcastCreatorDidGuard;
+        }
+
+        assert!(defra_core::signing::get_broadcast_creator_did().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes **#757**. New finding from the post-#756 ACP audit completion sweep — a P1 thread-local state leakage that can silently spoof identity on the P2P wire under panic/early-return conditions.

## The bug

The mutation runner sets two thread-locals during execution:
- \`encryption_config\` (consumed by AutoCommitMutator for encrypted writes)
- \`broadcast_creator_did\` (used by P2P PushLog to attribute the doc owner)

Both were cleared only on the happy path at the bottom of the function. Mutations that early-returned via \`?\` or panicked left stale state on the tokio blocking-pool worker thread. The next \`spawn_blocking\` closure that landed on the same worker inherited the previous caller's state:

- **broadcast_creator_did** → silent identity spoofing on the P2P wire. The next anonymous mutation would broadcast its document with the previous authenticated caller's DID, and the receiving peer would register it under that DID via \`acp_merge_handler\`.
- **encryption_config** → the next unencrypted mutation inherits the previous caller's encryption key, encrypting data the user expected to be plaintext (or vice versa).

## Why a guard already exists for the third thread-local

\`signing_config\` is already correctly handled via the \`SigningConfigReset\` RAII guard at \`mutation.rs:199-205\`. The author of that guard solved exactly this problem for one thread-local but didn't extend the pattern to the other two.

## Fix

Two new module-level RAII guards in [crates/query/src/runner/mutation.rs](crates/query/src/runner/mutation.rs):

\`\`\`rust
struct EncryptionConfigGuard;
impl Drop for EncryptionConfigGuard {
    fn drop(&mut self) {
        defra_core::encryption::set_encryption_config(None);
    }
}

struct BroadcastCreatorDidGuard;
impl Drop for BroadcastCreatorDidGuard {
    fn drop(&mut self) {
        defra_core::signing::set_broadcast_creator_did(None);
    }
}
\`\`\`

Both bind at the existing set sites and clear on every exit path (happy, \`?\` early-return, panic unwind). The manual cleanups at the bottom of the function are removed — the guards handle them.

**Self-healing**: the guards clear to \`None\` regardless of entry state. So even if a previous task leaked state, this function leaves the worker thread clean on exit.

## Why I didn't restore-previous-value

The function "owns" the mutation context for the duration of the call. There's no legitimate caller that needs to preserve thread-local state across the boundary — every entry to the runner sets its own values explicitly. Always clearing to None is simpler, safer, and prevents accidentally chaining stale state through nested mutation invocations.

## Test plan

6 new unit tests in the existing \`tests\` module:

- \`encryption_config_guard_clears_on_normal_drop\`
- \`encryption_config_guard_clears_on_panic_unwind\` — uses \`std::panic::catch_unwind\` to verify Drop runs through panic
- \`encryption_config_guard_self_heals_from_leaked_state\`
- \`broadcast_creator_did_guard_clears_on_normal_drop\`
- \`broadcast_creator_did_guard_clears_on_panic_unwind\`
- \`broadcast_creator_did_guard_self_heals_from_leaked_state\`

Verification:
- [x] \`cargo test -p query\` → 210 pass (6 new + 204 existing)
- [x] \`cargo test -p integration-test --test acp --test basic --test query --test nac --test encryption -- --skip ::go_\` → 91 pass, 0 fail
- [x] \`cargo clippy --all -- -D warnings\` → clean
- [x] \`cargo fmt --all\`

## Why this matters

The HTTP query layer wraps mutations in \`spawn_blocking\` (in [query_context.rs](crates/http/src/query_context.rs)) which pins execution to a single thread, but the **same worker is reused across many sequential closures**. Without the guards, identity attribution drift was a silent, hard-to-trace bug class.

## Related

- Discovered during the post-#756 ACP audit completion sweep
- The \`signing.rs:300-302\` comment (\"thread_local! doesn't work here because tokio can migrate async tasks between OS threads at .await points\") documents exactly the concern — the fix here is to add the same defensive scoping to the other thread-locals