### PR TITLE
fix(encryption): random per-write keys, replace deterministic derivation (#651)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,6 +3699,7 @@ dependencies = [
  "libipld",
  "multibase",
  "multihash 0.18.1",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_ipld_dagcbor",

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -47,8 +47,6 @@ impl Node {
         .with_query_timeout(config.api.query_timeout);
 
         if !config.datastore.no_encryption {
-            let encryption_key = b"examplekey1234567890examplekey12".to_vec();
-            query_runner = query_runner.with_encryption_key(encryption_key);
             info!("CRDT delta encryption enabled");
         }
 

--- a/crates/db-blocks/src/compute.rs
+++ b/crates/db-blocks/src/compute.rs
@@ -56,7 +56,7 @@ pub fn compute_document_blocks(
         // Encrypt delta and create Encryption metadata block if configured
         let (value_bytes, encryption_cid) = if let Some(enc) = encryption_config {
             if enc.should_encrypt_field(field_name) {
-                let key = enc.derive_key(field_name, &doc_id_str);
+                let key = defra_core::encryption::generate_encryption_key();
                 let encrypted = encrypt_delta(&value_bytes, &key)?;
 
                 let is_field_level = enc.encrypt_fields.iter().any(|f| f == field_name);
@@ -144,7 +144,7 @@ pub fn compute_document_blocks(
     // Composite encryption CID for doc-level encryption
     let composite_encryption_cid = if let Some(enc) = encryption_config {
         if enc.encrypt_doc {
-            let key = enc.derive_key("", &doc_id_str);
+            let key = defra_core::encryption::generate_encryption_key();
             let enc_block = Encryption {
                 doc_id: doc_id_str.as_bytes().to_vec(),
                 field_name: None,

--- a/crates/db-blocks/src/write.rs
+++ b/crates/db-blocks/src/write.rs
@@ -102,7 +102,7 @@ pub async fn write_document_blocks(
             // Encrypt delta and create Encryption metadata block if configured
             let (value_bytes, encryption_cid) = if let Some(enc) = encryption_config {
                 if enc.should_encrypt_field(field_name) {
-                    let key = enc.derive_key(field_name, &doc_id_str);
+                    let key = defra_core::encryption::generate_encryption_key();
                     let encrypted = encrypt_delta(&value_bytes, &key)?;
 
                     tracing::debug!(
@@ -299,7 +299,7 @@ pub async fn write_document_blocks(
     // encryption for composites but the Encryption link is still set on the block.
     let composite_encryption_cid = if let Some(enc) = encryption_config {
         if enc.encrypt_doc {
-            let key = enc.derive_key("", &doc_id_str); // doc-level: empty field name
+            let key = defra_core::encryption::generate_encryption_key();
             let enc_block = Encryption {
                 doc_id: doc_id_str.as_bytes().to_vec(),
                 field_name: None,

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -27,6 +27,9 @@ libipld.workspace = true
 # Cryptography (for CID generation)
 sha2.workspace = true
 
+# Random number generation (per-write encryption keys)
+rand = "0.8"
+
 # Async
 async-trait.workspace = true
 

--- a/crates/defra-core/src/encryption.rs
+++ b/crates/defra-core/src/encryption.rs
@@ -2,8 +2,25 @@
 //!
 //! Provides the EncryptionConfig type and thread-local storage for passing
 //! encryption config from the query layer to the block builder layer.
+//!
+//! # Key generation model
+//!
+//! Each encrypted write generates a fresh random AES-256 key via
+//! [`generate_encryption_key`]. The key is stored alongside its ciphertext
+//! in a separate `Encryption` block (see
+//! [`crate::block_signature::Encryption`]), and the data block links to it
+//! via its `encryption: Option<Cid>` field. Decryption loads the
+//! `Encryption` block by CID and reads the key directly — no master key
+//! is needed at the receiver.
+//!
+//! This matches Go DefraDB's `internal/encryption/encryptor.go` exactly.
+//! The previous Rust implementation derived keys deterministically from
+//! `SHA-256(field_name || doc_id || master_key)`, which was both wire-
+//! incompatible with Go (different key bytes) and cryptographically
+//! weaker (one master-key compromise revealed every past, present, and
+//! future document). See #651 for the audit trail.
 
-use sha2::{Digest, Sha256};
+use rand::RngCore;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -62,12 +79,16 @@ impl AsRef<[u8]> for EncryptionKey {
     }
 }
 
-/// Encryption configuration for CRDT delta encryption.
-#[derive(Debug, Clone)]
+/// Encryption policy for a CRDT document mutation.
+///
+/// Carries which fields should be encrypted; does NOT carry any key
+/// material. Each encrypted write generates a fresh random key via
+/// [`generate_encryption_key`] and stores it in the per-block
+/// `Encryption` metadata.
+#[derive(Debug, Clone, Default)]
 pub struct EncryptionConfig {
     pub encrypt_doc: bool,
     pub encrypt_fields: Vec<String>,
-    pub encryption_key: Vec<u8>,
 }
 
 impl EncryptionConfig {
@@ -75,27 +96,23 @@ impl EncryptionConfig {
     pub fn should_encrypt_field(&self, field_name: &str) -> bool {
         self.encrypt_doc || self.encrypt_fields.iter().any(|f| f == field_name)
     }
+}
 
-    /// Derive the encryption key for a specific field and document.
-    ///
-    /// Key derivation: `SHA-256(fieldName + docID + masterKey)`
-    /// - Doc-level: fieldName = "" (empty string)
-    /// - Field-level: fieldName = specific field name
-    ///
-    /// Uses SHA-256 to ensure all input material (including the master key)
-    /// contributes to the derived key regardless of field name or doc ID length.
-    pub fn derive_key(&self, field_name: &str, doc_id: &str) -> [u8; 32] {
-        let field = if self.encrypt_fields.iter().any(|f| f == field_name) {
-            field_name
-        } else {
-            "" // doc-level
-        };
-        let mut hasher = Sha256::new();
-        hasher.update(field.as_bytes());
-        hasher.update(doc_id.as_bytes());
-        hasher.update(&self.encryption_key);
-        hasher.finalize().into()
-    }
+/// Generate a fresh 32-byte AES-256 key from the OS RNG.
+///
+/// Matches Go's `internal/encryption/encryptor.go::generateEncryptionKey`:
+/// each write gets a unique random key. The key is stored alongside the
+/// ciphertext in a separate `Encryption` block (see
+/// [`crate::block_signature::Encryption`]), and the data block points
+/// at it via the `encryption: Option<Cid>` link.
+///
+/// Uses [`rand::rngs::OsRng`] which reads from the OS-provided
+/// cryptographically secure random source (`getrandom` on Linux,
+/// `SecRandomCopyBytes` on macOS, `BCryptGenRandom` on Windows).
+pub fn generate_encryption_key() -> [u8; 32] {
+    let mut key = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut key);
+    key
 }
 
 thread_local! {
@@ -153,25 +170,13 @@ pub fn clear_doc_encryption_store() {
 
 #[cfg(test)]
 mod tests {
-    use super::EncryptionConfig;
+    use super::generate_encryption_key;
 
     #[test]
-    fn derive_key_mixes_in_master_key_for_long_doc_ids() {
-        let doc_id = "bae-c94acbfa-1234-5678-90ab-cdef12345678";
-        let config_a = EncryptionConfig {
-            encrypt_doc: true,
-            encrypt_fields: vec![],
-            encryption_key: b"first-master-key-material-123456".to_vec(),
-        };
-        let config_b = EncryptionConfig {
-            encrypt_doc: true,
-            encrypt_fields: vec![],
-            encryption_key: b"second-master-key-material654321".to_vec(),
-        };
-
-        assert_ne!(
-            config_a.derive_key("", doc_id),
-            config_b.derive_key("", doc_id)
-        );
+    fn generate_encryption_key_is_random() {
+        let k1 = generate_encryption_key();
+        let k2 = generate_encryption_key();
+        assert_ne!(k1, k2);
+        assert_eq!(k1.len(), 32);
     }
 }

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -194,7 +194,6 @@ pub struct EmbeddedNodeConfig {
     pub transport: TransportConfig,
     pub signing: SigningConfig,
     pub document_acp: DocumentAcpConfig,
-    pub encryption_key: Option<Vec<u8>>,
     pub max_concurrent_dag_fetches: Option<usize>,
     pub max_concurrent_push_tasks: Option<usize>,
     pub rate_limit_burst: Option<u32>,

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -120,11 +120,6 @@ impl NodeBuilder {
         self
     }
 
-    pub fn with_encryption_key(mut self, key: Vec<u8>) -> Self {
-        self.config.encryption_key = Some(key);
-        self
-    }
-
     pub async fn build(mut self) -> Result<EmbeddedNode<EmbeddedStore>> {
         let (store, persistence) = if let Some(path) = self.data_path.take() {
             if let Some(parent) = path.parent() {
@@ -302,7 +297,7 @@ where
         db::DbCollectionProvider::new_arc(database.clone());
     let txn_registry = Arc::new(db::DbTransactionRegistry::new(database.clone()));
 
-    let mut query_runner = query::QueryRunner::with_arc_registry_and_provider(
+    let query_runner = query::QueryRunner::with_arc_registry_and_provider(
         fetcher,
         collection_provider,
         txn_registry.clone(),
@@ -315,10 +310,6 @@ where
     )
     .with_acp(document_acp.clone())
     .with_lens_store(database.lens_store().clone());
-
-    if let Some(key) = config.encryption_key {
-        query_runner = query_runner.with_encryption_key(key);
-    }
 
     let query_runner: Arc<dyn query::QueryExecutor> = Arc::new(query_runner);
 

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -209,7 +209,6 @@ fn resolve_embedded_config(
         transport: embedded::TransportConfig::None,
         signing,
         document_acp,
-        encryption_key: Some(b"examplekey1234567890examplekey12".to_vec()),
         max_concurrent_dag_fetches: if options.max_concurrent_dag_fetches > 0 {
             Some(options.max_concurrent_dag_fetches)
         } else {

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -90,8 +90,6 @@ pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRe
     /// Used when a request doesn't include an explicit identity (e.g., no bearer token).
     /// Typically set from the `--identity` CLI flag.
     pub(crate) default_identity: Option<Did>,
-    /// Encryption key for CRDT delta encryption (optional).
-    pub(crate) encryption_key: Option<Vec<u8>>,
     /// Optional lens transform store for view queries with transforms
     pub(crate) lens_store: Option<Arc<dyn lens::TransformStore>>,
     /// Optional NAC checker for query-level enforcement.
@@ -113,7 +111,6 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             mutator: None,
             acp: None,
             default_identity: None,
-            encryption_key: None,
             lens_store: None,
             nac: None,
             query_timeout: 30,
@@ -132,7 +129,6 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             mutator: None,
             acp: None,
             default_identity: None,
-            encryption_key: None,
             lens_store: None,
             nac: None,
             query_timeout: 30,
@@ -153,7 +149,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             mutator: None,
             acp: None,
             default_identity: None,
-            encryption_key: None,
             lens_store: None,
             nac: None,
             query_timeout: 30,
@@ -177,7 +172,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             mutator: None,
             acp: None,
             default_identity: None,
-            encryption_key: None,
             lens_store: None,
             nac: None,
             query_timeout: 30,
@@ -200,7 +194,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             mutator: None,
             acp: None,
             default_identity: None,
-            encryption_key: None,
             lens_store: None,
             nac: None,
             query_timeout: 30,
@@ -249,12 +242,6 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// over the default.
     pub fn with_default_identity(mut self, identity: Did) -> Self {
         self.default_identity = Some(identity);
-        self
-    }
-
-    /// Set the encryption key for CRDT delta encryption.
-    pub fn with_encryption_key(mut self, key: Vec<u8>) -> Self {
-        self.encryption_key = Some(key);
         self
     }
 

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -354,15 +354,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         // Set encryption config for this mutation (thread-local, read by AutoCommitMutator)
         if mutation.encrypt_doc || !mutation.encrypt_fields.is_empty() {
-            if let Some(ref key) = self.encryption_key {
-                defra_core::encryption::set_encryption_config(Some(
-                    defra_core::encryption::EncryptionConfig {
-                        encrypt_doc: mutation.encrypt_doc,
-                        encrypt_fields: mutation.encrypt_fields.clone(),
-                        encryption_key: key.clone(),
-                    },
-                ));
-            }
+            defra_core::encryption::set_encryption_config(Some(
+                defra_core::encryption::EncryptionConfig {
+                    encrypt_doc: mutation.encrypt_doc,
+                    encrypt_fields: mutation.encrypt_fields.clone(),
+                },
+            ));
         } else {
             defra_core::encryption::set_encryption_config(None);
         }

--- a/tools/integration-test/tests/encryption.rs
+++ b/tools/integration-test/tests/encryption.rs
@@ -2,6 +2,8 @@
 mod acp;
 #[path = "encryption/block_verify.rs"]
 mod block_verify;
+#[path = "encryption/cross_runtime_p2p.rs"]
+mod cross_runtime_p2p;
 #[path = "encryption/index.rs"]
 mod index;
 #[path = "encryption/key_management.rs"]

--- a/tools/integration-test/tests/encryption/cross_runtime_p2p.rs
+++ b/tools/integration-test/tests/encryption/cross_runtime_p2p.rs
@@ -1,0 +1,98 @@
+//! P2P replication parity test for issue #651.
+//!
+//! Validates that after switching Rust to random per-write encryption keys
+//! (matching Go's `crypto/rand` model), an encrypted document written on one
+//! node replicates and decrypts cleanly on a peer. Before #651 was fixed,
+//! Rust used deterministic `SHA-256(field_name || doc_id || master_key)` key
+//! derivation — wire-incompatible with Go and cryptographically weaker.
+//!
+//! Only `rust_rust` is covered here because Go-side P2P encrypted replication
+//! currently hangs in this harness for reasons unrelated to #651 (observed
+//! with `go_go_` as well, which exercises no Rust code).
+
+use std::time::{Duration, Instant};
+
+use integration_test::TestCluster;
+
+#[tokio::test]
+async fn rust_rust_encrypted_p2p_replication() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_encryption()
+        .build()
+        .await
+        .expect("build rust 2-node cluster with p2p + encryption");
+
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    let timeout = Duration::from_secs(15);
+    cluster
+        .wait_for_log(0, "p2p_listening", timeout)
+        .await
+        .expect("node0 P2P listener did not start");
+    cluster
+        .wait_for_log(1, "p2p_listening", timeout)
+        .await
+        .expect("node1 P2P listener did not start");
+
+    let info1 = node1.p2p_info().expect("failed to get node1 p2p info");
+    let addr1 = info1
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("node1 has no P2P address");
+
+    let schema = "type Vault { secret: String  pin: String  notes: String }";
+    node0.schema_add(schema).expect("add Vault schema on node0");
+    node1.schema_add(schema).expect("add Vault schema on node1");
+
+    node0.p2p_connect(&[addr1]).expect("connect peers");
+    node0
+        .p2p_collection_add(&["Vault"])
+        .expect("collection add node0");
+    node1
+        .p2p_collection_add(&["Vault"])
+        .expect("collection add node1");
+    node0
+        .p2p_replicator_set(&["Vault"], addr1)
+        .expect("replicator 0->1");
+
+    let created = node0
+        .query(
+            r#"mutation { add_Vault(input: {secret: "topsecret", pin: "4242", notes: "hello"}, encryptFields: [secret, pin]) { _docID } }"#,
+        )
+        .expect("create encrypted Vault on node0");
+    let doc_id = created["add_Vault"][0]["_docID"]
+        .as_str()
+        .or_else(|| created["add_Vault"]["_docID"].as_str())
+        .expect("missing _docID")
+        .to_string();
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let result = node1
+            .query("query { Vault { _docID secret pin notes } }")
+            .expect("query Vault on node1");
+        if let Some(rows) = result["Vault"].as_array() {
+            if let Some(row) = rows.iter().find(|r| r["_docID"].as_str() == Some(&doc_id)) {
+                assert_eq!(
+                    row["secret"], "topsecret",
+                    "secret must decrypt after P2P replication with random per-write keys"
+                );
+                assert_eq!(
+                    row["pin"], "4242",
+                    "pin must decrypt after P2P replication with random per-write keys"
+                );
+                assert_eq!(row["notes"], "hello", "plaintext notes must replicate");
+                return;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "encrypted doc did not replicate within timeout"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #651. Replaces Rust's deterministic `SHA-256(field_name || doc_id || master_key)` AES key derivation with random 32-byte keys per write, matching Go's `internal/encryption/encryptor.go`.

Each encrypted write now generates a fresh key from `OsRng`, which is stored in its own `Encryption` block alongside the ciphertext. The decrypt path already reads keys directly from that block, so **old Rust-encrypted data continues to decrypt cleanly** — no migration tool, no version tag, no breaking change on read.

This unblocks cross-runtime parity: Rust-written encrypted blocks are now wire-compatible with Go's, and Go-written blocks were already decryptable on Rust.

### Why the previous scheme was broken

- **Wire-incompatible with Go**: same master key still produced different key bytes, so Rust and Go couldn't round-trip encrypted data.
- **Cryptographically weaker**: one master-key compromise revealed *every* past, present, and future document on that node. No per-row isolation.

### What changes

- Drop `EncryptionConfig::derive_key` and the `encryption_key` field from the struct.
- Add `defra_core::encryption::generate_encryption_key()` (fresh 32 bytes from `OsRng`).
- Drop `QueryRunner::with_encryption_key` + the vestigial hardcoded test-key plumbing in CLI, FFI, and embedded.
- Wire format (`block_signature::Encryption`) is unchanged — it already carried the key bytes opaquely.
- Decryption path (`db-merge/merge_handler`) is unchanged — it reads `enc_block.key` directly.

Net: ~150 lines deleted, ~30 added.

### What does NOT change

- `Encryption` block CBOR shape (identical to Go)
- P2P replication protocol
- Searchable Encryption (separate code path, HMAC-SHA256)
- Old Rust-encrypted data (still decrypts)

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] `cargo test --workspace` passes (all crates)
- [x] `cargo test -p integration-test --test encryption` — **11/11 passing** including the new `rust_rust_encrypted_p2p_replication` parity test that exercises random-key generation end-to-end over P2P
- [x] Verified against `../defradb/build/defradb` Go binary (Go-side encryption tests still pass)

### New test

`tools/integration-test/tests/encryption/cross_runtime_p2p.rs` spins up two Rust nodes with `.with_p2p().with_encryption()`, encrypts fields on node0, and asserts node1 replicates and decrypts them. This is the regression guard against deterministic key derivation creeping back in.

Note: `go_rust_` and `go_go_` variants of the P2P parity test were drafted but hang on replication in this harness for reasons unrelated to #651 (the `go_go_` variant exercises no Rust code). That's a separate harness / Go-side P2P encrypted replication issue to file as a follow-up.

## Follow-ups

1. Audit `crypto::encryption::aes::encrypt_aes` nonce sourcing + length (30-min review)
2. Cross-runtime epic for master KEK + key wrapping (true at-rest protection — joint design with Go maintainers)
3. Key rotation epic
4. Go-side P2P encrypted replication harness issue (blocks the full cross-runtime P2P parity test)