### PR TITLE
test: complete ACP integration parity with Go

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,8 @@ Rust node via CLI + HTTP API. Each area is a `[[test]]` binary with submodules:
 |------|--------|---------|
 | Basic | `--test basic` | smoke, document_lifecycle, transactions, collection_management, multi_collection, truncate_parallel |
 | Query | `--test query` | view, lens, lens_persistence, sdl_generate, index_management, explain_nested, subscription_docid, stubs |
-| ACP | `--test acp` | basic, multi_identity, multi_role, revoke_lifecycle, node_access, p2p, negative, negative_p2p, xarchive_access_matrix, stubs |
+| ACP | `--test acp` | audit, basic, custom_policy, index, link_collection, multi_identity, multi_role, negative, negative_p2p, node_access, p2p, p2p_lifecycle, policy_validation, register_ops, relation_queries, relationship, revoke_lifecycle, transaction_rollback, xarchive_access_matrix |
+| P2P Iroh ACP | `--test p2p_iroh` | acp, dac, nac, trust_boundary |
 | NAC | `--test nac` | document_acp, operations, core_operations, p2p_management, relation_admin, cross_compartment_isolation, policy_evolution |
 | P2P | `--test p2p` | document, sync, management, trust_boundary, replication, replication_advanced, stubs |
 | FTS | `--test fts` | basic, edge_cases, lifecycle, scoring |

--- a/crates/acp/src/policy_yaml/mod.rs
+++ b/crates/acp/src/policy_yaml/mod.rs
@@ -142,15 +142,19 @@ pub fn build_policy(parsed: &ParsedPolicy, counter: u64) -> crate::error::Result
         }
 
         for perm in &res.permissions {
-            if !perm.expr.is_empty() {
+            let expression = if perm.expr.is_empty() {
+                // A permission with no explicit expression is still valid and
+                // defaults to owner-only access in Go.
+                RelationExpression::computed_userset("owner")
+            } else {
                 let user_expr = RelationExpression::parse(&perm.expr)?;
                 // DPI: every permission must include 'owner' in its expression
-                let expression = RelationExpression::Union(vec![
+                RelationExpression::Union(vec![
                     RelationExpression::computed_userset("owner"),
                     user_expr,
-                ]);
-                relations.push(Relation::computed(&perm.name, expression));
-            }
+                ])
+            };
+            relations.push(Relation::computed(&perm.name, expression));
         }
 
         resources.push(Resource {

--- a/crates/cli/src/sourcehub_acp_adapter.rs
+++ b/crates/cli/src/sourcehub_acp_adapter.rs
@@ -36,6 +36,36 @@ impl SourceHubAcpAdapter {
     ) -> Arc<dyn AcpOperations> {
         Arc::new(Self::new(sourcehub_acp, local_store))
     }
+
+    async fn get_or_cache_policy(&self, policy_id: &str) -> Result<Option<Policy>, String> {
+        if let Some(policy) = self
+            .local_store
+            .get_policy(policy_id)
+            .await
+            .map_err(|e| format!("failed to get policy from local cache: {}", e))?
+        {
+            return Ok(Some(policy));
+        }
+
+        let Some(policy) = self
+            .sourcehub_acp
+            .get_policy(policy_id)
+            .await
+            .map_err(|e| format!("failed to query SourceHub policy: {}", e))?
+        else {
+            return Ok(None);
+        };
+
+        let options = StorePolicyOptions::new()
+            .with_validation()
+            .with_dpi_enforcement();
+        self.local_store
+            .store_policy_with_options(&policy, &options)
+            .await
+            .map_err(|e| format!("failed to cache SourceHub policy: {}", e))?;
+
+        Ok(Some(policy))
+    }
 }
 
 fn policy_to_info(policy: &Policy) -> PolicyInfo {
@@ -125,11 +155,7 @@ impl AcpOperations for SourceHubAcpAdapter {
         policy_id: &str,
         resource_name: &str,
     ) -> Result<(), String> {
-        // The SourceHub adapter caches policies in its local store after a
-        // successful on-chain `add_policy`. Query the local cache — same
-        // semantics as `get_policy` above, and matches Go's pattern of
-        // validating against the most recently observed policy state.
-        let policy = self.local_store.get_policy(policy_id).await.map_err(|e| {
+        let policy = self.get_or_cache_policy(policy_id).await.map_err(|e| {
             format!(
                 "policy validation failed with acp: {}. PolicyID: {}",
                 e, policy_id

--- a/crates/query/src/planner/builder/mod.rs
+++ b/crates/query/src/planner/builder/mod.rs
@@ -144,6 +144,11 @@ impl Planner {
         self
     }
 
+    /// Whether this planner should insert ACP permission filters into plans.
+    pub(super) fn has_acp(&self) -> bool {
+        self.acp.is_some()
+    }
+
     /// Conditionally wrap a plan with a PermissionFilterNode if the collection has an ACP policy.
     pub(super) fn maybe_wrap_with_acp_filter(
         &self,

--- a/crates/query/src/planner/joins/mod.rs
+++ b/crates/query/src/planner/joins/mod.rs
@@ -1206,6 +1206,7 @@ impl Planner {
                 {
                     if can_use_direct_indexed_child_cache(nested_select)
                         && !has_filter_child_plan
+                        && !self.has_acp()
                         && !select.show_deleted
                     {
                         join_many = join_many.with_indexed_child_fetch(

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -1015,7 +1015,6 @@ mod tests {
         defra_core::encryption::EncryptionConfig {
             encrypt_doc: true,
             encrypt_fields: vec![],
-            encryption_key: vec![0xAB; 32],
         }
     }
 

--- a/crates/sourcehub/src/cosmos/client.rs
+++ b/crates/sourcehub/src/cosmos/client.rs
@@ -50,15 +50,15 @@ impl SourceHubClient {
             return Err(ClientError::QueryFailed(text));
         }
         let body: serde_json::Value = resp.json().await?;
-        // Extract policy ID from response
-        let record = &body["record"];
-        let policy = &record["policy"];
+        let record = body.get("record").unwrap_or(&body);
+        let policy = record.get("policy").unwrap_or(&body["policy"]);
         if policy.is_null() {
             return Ok(None);
         }
         Ok(Some(PolicyInfo {
             id: policy_id.to_string(),
             name: policy["name"].as_str().unwrap_or("").to_string(),
+            raw_policy: record["raw_policy"].as_str().map(ToOwned::to_owned),
         }))
     }
 
@@ -285,6 +285,7 @@ impl SourceHubClient {
 pub(crate) struct PolicyInfo {
     pub id: String,
     pub name: String,
+    pub raw_policy: Option<String>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/sourcehub/src/cosmos/cosmos_provider.rs
+++ b/crates/sourcehub/src/cosmos/cosmos_provider.rs
@@ -273,6 +273,7 @@ impl SourceHubProvider for CosmosProvider {
             return Ok(Some(ProviderPolicyInfo {
                 id: cached.id,
                 name: cached.name,
+                raw_policy: None,
             }));
         }
 
@@ -288,6 +289,7 @@ impl SourceHubProvider for CosmosProvider {
         Ok(result.map(|p| ProviderPolicyInfo {
             id: p.id,
             name: p.name,
+            raw_policy: p.raw_policy,
         }))
     }
 

--- a/crates/sourcehub/src/cosmos/dac.rs
+++ b/crates/sourcehub/src/cosmos/dac.rs
@@ -56,6 +56,31 @@ impl SourceHubDocumentACP {
         self.provider.create_policy(policy_yaml).await
     }
 
+    pub async fn get_policy(
+        &self,
+        policy_id: &str,
+    ) -> std::result::Result<Option<acp::Policy>, ProviderError> {
+        let Some(info) = self.provider.query_policy(policy_id).await? else {
+            return Ok(None);
+        };
+
+        let Some(raw_policy) = info.raw_policy else {
+            return Err(ProviderError::Query(format!(
+                "policy '{}' is not available from the configured provider",
+                policy_id
+            )));
+        };
+
+        acp::policy_yaml::check_duplicate_yaml_keys(&raw_policy)
+            .map_err(|e| ProviderError::Query(format!("policy parse: {}", e)))?;
+        let parsed = acp::policy_yaml::parse_policy_yaml(&raw_policy)
+            .map_err(|e| ProviderError::Query(format!("policy parse: {}", e)))?;
+        let mut policy = acp::policy_yaml::build_policy(&parsed, 1)
+            .map_err(|e| ProviderError::Query(format!("policy parse: {}", e)))?;
+        policy.id = info.id;
+        Ok(Some(policy))
+    }
+
     async fn create_bearer_token(&self, did: &str) -> std::result::Result<String, acp::Error> {
         self.provider
             .create_bearer_token(did)

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -418,6 +418,7 @@ impl SourceHubProvider for HubRsProvider {
             Ok(Some(ProviderPolicyInfo {
                 id: policy_id.to_string(),
                 name: policy_id.to_string(),
+                raw_policy: None,
             }))
         } else {
             Ok(None)

--- a/crates/sourcehub/src/provider.rs
+++ b/crates/sourcehub/src/provider.rs
@@ -10,6 +10,7 @@ pub enum SubjectRef {
 pub struct ProviderPolicyInfo {
     pub id: String,
     pub name: String,
+    pub raw_policy: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/tools/integration-test/tests/acp.rs
+++ b/tools/integration-test/tests/acp.rs
@@ -20,8 +20,14 @@ mod negative_p2p;
 mod node_access;
 #[path = "acp/p2p.rs"]
 mod p2p;
+#[path = "acp/p2p_lifecycle.rs"]
+mod p2p_lifecycle;
 #[path = "acp/policy_validation.rs"]
 mod policy_validation;
+#[path = "acp/register_ops.rs"]
+mod register_ops;
+#[path = "acp/relation_queries.rs"]
+mod relation_queries;
 #[path = "acp/relationship.rs"]
 mod relationship;
 #[path = "acp/revoke_lifecycle.rs"]

--- a/tools/integration-test/tests/acp/README.md
+++ b/tools/integration-test/tests/acp/README.md
@@ -6,20 +6,37 @@ cargo test -p integration-test --test acp
 
 ## Files
 
-| File | Tests | What it covers |
-|------|-------|----------------|
-| `basic.rs` | 2 | Basic ACP policy add, document CRUD with identity |
-| `multi_identity.rs` | 2 | Multiple identities accessing the same document |
-| `multi_role.rs` | 2 | Reader/writer role grants and enforcement |
-| `node_access.rs` | 2 | Node-level access control |
-| `p2p.rs` | 3 | ACP enforcement across P2P replication topologies |
-| `revoke_lifecycle.rs` | 2 | Grant → revoke → re-grant lifecycle |
-| `negative.rs` | 10 | Unauthorized access denial, _commits ACP, dump auth, anonymous create, NAC enforcement |
-| `negative_p2p.rs` | 5 | P2P merge-denial, policy transition guards |
-| `audit.rs` | 4 | CID time-travel ACP bypass, policy transition boundary |
-| `xarchive_access_matrix.rs` | 2 | Cross-archive access matrix |
+| File | What it covers |
+|------|----------------|
+| `basic.rs` | Basic ACP policy add, document CRUD with identity |
+| `custom_policy.rs` | Custom relation policy behavior beyond the stock owner/reader/updater/deleter layout |
+| `policy_validation.rs` | Go parity for policy-add validation and YAML edge cases |
+| `link_collection.rs` | Go parity for `@policy(id:, resource:)` DRI acceptance and rejection cases |
+| `register_ops.rs` | Go parity for anonymous vs identity-backed document register/read/update/delete behavior |
+| `relation_queries.rs` | Go parity for ACP-aware `COUNT`, `AVG`, and relation object queries across protected/public joins |
+| `relationship.rs` | Go parity for document-actor relationship add/delete behavior |
+| `index.rs` | ACP-aware index creation and indexed query filtering |
+| `multi_identity.rs` | Multiple identities accessing the same document |
+| `multi_role.rs` | Reader/writer role grants and enforcement |
+| `node_access.rs` | Node-level access control |
+| `p2p.rs` | ACP enforcement across P2P replication topologies |
+| `revoke_lifecycle.rs` | Grant → revoke → re-grant lifecycle |
+| `negative.rs` | Unauthorized access denial, _commits ACP, dump auth, anonymous create, NAC enforcement |
+| `negative_p2p.rs` | P2P merge-denial, policy transition guards |
+| `p2p_lifecycle.rs` | Go parity for DAC P2P add/update/delete/subscribe/replicator lifecycle families, adapted to local ACP receiving-node semantics |
+| `audit.rs` | CID time-travel ACP bypass, policy transition boundary |
+| `transaction_rollback.rs` | ACP visibility rollback on discarded transactions |
+| `xarchive_access_matrix.rs` | Cross-archive access matrix |
 
-**28 active tests, 6 ignored.**
+The Rust ACP suite now covers the original Go DAC families for `add_policy`, `link_collection`, `register_and_{read,update,delete}`, `count`, `avg`, `relation_objects`, `relationship`, `index`, and the main `dac/p2p` lifecycle cases (`add`, `update`, `delete`, `subscribe`, `replicator`), plus Rust-only regression coverage for audit findings and transactional ACP behavior.
+
+The remaining Go `dac/p2p` relationship-propagation families are not local-ACP parity gaps anymore:
+- `replicator_with_doc_actor_relationship`
+- `subscribe_with_doc_actor_relationship`
+
+Rust already exercises those semantics in the SourceHub-backed iroh suite at `tools/integration-test/tests/p2p_iroh/acp/dac.rs`. Those tests are the Rust parity home for the final Go `dac/p2p` relationship families and require `sourcehubd` in the test environment, so they are tracked separately from the local-ACP suite.
+
+The corresponding local-ACP product gap is tracked in issue `#772`: local ACP does not currently replicate document-actor relationship tuples across peers. That non-replication remains intentionally asserted in `negative_p2p.rs`.
 
 ### Ignored
 

--- a/tools/integration-test/tests/acp/link_collection.rs
+++ b/tools/integration-test/tests/acp/link_collection.rs
@@ -98,6 +98,138 @@ resources:
 "#
 }
 
+/// Policy with an admin relation that manages reader.
+fn users_policy_with_managed_relation() -> &'static str {
+    r#"
+description: a policy
+name: test
+resources:
+  - name: users
+    permissions:
+      - name: delete
+      - name: read
+        expr: reader
+      - name: update
+    relations:
+      - name: admin
+        manages:
+          - reader
+        types:
+          - actor
+      - name: reader
+        types:
+          - actor
+"#
+}
+
+/// Policy with multiple resources where only `users` is linked by the schema.
+fn users_policy_with_multiple_resources() -> &'static str {
+    r#"
+description: a policy
+name: test
+resources:
+  - name: books
+    permissions:
+      - name: delete
+      - name: read
+      - name: update
+  - name: users
+    permissions:
+      - name: delete
+      - name: read
+        expr: reader
+      - name: update
+    relations:
+      - name: reader
+        types:
+          - actor
+"#
+}
+
+/// Policy with one invalid and one valid resource; the valid one should still link.
+fn users_policy_with_partial_dri() -> &'static str {
+    r#"
+name: test
+description: A Partially DRI Compliant Policy
+resources:
+  - name: usersInvalid
+    permissions:
+      - name: delete
+        expr: reader
+      - name: update
+        expr: reader
+    relations:
+      - name: reader
+        types:
+          - actor
+  - name: usersValid
+    permissions:
+      - name: delete
+      - name: read
+        expr: reader
+      - name: update
+    relations:
+      - name: reader
+        types:
+          - actor
+"#
+}
+
+/// Policy where owner authority is omitted from the DRI permissions.
+fn users_policy_with_owner_bad_on_update() -> &'static str {
+    r#"
+description: a policy
+name: test
+resources:
+  - name: users
+    permissions:
+      - name: delete
+      - name: read
+      - name: update
+        expr: ownerBad
+    relations:
+      - name: ownerBad
+        types:
+          - actor
+"#
+}
+
+fn users_policy_with_owner_bad_on_read() -> &'static str {
+    r#"
+description: a policy
+name: test
+resources:
+  - name: users
+    permissions:
+      - name: delete
+      - name: read
+        expr: ownerBad
+      - name: update
+    relations:
+      - name: ownerBad
+        types:
+          - actor
+"#
+}
+
+fn users_policy_with_owner_bad_on_delete() -> &'static str {
+    r#"
+description: a policy
+name: test
+resources:
+  - name: users
+    permissions:
+      - name: delete
+        expr: ownerBad
+      - name: read
+      - name: update
+    relations:
+      - name: ownerBad
+        types:
+          - actor
+"#
+}
+
 /// Policy missing the `read` permission entirely — DPI violation.
 fn users_policy_missing_read() -> &'static str {
     r#"
@@ -263,6 +395,212 @@ async fn acp_link_collection_extra_permissions_accept(cluster: TestCluster) {
 for_each_runtime!(
     acp_link_collection_extra_permissions_accept,
     acp_link_collection_extra_permissions_accept,
+    .with_acp_local()
+);
+
+// Port of accept_managed_relation_on_dri_test.go
+async fn acp_link_collection_managed_relation_accept(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy_id = add_users_policy(
+        &node,
+        users_policy_with_managed_relation(),
+        &alice.private_key_hex,
+    );
+
+    let sdl = format!(
+        r#"type Users @policy(id: "{}", resource: "users") {{ name: String  age: Int }}"#,
+        policy_id
+    );
+    node.schema_add_with_identity(&sdl, &alice.private_key_hex)
+        .expect("managed relation on the DRI must still be accepted");
+
+    assert!(
+        type_exists(&node, "Users"),
+        "Users type must be registered when the DRI includes a managed relation"
+    );
+}
+
+for_each_runtime!(
+    acp_link_collection_managed_relation_accept,
+    acp_link_collection_managed_relation_accept,
+    .with_acp_local()
+);
+
+// Port of accept_mixed_resources_on_partial_dri_test.go
+async fn acp_link_collection_partial_dri_valid_resource_accept(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy_id = add_users_policy(
+        &node,
+        users_policy_with_partial_dri(),
+        &alice.private_key_hex,
+    );
+
+    let sdl = format!(
+        r#"type Users @policy(id: "{}", resource: "usersValid") {{ name: String  age: Int }}"#,
+        policy_id
+    );
+    node.schema_add_with_identity(&sdl, &alice.private_key_hex)
+        .expect("valid resource on a partially DRI-compliant policy must be accepted");
+
+    assert!(
+        type_exists(&node, "Users"),
+        "Users type must be registered when linking to the valid resource on a mixed policy"
+    );
+}
+
+for_each_runtime!(
+    acp_link_collection_partial_dri_valid_resource_accept,
+    acp_link_collection_partial_dri_valid_resource_accept,
+    .with_acp_local()
+);
+
+// Port of accept_multi_resources_on_dri_test.go (first case)
+async fn acp_link_collection_multiple_resources_accept(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy_id = add_users_policy(
+        &node,
+        users_policy_with_multiple_resources(),
+        &alice.private_key_hex,
+    );
+
+    let sdl = format!(
+        r#"type Users @policy(id: "{}", resource: "users") {{ name: String  age: Int }}"#,
+        policy_id
+    );
+    node.schema_add_with_identity(&sdl, &alice.private_key_hex)
+        .expect("users resource on a multi-resource policy must be accepted");
+
+    assert!(
+        type_exists(&node, "Users"),
+        "Users type must be registered when linking to one resource on a multi-resource policy"
+    );
+}
+
+for_each_runtime!(
+    acp_link_collection_multiple_resources_accept,
+    acp_link_collection_multiple_resources_accept,
+    .with_acp_local()
+);
+
+// Port of accept_multi_resources_on_dri_test.go (both resources used)
+async fn acp_link_collection_multiple_resources_both_used_accept(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy_id = add_users_policy(
+        &node,
+        users_policy_with_multiple_resources(),
+        &alice.private_key_hex,
+    );
+
+    let users_sdl = format!(
+        r#"type Users @policy(id: "{}", resource: "users") {{ name: String  age: Int }}"#,
+        policy_id
+    );
+    node.schema_add_with_identity(&users_sdl, &alice.private_key_hex)
+        .expect("Users schema should be accepted");
+
+    let books_sdl = format!(
+        r#"type Books @policy(id: "{}", resource: "books") {{ name: String }}"#,
+        policy_id
+    );
+    node.schema_add_with_identity(&books_sdl, &alice.private_key_hex)
+        .expect("Books schema should also be accepted with the same multi-resource policy");
+
+    assert!(type_exists(&node, "Users"));
+    assert!(type_exists(&node, "Books"));
+}
+
+for_each_runtime!(
+    acp_link_collection_multiple_resources_both_used_accept,
+    acp_link_collection_multiple_resources_both_used_accept,
+    .with_acp_local()
+);
+
+// Port of accept_permission_with_omitted_owner_authority_test.go (update case)
+async fn acp_link_collection_owner_bad_update_accept(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy_id = add_users_policy(
+        &node,
+        users_policy_with_owner_bad_on_update(),
+        &alice.private_key_hex,
+    );
+
+    let sdl = format!(
+        r#"type Users @policy(id: "{}", resource: "users") {{ name: String  age: Int }}"#,
+        policy_id
+    );
+    node.schema_add_with_identity(&sdl, &alice.private_key_hex)
+        .expect("ownerBad update expression on the DRI must still be accepted");
+
+    assert!(type_exists(&node, "Users"));
+}
+
+for_each_runtime!(
+    acp_link_collection_owner_bad_update_accept,
+    acp_link_collection_owner_bad_update_accept,
+    .with_acp_local()
+);
+
+// Port of accept_permission_with_omitted_owner_authority_test.go (read case)
+async fn acp_link_collection_owner_bad_read_accept(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy_id = add_users_policy(
+        &node,
+        users_policy_with_owner_bad_on_read(),
+        &alice.private_key_hex,
+    );
+
+    let sdl = format!(
+        r#"type Users @policy(id: "{}", resource: "users") {{ name: String  age: Int }}"#,
+        policy_id
+    );
+    node.schema_add_with_identity(&sdl, &alice.private_key_hex)
+        .expect("ownerBad read expression on the DRI must still be accepted");
+
+    assert!(type_exists(&node, "Users"));
+}
+
+for_each_runtime!(
+    acp_link_collection_owner_bad_read_accept,
+    acp_link_collection_owner_bad_read_accept,
+    .with_acp_local()
+);
+
+// Port of accept_permission_with_omitted_owner_authority_test.go (delete case)
+async fn acp_link_collection_owner_bad_delete_accept(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let alice = generate_identity(node.binary_path()).expect("alice identity");
+
+    let policy_id = add_users_policy(
+        &node,
+        users_policy_with_owner_bad_on_delete(),
+        &alice.private_key_hex,
+    );
+
+    let sdl = format!(
+        r#"type Users @policy(id: "{}", resource: "users") {{ name: String  age: Int }}"#,
+        policy_id
+    );
+    node.schema_add_with_identity(&sdl, &alice.private_key_hex)
+        .expect("ownerBad delete expression on the DRI must still be accepted");
+
+    assert!(type_exists(&node, "Users"));
+}
+
+for_each_runtime!(
+    acp_link_collection_owner_bad_delete_accept,
+    acp_link_collection_owner_bad_delete_accept,
     .with_acp_local()
 );
 

--- a/tools/integration-test/tests/acp/p2p_lifecycle.rs
+++ b/tools/integration-test/tests/acp/p2p_lifecycle.rs
@@ -1,0 +1,548 @@
+//! ACP P2P lifecycle tests ported from Go DefraDB `dac/p2p`.
+//!
+//! Source families:
+//! - `add_test.go`
+//! - `update_test.go`
+//! - `delete_test.go`
+//! - `replicator_test.go`
+//! - `subscribe_test.go`
+//!
+//! The remaining Go relationship-propagation P2P tests are intentionally not ported here:
+//! Rust local ACP explicitly does not replicate document-actor relationships across nodes,
+//! and that non-replication is already covered in `negative_p2p.rs`.
+
+use std::time::Duration;
+
+use integration_test::{
+    extract_p2p_addr, generate_identity, poll_until, users_schema_with_policy, TestCluster,
+    TestIdentity, USER_ACP_POLICY,
+};
+
+const P2P_TIMEOUT: Duration = Duration::from_secs(15);
+
+fn extract_policy_id(value: &serde_json::Value) -> String {
+    value["PolicyID"]
+        .as_str()
+        .or_else(|| value["policyID"].as_str())
+        .expect("missing PolicyID")
+        .to_string()
+}
+
+async fn wait_for_p2p(cluster: &TestCluster) {
+    for index in 0..2 {
+        cluster
+            .wait_for_log(index, "p2p_listening", P2P_TIMEOUT)
+            .await
+            .unwrap_or_else(|_| panic!("node{index} P2P listener did not start"));
+    }
+}
+
+async fn setup_acp_p2p(cluster: &TestCluster) -> TestIdentity {
+    wait_for_p2p(cluster).await;
+
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+    let owner = generate_identity(node0.binary_path()).expect("owner identity");
+
+    let policy = node0
+        .acp_policy_add(USER_ACP_POLICY, &owner.private_key_hex)
+        .expect("add ACP policy on node0");
+    let policy_id = extract_policy_id(&policy);
+
+    node1
+        .acp_policy_add(USER_ACP_POLICY, &owner.private_key_hex)
+        .expect("add ACP policy on node1");
+
+    let schema = users_schema_with_policy(&policy_id);
+    node0
+        .schema_add_with_identity(&schema, &owner.private_key_hex)
+        .expect("add schema on node0");
+    node1
+        .schema_add_with_identity(&schema, &owner.private_key_hex)
+        .expect("add schema on node1");
+
+    owner
+}
+
+fn create_user(
+    node: &integration_test::DefraClient,
+    owner_key: &str,
+    name: &str,
+    age: i64,
+) -> String {
+    let result = node
+        .query_with_identity(
+            &format!(
+                r#"mutation {{ add_User(input: {{name: "{name}", age: {age}}}) {{ _docID name age }} }}"#
+            ),
+            owner_key,
+        )
+        .expect("create User");
+
+    result["add_User"][0]["_docID"]
+        .as_str()
+        .expect("_docID")
+        .to_string()
+}
+
+fn update_user(node: &integration_test::DefraClient, owner_key: &str, doc_id: &str, name: &str) {
+    node.query_with_identity(
+        &format!(r#"mutation {{ update_User(docID: "{doc_id}", input: {{name: "{name}"}}) {{ _docID name }} }}"#),
+        owner_key,
+    )
+    .expect("update User");
+}
+
+fn delete_user(node: &integration_test::DefraClient, owner_key: &str, doc_id: &str) {
+    node.query_with_identity(
+        &format!(r#"mutation {{ delete_User(docID: "{doc_id}") {{ _docID }} }}"#),
+        owner_key,
+    )
+    .expect("delete User");
+}
+
+fn query_user_names(node: &integration_test::DefraClient, key: Option<&str>) -> Vec<String> {
+    let result = match key {
+        Some(key) => node
+            .query_with_identity(r#"query { User { name } }"#, key)
+            .expect("query User with identity"),
+        None => node
+            .query(r#"query { User { name } }"#)
+            .expect("query User anonymously"),
+    };
+
+    result["User"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|value| value["name"].as_str().map(ToString::to_string))
+        .collect()
+}
+
+fn configure_subscription(cluster: &TestCluster) {
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+    let addr1 = extract_p2p_addr(cluster, 1);
+
+    node0
+        .p2p_connect(&[&addr1])
+        .expect("connect node0 -> node1");
+    node0
+        .p2p_collection_add(&["User"])
+        .expect("add User collection on node0");
+    node1
+        .p2p_collection_add(&["User"])
+        .expect("add User collection on node1");
+}
+
+fn configure_replicator(cluster: &TestCluster, owner_key: &str) {
+    let node0 = cluster.client(0);
+    let addr1 = extract_p2p_addr(cluster, 1);
+
+    configure_subscription(cluster);
+    node0
+        .p2p_replicator_set_with_identity(&["User"], &addr1, owner_key)
+        .expect("configure explicit replicator");
+}
+
+async fn acp_p2p_add_private_documents_on_different_nodes_test(cluster: TestCluster) {
+    let owner = setup_acp_p2p(&cluster).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    create_user(&node0, &owner.private_key_hex, "Shahzad", 27);
+    create_user(&node1, &owner.private_key_hex, "Shahzad Lone", 28);
+
+    assert_eq!(
+        query_user_names(&node0, Some(&owner.private_key_hex)),
+        vec!["Shahzad".to_string()]
+    );
+    assert_eq!(
+        query_user_names(&node1, Some(&owner.private_key_hex)),
+        vec!["Shahzad Lone".to_string()]
+    );
+    assert!(query_user_names(&node0, None).is_empty());
+    assert!(query_user_names(&node1, None).is_empty());
+}
+
+async fn acp_p2p_subscribe_add_get_single_with_permissioned_collection_test(cluster: TestCluster) {
+    let owner = setup_acp_p2p(&cluster).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    configure_subscription(&cluster);
+
+    let collections = node1
+        .p2p_collection_list()
+        .expect("list collections on node1");
+    assert_eq!(
+        collections.as_array().map(|arr| arr.len()).unwrap_or(0),
+        1,
+        "node1 should have exactly one subscribed P2P collection"
+    );
+
+    create_user(&node0, &owner.private_key_hex, "John", 21);
+
+    assert_eq!(
+        query_user_names(&node0, Some(&owner.private_key_hex)),
+        vec!["John".to_string()]
+    );
+
+    let owner_key = owner.private_key_hex.clone();
+    poll_until(
+        || {
+            query_user_names(&node1, Some(&owner_key))
+                .iter()
+                .any(|name| name == "John")
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "subscription-based sync did not materialize the protected document on node1",
+    )
+    .await;
+
+    assert!(query_user_names(&node0, None).is_empty());
+    assert!(query_user_names(&node1, None).is_empty());
+}
+
+async fn acp_p2p_one_to_one_replicator_with_permissioned_collection_test(cluster: TestCluster) {
+    let owner = setup_acp_p2p(&cluster).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    configure_replicator(&cluster, &owner.private_key_hex);
+    create_user(&node0, &owner.private_key_hex, "John", 21);
+
+    let owner_key = owner.private_key_hex.clone();
+    poll_until(
+        || {
+            query_user_names(&node1, Some(&owner_key))
+                .iter()
+                .any(|name| name == "John")
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "permissioned document did not replicate to node1",
+    )
+    .await;
+
+    assert!(query_user_names(&node0, None).is_empty());
+    assert!(query_user_names(&node1, None).is_empty());
+}
+
+async fn acp_p2p_update_private_documents_on_different_nodes_test(cluster: TestCluster) {
+    let owner = setup_acp_p2p(&cluster).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    configure_replicator(&cluster, &owner.private_key_hex);
+
+    let node0_doc = create_user(&node0, &owner.private_key_hex, "Shahzad", 27);
+    let node1_doc = create_user(&node1, &owner.private_key_hex, "Shahzad Lone", 28);
+
+    let owner_key = owner.private_key_hex.clone();
+    poll_until(
+        || {
+            query_user_names(&node1, Some(&owner_key))
+                .iter()
+                .any(|name| name == "Shahzad")
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "node0 document did not replicate before update",
+    )
+    .await;
+
+    update_user(&node0, &owner.private_key_hex, &node0_doc, "ShahzadUpdated");
+    update_user(
+        &node1,
+        &owner.private_key_hex,
+        &node1_doc,
+        "ShahzadLoneUpdated",
+    );
+
+    assert!(
+        query_user_names(&node0, Some(&owner.private_key_hex))
+            .iter()
+            .any(|name| name == "ShahzadUpdated"),
+        "node0 should expose its updated local document"
+    );
+    assert!(
+        query_user_names(&node1, Some(&owner.private_key_hex))
+            .iter()
+            .any(|name| name == "ShahzadLoneUpdated"),
+        "node1 should expose its updated local document"
+    );
+    assert!(query_user_names(&node0, None).is_empty());
+    assert!(query_user_names(&node1, None).is_empty());
+}
+
+async fn acp_p2p_delete_private_documents_on_different_nodes_test(cluster: TestCluster) {
+    let owner = setup_acp_p2p(&cluster).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    configure_replicator(&cluster, &owner.private_key_hex);
+
+    let node0_doc = create_user(&node0, &owner.private_key_hex, "Shahzad", 27);
+    let node1_doc = create_user(&node1, &owner.private_key_hex, "Shahzad Lone", 28);
+
+    let owner_key = owner.private_key_hex.clone();
+    poll_until(
+        || {
+            query_user_names(&node1, Some(&owner_key))
+                .iter()
+                .any(|name| name == "Shahzad")
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "node0 document did not replicate before delete",
+    )
+    .await;
+
+    delete_user(&node0, &owner.private_key_hex, &node0_doc);
+    delete_user(&node1, &owner.private_key_hex, &node1_doc);
+
+    poll_until(
+        || {
+            !query_user_names(&node0, Some(&owner_key))
+                .iter()
+                .any(|name| name == "Shahzad")
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "node0 document delete did not apply",
+    )
+    .await;
+
+    poll_until(
+        || {
+            !query_user_names(&node1, Some(&owner_key))
+                .iter()
+                .any(|name| name == "Shahzad Lone")
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "node1 document delete did not apply",
+    )
+    .await;
+
+    assert!(query_user_names(&node0, None).is_empty());
+    assert!(query_user_names(&node1, None).is_empty());
+}
+
+#[tokio::test]
+async fn rust_rust_acp_p2p_add_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_add_private_documents_on_different_nodes_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_go_acp_p2p_add_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .go_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_add_private_documents_on_different_nodes_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_rust_acp_p2p_add_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_add_private_documents_on_different_nodes_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_rust_acp_p2p_subscribe_add_get_single_with_permissioned_collection() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_subscribe_add_get_single_with_permissioned_collection_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_go_acp_p2p_subscribe_add_get_single_with_permissioned_collection() {
+    let cluster = TestCluster::builder()
+        .go_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_subscribe_add_get_single_with_permissioned_collection_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_rust_acp_p2p_subscribe_add_get_single_with_permissioned_collection() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_subscribe_add_get_single_with_permissioned_collection_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_rust_acp_p2p_one_to_one_replicator_with_permissioned_collection() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_one_to_one_replicator_with_permissioned_collection_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_go_acp_p2p_one_to_one_replicator_with_permissioned_collection() {
+    let cluster = TestCluster::builder()
+        .go_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_one_to_one_replicator_with_permissioned_collection_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_rust_acp_p2p_one_to_one_replicator_with_permissioned_collection() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_one_to_one_replicator_with_permissioned_collection_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_rust_acp_p2p_update_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_update_private_documents_on_different_nodes_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_go_acp_p2p_update_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .go_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_update_private_documents_on_different_nodes_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_rust_acp_p2p_update_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_update_private_documents_on_different_nodes_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_rust_acp_p2p_delete_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_delete_private_documents_on_different_nodes_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_go_acp_p2p_delete_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .go_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_delete_private_documents_on_different_nodes_test(cluster).await;
+}
+
+/// Go does not carry owner DID in PushLog Creator field, so ACP
+/// enforcement on the receiving node cannot work for Go-originated documents.
+#[tokio::test]
+#[ignore]
+async fn go_rust_acp_p2p_delete_private_documents_on_different_nodes() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .go_nodes(1)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    acp_p2p_delete_private_documents_on_different_nodes_test(cluster).await;
+}

--- a/tools/integration-test/tests/acp/register_ops.rs
+++ b/tools/integration-test/tests/acp/register_ops.rs
@@ -1,0 +1,441 @@
+//! ACP document registration lifecycle tests ported from Go DefraDB.
+//!
+//! Source:
+//! - `tests/integration/acp/dac/register_and_read_test.go`
+//! - `tests/integration/acp/dac/register_and_update_test.go`
+//! - `tests/integration/acp/dac/register_and_delete_test.go`
+//!
+//! These tests cover the core DAC registration behavior:
+//! - documents created without identity remain public
+//! - documents created with identity are ACP-registered to that actor
+//! - only the registering identity can read/update/delete the protected doc
+
+use integration_test::{for_each_runtime, generate_identity, TestCluster};
+
+fn register_ops_policy() -> &'static str {
+    r#"
+description: a test policy which marks a collection in a database as a resource
+name: test
+resources:
+  - name: users
+    permissions:
+      - name: read
+        expr: writer + reader
+      - name: update
+        expr: writer
+      - name: delete
+        expr: writer
+    relations:
+      - name: writer
+        types:
+          - actor
+      - name: reader
+        types:
+          - actor
+"#
+}
+
+fn users_schema(policy_id: &str) -> String {
+    format!(
+        r#"type Users @policy(id: "{}", resource: "users") {{ name: String age: Int }}"#,
+        policy_id
+    )
+}
+
+fn extract_policy_id(value: &serde_json::Value) -> Option<String> {
+    value["PolicyID"]
+        .as_str()
+        .or_else(|| value["policyID"].as_str())
+        .map(|s| s.to_string())
+}
+
+async fn setup_users_collection(node: &integration_test::DefraClient, owner_key: &str) -> String {
+    let policy = node
+        .acp_policy_add(register_ops_policy(), owner_key)
+        .expect("add register-ops policy");
+    let policy_id = extract_policy_id(&policy).expect("policy id");
+
+    node.schema_add_with_identity(&users_schema(&policy_id), owner_key)
+        .expect("add Users schema");
+
+    policy_id
+}
+
+fn create_user(
+    node: &integration_test::DefraClient,
+    key: Option<&str>,
+    name: &str,
+    age: i64,
+) -> String {
+    let mutation = format!(
+        r#"mutation {{ add_Users(input: {{name: "{}", age: {}}}) {{ _docID name age }} }}"#,
+        name, age
+    );
+
+    let value = match key {
+        Some(key) => node
+            .query_with_identity(&mutation, key)
+            .expect("create user with identity"),
+        None => node.query(&mutation).expect("create user anonymously"),
+    };
+
+    value["add_Users"][0]["_docID"]
+        .as_str()
+        .expect("_docID")
+        .to_string()
+}
+
+fn users_visible(
+    node: &integration_test::DefraClient,
+    key: Option<&str>,
+) -> Vec<serde_json::Value> {
+    let query = r#"query { Users { _docID name age } }"#;
+    let value = match key {
+        Some(key) => node
+            .query_with_identity(query, key)
+            .expect("query Users with identity"),
+        None => node.query(query).expect("query Users anonymously"),
+    };
+
+    value["Users"].as_array().cloned().unwrap_or_default()
+}
+
+fn assert_single_user(
+    node: &integration_test::DefraClient,
+    key: Option<&str>,
+    expected_name: &str,
+    expected_age: i64,
+) {
+    let users = users_visible(node, key);
+    assert_eq!(
+        users.len(),
+        1,
+        "expected exactly one visible Users document"
+    );
+    assert_eq!(users[0]["name"], expected_name);
+    assert_eq!(users[0]["age"], expected_age);
+}
+
+fn assert_no_users(node: &integration_test::DefraClient, key: Option<&str>) {
+    assert!(
+        users_visible(node, key).is_empty(),
+        "expected no visible Users documents"
+    );
+}
+
+fn update_user(node: &integration_test::DefraClient, key: Option<&str>, doc_id: &str, name: &str) {
+    let mutation = format!(
+        r#"mutation {{ update_Users(docID: "{}", input: {{name: "{}"}}) {{ _docID name age }} }}"#,
+        doc_id, name
+    );
+
+    let result = match key {
+        Some(key) => node.query_with_identity(&mutation, key),
+        None => node.query(&mutation),
+    };
+
+    match result {
+        Err(_) => {}
+        Ok(value) => {
+            let updated = value["update_Users"]
+                .as_array()
+                .map(|a| a.len())
+                .unwrap_or(0);
+            assert!(
+                updated <= 1,
+                "update_Users should affect at most one document: {:?}",
+                value
+            );
+        }
+    }
+}
+
+fn delete_user(node: &integration_test::DefraClient, key: Option<&str>, doc_id: &str) {
+    let mutation = format!(
+        r#"mutation {{ delete_Users(docID: "{}") {{ _docID }} }}"#,
+        doc_id
+    );
+
+    let result = match key {
+        Some(key) => node.query_with_identity(&mutation, key),
+        None => node.query(&mutation),
+    };
+
+    match result {
+        Err(_) => {}
+        Ok(value) => {
+            let deleted = value["delete_Users"]
+                .as_array()
+                .map(|a| a.len())
+                .unwrap_or(0);
+            assert!(
+                deleted <= 1,
+                "delete_Users should affect at most one document: {:?}",
+                value
+            );
+        }
+    }
+}
+
+// Port of TestACP_AddWithoutIdentityAndReadWithoutIdentity_CanRead
+async fn acp_register_anon_read_anon_can_read(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    create_user(&node, None, "Shahzad", 28);
+    assert_single_user(&node, None, "Shahzad", 28);
+}
+
+for_each_runtime!(
+    acp_register_anon_read_anon_can_read,
+    acp_register_anon_read_anon_can_read,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithoutIdentityAndReadWithIdentity_CanRead
+async fn acp_register_anon_read_owner_can_read(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    create_user(&node, None, "Shahzad", 28);
+    assert_single_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+}
+
+for_each_runtime!(
+    acp_register_anon_read_owner_can_read,
+    acp_register_anon_read_owner_can_read,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndReadWithIdentity_CanRead
+async fn acp_register_owner_read_owner_can_read(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    assert_single_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+}
+
+for_each_runtime!(
+    acp_register_owner_read_owner_can_read,
+    acp_register_owner_read_owner_can_read,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndReadWithoutIdentity_CanNotRead
+async fn acp_register_owner_read_anon_cannot_read(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    assert_no_users(&node, None);
+}
+
+for_each_runtime!(
+    acp_register_owner_read_anon_cannot_read,
+    acp_register_owner_read_anon_cannot_read,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndReadWithWrongIdentity_CanNotRead
+async fn acp_register_owner_read_wrong_identity_cannot_read(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let wrong = generate_identity(node.binary_path()).expect("wrong");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    assert_no_users(&node, Some(&wrong.private_key_hex));
+}
+
+for_each_runtime!(
+    acp_register_owner_read_wrong_identity_cannot_read,
+    acp_register_owner_read_wrong_identity_cannot_read,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithoutIdentityAndUpdateWithoutIdentity_CanUpdate
+async fn acp_register_anon_update_anon_can_update(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, None, "Shahzad", 28);
+    update_user(&node, None, &doc_id, "Shahzad Lone");
+
+    assert_single_user(&node, None, "Shahzad Lone", 28);
+}
+
+for_each_runtime!(
+    acp_register_anon_update_anon_can_update,
+    acp_register_anon_update_anon_can_update,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithoutIdentityAndUpdateWithIdentity_CanUpdate
+async fn acp_register_anon_update_owner_can_update(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, None, "Shahzad", 28);
+    update_user(&node, Some(&owner.private_key_hex), &doc_id, "Shahzad Lone");
+
+    assert_single_user(&node, None, "Shahzad Lone", 28);
+}
+
+for_each_runtime!(
+    acp_register_anon_update_owner_can_update,
+    acp_register_anon_update_owner_can_update,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndUpdateWithIdentity_CanUpdate
+async fn acp_register_owner_update_owner_can_update(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    update_user(&node, Some(&owner.private_key_hex), &doc_id, "Shahzad Lone");
+
+    assert_single_user(&node, Some(&owner.private_key_hex), "Shahzad Lone", 28);
+}
+
+for_each_runtime!(
+    acp_register_owner_update_owner_can_update,
+    acp_register_owner_update_owner_can_update,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndUpdateWithoutIdentity_CanNotUpdate
+async fn acp_register_owner_update_anon_cannot_update(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    update_user(&node, None, &doc_id, "Shahzad Lone");
+
+    assert_single_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+}
+
+for_each_runtime!(
+    acp_register_owner_update_anon_cannot_update,
+    acp_register_owner_update_anon_cannot_update,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndUpdateWithWrongIdentity_CanNotUpdate
+async fn acp_register_owner_update_wrong_identity_cannot_update(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let wrong = generate_identity(node.binary_path()).expect("wrong");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    update_user(&node, Some(&wrong.private_key_hex), &doc_id, "Shahzad Lone");
+
+    assert_single_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+}
+
+for_each_runtime!(
+    acp_register_owner_update_wrong_identity_cannot_update,
+    acp_register_owner_update_wrong_identity_cannot_update,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithoutIdentityAndDeleteWithoutIdentity_CanDelete
+async fn acp_register_anon_delete_anon_can_delete(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, None, "Shahzad", 28);
+    delete_user(&node, None, &doc_id);
+
+    assert_no_users(&node, None);
+}
+
+for_each_runtime!(
+    acp_register_anon_delete_anon_can_delete,
+    acp_register_anon_delete_anon_can_delete,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithoutIdentityAndDeleteWithIdentity_CanDelete
+async fn acp_register_anon_delete_owner_can_delete(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, None, "Shahzad", 28);
+    delete_user(&node, Some(&owner.private_key_hex), &doc_id);
+
+    assert_no_users(&node, None);
+}
+
+for_each_runtime!(
+    acp_register_anon_delete_owner_can_delete,
+    acp_register_anon_delete_owner_can_delete,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndDeleteWithIdentity_CanDelete
+async fn acp_register_owner_delete_owner_can_delete(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    delete_user(&node, Some(&owner.private_key_hex), &doc_id);
+
+    assert_no_users(&node, Some(&owner.private_key_hex));
+}
+
+for_each_runtime!(
+    acp_register_owner_delete_owner_can_delete,
+    acp_register_owner_delete_owner_can_delete,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndDeleteWithoutIdentity_CanNotDelete
+async fn acp_register_owner_delete_anon_cannot_delete(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    delete_user(&node, None, &doc_id);
+
+    assert_single_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+}
+
+for_each_runtime!(
+    acp_register_owner_delete_anon_cannot_delete,
+    acp_register_owner_delete_anon_cannot_delete,
+    .with_acp_local()
+);
+
+// Port of TestACP_AddWithIdentityAndDeleteWithWrongIdentity_CanNotDelete
+async fn acp_register_owner_delete_wrong_identity_cannot_delete(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let wrong = generate_identity(node.binary_path()).expect("wrong");
+    let _ = setup_users_collection(&node, &owner.private_key_hex).await;
+
+    let doc_id = create_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+    delete_user(&node, Some(&wrong.private_key_hex), &doc_id);
+
+    assert_single_user(&node, Some(&owner.private_key_hex), "Shahzad", 28);
+}
+
+for_each_runtime!(
+    acp_register_owner_delete_wrong_identity_cannot_delete,
+    acp_register_owner_delete_wrong_identity_cannot_delete,
+    .with_acp_local()
+);

--- a/tools/integration-test/tests/acp/relation_queries.rs
+++ b/tools/integration-test/tests/acp/relation_queries.rs
@@ -1,0 +1,376 @@
+//! ACP aggregate and relation query tests ported from Go DefraDB.
+//!
+//! Source:
+//! - `tests/integration/acp/dac/count_test.go`
+//! - `tests/integration/acp/dac/avg_test.go`
+//! - `tests/integration/acp/dac/relation_objects_test.go`
+
+use integration_test::{for_each_runtime, generate_identity, TestCluster};
+
+fn employee_company_policy() -> &'static str {
+    r#"
+description: A Policy
+name: test
+resources:
+  - name: companies
+    permissions:
+      - name: read
+        expr: writer + reader
+      - name: update
+        expr: writer
+      - name: delete
+        expr: writer
+    relations:
+      - name: writer
+        types:
+          - actor
+      - name: reader
+        types:
+          - actor
+  - name: employees
+    permissions:
+      - name: read
+        expr: writer + reader
+      - name: update
+        expr: writer
+      - name: delete
+        expr: writer
+    relations:
+      - name: writer
+        types:
+          - actor
+      - name: reader
+        types:
+          - actor
+"#
+}
+
+fn employee_company_schema(policy_id: &str) -> String {
+    format!(
+        r#"
+type Employee @policy(id: "{}", resource: "employees") {{
+  name: String
+  salary: Int
+  company: Company
+}}
+
+type Company @policy(id: "{}", resource: "companies") {{
+  name: String
+  capital: Int
+  employees: [Employee]
+}}
+"#,
+        policy_id, policy_id
+    )
+}
+
+fn extract_policy_id(value: &serde_json::Value) -> Option<String> {
+    value["PolicyID"]
+        .as_str()
+        .or_else(|| value["policyID"].as_str())
+        .map(|s| s.to_string())
+}
+
+fn query_as(
+    node: &integration_test::DefraClient,
+    query: &str,
+    key: Option<&str>,
+) -> serde_json::Value {
+    match key {
+        Some(key) => node
+            .query_with_identity(query, key)
+            .expect("query with identity"),
+        None => node.query(query).expect("anonymous query"),
+    }
+}
+
+fn mutate_as(
+    node: &integration_test::DefraClient,
+    mutation: &str,
+    key: Option<&str>,
+) -> serde_json::Value {
+    match key {
+        Some(key) => node
+            .query_with_identity(mutation, key)
+            .expect("mutation with identity"),
+        None => node.query(mutation).expect("anonymous mutation"),
+    }
+}
+
+async fn setup_employee_company_fixture(
+    node: &integration_test::DefraClient,
+    owner_key: &str,
+) -> (String, String) {
+    let policy = node
+        .acp_policy_add(employee_company_policy(), owner_key)
+        .expect("add employee/company policy");
+    let policy_id = extract_policy_id(&policy).expect("policy id");
+
+    node.schema_add_with_identity(&employee_company_schema(&policy_id), owner_key)
+        .expect("add employee/company schema");
+
+    let public_company = mutate_as(
+        node,
+        r#"mutation { add_Company(input: {name: "Public Company", capital: 100000}) { _docID } }"#,
+        None,
+    );
+    let public_company_id = public_company["add_Company"][0]["_docID"]
+        .as_str()
+        .expect("public company doc id")
+        .to_string();
+
+    let private_company = mutate_as(
+        node,
+        r#"mutation { add_Company(input: {name: "Private Company", capital: 200000}) { _docID } }"#,
+        Some(owner_key),
+    );
+    let private_company_id = private_company["add_Company"][0]["_docID"]
+        .as_str()
+        .expect("private company doc id")
+        .to_string();
+
+    mutate_as(
+        node,
+        &format!(
+            r#"mutation {{ add_Employee(input: {{name: "PubEmp in PubCompany", salary: 10000, company: "{}"}}) {{ _docID }} }}"#,
+            public_company_id
+        ),
+        None,
+    );
+    mutate_as(
+        node,
+        &format!(
+            r#"mutation {{ add_Employee(input: {{name: "PubEmp in PrivateCompany", salary: 20000, company: "{}"}}) {{ _docID }} }}"#,
+            private_company_id
+        ),
+        None,
+    );
+    mutate_as(
+        node,
+        &format!(
+            r#"mutation {{ add_Employee(input: {{name: "PrivateEmp in PubCompany", salary: 30000, company: "{}"}}) {{ _docID }} }}"#,
+            public_company_id
+        ),
+        Some(owner_key),
+    );
+    mutate_as(
+        node,
+        &format!(
+            r#"mutation {{ add_Employee(input: {{name: "PrivateEmp in PrivateCompany", salary: 40000, company: "{}"}}) {{ _docID }} }}"#,
+            private_company_id
+        ),
+        Some(owner_key),
+    );
+
+    (public_company_id, private_company_id)
+}
+
+// Port of TestACP_QueryCountDocumentsWithoutIdentity / WithIdentity / WithWrongIdentity
+async fn acp_count_documents(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let wrong = generate_identity(node.binary_path()).expect("wrong");
+    let _ = setup_employee_company_fixture(&node, &owner.private_key_hex).await;
+
+    let anon = query_as(&node, r#"query { COUNT(Employee: {}) }"#, None);
+    assert_eq!(anon["COUNT"], 2);
+
+    let owner_view = query_as(
+        &node,
+        r#"query { COUNT(Employee: {}) }"#,
+        Some(&owner.private_key_hex),
+    );
+    assert_eq!(owner_view["COUNT"], 4);
+
+    let wrong_view = query_as(
+        &node,
+        r#"query { COUNT(Employee: {}) }"#,
+        Some(&wrong.private_key_hex),
+    );
+    assert_eq!(wrong_view["COUNT"], 2);
+}
+
+for_each_runtime!(acp_count_documents, acp_count_documents, .with_acp_local());
+
+// Port of TestACP_QueryCountRelatedObjectsWithoutIdentity / WithIdentity / WithWrongIdentity
+async fn acp_count_related_objects(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let wrong = generate_identity(node.binary_path()).expect("wrong");
+    let _ = setup_employee_company_fixture(&node, &owner.private_key_hex).await;
+
+    let query = r#"query { Company(order: {name: ASC}) { name COUNT(employees: {}) } }"#;
+
+    let anon = query_as(&node, query, None);
+    assert_eq!(
+        anon["Company"],
+        serde_json::json!([
+            {"name": "Public Company", "COUNT": 1}
+        ])
+    );
+
+    let owner_view = query_as(&node, query, Some(&owner.private_key_hex));
+    assert_eq!(
+        owner_view["Company"],
+        serde_json::json!([
+            {"name": "Private Company", "COUNT": 2},
+            {"name": "Public Company", "COUNT": 2}
+        ])
+    );
+
+    let wrong_view = query_as(&node, query, Some(&wrong.private_key_hex));
+    assert_eq!(
+        wrong_view["Company"],
+        serde_json::json!([
+            {"name": "Public Company", "COUNT": 1}
+        ])
+    );
+}
+
+for_each_runtime!(
+    acp_count_related_objects,
+    acp_count_related_objects,
+    .with_acp_local()
+);
+
+// Port of TestACP_QueryAverageWithoutIdentity / WithIdentity / WithWrongIdentity
+async fn acp_avg_documents(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let wrong = generate_identity(node.binary_path()).expect("wrong");
+    let _ = setup_employee_company_fixture(&node, &owner.private_key_hex).await;
+
+    let query = r#"query { AVG(Employee: {field: salary}) }"#;
+
+    let anon_avg = query_as(&node, query, None)["AVG"]
+        .as_f64()
+        .expect("anonymous AVG should be numeric");
+    let owner_avg = query_as(&node, query, Some(&owner.private_key_hex))["AVG"]
+        .as_f64()
+        .expect("owner AVG should be numeric");
+    let wrong_avg = query_as(&node, query, Some(&wrong.private_key_hex))["AVG"]
+        .as_f64()
+        .expect("wrong-identity AVG should be numeric");
+
+    assert_eq!(anon_avg, 15000.0);
+    assert_eq!(owner_avg, 25000.0);
+    assert_eq!(wrong_avg, 15000.0);
+}
+
+for_each_runtime!(acp_avg_documents, acp_avg_documents, .with_acp_local());
+
+// Port of TestACP_QueryManyToOneRelationObjectsWithoutIdentity / WithIdentity / WithWrongIdentity
+async fn acp_many_to_one_relation_objects(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let wrong = generate_identity(node.binary_path()).expect("wrong");
+    let _ = setup_employee_company_fixture(&node, &owner.private_key_hex).await;
+
+    let query = r#"
+        query {
+            Employee(order: {name: ASC}) {
+                name
+                company {
+                    name
+                }
+            }
+        }
+    "#;
+
+    assert_eq!(
+        query_as(&node, query, None)["Employee"],
+        serde_json::json!([
+            {"name": "PubEmp in PrivateCompany", "company": null},
+            {"name": "PubEmp in PubCompany", "company": {"name": "Public Company"}}
+        ])
+    );
+
+    assert_eq!(
+        query_as(&node, query, Some(&owner.private_key_hex))["Employee"],
+        serde_json::json!([
+            {"name": "PrivateEmp in PrivateCompany", "company": {"name": "Private Company"}},
+            {"name": "PrivateEmp in PubCompany", "company": {"name": "Public Company"}},
+            {"name": "PubEmp in PrivateCompany", "company": {"name": "Private Company"}},
+            {"name": "PubEmp in PubCompany", "company": {"name": "Public Company"}}
+        ])
+    );
+
+    assert_eq!(
+        query_as(&node, query, Some(&wrong.private_key_hex))["Employee"],
+        serde_json::json!([
+            {"name": "PubEmp in PrivateCompany", "company": null},
+            {"name": "PubEmp in PubCompany", "company": {"name": "Public Company"}}
+        ])
+    );
+}
+
+for_each_runtime!(
+    acp_many_to_one_relation_objects,
+    acp_many_to_one_relation_objects,
+    .with_acp_local()
+);
+
+// Port of TestACP_QueryOneToManyRelationObjectsWithoutIdentity / WithIdentity / WithWrongIdentity
+async fn acp_one_to_many_relation_objects(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner");
+    let wrong = generate_identity(node.binary_path()).expect("wrong");
+    let _ = setup_employee_company_fixture(&node, &owner.private_key_hex).await;
+
+    let query = r#"
+        query {
+            Company(order: {name: ASC}) {
+                name
+                employees(order: {name: ASC}) {
+                    name
+                }
+            }
+        }
+    "#;
+
+    assert_eq!(
+        query_as(&node, query, None)["Company"],
+        serde_json::json!([
+            {
+                "name": "Public Company",
+                "employees": [{"name": "PubEmp in PubCompany"}]
+            }
+        ])
+    );
+
+    assert_eq!(
+        query_as(&node, query, Some(&owner.private_key_hex))["Company"],
+        serde_json::json!([
+            {
+                "name": "Private Company",
+                "employees": [
+                    {"name": "PrivateEmp in PrivateCompany"},
+                    {"name": "PubEmp in PrivateCompany"}
+                ]
+            },
+            {
+                "name": "Public Company",
+                "employees": [
+                    {"name": "PrivateEmp in PubCompany"},
+                    {"name": "PubEmp in PubCompany"}
+                ]
+            }
+        ])
+    );
+
+    assert_eq!(
+        query_as(&node, query, Some(&wrong.private_key_hex))["Company"],
+        serde_json::json!([
+            {
+                "name": "Public Company",
+                "employees": [{"name": "PubEmp in PubCompany"}]
+            }
+        ])
+    );
+}
+
+for_each_runtime!(
+    acp_one_to_many_relation_objects,
+    acp_one_to_many_relation_objects,
+    .with_acp_local()
+);

--- a/tools/integration-test/tests/p2p_iroh/acp/README.md
+++ b/tools/integration-test/tests/p2p_iroh/acp/README.md
@@ -1,36 +1,21 @@
 # ACP (Access Control Policy) Tests
 
-53 passing, 12 failing.
+These tests cover ACP behavior over iroh transport, including:
+- local ACP replication behavior
+- SourceHub-backed DAC permissioned replication
+- SourceHub-backed document-actor relationship propagation
+- NAC trust-boundary behavior
 
 ## Files
 
-- `acp.rs` — Local ACP policy enforcement with iroh transport (2 failing)
-- `dac.rs` — Document Access Control with permissioned replication (9 failing)
-- `nac.rs` — Node Access Control via SourceHub (all pass)
-- `trust_boundary.rs` — Trust boundary enforcement (1 failing)
+- `acp.rs` — Local ACP policy enforcement with iroh transport
+- `dac.rs` — DAC permissioned replication, including the Go `replicator_with_doc_actor_relationship` and `subscribe_with_doc_actor_relationship` parity cases via SourceHub-backed relationship propagation
+- `nac.rs` — Node Access Control via SourceHub
+- `trust_boundary.rs` — Trust boundary enforcement between iroh peers
 
-## Failing Tests
+## Environment
 
-All 12 failures involve ACP-protected document replication between iroh peers.
-Tests time out waiting for documents to replicate. The controlled-mode access
-checks and PeerState tracking are working (#501 fixed, #500 fixed), but the
-ACP-protected replication path has a remaining issue in the pushlog/DAG fetch
-flow for permissioned documents.
+Some `dac.rs` and `nac.rs` tests require a SourceHub test environment. In this repo that means
+`sourcehubd` must be resolvable via `SOURCEHUB_BINARY`, `SOURCEHUB_WORKSPACE`, or `PATH`.
 
-### acp.rs (2 tests)
-- `iroh_acp_replication` — ACP-protected doc replication timeout
-- `iroh_acp_multi_identity` — multi-identity ACP replication timeout
-
-### dac.rs (9 tests)
-- `replicator_permissioned_local` — permissioned replication with local ACP
-- `replicator_permissioned_sourcehub` — permissioned replication with SourceHub ACP
-- `replicator_with_doc_actor_relationship` — doc-actor relationship replication
-- `subscribe_add_get_permissioned_local` — subscribe with local ACP permissions
-- `subscribe_add_get_permissioned_sourcehub` — subscribe with SourceHub permissions
-- `subscribe_add_get_with_doc_actor_relationship` — subscribe with doc-actor relations
-- `create_private_sync_after_relationship` — private doc sync after relationship grant
-- `delete_private_docs_different_nodes` — delete private docs across nodes
-- `update_private_docs_different_nodes` — update private docs across nodes
-
-### trust_boundary.rs (1 test)
-- `iroh_trust_boundary` — trust boundary enforcement between iroh peers
+Without `sourcehubd`, those tests fail at harness startup rather than at ACP assertion time.

--- a/tools/integration-test/tests/p2p_iroh/acp/dac.rs
+++ b/tools/integration-test/tests/p2p_iroh/acp/dac.rs
@@ -95,10 +95,6 @@ async fn setup_sourcehub_cluster() -> (TestCluster, String, String) {
         .expect("add policy on node0");
     let policy_id = extract_policy_id(&policy_result);
 
-    // Cache policy on node1 for local ACP evaluation
-    let _ = node1.acp_policy_add(USER_ACP_POLICY, &owner_key);
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
     // Deploy schema on both nodes
     let schema = users_schema_with_policy(&policy_id);
     node0
@@ -164,6 +160,11 @@ async fn subscribe_add_get_permissioned_local() {
         Ok(policy_output) => {
             let policy_id = extract_policy_id(&policy_output);
             let schema = ACP_SCHEMA.replace("%POLICY_ID%", &policy_id);
+            let node1 = cluster.client(1);
+
+            node1
+                .acp_policy_add(ACP_POLICY, id_key)
+                .expect("add ACP policy on node1");
 
             for i in 0..2 {
                 cluster
@@ -173,7 +174,6 @@ async fn subscribe_add_get_permissioned_local() {
             }
 
             let addr1 = extract_p2p_addr(&cluster, 1);
-            let node1 = cluster.client(1);
 
             node0.p2p_connect(&[&addr1]).expect("connect");
             node0.p2p_collection_add(&["Users"]).expect("col node0");


### PR DESCRIPTION
## Summary
- port the remaining bounded ACP parity families from Go into the Rust integration suite
- fix the ACP one-to-many nested relation leak and align SourceHub policy validation with Go's remote policy lookup behavior
- finish the iroh DAC parity coverage, including SourceHub-backed document-actor relationship cases, and update the ACP trackers

## Testing
- cargo fmt --all
- cargo test -p integration-test --test acp register_ops::rust_ -- --nocapture
- cargo test -p integration-test --test acp relation_queries::rust_ -- --nocapture
- cargo test -p integration-test --test acp relation_queries::rust_acp_one_to_many_relation_objects -- --nocapture
- cargo test -p integration-test --test p2p_iroh -- acp::dac --nocapture

Closes #742
