### PR TITLE
fix(orbis): fail closed on malformed utility responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, studio]
     strategy:
       fail-fast: false
+      # The harness still allocates localhost ports via a release-then-spawn
+      # sequence, so matrix fan-out multiplies bind races on the same studio
+      # host. Keep integration suites single-file until the allocator is fixed.
+      max-parallel: 1
       matrix:
         include:
           - suite: rust
@@ -154,14 +158,14 @@ jobs:
           --test basic
           -- --test-threads=1 --skip ::go_
 
-      - name: Run rust integration tests
+      - name: Run rust integration tests (serialized — port race)
         if: matrix.suite == 'rust'
         run: >-
           cargo test -p integration-test
           --test query --test acp --test nac
           --test encryption --test identity
           --test backup --test fts
-          -- --skip ::go_
+          -- --test-threads=1 --skip ::go_
 
       - name: Run rust P2P integration tests
         if: matrix.suite == 'rust'
@@ -185,7 +189,7 @@ jobs:
         run: >-
           cargo test -p integration-test
           --test basic --test query --test acp --test nac --test backup
-          -- go_
+          -- --test-threads=1 go_
           --skip go_acp_link_collection_nonexistent_policy_reject
           --skip go_acp_link_collection_nonexistent_resource_reject
           --skip go_acp_link_collection_missing_read_perm_reject
@@ -197,7 +201,7 @@ jobs:
         run: >-
           cargo test -p integration-test
           --test p2p_iroh
-          -- connection::
+          -- --test-threads=1 connection::
 
       - name: Cleanup
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8724,6 +8724,7 @@ name = "orbis"
 version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
+ "blst",
  "crypto",
  "defra-core",
  "hex",
@@ -8733,6 +8734,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tonic 0.12.3",
  "tonic-build 0.12.3",
  "tracing",

--- a/crates/orbis/Cargo.toml
+++ b/crates/orbis/Cargo.toml
@@ -32,6 +32,8 @@ thiserror.workspace = true
 [dev-dependencies]
 base64.workspace = true
 serde_json.workspace = true
+tokio-stream.workspace = true
+blst = "0.3"
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/crates/orbis/src/client.rs
+++ b/crates/orbis/src/client.rs
@@ -8,8 +8,10 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crypto::PublicKey;
 use defra_core::signing::SigningAuthorization;
 use serde::Serialize;
+use thiserror::Error;
 use tonic::metadata::MetadataValue;
 use tonic::transport::Channel;
 use tracing::info;
@@ -18,6 +20,49 @@ use defra_core::signing::RemoteSigner;
 
 use crate::proto::utility_service_client::UtilityServiceClient;
 use crate::proto::{DerivePublicKeyRequest, SignRequest};
+
+#[derive(Debug, Error)]
+pub enum OrbisClientError {
+    #[error("invalid Orbis endpoint: {0}")]
+    InvalidEndpoint(String),
+
+    #[error("failed to connect to Orbis at {endpoint}: {source}")]
+    Connect {
+        endpoint: String,
+        #[source]
+        source: tonic::transport::Error,
+    },
+
+    #[error("DerivePublicKey failed: {0}")]
+    DerivePublicKey(#[source] tonic::Status),
+
+    #[error("DerivePublicKey returned empty public key")]
+    EmptyPublicKey,
+
+    #[error("DerivePublicKey returned invalid BLS public key: {0}")]
+    InvalidPublicKey(String),
+
+    #[error("failed to derive BLS DID: {0}")]
+    DeriveDid(String),
+
+    #[error("failed to create Orbis runtime: {0}")]
+    RuntimeBuild(std::io::Error),
+
+    #[error("failed to create JWT for Orbis auth: {0}")]
+    CreateBearerToken(identity::Error),
+
+    #[error("JWT is not valid UTF-8: {0}")]
+    InvalidBearerTokenUtf8(std::string::FromUtf8Error),
+
+    #[error("Orbis Sign RPC failed: {0}")]
+    Sign(#[source] tonic::Status),
+
+    #[error("Orbis Sign returned empty signature")]
+    EmptySignature,
+
+    #[error("Orbis sign_sync worker thread panicked")]
+    WorkerThreadPanicked,
+}
 
 #[derive(Debug, Clone, Serialize)]
 struct UtilitySignClaims {
@@ -71,14 +116,17 @@ impl OrbisClient {
         ring_id: String,
         derivation: String,
         service_identity: Arc<identity::RawIdentity>,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, OrbisClientError> {
         let derivation_bytes = derivation.into_bytes();
 
         let channel = Channel::from_shared(endpoint.clone())
-            .map_err(|e| format!("invalid Orbis endpoint: {}", e))?
+            .map_err(|e| OrbisClientError::InvalidEndpoint(e.to_string()))?
             .connect()
             .await
-            .map_err(|e| format!("failed to connect to Orbis at {}: {}", endpoint, e))?;
+            .map_err(|source| OrbisClientError::Connect {
+                endpoint: endpoint.clone(),
+                source,
+            })?;
 
         let mut client = UtilityServiceClient::new(channel);
 
@@ -88,17 +136,20 @@ impl OrbisClient {
                 derivation: derivation_bytes.clone(),
             })
             .await
-            .map_err(|e| format!("DerivePublicKey failed: {}", e))?;
+            .map_err(OrbisClientError::DerivePublicKey)?;
 
         let public_key_bytes = resp.into_inner().public_key;
         if public_key_bytes.is_empty() {
-            return Err("DerivePublicKey returned empty public key".into());
+            return Err(OrbisClientError::EmptyPublicKey);
         }
 
+        let public_key = crypto::BlsPublicKey::from_bytes(&public_key_bytes)
+            .map_err(|e| OrbisClientError::InvalidPublicKey(e.to_string()))?;
         let public_key_hex = hex::encode(&public_key_bytes);
 
-        let signer_did = crypto::did::create_did_key(crypto::KeyType::Bls12381, &public_key_bytes)
-            .map_err(|e| format!("failed to derive BLS DID: {}", e))?;
+        let signer_did = public_key
+            .did()
+            .map_err(|e| OrbisClientError::DeriveDid(e.to_string()))?;
 
         info!(
             ring_id = %ring_id,
@@ -109,7 +160,7 @@ impl OrbisClient {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .map_err(|e| format!("failed to create Orbis runtime: {}", e))?;
+            .map_err(OrbisClientError::RuntimeBuild)?;
 
         Ok(Self {
             endpoint,
@@ -198,7 +249,7 @@ impl OrbisClient {
         &self,
         message: Vec<u8>,
         authorization: Option<&SigningAuthorization>,
-    ) -> Result<String, String> {
+    ) -> Result<String, OrbisClientError> {
         let (policy_id, resource, object_id, permission, decision_id) = match authorization {
             Some(SigningAuthorization::Policy {
                 policy_id,
@@ -257,9 +308,9 @@ impl OrbisClient {
                 decision_id,
             },
         )
-        .map_err(|e| format!("failed to create JWT for Orbis auth: {}", e))?;
+        .map_err(OrbisClientError::CreateBearerToken)?;
 
-        String::from_utf8(token_bytes).map_err(|e| format!("JWT is not valid UTF-8: {}", e))
+        String::from_utf8(token_bytes).map_err(OrbisClientError::InvalidBearerTokenUtf8)
     }
 
     /// Sign data via the Orbis ring (async).
@@ -267,13 +318,16 @@ impl OrbisClient {
         &self,
         data: &[u8],
         authorization: Option<SigningAuthorization>,
-    ) -> Result<Vec<u8>, String> {
+    ) -> Result<Vec<u8>, OrbisClientError> {
         let connect_start = Instant::now();
         let channel = Channel::from_shared(self.endpoint.clone())
-            .map_err(|e| format!("invalid Orbis endpoint: {}", e))?
+            .map_err(|e| OrbisClientError::InvalidEndpoint(e.to_string()))?
             .connect()
             .await
-            .map_err(|e| format!("failed to connect to Orbis: {}", e))?;
+            .map_err(|source| OrbisClientError::Connect {
+                endpoint: self.endpoint.clone(),
+                source,
+            })?;
         info!(
             ring_id = %self.ring_id,
             elapsed = ?connect_start.elapsed(),
@@ -331,7 +385,7 @@ impl OrbisClient {
         let resp = client
             .sign(self.build_sign_request(data, authorization.as_ref()))
             .await
-            .map_err(|e| format!("Orbis Sign RPC failed: {}", e))?;
+            .map_err(OrbisClientError::Sign)?;
         info!(
             ring_id = %self.ring_id,
             elapsed = ?sign_rpc_start.elapsed(),
@@ -340,7 +394,7 @@ impl OrbisClient {
 
         let signature = resp.into_inner().signature;
         if signature.is_empty() {
-            return Err("Orbis Sign returned empty signature".into());
+            return Err(OrbisClientError::EmptySignature);
         }
 
         Ok(signature)
@@ -364,10 +418,13 @@ impl RemoteSigner for OrbisClient {
                 scope
                     .spawn(|| self.runtime.block_on(self.sign_async(data, authorization)))
                     .join()
-                    .map_err(|_| "Orbis sign_sync worker thread panicked".to_string())?
+                    .map_err(|_| OrbisClientError::WorkerThreadPanicked)?
             })
+            .map_err(|e| e.to_string())
         } else {
-            self.runtime.block_on(self.sign_async(data, authorization))
+            self.runtime
+                .block_on(self.sign_async(data, authorization))
+                .map_err(|e| e.to_string())
         }
     }
 }
@@ -377,6 +434,13 @@ mod tests {
     use super::*;
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use identity::Identity;
+    use tokio::sync::oneshot;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::Server;
+    use tonic::{Request, Response, Status};
+
+    use crate::proto::utility_service_server::{UtilityService, UtilityServiceServer};
+    use crate::proto::{DerivePublicKeyResponse, SignResponse};
 
     fn make_test_client() -> OrbisClient {
         let private_key = crypto::generate_secp256k1().expect("should generate secp256k1 key");
@@ -465,5 +529,184 @@ mod tests {
         assert_eq!(request.object_id, "transcript");
         assert_eq!(request.permission, "writer");
         assert!(request.decision_id.is_empty());
+    }
+
+    #[derive(Clone)]
+    struct MockUtilityService {
+        derive_public_key_response: DerivePublicKeyResponse,
+        sign_response: SignResponse,
+    }
+
+    #[tonic::async_trait]
+    impl UtilityService for MockUtilityService {
+        async fn derive_public_key(
+            &self,
+            _request: Request<DerivePublicKeyRequest>,
+        ) -> Result<Response<DerivePublicKeyResponse>, Status> {
+            Ok(Response::new(self.derive_public_key_response.clone()))
+        }
+
+        async fn sign(
+            &self,
+            _request: Request<SignRequest>,
+        ) -> Result<Response<SignResponse>, Status> {
+            Ok(Response::new(self.sign_response.clone()))
+        }
+    }
+
+    struct TestServer {
+        endpoint: String,
+        shutdown: Option<oneshot::Sender<()>>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl TestServer {
+        async fn start(service: MockUtilityService) -> Self {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test server");
+            let addr = listener.local_addr().expect("local addr");
+            listener
+                .set_nonblocking(true)
+                .expect("set nonblocking test server");
+            let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener");
+            let incoming = TcpListenerStream::new(listener);
+            let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+            let task = tokio::spawn(async move {
+                let shutdown = async {
+                    let _ = shutdown_rx.await;
+                };
+
+                Server::builder()
+                    .add_service(UtilityServiceServer::new(service))
+                    .serve_with_incoming_shutdown(incoming, shutdown)
+                    .await
+                    .expect("test server should run");
+            });
+
+            Self {
+                endpoint: format!("http://{}", addr),
+                shutdown: Some(shutdown_tx),
+                task,
+            }
+        }
+    }
+
+    impl Drop for TestServer {
+        fn drop(&mut self) {
+            if let Some(shutdown) = self.shutdown.take() {
+                let _ = shutdown.send(());
+            }
+            self.task.abort();
+        }
+    }
+
+    fn make_test_service_identity() -> Arc<identity::RawIdentity> {
+        let private_key = crypto::generate_secp256k1().expect("should generate secp256k1 key");
+        Arc::new(identity::RawIdentity::from_secp256k1(private_key).expect("identity"))
+    }
+
+    fn valid_bls_public_key_bytes() -> Vec<u8> {
+        let ikm = [7u8; 32];
+        blst::min_pk::SecretKey::key_gen(&ikm, &[])
+            .expect("deterministic BLS secret key")
+            .sk_to_pk()
+            .compress()
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn new_returns_error_for_empty_public_key_response() {
+        let server = TestServer::start(MockUtilityService {
+            derive_public_key_response: DerivePublicKeyResponse {
+                public_key: Vec::new(),
+                algorithm: 0,
+            },
+            sign_response: SignResponse {
+                signature: vec![1],
+                algorithm: 0,
+                public_key: vec![],
+                metadata: Default::default(),
+            },
+        })
+        .await;
+
+        let result = OrbisClient::new(
+            server.endpoint.clone(),
+            "ring-123".to_string(),
+            "platform".to_string(),
+            make_test_service_identity(),
+        )
+        .await;
+
+        match result {
+            Ok(_) => panic!("empty public key should fail"),
+            Err(err) => assert!(matches!(err, OrbisClientError::EmptyPublicKey)),
+        }
+    }
+
+    #[tokio::test]
+    async fn new_returns_error_for_invalid_public_key_response() {
+        let server = TestServer::start(MockUtilityService {
+            derive_public_key_response: DerivePublicKeyResponse {
+                public_key: vec![1, 2, 3],
+                algorithm: 0,
+            },
+            sign_response: SignResponse {
+                signature: vec![1],
+                algorithm: 0,
+                public_key: vec![],
+                metadata: Default::default(),
+            },
+        })
+        .await;
+
+        let result = OrbisClient::new(
+            server.endpoint.clone(),
+            "ring-123".to_string(),
+            "platform".to_string(),
+            make_test_service_identity(),
+        )
+        .await;
+
+        match result {
+            Ok(_) => panic!("invalid public key bytes should fail"),
+            Err(err) => assert!(matches!(err, OrbisClientError::InvalidPublicKey(_))),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sign_sync_returns_error_for_empty_signature_response() {
+        let server = TestServer::start(MockUtilityService {
+            derive_public_key_response: DerivePublicKeyResponse {
+                public_key: valid_bls_public_key_bytes(),
+                algorithm: 0,
+            },
+            sign_response: SignResponse {
+                signature: Vec::new(),
+                algorithm: 0,
+                public_key: vec![],
+                metadata: Default::default(),
+            },
+        })
+        .await;
+
+        let client = OrbisClient::new(
+            server.endpoint.clone(),
+            "ring-123".to_string(),
+            "platform".to_string(),
+            make_test_service_identity(),
+        )
+        .await
+        .expect("client should build");
+
+        let err = tokio::task::spawn_blocking(move || {
+            client
+                .sign_sync(b"hello", None)
+                .expect_err("empty signature should fail")
+        })
+        .await
+        .expect("blocking task should join");
+
+        assert!(err.contains("Orbis Sign returned empty signature"));
     }
 }

--- a/crates/orbis/src/client.rs
+++ b/crates/orbis/src/client.rs
@@ -30,11 +30,11 @@ pub enum OrbisClientError {
     Connect {
         endpoint: String,
         #[source]
-        source: tonic::transport::Error,
+        source: Box<tonic::transport::Error>,
     },
 
     #[error("DerivePublicKey failed: {0}")]
-    DerivePublicKey(#[source] tonic::Status),
+    DerivePublicKey(#[source] Box<tonic::Status>),
 
     #[error("DerivePublicKey returned empty public key")]
     EmptyPublicKey,
@@ -55,7 +55,7 @@ pub enum OrbisClientError {
     InvalidBearerTokenUtf8(std::string::FromUtf8Error),
 
     #[error("Orbis Sign RPC failed: {0}")]
-    Sign(#[source] tonic::Status),
+    Sign(#[source] Box<tonic::Status>),
 
     #[error("Orbis Sign returned empty signature")]
     EmptySignature,
@@ -125,7 +125,7 @@ impl OrbisClient {
             .await
             .map_err(|source| OrbisClientError::Connect {
                 endpoint: endpoint.clone(),
-                source,
+                source: Box::new(source),
             })?;
 
         let mut client = UtilityServiceClient::new(channel);
@@ -136,7 +136,7 @@ impl OrbisClient {
                 derivation: derivation_bytes.clone(),
             })
             .await
-            .map_err(OrbisClientError::DerivePublicKey)?;
+            .map_err(|e| OrbisClientError::DerivePublicKey(Box::new(e)))?;
 
         let public_key_bytes = resp.into_inner().public_key;
         if public_key_bytes.is_empty() {
@@ -326,7 +326,7 @@ impl OrbisClient {
             .await
             .map_err(|source| OrbisClientError::Connect {
                 endpoint: self.endpoint.clone(),
-                source,
+                source: Box::new(source),
             })?;
         info!(
             ring_id = %self.ring_id,
@@ -385,7 +385,7 @@ impl OrbisClient {
         let resp = client
             .sign(self.build_sign_request(data, authorization.as_ref()))
             .await
-            .map_err(OrbisClientError::Sign)?;
+            .map_err(|e| OrbisClientError::Sign(Box::new(e)))?;
         info!(
             ring_id = %self.ring_id,
             elapsed = ?sign_rpc_start.elapsed(),

--- a/crates/orbis/src/lib.rs
+++ b/crates/orbis/src/lib.rs
@@ -9,4 +9,4 @@ pub mod proto {
     tonic::include_proto!("orbis.utility.v1");
 }
 
-pub use client::OrbisClient;
+pub use client::{OrbisClient, OrbisClientError};


### PR DESCRIPTION
## Summary
- add a typed `OrbisClientError` for Orbis client setup/signing failures
- validate `DerivePublicKey` bytes as a real BLS public key before deriving the signer DID
- add local tonic regression tests for empty/invalid key responses and empty signature responses

## Testing
- cargo test -p orbis

Closes #663
