### PR TITLE
perf(crypto): borrow cached key material

### DIFF
--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -99,7 +99,7 @@ impl GenerateArgs {
                     Error::Keyring(format!("failed to generate Ed25519 key: {}", e))
                 })?;
                 keyring
-                    .set("peer-key", &private_key.raw())
+                    .set("peer-key", private_key.raw())
                     .map_err(|e| Error::Keyring(e.to_string()))?;
             }
 

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -33,11 +33,11 @@ impl Node {
                 let key_bytes = private_key.raw();
 
                 // Store in keyring
-                kr.set(PEER_KEY, &key_bytes)
+                kr.set(PEER_KEY, key_bytes)
                     .map_err(|e| Error::Keyring(e.to_string()))?;
 
-                let did = Self::derive_and_log_identity_did(&key_bytes)?;
-                let keypair = Self::keypair_from_ed25519_bytes(&key_bytes)?;
+                let did = Self::derive_and_log_identity_did(key_bytes)?;
+                let keypair = Self::keypair_from_ed25519_bytes(key_bytes)?;
                 Ok((keypair, did))
             }
             Err(e) => Err(Error::Keyring(e.to_string())),

--- a/crates/cli/tests/client_tests.rs
+++ b/crates/cli/tests/client_tests.rs
@@ -111,7 +111,7 @@ fn test_generate_auth_token_secp256k1_32_bytes() {
     let key_bytes = private_key.raw();
     assert_eq!(key_bytes.len(), 32, "secp256k1 key should be 32 bytes");
 
-    let hex_key = hex::encode(&key_bytes);
+    let hex_key = hex::encode(key_bytes);
     let result = cli::commands::client::generate_auth_token(&hex_key, "http://localhost:9181");
 
     assert!(result.is_ok(), "Should generate token for secp256k1 key");
@@ -131,7 +131,7 @@ fn test_generate_auth_token_ed25519_64_bytes() {
     let key_bytes = private_key.raw();
     assert_eq!(key_bytes.len(), 64, "ed25519 key should be 64 bytes");
 
-    let hex_key = hex::encode(&key_bytes);
+    let hex_key = hex::encode(key_bytes);
     let result = cli::commands::client::generate_auth_token(&hex_key, "http://localhost:9181");
 
     assert!(result.is_ok(), "Should generate token for ed25519 key");

--- a/crates/crypto/src/batch.rs
+++ b/crates/crypto/src/batch.rs
@@ -142,8 +142,8 @@ mod tests {
         let public_key = private_key.public_key();
         SigningConfig {
             key_type: "ed25519".to_string(),
-            private_key_bytes: private_key.raw(),
-            public_key_bytes: public_key.raw(),
+            private_key_bytes: private_key.raw_owned(),
+            public_key_bytes: public_key.raw_owned(),
             public_key_hex: public_key.to_hex_string(),
             remote_signer: None,
             signing_authorization: None,
@@ -155,8 +155,8 @@ mod tests {
         let public_key = private_key.public_key();
         SigningConfig {
             key_type: "secp256k1".to_string(),
-            private_key_bytes: private_key.raw(),
-            public_key_bytes: public_key.raw(),
+            private_key_bytes: private_key.raw_owned(),
+            public_key_bytes: public_key.raw_owned(),
             public_key_hex: public_key.to_hex_string(),
             remote_signer: None,
             signing_authorization: None,

--- a/crates/crypto/src/keys/bls.rs
+++ b/crates/crypto/src/keys/bls.rs
@@ -53,8 +53,8 @@ impl Key for BlsPublicKey {
         self.raw_bytes == other.raw()
     }
 
-    fn raw(&self) -> Vec<u8> {
-        self.raw_bytes.clone()
+    fn raw(&self) -> &[u8] {
+        &self.raw_bytes
     }
 
     fn key_type(&self) -> KeyType {

--- a/crates/crypto/src/keys/ed25519.rs
+++ b/crates/crypto/src/keys/ed25519.rs
@@ -136,7 +136,7 @@ impl Key for Ed25519PrivateKey {
         if self_raw.len() != other_raw.len() {
             return false;
         }
-        self_raw.ct_eq(&other_raw).into()
+        self_raw.ct_eq(other_raw).into()
     }
 
     fn raw(&self) -> &[u8] {
@@ -224,7 +224,7 @@ impl Key for Ed25519PublicKey {
         if self_raw.len() != other_raw.len() {
             return false;
         }
-        self_raw.ct_eq(&other_raw).into()
+        self_raw.ct_eq(other_raw).into()
     }
 
     fn raw(&self) -> &[u8] {
@@ -274,7 +274,7 @@ impl PublicKey for Ed25519PublicKey {
     }
 
     fn did(&self) -> Result<String> {
-        crate::did::create_did_key(KeyType::Ed25519, &self.raw())
+        crate::did::create_did_key(KeyType::Ed25519, self.raw())
     }
 }
 

--- a/crates/crypto/src/keys/ed25519.rs
+++ b/crates/crypto/src/keys/ed25519.rs
@@ -6,9 +6,9 @@
 //! - Signatures: 64 bytes
 
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey, PUBLIC_KEY_LENGTH};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use subtle::ConstantTimeEq;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use defra_core::Result;
 
@@ -39,6 +39,8 @@ use crate::types::KeyType;
 #[derive(Clone)]
 pub struct Ed25519PrivateKey {
     key: SigningKey,
+    raw_bytes: Zeroizing<Vec<u8>>,
+    public_key: Ed25519PublicKey,
 }
 
 impl PartialEq for Ed25519PrivateKey {
@@ -104,12 +106,22 @@ impl Ed25519PrivateKey {
         }
 
         seed.zeroize();
-        Ok(Self { key })
+        let public_key = Ed25519PublicKey::from_verifying_key(key.verifying_key());
+        Ok(Self {
+            key,
+            raw_bytes: Zeroizing::new(bytes.to_vec()),
+            public_key,
+        })
     }
 
     /// Get the underlying ed25519-dalek signing key
     pub fn underlying(&self) -> &SigningKey {
         &self.key
+    }
+
+    /// Derive the corresponding Ed25519 public key without dynamic dispatch.
+    pub fn to_public_key(&self) -> Ed25519PublicKey {
+        self.public_key.clone()
     }
 }
 
@@ -127,15 +139,8 @@ impl Key for Ed25519PrivateKey {
         self_raw.ct_eq(&other_raw).into()
     }
 
-    fn raw(&self) -> Vec<u8> {
-        // Return 64 bytes: 32-byte seed + 32-byte public key
-        // DefraDB format (not RFC 8032 standard) for Go compatibility
-        let seed = self.key.to_bytes();
-        let public = self.key.verifying_key().to_bytes();
-        let mut result = Vec::with_capacity(64);
-        result.extend_from_slice(&seed);
-        result.extend_from_slice(&public);
-        result
+    fn raw(&self) -> &[u8] {
+        &self.raw_bytes
     }
 
     fn key_type(&self) -> KeyType {
@@ -149,19 +154,16 @@ impl PrivateKey for Ed25519PrivateKey {
         Ok(signature.to_bytes().to_vec())
     }
 
-    fn public_key(&self) -> Box<dyn PublicKey> {
-        Box::new(Ed25519PublicKey {
-            key: self.key.verifying_key(),
-        })
+    fn public_key(&self) -> &dyn PublicKey {
+        &self.public_key
     }
 }
 
 /// Ed25519 public key wrapper
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Ed25519PublicKey {
-    #[serde(with = "ed25519_public_key_serde")]
     key: VerifyingKey,
+    raw_bytes: [u8; PUBLIC_KEY_LENGTH],
 }
 
 impl Ed25519PublicKey {
@@ -192,12 +194,22 @@ impl Ed25519PublicKey {
         let key = VerifyingKey::from_bytes(&key_bytes)
             .map_err(|e| crypto_error(format!("invalid Ed25519 public key: {}", e)))?;
 
-        Ok(Self { key })
+        Ok(Self {
+            key,
+            raw_bytes: key_bytes,
+        })
     }
 
     /// Get the underlying ed25519-dalek verifying key
     pub fn underlying(&self) -> &VerifyingKey {
         &self.key
+    }
+
+    fn from_verifying_key(key: VerifyingKey) -> Self {
+        Self {
+            raw_bytes: key.to_bytes(),
+            key,
+        }
     }
 }
 
@@ -215,12 +227,31 @@ impl Key for Ed25519PublicKey {
         self_raw.ct_eq(&other_raw).into()
     }
 
-    fn raw(&self) -> Vec<u8> {
-        self.key.to_bytes().to_vec()
+    fn raw(&self) -> &[u8] {
+        &self.raw_bytes
     }
 
     fn key_type(&self) -> KeyType {
         KeyType::Ed25519
+    }
+}
+
+impl Serialize for Ed25519PublicKey {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.raw_bytes)
+    }
+}
+
+impl<'de> Deserialize<'de> for Ed25519PublicKey {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <Vec<u8>>::deserialize(deserializer)?;
+        Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }
 
@@ -263,33 +294,4 @@ pub fn ed25519_key_from_seed(seed: &[u8]) -> Result<Vec<u8>> {
     full_key.extend_from_slice(verifying_key.as_bytes());
     seed_array.zeroize();
     Ok(full_key)
-}
-
-// Custom serde module for VerifyingKey
-mod ed25519_public_key_serde {
-    use ed25519_dalek::VerifyingKey;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(key: &VerifyingKey, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_bytes(&key.to_bytes())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<VerifyingKey, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bytes = <Vec<u8>>::deserialize(deserializer)?;
-        if bytes.len() != 32 {
-            return Err(serde::de::Error::custom(
-                "invalid Ed25519 public key length",
-            ));
-        }
-        let key_bytes: [u8; 32] = bytes
-            .try_into()
-            .map_err(|_| serde::de::Error::custom("invalid Ed25519 public key bytes"))?;
-        VerifyingKey::from_bytes(&key_bytes).map_err(serde::de::Error::custom)
-    }
 }

--- a/crates/crypto/src/keys/mod.rs
+++ b/crates/crypto/src/keys/mod.rs
@@ -18,7 +18,12 @@ pub trait Key: defra_core::thread_bounds::MaybeSendSync {
     fn equal(&self, other: &dyn Key) -> bool;
 
     /// Get the raw bytes of this key
-    fn raw(&self) -> Vec<u8>;
+    fn raw(&self) -> &[u8];
+
+    /// Get an owned copy of the raw bytes when required by external APIs.
+    fn raw_owned(&self) -> Vec<u8> {
+        self.raw().to_vec()
+    }
 
     /// Get the hex-encoded string representation of this key
     fn to_hex_string(&self) -> String {
@@ -44,5 +49,5 @@ pub trait PrivateKey: Key {
     fn sign(&self, data: &[u8]) -> defra_core::Result<Vec<u8>>;
 
     /// Get the corresponding public key
-    fn public_key(&self) -> Box<dyn PublicKey>;
+    fn public_key(&self) -> &dyn PublicKey;
 }

--- a/crates/crypto/src/keys/secp256k1.rs
+++ b/crates/crypto/src/keys/secp256k1.rs
@@ -9,9 +9,10 @@ use k256::ecdsa::{
     signature::DigestSigner, signature::DigestVerifier, Signature, SigningKey, VerifyingKey,
 };
 use k256::EncodedPoint;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
 
 use defra_core::Result;
 
@@ -23,6 +24,8 @@ use crate::types::{KeyType, SECP256K1_PRIVATE_KEY_SIZE};
 #[derive(Clone)]
 pub struct Secp256k1PrivateKey {
     key: SigningKey,
+    raw_bytes: Zeroizing<Vec<u8>>,
+    public_key: Secp256k1PublicKey,
 }
 
 impl PartialEq for Secp256k1PrivateKey {
@@ -67,12 +70,22 @@ impl Secp256k1PrivateKey {
 
         let key = SigningKey::from_slice(bytes)
             .map_err(|e| crypto_error(format!("invalid secp256k1 private key: {}", e)))?;
-        Ok(Self { key })
+        let public_key = Secp256k1PublicKey::from_verifying_key(*key.verifying_key());
+        Ok(Self {
+            key,
+            raw_bytes: Zeroizing::new(bytes.to_vec()),
+            public_key,
+        })
     }
 
     /// Get the underlying k256 signing key
     pub fn underlying(&self) -> &SigningKey {
         &self.key
+    }
+
+    /// Derive the corresponding secp256k1 public key without dynamic dispatch.
+    pub fn to_public_key(&self) -> Secp256k1PublicKey {
+        self.public_key.clone()
     }
 }
 
@@ -90,8 +103,8 @@ impl Key for Secp256k1PrivateKey {
         self_raw.ct_eq(&other_raw).into()
     }
 
-    fn raw(&self) -> Vec<u8> {
-        self.key.to_bytes().to_vec()
+    fn raw(&self) -> &[u8] {
+        &self.raw_bytes
     }
 
     fn key_type(&self) -> KeyType {
@@ -117,19 +130,16 @@ impl PrivateKey for Secp256k1PrivateKey {
         Ok(signature.to_der().as_bytes().to_vec())
     }
 
-    fn public_key(&self) -> Box<dyn PublicKey> {
-        Box::new(Secp256k1PublicKey {
-            key: *self.key.verifying_key(),
-        })
+    fn public_key(&self) -> &dyn PublicKey {
+        &self.public_key
     }
 }
 
 /// secp256k1 public key wrapper
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Secp256k1PublicKey {
-    #[serde(with = "secp256k1_public_key_serde")]
     key: VerifyingKey,
+    raw_bytes: Vec<u8>,
 }
 
 impl Secp256k1PublicKey {
@@ -154,12 +164,17 @@ impl Secp256k1PublicKey {
         let key = VerifyingKey::from_encoded_point(&point)
             .map_err(|_| crypto_error("invalid secp256k1 public key: not on curve"))?;
 
-        Ok(Self { key })
+        Ok(Self::from_verifying_key(key))
     }
 
     /// Get the underlying k256 verifying key
     pub fn underlying(&self) -> &VerifyingKey {
         &self.key
+    }
+
+    fn from_verifying_key(key: VerifyingKey) -> Self {
+        let raw_bytes = key.to_encoded_point(true).as_bytes().to_vec();
+        Self { key, raw_bytes }
     }
 }
 
@@ -177,13 +192,31 @@ impl Key for Secp256k1PublicKey {
         self_raw.ct_eq(&other_raw).into()
     }
 
-    fn raw(&self) -> Vec<u8> {
-        // Always return compressed format (33 bytes with 0x02/0x03 prefix)
-        self.key.to_encoded_point(true).as_bytes().to_vec()
+    fn raw(&self) -> &[u8] {
+        &self.raw_bytes
     }
 
     fn key_type(&self) -> KeyType {
         KeyType::Secp256k1
+    }
+}
+
+impl Serialize for Secp256k1PublicKey {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.raw_bytes)
+    }
+}
+
+impl<'de> Deserialize<'de> for Secp256k1PublicKey {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <Vec<u8>>::deserialize(deserializer)?;
+        Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }
 
@@ -234,30 +267,4 @@ pub fn secp256k1_private_key_to_xy(private_bytes: &[u8]) -> Result<(Vec<u8>, Vec
         .ok_or_else(|| crypto_error("secp256k1: missing y coordinate"))?
         .to_vec();
     Ok((x, y))
-}
-
-// Custom serde module for VerifyingKey
-mod secp256k1_public_key_serde {
-    use k256::ecdsa::VerifyingKey;
-    use k256::EncodedPoint;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(key: &VerifyingKey, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // Serialize as compressed format
-        let bytes = key.to_encoded_point(true);
-        serializer.serialize_bytes(bytes.as_bytes())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<VerifyingKey, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bytes = <Vec<u8>>::deserialize(deserializer)?;
-        let point = EncodedPoint::from_bytes(&bytes)
-            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
-        VerifyingKey::from_encoded_point(&point).map_err(serde::de::Error::custom)
-    }
 }

--- a/crates/crypto/src/keys/secp256k1.rs
+++ b/crates/crypto/src/keys/secp256k1.rs
@@ -100,7 +100,7 @@ impl Key for Secp256k1PrivateKey {
         if self_raw.len() != other_raw.len() {
             return false;
         }
-        self_raw.ct_eq(&other_raw).into()
+        self_raw.ct_eq(other_raw).into()
     }
 
     fn raw(&self) -> &[u8] {
@@ -189,7 +189,7 @@ impl Key for Secp256k1PublicKey {
         if self_raw.len() != other_raw.len() {
             return false;
         }
-        self_raw.ct_eq(&other_raw).into()
+        self_raw.ct_eq(other_raw).into()
     }
 
     fn raw(&self) -> &[u8] {

--- a/crates/crypto/src/keys/secp256r1.rs
+++ b/crates/crypto/src/keys/secp256r1.rs
@@ -9,9 +9,10 @@
 
 use p256::ecdsa::{signature::DigestSigner, Signature, SigningKey, VerifyingKey};
 use p256::EncodedPoint;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
 
 use defra_core::Result;
 
@@ -23,6 +24,8 @@ use crate::types::{KeyType, SECP256R1_PRIVATE_KEY_SIZE};
 #[derive(Clone)]
 pub struct Secp256r1PrivateKey {
     key: SigningKey,
+    raw_bytes: Zeroizing<Vec<u8>>,
+    public_key: Secp256r1PublicKey,
 }
 
 impl PartialEq for Secp256r1PrivateKey {
@@ -58,12 +61,22 @@ impl Secp256r1PrivateKey {
 
         let key = SigningKey::from_slice(bytes)
             .map_err(|e| crypto_error(format!("invalid secp256r1 private key: {}", e)))?;
-        Ok(Self { key })
+        let public_key = Secp256r1PublicKey::from_verifying_key(*key.verifying_key());
+        Ok(Self {
+            key,
+            raw_bytes: Zeroizing::new(bytes.to_vec()),
+            public_key,
+        })
     }
 
     /// Get the underlying p256 signing key
     pub fn underlying(&self) -> &SigningKey {
         &self.key
+    }
+
+    /// Derive the corresponding secp256r1 public key without dynamic dispatch.
+    pub fn to_public_key(&self) -> Secp256r1PublicKey {
+        self.public_key.clone()
     }
 }
 
@@ -80,8 +93,8 @@ impl Key for Secp256r1PrivateKey {
         self_raw.ct_eq(&other_raw).into()
     }
 
-    fn raw(&self) -> Vec<u8> {
-        self.key.to_bytes().to_vec()
+    fn raw(&self) -> &[u8] {
+        &self.raw_bytes
     }
 
     fn key_type(&self) -> KeyType {
@@ -103,18 +116,16 @@ impl PrivateKey for Secp256r1PrivateKey {
         Ok(signature.to_der().as_bytes().to_vec())
     }
 
-    fn public_key(&self) -> Box<dyn PublicKey> {
-        Box::new(Secp256r1PublicKey {
-            key: *self.key.verifying_key(),
-        })
+    fn public_key(&self) -> &dyn PublicKey {
+        &self.public_key
     }
 }
 
 /// secp256r1 (P-256) public key wrapper
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct Secp256r1PublicKey {
-    #[serde(with = "secp256r1_public_key_serde")]
     key: VerifyingKey,
+    raw_bytes: Vec<u8>,
 }
 
 impl PartialEq for Secp256r1PublicKey {
@@ -148,12 +159,17 @@ impl Secp256r1PublicKey {
         let key = VerifyingKey::from_encoded_point(&point)
             .map_err(|_| crypto_error("invalid secp256r1 public key: not on curve"))?;
 
-        Ok(Self { key })
+        Ok(Self::from_verifying_key(key))
     }
 
     /// Get the underlying p256 verifying key
     pub fn underlying(&self) -> &VerifyingKey {
         &self.key
+    }
+
+    fn from_verifying_key(key: VerifyingKey) -> Self {
+        let raw_bytes = key.to_encoded_point(true).as_bytes().to_vec();
+        Self { key, raw_bytes }
     }
 }
 
@@ -171,12 +187,31 @@ impl Key for Secp256r1PublicKey {
         self_raw.ct_eq(&other_raw).into()
     }
 
-    fn raw(&self) -> Vec<u8> {
-        self.key.to_encoded_point(true).as_bytes().to_vec()
+    fn raw(&self) -> &[u8] {
+        &self.raw_bytes
     }
 
     fn key_type(&self) -> KeyType {
         KeyType::Secp256r1
+    }
+}
+
+impl Serialize for Secp256r1PublicKey {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(&self.raw_bytes)
+    }
+}
+
+impl<'de> Deserialize<'de> for Secp256r1PublicKey {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = <Vec<u8>>::deserialize(deserializer)?;
+        Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }
 
@@ -229,30 +264,4 @@ pub fn secp256r1_private_key_to_xy(private_bytes: &[u8]) -> Result<(Vec<u8>, Vec
         .ok_or_else(|| crypto_error("secp256r1: missing y coordinate"))?
         .to_vec();
     Ok((x, y))
-}
-
-// Custom serde module for VerifyingKey
-mod secp256r1_public_key_serde {
-    use p256::ecdsa::VerifyingKey;
-    use p256::EncodedPoint;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<S>(key: &VerifyingKey, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // Serialize as compressed format
-        let bytes = key.to_encoded_point(true);
-        serializer.serialize_bytes(bytes.as_bytes())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<VerifyingKey, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bytes = <Vec<u8>>::deserialize(deserializer)?;
-        let point = EncodedPoint::from_bytes(&bytes)
-            .map_err(|e| serde::de::Error::custom(e.to_string()))?;
-        VerifyingKey::from_encoded_point(&point).map_err(serde::de::Error::custom)
-    }
 }

--- a/crates/crypto/src/keys/secp256r1.rs
+++ b/crates/crypto/src/keys/secp256r1.rs
@@ -90,7 +90,7 @@ impl Key for Secp256r1PrivateKey {
         if self_raw.len() != other_raw.len() {
             return false;
         }
-        self_raw.ct_eq(&other_raw).into()
+        self_raw.ct_eq(other_raw).into()
     }
 
     fn raw(&self) -> &[u8] {
@@ -184,7 +184,7 @@ impl Key for Secp256r1PublicKey {
         if self_raw.len() != other_raw.len() {
             return false;
         }
-        self_raw.ct_eq(&other_raw).into()
+        self_raw.ct_eq(other_raw).into()
     }
 
     fn raw(&self) -> &[u8] {

--- a/crates/crypto/tests/keys_tests.rs
+++ b/crates/crypto/tests/keys_tests.rs
@@ -24,6 +24,16 @@ fn test_generate_ed25519() {
 }
 
 #[test]
+fn test_private_key_raw_returns_stable_borrow() {
+    let key = generate_ed25519().unwrap();
+    let first = key.raw();
+    let second = key.raw();
+
+    assert!(std::ptr::eq(first.as_ptr(), second.as_ptr()));
+    assert_eq!(first, second);
+}
+
+#[test]
 fn test_generate_key_secp256k1() {
     let key = generate_key(KeyType::Secp256k1).unwrap();
     assert_eq!(key.key_type(), KeyType::Secp256k1);
@@ -105,6 +115,15 @@ fn test_public_key_from_string() {
 
     let parsed = public_key_from_string(KeyType::Ed25519, &hex_str).unwrap();
     assert_eq!(parsed.raw(), public_key.raw());
+}
+
+#[test]
+fn test_private_key_public_key_returns_cached_reference() {
+    let private_key = generate_secp256k1().unwrap();
+    let first = private_key.public_key() as *const dyn crypto::PublicKey;
+    let second = private_key.public_key() as *const dyn crypto::PublicKey;
+
+    assert_eq!(first, second);
 }
 
 #[test]

--- a/crates/crypto/tests/keys_tests.rs
+++ b/crates/crypto/tests/keys_tests.rs
@@ -75,7 +75,7 @@ fn test_private_key_from_bytes_secp256k1() {
     let original = generate_secp256k1().unwrap();
     let bytes = original.raw();
 
-    let parsed = private_key_from_bytes(KeyType::Secp256k1, &bytes).unwrap();
+    let parsed = private_key_from_bytes(KeyType::Secp256k1, bytes).unwrap();
     assert_eq!(parsed.raw(), bytes);
 }
 
@@ -84,7 +84,7 @@ fn test_private_key_from_bytes_ed25519() {
     let original = generate_ed25519().unwrap();
     let bytes = original.raw();
 
-    let parsed = private_key_from_bytes(KeyType::Ed25519, &bytes).unwrap();
+    let parsed = private_key_from_bytes(KeyType::Ed25519, bytes).unwrap();
     assert_eq!(parsed.raw(), bytes);
 }
 
@@ -103,7 +103,7 @@ fn test_public_key_from_bytes() {
     let public_key = private_key.public_key();
     let bytes = public_key.raw();
 
-    let parsed = public_key_from_bytes(KeyType::Secp256k1, &bytes).unwrap();
+    let parsed = public_key_from_bytes(KeyType::Secp256k1, bytes).unwrap();
     assert_eq!(parsed.raw(), bytes);
 }
 
@@ -216,7 +216,7 @@ fn test_private_key_from_bytes_valid_secp256k1() {
     let original = generate_secp256k1().unwrap();
     let key_bytes = original.raw();
 
-    let parsed = private_key_from_bytes(KeyType::Secp256k1, &key_bytes).unwrap();
+    let parsed = private_key_from_bytes(KeyType::Secp256k1, key_bytes).unwrap();
 
     assert_eq!(
         parsed.key_type(),
@@ -240,7 +240,7 @@ fn test_private_key_from_bytes_valid_ed25519() {
     let original = generate_ed25519().unwrap();
     let key_bytes = original.raw();
 
-    let parsed = private_key_from_bytes(KeyType::Ed25519, &key_bytes).unwrap();
+    let parsed = private_key_from_bytes(KeyType::Ed25519, key_bytes).unwrap();
 
     assert_eq!(parsed.key_type(), KeyType::Ed25519, "Key type should match");
     assert_eq!(parsed.raw(), key_bytes, "Raw bytes should match");
@@ -281,7 +281,7 @@ fn test_private_key_from_bytes_invalid_ed25519_length() {
 fn test_private_key_from_bytes_secp256r1() {
     let generated = generate_key(KeyType::Secp256r1).unwrap();
     let key_bytes = generated.raw();
-    let key = private_key_from_bytes(KeyType::Secp256r1, &key_bytes).unwrap();
+    let key = private_key_from_bytes(KeyType::Secp256r1, key_bytes).unwrap();
     assert_eq!(key.key_type(), KeyType::Secp256r1);
     assert_eq!(key.raw(), key_bytes);
 }
@@ -318,7 +318,7 @@ fn test_public_key_from_bytes_valid_secp256k1() {
     let public_key = private_key.public_key();
     let key_bytes = public_key.raw();
 
-    let parsed = public_key_from_bytes(KeyType::Secp256k1, &key_bytes).unwrap();
+    let parsed = public_key_from_bytes(KeyType::Secp256k1, key_bytes).unwrap();
 
     assert_eq!(
         parsed.key_type(),
@@ -334,7 +334,7 @@ fn test_public_key_from_bytes_valid_ed25519() {
     let public_key = private_key.public_key();
     let key_bytes = public_key.raw();
 
-    let parsed = public_key_from_bytes(KeyType::Ed25519, &key_bytes).unwrap();
+    let parsed = public_key_from_bytes(KeyType::Ed25519, key_bytes).unwrap();
 
     assert_eq!(parsed.key_type(), KeyType::Ed25519, "Key type should match");
     assert_eq!(parsed.raw(), key_bytes, "Raw bytes should match");

--- a/crates/crypto/tests/merkle_proof_tests.rs
+++ b/crates/crypto/tests/merkle_proof_tests.rs
@@ -285,12 +285,10 @@ async fn test_signed_proof_wrong_key_fails() {
         result.is_err(),
         "wrong key should return Err, not Ok(false)"
     );
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("identity does not match")
-    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("identity does not match"));
 }
 
 #[tokio::test]

--- a/crates/crypto/tests/merkle_proof_tests.rs
+++ b/crates/crypto/tests/merkle_proof_tests.rs
@@ -890,7 +890,7 @@ async fn test_signed_proof_signature_failure_returns_err() {
 
     // Direct verify() path
     let pub_key = private_key.public_key();
-    let result_verify = signed.verify(pub_key.as_ref());
+    let result_verify = signed.verify(pub_key);
     assert!(
         result_verify.is_err(),
         "verify() must return Err on signature failure, got {:?}",
@@ -931,13 +931,13 @@ async fn test_signed_proof_identity_mismatch_returns_err() {
 
     // Using a key of a different curve type — hits the key_type check first.
     let other_pub = other_key.public_key();
-    let result_type = signed.verify(other_pub.as_ref());
+    let result_type = signed.verify(other_pub);
     assert!(result_type.is_err(), "key type mismatch should return Err");
 
     // Using a different ed25519 key — hits the identity check.
     let wrong_ed = generate_ed25519().unwrap();
     let wrong_pub = wrong_ed.public_key();
-    let result_identity = signed.verify(wrong_pub.as_ref());
+    let result_identity = signed.verify(wrong_pub);
     assert!(
         result_identity.is_err(),
         "identity mismatch should return Err, got {:?}",
@@ -967,6 +967,6 @@ async fn test_valid_signed_proof_still_returns_ok_true() {
     let signed = SignedMerkleProof::sign(proof, &private_key as &dyn PrivateKey).unwrap();
 
     let pub_key = private_key.public_key();
-    assert!(signed.verify(pub_key.as_ref()).unwrap());
+    assert!(signed.verify(pub_key).unwrap());
     assert!(signed.verify_with_embedded_key().unwrap());
 }

--- a/crates/crypto/tests/merkle_proof_tests.rs
+++ b/crates/crypto/tests/merkle_proof_tests.rs
@@ -240,7 +240,7 @@ async fn test_signed_proof_ed25519() {
     let signed = SignedMerkleProof::sign(proof, &private_key as &dyn PrivateKey).unwrap();
 
     // Verify with explicit public key
-    assert!(signed.verify(public_key.as_ref()).unwrap());
+    assert!(signed.verify(public_key).unwrap());
 
     // Verify with embedded key
     assert!(signed.verify_with_embedded_key().unwrap());
@@ -259,7 +259,7 @@ async fn test_signed_proof_secp256k1() {
     let signed = SignedMerkleProof::sign(proof, &private_key as &dyn PrivateKey).unwrap();
 
     // Verify with explicit public key
-    assert!(signed.verify(public_key.as_ref()).unwrap());
+    assert!(signed.verify(public_key).unwrap());
 
     // Verify with embedded key
     assert!(signed.verify_with_embedded_key().unwrap());
@@ -280,15 +280,17 @@ async fn test_signed_proof_wrong_key_fails() {
 
     let signed = SignedMerkleProof::sign(proof, &private_key1 as &dyn PrivateKey).unwrap();
 
-    let result = signed.verify(wrong_public_key.as_ref());
+    let result = signed.verify(wrong_public_key);
     assert!(
         result.is_err(),
         "wrong key should return Err, not Ok(false)"
     );
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("identity does not match"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("identity does not match")
+    );
 }
 
 #[tokio::test]
@@ -407,7 +409,7 @@ async fn test_key_type_mismatch_returns_error() {
     // Try to verify with secp256k1 key - should return error, not false
     let secp_key = generate_secp256k1().unwrap();
     let secp_public = secp_key.public_key();
-    let result = signed.verify(secp_public.as_ref());
+    let result = signed.verify(secp_public);
 
     assert!(result.is_err(), "Key type mismatch should return error");
     let err_msg = result.unwrap_err().to_string();

--- a/crates/db-blocks/src/tests.rs
+++ b/crates/db-blocks/src/tests.rs
@@ -149,7 +149,7 @@ fn test_compute_signature_supports_remote_secp256r1() {
     let signer = defra_core::signing::SigningConfig {
         key_type: "secp256r1".to_string(),
         private_key_bytes: Vec::new(),
-        public_key_bytes: public_key.raw(),
+        public_key_bytes: public_key.raw_owned(),
         public_key_hex: hex::encode(public_key.raw()),
         remote_signer: Some(Arc::new(TestRemoteSecp256r1Signer { private_key })),
         signing_authorization: None,
@@ -214,7 +214,7 @@ fn test_compute_signature_passes_signing_authorization_to_remote_signer() {
     let signer = defra_core::signing::SigningConfig {
         key_type: "secp256r1".to_string(),
         private_key_bytes: Vec::new(),
-        public_key_bytes: public_key.raw(),
+        public_key_bytes: public_key.raw_owned(),
         public_key_hex: hex::encode(public_key.raw()),
         remote_signer: Some(Arc::new(CapturingRemoteSigner {
             private_key,

--- a/crates/ffi/src/acp/identity.rs
+++ b/crates/ffi/src/acp/identity.rs
@@ -450,7 +450,7 @@ mod tests {
         let _guard = remote_test_lock().lock().unwrap();
 
         let private_key = crypto::generate_secp256r1().unwrap();
-        *remote_key_store().lock().unwrap() = private_key.raw();
+        *remote_key_store().lock().unwrap() = private_key.raw().to_vec();
 
         let raw_identity = identity::RawIdentity::from_secp256r1(private_key).unwrap();
         let did = raw_identity.did().unwrap().to_string();
@@ -497,7 +497,7 @@ mod tests {
         let _guard = remote_test_lock().lock().unwrap();
 
         let private_key = crypto::generate_secp256r1().unwrap();
-        *remote_key_store().lock().unwrap() = private_key.raw();
+        *remote_key_store().lock().unwrap() = private_key.raw().to_vec();
 
         let raw_identity = identity::RawIdentity::from_secp256r1(private_key).unwrap();
         let did = raw_identity.did().unwrap().to_string();
@@ -566,7 +566,7 @@ mod tests {
         assert!(crate::runtime::init_runtime());
 
         let private_key = crypto::generate_secp256r1().unwrap();
-        *remote_key_store().lock().unwrap() = private_key.raw();
+        *remote_key_store().lock().unwrap() = private_key.raw().to_vec();
 
         let raw_identity = identity::RawIdentity::from_secp256r1(private_key).unwrap();
         let did = raw_identity.did().unwrap().to_string();

--- a/crates/identity/src/raw.rs
+++ b/crates/identity/src/raw.rs
@@ -20,6 +20,7 @@ pub struct RawIdentity {
 }
 
 /// Internal enum to hold different key types without dynamic dispatch.
+#[allow(clippy::large_enum_variant)]
 enum IdentityInner {
     Ed25519 {
         private_key: Ed25519PrivateKey,
@@ -77,19 +78,19 @@ impl RawIdentity {
         match private_key.key_type() {
             KeyType::Ed25519 => {
                 let raw_bytes = private_key.raw();
-                let ed25519_key = Ed25519PrivateKey::from_bytes(&raw_bytes)
+                let ed25519_key = Ed25519PrivateKey::from_bytes(raw_bytes)
                     .map_err(|e| Error::InvalidKeyBytes(KeyType::Ed25519, e.to_string()))?;
                 Self::from_ed25519(ed25519_key)
             }
             KeyType::Secp256k1 => {
                 let raw_bytes = private_key.raw();
-                let secp256k1_key = Secp256k1PrivateKey::from_bytes(&raw_bytes)
+                let secp256k1_key = Secp256k1PrivateKey::from_bytes(raw_bytes)
                     .map_err(|e| Error::InvalidKeyBytes(KeyType::Secp256k1, e.to_string()))?;
                 Self::from_secp256k1(secp256k1_key)
             }
             KeyType::Secp256r1 => {
                 let raw_bytes = private_key.raw();
-                let secp256r1_key = Secp256r1PrivateKey::from_bytes(&raw_bytes)
+                let secp256r1_key = Secp256r1PrivateKey::from_bytes(raw_bytes)
                     .map_err(|e| Error::InvalidKeyBytes(KeyType::Secp256r1, e.to_string()))?;
                 Self::from_secp256r1(secp256r1_key)
             }

--- a/crates/identity/src/raw.rs
+++ b/crates/identity/src/raw.rs
@@ -38,11 +38,7 @@ enum IdentityInner {
 impl RawIdentity {
     /// Creates a new RawIdentity from an Ed25519 private key.
     pub fn from_ed25519(private_key: Ed25519PrivateKey) -> Result<Self> {
-        let public_key_box = private_key.public_key();
-        let public_key_raw = public_key_box.raw();
-        let public_key = Ed25519PublicKey::from_bytes(&public_key_raw).map_err(|e| {
-            Error::PublicKeyDerivation(format!("Ed25519 public key derivation failed: {}", e))
-        })?;
+        let public_key = private_key.to_public_key();
 
         Ok(Self {
             inner: IdentityInner::Ed25519 {
@@ -54,11 +50,7 @@ impl RawIdentity {
 
     /// Creates a new RawIdentity from a secp256k1 private key.
     pub fn from_secp256k1(private_key: Secp256k1PrivateKey) -> Result<Self> {
-        let public_key_box = private_key.public_key();
-        let public_key_raw = public_key_box.raw();
-        let public_key = Secp256k1PublicKey::from_bytes(&public_key_raw).map_err(|e| {
-            Error::PublicKeyDerivation(format!("secp256k1 public key derivation failed: {}", e))
-        })?;
+        let public_key = private_key.to_public_key();
 
         Ok(Self {
             inner: IdentityInner::Secp256k1 {
@@ -70,11 +62,7 @@ impl RawIdentity {
 
     /// Creates a new RawIdentity from a secp256r1 (P-256) private key.
     pub fn from_secp256r1(private_key: Secp256r1PrivateKey) -> Result<Self> {
-        let public_key_box = private_key.public_key();
-        let public_key_raw = public_key_box.raw();
-        let public_key = Secp256r1PublicKey::from_bytes(&public_key_raw).map_err(|e| {
-            Error::PublicKeyDerivation(format!("secp256r1 public key derivation failed: {}", e))
-        })?;
+        let public_key = private_key.to_public_key();
 
         Ok(Self {
             inner: IdentityInner::Secp256r1 {
@@ -175,18 +163,18 @@ impl RawIdentity {
     /// Returns the raw private key bytes.
     pub fn private_key_bytes(&self) -> Vec<u8> {
         match &self.inner {
-            IdentityInner::Ed25519 { private_key, .. } => private_key.raw(),
-            IdentityInner::Secp256k1 { private_key, .. } => private_key.raw(),
-            IdentityInner::Secp256r1 { private_key, .. } => private_key.raw(),
+            IdentityInner::Ed25519 { private_key, .. } => private_key.raw_owned(),
+            IdentityInner::Secp256k1 { private_key, .. } => private_key.raw_owned(),
+            IdentityInner::Secp256r1 { private_key, .. } => private_key.raw_owned(),
         }
     }
 
     /// Returns the raw public key bytes.
     pub fn public_key_bytes(&self) -> Vec<u8> {
         match &self.inner {
-            IdentityInner::Ed25519 { public_key, .. } => public_key.raw(),
-            IdentityInner::Secp256k1 { public_key, .. } => public_key.raw(),
-            IdentityInner::Secp256r1 { public_key, .. } => public_key.raw(),
+            IdentityInner::Ed25519 { public_key, .. } => public_key.raw_owned(),
+            IdentityInner::Secp256k1 { public_key, .. } => public_key.raw_owned(),
+            IdentityInner::Secp256r1 { public_key, .. } => public_key.raw_owned(),
         }
     }
 }

--- a/crates/identity/tests/property_tests.rs
+++ b/crates/identity/tests/property_tests.rs
@@ -45,8 +45,8 @@ proptest! {
         let key1 = generate_ed25519().unwrap();
         let bytes = key1.raw();
 
-        let identity1 = RawIdentity::from_bytes(KeyType::Ed25519, &bytes).unwrap();
-        let identity2 = RawIdentity::from_bytes(KeyType::Ed25519, &bytes).unwrap();
+        let identity1 = RawIdentity::from_bytes(KeyType::Ed25519, bytes).unwrap();
+        let identity2 = RawIdentity::from_bytes(KeyType::Ed25519, bytes).unwrap();
 
         let did1 = identity1.did().unwrap();
         let did2 = identity2.did().unwrap();
@@ -59,8 +59,8 @@ proptest! {
         let key1 = generate_secp256k1().unwrap();
         let bytes = key1.raw();
 
-        let identity1 = RawIdentity::from_bytes(KeyType::Secp256k1, &bytes).unwrap();
-        let identity2 = RawIdentity::from_bytes(KeyType::Secp256k1, &bytes).unwrap();
+        let identity1 = RawIdentity::from_bytes(KeyType::Secp256k1, bytes).unwrap();
+        let identity2 = RawIdentity::from_bytes(KeyType::Secp256k1, bytes).unwrap();
 
         let did1 = identity1.did().unwrap();
         let did2 = identity2.did().unwrap();

--- a/crates/identity/tests/raw_tests.rs
+++ b/crates/identity/tests/raw_tests.rs
@@ -30,7 +30,7 @@ fn test_from_bytes_ed25519() {
     let key = generate_ed25519().unwrap();
     let bytes = key.raw();
 
-    let identity = RawIdentity::from_bytes(KeyType::Ed25519, &bytes).unwrap();
+    let identity = RawIdentity::from_bytes(KeyType::Ed25519, bytes).unwrap();
     assert_eq!(identity.key_type(), KeyType::Ed25519);
 }
 
@@ -39,7 +39,7 @@ fn test_from_bytes_secp256k1() {
     let key = generate_secp256k1().unwrap();
     let bytes = key.raw();
 
-    let identity = RawIdentity::from_bytes(KeyType::Secp256k1, &bytes).unwrap();
+    let identity = RawIdentity::from_bytes(KeyType::Secp256k1, bytes).unwrap();
     assert_eq!(identity.key_type(), KeyType::Secp256k1);
 }
 
@@ -72,7 +72,7 @@ fn test_from_secp256r1() {
 fn test_from_bytes_secp256r1() {
     let key = crypto::generate_secp256r1().unwrap();
     let key_bytes = key.raw();
-    let identity = RawIdentity::from_bytes(KeyType::Secp256r1, &key_bytes).unwrap();
+    let identity = RawIdentity::from_bytes(KeyType::Secp256r1, key_bytes).unwrap();
     assert_eq!(identity.key_type(), KeyType::Secp256r1);
 }
 
@@ -196,7 +196,7 @@ fn test_from_identity_key_type_ed25519() {
     let key = generate_ed25519().unwrap();
     let bytes = key.raw();
 
-    let identity = RawIdentity::from_identity_key_type(IdentityKeyType::Ed25519, &bytes).unwrap();
+    let identity = RawIdentity::from_identity_key_type(IdentityKeyType::Ed25519, bytes).unwrap();
     assert_eq!(identity.identity_key_type(), IdentityKeyType::Ed25519);
     assert_eq!(identity.key_type(), KeyType::Ed25519);
 }
@@ -206,7 +206,7 @@ fn test_from_identity_key_type_secp256k1() {
     let key = generate_secp256k1().unwrap();
     let bytes = key.raw();
 
-    let identity = RawIdentity::from_identity_key_type(IdentityKeyType::Secp256k1, &bytes).unwrap();
+    let identity = RawIdentity::from_identity_key_type(IdentityKeyType::Secp256k1, bytes).unwrap();
     assert_eq!(identity.identity_key_type(), IdentityKeyType::Secp256k1);
     assert_eq!(identity.key_type(), KeyType::Secp256k1);
 }

--- a/crates/identity/tests/raw_tests.rs
+++ b/crates/identity/tests/raw_tests.rs
@@ -167,7 +167,7 @@ fn test_sign_with_secp256r1() {
 #[test]
 fn test_priv_key_trait_method() {
     let key = generate_ed25519().unwrap();
-    let expected_bytes = key.raw();
+    let expected_bytes = key.raw_owned();
     let identity = RawIdentity::from_private_key(key).unwrap();
 
     let priv_key = identity.priv_key();

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -1015,7 +1015,6 @@ mod tests {
         defra_core::encryption::EncryptionConfig {
             encrypt_doc: true,
             encrypt_fields: vec![],
-            encryption_key: vec![0xAB; 32],
         }
     }
 

--- a/crates/sourcehub/src/cosmos/cosmos_provider.rs
+++ b/crates/sourcehub/src/cosmos/cosmos_provider.rs
@@ -329,13 +329,15 @@ mod tests {
     fn store_remote_secp256r1_identity(did: &str) {
         let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
         let public_key = private_key.public_key();
+        let public_key_bytes = public_key.raw_owned();
+        let public_key_hex = hex::encode(&public_key_bytes);
         defra_core::signing::store_identity(
             did,
             defra_core::signing::SigningConfig {
                 key_type: "secp256r1".to_string(),
                 private_key_bytes: Vec::new(),
-                public_key_bytes: public_key.raw(),
-                public_key_hex: hex::encode(public_key.raw()),
+                public_key_bytes,
+                public_key_hex,
                 remote_signer: None,
                 signing_authorization: None,
             },

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -631,13 +631,15 @@ mod tests {
     fn store_remote_secp256r1_identity(did: &str) {
         let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
         let public_key = private_key.public_key();
+        let public_key_bytes = public_key.raw_owned();
+        let public_key_hex = hex::encode(&public_key_bytes);
         defra_core::signing::store_identity(
             did,
             defra_core::signing::SigningConfig {
                 key_type: "secp256r1".to_string(),
                 private_key_bytes: Vec::new(),
-                public_key_bytes: public_key.raw(),
-                public_key_hex: hex::encode(public_key.raw()),
+                public_key_bytes,
+                public_key_hex,
                 remote_signer: None,
                 signing_authorization: None,
             },


### PR DESCRIPTION
## Summary
- change `Key::raw()` to return `&[u8]`
- change `PrivateKey::public_key()` to return `&dyn PublicKey`
- cache private/public key material in the concrete key types so repeated key comparisons and serialization paths can borrow instead of allocating
- update affected tests and helper call sites to use owned copies only where APIs still require `Vec<u8>`

## Validation
- cargo check --workspace
- cargo test -p crypto --test keys_tests --test merkle_proof_tests
- cargo test -p identity --test raw_tests
- cargo test -p sourcehub --lib resolve_registered_or_passthrough_bearer_token

Closes #679
