### PR TITLE
Replicate local ACP relationship changes over P2P

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, studio]
     strategy:
       fail-fast: false
+      # The harness still allocates localhost ports via a release-then-spawn
+      # sequence, so matrix fan-out multiplies bind races on the same studio
+      # host. Keep integration suites single-file until the allocator is fixed.
+      max-parallel: 1
       matrix:
         include:
           - suite: rust
@@ -154,14 +158,14 @@ jobs:
           --test basic
           -- --test-threads=1 --skip ::go_
 
-      - name: Run rust integration tests
+      - name: Run rust integration tests (serialized — port race)
         if: matrix.suite == 'rust'
         run: >-
           cargo test -p integration-test
           --test query --test acp --test nac
           --test encryption --test identity
           --test backup --test fts
-          -- --skip ::go_
+          -- --test-threads=1 --skip ::go_
 
       - name: Run rust P2P integration tests
         if: matrix.suite == 'rust'
@@ -185,7 +189,7 @@ jobs:
         run: >-
           cargo test -p integration-test
           --test basic --test query --test acp --test nac --test backup
-          -- go_
+          -- --test-threads=1 go_
           --skip go_acp_link_collection_nonexistent_policy_reject
           --skip go_acp_link_collection_nonexistent_resource_reject
           --skip go_acp_link_collection_missing_read_perm_reject
@@ -197,7 +201,7 @@ jobs:
         run: >-
           cargo test -p integration-test
           --test p2p_iroh
-          -- connection::
+          -- --test-threads=1 connection::
 
       - name: Cleanup
         if: always()

--- a/crates/acp/src/dac.rs
+++ b/crates/acp/src/dac.rs
@@ -4,11 +4,29 @@
 
 use async_trait::async_trait;
 use identity::Did;
+use serde::{Deserialize, Serialize};
 use storage::corekv::MaybeSendSync;
 
 use crate::error::Result;
 use crate::identity::Identity;
 use crate::permission::DocumentPermission;
+
+/// A document-scoped actor relationship snapshot suitable for P2P replication.
+///
+/// `actor` is either a DID string or `"*"` for wildcard grants.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplicatedActorRelationship {
+    pub relation: String,
+    pub actor: String,
+}
+
+/// Replicated actor relationships for a single document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplicatedDocActorRelationships {
+    pub policy_id: String,
+    pub resource_name: String,
+    pub relationships: Vec<ReplicatedActorRelationship>,
+}
 
 /// Document ACP interface (matches Go acp/dac/dac.go)
 ///
@@ -160,6 +178,36 @@ pub trait DocumentACP: MaybeSendSync {
         relation: &str,
         managing_relations: &[String],
     ) -> Result<bool>;
+
+    /// Export the current non-owner actor relationships for a document.
+    ///
+    /// This is used by Rust-only local ACP P2P replication to propagate
+    /// relationship grants and revocations alongside document republishes.
+    async fn export_actor_relationships(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<Vec<ReplicatedActorRelationship>> {
+        let _ = (policy_id, resource_name, doc_id);
+        Ok(Vec::new())
+    }
+
+    /// Replace the current non-owner actor relationships for a document.
+    ///
+    /// Implementations should reconcile the local document-scoped actor
+    /// relationships to match the provided snapshot while preserving the
+    /// existing owner registration.
+    async fn replace_actor_relationships(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+        relationships: &[ReplicatedActorRelationship],
+    ) -> Result<()> {
+        let _ = (policy_id, resource_name, doc_id, relationships);
+        Ok(())
+    }
 
     /// Unregister a document, removing all ACP tuples.
     ///

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -40,7 +40,7 @@ mod validation;
 pub mod zanzibar;
 
 pub use auth_error::normalize_auth_error;
-pub use dac::DocumentACP;
+pub use dac::{DocumentACP, ReplicatedActorRelationship, ReplicatedDocActorRelationships};
 pub use error::{Error, Result};
 pub use identity::Identity;
 pub use local::{LocalDocumentACP, MemoryAcpStore};

--- a/crates/acp/src/zanzibar/acp/document_acp.rs
+++ b/crates/acp/src/zanzibar/acp/document_acp.rs
@@ -7,7 +7,7 @@ use zanzibar::store::ZanzibarStore;
 use zanzibar::types::{Relationship, Subject};
 
 use super::{ZanzibarDocumentACP, OWNER_RELATION};
-use crate::dac::DocumentACP;
+use crate::dac::{DocumentACP, ReplicatedActorRelationship};
 use crate::error::{Error, Result};
 use crate::identity::Identity;
 use crate::permission::DocumentPermission;
@@ -302,6 +302,102 @@ impl<S: ZanzibarStore + ?Sized + 'static> DocumentACP for ZanzibarDocumentACP<S>
         }
 
         Ok(deleted)
+    }
+
+    async fn export_actor_relationships(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<Vec<ReplicatedActorRelationship>> {
+        self.ensure_policy(policy_id, resource_name).await?;
+
+        let Some(policy) = self.store.get_policy(policy_id).await? else {
+            return Ok(Vec::new());
+        };
+        let Some(resource) = policy.get_resource(resource_name) else {
+            return Ok(Vec::new());
+        };
+
+        let mut relationships = Vec::new();
+        for relation in &resource.relations {
+            if relation.name == OWNER_RELATION {
+                continue;
+            }
+
+            let subjects = self
+                .store
+                .get_relation_subjects(policy_id, resource_name, doc_id, &relation.name)
+                .await?;
+
+            for subject in subjects {
+                let actor = match subject {
+                    Subject::Entity(did) => did.to_string(),
+                    Subject::Wildcard => "*".to_string(),
+                    _ => continue,
+                };
+                relationships.push(ReplicatedActorRelationship {
+                    relation: relation.name.clone(),
+                    actor,
+                });
+            }
+        }
+
+        Ok(relationships)
+    }
+
+    async fn replace_actor_relationships(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+        relationships: &[ReplicatedActorRelationship],
+    ) -> Result<()> {
+        self.ensure_policy(policy_id, resource_name).await?;
+
+        let Some(policy) = self.store.get_policy(policy_id).await? else {
+            return Ok(());
+        };
+        let Some(resource) = policy.get_resource(resource_name) else {
+            return Ok(());
+        };
+
+        for relation in &resource.relations {
+            if relation.name == OWNER_RELATION {
+                continue;
+            }
+
+            let subjects = self
+                .store
+                .get_relation_subjects(policy_id, resource_name, doc_id, &relation.name)
+                .await?;
+
+            for subject in subjects {
+                if !matches!(subject, Subject::Entity(_) | Subject::Wildcard) {
+                    continue;
+                }
+                let rel = Relationship::new(resource_name, doc_id, &relation.name, subject);
+                let _ = self.store.delete_relationship(policy_id, &rel).await?;
+            }
+        }
+
+        for relationship in relationships {
+            let subject = if relationship.actor == "*" {
+                Subject::Wildcard
+            } else {
+                Subject::Entity(Did::new(&relationship.actor).map_err(|error| {
+                    Error::Storage(format!(
+                        "invalid replicated actor DID '{}': {}",
+                        relationship.actor, error
+                    ))
+                })?)
+            };
+
+            let rel = Relationship::new(resource_name, doc_id, &relationship.relation, subject);
+            self.store.store_relationship(policy_id, &rel).await?;
+        }
+
+        Ok(())
     }
 
     async fn unregister_doc_object(

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -81,8 +81,8 @@ impl Node {
             server = server.with_node_identity_did(did);
         }
 
-        if let Some(adapter) = p2p_adapter {
-            server = server.with_p2p_arc(adapter);
+        if let Some(adapter) = &p2p_adapter {
+            server = server.with_p2p_arc(adapter.clone());
             if config.net.transport == TransportType::Iroh {
                 info!("P2P HTTP endpoints enabled (iroh)");
             } else {
@@ -119,6 +119,7 @@ impl Node {
                     database.clone(),
                     acp_setup.document_acp.clone(),
                     zanzibar_store,
+                    p2p_adapter.clone(),
                 );
                 server = server.with_doc_acp_arc(doc_acp_adapter);
                 info!("Document ACP HTTP endpoints enabled");

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -113,6 +113,7 @@ impl Node {
         let (failure_tx, failure_rx) = tokio::sync::mpsc::channel::<p2p::sync::PushFailure>(1024);
         coordinator.set_failure_channel(failure_tx);
         let coordinator = Arc::new(coordinator);
+        let coordinator_for_acp = coordinator.clone();
 
         match coordinator.load_p2p_collections().await {
             Ok(count) => {
@@ -383,6 +384,7 @@ impl Node {
             mutator: Arc::new(db_merge::BroadcastMutator::new(database, coordinator)),
             http_adapter: Some(Arc::new(adapter)),
             wire_merge_acp: Some(Box::new(move |acp| {
+                coordinator_for_acp.set_document_acp(acp.clone());
                 merge_handler_for_acp.set_document_acp(acp);
             })),
             wire_doc_pusher_acp: Some(Box::new(move |acp| {
@@ -444,6 +446,7 @@ impl Node {
         let (failure_tx, failure_rx) = tokio::sync::mpsc::channel::<p2p::sync::PushFailure>(1024);
         coordinator.set_failure_channel(failure_tx);
         let coordinator = Arc::new(coordinator);
+        let coordinator_for_acp = coordinator.clone();
 
         match coordinator.load_p2p_collections().await {
             Ok(count) => {
@@ -684,6 +687,7 @@ impl Node {
             mutator: Arc::new(db_merge::BroadcastMutator::new(database, coordinator)),
             http_adapter: Some(Arc::new(adapter)),
             wire_merge_acp: Some(Box::new(move |acp| {
+                coordinator_for_acp.set_document_acp(acp.clone());
                 merge_handler_for_acp.set_document_acp(acp);
             })),
             wire_doc_pusher_acp: Some(Box::new(move |acp| {

--- a/crates/cli/src/doc_acp_adapter.rs
+++ b/crates/cli/src/doc_acp_adapter.rs
@@ -12,6 +12,7 @@ pub struct DocumentAcpAdapter<S: Store> {
     database: Arc<db::DB<S>>,
     acp: Arc<dyn acp::DocumentACP>,
     store: Arc<dyn acp::ZanzibarStore>,
+    p2p: Option<Arc<dyn defra_http::router::P2POperations>>,
 }
 
 impl<S: Store + 'static> DocumentAcpAdapter<S> {
@@ -20,11 +21,13 @@ impl<S: Store + 'static> DocumentAcpAdapter<S> {
         database: Arc<db::DB<S>>,
         acp: Arc<dyn acp::DocumentACP>,
         store: Arc<dyn acp::ZanzibarStore>,
+        p2p: Option<Arc<dyn defra_http::router::P2POperations>>,
     ) -> Self {
         Self {
             database,
             acp,
             store,
+            p2p,
         }
     }
 
@@ -33,8 +36,9 @@ impl<S: Store + 'static> DocumentAcpAdapter<S> {
         database: Arc<db::DB<S>>,
         acp: Arc<dyn acp::DocumentACP>,
         store: Arc<dyn acp::ZanzibarStore>,
+        p2p: Option<Arc<dyn defra_http::router::P2POperations>>,
     ) -> Arc<dyn DocumentAcpOperations> {
-        Arc::new(Self::new(database, acp, store))
+        Arc::new(Self::new(database, acp, store, p2p))
     }
 
     /// Look up policy info for a collection by name.
@@ -111,7 +115,8 @@ impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
             .validate_and_get_managing_relations(&policy_id, &resource_name, relation)
             .await?;
 
-        self.acp
+        let added = self
+            .acp
             .add_actor_relationship(
                 requestor,
                 &target,
@@ -122,7 +127,22 @@ impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
                 &managing,
             )
             .await
-            .map_err(|e| format!("{}", e))
+            .map_err(|e| format!("{}", e))?;
+
+        if added {
+            if let Some(p2p) = &self.p2p {
+                if let Err(error) = p2p.republish_document(collection, doc_id).await {
+                    tracing::debug!(
+                        error = %error,
+                        collection,
+                        doc_id,
+                        "best-effort DAC republish after grant failed"
+                    );
+                }
+            }
+        }
+
+        Ok(added)
     }
 
     async fn delete_doc_relationship(
@@ -147,7 +167,8 @@ impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
             .validate_and_get_managing_relations(&policy_id, &resource_name, relation)
             .await?;
 
-        self.acp
+        let deleted = self
+            .acp
             .delete_actor_relationship(
                 requestor,
                 &target,
@@ -158,6 +179,21 @@ impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
                 &managing,
             )
             .await
-            .map_err(|e| format!("{}", e))
+            .map_err(|e| format!("{}", e))?;
+
+        if deleted {
+            if let Some(p2p) = &self.p2p {
+                if let Err(error) = p2p.republish_document(collection, doc_id).await {
+                    tracing::debug!(
+                        error = %error,
+                        collection,
+                        doc_id,
+                        "best-effort DAC republish after revoke failed"
+                    );
+                }
+            }
+        }
+
+        Ok(deleted)
     }
 }

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -489,6 +489,46 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
+    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> P2PResult<()> {
+        let coordinator = self
+            .sync_coordinator
+            .as_ref()
+            .ok_or_else(|| P2PError::Unsupported("sync coordinator not configured".into()))?;
+        let pusher = self
+            .doc_pusher
+            .as_ref()
+            .ok_or_else(|| P2PError::Unsupported("document pusher not configured".into()))?;
+        let collection_id = pusher.get_collection_id(collection_name).ok_or_else(|| {
+            P2PError::NotFound(format!("collection '{collection_name}' not found"))
+        })?;
+        let head_blocks = pusher
+            .load_document_head_blocks(doc_id)
+            .await
+            .map_err(P2PError::Internal)?;
+        let acp_actor_relationships = pusher
+            .load_doc_actor_relationships(collection_name, doc_id)
+            .await
+            .map_err(P2PError::Internal)?;
+
+        for (cid, block) in head_blocks {
+            coordinator
+                .broadcast_local_update_with_creator_and_relationships(
+                    &cid,
+                    &block,
+                    doc_id,
+                    &collection_id,
+                    None,
+                    acp_actor_relationships.clone(),
+                )
+                .await
+                .map_err(|error| {
+                    P2PError::Transport(format!("failed to republish document head {cid}: {error}"))
+                })?;
+        }
+
+        Ok(())
+    }
+
     async fn sync_documents(&self, collection_name: &str, doc_ids: Vec<String>) -> P2PResult<()> {
         let pusher = self
             .doc_pusher

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use blockstore::Blockstore;
+use cid::Cid;
 
 use defra_http::router::{
     ExplicitReplayCapabilityInput, P2PError, P2POperations, P2PResult, ReplicatorInfo,
@@ -70,6 +71,14 @@ pub trait DocPusher: Send + Sync {
         doc_id: &str,
         collection_id: &str,
     ) -> Result<(), String>;
+
+    async fn load_document_head_blocks(&self, doc_id: &str) -> Result<Vec<(Cid, Vec<u8>)>, String>;
+
+    async fn load_doc_actor_relationships(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> Result<Option<acp::ReplicatedDocActorRelationships>, String>;
 }
 
 /// Trait for syncing collection versions (schema definitions) via Bitswap.
@@ -762,6 +771,46 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             if let Ok(mut tracked) = self.tracked_documents.write() {
                 tracked.remove(doc_id);
             }
+        }
+
+        Ok(())
+    }
+
+    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> P2PResult<()> {
+        let coordinator = self
+            .sync_coordinator
+            .as_ref()
+            .ok_or_else(|| P2PError::Unsupported("sync coordinator not configured".into()))?;
+        let pusher = self
+            .doc_pusher
+            .as_ref()
+            .ok_or_else(|| P2PError::Unsupported("document pusher not configured".into()))?;
+        let collection_id = pusher.get_collection_id(collection_name).ok_or_else(|| {
+            P2PError::NotFound(format!("collection '{collection_name}' not found"))
+        })?;
+        let head_blocks = pusher
+            .load_document_head_blocks(doc_id)
+            .await
+            .map_err(P2PError::Internal)?;
+        let acp_actor_relationships = pusher
+            .load_doc_actor_relationships(collection_name, doc_id)
+            .await
+            .map_err(P2PError::Internal)?;
+
+        for (cid, block) in head_blocks {
+            coordinator
+                .broadcast_local_update_with_creator_and_relationships(
+                    &cid,
+                    &block,
+                    doc_id,
+                    &collection_id,
+                    None,
+                    acp_actor_relationships.clone(),
+                )
+                .await
+                .map_err(|error| {
+                    P2PError::Transport(format!("failed to republish document head {cid}: {error}"))
+                })?;
         }
 
         Ok(())

--- a/crates/cli/src/p2p_collection_lookup.rs
+++ b/crates/cli/src/p2p_collection_lookup.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use cid::Cid;
 
 use p2p::P2PHostHandle;
 
@@ -73,6 +74,21 @@ impl DocPusher for LookupOnlyDocPusher {
         _collection_id: &str,
     ) -> Result<(), String> {
         Err("retry_doc not available (no database context)".to_string())
+    }
+
+    async fn load_document_head_blocks(
+        &self,
+        _doc_id: &str,
+    ) -> Result<Vec<(Cid, Vec<u8>)>, String> {
+        Err("load_document_head_blocks not available (no database context)".to_string())
+    }
+
+    async fn load_doc_actor_relationships(
+        &self,
+        _collection_name: &str,
+        _doc_id: &str,
+    ) -> Result<Option<acp::ReplicatedDocActorRelationships>, String> {
+        Err("load_doc_actor_relationships not available (no database context)".to_string())
     }
 }
 

--- a/crates/cli/src/p2p_doc_pusher.rs
+++ b/crates/cli/src/p2p_doc_pusher.rs
@@ -2,7 +2,9 @@
 
 use std::sync::Arc;
 
+use acp::ReplicatedDocActorRelationships;
 use async_trait::async_trait;
+use cid::Cid;
 
 use p2p::P2PHostHandle;
 
@@ -168,6 +170,70 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             collection_id,
         )
         .await
+    }
+
+    async fn load_document_head_blocks(&self, doc_id: &str) -> Result<Vec<(Cid, Vec<u8>)>, String> {
+        let provider = db_merge::DbHeadProvider::new(self.db.clone());
+        let heads =
+            <db_merge::DbHeadProvider<S> as p2p::sync::DocumentHeadProvider>::get_document_heads(
+                &provider, doc_id,
+            )
+            .await
+            .map_err(|e| format!("failed to load document heads: {}", e))?;
+
+        let txn = self
+            .db
+            .new_txn(true)
+            .await
+            .map_err(|e| format!("failed to create read transaction: {}", e))?;
+        let blockstore = txn
+            .blockstore()
+            .map_err(|e| format!("failed to get blockstore: {}", e))?;
+
+        let mut blocks = Vec::with_capacity(heads.len());
+        for cid in heads {
+            let bytes = blockstore
+                .get(&cid.to_bytes())
+                .await
+                .map_err(|e| format!("failed to read head block {cid}: {e}"))?
+                .ok_or_else(|| format!("head block {cid} not found"))?;
+            blocks.push((cid, bytes));
+        }
+        Ok(blocks)
+    }
+
+    async fn load_doc_actor_relationships(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> Result<Option<ReplicatedDocActorRelationships>, String> {
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(None);
+        };
+        let collection = match self.db.get_collection(collection_name) {
+            Ok(Some(collection)) => collection,
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                return Err(format!(
+                    "failed to load collection for ACP relationships: {}",
+                    e
+                ));
+            }
+        };
+        let Some(policy) = collection.schema().policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let relationships = acp
+            .export_actor_relationships(&policy.id, &policy.resource_name, doc_id)
+            .await
+            .map_err(|e| format!("failed to export ACP relationships: {}", e))?;
+
+        Ok(Some(ReplicatedDocActorRelationships {
+            policy_id: policy.id.clone(),
+            resource_name: policy.resource_name.clone(),
+            relationships,
+        }))
     }
 }
 

--- a/crates/cli/src/transport_doc_pusher.rs
+++ b/crates/cli/src/transport_doc_pusher.rs
@@ -6,7 +6,9 @@
 
 use std::sync::Arc;
 
+use acp::ReplicatedDocActorRelationships;
 use async_trait::async_trait;
+use cid::Cid;
 use p2p::transport::PeerId;
 use p2p::P2PTransport;
 
@@ -26,6 +28,14 @@ pub trait TransportDocPusher: Send + Sync {
         doc_id: &str,
         collection_id: &str,
     ) -> Result<(), String>;
+
+    async fn load_document_head_blocks(&self, doc_id: &str) -> Result<Vec<(Cid, Vec<u8>)>, String>;
+
+    async fn load_doc_actor_relationships(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> Result<Option<ReplicatedDocActorRelationships>, String>;
 
     fn get_collection_id(&self, name: &str) -> Option<String>;
 
@@ -108,6 +118,70 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             collection_id,
         )
         .await
+    }
+
+    async fn load_document_head_blocks(&self, doc_id: &str) -> Result<Vec<(Cid, Vec<u8>)>, String> {
+        let provider = db_merge::DbHeadProvider::new(self.db.clone());
+        let heads =
+            <db_merge::DbHeadProvider<S> as p2p::sync::DocumentHeadProvider>::get_document_heads(
+                &provider, doc_id,
+            )
+            .await
+            .map_err(|e| format!("failed to load document heads: {}", e))?;
+
+        let txn = self
+            .db
+            .new_txn(true)
+            .await
+            .map_err(|e| format!("failed to create read transaction: {}", e))?;
+        let blockstore = txn
+            .blockstore()
+            .map_err(|e| format!("failed to get blockstore: {}", e))?;
+
+        let mut blocks = Vec::with_capacity(heads.len());
+        for cid in heads {
+            let bytes = blockstore
+                .get(&cid.to_bytes())
+                .await
+                .map_err(|e| format!("failed to read head block {cid}: {e}"))?
+                .ok_or_else(|| format!("head block {cid} not found"))?;
+            blocks.push((cid, bytes));
+        }
+        Ok(blocks)
+    }
+
+    async fn load_doc_actor_relationships(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> Result<Option<ReplicatedDocActorRelationships>, String> {
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(None);
+        };
+        let collection = match self.db.get_collection(collection_name) {
+            Ok(Some(collection)) => collection,
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                return Err(format!(
+                    "failed to load collection for ACP relationships: {}",
+                    e
+                ));
+            }
+        };
+        let Some(policy) = collection.schema().policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let relationships = acp
+            .export_actor_relationships(&policy.id, &policy.resource_name, doc_id)
+            .await
+            .map_err(|e| format!("failed to export ACP relationships: {}", e))?;
+
+        Ok(Some(ReplicatedDocActorRelationships {
+            policy_id: policy.id.clone(),
+            resource_name: policy.resource_name.clone(),
+            relationships,
+        }))
     }
 
     fn get_collection_id(&self, name: &str) -> Option<String> {

--- a/crates/embedded/src/iroh_adapter.rs
+++ b/crates/embedded/src/iroh_adapter.rs
@@ -606,10 +606,20 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             .load_document_head_blocks(doc_id)
             .await
             .map_err(P2PError::from)?;
+        let acp_actor_relationships = pusher
+            .load_doc_actor_relationships(collection_name, doc_id)
+            .await?;
 
         for (cid, block) in head_blocks {
             coordinator
-                .broadcast_local_update(&cid, &block, doc_id, &collection_id)
+                .broadcast_local_update_with_creator_and_relationships(
+                    &cid,
+                    &block,
+                    doc_id,
+                    &collection_id,
+                    None,
+                    acp_actor_relationships.clone(),
+                )
                 .await
                 .map_err(|error| {
                     P2PError::transport(format!("failed to republish document head {cid}: {error}"))

--- a/crates/embedded/src/libp2p_adapter.rs
+++ b/crates/embedded/src/libp2p_adapter.rs
@@ -631,10 +631,20 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             P2PError::not_found(format!("collection '{collection_name}' not found"))
         })?;
         let head_blocks = pusher.load_document_head_blocks(doc_id).await?;
+        let acp_actor_relationships = pusher
+            .load_doc_actor_relationships(collection_name, doc_id)
+            .await?;
 
         for (cid, block) in head_blocks {
             coordinator
-                .broadcast_local_update(&cid, &block, doc_id, &collection_id)
+                .broadcast_local_update_with_creator_and_relationships(
+                    &cid,
+                    &block,
+                    doc_id,
+                    &collection_id,
+                    None,
+                    acp_actor_relationships.clone(),
+                )
                 .await
                 .map_err(|error| {
                     P2PError::transport(format!("failed to republish document head {cid}: {error}"))

--- a/crates/embedded/src/libp2p_doc_pusher.rs
+++ b/crates/embedded/src/libp2p_doc_pusher.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::libp2p_adapter::CollectionLookup;
 use crate::{P2PError, P2PResult};
+use acp::ReplicatedDocActorRelationships;
 use async_trait::async_trait;
 use cid::Cid;
 use p2p::P2PHostHandle;
@@ -45,6 +46,12 @@ pub trait DocPusher: Send + Sync {
     ) -> P2PResult<()>;
 
     async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>>;
+
+    async fn load_doc_actor_relationships(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> P2PResult<Option<ReplicatedDocActorRelationships>>;
 }
 
 /// Database-backed `DocPusher` implementation.
@@ -239,6 +246,41 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             blocks.push((cid, bytes));
         }
         Ok(blocks)
+    }
+
+    async fn load_doc_actor_relationships(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> P2PResult<Option<ReplicatedDocActorRelationships>> {
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(None);
+        };
+        let collection = match self.db.get_collection(collection_name) {
+            Ok(Some(collection)) => collection,
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                return Err(P2PError::internal(format!(
+                    "failed to load collection for ACP relationships: {error}"
+                )));
+            }
+        };
+        let Some(policy) = collection.schema().policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let relationships = acp
+            .export_actor_relationships(&policy.id, &policy.resource_name, doc_id)
+            .await
+            .map_err(|error| {
+                P2PError::internal(format!("failed to export ACP relationships: {error}"))
+            })?;
+
+        Ok(Some(ReplicatedDocActorRelationships {
+            policy_id: policy.id.clone(),
+            resource_name: policy.resource_name.clone(),
+            relationships,
+        }))
     }
 }
 

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -159,6 +159,7 @@ where
         version_syncer,
     );
     adapter.set_initial_tracked_documents(restored_doc_ids);
+    let coordinator_for_acp = coordinator.clone();
     let broadcast_mutator = Arc::new(db_merge::BroadcastMutator::new(
         database.clone(),
         coordinator,
@@ -183,6 +184,7 @@ where
         mutator: broadcast_mutator,
         merge_handler,
         wire_document_acp: Some(Box::new(move |acp| {
+            coordinator_for_acp.set_document_acp(acp.clone());
             doc_pusher_for_acp.set_document_acp(acp.clone());
             broadcast_mutator_for_acp.set_document_acp(acp);
         })),
@@ -291,6 +293,7 @@ where
         version_syncer,
     );
     adapter.set_initial_tracked_documents(restored_doc_ids);
+    let coordinator_for_acp = coordinator.clone();
     let broadcast_mutator = Arc::new(db_merge::BroadcastMutator::new(
         database.clone(),
         coordinator,
@@ -316,6 +319,7 @@ where
         mutator: broadcast_mutator,
         merge_handler,
         wire_document_acp: Some(Box::new(move |acp| {
+            coordinator_for_acp.set_document_acp(acp.clone());
             doc_pusher_for_acp.set_document_acp(acp.clone());
             broadcast_mutator_for_acp.set_document_acp(acp);
         })),

--- a/crates/embedded/src/transport_doc_pusher.rs
+++ b/crates/embedded/src/transport_doc_pusher.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::{P2PError, P2PResult};
+use acp::ReplicatedDocActorRelationships;
 use async_trait::async_trait;
 use cid::Cid;
 use p2p::transport::PeerId;
@@ -20,6 +21,12 @@ pub trait TransportDocPusher: Send + Sync {
         -> P2PResult<()>;
 
     async fn load_document_head_blocks(&self, doc_id: &str) -> P2PResult<Vec<(Cid, Vec<u8>)>>;
+
+    async fn load_doc_actor_relationships(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> P2PResult<Option<ReplicatedDocActorRelationships>>;
 
     fn get_collection_id(&self, name: &str) -> Option<String>;
 
@@ -135,6 +142,41 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             blocks.push((cid, bytes));
         }
         Ok(blocks)
+    }
+
+    async fn load_doc_actor_relationships(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> P2PResult<Option<ReplicatedDocActorRelationships>> {
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(None);
+        };
+        let collection = match self.db.get_collection(collection_name) {
+            Ok(Some(collection)) => collection,
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                return Err(P2PError::internal(format!(
+                    "failed to load collection for ACP relationships: {error}"
+                )));
+            }
+        };
+        let Some(policy) = collection.schema().policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let relationships = acp
+            .export_actor_relationships(&policy.id, &policy.resource_name, doc_id)
+            .await
+            .map_err(|error| {
+                P2PError::internal(format!("failed to export ACP relationships: {error}"))
+            })?;
+
+        Ok(Some(ReplicatedDocActorRelationships {
+            policy_id: policy.id.clone(),
+            resource_name: policy.resource_name.clone(),
+            relationships,
+        }))
     }
 
     fn get_collection_id(&self, name: &str) -> Option<String> {

--- a/crates/ffi/src/acp/dac.rs
+++ b/crates/ffi/src/acp/dac.rs
@@ -470,12 +470,13 @@ pub unsafe extern "C" fn delete_dac_actor_relationship(
             );
         }
 
-        // Validate node handle and get database, document_acp, and policy_store
-        let (database, document_acp, policy_store) = match NODES.get(node_ptr, |state| {
+        // Validate node handle and get database, document_acp, policy_store, and optional p2p
+        let (database, document_acp, policy_store, p2p_system) = match NODES.get(node_ptr, |state| {
             (
                 state.database.clone(),
                 state.document_acp.clone(),
                 state.policy_store.clone(),
+                state.p2p.clone(),
             )
         }) {
             Some(tuple) => tuple,
@@ -538,6 +539,25 @@ pub unsafe extern "C" fn delete_dac_actor_relationship(
                 )
                 .await
                 .map_err(|e| e.to_string())?;
+
+            if deleted {
+                if let Some(system) = p2p_system {
+                    if let Err(error) = system
+                        .system
+                        .ops()
+                        .republish_document(&collection_id_str, &doc_id_str)
+                        .await
+                        .map_err(crate::p2p::FfiP2PError::from)
+                    {
+                        tracing::debug!(
+                            error = %error,
+                            collection_id = %collection_id_str,
+                            doc_id = %doc_id_str,
+                            "best-effort DAC republish after revoke failed"
+                        );
+                    }
+                }
+            }
 
             let json = serde_json::json!({ "deleted": deleted }).to_string();
             Ok::<String, String>(json)

--- a/crates/http/src/mock/p2p.rs
+++ b/crates/http/src/mock/p2p.rs
@@ -156,6 +156,10 @@ impl P2POperations for MockP2POperations {
         Ok(())
     }
 
+    async fn republish_document(&self, _collection_name: &str, _doc_id: &str) -> P2PResult<()> {
+        Ok(())
+    }
+
     async fn sync_documents(&self, _collection_name: &str, _doc_ids: Vec<String>) -> P2PResult<()> {
         Ok(())
     }
@@ -245,6 +249,10 @@ impl P2POperations for FailingMockP2POperations {
     }
 
     async fn remove_documents(&self, _docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
+    }
+
+    async fn republish_document(&self, _collection_name: &str, _doc_id: &str) -> P2PResult<()> {
         Err(P2PError::Internal(self.error.clone()))
     }
 

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -99,6 +99,9 @@ pub trait P2POperations: Send + Sync {
     /// Remove documents from P2P replication.
     async fn remove_documents(&self, docs: Vec<P2pDocumentRequest>) -> P2PResult<()>;
 
+    /// Re-broadcast the current document heads.
+    async fn republish_document(&self, collection_name: &str, doc_id: &str) -> P2PResult<()>;
+
     /// Sync specific documents from connected peers.
     async fn sync_documents(&self, collection_name: &str, doc_ids: Vec<String>) -> P2PResult<()>;
 

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -3,6 +3,8 @@
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
+use acp::ReplicatedDocActorRelationships;
+
 use super::cbor::{nullable_bytes, optional_bytes};
 use super::metadata::MetaData;
 use super::traits::Message;
@@ -46,6 +48,14 @@ pub struct PushLogRequest {
         default
     )]
     pub explicit_replay_capability: Option<String>,
+
+    /// Optional local-ACP actor relationship snapshot for this document.
+    #[serde(
+        rename = "ACPActorRelationships",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
 }
 
 impl PushLogRequest {
@@ -65,6 +75,7 @@ impl PushLogRequest {
             creator,
             block,
             explicit_replay_capability: None,
+            acp_actor_relationships: None,
         }
     }
 }
@@ -260,6 +271,14 @@ pub struct PushLogBroadcast {
     /// Uses bytes_as_cbor for CBOR byte string compatibility with Go.
     #[serde(rename = "Block", with = "super::cbor::bytes_as_cbor")]
     pub block: Bytes,
+
+    /// Optional local-ACP actor relationship snapshot for this document.
+    #[serde(
+        rename = "ACPActorRelationships",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
 }
 
 impl PushLogBroadcast {
@@ -270,6 +289,7 @@ impl PushLogBroadcast {
         collection_id: String,
         creator: String,
         block: Bytes,
+        acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
     ) -> Self {
         Self {
             doc_id,
@@ -277,6 +297,7 @@ impl PushLogBroadcast {
             collection_id,
             creator,
             block,
+            acp_actor_relationships,
         }
     }
 
@@ -288,17 +309,20 @@ impl PushLogBroadcast {
             collection_id: req.collection_id.clone(),
             creator: req.creator.clone(),
             block: req.block.clone(),
+            acp_actor_relationships: req.acp_actor_relationships.clone(),
         }
     }
 
     /// Convert to a PushLogRequest (adds default metadata, O(1) Bytes clone).
     pub fn to_request(&self) -> PushLogRequest {
-        PushLogRequest::new(
+        let mut request = PushLogRequest::new(
             self.doc_id.clone(),
             self.cid.clone(),
             self.collection_id.clone(),
             self.creator.clone(),
             self.block.clone(),
-        )
+        );
+        request.acp_actor_relationships = self.acp_actor_relationships.clone();
+        request
     }
 }

--- a/crates/p2p/src/sync/broadcaster.rs
+++ b/crates/p2p/src/sync/broadcaster.rs
@@ -11,6 +11,8 @@
 use bytes::Bytes;
 use cid::Cid;
 
+use acp::ReplicatedDocActorRelationships;
+
 use crate::error::{Error, Result};
 use crate::message::PushLogBroadcast;
 use crate::topics::DefraTopic;
@@ -142,6 +144,7 @@ impl<T: P2PTransport> Broadcaster<T> {
         doc_id: &str,
         collection_id: &str,
         creator: &str,
+        acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
     ) -> PushLogBroadcast {
         PushLogBroadcast::new(
             doc_id.to_string(),
@@ -149,6 +152,7 @@ impl<T: P2PTransport> Broadcaster<T> {
             collection_id.to_string(),
             creator.to_string(),
             Bytes::copy_from_slice(block),
+            acp_actor_relationships,
         )
     }
 
@@ -178,6 +182,7 @@ mod tests {
             doc_id,
             collection_id,
             creator,
+            None,
         );
 
         assert_eq!(broadcast.doc_id, doc_id);

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -77,6 +77,7 @@ fn create_test_coordinator(
             collection_store: Arc::new(NoOpCollectionStorage),
             head_provider: Arc::new(NoOpHeadProvider),
         },
+        document_acp: std::sync::OnceLock::new(),
     };
 
     (coordinator, events)

--- a/crates/p2p/src/sync/coordinator/accessors.rs
+++ b/crates/p2p/src/sync/coordinator/accessors.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use acp::{DocumentACP, ReplicatedDocActorRelationships};
 use blockstore::Blockstore;
 
 use super::SyncCoordinator;
@@ -45,5 +46,36 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Get the sync manager reference.
     pub fn manager(&self) -> &SyncManager<B> {
         &self.manager
+    }
+
+    /// Wire document ACP into the coordinator for local ACP relationship replay.
+    pub fn set_document_acp(&self, acp: Arc<dyn DocumentACP>) {
+        let _ = self.document_acp.set(acp);
+    }
+
+    pub(crate) async fn apply_replicated_actor_relationships(
+        &self,
+        doc_id: &str,
+        snapshot: Option<&ReplicatedDocActorRelationships>,
+    ) -> crate::Result<()> {
+        let Some(snapshot) = snapshot else {
+            return Ok(());
+        };
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(());
+        };
+
+        acp.replace_actor_relationships(
+            &snapshot.policy_id,
+            &snapshot.resource_name,
+            doc_id,
+            &snapshot.relationships,
+        )
+        .await
+        .map_err(|error| {
+            crate::Error::Behaviour(format!(
+                "failed to apply replicated ACP relationships: {error}"
+            ))
+        })
     }
 }

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 
+use acp::ReplicatedDocActorRelationships;
 use blockstore::Blockstore;
 use bytes::Bytes;
 use cid::Cid;
@@ -48,8 +49,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         doc_id: &str,
         collection_id: &str,
     ) -> Result<BroadcastResult> {
-        self.broadcast_local_update_with_creator(cid, block, doc_id, collection_id, None)
-            .await
+        self.broadcast_local_update_with_creator_and_relationships(
+            cid,
+            block,
+            doc_id,
+            collection_id,
+            None,
+            None,
+        )
+        .await
     }
 
     /// Broadcast a local update with an optional creator override.
@@ -65,9 +73,36 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collection_id: &str,
         creator_override: Option<&str>,
     ) -> Result<BroadcastResult> {
+        self.broadcast_local_update_with_creator_and_relationships(
+            cid,
+            block,
+            doc_id,
+            collection_id,
+            creator_override,
+            None,
+        )
+        .await
+    }
+
+    /// Broadcast a local update with optional creator and ACP relationship snapshot.
+    pub async fn broadcast_local_update_with_creator_and_relationships(
+        &self,
+        cid: &Cid,
+        block: &[u8],
+        doc_id: &str,
+        collection_id: &str,
+        creator_override: Option<&str>,
+        acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
+    ) -> Result<BroadcastResult> {
         let creator = creator_override.unwrap_or(&self.access.local_peer_id);
-        let broadcast =
-            Broadcaster::<T>::create_broadcast(cid, block, doc_id, collection_id, creator);
+        let broadcast = Broadcaster::<T>::create_broadcast(
+            cid,
+            block,
+            doc_id,
+            collection_id,
+            creator,
+            acp_actor_relationships,
+        );
         self.runtime.broadcaster.broadcast_update(&broadcast).await
     }
 

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -125,6 +125,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     collection_store,
                     head_provider,
                 },
+                document_acp: std::sync::OnceLock::new(),
             },
             events,
         ))

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -56,6 +56,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
                         sender_peer: Some(source_peer.to_string()),
                         is_explicit_replicator: false,
                         explicit_replay_authorization: None,
+                        acp_actor_relationships: None,
                     })
                     .await;
                 return;
@@ -147,6 +148,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
                 sender_peer: Some(source_peer.to_string()),
                 is_explicit_replicator: false,
                 explicit_replay_authorization: None,
+                acp_actor_relationships: None,
             })
             .await;
     } else {

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -228,6 +228,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                                     sender_peer: Some(peer_id.to_string()),
                                     is_explicit_replicator: false,
                                     explicit_replay_authorization: None,
+                                    acp_actor_relationships: None,
                                 })
                                 .await;
                         } else {

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -56,6 +56,7 @@ pub use result_types::{CreateReplicatorResult, LoadReplicatorsResult};
 
 use std::sync::Arc;
 
+use acp::DocumentACP;
 use blockstore::Blockstore;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
@@ -147,6 +148,9 @@ pub struct SyncCoordinator<B: Blockstore, T: P2PTransport> {
 
     /// Subscription and doc-sync support state.
     pub(super) subscriptions: SyncSubscriptionState,
+
+    /// Optional document ACP used for local ACP relationship snapshot replay.
+    pub(super) document_acp: std::sync::OnceLock<Arc<dyn DocumentACP>>,
 }
 
 /// Type alias for SyncCoordinator using the libp2p transport.

--- a/crates/p2p/src/sync/manager/events.rs
+++ b/crates/p2p/src/sync/manager/events.rs
@@ -2,6 +2,8 @@
 
 use cid::Cid;
 
+use acp::ReplicatedDocActorRelationships;
+
 use crate::ExplicitReplayAuthorization;
 
 /// Events emitted by the SyncManager for higher layers to process.
@@ -29,6 +31,8 @@ pub enum SyncEvent {
         is_explicit_replicator: bool,
         /// Capability-based explicit replay authorization carried by two-stream pushes.
         explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
+        /// Optional local-ACP actor relationship snapshot for the document.
+        acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
     },
 
     /// A block was already merged (received duplicate).
@@ -36,6 +40,7 @@ pub enum SyncEvent {
         cid: Cid,
         doc_id: String,
         collection_id: String,
+        acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
     },
 
     /// Failed to process a sync request.
@@ -65,6 +70,8 @@ pub enum SyncEvent {
         is_explicit_replicator: bool,
         /// Capability-based explicit replay authorization carried by two-stream pushes.
         explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
+        /// Optional local-ACP actor relationship snapshot for the document.
+        acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
     },
 
     /// DAG is ready for merge after Bitswap fetch completed.
@@ -86,5 +93,7 @@ pub enum SyncEvent {
         is_explicit_replicator: bool,
         /// Capability-based explicit replay authorization carried by two-stream pushes.
         explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
+        /// Optional local-ACP actor relationship snapshot for the document.
+        acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
     },
 }

--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
+use acp::ReplicatedDocActorRelationships;
 use cid::Cid;
 
 use crate::ExplicitReplayAuthorization;
@@ -39,6 +40,8 @@ pub struct PendingDag {
     pub is_explicit_replicator: bool,
     /// Capability-based explicit replay authorization carried by two-stream pushes.
     pub explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
+    /// Optional local-ACP actor relationship snapshot for the document.
+    pub acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
     /// When this entry was inserted (for TTL eviction).
     pub inserted_at: Instant,
 }

--- a/crates/p2p/src/sync/manager/process/bitswap.rs
+++ b/crates/p2p/src/sync/manager/process/bitswap.rs
@@ -61,6 +61,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                             sender_peer: dag.source_peer,
                             is_explicit_replicator: dag.is_explicit_replicator,
                             explicit_replay_authorization: dag.explicit_replay_authorization,
+                            acp_actor_relationships: dag.acp_actor_relationships,
                         })
                         .await
                         .is_err()

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -116,6 +116,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 source_peer: Some(source_peer),
                 is_explicit_replicator: false,
                 explicit_replay_authorization: None,
+                acp_actor_relationships: None,
                 inserted_at: Instant::now(),
             },
         ) {
@@ -154,6 +155,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 source_peer: Some(source_peer),
                 is_explicit_replicator: false,
                 explicit_replay_authorization: None,
+                acp_actor_relationships: None,
                 inserted_at: Instant::now(),
             },
         ) {
@@ -273,6 +275,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 sender_peer: info.source_peer.clone(),
                 is_explicit_replicator: info.is_explicit_replicator,
                 explicit_replay_authorization: info.explicit_replay_authorization.clone(),
+                acp_actor_relationships: info.acp_actor_relationships.clone(),
             })
             .await;
 

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -83,6 +83,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                                 cid,
                                 doc_id: msg.doc_id.clone(),
                                 collection_id: msg.collection_id.clone(),
+                                acp_actor_relationships: msg.acp_actor_relationships.clone(),
                             })
                             .await
                             .is_err()
@@ -150,6 +151,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         cid: *cid,
                         doc_id: msg.doc_id.clone(),
                         collection_id: msg.collection_id.clone(),
+                        acp_actor_relationships: msg.acp_actor_relationships.clone(),
                     })
                     .await
                     .is_err()
@@ -256,6 +258,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     sender_peer: sender_peer.map(str::to_owned),
                     is_explicit_replicator,
                     explicit_replay_authorization,
+                    acp_actor_relationships: msg.acp_actor_relationships.clone(),
                 })
                 .await
                 .is_err()
@@ -316,6 +319,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                                 is_explicit_replicator,
                                 explicit_replay_authorization: explicit_replay_authorization
                                     .clone(),
+                                acp_actor_relationships: msg.acp_actor_relationships.clone(),
                                 inserted_at: now,
                             },
                         );
@@ -350,6 +354,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     sender_peer: sender_peer.map(str::to_owned),
                     is_explicit_replicator,
                     explicit_replay_authorization,
+                    acp_actor_relationships: msg.acp_actor_relationships.clone(),
                 })
                 .await
                 .is_err()

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -3,6 +3,8 @@
 use blockstore::Blockstore;
 use cid::Cid;
 
+use acp::ReplicatedDocActorRelationships;
+
 use super::config::ReplicationConfig;
 use super::result::ReplicationResult;
 use crate::sync::coordinator::SyncCoordinator;
@@ -75,6 +77,7 @@ pub(super) async fn handle_block_received<B, T, H>(
     config: &ReplicationConfig,
     cid: Cid,
     metadata: BlockMetadata<'_>,
+    acp_actor_relationships: Option<&ReplicatedDocActorRelationships>,
 ) -> ReplicationResult
 where
     B: Blockstore + 'static,
@@ -166,6 +169,16 @@ where
                 }
             }
 
+            if let Err(error) = coordinator
+                .apply_replicated_actor_relationships(&doc_id_for_result, acp_actor_relationships)
+                .await
+            {
+                return ReplicationResult::Failed {
+                    cid,
+                    error: error.to_string(),
+                };
+            }
+
             ReplicationResult::Merged {
                 cid,
                 doc_id: doc_id_for_result,
@@ -178,6 +191,18 @@ where
                     return ReplicationResult::MergedButNotMarked {
                         cid,
                         error: format!("skipped but failed to mark: {}", e),
+                    };
+                }
+                if let Err(error) = coordinator
+                    .apply_replicated_actor_relationships(
+                        &doc_id_for_result,
+                        acp_actor_relationships,
+                    )
+                    .await
+                {
+                    return ReplicationResult::Failed {
+                        cid,
+                        error: error.to_string(),
                     };
                 }
             }
@@ -199,10 +224,17 @@ where
 
 /// Returns true if this event type can be batch-merged.
 pub(super) fn is_mergeable_event(event: &SyncEvent) -> bool {
-    matches!(
-        event,
-        SyncEvent::BlockReceived { .. } | SyncEvent::DagReady { .. }
-    )
+    match event {
+        SyncEvent::BlockReceived {
+            acp_actor_relationships,
+            ..
+        }
+        | SyncEvent::DagReady {
+            acp_actor_relationships,
+            ..
+        } => acp_actor_relationships.is_none(),
+        _ => false,
+    }
 }
 
 /// Extract merge block metadata from a SyncEvent.
@@ -226,6 +258,7 @@ fn event_to_merge_metadata(
             sender_peer,
             is_explicit_replicator,
             explicit_replay_authorization,
+            ..
         } => (
             *cid,
             doc_id.clone(),
@@ -243,6 +276,7 @@ fn event_to_merge_metadata(
             sender_peer,
             is_explicit_replicator,
             explicit_replay_authorization,
+            ..
         } => (
             *root_cid,
             doc_id.clone(),
@@ -401,6 +435,7 @@ where
             sender_peer,
             is_explicit_replicator,
             explicit_replay_authorization,
+            acp_actor_relationships,
         } => {
             handle_block_received(
                 coordinator,
@@ -415,6 +450,7 @@ where
                     is_explicit_replicator,
                 )
                 .with_explicit_replay_authorization(explicit_replay_authorization),
+                acp_actor_relationships.as_ref(),
             )
             .await
         }
@@ -422,13 +458,26 @@ where
             cid,
             doc_id,
             collection_id,
-        } => ReplicationResult::Skipped {
-            cid,
-            doc_id,
-            collection_id,
-            reason: "already merged".to_string(),
-            terminal: true,
-        },
+            acp_actor_relationships,
+        } => {
+            if let Err(error) = coordinator
+                .apply_replicated_actor_relationships(&doc_id, acp_actor_relationships.as_ref())
+                .await
+            {
+                ReplicationResult::Failed {
+                    cid,
+                    error: error.to_string(),
+                }
+            } else {
+                ReplicationResult::Skipped {
+                    cid,
+                    doc_id,
+                    collection_id,
+                    reason: "already merged".to_string(),
+                    terminal: true,
+                }
+            }
+        }
         SyncEvent::SyncError { cid, error } => ReplicationResult::Failed { cid, error },
         SyncEvent::DagNeedsFetch {
             root_cid,
@@ -444,6 +493,7 @@ where
             sender_peer,
             is_explicit_replicator,
             explicit_replay_authorization,
+            acp_actor_relationships,
         } => {
             // DAG is complete after Bitswap fetch - process as block received
             tracing::info!(
@@ -464,6 +514,7 @@ where
                     is_explicit_replicator,
                 )
                 .with_explicit_replay_authorization(explicit_replay_authorization),
+                acp_actor_relationships.as_ref(),
             )
             .await
         }

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -471,6 +471,7 @@ mod tests {
             sender_peer: None,
             is_explicit_replicator: false,
             explicit_replay_authorization: None,
+            acp_actor_relationships: None,
         })
         .await
         .unwrap();
@@ -577,6 +578,7 @@ mod tests {
             &config,
             cid,
             BlockMetadata::normal("doc1", "col1", "peer1", Some("sender1"), true),
+            None,
         )
         .await;
 
@@ -599,6 +601,7 @@ mod tests {
             &config,
             cid,
             BlockMetadata::normal("doc1", "col1", "peer1", Some("sender1"), true),
+            None,
         )
         .await;
 
@@ -684,6 +687,7 @@ mod tests {
             sender_peer: None,
             is_explicit_replicator: false,
             explicit_replay_authorization: None,
+            acp_actor_relationships: None,
         })
         .await
         .unwrap();

--- a/crates/p2p/src/sync/replication/recovery.rs
+++ b/crates/p2p/src/sync/replication/recovery.rs
@@ -77,6 +77,7 @@ where
             &config,
             cid,
             BlockMetadata::recovery(),
+            None,
         )
         .await;
 

--- a/crates/p2p/tests/message_tests.rs
+++ b/crates/p2p/tests/message_tests.rs
@@ -267,6 +267,7 @@ fn test_pushlog_broadcast_serialization() {
         "collection1".to_string(),
         "creator1".to_string(),
         Bytes::from(vec![5, 6, 7, 8]),
+        None,
     );
 
     let encoded = encode_with_ciborium(&broadcast);
@@ -288,6 +289,7 @@ fn test_pushlog_broadcast_cbor_field_names() {
         "collection3".to_string(),
         "creator3".to_string(),
         Bytes::from(vec![4, 5, 6]),
+        None,
     );
 
     let encoded = encode_with_ciborium(&broadcast);
@@ -367,6 +369,7 @@ fn test_pushlog_broadcast_to_request() {
         "col3".to_string(),
         "creator3".to_string(),
         Bytes::from(vec![100, 110, 120]),
+        None,
     );
 
     let request = broadcast.to_request();

--- a/crates/p2p/tests/sync_manager_tests.rs
+++ b/crates/p2p/tests/sync_manager_tests.rs
@@ -38,6 +38,7 @@ fn create_test_broadcast(cid: &Cid) -> PushLogBroadcast {
         "collection1".to_string(),
         "creator1".to_string(),
         Bytes::from(BLOCK_DATA.to_vec()),
+        None,
     )
 }
 
@@ -213,6 +214,7 @@ async fn test_process_pushlog_invalid_cid_returns_error() {
         "collection1".to_string(),
         "creator1".to_string(),
         Bytes::from(b"block data".to_vec()),
+        None,
     );
 
     // Processing should fail with InvalidCid error
@@ -240,6 +242,7 @@ async fn test_process_pushlog_cid_mismatch_returns_error() {
         "collection1".to_string(),
         "creator1".to_string(),
         Bytes::from(b"tampered content".to_vec()),
+        None,
     );
 
     let result = manager.process_pushlog(&msg, None, false, None).await;
@@ -425,6 +428,7 @@ async fn test_pending_dag_completes_when_missing_block_arrives_via_pushlog() {
         "collection1".to_string(),
         "creator1".to_string(),
         Bytes::from(composite_block),
+        None,
     );
 
     manager
@@ -453,6 +457,7 @@ async fn test_pending_dag_completes_when_missing_block_arrives_via_pushlog() {
         "collection1".to_string(),
         "creator1".to_string(),
         Bytes::from(field_block),
+        None,
     );
 
     manager

--- a/tools/integration-test/tests/acp/negative_p2p.rs
+++ b/tools/integration-test/tests/acp/negative_p2p.rs
@@ -5,14 +5,15 @@ use integration_test::{
     USER_ACP_POLICY,
 };
 
-/// 02-24: P2P replication does not grant cross-node access to ACP-protected documents.
+/// 02-24: P2P replication must not grant access to identities without a relationship.
 ///
-/// When a document replicates from node0 to node1, the ACP state does NOT replicate.
-/// An identity that was not granted access on node1 must not be able to read the
-/// protected document on node1 even after replication.
+/// When a document replicates from node0 to node1, only the explicit document
+/// relationships should carry across. An unrelated identity must not gain read
+/// access on the receiving node just because the document replicated.
 ///
-/// This tests the merge-denial property: receiving a replicated block does not
-/// automatically grant read permission to any identity on the receiving node.
+/// This keeps the merge-denial property: receiving a replicated block must not
+/// automatically grant read permission to identities without a matching ACP
+/// relationship.
 async fn p2p_merge_denial_test(cluster: TestCluster) {
     let node0 = cluster.client(0);
     let node1 = cluster.client(1);
@@ -20,6 +21,7 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
 
     let alice = generate_identity(&binary).expect("Alice identity");
     let bob = generate_identity(&binary).expect("Bob identity");
+    let charlie = generate_identity(&binary).expect("Charlie identity");
 
     let timeout = Duration::from_secs(15);
     cluster
@@ -112,15 +114,14 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
     )
     .await;
 
-    // Bob queries node1 — the ACP grant from node0 did NOT replicate.
-    // Bob must see 0 documents on node1 (merge-denial: replication ≠ access grant).
+    // Bob queries node1. His reader grant from node0 should now replicate.
     let bob_node1 = node1
         .query_with_identity("query { User { _docID name } }", &bob.private_key_hex)
         .expect("Bob query on node1");
     let bob_node1_count = bob_node1["User"].as_array().map(|a| a.len()).unwrap_or(0);
     assert_eq!(
-        bob_node1_count, 0,
-        "ACP relationships must not replicate — Bob must not access the document on node1 without an explicit grant there"
+        bob_node1_count, 1,
+        "Bob must see the replicated document on node1 after the reader grant replicates"
     );
 
     let bob_commits_node1 = node1
@@ -136,9 +137,38 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
         .as_array()
         .map(|a| a.len())
         .unwrap_or(0);
+    assert!(
+        bob_commits_count > 0,
+        "Bob must read _commits on node1 after the reader grant replicates"
+    );
+
+    // Charlie was never granted access, so replication must not make the
+    // document visible to him on node1.
+    let charlie_node1 = node1
+        .query_with_identity("query { User { _docID name } }", &charlie.private_key_hex)
+        .expect("Charlie query on node1");
+    let charlie_node1_count = charlie_node1["User"].as_array().map(|a| a.len()).unwrap_or(0);
     assert_eq!(
-        bob_commits_count, 0,
-        "Bob must not read _commits on node1 before a local ACP grant"
+        charlie_node1_count, 0,
+        "replication must not grant access on node1 to identities without a relationship"
+    );
+
+    let charlie_commits_node1 = node1
+        .query_with_identity(
+            &format!(
+                r#"query {{ _commits(docID: "{}") {{ cid height }} }}"#,
+                doc_id
+            ),
+            &charlie.private_key_hex,
+        )
+        .expect("Charlie commits query on node1");
+    let charlie_commits_count = charlie_commits_node1["_commits"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
+    assert_eq!(
+        charlie_commits_count, 0,
+        "Charlie must not read _commits on node1 without a local or replicated grant"
     );
 
     // Alice can still read the document on node1 (she's the owner, not relying on grant)
@@ -151,39 +181,6 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
         "Alice must read her document on node1 as owner"
     );
 
-    node1
-        .acp_relationship_add("User", &doc_id, "reader", &bob.did, &alice.private_key_hex)
-        .expect("grant Bob reader on node1");
-
-    let bob_node1_after_grant = node1
-        .query_with_identity("query { User { _docID name } }", &bob.private_key_hex)
-        .expect("Bob query on node1 after grant");
-    assert_eq!(
-        bob_node1_after_grant["User"]
-            .as_array()
-            .map(|a| a.len())
-            .unwrap_or(0),
-        1,
-        "Bob must see the replicated document on node1 after a local reader grant"
-    );
-
-    let bob_commits_after_grant = node1
-        .query_with_identity(
-            &format!(
-                r#"query {{ _commits(docID: "{}") {{ cid height }} }}"#,
-                doc_id
-            ),
-            &bob.private_key_hex,
-        )
-        .expect("Bob commits query on node1 after grant");
-    let bob_commits_after_grant_count = bob_commits_after_grant["_commits"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0);
-    assert!(
-        bob_commits_after_grant_count > 0,
-        "Bob must see _commits on node1 after a local reader grant"
-    );
 }
 
 #[tokio::test]

--- a/tools/integration-test/tests/acp/negative_p2p.rs
+++ b/tools/integration-test/tests/acp/negative_p2p.rs
@@ -147,7 +147,10 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
     let charlie_node1 = node1
         .query_with_identity("query { User { _docID name } }", &charlie.private_key_hex)
         .expect("Charlie query on node1");
-    let charlie_node1_count = charlie_node1["User"].as_array().map(|a| a.len()).unwrap_or(0);
+    let charlie_node1_count = charlie_node1["User"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0);
     assert_eq!(
         charlie_node1_count, 0,
         "replication must not grant access on node1 to identities without a relationship"
@@ -180,7 +183,6 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
         1,
         "Alice must read her document on node1 as owner"
     );
-
 }
 
 #[tokio::test]

--- a/tools/integration-test/tests/acp/negative_p2p.rs
+++ b/tools/integration-test/tests/acp/negative_p2p.rs
@@ -114,6 +114,22 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
     )
     .await;
 
+    let node1_ref = &node1;
+    let bob_key = bob.private_key_hex.clone();
+    poll_until(
+        || {
+            node1_ref
+                .query_with_identity("query { User { _docID name } }", &bob_key)
+                .ok()
+                .and_then(|v| v["User"].as_array().map(|a| a.len() == 1))
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "Bob did not gain access on node1 after the replicated reader grant",
+    )
+    .await;
+
     // Bob queries node1. His reader grant from node0 should now replicate.
     let bob_node1 = node1
         .query_with_identity("query { User { _docID name } }", &bob.private_key_hex)
@@ -123,6 +139,26 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
         bob_node1_count, 1,
         "Bob must see the replicated document on node1 after the reader grant replicates"
     );
+
+    poll_until(
+        || {
+            node1_ref
+                .query_with_identity(
+                    &format!(
+                        r#"query {{ _commits(docID: "{}") {{ cid height }} }}"#,
+                        doc_id
+                    ),
+                    &bob_key,
+                )
+                .ok()
+                .and_then(|v| v["_commits"].as_array().map(|a| !a.is_empty()))
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "Bob did not gain _commits visibility on node1 after the replicated reader grant",
+    )
+    .await;
 
     let bob_commits_node1 = node1
         .query_with_identity(

--- a/tools/integration-test/tests/p2p_iroh/acp/acp.rs
+++ b/tools/integration-test/tests/p2p_iroh/acp/acp.rs
@@ -2,7 +2,8 @@
 //!
 //! Verifies that ACP policies work correctly with iroh P2P replication:
 //! - Both public and protected docs replicate
-//! - ACP enforcement is node-local (relationships don't replicate)
+//! - ACP-enforced visibility is preserved on the receiving node
+//! - Relationship replication is covered by the DAC-specific ACP P2P tests
 //! - Owner identity sees protected docs on originating node
 //! - Anonymous sees only public docs on originating node
 //!

--- a/tools/integration-test/tests/p2p_iroh/acp/dac.rs
+++ b/tools/integration-test/tests/p2p_iroh/acp/dac.rs
@@ -315,6 +315,211 @@ async fn replicator_permissioned_local() {
     );
 }
 
+async fn setup_local_cluster() -> (TestCluster, String, String) {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_acp_local()
+        .with_iroh_transport()
+        .build()
+        .await
+        .unwrap();
+
+    for i in 0..2 {
+        cluster
+            .wait_for_log(i, "p2p_listening", P2P_TIMEOUT)
+            .await
+            .unwrap_or_else(|_| panic!("node{} P2P listener", i));
+    }
+
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+    let binary = node0.binary_path().to_path_buf();
+    let owner = generate_identity(&binary).expect("generate owner identity");
+    let owner_key = owner.private_key_hex.clone();
+
+    let policy_id = extract_policy_id(
+        &node0
+            .acp_policy_add(ACP_POLICY, &owner_key)
+            .expect("add local ACP policy on node0"),
+    );
+    node1
+        .acp_policy_add(ACP_POLICY, &owner_key)
+        .expect("add local ACP policy on node1");
+
+    let schema = ACP_SCHEMA.replace("%POLICY_ID%", &policy_id);
+    node0
+        .schema_add_with_identity(&schema, &owner_key)
+        .expect("schema node0");
+    node1
+        .schema_add_with_identity(&schema, &owner_key)
+        .expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect");
+    node0.p2p_collection_add(&["Users"]).expect("col node0");
+    node1.p2p_collection_add(&["Users"]).expect("col node1");
+    node0
+        .p2p_replicator_set(&["Users"], &addr1)
+        .expect("replicator");
+
+    (cluster, policy_id, owner_key)
+}
+
+#[tokio::test]
+#[serial]
+async fn local_relationship_grant_replicates_to_peer() {
+    let (cluster, _policy_id, owner_key) = setup_local_cluster().await;
+
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+    let binary = node0.binary_path().to_path_buf();
+    let reader = generate_identity(&binary).expect("generate reader identity");
+
+    let data = node0
+        .query_with_identity(
+            r#"mutation { add_Users(input: {name: "GrantTarget", age: 41}) { _docID } }"#,
+            &owner_key,
+        )
+        .expect("create GrantTarget");
+    let doc_id = extract_doc_id(&data, "add_Users");
+
+    let owner_key_clone = owner_key.clone();
+    poll_until(
+        || {
+            let r = node1
+                .query_with_identity("query { Users { name } }", &owner_key_clone)
+                .unwrap_or_default();
+            r["Users"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .any(|u| u["name"].as_str() == Some("GrantTarget"))
+                })
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(300),
+        "GrantTarget did not replicate to node1 for owner",
+    )
+    .await;
+
+    let before = node1
+        .query_with_identity("query { Users { name } }", &reader.private_key_hex)
+        .unwrap_or_default();
+    assert_eq!(
+        before["Users"].as_array().map(|a| a.len()).unwrap_or(0),
+        0,
+        "reader should not see local ACP doc before relationship grant"
+    );
+
+    node0
+        .acp_relationship_add("Users", &doc_id, "reader", &reader.did, &owner_key)
+        .expect("grant reader relationship");
+
+    let reader_key = reader.private_key_hex.clone();
+    poll_until(
+        || {
+            let r = node1
+                .query_with_identity("query { Users { name } }", &reader_key)
+                .unwrap_or_default();
+            r["Users"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .any(|u| u["name"].as_str() == Some("GrantTarget"))
+                })
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(300),
+        "local ACP relationship grant did not replicate to node1",
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn local_relationship_revoke_replicates_to_peer() {
+    let (cluster, _policy_id, owner_key) = setup_local_cluster().await;
+
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+    let binary = node0.binary_path().to_path_buf();
+    let reader = generate_identity(&binary).expect("generate reader identity");
+
+    let data = node0
+        .query_with_identity(
+            r#"mutation { add_Users(input: {name: "RevokeTarget", age: 42}) { _docID } }"#,
+            &owner_key,
+        )
+        .expect("create RevokeTarget");
+    let doc_id = extract_doc_id(&data, "add_Users");
+
+    let owner_key_clone = owner_key.clone();
+    poll_until(
+        || {
+            let r = node1
+                .query_with_identity("query { Users { name } }", &owner_key_clone)
+                .unwrap_or_default();
+            r["Users"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .any(|u| u["name"].as_str() == Some("RevokeTarget"))
+                })
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(300),
+        "RevokeTarget did not replicate to node1 for owner",
+    )
+    .await;
+
+    node0
+        .acp_relationship_add("Users", &doc_id, "reader", &reader.did, &owner_key)
+        .expect("grant reader relationship");
+
+    let reader_key = reader.private_key_hex.clone();
+    poll_until(
+        || {
+            let r = node1
+                .query_with_identity("query { Users { name } }", &reader_key)
+                .unwrap_or_default();
+            r["Users"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .any(|u| u["name"].as_str() == Some("RevokeTarget"))
+                })
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(300),
+        "reader did not gain replicated local ACP access on node1",
+    )
+    .await;
+
+    node0
+        .acp_relationship_delete("Users", &doc_id, "reader", &reader.did, &owner_key)
+        .expect("revoke reader relationship");
+
+    poll_until(
+        || {
+            let r = node1
+                .query_with_identity("query { Users { name } }", &reader_key)
+                .unwrap_or_default();
+            r["Users"]
+                .as_array()
+                .map(|arr| arr.is_empty())
+                .unwrap_or(false)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(300),
+        "local ACP relationship revoke did not replicate to node1",
+    )
+    .await;
+}
+
 // ---------------------------------------------------------------------------
 // SourceHub ACP tests
 // ---------------------------------------------------------------------------

--- a/tools/integration-test/tests/p2p_iroh/acp/trust_boundary.rs
+++ b/tools/integration-test/tests/p2p_iroh/acp/trust_boundary.rs
@@ -7,7 +7,7 @@
 //! - ACP-protected docs replicate from Core to Near
 //! - Owner sees both public and protected docs on Core
 //! - Anonymous sees only public doc on Core
-//! - ACP state is node-local (not replicated)
+//! - Receiving-node visibility still respects ACP after replication
 //! - Non-owner identity visibility rules
 //!
 //! Run with:


### PR DESCRIPTION
Closes #772

## Summary
- propagate local ACP document actor relationships by attaching a document-scoped relationship snapshot to republished P2P document updates
- apply replicated relationship snapshots on receiving peers after merge or duplicate-block handling, wired through both embedded and CLI P2P runtimes
- add focused iroh integration coverage for local ACP relationship grant and revoke replication

## Testing
- cargo check -p p2p -p acp --message-format short
- cargo check -p embedded -p ffi --message-format short
- cargo check -p cli -p defra-http --features iroh --message-format short
- cargo test -p integration-test --test p2p_iroh local_relationship_ -- --nocapture

## Notes
- `cargo test -p integration-test --test p2p_iroh acp::dac -- --nocapture` is not fully runnable in this environment because `sourcehubd` is unavailable locally; the relevant local ACP replication cases are covered above.