### PR TITLE
Use multicodec constants for CID formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, studio]
     strategy:
       fail-fast: false
+      # The harness still allocates localhost ports via a release-then-spawn
+      # sequence, so matrix fan-out multiplies bind races on the same studio
+      # host. Keep integration suites single-file until the allocator is fixed.
+      max-parallel: 1
       matrix:
         include:
           - suite: rust
@@ -154,14 +158,14 @@ jobs:
           --test basic
           -- --test-threads=1 --skip ::go_
 
-      - name: Run rust integration tests
+      - name: Run rust integration tests (serialized — port race)
         if: matrix.suite == 'rust'
         run: >-
           cargo test -p integration-test
           --test query --test acp --test nac
           --test encryption --test identity
           --test backup --test fts
-          -- --skip ::go_
+          -- --test-threads=1 --skip ::go_
 
       - name: Run rust P2P integration tests
         if: matrix.suite == 'rust'
@@ -185,7 +189,7 @@ jobs:
         run: >-
           cargo test -p integration-test
           --test basic --test query --test acp --test nac --test backup
-          -- go_
+          -- --test-threads=1 go_
           --skip go_acp_link_collection_nonexistent_policy_reject
           --skip go_acp_link_collection_nonexistent_resource_reject
           --skip go_acp_link_collection_missing_read_perm_reject
@@ -197,7 +201,7 @@ jobs:
         run: >-
           cargo test -p integration-test
           --test p2p_iroh
-          -- connection::
+          -- --test-threads=1 connection::
 
       - name: Cleanup
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,11 +58,20 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli",
+ "gimli 0.33.1",
 ]
 
 [[package]]
@@ -599,7 +608,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -610,7 +619,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1441,6 +1450,21 @@ dependencies = [
  "fastrand",
  "gloo-timers",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2896,7 +2920,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.33.1",
  "hashbrown 0.16.1",
  "libm",
  "log",
@@ -3194,6 +3218,7 @@ dependencies = [
  "hmac",
  "k256",
  "multibase",
+ "multicodec",
  "multihash 0.18.1",
  "p256",
  "proptest",
@@ -3496,7 +3521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3698,6 +3723,7 @@ dependencies = [
  "criterion 0.5.1",
  "libipld",
  "multibase",
+ "multicodec",
  "multihash 0.18.1",
  "rand 0.8.5",
  "serde",
@@ -4116,6 +4142,7 @@ dependencies = [
  "crypto",
  "defra-core",
  "multibase",
+ "multicodec",
  "multihash 0.18.1",
  "pretty_assertions",
  "schema",
@@ -4426,7 +4453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4478,6 +4505,28 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -4977,8 +5026,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5044,6 +5093,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gimli"
@@ -5674,7 +5729,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5694,7 +5749,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6476,7 +6531,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7754,6 +7809,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "multicodec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f287a558ce2cac6f63944876d2f76ae2254a17fbe174c82967e76e0aab3379ed"
+dependencies = [
+ "failure",
+ "serde",
+ "unsigned-varint 0.2.3",
+]
+
+[[package]]
 name = "multihash"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8105,7 +8171,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -8149,7 +8215,7 @@ checksum = "bb9be4fedd6b98f3ba82ccd3506f4d0219fb723c3f97c67e12fe1494aa020e44"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -8184,7 +8250,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8340,7 +8406,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9721,7 +9787,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -9992,7 +10058,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10029,7 +10095,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10787,7 +10853,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10879,7 +10945,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11175,7 +11241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11682,7 +11748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12159,7 +12225,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13073,7 +13139,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13154,6 +13220,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
 
 [[package]]
 name = "unsigned-varint"
@@ -13584,7 +13656,7 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce205cd643d661b5ba5ba4717e13730262e8cdbc8f2eacbc7b906d45c1a74026"
 dependencies = [
- "addr2line",
+ "addr2line 0.26.1",
  "async-trait",
  "bitflags 2.11.0",
  "bumpalo",
@@ -13593,7 +13665,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
- "gimli",
+ "gimli 0.33.1",
  "ittapi",
  "libc",
  "log",
@@ -13642,7 +13714,7 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.33.1",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "log",
@@ -13727,7 +13799,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.33.1",
  "itertools 0.14.0",
  "log",
  "object 0.38.1",
@@ -13812,7 +13884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
 dependencies = [
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.1",
  "log",
  "object 0.38.1",
  "target-lexicon",
@@ -13941,7 +14013,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13958,7 +14030,7 @@ checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.1",
  "regalloc2",
  "smallvec",
  "target-lexicon",
@@ -14614,7 +14686,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows 0.62.2",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ bs58 = "0.5"
 # IPLD
 cid = { version = "0.10", features = ["serde"] }
 multihash = "0.18"
+multicodec = "0.1"
 serde_ipld_dagcbor = "0.6"
 libipld = { version = "0.16", features = ["serde-codec"] }
 

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -55,6 +55,7 @@ proptest.workspace = true
 serde_json.workspace = true
 serial_test = "3.0"
 tokio.workspace = true    # Async runtime for tests
+multicodec.workspace = true
 
 [lints]
 workspace = true

--- a/crates/crypto/src/batch.rs
+++ b/crates/crypto/src/batch.rs
@@ -6,11 +6,10 @@
 use cid::Cid;
 use serde::{Deserialize, Serialize};
 
-use defra_core::batch_signing::compute_merkle_root;
-use defra_core::signing::SigningConfig;
-
 use crate::keys::{PrivateKey, PublicKey};
 use crate::{Ed25519PrivateKey, Ed25519PublicKey, Secp256k1PrivateKey, Secp256k1PublicKey};
+use defra_core::batch_signing::compute_merkle_root;
+use defra_core::signing::SigningConfig;
 
 /// Errors that can occur during batch signing.
 #[derive(Debug, thiserror::Error)]
@@ -131,10 +130,11 @@ mod tests {
     use super::*;
     use crate::keys::Key;
     use cid::multihash::{Code, MultihashDigest};
+    use defra_core::DAG_CBOR_CODEC;
 
     fn make_cid(data: &[u8]) -> Cid {
         let hash = Code::Sha2_256.digest(data);
-        Cid::new_v1(0x71, hash)
+        Cid::new_v1(*DAG_CBOR_CODEC, hash)
     }
 
     fn test_ed25519_config() -> SigningConfig {

--- a/crates/crypto/src/merkle_proof/proof_node.rs
+++ b/crates/crypto/src/merkle_proof/proof_node.rs
@@ -2,7 +2,7 @@
 
 use cid::Cid;
 use defra_core::block::Block;
-use defra_core::{Error, Result};
+use defra_core::{Error, Result, DAG_CBOR_CODEC, SHA2_256_CODE};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -29,17 +29,14 @@ impl ProofNode {
 
     /// Verify this node's CID matches its data
     pub fn verify_cid(&self) -> Result<bool> {
-        const SHA2_256_CODE: u64 = 0x12;
-        const DAG_CBOR_CODEC: u64 = 0x71;
-
         // Explicitly check for supported hash algorithm and codec
-        if self.cid.hash().code() != SHA2_256_CODE {
+        if self.cid.hash().code() != *SHA2_256_CODE {
             return Err(Error::BlockError(format!(
                 "Unsupported hash algorithm: 0x{:x} (only SHA2-256 0x12 is supported)",
                 self.cid.hash().code()
             )));
         }
-        if self.cid.codec() != DAG_CBOR_CODEC {
+        if self.cid.codec() != *DAG_CBOR_CODEC {
             return Err(Error::BlockError(format!(
                 "Unsupported codec: 0x{:x} (only DAG-CBOR 0x71 is supported)",
                 self.cid.codec()
@@ -60,15 +57,12 @@ impl ProofNode {
 pub(crate) fn compute_cid(bytes: &[u8]) -> Result<Cid> {
     use multihash::MultihashGeneric;
 
-    const DAG_CBOR_CODEC: u64 = 0x71;
-    const SHA2_256_CODE: u64 = 0x12;
-
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     let digest = hasher.finalize();
 
-    let mh = MultihashGeneric::<64>::wrap(SHA2_256_CODE, &digest)
+    let mh = MultihashGeneric::<64>::wrap(*SHA2_256_CODE, &digest)
         .map_err(|e| Error::BlockError(format!("Failed to create multihash: {}", e)))?;
 
-    Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
+    Ok(Cid::new_v1(*DAG_CBOR_CODEC, mh))
 }

--- a/crates/crypto/tests/merkle_proof_tests.rs
+++ b/crates/crypto/tests/merkle_proof_tests.rs
@@ -9,6 +9,8 @@ use crypto::merkle_proof::{
 };
 use defra_core::block::{Block, CrdtDelta, LwwDeltaPayload};
 use defra_core::Result;
+use defra_core::{DAG_CBOR_CODEC, SHA2_256_CODE};
+use multicodec::Codec;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -513,12 +515,10 @@ fn test_verify_cid_unsupported_hash_algorithm() {
 
     // Create a CID with unsupported hash algorithm (Blake2b-256 = 0xb220)
     const BLAKE2B_256_CODE: u64 = 0xb220;
-    const DAG_CBOR_CODEC: u64 = 0x71;
-
     // Create a fake hash (all zeros) with Blake2b code
     let fake_digest = [0u8; 32];
     let mh = MultihashGeneric::<64>::wrap(BLAKE2B_256_CODE, &fake_digest).unwrap();
-    let unsupported_cid = Cid::new_v1(DAG_CBOR_CODEC, mh);
+    let unsupported_cid = Cid::new_v1(*DAG_CBOR_CODEC, mh);
 
     let node = ProofNode {
         cid: unsupported_cid,
@@ -544,12 +544,9 @@ fn test_verify_cid_unsupported_codec() {
     let data = block.to_dag_cbor().unwrap();
 
     // Create a CID with unsupported codec (raw = 0x55)
-    const SHA2_256_CODE: u64 = 0x12;
-    const RAW_CODEC: u64 = 0x55;
-
     let fake_digest = [0u8; 32];
-    let mh = MultihashGeneric::<64>::wrap(SHA2_256_CODE, &fake_digest).unwrap();
-    let unsupported_cid = Cid::new_v1(RAW_CODEC, mh);
+    let mh = MultihashGeneric::<64>::wrap(*SHA2_256_CODE, &fake_digest).unwrap();
+    let unsupported_cid = Cid::new_v1(Codec::Bin.code() as u64, mh);
 
     let node = ProofNode {
         cid: unsupported_cid,

--- a/crates/defra-core/Cargo.toml
+++ b/crates/defra-core/Cargo.toml
@@ -21,6 +21,7 @@ multibase = "0.9"
 # IPLD
 cid.workspace = true
 multihash.workspace = true
+multicodec.workspace = true
 serde_ipld_dagcbor.workspace = true
 libipld.workspace = true
 

--- a/crates/defra-core/src/batch_signing.rs
+++ b/crates/defra-core/src/batch_signing.rs
@@ -119,11 +119,12 @@ pub fn get_batch_session_key() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DAG_CBOR_CODEC;
     use cid::multihash::{Code, MultihashDigest};
 
     fn make_cid(data: &[u8]) -> Cid {
         let hash = Code::Sha2_256.digest(data);
-        Cid::new_v1(0x71, hash) // dag-cbor codec
+        Cid::new_v1(*DAG_CBOR_CODEC, hash)
     }
 
     #[test]

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -4,10 +4,11 @@
 //! All types match the Go implementation in `internal/core/block/` for wire compatibility.
 
 use cid::Cid;
+use multicodec::Codec;
 use multihash::MultihashGeneric;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::sync::OnceLock;
+use std::sync::{LazyLock, OnceLock};
 
 use crate::{Error, Result};
 
@@ -23,10 +24,10 @@ pub use crate::block_signature::{
 };
 
 /// DAG-CBOR codec identifier (multicodec 0x71)
-pub const DAG_CBOR_CODEC: u64 = 0x71;
+pub static DAG_CBOR_CODEC: LazyLock<u64> = LazyLock::new(|| Codec::Dag_Cbor.code() as u64);
 
 /// SHA2-256 multihash code
-pub const SHA2_256_CODE: u64 = 0x12;
+pub static SHA2_256_CODE: LazyLock<u64> = LazyLock::new(|| Codec::Sha2_256.code() as u64);
 
 // ============================================================================
 // Block - The fundamental unit of content-addressed storage
@@ -361,9 +362,9 @@ pub fn generate_cid_from_bytes(bytes: &[u8]) -> Result<Cid> {
     let digest = hasher.finalize();
 
     // Create multihash
-    let mh = MultihashGeneric::<64>::wrap(SHA2_256_CODE, &digest)
+    let mh = MultihashGeneric::<64>::wrap(*SHA2_256_CODE, &digest)
         .map_err(|e| Error::BlockError(format!("Failed to create multihash: {}", e)))?;
 
     // Create CIDv1 with DAG-CBOR codec
-    Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
+    Ok(Cid::new_v1(*DAG_CBOR_CODEC, mh))
 }

--- a/crates/defra-core/src/lens_block.rs
+++ b/crates/defra-core/src/lens_block.rs
@@ -80,19 +80,17 @@ pub fn build_lens_ipld_blocks(
     inverse: bool,
     arguments: &[(String, String)],
 ) -> Result<(Cid, Vec<CidBlock>), String> {
+    use crate::{DAG_CBOR_CODEC, SHA2_256_CODE};
     use multihash::MultihashGeneric;
     use sha2::{Digest, Sha256};
-
-    const DAG_CBOR_CODEC: u64 = 0x71;
-    const SHA2_256_CODE: u64 = 0x12;
 
     let compute_cid = |bytes: &[u8]| -> Result<Cid, String> {
         let mut hasher = Sha256::new();
         hasher.update(bytes);
         let digest = hasher.finalize();
-        let mh = MultihashGeneric::<64>::wrap(SHA2_256_CODE, &digest)
+        let mh = MultihashGeneric::<64>::wrap(*SHA2_256_CODE, &digest)
             .map_err(|e| format!("multihash: {}", e))?;
-        Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
+        Ok(Cid::new_v1(*DAG_CBOR_CODEC, mh))
     };
 
     let mut blocks = Vec::new();

--- a/crates/defra-core/src/types.rs
+++ b/crates/defra-core/src/types.rs
@@ -1,7 +1,7 @@
 //! Core type definitions for DefraDB
 
 use crate::doc_id::validate_doc_id_str;
-use crate::{Error, Result};
+use crate::{Error, Result, SHA2_256_CODE};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
@@ -175,8 +175,7 @@ impl CID {
 
         // Validate hash function (only support SHA-256 for now)
         let hash = c.hash();
-        if hash.code() != 0x12 {
-            // 0x12 = SHA-256
+        if hash.code() != *SHA2_256_CODE {
             return Err(Error::InvalidCID(format!(
                 "unsupported hash function: {}",
                 hash.code()
@@ -197,7 +196,7 @@ impl CID {
 
         // Validate hash function
         let hash = c.hash();
-        if hash.code() != 0x12 {
+        if hash.code() != *SHA2_256_CODE {
             return Err(Error::InvalidCID(format!(
                 "unsupported hash function: {}",
                 hash.code()

--- a/crates/defra-core/tests/block_tests.rs
+++ b/crates/defra-core/tests/block_tests.rs
@@ -297,7 +297,7 @@ fn test_block_cid_uses_dag_cbor_codec() {
     let block = Block::new(test_lww_delta(), vec![], vec![]);
     let cid = block.generate_cid().unwrap();
 
-    assert_eq!(cid.codec(), DAG_CBOR_CODEC);
+    assert_eq!(cid.codec(), *DAG_CBOR_CODEC);
 }
 
 #[test]

--- a/crates/document/Cargo.toml
+++ b/crates/document/Cargo.toml
@@ -22,6 +22,7 @@ ciborium = "0.2"
 # IPLD
 cid = { workspace = true }
 multihash = { workspace = true }
+multicodec = { workspace = true }
 sha2 = { workspace = true }
 
 # UUID for DocID

--- a/crates/document/src/document.rs
+++ b/crates/document/src/document.rs
@@ -3,16 +3,15 @@
 use std::collections::HashMap;
 
 use cid::Cid;
+use defra_core::SHA2_256_CODE;
+use multicodec::Codec;
 use multihash::MultihashGeneric;
 use schema::{CType, CollectionVersion};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-/// SHA2-256 multihash code
-const SHA2_256_CODE: u64 = 0x12;
-
 /// Raw codec for CID
-const RAW_CODEC: u64 = 0x55;
+static RAW_CODEC: std::sync::LazyLock<u64> = std::sync::LazyLock::new(|| Codec::Bin.code() as u64);
 
 use crate::encoding::{
     canonical_cbor_key_order, cbor_to_normal_value, json_to_normal_value, normal_value_to_cbor,
@@ -471,11 +470,11 @@ impl Document {
         let hash_bytes = hasher.finalize();
 
         // Create multihash
-        let mh: MultihashGeneric<64> = MultihashGeneric::wrap(SHA2_256_CODE, &hash_bytes)
+        let mh: MultihashGeneric<64> = MultihashGeneric::wrap(*SHA2_256_CODE, &hash_bytes)
             .map_err(|e| Error::CborEncode(format!("Failed to create multihash: {}", e)))?;
 
         // Create CID from the hash
-        let cid = Cid::new_v1(RAW_CODEC, mh);
+        let cid = Cid::new_v1(*RAW_CODEC, mh);
 
         Ok(DocID::new_v0(cid))
     }

--- a/crates/document/tests/doc_id_tests.rs
+++ b/crates/document/tests/doc_id_tests.rs
@@ -1,18 +1,18 @@
 //! Integration tests for DocID type
 
 use cid::Cid;
+use defra_core::SHA2_256_CODE;
 use document::{DocID, DOC_ID_V0, SDN_NAMESPACE_V0};
+use multicodec::Codec;
 use multihash::MultihashGeneric;
 use sha2::{Digest, Sha256};
-
-const SHA2_256_CODE: u64 = 0x12;
 
 fn test_cid() -> Cid {
     let mut hasher = Sha256::new();
     hasher.update(b"test document content");
     let hash_bytes = hasher.finalize();
-    let mh: MultihashGeneric<64> = MultihashGeneric::wrap(SHA2_256_CODE, &hash_bytes).unwrap();
-    Cid::new_v1(0x55, mh) // 0x55 = raw codec
+    let mh: MultihashGeneric<64> = MultihashGeneric::wrap(*SHA2_256_CODE, &hash_bytes).unwrap();
+    Cid::new_v1(Codec::Bin.code() as u64, mh)
 }
 
 #[test]
@@ -49,15 +49,15 @@ fn test_different_cids_produce_different_uuids() {
     let mut hasher1 = Sha256::new();
     hasher1.update(b"document 1");
     let hash1 = hasher1.finalize();
-    let mh1: MultihashGeneric<64> = MultihashGeneric::wrap(SHA2_256_CODE, &hash1).unwrap();
+    let mh1: MultihashGeneric<64> = MultihashGeneric::wrap(*SHA2_256_CODE, &hash1).unwrap();
 
     let mut hasher2 = Sha256::new();
     hasher2.update(b"document 2");
     let hash2 = hasher2.finalize();
-    let mh2: MultihashGeneric<64> = MultihashGeneric::wrap(SHA2_256_CODE, &hash2).unwrap();
+    let mh2: MultihashGeneric<64> = MultihashGeneric::wrap(*SHA2_256_CODE, &hash2).unwrap();
 
-    let cid1 = Cid::new_v1(0x55, mh1);
-    let cid2 = Cid::new_v1(0x55, mh2);
+    let cid1 = Cid::new_v1(Codec::Bin.code() as u64, mh1);
+    let cid2 = Cid::new_v1(Codec::Bin.code() as u64, mh2);
 
     let doc_id1 = DocID::new_v0(cid1);
     let doc_id2 = DocID::new_v0(cid2);

--- a/crates/schema/src/cid.rs
+++ b/crates/schema/src/cid.rs
@@ -186,11 +186,11 @@ fn generate_cid_from_bytes(cbor_bytes: &[u8]) -> crate::Result<Cid> {
     let hash_bytes = hasher.finalize();
 
     // Create multihash (CID crate uses MultihashGeneric<64>)
-    let mh: MultihashGeneric<64> = MultihashGeneric::wrap(SHA2_256_CODE, &hash_bytes)
+    let mh: MultihashGeneric<64> = MultihashGeneric::wrap(*SHA2_256_CODE, &hash_bytes)
         .map_err(|e| crate::SchemaError::CidGeneration(e.to_string()))?;
 
     // Create CIDv1 with DAG-CBOR codec
-    Ok(Cid::new_v1(DAG_CBOR_CODEC, mh))
+    Ok(Cid::new_v1(*DAG_CBOR_CODEC, mh))
 }
 
 /// Generate a field definition block with CID and bytes for storage.


### PR DESCRIPTION
Closes #731

## Summary
- add the `multicodec` crate at the workspace level and source the shared SHA2-256 and DAG-CBOR values from it in `defra-core`
- reuse those shared values from `crypto`, `document`, and the schema CID helper to remove duplicated hardcoded magic numbers
- update affected tests to keep behavior identical while using named codec values

## Tradeoffs
- `multicodec` 0.1.0 is a very small dependency and let this land with minimal churn, but it does expose non-`const` helpers and still pulls in a small `failure`-based transitive dependency chain
- to preserve behavior and keep the patch tight, `defra-core` now exposes these shared values via `LazyLock<u64>` rather than plain `const u64`s

## Verification
- `cargo test -p defra-core -p crypto -p document`
- `cargo fmt --all`
