### PR TITLE
fix(crypto): merkle proof verification fails closed with Err (#733)

### DIFF
--- a/crates/crypto/src/merkle_proof/proof.rs
+++ b/crates/crypto/src/merkle_proof/proof.rs
@@ -37,12 +37,14 @@ impl MerkleProof {
 
     /// Verify this proof is valid
     ///
-    /// Checks:
-    /// 1. Path is non-empty (Err)
-    /// 2. First node CID matches leaf_cid (Err — wrong input)
-    /// 3. Last node CID matches root_cid (Err — wrong input)
-    /// 4. Each node's CID matches its content hash (Ok(false) — cryptographic failure)
-    /// 5. Each node's heads contains the next node's CID (Ok(false) — broken chain)
+    /// Checks (all return `Err` on failure to match Go's convention and the
+    /// rest of the Rust crypto crate — see #733):
+    ///
+    /// 1. Path is non-empty
+    /// 2. First node CID matches `leaf_cid`
+    /// 3. Last node CID matches `root_cid`
+    /// 4. Each node's CID matches its content hash (cryptographic failure)
+    /// 5. Each node's `heads` contains the next node's CID (broken chain)
     ///
     /// The chain structure is: leaf (newest) -> ... -> root (oldest).
     /// Each node points to its parent(s) via the `heads` field.
@@ -50,9 +52,16 @@ impl MerkleProof {
     /// # Returns
     ///
     /// - `Ok(true)` — proof verifies
-    /// - `Ok(false)` — proof is structurally valid but cryptographically incorrect
-    ///   (content hash mismatch, broken chain link)
-    /// - `Err(_)` — caller supplied structurally invalid input (empty path, anchor mismatch)
+    /// - `Err(_)` — verification failed at any of the checks above. The
+    ///   error variant is `Error::BlockError` for structural input errors
+    ///   (empty path, anchor mismatch) and `Error::Crypto` for cryptographic
+    ///   failures (hash mismatch, broken chain link).
+    ///
+    /// Note: this function never returns `Ok(false)`. Both invariants are
+    /// security-sensitive enough that a caller who treats `Ok` as success
+    /// (e.g. `if result.is_ok()` or `let _ = result?; trust_proof()`)
+    /// must not be able to bypass verification by writing the obvious code.
+    /// See #733.
     pub fn verify(&self) -> Result<bool> {
         // Anchor/structural failures are caller errors — return Err so they can't be
         // silently ignored. Match Go's convention where "nothing to verify" is an error.
@@ -73,15 +82,21 @@ impl MerkleProof {
         }
 
         // Verify each node's CID matches its content.
-        // A hash mismatch is a legitimate cryptographic "no" — return Ok(false).
-        for node in &self.path {
+        // A hash mismatch is a cryptographic verification failure — return
+        // Err so callers using `?` propagate it instead of treating Ok(false)
+        // as success. See #733.
+        for (idx, node) in self.path.iter().enumerate() {
             if !node.verify_cid()? {
-                return Ok(false);
+                return Err(Error::Crypto(format!(
+                    "proof node CID does not match content hash at path index {}",
+                    idx
+                )));
             }
         }
 
-        // Verify chain integrity: each node's heads should contain the next node's CID.
-        // A broken chain link is a legitimate cryptographic "no" — return Ok(false).
+        // Verify chain integrity: each node's heads should contain the next
+        // node's CID. A broken chain link is a cryptographic verification
+        // failure — return Err for the same reason as the hash check above.
         for i in 0..self.path.len() - 1 {
             let current_block = self.path[i].decode_block()?;
             let next_cid = &self.path[i + 1].cid;
@@ -93,7 +108,13 @@ impl MerkleProof {
                 .unwrap_or(false);
 
             if !has_link {
-                return Ok(false);
+                return Err(Error::Crypto(format!(
+                    "proof chain is broken: node at path index {} does not list \
+                     node at index {} (cid: {}) in its heads",
+                    i,
+                    i + 1,
+                    next_cid
+                )));
             }
         }
 

--- a/crates/crypto/tests/merkle_proof_tests.rs
+++ b/crates/crypto/tests/merkle_proof_tests.rs
@@ -116,9 +116,10 @@ async fn test_proof_wrong_root_fails() {
 
 #[tokio::test]
 async fn test_proof_missing_link_fails() {
-    // Missing chain link is a legitimate cryptographic "no" — returns Ok(false).
-    // Create two unrelated blocks; their CIDs become the anchors so the structural
-    // checks pass, but the heads chain between them is broken.
+    // #733: a missing chain link is a cryptographic verification failure
+    // and must return Err — not Ok(false). Create two unrelated blocks;
+    // their CIDs become the anchors so the structural checks pass, but
+    // the heads chain between them is broken.
     let block1 = Block::new(create_test_delta("doc1", "name"), vec![], vec![]);
     let cid1 = block1.generate_cid().unwrap();
     let node1 = ProofNode::from_block(&block1).unwrap();
@@ -128,9 +129,16 @@ async fn test_proof_missing_link_fails() {
     let node2 = ProofNode::from_block(&block2).unwrap();
 
     let proof = MerkleProof::new(cid1, cid2, vec![node1, node2]);
+    let result = proof.verify();
     assert!(
-        !proof.verify().unwrap(),
-        "broken chain link should return Ok(false)"
+        result.is_err(),
+        "broken chain link must return Err, not Ok(false) — see #733"
+    );
+    let err = result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        err.contains("chain") || err.contains("crypto"),
+        "expected chain-broken error, got: {}",
+        err
     );
 }
 
@@ -722,7 +730,7 @@ fn test_merkle_proof_from_dag_cbor_wrong_schema_fails() {
 // These tests lock in the Rust behavior to match Go's conventions:
 // - Cryptographic signature failures return Err (match Go's ErrSignatureVerification)
 // - Caller-supplied anchor mismatches return Err (configuration error)
-// - Hash/chain mismatches during verification return Ok(false) (legitimate "no")
+// - Hash/chain mismatches during verification return Err (#733)
 // - No hardcoded path length limit (Go has none)
 // =========================================================================
 
@@ -786,10 +794,16 @@ async fn test_large_chain_proof_verifies_without_limit() {
 
 #[tokio::test]
 async fn test_verify_err_vs_ok_false_semantics() {
-    // Parity test documenting the Err vs Ok(false) contract:
+    // Parity test documenting the verification contract (#733).
     //
-    // - Empty path, wrong leaf anchor, wrong root anchor: Err (caller mistake)
-    // - Content hash mismatch, broken chain link: Ok(false) (cryptographic "no")
+    // Every failure mode returns Err — not Ok(false). Matches Go's
+    // convention and the rest of the Rust crypto crate. Closes the
+    // silent-bypass risk where a caller writes `if result.is_ok()` or
+    // `let _ = result?; trust_proof()` and treats a verification failure
+    // as success.
+    //
+    // - Empty path, wrong leaf anchor, wrong root anchor: Err::BlockError (caller mistake)
+    // - Content hash mismatch, broken chain link: Err::Crypto (cryptographic failure)
 
     // 1. Empty path → Err
     let empty = MerkleProof::new(Cid::default(), Cid::default(), vec![]);
@@ -808,12 +822,52 @@ async fn test_verify_err_vs_ok_false_semantics() {
     let wrong_root = MerkleProof::new(cid_a, cid_b, vec![node_a.clone()]);
     assert!(wrong_root.verify().is_err());
 
-    // 4. Broken chain link → Ok(false) (cids match the path, but block_a.heads doesn't contain cid_b)
+    // 4. Broken chain link → Err (cids match the path, but block_a.heads
+    //    doesn't contain cid_b). Used to be Ok(false); flipped to Err in
+    //    the #733 fix.
     let node_b = ProofNode::from_block(&block_b).unwrap();
     let broken = MerkleProof::new(cid_a, cid_b, vec![node_a, node_b]);
     let result = broken.verify();
-    assert!(result.is_ok(), "broken chain link should be Ok, not Err");
-    assert!(!result.unwrap(), "broken chain link should return false");
+    assert!(
+        result.is_err(),
+        "broken chain link must return Err — see #733"
+    );
+    let err = result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        err.contains("chain") || err.contains("crypto"),
+        "expected chain-broken error, got: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_verify_hash_mismatch_returns_err() {
+    // #733: a content hash mismatch is a cryptographic verification
+    // failure and must return Err. This locks in the fix specifically
+    // for the path-4 hash-mismatch branch in proof.rs.
+    use crypto::merkle_proof::ProofNode;
+
+    let block = Block::new(create_test_delta("doc", "field"), vec![], vec![]);
+    let cid = block.generate_cid().unwrap();
+    let mut node = ProofNode::from_block(&block).unwrap();
+
+    // Tamper with the encoded bytes so the recomputed hash no longer
+    // matches the stored cid. ProofNode stores raw bytes in `data`;
+    // flipping the last byte changes the content hash without changing
+    // the cid.
+    if let Some(last) = node.data.last_mut() {
+        *last ^= 0xFF;
+    }
+
+    let proof = MerkleProof::new(cid, cid, vec![node]);
+    let result = proof.verify();
+    assert!(result.is_err(), "hash mismatch must return Err — see #733");
+    let err = result.unwrap_err().to_string().to_lowercase();
+    assert!(
+        err.contains("hash") || err.contains("content") || err.contains("crypto"),
+        "expected hash-mismatch error, got: {}",
+        err
+    );
 }
 
 #[tokio::test]

--- a/crates/wasm/src/client.rs
+++ b/crates/wasm/src/client.rs
@@ -124,7 +124,10 @@ impl DefraClient {
 
     /// Verify a Merkle proof.
     ///
-    /// Returns true if the proof is valid.
+    /// Returns `true` if the proof verifies successfully. Throws on any
+    /// failure (structural input error, hash mismatch, broken chain).
+    /// Never returns `false` — see [`crate::verification::verify_merkle_proof`]
+    /// and issue #733 for rationale.
     #[wasm_bindgen]
     pub fn verify_proof(&self, proof_json: &str) -> std::result::Result<bool, JsValue> {
         crate::verification::verify_merkle_proof(proof_json)

--- a/crates/wasm/src/verification.rs
+++ b/crates/wasm/src/verification.rs
@@ -18,7 +18,18 @@ use crate::error::{Result, WasmError};
 /// - `root_cid`: The CID of the root block
 /// - `path`: Array of proof nodes
 ///
-/// Returns true if the proof is valid.
+/// # Behavior
+///
+/// - **Returns `true`** if the proof verifies successfully.
+/// - **Throws** (resolves to `Err` in Rust → exception in JS) for any
+///   verification failure: structural input errors (empty path, anchor
+///   mismatch), cryptographic failures (content hash mismatch, broken
+///   chain link), and decode errors.
+///
+/// **This function never returns `false`.** Verification failures are
+/// always surfaced as exceptions so JS callers cannot accidentally
+/// bypass them by using truthiness checks on a `false` result. See
+/// issue #733 for the rationale.
 #[wasm_bindgen]
 pub fn verify_merkle_proof(proof_json: &str) -> std::result::Result<bool, JsValue> {
     verify_merkle_proof_impl(proof_json).map_err(|e| e.into())
@@ -35,6 +46,9 @@ fn verify_merkle_proof_impl(proof_json: &str) -> Result<bool> {
 /// Verify a Merkle proof from DAG-CBOR bytes.
 ///
 /// This is the native format for proofs transmitted over the wire.
+///
+/// Behavior is identical to [`verify_merkle_proof`] — returns `true` on
+/// success and throws on any failure (#733). Never returns `false`.
 #[wasm_bindgen]
 pub fn verify_merkle_proof_cbor(proof_bytes: &[u8]) -> std::result::Result<bool, JsValue> {
     verify_merkle_proof_cbor_impl(proof_bytes).map_err(|e| e.into())
@@ -47,7 +61,10 @@ fn verify_merkle_proof_cbor_impl(proof_bytes: &[u8]) -> Result<bool> {
 
 /// Verify a signed Merkle proof using the embedded public key.
 ///
-/// Returns true if both the signature and proof are valid.
+/// Returns `true` if both the signature and proof verify successfully.
+/// Throws on any failure (signature verification failure, hash mismatch,
+/// broken chain, structural input error). Never returns `false` — see
+/// issue #733 for rationale.
 #[wasm_bindgen]
 pub fn verify_signed_proof(proof_bytes: &[u8]) -> std::result::Result<bool, JsValue> {
     verify_signed_proof_impl(proof_bytes).map_err(|e| e.into())


### PR DESCRIPTION
## Summary

Closes **#733**. The merkle proof verifier returned \`Ok(false)\` for cryptographic verification failures (CID hash mismatch, broken chain link). Every other verification site in the Rust crypto crate returns \`Err\` for crypto failures, and Go DefraDB does the same.

## Why this is more than code quality (P1, not low-priority)

The \`Ok(false)\` pattern is a silent bypass risk for any caller writing the idiomatic Rust patterns:
- \`if result.is_ok() { trust_proof() }\` — \`Ok(false)\` looks like success
- \`let _ = result?; trust_proof()\` — flows through \`?\` cleanly
- \`result.unwrap_or(true)\` — defensive defaults treat the error state as success

Today's wasm callers happen to pass the \`Result\` through and JS truthiness covers \`Ok(false)\` as falsy. Not directly exploitable in current code, but a migration hazard for any future Rust caller and inconsistent with both Go and the rest of the crypto crate (the sibling \`signed_proof.rs\` already returns \`Err\` for identity/signature failures, per the audit-era convention).

## Fix

[\`crates/crypto/src/merkle_proof/proof.rs\`](crates/crypto/src/merkle_proof/proof.rs) — hash mismatch and broken chain link both return \`Err::Crypto\` with a descriptive message that includes the failing node index and the relevant CID:

\`\`\`rust
return Err(Error::Crypto(format!(
    \"proof node CID does not match content hash at path index {}\",
    idx
)));
return Err(Error::Crypto(format!(
    \"proof chain is broken: node at path index {} does not list \
     node at index {} (cid: {}) in its heads\",
    i, i + 1, next_cid
)));
\`\`\`

After this change, \`MerkleProof::verify()\` never returns \`Ok(false)\` — only \`Ok(true)\` on success or \`Err\` on any failure mode. The type signature stays \`Result<bool>\` for API stability; the \`bool\` is always \`true\` on success.

## Test updates

- **\`test_proof_missing_link_fails\`** — flipped from \`!result.unwrap()\` to \`result.is_err()\` plus an assertion that the error message contains \"chain\" or \"crypto\"
- **\`test_verify_err_vs_ok_false_semantics\`** — updated commentary and flipped the broken-chain branch to assert \`Err\`
- **\`test_verify_hash_mismatch_returns_err\`** (new) — locks in the hash-mismatch branch by tampering \`ProofNode.data\` and asserting the returned \`Err\` contains the expected message

## Wasm wrapper changes

Doc comments on \`verify_merkle_proof\`, \`verify_merkle_proof_cbor\`, \`verify_signed_proof\`, and \`DefraClient::verify_proof\` now document that they **never return false** — failures throw exceptions in JS. This is the intended behavior change per #733: forces JS callers to handle verification failures via try/catch instead of relying on truthiness checks that could silently bypass the verifier.

The wasm function signatures stay \`Result<bool, JsValue>\` (no API break). The \`bool\` branch only ever carries \`true\` after the change.

## Test plan

- [x] \`cargo test -p crypto\` → 206 pass (including 38 merkle_proof_tests with the 3 changed/new tests)
- [x] \`cargo test --workspace --exclude integration-test --exclude ffi-test --exclude defra-wasm\` → all green
- [x] \`cargo test -p integration-test --test acp -- --skip ::go_\` → 43/43 pass (no regression)
- [x] \`cargo clippy -p crypto --tests -- -D warnings\` → clean
- [x] \`cargo fmt -p crypto\` → applied

## Why no JS-side regression for current callers

The single internal caller \`DefraClient::verify_proof\` just propagates the \`Result\` through; it doesn't introspect \`bool\`. External JS callers of \`verify_merkle_proof\` / \`verify_signed_proof\` are not enumerated in this repo and were always supposed to handle exceptions for verification failures (the function already returned \`Err\` for structural input errors). The change makes the failure semantics consistent across all failure modes.

## Related

- Original issue: #733 (re-labeled to priority:p1 + area:security earlier today)
- Discovered during the post-#756 ACP audit completion sweep
- The sibling \`signed_proof.rs\` already returns \`Err\` for identity/signature mismatches via the same convention this PR adds to \`proof.rs\`