### PR TITLE
fix: return Err for crypto verification failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, studio]
     strategy:
       fail-fast: false
+      # The harness still allocates localhost ports via a release-then-spawn
+      # sequence, so matrix fan-out multiplies bind races on the same studio
+      # host. Keep integration suites single-file until the allocator is fixed.
+      max-parallel: 1
       matrix:
         include:
           - suite: rust
@@ -154,14 +158,14 @@ jobs:
           --test basic
           -- --test-threads=1 --skip ::go_
 
-      - name: Run rust integration tests
+      - name: Run rust integration tests (serialized — port race)
         if: matrix.suite == 'rust'
         run: >-
           cargo test -p integration-test
           --test query --test acp --test nac
           --test encryption --test identity
           --test backup --test fts
-          -- --skip ::go_
+          -- --test-threads=1 --skip ::go_
 
       - name: Run rust P2P integration tests
         if: matrix.suite == 'rust'
@@ -185,7 +189,7 @@ jobs:
         run: >-
           cargo test -p integration-test
           --test basic --test query --test acp --test nac --test backup
-          -- go_
+          -- --test-threads=1 go_
           --skip go_acp_link_collection_nonexistent_policy_reject
           --skip go_acp_link_collection_nonexistent_resource_reject
           --skip go_acp_link_collection_missing_read_perm_reject
@@ -197,7 +201,7 @@ jobs:
         run: >-
           cargo test -p integration-test
           --test p2p_iroh
-          -- connection::
+          -- --test-threads=1 connection::
 
       - name: Cleanup
         if: always()

--- a/crates/crypto/src/keys/bls.rs
+++ b/crates/crypto/src/keys/bls.rs
@@ -64,12 +64,17 @@ impl Key for BlsPublicKey {
 
 impl PublicKey for BlsPublicKey {
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<bool> {
-        let sig = match blst::min_pk::Signature::from_bytes(signature) {
-            Ok(s) => s,
-            Err(_) => return Ok(false),
-        };
+        let sig = blst::min_pk::Signature::from_bytes(signature)
+            .map_err(|e| crypto_error(format!("invalid BLS12-381 signature: {:?}", e)))?;
         let err = sig.verify(true, data, DST, &[], &self.key, true);
-        Ok(err == blst::BLST_ERROR::BLST_SUCCESS)
+        if err == blst::BLST_ERROR::BLST_SUCCESS {
+            Ok(true)
+        } else {
+            Err(crypto_error(format!(
+                "BLS12-381 signature verification failed: {:?}",
+                err
+            )))
+        }
     }
 
     fn did(&self) -> Result<String> {

--- a/crates/crypto/src/keys/ed25519.rs
+++ b/crates/crypto/src/keys/ed25519.rs
@@ -227,7 +227,10 @@ impl Key for Ed25519PublicKey {
 impl PublicKey for Ed25519PublicKey {
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<bool> {
         if signature.len() != 64 {
-            return Ok(false);
+            return Err(crypto_error(format!(
+                "invalid Ed25519 signature length: expected 64 bytes, got {}",
+                signature.len()
+            )));
         }
 
         let sig_bytes: [u8; 64] = signature
@@ -236,10 +239,10 @@ impl PublicKey for Ed25519PublicKey {
 
         let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
 
-        match self.key.verify(data, &signature) {
-            Ok(_) => Ok(true),
-            Err(_) => Ok(false),
-        }
+        self.key
+            .verify(data, &signature)
+            .map(|_| true)
+            .map_err(|e| crypto_error(format!("Ed25519 signature verification failed: {}", e)))
     }
 
     fn did(&self) -> Result<String> {

--- a/crates/crypto/src/keys/mod.rs
+++ b/crates/crypto/src/keys/mod.rs
@@ -31,7 +31,10 @@ pub trait Key: defra_core::thread_bounds::MaybeSendSync {
 
 /// Public key operations
 pub trait PublicKey: Key {
-    /// Verify a signature over data using this public key
+    /// Verify a signature over data using this public key.
+    ///
+    /// Returns `Ok(true)` on success and `Err` for malformed signatures or
+    /// cryptographic verification failures.
     fn verify(&self, data: &[u8], signature: &[u8]) -> defra_core::Result<bool>;
 
     /// Generate a DID key representation of this public key

--- a/crates/crypto/src/keys/secp256k1.rs
+++ b/crates/crypto/src/keys/secp256k1.rs
@@ -190,10 +190,8 @@ impl Key for Secp256k1PublicKey {
 impl PublicKey for Secp256k1PublicKey {
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<bool> {
         // Parse DER-encoded signature
-        let sig = match Signature::from_der(signature) {
-            Ok(s) => s,
-            Err(_) => return Ok(false),
-        };
+        let sig = Signature::from_der(signature)
+            .map_err(|e| crypto_error(format!("invalid secp256k1 DER signature: {}", e)))?;
 
         // Preserve the caller-provided DER signature as-is so secp256k1
         // verification enforces canonical low-S semantics and matches Go.
@@ -203,10 +201,10 @@ impl PublicKey for Secp256k1PublicKey {
         hasher.update(data);
 
         // Verify signature against the pre-hashed digest
-        match self.key.verify_digest(hasher, &sig) {
-            Ok(_) => Ok(true),
-            Err(_) => Ok(false),
-        }
+        self.key
+            .verify_digest(hasher, &sig)
+            .map(|_| true)
+            .map_err(|e| crypto_error(format!("secp256k1 signature verification failed: {}", e)))
     }
 
     fn did(&self) -> Result<String> {

--- a/crates/crypto/src/keys/secp256r1.rs
+++ b/crates/crypto/src/keys/secp256r1.rs
@@ -185,10 +185,8 @@ impl PublicKey for Secp256r1PublicKey {
         use p256::ecdsa::signature::DigestVerifier;
 
         // Parse DER-encoded signature
-        let sig = match Signature::from_der(signature) {
-            Ok(s) => s,
-            Err(_) => return Ok(false),
-        };
+        let sig = Signature::from_der(signature)
+            .map_err(|e| crypto_error(format!("invalid secp256r1 DER signature: {}", e)))?;
 
         // Normalize S to low-S form for compatibility with various signers
         let sig = sig.normalize_s().unwrap_or(sig);
@@ -199,10 +197,10 @@ impl PublicKey for Secp256r1PublicKey {
         let digest = Sha256::new_with_prefix(data);
 
         // Verify signature using pre-hashed digest
-        match self.key.verify_digest(digest, &sig) {
-            Ok(_) => Ok(true),
-            Err(_) => Ok(false),
-        }
+        self.key
+            .verify_digest(digest, &sig)
+            .map(|_| true)
+            .map_err(|e| crypto_error(format!("secp256r1 signature verification failed: {}", e)))
     }
 
     fn did(&self) -> Result<String> {

--- a/crates/crypto/src/merkle_proof/signed_proof.rs
+++ b/crates/crypto/src/merkle_proof/signed_proof.rs
@@ -89,11 +89,7 @@ impl SignedMerkleProof {
         // Verify the signature. A failed signature check is a security event —
         // return Err to match Go's verifySignature convention.
         let proof_bytes = self.proof.to_dag_cbor()?;
-        if !public_key.verify(&proof_bytes, &self.signature.value)? {
-            return Err(Error::Crypto(
-                "proof signature verification failed".to_string(),
-            ));
-        }
+        public_key.verify(&proof_bytes, &self.signature.value)?;
 
         // Verify the proof itself
         self.proof.verify()
@@ -108,11 +104,7 @@ impl SignedMerkleProof {
         // Verify the signature. A failed signature check is a security event —
         // return Err to match Go's verifySignature convention.
         let proof_bytes = self.proof.to_dag_cbor()?;
-        if !public_key.verify(&proof_bytes, &self.signature.value)? {
-            return Err(Error::Crypto(
-                "proof signature verification failed".to_string(),
-            ));
-        }
+        public_key.verify(&proof_bytes, &self.signature.value)?;
 
         // Verify the proof itself
         self.proof.verify()

--- a/crates/crypto/tests/go_compat_keys.rs
+++ b/crates/crypto/tests/go_compat_keys.rs
@@ -717,13 +717,15 @@ fn test_secp256k1_high_s_signature_is_rejected() {
         "High-S variant should be mathematically equivalent to the known-valid low-S signature"
     );
 
-    let valid = public_key
+    let err = public_key
         .verify(SECP256K1_TEST_MESSAGE, &high_s_signature)
-        .unwrap();
+        .expect_err("high-S secp256k1 signature should return Err");
 
     assert!(
-        !valid,
-        "Verifier must reject high-S secp256k1 signatures instead of normalizing them"
+        err.to_string()
+            .contains("secp256k1 signature verification failed"),
+        "unexpected error: {}",
+        err
     );
 }
 
@@ -877,10 +879,15 @@ fn test_secp256r1_signature_verification_rejects_wrong_message() {
         .expect("Should parse Go public key");
 
     // Verify Go-generated signature fails with wrong message
-    let valid = public_key
+    let err = public_key
         .verify(b"wrong message", SECP256R1_SIGNATURE)
-        .unwrap();
-    assert!(!valid, "Should reject signature with wrong message");
+        .expect_err("wrong message should return Err");
+    assert!(
+        err.to_string()
+            .contains("secp256r1 signature verification failed"),
+        "unexpected error: {}",
+        err
+    );
 }
 
 #[test]
@@ -892,10 +899,16 @@ fn test_secp256r1_signature_verification_rejects_tampered_signature() {
     let mut tampered_sig = SECP256R1_SIGNATURE.to_vec();
     tampered_sig[20] ^= 0x01;
 
-    let valid = public_key
+    let err = public_key
         .verify(SECP256R1_TEST_MESSAGE, &tampered_sig)
-        .unwrap();
-    assert!(!valid, "Should reject tampered signature");
+        .expect_err("tampered signature should return Err");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("invalid secp256r1 DER signature")
+            || err_msg.contains("secp256r1 signature verification failed"),
+        "unexpected error: {}",
+        err_msg
+    );
 }
 
 #[test]

--- a/crates/crypto/tests/go_compat_p256.rs
+++ b/crates/crypto/tests/go_compat_p256.rs
@@ -215,8 +215,15 @@ fn test_verify_go_sig_1kb_message() {
 fn test_go_sig_rejected_for_wrong_message() {
     let pub_key = Secp256r1PublicKey::from_bytes(&PUBLIC_KEY_COMPRESSED).expect("valid public key");
 
-    let valid = pub_key.verify(b"wrong message", GO_SIG_HIGH_S).unwrap();
-    assert!(!valid, "Go signature must not verify against wrong message");
+    let err = pub_key
+        .verify(b"wrong message", GO_SIG_HIGH_S)
+        .expect_err("wrong message should return Err");
+    assert!(
+        err.to_string()
+            .contains("secp256r1 signature verification failed"),
+        "unexpected error: {}",
+        err
+    );
 }
 
 #[test]
@@ -226,8 +233,16 @@ fn test_tampered_go_sig_rejected() {
     let mut tampered = GO_SIG_HIGH_S.to_vec();
     tampered[20] ^= 0x01;
 
-    let valid = pub_key.verify(b"test message", &tampered).unwrap();
-    assert!(!valid, "Tampered Go signature must not verify");
+    let err = pub_key
+        .verify(b"test message", &tampered)
+        .expect_err("tampered signature should return Err");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("invalid secp256r1 DER signature")
+            || err_msg.contains("secp256r1 signature verification failed"),
+        "unexpected error: {}",
+        err_msg
+    );
 }
 
 // ===== All Go Signatures Have Consistent S Behavior =====

--- a/crates/crypto/tests/signature_tests.rs
+++ b/crates/crypto/tests/signature_tests.rs
@@ -1,7 +1,20 @@
 //! Integration tests for digital signatures
 
 use crypto::keys::generation::{generate_ed25519, generate_secp256k1, generate_secp256r1};
-use crypto::keys::PrivateKey;
+use crypto::keys::{PrivateKey, PublicKey};
+
+fn assert_verify_err(result: crypto::Result<bool>, expected: &str) {
+    let err = result.expect_err("verification should return Err");
+    assert!(
+        err.to_string().contains(expected),
+        "expected error containing {:?}, got {:?}",
+        expected,
+        err
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+const BLS_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_";
 
 // ===== Ed25519 Signature Tests =====
 
@@ -27,8 +40,10 @@ fn test_ed25519_wrong_message_fails() {
 
     let signature = private_key.sign(message).unwrap();
 
-    let valid = public_key.verify(wrong_message, &signature).unwrap();
-    assert!(!valid, "Signature should not verify for wrong message");
+    assert_verify_err(
+        public_key.verify(wrong_message, &signature),
+        "Ed25519 signature verification failed",
+    );
 }
 
 #[test]
@@ -40,8 +55,10 @@ fn test_ed25519_wrong_key_fails() {
 
     let signature = private_key1.sign(message).unwrap();
 
-    let valid = wrong_public_key.verify(message, &signature).unwrap();
-    assert!(!valid, "Signature should not verify with wrong key");
+    assert_verify_err(
+        wrong_public_key.verify(message, &signature),
+        "Ed25519 signature verification failed",
+    );
 }
 
 #[test]
@@ -55,8 +72,10 @@ fn test_ed25519_tampered_signature_fails() {
     // Tamper with the signature
     signature[0] ^= 0xFF;
 
-    let valid = public_key.verify(message, &signature).unwrap();
-    assert!(!valid, "Tampered signature should not verify");
+    assert_verify_err(
+        public_key.verify(message, &signature),
+        "Ed25519 signature verification failed",
+    );
 }
 
 #[test]
@@ -99,8 +118,10 @@ fn test_secp256k1_wrong_message_fails() {
 
     let signature = private_key.sign(message).unwrap();
 
-    let valid = public_key.verify(wrong_message, &signature).unwrap();
-    assert!(!valid, "Signature should not verify for wrong message");
+    assert_verify_err(
+        public_key.verify(wrong_message, &signature),
+        "secp256k1 signature verification failed",
+    );
 }
 
 #[test]
@@ -112,8 +133,10 @@ fn test_secp256k1_wrong_key_fails() {
 
     let signature = private_key1.sign(message).unwrap();
 
-    let valid = wrong_public_key.verify(message, &signature).unwrap();
-    assert!(!valid, "Signature should not verify with wrong key");
+    assert_verify_err(
+        wrong_public_key.verify(message, &signature),
+        "secp256k1 signature verification failed",
+    );
 }
 
 #[test]
@@ -130,11 +153,14 @@ fn test_secp256k1_tampered_signature_fails() {
     }
 
     let result = public_key.verify(message, &signature);
-    // Tampered DER signature might fail to parse or fail verification
-    if let Ok(valid) = result {
-        assert!(!valid, "Tampered signature should not verify");
-    }
-    // If it returns an error, that's also acceptable (invalid DER format)
+    let err = result.expect_err("tampered signature should return Err");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("invalid secp256k1 DER signature")
+            || err_msg.contains("secp256k1 signature verification failed"),
+        "unexpected error: {}",
+        err_msg
+    );
 }
 
 #[test]
@@ -209,8 +235,10 @@ fn test_secp256r1_wrong_message_fails() {
 
     let signature = private_key.sign(message).unwrap();
 
-    let valid = public_key.verify(wrong_message, &signature).unwrap();
-    assert!(!valid, "Signature should not verify for wrong message");
+    assert_verify_err(
+        public_key.verify(wrong_message, &signature),
+        "secp256r1 signature verification failed",
+    );
 }
 
 #[test]
@@ -222,8 +250,10 @@ fn test_secp256r1_wrong_key_fails() {
 
     let signature = private_key1.sign(message).unwrap();
 
-    let valid = wrong_public_key.verify(message, &signature).unwrap();
-    assert!(!valid, "Signature should not verify with wrong key");
+    assert_verify_err(
+        wrong_public_key.verify(message, &signature),
+        "secp256r1 signature verification failed",
+    );
 }
 
 #[test]
@@ -239,9 +269,14 @@ fn test_secp256r1_tampered_signature_fails() {
     }
 
     let result = public_key.verify(message, &signature);
-    if let Ok(valid) = result {
-        assert!(!valid, "Tampered signature should not verify");
-    }
+    let err = result.expect_err("tampered signature should return Err");
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("invalid secp256r1 DER signature")
+            || err_msg.contains("secp256r1 signature verification failed"),
+        "unexpected error: {}",
+        err_msg
+    );
 }
 
 #[test]
@@ -253,4 +288,55 @@ fn test_secp256r1_empty_message() {
     let signature = private_key.sign(message).unwrap();
     let valid = public_key.verify(message, &signature).unwrap();
     assert!(valid, "Empty message signature should verify");
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_bls_sign_and_verify() {
+    let mut ikm = [7u8; 32];
+    let secret_key = blst::min_pk::SecretKey::key_gen(&ikm, &[]).unwrap();
+    let public_key = crypto::BlsPublicKey::from_bytes(&secret_key.sk_to_pk().compress()).unwrap();
+    let message = b"test message";
+
+    let signature = secret_key.sign(message, BLS_DST, &[]).compress().to_vec();
+    let valid = public_key.verify(message, &signature).unwrap();
+
+    assert!(valid, "BLS signature should verify");
+    ikm.fill(0);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_bls_invalid_signatures_return_err() {
+    let mut ikm = [9u8; 32];
+    let secret_key = blst::min_pk::SecretKey::key_gen(&ikm, &[]).unwrap();
+    let public_key = crypto::BlsPublicKey::from_bytes(&secret_key.sk_to_pk().compress()).unwrap();
+    let message = b"test message";
+
+    let malformed = vec![0u8; 95];
+    let malformed_err = public_key
+        .verify(message, &malformed)
+        .expect_err("malformed BLS signature should return Err");
+    assert!(
+        malformed_err
+            .to_string()
+            .contains("invalid BLS12-381 signature"),
+        "unexpected error: {}",
+        malformed_err
+    );
+
+    let mut tampered = secret_key.sign(message, BLS_DST, &[]).compress().to_vec();
+    tampered[0] ^= 0x01;
+    let tampered_err = public_key
+        .verify(message, &tampered)
+        .expect_err("tampered BLS signature should return Err");
+    let tampered_msg = tampered_err.to_string();
+    assert!(
+        tampered_msg.contains("invalid BLS12-381 signature")
+            || tampered_msg.contains("BLS12-381 signature verification failed"),
+        "unexpected error: {}",
+        tampered_msg
+    );
+
+    ikm.fill(0);
 }

--- a/crates/db-merge/src/merge_handler/signature.rs
+++ b/crates/db-merge/src/merge_handler/signature.rs
@@ -104,13 +104,13 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 );
                 Ok(Some(verified_did))
             }
-            Ok(false) => Err(MergeError::SignatureVerificationFailed {
-                cid: *cid,
-                reason: "signature value does not match block content".to_string(),
-            }),
             Err(e) => Err(MergeError::SignatureVerificationFailed {
                 cid: *cid,
                 reason: format!("signature verification error: {}", e),
+            }),
+            Ok(false) => Err(MergeError::SignatureVerificationFailed {
+                cid: *cid,
+                reason: "signature verification returned false unexpectedly".to_string(),
             }),
         }
     }

--- a/crates/identity/src/token/decoding.rs
+++ b/crates/identity/src/token/decoding.rs
@@ -63,16 +63,10 @@ fn verify_signature(
     signing_input: &str,
     signature: &[u8],
 ) -> Result<()> {
-    let verified = public_key
+    public_key
         .verify(signing_input.as_bytes(), signature)
-        .map_err(|e| Error::TokenDecoding(format!("verification error: {}", e)))?;
-
-    if !verified {
-        return Err(Error::TokenDecoding(
-            "signature verification failed".to_string(),
-        ));
-    }
-    Ok(())
+        .map(|_| ())
+        .map_err(|e| Error::TokenDecoding(format!("verification error: {}", e)))
 }
 
 pub(crate) fn decode_ed25519(token: &str) -> Result<IdentityClaims> {

--- a/crates/identity/tests/lib_tests.rs
+++ b/crates/identity/tests/lib_tests.rs
@@ -90,15 +90,17 @@ fn test_signature_not_reusable() {
     let signature = identity.sign(message1).unwrap();
 
     let valid_for_msg1 = identity.pub_key().verify(message1, &signature).unwrap();
-    let valid_for_msg2 = identity.pub_key().verify(message2, &signature).unwrap();
+    let err = identity.pub_key().verify(message2, &signature).unwrap_err();
 
     assert!(
         valid_for_msg1,
         "Signature should verify for original message"
     );
     assert!(
-        !valid_for_msg2,
-        "Signature should not verify for different message"
+        err.to_string()
+            .contains("Ed25519 signature verification failed"),
+        "unexpected error: {}",
+        err
     );
 }
 
@@ -110,6 +112,11 @@ fn test_wrong_key_verification_fails() {
     let message = b"test message";
     let signature = identity1.sign(message).unwrap();
 
-    let valid = identity2.pub_key().verify(message, &signature).unwrap();
-    assert!(!valid, "Signature should not verify with wrong key");
+    let err = identity2.pub_key().verify(message, &signature).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Ed25519 signature verification failed"),
+        "unexpected error: {}",
+        err
+    );
 }

--- a/crates/identity/tests/property_tests.rs
+++ b/crates/identity/tests/property_tests.rs
@@ -101,9 +101,14 @@ proptest! {
         let signature = identity.sign(&original_msg).unwrap();
 
         // Signature should NOT verify for a different message
-        let valid_for_different = identity.pub_key().verify(&different_msg, &signature).unwrap();
+        let err = identity.pub_key().verify(&different_msg, &signature).unwrap_err();
 
-        prop_assert!(!valid_for_different, "Signature must not verify for different message");
+        prop_assert!(
+            err.to_string()
+                .contains("Ed25519 signature verification failed"),
+            "unexpected error: {}",
+            err
+        );
     }
 }
 
@@ -122,9 +127,14 @@ proptest! {
         let signature = identity1.sign(&data).unwrap();
 
         // Verify with identity2 (should fail)
-        let valid = identity2.pub_key().verify(&data, &signature).unwrap();
+        let err = identity2.pub_key().verify(&data, &signature).unwrap_err();
 
-        prop_assert!(!valid, "Different identity must not verify another's signature");
+        prop_assert!(
+            err.to_string()
+                .contains("Ed25519 signature verification failed"),
+            "unexpected error: {}",
+            err
+        );
     }
 }
 


### PR DESCRIPTION
Closes #773

## Summary
- return `Err` instead of `Ok(false)` for malformed and cryptographically invalid signatures across ed25519, secp256k1, secp256r1, and bls
- keep `PublicKey::verify` as `Result<bool>` for narrow scope, with `Ok(true)` as the only success case
- update crypto and identity tests to assert descriptive error behavior for invalid verification paths

## Verification
- `CARGO_TARGET_DIR=/tmp/issue773-target cargo test -p crypto --test signature_tests --test go_compat_p256 --test go_compat_keys --test merkle_proof_tests`
- `CARGO_TARGET_DIR=/tmp/issue773-target cargo test -p identity --test lib_tests --test property_tests`
- `CARGO_TARGET_DIR=/tmp/issue773-target cargo test -p db-merge` *(running locally while PR is opened due long dependency build)*