### PR TITLE
Fix SSE ACP metadata leak on /api/v0/events

### DIFF
--- a/crates/db-merge/src/merge_handler/collection.rs
+++ b/crates/db-merge/src/merge_handler/collection.rs
@@ -185,6 +185,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                                         .to_string();
                                     bus.publish(Message::merge_complete(MergeCompleteData {
                                         doc_id: doc_id_str,
+                                        subject_doc_id: None,
                                         cid: *link_cid,
                                         collection_id: col_id,
                                         by_peer: metadata.sender_peer.unwrap_or("").to_string(),
@@ -204,6 +205,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                                         .to_string();
                                     bus.publish(Message::merge_complete(MergeCompleteData {
                                         doc_id: doc_id_str,
+                                        subject_doc_id: None,
                                         cid: *link_cid,
                                         collection_id: col_id,
                                         by_peer: metadata.sender_peer.unwrap_or("").to_string(),
@@ -455,6 +457,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                             pe.push(PendingMergeEvent {
                                 message: Message::merge_complete(MergeCompleteData {
                                     doc_id: doc_id_str,
+                                    subject_doc_id: None,
                                     cid: *link_cid,
                                     collection_id: col_id,
                                     by_peer: metadata.sender_peer.unwrap_or("").to_string(),
@@ -474,6 +477,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                             pe.push(PendingMergeEvent {
                                 message: Message::merge_complete(MergeCompleteData {
                                     doc_id: doc_id_str,
+                                    subject_doc_id: None,
                                     cid: *link_cid,
                                     collection_id: col_id,
                                     by_peer: metadata.sender_peer.unwrap_or("").to_string(),

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -262,6 +262,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     if let Some(bus) = self.db.event_bus() {
                         let merge_complete = MergeCompleteData {
                             doc_id: doc_id_str.clone(),
+                            subject_doc_id: None,
                             cid: *cid,
                             collection_id: metadata
                                 .collection_id
@@ -327,6 +328,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     if !from_collection {
                         let merge_complete = MergeCompleteData {
                             doc_id: doc_id_str.clone(),
+                            subject_doc_id: None,
                             cid: *cid,
                             collection_id: metadata
                                 .collection_id
@@ -340,6 +342,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     if state.is_branchable {
                         let merge_complete = MergeCompleteData {
                             doc_id: String::new(),
+                            subject_doc_id: Some(doc_id_str.clone()),
                             cid: *cid,
                             collection_id: metadata
                                 .collection_id
@@ -548,6 +551,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 if outcome.is_terminal_skip() && !from_collection {
                     let merge_complete = MergeCompleteData {
                         doc_id: doc_id_str.clone(),
+                        subject_doc_id: None,
                         cid: *cid,
                         collection_id: metadata
                             .collection_id
@@ -617,6 +621,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     if !from_collection {
                         let merge_complete = MergeCompleteData {
                             doc_id: doc_id_str.clone(),
+                            subject_doc_id: None,
                             cid: *cid,
                             collection_id: metadata
                                 .collection_id
@@ -632,6 +637,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     if state.is_branchable {
                         let merge_complete = MergeCompleteData {
                             doc_id: String::new(),
+                            subject_doc_id: Some(doc_id_str.clone()),
                             cid: *cid,
                             collection_id: metadata
                                 .collection_id

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -83,6 +83,7 @@ impl<S: Store> BatchMutator<S> {
 
     fn emit_update_event(&self, event: PendingUpdateEvent) {
         if let Some(bus) = self.db.event_bus() {
+            let subject_doc_id = event.doc_id.clone();
             let update = Update::new(
                 event.doc_id,
                 event.cid,
@@ -94,8 +95,9 @@ impl<S: Store> BatchMutator<S> {
             bus.publish(Message::update(update));
 
             if event.branchable {
-                let collection_update = Update::new(
+                let collection_update = Update::new_with_subject_doc_id(
                     String::new(),
+                    subject_doc_id,
                     event.cid,
                     event.collection_id,
                     vec![],

--- a/crates/db/src/auto_commit_mutator/helpers.rs
+++ b/crates/db/src/auto_commit_mutator/helpers.rs
@@ -30,8 +30,9 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             bus.publish(Message::update(update));
 
             if collection.schema().is_branchable {
-                let col_update = Update::new(
+                let col_update = Update::new_with_subject_doc_id(
                     String::new(), // empty doc_id → keyed by collection_id
+                    doc_id_str.to_string(),
                     cid,
                     collection.collection_id().to_string(),
                     vec![],

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -146,6 +146,7 @@ where
                 } => {
                     event_bus.publish(events::Message::merge_complete(events::MergeCompleteData {
                         doc_id: doc_id.clone(),
+                        subject_doc_id: None,
                         cid: *cid,
                         collection_id: collection_id.clone(),
                         by_peer: local_peer.clone(),
@@ -178,6 +179,7 @@ where
                         event_bus.publish(events::Message::merge_complete(
                             events::MergeCompleteData {
                                 doc_id: doc_id.clone(),
+                                subject_doc_id: None,
                                 cid: *cid,
                                 collection_id: collection_id.clone(),
                                 by_peer: local_peer.clone(),

--- a/crates/events/src/channel_bus.rs
+++ b/crates/events/src/channel_bus.rs
@@ -286,6 +286,7 @@ mod tests {
         bus.publish(Message::merge());
         bus.publish(Message::merge_complete(crate::MergeCompleteData {
             doc_id: "test-doc".to_string(),
+            subject_doc_id: None,
             cid: cid::Cid::default(),
             collection_id: "test-col".to_string(),
             by_peer: "test-peer".to_string(),

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -58,6 +58,8 @@ impl std::fmt::Display for EventName {
 pub struct MergeCompleteData {
     /// Document ID that was merged.
     pub doc_id: String,
+    /// Document ID used for authorization when this is a collection-level event.
+    pub subject_doc_id: Option<String>,
     /// CID of the merged block.
     pub cid: Cid,
     /// Collection ID the document belongs to.
@@ -111,6 +113,8 @@ pub struct AcpCacheInvalidatedData {
 pub struct Update {
     /// Document ID that was updated.
     pub doc_id: String,
+    /// Document ID used for authorization when this is a collection-level event.
+    pub subject_doc_id: Option<String>,
     /// CID of the update block.
     pub cid: Cid,
     /// Collection ID (schema version ID) the document belongs to.
@@ -135,6 +139,28 @@ impl Update {
     ) -> Self {
         Self {
             doc_id,
+            subject_doc_id: None,
+            cid,
+            collection_id,
+            block: block.into(),
+            is_retry,
+            is_relay,
+        }
+    }
+
+    /// Create a new Update event with an internal authorization subject document ID.
+    pub fn new_with_subject_doc_id(
+        doc_id: String,
+        subject_doc_id: String,
+        cid: Cid,
+        collection_id: String,
+        block: impl Into<Bytes>,
+        is_retry: bool,
+        is_relay: bool,
+    ) -> Self {
+        Self {
+            doc_id,
+            subject_doc_id: Some(subject_doc_id),
             cid,
             collection_id,
             block: block.into(),
@@ -323,6 +349,7 @@ mod tests {
 
         let mc_data = MergeCompleteData {
             doc_id: "doc-789".to_string(),
+            subject_doc_id: None,
             cid: Cid::default(),
             collection_id: "col-abc".to_string(),
             by_peer: "peer-xyz".to_string(),

--- a/crates/http/src/handlers/events.rs
+++ b/crates/http/src/handlers/events.rs
@@ -1,19 +1,98 @@
 //! SSE endpoint for streaming event bus events.
 
 use std::convert::Infallible;
+use std::sync::Arc;
 
 use axum::{
     extract::{Query, State},
     response::sse::{Event, Sse},
 };
+use query::executor::QueryRequest;
+use query::subscription::response_has_data;
 use serde::Deserialize;
 
 use crate::error::HttpError;
+use crate::identity_extractor::ExtractIdentity;
+use crate::nac_guard::require_permission;
+use crate::query_context::{
+    execute_with_resolved_context, resolve_dac_bypass, resolve_signing_config,
+};
 use crate::router::AppState;
+use crate::router::NodePermission;
 
 #[derive(Debug, Deserialize)]
 pub struct EventsQuery {
     pub event: Option<String>,
+}
+
+fn required_permission_for_event_filter(event: Option<&str>) -> NodePermission {
+    match event {
+        Some("topic-peer-event") => NodePermission::P2pPeerInfo,
+        Some("acp-cache-invalidated") | Some("acp-height-advanced") => NodePermission::DacStatus,
+        Some("update") | Some("merge-complete") | None | Some(_) => NodePermission::DocumentRead,
+    }
+}
+
+#[derive(Clone)]
+struct EventAccessContext {
+    executor: Arc<dyn query::executor::QueryExecutor>,
+    collection_mgmt: Option<Arc<dyn crate::router::CollectionManagementOperations>>,
+    signing_config: Option<defra_core::signing::SigningConfig>,
+    dac_bypass: bool,
+    did: Option<identity::Did>,
+    acp_enabled: bool,
+}
+
+impl EventAccessContext {
+    async fn can_observe_document_event(
+        &self,
+        collection_id: &str,
+        doc_id: &str,
+    ) -> Result<bool, HttpError> {
+        if !self.acp_enabled {
+            return Ok(true);
+        }
+
+        let Some(collection_mgmt) = &self.collection_mgmt else {
+            // Without collection metadata we cannot safely prove visibility.
+            return Ok(false);
+        };
+
+        let collection = collection_mgmt
+            .find_collection_by_id(collection_id)
+            .await
+            .map_err(HttpError::Internal)?
+            .or(collection_mgmt
+                .get_collection_by_version_id(collection_id)
+                .await
+                .map_err(HttpError::Internal)?);
+
+        let Some(collection) = collection else {
+            return Ok(false);
+        };
+
+        if collection.policy.is_none() {
+            return Ok(true);
+        }
+
+        if doc_id.is_empty() {
+            return Ok(false);
+        }
+
+        let query = format!(
+            r#"query {{ {}(docID: "{}") {{ _docID }} }}"#,
+            collection.name, doc_id
+        );
+        let response = execute_with_resolved_context(
+            self.executor.clone(),
+            QueryRequest::new(query).with_identity(self.did.clone()),
+            self.signing_config.clone(),
+            self.dac_bypass,
+        )
+        .await;
+
+        Ok(response_has_data(&response))
+    }
 }
 
 /// GET /api/v0/events — stream event bus events as SSE.
@@ -21,8 +100,16 @@ pub struct EventsQuery {
 /// Optional query param `?event=topic-peer-event` filters by event name.
 pub async fn events_sse(
     State(state): State<AppState>,
+    identity: ExtractIdentity,
     Query(params): Query<EventsQuery>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, HttpError> {
+    require_permission(
+        &state,
+        &identity,
+        required_permission_for_event_filter(params.event.as_deref()),
+    )
+    .await?;
+
     let event_bus = state
         .event_bus
         .as_ref()
@@ -38,6 +125,14 @@ pub async fn events_sse(
     };
 
     let mut subscription = event_bus.subscribe(&filter);
+    let access = EventAccessContext {
+        executor: state.executor.clone(),
+        collection_mgmt: state.collection_mgmt.clone(),
+        signing_config: resolve_signing_config(&state, &identity),
+        dac_bypass: resolve_dac_bypass(&state, &identity).await,
+        did: identity.did().cloned(),
+        acp_enabled: state.doc_acp.is_some() || state.acp.is_some(),
+    };
 
     let stream = async_stream::stream! {
         while let Some(message) = subscription.recv().await {
@@ -51,6 +146,13 @@ pub async fn events_sse(
                     }
                 })
             } else if let Some(update) = message.as_update() {
+                let Ok(can_observe) = access.can_observe_document_event(&update.collection_id, &update.doc_id).await else {
+                    continue;
+                };
+                if !can_observe {
+                    continue;
+                }
+
                 serde_json::json!({
                     "name": "update",
                     "data": {
@@ -60,6 +162,13 @@ pub async fn events_sse(
                     }
                 })
             } else if let Some(data) = message.as_merge_complete() {
+                let Ok(can_observe) = access.can_observe_document_event(&data.collection_id, &data.doc_id).await else {
+                    continue;
+                };
+                if !can_observe {
+                    continue;
+                }
+
                 serde_json::json!({
                     "name": "merge-complete",
                     "data": {

--- a/crates/http/src/handlers/events.rs
+++ b/crates/http/src/handlers/events.rs
@@ -25,11 +25,47 @@ pub struct EventsQuery {
     pub event: Option<String>,
 }
 
-fn required_permission_for_event_filter(event: Option<&str>) -> NodePermission {
+#[derive(Debug)]
+struct EventSubscriptionFilter {
+    permissions: &'static [NodePermission],
+    events: Vec<events::EventName>,
+}
+
+const WILDCARD_EVENT_PERMISSIONS: &[NodePermission] = &[
+    NodePermission::DocumentRead,
+    NodePermission::P2pPeerInfo,
+    NodePermission::DacStatus,
+];
+
+fn parse_event_filter(event: Option<&str>) -> Result<EventSubscriptionFilter, HttpError> {
     match event {
-        Some("topic-peer-event") => NodePermission::P2pPeerInfo,
-        Some("acp-cache-invalidated") | Some("acp-height-advanced") => NodePermission::DacStatus,
-        Some("update") | Some("merge-complete") | None | Some(_) => NodePermission::DocumentRead,
+        None => Ok(EventSubscriptionFilter {
+            permissions: WILDCARD_EVENT_PERMISSIONS,
+            events: vec![events::EventName::WildCard],
+        }),
+        Some("topic-peer-event") => Ok(EventSubscriptionFilter {
+            permissions: &[NodePermission::P2pPeerInfo],
+            events: vec![events::EventName::TopicPeerEvent],
+        }),
+        Some("acp-cache-invalidated") => Ok(EventSubscriptionFilter {
+            permissions: &[NodePermission::DacStatus],
+            events: vec![events::EventName::AcpCacheInvalidated],
+        }),
+        Some("acp-height-advanced") => Ok(EventSubscriptionFilter {
+            permissions: &[NodePermission::DacStatus],
+            events: vec![events::EventName::AcpHeightAdvanced],
+        }),
+        Some("update") => Ok(EventSubscriptionFilter {
+            permissions: &[NodePermission::DocumentRead],
+            events: vec![events::EventName::Update],
+        }),
+        Some("merge-complete") => Ok(EventSubscriptionFilter {
+            permissions: &[NodePermission::DocumentRead],
+            events: vec![events::EventName::MergeComplete],
+        }),
+        Some(other) => Err(HttpError::BadRequest(format!(
+            "unsupported event filter: {other}"
+        ))),
     }
 }
 
@@ -75,14 +111,33 @@ impl EventAccessContext {
             return Ok(true);
         }
 
-        if doc_id.is_empty() {
+        let subject_doc_id = if doc_id.is_empty() {
+            None
+        } else {
+            Some(doc_id)
+        };
+
+        if let Some(subject_doc_id) = subject_doc_id {
+            let query = format!(
+                r#"query {{ {}(docID: "{}") {{ _docID }} }}"#,
+                collection.name, subject_doc_id
+            );
+            let response = execute_with_resolved_context(
+                self.executor.clone(),
+                QueryRequest::new(query).with_identity(self.did.clone()),
+                self.signing_config.clone(),
+                self.dac_bypass,
+            )
+            .await;
+
+            return Ok(response_has_data(&response));
+        }
+
+        if !collection.is_branchable {
             return Ok(false);
         }
 
-        let query = format!(
-            r#"query {{ {}(docID: "{}") {{ _docID }} }}"#,
-            collection.name, doc_id
-        );
+        let query = format!(r#"query {{ {}(limit: 1) {{ _docID }} }}"#, collection.name);
         let response = execute_with_resolved_context(
             self.executor.clone(),
             QueryRequest::new(query).with_identity(self.did.clone()),
@@ -103,28 +158,17 @@ pub async fn events_sse(
     identity: ExtractIdentity,
     Query(params): Query<EventsQuery>,
 ) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, HttpError> {
-    require_permission(
-        &state,
-        &identity,
-        required_permission_for_event_filter(params.event.as_deref()),
-    )
-    .await?;
+    let filter = parse_event_filter(params.event.as_deref())?;
+    for permission in filter.permissions {
+        require_permission(&state, &identity, *permission).await?;
+    }
 
     let event_bus = state
         .event_bus
         .as_ref()
         .ok_or_else(|| HttpError::ServiceUnavailable("event bus is not available".to_string()))?;
 
-    let filter = match params.event.as_deref() {
-        Some("acp-cache-invalidated") => vec![events::EventName::AcpCacheInvalidated],
-        Some("acp-height-advanced") => vec![events::EventName::AcpHeightAdvanced],
-        Some("topic-peer-event") => vec![events::EventName::TopicPeerEvent],
-        Some("update") => vec![events::EventName::Update],
-        Some("merge-complete") => vec![events::EventName::MergeComplete],
-        _ => vec![events::EventName::WildCard],
-    };
-
-    let mut subscription = event_bus.subscribe(&filter);
+    let mut subscription = event_bus.subscribe(&filter.events);
     let access = EventAccessContext {
         executor: state.executor.clone(),
         collection_mgmt: state.collection_mgmt.clone(),
@@ -146,7 +190,8 @@ pub async fn events_sse(
                     }
                 })
             } else if let Some(update) = message.as_update() {
-                let Ok(can_observe) = access.can_observe_document_event(&update.collection_id, &update.doc_id).await else {
+                let subject_doc_id = update.subject_doc_id.as_deref().unwrap_or(&update.doc_id);
+                let Ok(can_observe) = access.can_observe_document_event(&update.collection_id, subject_doc_id).await else {
                     continue;
                 };
                 if !can_observe {
@@ -162,7 +207,8 @@ pub async fn events_sse(
                     }
                 })
             } else if let Some(data) = message.as_merge_complete() {
-                let Ok(can_observe) = access.can_observe_document_event(&data.collection_id, &data.doc_id).await else {
+                let subject_doc_id = data.subject_doc_id.as_deref().unwrap_or(&data.doc_id);
+                let Ok(can_observe) = access.can_observe_document_event(&data.collection_id, subject_doc_id).await else {
                     continue;
                 };
                 if !can_observe {
@@ -214,4 +260,22 @@ pub async fn events_sse(
     };
 
     Ok(Sse::new(stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_event_filter_rejects_unknown_filters() {
+        let err = parse_event_filter(Some("typo-event")).unwrap_err();
+        assert!(matches!(err, HttpError::BadRequest(_)));
+    }
+
+    #[test]
+    fn parse_event_filter_wildcard_requires_all_stream_permissions() {
+        let filter = parse_event_filter(None).expect("wildcard filter");
+        assert_eq!(filter.events, vec![events::EventName::WildCard]);
+        assert_eq!(filter.permissions, WILDCARD_EVENT_PERMISSIONS);
+    }
 }

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -49,6 +49,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             Method::POST => RoutePermission::Dynamic,
             _ => RoutePermission::Required(NodePermission::DocumentRead),
         },
+        "/api/v0/events" => RoutePermission::Dynamic,
         "/api/v0/schema" => match *method {
             Method::GET => RoutePermission::Required(NodePermission::CollectionGet),
             Method::POST => RoutePermission::Required(NodePermission::CollectionPatch),

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -1015,7 +1015,6 @@ mod tests {
         defra_core::encryption::EncryptionConfig {
             encrypt_doc: true,
             encrypt_fields: vec![],
-            encryption_key: vec![0xAB; 32],
         }
     }
 

--- a/tools/integration-test/tests/acp.rs
+++ b/tools/integration-test/tests/acp.rs
@@ -4,6 +4,8 @@ mod audit;
 mod basic;
 #[path = "acp/custom_policy.rs"]
 mod custom_policy;
+#[path = "acp/events_sse.rs"]
+mod events_sse;
 #[path = "acp/index.rs"]
 mod index;
 #[path = "acp/link_collection.rs"]

--- a/tools/integration-test/tests/acp/events_sse.rs
+++ b/tools/integration-test/tests/acp/events_sse.rs
@@ -92,6 +92,13 @@ async fn open_events_sse_with_auth(
     (handle, events)
 }
 
+fn branchable_users_schema_with_policy(policy_id: &str) -> String {
+    format!(
+        r#"type User @branchable @policy(id: "{}", resource: "users") {{ name: String  age: Int }}"#,
+        policy_id
+    )
+}
+
 async fn acp_events_sse_filters_unauthorized_subscribers_test(cluster: TestCluster) {
     let node = cluster.client(0);
     let binary_path = node.binary_path().to_path_buf();
@@ -171,4 +178,74 @@ async fn rust_acp_events_sse_filters_unauthorized_subscribers() {
         .await
         .unwrap();
     acp_events_sse_filters_unauthorized_subscribers_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_acp_events_sse_preserves_authorized_branchable_collection_updates() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+
+    let node = cluster.client(0);
+    let binary_path = node.binary_path().to_path_buf();
+    let api_url = cluster.api_url(0).to_string();
+
+    let alice = generate_identity(&binary_path).expect("generate Alice identity");
+
+    let policy = node
+        .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+        .expect("add ACP policy");
+    let policy_id = policy["PolicyID"]
+        .as_str()
+        .or_else(|| policy["policyID"].as_str())
+        .expect("missing PolicyID");
+
+    let schema = branchable_users_schema_with_policy(policy_id);
+    node.schema_add_with_identity(&schema, &alice.private_key_hex)
+        .expect("add branchable schema with ACP policy");
+
+    let created = node
+        .query_with_identity(
+            r#"mutation { add_User(input: {name: "Secret", age: 42}) { _docID } }"#,
+            &alice.private_key_hex,
+        )
+        .expect("create protected branchable doc");
+    let doc_id = created["add_User"][0]["_docID"]
+        .as_str()
+        .expect("missing _docID")
+        .to_string();
+
+    let (alice_handle, alice_events) =
+        open_events_sse_with_auth(&api_url, "update", &alice.private_key_hex).await;
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    node.query_with_identity(
+        r#"mutation { update_User(filter: {name: {_eq: "Secret"}}, input: {age: 43}) { _docID } }"#,
+        &alice.private_key_hex,
+    )
+    .expect("update protected branchable doc");
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    alice_handle.abort();
+
+    let alice_events = alice_events.lock().unwrap().clone();
+    assert!(
+        alice_events.iter().any(|event| {
+            event.pointer("/data/doc_id").and_then(Value::as_str) == Some(doc_id.as_str())
+        }),
+        "authorized subscriber should still receive the document-scoped update, got: {:?}",
+        alice_events
+    );
+    assert!(
+        alice_events
+            .iter()
+            .any(|event| event.pointer("/data/doc_id").and_then(Value::as_str) == Some("")),
+        "authorized subscriber should still receive the branchable collection-level update, got: {:?}",
+        alice_events
+    );
 }

--- a/tools/integration-test/tests/acp/events_sse.rs
+++ b/tools/integration-test/tests/acp/events_sse.rs
@@ -1,0 +1,174 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use integration_test::{generate_identity, users_schema_with_policy, TestCluster, USER_ACP_POLICY};
+use serde_json::Value;
+use tokio::task::JoinHandle;
+
+fn auth_token(identity_hex: &str, audience: &str) -> String {
+    let key_bytes = hex::decode(identity_hex).expect("identity hex must decode");
+    let key_type = match key_bytes.len() {
+        32 => crypto::KeyType::Secp256k1,
+        64 => crypto::KeyType::Ed25519,
+        len => panic!("unsupported identity length: {len}"),
+    };
+    let identity =
+        identity::RawIdentity::from_bytes(key_type, &key_bytes).expect("raw identity from bytes");
+    let audience_host = audience
+        .strip_prefix("https://")
+        .or_else(|| audience.strip_prefix("http://"))
+        .unwrap_or(audience);
+    let token = identity::new_token(
+        &identity,
+        Duration::from_secs(15 * 60),
+        Some(audience_host.to_string()),
+        None,
+    )
+    .expect("generate auth token");
+    String::from_utf8(token).expect("token must be utf-8")
+}
+
+async fn open_events_sse_with_auth(
+    api_url: &str,
+    event_filter: &str,
+    identity_hex: &str,
+) -> (JoinHandle<()>, Arc<Mutex<Vec<Value>>>) {
+    let url = format!("{api_url}/api/v0/events?event={event_filter}");
+    let events: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = Arc::clone(&events);
+    let token = auth_token(identity_hex, api_url);
+    let (connected_tx, connected_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let handle = tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        let resp = match client.get(&url).bearer_auth(token).send().await {
+            Ok(resp) => {
+                assert!(
+                    resp.status().is_success(),
+                    "authenticated SSE request failed: status={}",
+                    resp.status()
+                );
+                let _ = connected_tx.send(());
+                resp
+            }
+            Err(err) => {
+                let _ = connected_tx.send(());
+                panic!("SSE request failed: {err}");
+            }
+        };
+
+        let mut buf = String::new();
+        let mut stream = resp.bytes_stream();
+        use futures::StreamExt;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.expect("SSE chunk error");
+            buf.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(pos) = buf.find("\n\n") {
+                let block = buf[..pos].to_string();
+                buf = buf[pos + 2..].to_string();
+
+                let mut event_type = String::new();
+                let mut data = String::new();
+                for line in block.lines() {
+                    if let Some(rest) = line.strip_prefix("event:") {
+                        event_type = rest.trim().to_string();
+                    } else if let Some(rest) = line.strip_prefix("data:") {
+                        data = rest.trim().to_string();
+                    }
+                }
+
+                if event_type == "next" {
+                    if let Ok(value) = serde_json::from_str::<Value>(&data) {
+                        events_clone.lock().unwrap().push(value);
+                    }
+                }
+            }
+        }
+    });
+
+    let _ = connected_rx.await;
+
+    (handle, events)
+}
+
+async fn acp_events_sse_filters_unauthorized_subscribers_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary_path = node.binary_path().to_path_buf();
+    let api_url = cluster.api_url(0).to_string();
+
+    let alice = generate_identity(&binary_path).expect("generate Alice identity");
+    let bob = generate_identity(&binary_path).expect("generate Bob identity");
+
+    let policy = node
+        .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+        .expect("add ACP policy");
+    let policy_id = policy["PolicyID"]
+        .as_str()
+        .or_else(|| policy["policyID"].as_str())
+        .expect("missing PolicyID");
+
+    let schema = users_schema_with_policy(policy_id);
+    node.schema_add_with_identity(&schema, &alice.private_key_hex)
+        .expect("add schema with ACP policy");
+
+    let created = node
+        .query_with_identity(
+            r#"mutation { add_User(input: {name: "Secret", age: 42}) { _docID } }"#,
+            &alice.private_key_hex,
+        )
+        .expect("create protected doc");
+    let doc_id = created["add_User"][0]["_docID"]
+        .as_str()
+        .expect("missing _docID")
+        .to_string();
+
+    let (bob_handle, bob_events) =
+        open_events_sse_with_auth(&api_url, "update", &bob.private_key_hex).await;
+    let (alice_handle, alice_events) =
+        open_events_sse_with_auth(&api_url, "update", &alice.private_key_hex).await;
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    node.query_with_identity(
+        r#"mutation { update_User(filter: {name: {_eq: "Secret"}}, input: {age: 43}) { _docID } }"#,
+        &alice.private_key_hex,
+    )
+    .expect("update protected doc");
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    bob_handle.abort();
+    alice_handle.abort();
+
+    let bob_events = bob_events.lock().unwrap().clone();
+    assert!(
+        bob_events.is_empty(),
+        "unauthorized subscriber should receive no update events, got: {:?}",
+        bob_events
+    );
+
+    let alice_events = alice_events.lock().unwrap().clone();
+    assert!(
+        !alice_events.is_empty(),
+        "authorized subscriber should receive at least one update event"
+    );
+    assert!(
+        alice_events.iter().any(|event| {
+            event.pointer("/data/doc_id").and_then(Value::as_str) == Some(doc_id.as_str())
+        }),
+        "authorized subscriber should receive the protected doc event, got: {:?}",
+        alice_events
+    );
+}
+
+#[tokio::test]
+async fn rust_acp_events_sse_filters_unauthorized_subscribers() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_events_sse_filters_unauthorized_subscribers_test(cluster).await;
+}


### PR DESCRIPTION
## Summary\n- filter  document-bearing SSE messages through subscriber identity before serializing metadata\n- scope  NAC permissions by event filter and preserve non-ACP collection-level update behavior\n- add a focused ACP regression test covering one unauthorized and one authorized subscriber case\n\n## Testing\n- cargo test -p defra-http handlers::events --lib\n- cargo test -p integration-test --test acp -- rust_acp_events_sse_filters_unauthorized_subscribers\n\nCloses #764.