### PR TITLE
fix(cli): wire ACP into PG schema manager for DRI validation

### DIFF
--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -152,6 +152,7 @@ impl Node {
             p2p_setup.mutator.clone(),
         );
 
+        let zanzibar_store_for_pg = zanzibar_store.clone();
         let http_server = Self::build_http_server(HttpServerArgs {
             database: database.clone(),
             config,
@@ -164,7 +165,13 @@ impl Node {
             user_did: user_did.as_ref(),
             node_identity_did,
         })?;
-        let pg_server = Self::build_pg_server(database, config, &query_setup)?;
+        let pg_server = Self::build_pg_server(
+            database,
+            config,
+            &query_setup,
+            &acp_setup,
+            zanzibar_store_for_pg,
+        )?;
 
         Ok((
             p2p_setup.host_handle,

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -195,6 +195,8 @@ impl Node {
         database: Arc<db::DB<S>>,
         config: &Config,
         query_setup: &QueryRunnerSetup<S>,
+        acp_setup: &DocumentAcpSetup,
+        zanzibar_store: Arc<dyn acp::ZanzibarStore>,
     ) -> Result<Option<pg_compat::PgServer>>
     where
         S: storage::corekv::Store + 'static,
@@ -211,7 +213,20 @@ impl Node {
                 .map_err(|e: std::net::AddrParseError| {
                     Error::InvalidApiAddress(config.api.pg_address.clone(), e.to_string())
                 })?;
-        let pg_schema_manager = crate::schema_adapter::SchemaAdapter::new_pg_arc(database);
+
+        // Wire ACP into the PG schema manager so `add_schema` validates
+        // `@policy(id:, resource:)` directives at schema-add time (#746).
+        // Mirrors the HTTP server's behavior — without this, PG users would
+        // be able to register schemas referencing nonexistent policies.
+        let pg_schema_manager = if config.acp.document_type != AcpDocumentType::None {
+            let acp_adapter = acp_setup
+                .http_adapter
+                .clone()
+                .unwrap_or_else(|| crate::acp_adapter::AcpAdapter::new_arc(zanzibar_store));
+            crate::schema_adapter::SchemaAdapter::new_pg_arc_with_acp(database, acp_adapter)
+        } else {
+            crate::schema_adapter::SchemaAdapter::new_pg_arc(database)
+        };
 
         Ok(Some(pg_compat::PgServer::new(
             pg_addr,

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -55,12 +55,22 @@ impl<S: Store + 'static> SchemaAdapter<S> {
 
     /// Create an Arc-wrapped adapter for PG wire protocol schema operations.
     ///
-    /// Note: the PG path currently does not thread ACP context through, so
-    /// schema-time DRI validation (#746) is skipped for PG users. When the
-    /// PG server gains access to `AppState.acp`, add a `_with_acp` variant
-    /// and call `new_with_acp` here too.
+    /// Use `new_pg_arc_with_acp` instead when the caller has an
+    /// `AcpOperations` handle — that variant enables schema-time DRI
+    /// validation (#746). This bare constructor exists for tests and
+    /// for embedded PG callers that don't have ACP configured.
     pub fn new_pg_arc(database: Arc<db::DB<S>>) -> Arc<dyn pg_compat::SchemaManager> {
         Arc::new(Self::new(database))
+    }
+
+    /// Create an Arc-wrapped PG schema manager with ACP wired in for
+    /// schema-time DRI validation (#746). Use this when the PG server
+    /// has access to an `AcpOperations` handle.
+    pub fn new_pg_arc_with_acp(
+        database: Arc<db::DB<S>>,
+        acp: Arc<dyn AcpOperations>,
+    ) -> Arc<dyn pg_compat::SchemaManager> {
+        Arc::new(Self::new_with_acp(database, acp))
     }
 
     async fn add_schema_inner(&self, sdl: &str) -> Result<Vec<CollectionVersion>, String> {


### PR DESCRIPTION
## Summary

Closes the explicit follow-up from PR #756 — PG wire protocol users were not getting schema-time DRI/DPI validation because \`build_pg_server\` didn't have access to the ACP context. This PR adds it.

**Stacked on #756.** Should be merged after #756 lands.

## What #756 left undone

PR #756 added the DRI/DPI validation hook to \`SchemaAdapter\` and wired it through \`build_http_server\`. The PG path in \`build_pg_server\` was deliberately skipped with a comment in \`schema_adapter.rs\`:

> Note: the PG path currently does not thread ACP context through, so schema-time DRI validation (#746) is skipped for PG users. When the PG server gains access to AppState.acp, add a _with_acp variant and call new_with_acp here too.

## What this PR adds

- [crates/cli/src/schema_adapter.rs](crates/cli/src/schema_adapter.rs) — restore \`new_pg_arc_with_acp\` constructor (the HTTP variant exists, this is its PG sibling). Underlying \`add_schema_inner\` already validates when ACP is wired in — no logic changes.
- [crates/cli/src/commands/start/server_http.rs](crates/cli/src/commands/start/server_http.rs) — \`build_pg_server\` takes \`acp_setup\` and \`zanzibar_store\` so it can build the ACP adapter the same way \`build_http_server\` does.
- [crates/cli/src/commands/start/server.rs](crates/cli/src/commands/start/server.rs) — clone \`zanzibar_store\` so both \`build_http_server\` and \`build_pg_server\` can reach it.

After this change, PG users get the exact same \"failed to add collection: policyID specified does not exist with acp\" / \"resource does not exist on the specified policy\" / \"resource is missing required permission on policy\" error strings that HTTP users already get from #756.

## Test plan

- [x] \`cargo check -p cli\` clean
- [x] \`cargo clippy -p cli -- -D warnings\` clean
- [x] \`cargo fmt -p cli\` applied
- Integration tests for the PG path will run once #756 lands and the test infra picks up the new validator. The existing PG smoke tests don't currently exercise \`@policy\` schemas; adding such a test is a separate effort.

## Why no integration test in this PR

The integration test harness's PG client doesn't currently exercise the \`@policy\` schema path. Adding a dedicated PG-side DRI test would require either:
- Extending the harness's PG client to support raw SDL CREATE TABLE-like schema, OR  
- Using a separate test that issues schema via HTTP and queries via PG to confirm the validation trigger

Both are out of scope for this small follow-up. The HTTP path's tests in [link_collection.rs](tools/integration-test/tests/acp/link_collection.rs) (added in #756) cover the validator logic itself; this PR just wires it into a different entry point.

## Related

- PR #756 — adds the DRI/DPI validator (this PR is stacked on it)
- Issue #746 — the original bug