### PR TITLE
fix(cli): wire ACP into PG schema manager for DRI validation

### DIFF
--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -152,6 +152,7 @@ impl Node {
             p2p_setup.mutator.clone(),
         );
 
+        let zanzibar_store_for_pg = zanzibar_store.clone();
         let http_server = Self::build_http_server(HttpServerArgs {
             database: database.clone(),
             config,
@@ -164,7 +165,13 @@ impl Node {
             user_did: user_did.as_ref(),
             node_identity_did,
         })?;
-        let pg_server = Self::build_pg_server(database, config, &query_setup)?;
+        let pg_server = Self::build_pg_server(
+            database,
+            config,
+            &query_setup,
+            &acp_setup,
+            zanzibar_store_for_pg,
+        )?;
 
         Ok((
             p2p_setup.host_handle,

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -195,6 +195,8 @@ impl Node {
         database: Arc<db::DB<S>>,
         config: &Config,
         query_setup: &QueryRunnerSetup<S>,
+        acp_setup: &DocumentAcpSetup,
+        zanzibar_store: Arc<dyn acp::ZanzibarStore>,
     ) -> Result<Option<pg_compat::PgServer>>
     where
         S: storage::corekv::Store + 'static,
@@ -211,7 +213,20 @@ impl Node {
                 .map_err(|e: std::net::AddrParseError| {
                     Error::InvalidApiAddress(config.api.pg_address.clone(), e.to_string())
                 })?;
-        let pg_schema_manager = crate::schema_adapter::SchemaAdapter::new_pg_arc(database);
+
+        // Wire ACP into the PG schema manager so `add_schema` validates
+        // `@policy(id:, resource:)` directives at schema-add time (#746).
+        // Mirrors the HTTP server's behavior — without this, PG users would
+        // be able to register schemas referencing nonexistent policies.
+        let pg_schema_manager = if config.acp.document_type != AcpDocumentType::None {
+            let acp_adapter = acp_setup
+                .http_adapter
+                .clone()
+                .unwrap_or_else(|| crate::acp_adapter::AcpAdapter::new_arc(zanzibar_store));
+            crate::schema_adapter::SchemaAdapter::new_pg_arc_with_acp(database, acp_adapter)
+        } else {
+            crate::schema_adapter::SchemaAdapter::new_pg_arc(database)
+        };
 
         Ok(Some(pg_compat::PgServer::new(
             pg_addr,

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -55,12 +55,22 @@ impl<S: Store + 'static> SchemaAdapter<S> {
 
     /// Create an Arc-wrapped adapter for PG wire protocol schema operations.
     ///
-    /// Note: the PG path currently does not thread ACP context through, so
-    /// schema-time DRI validation (#746) is skipped for PG users. When the
-    /// PG server gains access to `AppState.acp`, add a `_with_acp` variant
-    /// and call `new_with_acp` here too.
+    /// Use `new_pg_arc_with_acp` instead when the caller has an
+    /// `AcpOperations` handle — that variant enables schema-time DRI
+    /// validation (#746). This bare constructor exists for tests and
+    /// for embedded PG callers that don't have ACP configured.
     pub fn new_pg_arc(database: Arc<db::DB<S>>) -> Arc<dyn pg_compat::SchemaManager> {
         Arc::new(Self::new(database))
+    }
+
+    /// Create an Arc-wrapped PG schema manager with ACP wired in for
+    /// schema-time DRI validation (#746). Use this when the PG server
+    /// has access to an `AcpOperations` handle.
+    pub fn new_pg_arc_with_acp(
+        database: Arc<db::DB<S>>,
+        acp: Arc<dyn AcpOperations>,
+    ) -> Arc<dyn pg_compat::SchemaManager> {
+        Arc::new(Self::new_with_acp(database, acp))
     }
 
     async fn add_schema_inner(&self, sdl: &str) -> Result<Vec<CollectionVersion>, String> {


### PR DESCRIPTION
Supersedes closed #763 after restacking on top of the squash-merged #756. This carries the same PG ACP plumbing change so schema-add validation applies on the PG path as well as HTTP.