### PR TITLE
refactor(db-merge): tighten replication bootstrap seam

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -96,7 +96,7 @@ impl Node {
         let collection_store: Arc<dyn p2p::sync::P2PCollectionStorage> =
             Arc::new(p2p::sync::P2PCollectionStore::new(store.clone()));
         let head_provider: Arc<dyn p2p::sync::DocumentHeadProvider> =
-            Arc::new(db_merge::DbHeadProvider::new(database.clone()));
+            Arc::new(db_merge::create_head_provider(database.clone()));
 
         let (mut coordinator, sync_events) = p2p::sync::SyncCoordinator::with_head_provider(
             p2p::Libp2pTransport::new(handle.clone()),
@@ -110,11 +110,10 @@ impl Node {
         .await
         .map_err(Error::P2P)?;
 
-        let (failure_tx, failure_rx) = tokio::sync::mpsc::channel::<p2p::sync::PushFailure>(1024);
-        coordinator.set_failure_channel(failure_tx);
+        let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
         let coordinator = Arc::new(coordinator);
 
-        match coordinator.load_p2p_collections().await {
+        match db_merge::load_persisted_collections(&coordinator).await {
             Ok(count) => {
                 if count > 0 {
                     info!("Loaded {} persisted P2P collection subscription(s)", count);
@@ -126,12 +125,15 @@ impl Node {
         }
 
         let merge_blockstore_for_syncer = merge_blockstore.clone();
-        let merge_handler_inner = Arc::new(db_merge::DbMergeHandler::new(
+        let replication = db_merge::create_replication_stack(
             database.clone(),
             merge_blockstore,
-        ));
-        let merge_handler = Arc::new(db_merge::AcpMergeHandler::new(merge_handler_inner.clone()));
-        let merge_handler_for_acp = merge_handler.clone();
+            coordinator.clone(),
+        );
+        let merge_handler_for_loop = replication.merge_handler.clone();
+        let merge_handler_inner_for_syncer = replication.merge_handler_inner.clone();
+        let broadcast_mutator = replication.broadcast_mutator.clone();
+        let merge_handler_for_acp = replication.merge_handler.clone();
 
         let coordinator_for_replication = coordinator.clone();
         let replication_task = tokio::spawn(async move {
@@ -139,7 +141,7 @@ impl Node {
             p2p::sync::ReplicationLoop::run_parallel(
                 coordinator_for_replication,
                 sync_events,
-                merge_handler,
+                merge_handler_for_loop,
                 p2p::sync::ReplicationConfig {
                     continue_on_error: true,
                     rebroadcast_on_merge: false,
@@ -231,7 +233,7 @@ impl Node {
         let version_syncer: Arc<dyn crate::p2p_adapter::VersionSyncer> =
             crate::version_syncer::DbVersionSyncer::new_arc(
                 merge_blockstore_for_syncer,
-                merge_handler_inner,
+                merge_handler_inner_for_syncer,
                 database.clone(),
             );
 
@@ -380,7 +382,7 @@ impl Node {
                 failure_recorder_task,
                 retry_loop_task,
             }),
-            mutator: Arc::new(db_merge::BroadcastMutator::new(database, coordinator)),
+            mutator: broadcast_mutator,
             http_adapter: Some(Arc::new(adapter)),
             wire_merge_acp: Some(Box::new(move |acp| {
                 merge_handler_for_acp.set_document_acp(acp);
@@ -409,7 +411,7 @@ impl Node {
         let collection_store: Arc<dyn p2p::sync::P2PCollectionStorage> =
             Arc::new(p2p::sync::P2PCollectionStore::new(store.clone()));
         let head_provider: Arc<dyn p2p::sync::DocumentHeadProvider> =
-            Arc::new(db_merge::DbHeadProvider::new(database.clone()));
+            Arc::new(db_merge::create_head_provider(database.clone()));
 
         let iroh_secret_key = Self::iroh_secret_key(peer_keypair.as_ref())?;
         let (command_tx, mut iroh_events, host_task) =
@@ -441,11 +443,10 @@ impl Node {
         .await
         .map_err(Error::P2P)?;
 
-        let (failure_tx, failure_rx) = tokio::sync::mpsc::channel::<p2p::sync::PushFailure>(1024);
-        coordinator.set_failure_channel(failure_tx);
+        let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
         let coordinator = Arc::new(coordinator);
 
-        match coordinator.load_p2p_collections().await {
+        match db_merge::load_persisted_collections(&coordinator).await {
             Ok(count) => {
                 if count > 0 {
                     info!("Loaded {} persisted P2P collection subscription(s)", count);
@@ -457,12 +458,15 @@ impl Node {
         }
 
         let merge_blockstore_for_syncer = merge_blockstore.clone();
-        let merge_handler_inner = Arc::new(db_merge::DbMergeHandler::new(
+        let replication = db_merge::create_replication_stack(
             database.clone(),
             merge_blockstore,
-        ));
-        let merge_handler = Arc::new(db_merge::AcpMergeHandler::new(merge_handler_inner.clone()));
-        let merge_handler_for_acp = merge_handler.clone();
+            coordinator.clone(),
+        );
+        let merge_handler_for_loop = replication.merge_handler.clone();
+        let merge_handler_inner_for_syncer = replication.merge_handler_inner.clone();
+        let broadcast_mutator = replication.broadcast_mutator.clone();
+        let merge_handler_for_acp = replication.merge_handler.clone();
 
         let coordinator_for_replication = coordinator.clone();
         let replication_task = tokio::spawn(async move {
@@ -470,7 +474,7 @@ impl Node {
             p2p::sync::ReplicationLoop::run(
                 coordinator_for_replication,
                 sync_events,
-                merge_handler,
+                merge_handler_for_loop,
                 p2p::sync::ReplicationConfig {
                     continue_on_error: true,
                     rebroadcast_on_merge: false,
@@ -537,7 +541,7 @@ impl Node {
         let version_syncer: Arc<dyn crate::transport_version_syncer::TransportVersionSyncer> =
             crate::transport_version_syncer::DbTransportVersionSyncer::new_arc(
                 merge_blockstore_for_syncer,
-                merge_handler_inner,
+                merge_handler_inner_for_syncer,
                 database.clone(),
                 transport.clone(),
             );
@@ -681,7 +685,7 @@ impl Node {
                 failure_recorder_task,
                 retry_loop_task,
             }),
-            mutator: Arc::new(db_merge::BroadcastMutator::new(database, coordinator)),
+            mutator: broadcast_mutator,
             http_adapter: Some(Arc::new(adapter)),
             wire_merge_acp: Some(Box::new(move |acp| {
                 merge_handler_for_acp.set_document_acp(acp);

--- a/crates/db-merge/src/lib.rs
+++ b/crates/db-merge/src/lib.rs
@@ -20,16 +20,16 @@ pub use broadcast_mutator::BroadcastMutator;
 pub use head_provider::DbHeadProvider;
 pub use merge_handler::{DbMergeHandler, MergeError};
 pub use peer_identity::{
-    PeerIdentityError, create_peer_to_did_mapper, peer_id_to_did, public_key_to_did,
+    create_peer_to_did_mapper, peer_id_to_did, public_key_to_did, PeerIdentityError,
 };
 pub use push_docs::{push_existing_docs, retry_doc};
 pub use push_docs_transport::{push_existing_docs_via_transport, retry_doc_via_transport};
 pub use replication::{
-    ReplicationStack, attach_failure_channel, create_acp_merge_handler, create_broadcast_mutator,
+    attach_failure_channel, create_acp_merge_handler, create_broadcast_mutator,
     create_head_provider, create_merge_handler, create_replication_stack,
-    load_document_head_blocks, load_persisted_collections,
+    load_document_head_blocks, load_persisted_collections, ReplicationStack,
 };
 pub use se::{
-    FieldQuery, FieldValueQuery, SECoordinator, fetch_doc_ids, generate_doc_artifacts,
-    generate_field_artifact, store_artifacts,
+    fetch_doc_ids, generate_doc_artifacts, generate_field_artifact, store_artifacts, FieldQuery,
+    FieldValueQuery, SECoordinator,
 };

--- a/crates/db-merge/src/lib.rs
+++ b/crates/db-merge/src/lib.rs
@@ -11,6 +11,7 @@ pub mod peer_identity;
 pub mod push_docs;
 pub mod push_docs_common;
 pub mod push_docs_transport;
+pub mod replication;
 pub mod se;
 
 // Re-export primary types
@@ -19,11 +20,16 @@ pub use broadcast_mutator::BroadcastMutator;
 pub use head_provider::DbHeadProvider;
 pub use merge_handler::{DbMergeHandler, MergeError};
 pub use peer_identity::{
-    create_peer_to_did_mapper, peer_id_to_did, public_key_to_did, PeerIdentityError,
+    PeerIdentityError, create_peer_to_did_mapper, peer_id_to_did, public_key_to_did,
 };
 pub use push_docs::{push_existing_docs, retry_doc};
 pub use push_docs_transport::{push_existing_docs_via_transport, retry_doc_via_transport};
+pub use replication::{
+    ReplicationStack, attach_failure_channel, create_acp_merge_handler, create_broadcast_mutator,
+    create_head_provider, create_merge_handler, create_replication_stack,
+    load_document_head_blocks, load_persisted_collections,
+};
 pub use se::{
-    fetch_doc_ids, generate_doc_artifacts, generate_field_artifact, store_artifacts, FieldQuery,
-    FieldValueQuery, SECoordinator,
+    FieldQuery, FieldValueQuery, SECoordinator, fetch_doc_ids, generate_doc_artifacts,
+    generate_field_artifact, store_artifacts,
 };

--- a/crates/db-merge/src/replication.rs
+++ b/crates/db-merge/src/replication.rs
@@ -1,0 +1,172 @@
+//! Small replication-facing facade over the concrete db-merge module layout.
+//!
+//! This keeps startup and doc-pusher code from depending on individual module
+//! paths, which makes later internal decomposition less invasive.
+
+use std::sync::Arc;
+
+use blockstore::Blockstore;
+use cid::Cid;
+use db::database::DB;
+use p2p::sync::{DocumentHeadProvider, PushFailure, SyncCoordinator};
+use p2p::transport::P2PTransport;
+use storage::corekv::Store;
+use tokio::sync::mpsc;
+
+use crate::acp_merge_handler::AcpMergeHandler;
+use crate::broadcast_mutator::BroadcastMutator;
+use crate::head_provider::DbHeadProvider;
+use crate::merge_handler::DbMergeHandler;
+
+pub struct ReplicationStack<S: Store, B: Blockstore + Send + Sync, T: P2PTransport> {
+    pub merge_handler_inner: Arc<DbMergeHandler<S, B>>,
+    pub merge_handler: Arc<AcpMergeHandler<S, B>>,
+    pub broadcast_mutator: Arc<BroadcastMutator<S, B, T>>,
+}
+
+pub fn create_head_provider<S: Store>(db: Arc<DB<S>>) -> DbHeadProvider<S> {
+    DbHeadProvider::new(db)
+}
+
+pub fn create_merge_handler<S: Store, B: Blockstore + Send + Sync>(
+    db: Arc<DB<S>>,
+    blockstore: Arc<B>,
+) -> DbMergeHandler<S, B> {
+    DbMergeHandler::new(db, blockstore)
+}
+
+pub fn create_acp_merge_handler<S: Store, B: Blockstore + Send + Sync>(
+    inner: Arc<DbMergeHandler<S, B>>,
+) -> AcpMergeHandler<S, B> {
+    AcpMergeHandler::new(inner)
+}
+
+pub fn create_broadcast_mutator<S: Store, B: Blockstore + 'static, T: P2PTransport>(
+    db: Arc<DB<S>>,
+    sync: Arc<SyncCoordinator<B, T>>,
+) -> BroadcastMutator<S, B, T> {
+    BroadcastMutator::new(db, sync)
+}
+
+pub fn create_replication_stack<
+    S: Store,
+    B: Blockstore + Send + Sync + 'static,
+    T: P2PTransport,
+>(
+    db: Arc<DB<S>>,
+    blockstore: Arc<B>,
+    sync: Arc<SyncCoordinator<B, T>>,
+) -> ReplicationStack<S, B, T> {
+    let merge_handler_inner = Arc::new(create_merge_handler(db.clone(), blockstore));
+    let merge_handler = Arc::new(create_acp_merge_handler(merge_handler_inner.clone()));
+    let broadcast_mutator = Arc::new(create_broadcast_mutator(db, sync));
+
+    ReplicationStack {
+        merge_handler_inner,
+        merge_handler,
+        broadcast_mutator,
+    }
+}
+
+pub fn attach_failure_channel<B: Blockstore + 'static, T: P2PTransport>(
+    coordinator: &mut SyncCoordinator<B, T>,
+    capacity: usize,
+) -> mpsc::Receiver<PushFailure> {
+    let (failure_tx, failure_rx) = mpsc::channel::<PushFailure>(capacity);
+    coordinator.set_failure_channel(failure_tx);
+    failure_rx
+}
+
+pub async fn load_persisted_collections<B: Blockstore + 'static, T: P2PTransport>(
+    coordinator: &Arc<SyncCoordinator<B, T>>,
+) -> Result<usize, String> {
+    coordinator
+        .load_p2p_collections()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+pub async fn load_document_head_blocks<S: Store + 'static>(
+    db: &Arc<DB<S>>,
+    doc_id: &str,
+) -> Result<Vec<(Cid, Vec<u8>)>, String> {
+    let provider = create_head_provider(db.clone());
+    let heads = <DbHeadProvider<S> as DocumentHeadProvider>::get_document_heads(&provider, doc_id)
+        .await
+        .map_err(|error| format!("failed to load document heads: {error}"))?;
+
+    let txn = db
+        .new_txn(true)
+        .await
+        .map_err(|error| format!("failed to create read transaction: {error}"))?;
+    let blockstore = txn
+        .blockstore()
+        .map_err(|error| format!("failed to get blockstore: {error}"))?;
+
+    let mut blocks = Vec::with_capacity(heads.len());
+    for cid in heads {
+        let bytes = blockstore
+            .get(&cid.to_bytes())
+            .await
+            .map_err(|error| format!("failed to read head block {cid}: {error}"))?
+            .ok_or_else(|| format!("head block {cid} not found"))?;
+        blocks.push((cid, bytes));
+    }
+
+    let _ = txn.discard();
+    Ok(blocks)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use db::AutoCommitMutator;
+    use document::Document;
+    use query::mutator::DocMutator;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use storage::backends::MemoryStore;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn load_document_head_blocks_returns_current_composite_block() {
+        let store = Arc::new(MemoryStore::new());
+        let db = Arc::new(DB::from_arc(store).unwrap());
+        db.create_collection(CollectionVersion::new(
+            "Transcript",
+            "v1",
+            "col-transcript",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "body", FieldKind::string()),
+                FieldDescription::new("3", "idx", FieldKind::int()),
+            ],
+        ))
+        .await
+        .unwrap();
+
+        let mutator = AutoCommitMutator::new(db.clone());
+        let result = mutator
+            .create_many("Transcript", vec![make_transcript("first", 1)])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        let doc_id = result.doc_id.to_string();
+        let commit_cid = result.commit_cid.expect("commit cid");
+        let commit_block = result.commit_block.expect("commit block");
+
+        let blocks = load_document_head_blocks(&db, &doc_id).await.unwrap();
+
+        assert_eq!(blocks, vec![(commit_cid, commit_block)]);
+    }
+
+    fn make_transcript(body: &str, idx: i64) -> Document {
+        let mut doc = Document::new();
+        doc.set("body", body.to_string());
+        doc.set("idx", idx);
+        doc
+    }
+}

--- a/crates/db/src/downsample/execute.rs
+++ b/crates/db/src/downsample/execute.rs
@@ -2,6 +2,7 @@
 
 use super::parse::*;
 use super::types::*;
+use crate::block_ops::decode_priority_varint;
 use crate::error::{Error, Result};
 use chrono::Utc;
 use document::{DocID, Document, NormalValue};

--- a/crates/db/src/downsample/execute.rs
+++ b/crates/db/src/downsample/execute.rs
@@ -2,8 +2,8 @@
 
 use super::parse::*;
 use super::types::*;
-use crate::block_ops::decode_priority_varint;
 use crate::error::{Error, Result};
+use db_blocks::decode_priority_varint;
 use chrono::Utc;
 use document::{DocID, Document, NormalValue};
 use query::fetcher::CommitsQueryOptions;

--- a/crates/db/src/downsample/execute.rs
+++ b/crates/db/src/downsample/execute.rs
@@ -3,8 +3,8 @@
 use super::parse::*;
 use super::types::*;
 use crate::error::{Error, Result};
-use db_blocks::decode_priority_varint;
 use chrono::Utc;
+use db_blocks::decode_priority_varint;
 use document::{DocID, Document, NormalValue};
 use query::fetcher::CommitsQueryOptions;
 use query::mutator::DocMutator;

--- a/crates/db/src/downsample/parse.rs
+++ b/crates/db/src/downsample/parse.rs
@@ -5,22 +5,6 @@ use document::NormalValue;
 use schema::{CollectionVersion, QuerySource, ScalarKind};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-pub(super) fn decode_priority_varint(buf: &[u8]) -> u64 {
-    let mut value: u64 = 0;
-    let mut shift: u32 = 0;
-    for &byte in buf {
-        if shift >= 64 {
-            return 0;
-        }
-        value |= ((byte & 0x7f) as u64) << shift;
-        if byte < 0x80 {
-            return value;
-        }
-        shift += 7;
-    }
-    value
-}
-
 pub(super) fn supported_downsample_aggregate_fields() -> [AggregateField; 5] {
     [
         AggregateField::Count,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -687,25 +687,28 @@ impl NodeBuilder {
         .map_err(|e| anyhow::anyhow!("SyncCoordinator creation failed: {}", e))?;
 
         // Failure channel (required by replication loop)
-        let (failure_tx, failure_rx) = tokio::sync::mpsc::channel::<p2p::sync::PushFailure>(1024);
-        coordinator.set_failure_channel(failure_tx);
+        let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
         spawn_failure_recorder(store.clone(), failure_rx);
 
         let coordinator = Arc::new(coordinator);
 
         if config.load_persisted_collections {
-            coordinator.load_p2p_collections().await.ok();
+            db_merge::load_persisted_collections(&coordinator)
+                .await
+                .ok();
         } else {
             tracing::info!("skipping persisted P2P collection subscriptions");
         }
 
         // 8. Merge handler
-        let merge_handler_inner = Arc::new(db_merge::DbMergeHandler::new(
+        let replication = db_merge::create_replication_stack(
             database.clone(),
             sync_blockstore,
-        ));
-        let merge_handler = Arc::new(db_merge::AcpMergeHandler::new(merge_handler_inner));
-        let merge_handler_for_acp = merge_handler.clone();
+            coordinator.clone(),
+        );
+        let merge_handler_for_loop = replication.merge_handler.clone();
+        let broadcast_mutator = replication.broadcast_mutator.clone();
+        let merge_handler_for_acp = replication.merge_handler.clone();
 
         // 9. Replication loop (transport-generic)
         let coord_for_repl = coordinator.clone();
@@ -713,7 +716,7 @@ impl NodeBuilder {
             p2p::sync::ReplicationLoop::run(
                 coord_for_repl,
                 sync_events,
-                merge_handler,
+                merge_handler_for_loop,
                 p2p::sync::ReplicationConfig::default(),
             )
             .await;
@@ -730,10 +733,6 @@ impl NodeBuilder {
         let collection_lookup: Arc<dyn CollectionLookup> = database.clone();
 
         // 12. BroadcastMutator (replaces AutoCommitMutator)
-        let broadcast_mutator = Arc::new(db_merge::BroadcastMutator::new(
-            database.clone(),
-            coordinator.clone(),
-        ));
         let broadcast_mutator_for_acp = broadcast_mutator.clone();
         let mutator: Arc<dyn query::DocMutator> = broadcast_mutator;
 

--- a/crates/embedded/src/libp2p_doc_pusher.rs
+++ b/crates/embedded/src/libp2p_doc_pusher.rs
@@ -210,35 +210,9 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
     }
 
     async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>> {
-        let provider = db_merge::DbHeadProvider::new(self.db.clone());
-        let heads =
-            <db_merge::DbHeadProvider<S> as p2p::sync::DocumentHeadProvider>::get_document_heads(
-                &provider, doc_id,
-            )
+        db_merge::load_document_head_blocks(&self.db, doc_id)
             .await
-            .map_err(|error| {
-                P2PError::internal(format!("failed to load document heads: {error}"))
-            })?;
-
-        let txn = self.db.new_txn(true).await.map_err(|error| {
-            P2PError::internal(format!("failed to create read transaction: {error}"))
-        })?;
-        let blockstore = txn
-            .blockstore()
-            .map_err(|error| P2PError::internal(format!("failed to get blockstore: {error}")))?;
-
-        let mut blocks = Vec::with_capacity(heads.len());
-        for cid in heads {
-            let bytes = blockstore
-                .get(&cid.to_bytes())
-                .await
-                .map_err(|error| {
-                    P2PError::internal(format!("failed to read head block {cid}: {error}"))
-                })?
-                .ok_or_else(|| P2PError::not_found(format!("head block {cid} not found")))?;
-            blocks.push((cid, bytes));
-        }
-        Ok(blocks)
+            .map_err(P2PError::internal)
     }
 }
 

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-use p2p::sync::{PushFailure, SyncConfig};
+use p2p::sync::SyncConfig;
 use p2p::topics::DefraTopic;
 
 use crate::libp2p_adapter::P2PAdapter;
@@ -98,7 +98,7 @@ where
     let collection_store: Arc<dyn p2p::sync::P2PCollectionStorage> =
         Arc::new(p2p::sync::P2PCollectionStore::new(store.clone()));
     let head_provider: Arc<dyn DocumentHeadProvider> =
-        Arc::new(db_merge::DbHeadProvider::new(database.clone()));
+        Arc::new(db_merge::create_head_provider(database.clone()));
     let (mut coordinator, sync_events_rx) = p2p::sync::SyncCoordinator::with_head_provider(
         p2p::Libp2pTransport::new(handle.clone()),
         blockstore.clone(),
@@ -111,16 +111,15 @@ where
     .await
     .map_err(|error| anyhow!("failed to create sync coordinator: {error}"))?;
 
-    let (failure_tx, failure_rx) = tokio::sync::mpsc::channel::<PushFailure>(1024);
-    coordinator.set_failure_channel(failure_tx);
+    let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
     let coordinator = Arc::new(coordinator);
-    let merge_handler_inner = Arc::new(db_merge::DbMergeHandler::new(
+    let replication = db_merge::create_replication_stack(
         database.clone(),
         blockstore.clone(),
-    ));
-    let merge_handler = Arc::new(db_merge::AcpMergeHandler::new(merge_handler_inner.clone()));
+        coordinator.clone(),
+    );
 
-    match coordinator.load_p2p_collections().await {
+    match db_merge::load_persisted_collections(&coordinator).await {
         Ok(count) if count > 0 => tracing::debug!(count, "loaded persisted P2P collections"),
         Ok(_) => {}
         Err(error) => tracing::warn!(error = %error, "failed to load persisted P2P collections"),
@@ -131,7 +130,7 @@ where
     let replication_task = spawn_replication_loop(
         coordinator.clone(),
         sync_events_rx,
-        merge_handler.clone(),
+        replication.merge_handler.clone(),
         event_bus.clone(),
     );
     let failure_recorder_task = spawn_failure_recorder(store.clone(), failure_rx);
@@ -141,7 +140,7 @@ where
     let doc_pusher: Arc<dyn crate::DocPusher> = doc_pusher_impl;
     let version_syncer = Some(DbVersionSyncer::new_arc(
         blockstore.clone(),
-        merge_handler_inner,
+        replication.merge_handler_inner.clone(),
         database.clone(),
     ));
     let retry_loop_task =
@@ -159,11 +158,7 @@ where
         version_syncer,
     );
     adapter.set_initial_tracked_documents(restored_doc_ids);
-    let broadcast_mutator = Arc::new(db_merge::BroadcastMutator::new(
-        database.clone(),
-        coordinator,
-    ));
-    let broadcast_mutator_for_acp = broadcast_mutator.clone();
+    let broadcast_mutator_for_acp = replication.broadcast_mutator.clone();
     let system = Arc::new(ManagedP2PSystem::new(
         TransportKind::Libp2p,
         Arc::new(adapter) as Arc<dyn P2POperations>,
@@ -180,8 +175,8 @@ where
 
     Ok(P2PSetup {
         system,
-        mutator: broadcast_mutator,
-        merge_handler,
+        mutator: replication.broadcast_mutator,
+        merge_handler: replication.merge_handler,
         wire_document_acp: Some(Box::new(move |acp| {
             doc_pusher_for_acp.set_document_acp(acp.clone());
             broadcast_mutator_for_acp.set_document_acp(acp);
@@ -226,7 +221,7 @@ where
     let collection_store: Arc<dyn p2p::sync::P2PCollectionStorage> =
         Arc::new(p2p::sync::P2PCollectionStore::new(store.clone()));
     let head_provider: Arc<dyn p2p::sync::DocumentHeadProvider> =
-        Arc::new(db_merge::DbHeadProvider::new(database.clone()));
+        Arc::new(db_merge::create_head_provider(database.clone()));
     let (mut coordinator, sync_events_rx) = p2p::sync::SyncCoordinator::with_head_provider(
         transport.clone(),
         blockstore.clone(),
@@ -239,16 +234,15 @@ where
     .await
     .map_err(|error| anyhow!("failed to create iroh sync coordinator: {error}"))?;
 
-    let (failure_tx, failure_rx) = tokio::sync::mpsc::channel::<PushFailure>(1024);
-    coordinator.set_failure_channel(failure_tx);
+    let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
     let coordinator = Arc::new(coordinator);
-    let merge_handler_inner = Arc::new(db_merge::DbMergeHandler::new(
+    let replication = db_merge::create_replication_stack(
         database.clone(),
         blockstore.clone(),
-    ));
-    let merge_handler = Arc::new(db_merge::AcpMergeHandler::new(merge_handler_inner.clone()));
+        coordinator.clone(),
+    );
 
-    match coordinator.load_p2p_collections().await {
+    match db_merge::load_persisted_collections(&coordinator).await {
         Ok(count) if count > 0 => tracing::debug!(count, "loaded persisted P2P collections"),
         Ok(_) => {}
         Err(error) => tracing::warn!(error = %error, "failed to load persisted P2P collections"),
@@ -259,7 +253,7 @@ where
     let replication_task = spawn_replication_loop(
         coordinator.clone(),
         sync_events_rx,
-        merge_handler.clone(),
+        replication.merge_handler.clone(),
         event_bus.clone(),
     );
     let failure_recorder_task = spawn_failure_recorder(store.clone(), failure_rx);
@@ -272,7 +266,7 @@ where
     let doc_pusher: Arc<dyn crate::TransportDocPusher> = doc_pusher_impl;
     let version_syncer = Some(DbTransportVersionSyncer::new_arc(
         blockstore.clone(),
-        merge_handler_inner,
+        replication.merge_handler_inner.clone(),
         database.clone(),
         transport.clone(),
     ));
@@ -291,11 +285,7 @@ where
         version_syncer,
     );
     adapter.set_initial_tracked_documents(restored_doc_ids);
-    let broadcast_mutator = Arc::new(db_merge::BroadcastMutator::new(
-        database.clone(),
-        coordinator,
-    ));
-    let broadcast_mutator_for_acp = broadcast_mutator.clone();
+    let broadcast_mutator_for_acp = replication.broadcast_mutator.clone();
     let system = Arc::new(ManagedP2PSystem::new(
         TransportKind::Iroh,
         Arc::new(adapter) as Arc<dyn P2POperations>,
@@ -313,8 +303,8 @@ where
 
     Ok(P2PSetup {
         system,
-        mutator: broadcast_mutator,
-        merge_handler,
+        mutator: replication.broadcast_mutator,
+        merge_handler: replication.merge_handler,
         wire_document_acp: Some(Box::new(move |acp| {
             doc_pusher_for_acp.set_document_acp(acp.clone());
             broadcast_mutator_for_acp.set_document_acp(acp);

--- a/crates/embedded/src/transport_doc_pusher.rs
+++ b/crates/embedded/src/transport_doc_pusher.rs
@@ -16,8 +16,12 @@ pub trait TransportDocPusher: Send + Sync {
         se_key: Option<&[u8]>,
     ) -> P2PResult<()>;
 
-    async fn retry_doc(&self, peer_id: &PeerId, doc_id: &str, collection_id: &str)
-        -> P2PResult<()>;
+    async fn retry_doc(
+        &self,
+        peer_id: &PeerId,
+        doc_id: &str,
+        collection_id: &str,
+    ) -> P2PResult<()>;
 
     async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>>;
 
@@ -106,35 +110,9 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
     }
 
     async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>> {
-        let provider = db_merge::DbHeadProvider::new(self.db.clone());
-        let heads =
-            <db_merge::DbHeadProvider<S> as p2p::sync::DocumentHeadProvider>::get_document_heads(
-                &provider, doc_id,
-            )
+        db_merge::load_document_head_blocks(&self.db, doc_id)
             .await
-            .map_err(|error| {
-                P2PError::internal(format!("failed to load document heads: {error}"))
-            })?;
-
-        let txn = self.db.new_txn(true).await.map_err(|error| {
-            P2PError::internal(format!("failed to create read transaction: {error}"))
-        })?;
-        let blockstore = txn
-            .blockstore()
-            .map_err(|error| P2PError::internal(format!("failed to get blockstore: {error}")))?;
-
-        let mut blocks = Vec::with_capacity(heads.len());
-        for cid in heads {
-            let bytes = blockstore
-                .get(&cid.to_bytes())
-                .await
-                .map_err(|error| {
-                    P2PError::internal(format!("failed to read head block {cid}: {error}"))
-                })?
-                .ok_or_else(|| P2PError::not_found(format!("head block {cid} not found")))?;
-            blocks.push((cid, bytes));
-        }
-        Ok(blocks)
+            .map_err(P2PError::internal)
     }
 
     fn get_collection_id(&self, name: &str) -> Option<String> {

--- a/crates/embedded/src/transport_doc_pusher.rs
+++ b/crates/embedded/src/transport_doc_pusher.rs
@@ -16,12 +16,8 @@ pub trait TransportDocPusher: Send + Sync {
         se_key: Option<&[u8]>,
     ) -> P2PResult<()>;
 
-    async fn retry_doc(
-        &self,
-        peer_id: &PeerId,
-        doc_id: &str,
-        collection_id: &str,
-    ) -> P2PResult<()>;
+    async fn retry_doc(&self, peer_id: &PeerId, doc_id: &str, collection_id: &str)
+        -> P2PResult<()>;
 
     async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>>;
 

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -1015,7 +1015,6 @@ mod tests {
         defra_core::encryption::EncryptionConfig {
             encrypt_doc: true,
             encrypt_fields: vec![],
-            encryption_key: vec![0xAB; 32],
         }
     }
 


### PR DESCRIPTION
Part of #669.

This PR finishes one bounded follow-up seam after the upstream `db` decomposition work.

## What changed

The main change is a small replication/bootstrap helper surface in `db-merge`:

- `db_merge::replication::ReplicationStack`
- `create_replication_stack`
- `attach_failure_channel`
- `load_persisted_collections`
- `load_document_head_blocks`

That helper surface is now used by the P2P bootstrap code in:

- `crates/embedded/src/node_p2p.rs`
- `crates/cli/src/commands/start/server_p2p.rs`
- `crates/defra-node/src/lib.rs`

This removes repeated construction/wiring of:

- `DbHeadProvider`
- `DbMergeHandler`
- `AcpMergeHandler`
- `BroadcastMutator`
- failure channel setup
- persisted collection loading
- document head block loading

I also fixed one remaining post-split import drift in `crates/db/src/downsample/execute.rs`, which was still referencing the removed internal `block_ops` path instead of `db-blocks`.

## Why this is useful

The upstream broad split is already done. This PR is intentionally smaller than that.

The goal here is to stabilize the replication-facing interface around the new crate layout so downstream startup code does not need to know as much about the concrete `db-merge` internals. That should make later cleanup or extraction work lower-risk without introducing a `db -> db-merge` cycle or changing the top-level `db` facade.

## What this PR is not

- not another broad `db` split
- not an API churn pass for the public `db` facade
- not a feature change in replication behavior

This is mostly a seam-tightening and duplication-reduction PR.

## Verification

I ran:

- `cargo test -p db-merge load_document_head_blocks_returns_current_composite_block --offline`
- `cargo check -p db --offline --quiet`
- `cargo check -p db-merge --offline --quiet`
- `cargo check -p embedded --offline --quiet`
- `cargo check -p cli --offline --quiet`
- `cargo check -p defra-node --offline --quiet`

## Reviewer notes

The easiest way to review this is:

1. Start with `crates/db-merge/src/replication.rs`
2. Then look at the three call-site conversions in `embedded`, `cli`, and `defra-node`
3. Finally glance at the small `downsample` import fix in `db`
