### PR TITLE
fix(query): explicit permission-denied error on ACP single-doc reads (#551)

### DIFF
--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -3,6 +3,7 @@
 //! This node wraps a source node and filters out documents that the
 //! identity context doesn't have permission to read.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use acp::{DocumentACP, DocumentPermission, Identity};
@@ -10,7 +11,7 @@ use async_trait::async_trait;
 use identity::Did;
 
 use crate::document::DocumentMapping;
-use crate::error::Result;
+use crate::error::{QueryError, Result};
 use crate::planner::{Doc, PlanNode};
 use crate::txn::check_doc_access_with_overlay;
 
@@ -40,6 +41,18 @@ pub struct PermissionFilterNode {
 
     /// Document mapping from source
     document_mapping: DocumentMapping,
+
+    /// Doc IDs the caller explicitly requested (e.g., via
+    /// `_docID: { _eq: "..." }` or `docID: "..."`). When non-empty and
+    /// at least one of these is denied, `next()` returns a
+    /// `permission_denied` error after the source is exhausted instead
+    /// of silently returning fewer results — matching Go's behavior and
+    /// closing the read-side gap reported in #551.
+    requested_doc_ids: HashSet<String>,
+
+    /// Subset of `requested_doc_ids` that were emitted by the source
+    /// but failed the read-permission check.
+    denied_requested_ids: Vec<String>,
 }
 
 impl PermissionFilterNode {
@@ -67,7 +80,20 @@ impl PermissionFilterNode {
             resource_name: resource_name.into(),
             current_doc: Doc::default(),
             document_mapping,
+            requested_doc_ids: HashSet::new(),
+            denied_requested_ids: Vec::new(),
         }
+    }
+
+    /// Mark a set of document IDs as explicitly requested by the caller.
+    ///
+    /// When any of these IDs are emitted by the source but denied by ACP,
+    /// `next()` will return a `permission_denied` error after the source is
+    /// drained instead of silently filtering them out. Browse queries
+    /// (no explicit doc IDs) keep the existing filter-only semantics.
+    pub fn with_requested_doc_ids(mut self, doc_ids: Vec<String>) -> Self {
+        self.requested_doc_ids = doc_ids.into_iter().collect();
+        self
     }
 
     /// Create from an optional DID for backward compatibility.
@@ -129,6 +155,19 @@ impl PlanNode for PermissionFilterNode {
         loop {
             // Get next document from source
             if !self.source.next().await? {
+                // Source drained. If the caller explicitly asked for
+                // specific doc IDs and any of those were denied by ACP,
+                // surface that as an explicit permission-denied error
+                // instead of silently returning fewer results (#551).
+                if !self.denied_requested_ids.is_empty() {
+                    let mut ids = std::mem::take(&mut self.denied_requested_ids);
+                    ids.sort();
+                    ids.dedup();
+                    return Err(QueryError::permission_denied(format!(
+                        "read denied for doc_id(s): {}",
+                        ids.join(", ")
+                    )));
+                }
                 return Ok(false);
             }
 
@@ -151,6 +190,12 @@ impl PlanNode for PermissionFilterNode {
             if self.has_read_permission(&doc_id).await? {
                 self.current_doc = doc.deep_clone();
                 return Ok(true);
+            }
+
+            // Denied. If this doc was explicitly requested by ID, remember
+            // it so we can surface an error after the source is drained.
+            if self.requested_doc_ids.contains(&doc_id) {
+                self.denied_requested_ids.push(doc_id);
             }
 
             // No permission, continue to next document

--- a/crates/query/src/planner/builder/mod.rs
+++ b/crates/query/src/planner/builder/mod.rs
@@ -150,19 +150,31 @@ impl Planner {
     }
 
     /// Conditionally wrap a plan with a PermissionFilterNode if the collection has an ACP policy.
+    ///
+    /// `requested_doc_ids` should be passed when the caller targets specific
+    /// documents by ID (e.g. via `_docID: { _eq: "..." }`); the filter then
+    /// surfaces an explicit permission-denied error when any of those IDs are
+    /// filtered out, instead of silently returning fewer results (#551).
     pub(super) fn maybe_wrap_with_acp_filter(
         &self,
         plan: Box<dyn PlanNode>,
         collection: &CollectionVersion,
+        requested_doc_ids: Option<&[String]>,
     ) -> Box<dyn PlanNode> {
         if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
-            Box::new(PermissionFilterNode::from_optional_did(
+            let mut node = PermissionFilterNode::from_optional_did(
                 plan,
                 acp.clone(),
                 self.identity_did.clone(),
                 &policy.id,
                 &policy.resource_name,
-            ))
+            );
+            if let Some(ids) = requested_doc_ids {
+                if !ids.is_empty() {
+                    node = node.with_requested_doc_ids(ids.to_vec());
+                }
+            }
+            Box::new(node)
         } else {
             plan
         }
@@ -575,7 +587,7 @@ impl Planner {
 
         // Insert ACP permission filter for the root collection (if ACP-protected).
         // Position: after Select/joins/similarity but before GroupBy/Aggregates/OrderBy/Limit.
-        plan = self.maybe_wrap_with_acp_filter(plan, &collection);
+        plan = self.maybe_wrap_with_acp_filter(plan, &collection, select.doc_ids.as_deref());
 
         // Apply GroupBy/OrderBy/Limit (or just OrderBy/Aggregates/Limit without GROUP BY)
         plan = self.apply_groupby_ordering_limit(

--- a/crates/query/src/planner/joins/aggregate_joins.rs
+++ b/crates/query/src/planner/joins/aggregate_joins.rs
@@ -454,7 +454,8 @@ impl Planner {
                     }
 
                     // Insert ACP permission filter for the aggregate child collection (if ACP-protected).
-                    child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+                    child_plan =
+                        self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
                     // Set up child mapping in parent for TypeJoin (after sub-join modifications)
                     mapping.set_child_at(effective_relation_index, child_scan_mapping.clone());

--- a/crates/query/src/planner/joins/filter_relation.rs
+++ b/crates/query/src/planner/joins/filter_relation.rs
@@ -85,7 +85,7 @@ impl Planner {
         let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
 
         // Insert ACP permission filter for the child collection (if ACP-protected).
-        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
         // Find the other side of the relation
         let target_relation_field = if let Some(rel_name) = &relation_field.relation_name {

--- a/crates/query/src/planner/joins/mod.rs
+++ b/crates/query/src/planner/joins/mod.rs
@@ -1046,7 +1046,7 @@ impl Planner {
             }
 
             // Insert ACP permission filter for the child collection (if ACP-protected).
-            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
             // Update parent mapping with the final child mapping (after sub-joins)
             // This ensures the nested relation mappings are included

--- a/crates/query/src/planner/joins/multi_level.rs
+++ b/crates/query/src/planner/joins/multi_level.rs
@@ -102,7 +102,7 @@ impl Planner {
             let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
 
             // Insert ACP permission filter for the child collection (if ACP-protected).
-            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
             // Find the other side of the relation
             let target_relation_field = if let Some(rel_name) = &relation_field.relation_name {
@@ -226,7 +226,7 @@ impl Planner {
         let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
 
         // Insert ACP permission filter for the child collection (if ACP-protected).
-        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
         // Add sub-joins for remaining path levels within the child plan
         if path.len() > 1 {

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -271,13 +271,22 @@ pub(crate) fn build_plan(
     // Insert ACP permission filter after Select, before OrderBy/Limit/Aggregates.
     // This ensures aggregates (count, average, etc.) operate on filtered documents.
     if let Some(acf) = acp_filter {
-        plan = Box::new(PermissionFilterNode::new(
+        let mut filter_node = PermissionFilterNode::new(
             plan,
             acf.acp,
             acf.identity,
             acf.policy_id,
             acf.resource_name,
-        ));
+        );
+        // If the caller asked for specific docs by ID, surface an explicit
+        // permission-denied error when any of them are filtered out
+        // (#551 — Backbone parity for read-side denial shape).
+        if let Some(ref doc_ids) = select.doc_ids {
+            if !doc_ids.is_empty() {
+                filter_node = filter_node.with_requested_doc_ids(doc_ids.clone());
+            }
+        }
+        plan = Box::new(filter_node);
     }
 
     // Check if we have GROUP BY

--- a/tools/integration-test/tests/acp/basic.rs
+++ b/tools/integration-test/tests/acp/basic.rs
@@ -77,3 +77,109 @@ async fn acp_basic_test(cluster: TestCluster) {
 }
 
 for_each_runtime!(acp_basic, acp_basic_test, .with_acp_local());
+
+/// Regression test for #551 — single-doc reads against an ACP-protected
+/// document by a user without permission must surface an explicit
+/// permission-denied GraphQL error, not a silent empty result.
+///
+/// Browse queries (no explicit doc ID) keep the existing filter-only
+/// semantics; only explicit `User(docID: "...")` lookups error.
+///
+/// Rust-only: Go DefraDB still returns empty results in this case, which
+/// is the upstream gap Backbone CI hit. Once Go gains the same behavior
+/// this test can move to `for_each_runtime!`.
+#[tokio::test]
+async fn rust_acp_explicit_denial_on_single_doc_read() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_acp_local()
+        .build()
+        .await
+        .expect("build rust cluster with local acp");
+    acp_explicit_denial_on_single_doc_read_test(cluster).await;
+}
+
+async fn acp_explicit_denial_on_single_doc_read_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary_path = node.binary_path().to_path_buf();
+
+    let alice = generate_identity(&binary_path).expect("generate Alice");
+    let bob = generate_identity(&binary_path).expect("generate Bob");
+
+    let policy_result = node
+        .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+        .expect("add policy");
+    let policy_id = policy_result["PolicyID"]
+        .as_str()
+        .or_else(|| policy_result["policyID"].as_str())
+        .expect("missing PolicyID");
+
+    let schema = users_schema_with_policy(policy_id);
+    node.schema_add_with_identity(&schema, &alice.private_key_hex)
+        .expect("add schema");
+
+    let data = node
+        .query_with_identity(
+            r#"mutation { add_User(input: {name: "Secret", age: 42}) { _docID name } }"#,
+            &alice.private_key_hex,
+        )
+        .expect("create protected doc");
+    let doc_id = data["add_User"][0]["_docID"]
+        .as_str()
+        .expect("missing _docID")
+        .to_string();
+
+    // Browse query: still silently filtered (Bob sees an empty array).
+    let browse_result = node
+        .query_with_identity("query { User { _docID name } }", &bob.private_key_hex)
+        .expect("Bob browse query failed");
+    let browse_users = browse_result["User"]
+        .as_array()
+        .expect("browse result not array");
+    assert_eq!(
+        browse_users.len(),
+        0,
+        "browse queries should still silently filter denied docs"
+    );
+
+    // Explicit single-doc query: must surface an error mentioning the denied doc ID.
+    // Different runtimes wrap denial errors differently — accept either an Err from
+    // the client or an `errors[]` field in the JSON response.
+    let single_doc_query = format!(r#"query {{ User(docID: "{}") {{ _docID name }} }}"#, doc_id);
+    let single_doc_result = node.query_with_identity(&single_doc_query, &bob.private_key_hex);
+
+    let denial_message = match &single_doc_result {
+        Err(err) => err.to_string(),
+        Ok(value) => {
+            // Some HTTP layers surface GraphQL errors as a 200 response with
+            // an `errors[]` field; check both shapes.
+            let errors = value
+                .get("errors")
+                .and_then(|v| v.as_array())
+                .filter(|arr| !arr.is_empty());
+            match errors {
+                Some(arr) => arr
+                    .iter()
+                    .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("; "),
+                None => panic!(
+                    "expected explicit permission-denied error for single-doc read, got: {}",
+                    serde_json::to_string_pretty(value).unwrap()
+                ),
+            }
+        }
+    };
+
+    assert!(
+        denial_message.to_lowercase().contains("denied")
+            || denial_message.to_lowercase().contains("permission"),
+        "denial message should mention permission/denied, got: {}",
+        denial_message
+    );
+    assert!(
+        denial_message.contains(&doc_id),
+        "denial message should reference the requested doc id, got: {}",
+        denial_message
+    );
+}


### PR DESCRIPTION
## Summary

Closes #551. When a GraphQL read targets a specific document by ID (e.g. `User(docID: \"...\")`) and the caller lacks read permission, the query now returns an explicit `permission_denied` error in `errors[]` instead of silently filtering the document out and returning an empty result set.

Backbone full-stack CI hit this gap when an unauthorized service read a `Transcript` before being granted the `reader` relation. The silent empty result made denial assertions weak — Backbone could only check 'empty means denied', which hides unrelated bugs.

## What changes

- [crates/query/src/plan/permission_filter.rs](crates/query/src/plan/permission_filter.rs) — `PermissionFilterNode` now tracks which user-requested doc IDs were denied during iteration and surfaces them in a single `permission_denied` error after the source is drained.
- [crates/query/src/runner/plan.rs](crates/query/src/runner/plan.rs) and [crates/query/src/planner/builder/mod.rs](crates/query/src/planner/builder/mod.rs) — wire `select.doc_ids` into the filter node so it knows which IDs were explicitly requested.
- Join-time ACP wrapping passes `None` (joins follow doc IDs from parent traversal, not from the user request) — preserves existing behavior for nested reads.

## What does NOT change

- **Browse queries** (`{ User { ... } }` with no `docID`) keep their current filter-only semantics. Collection scans still return whatever the caller is permitted to see, so existing assertions like \"Bob sees 0 docs before grant\" continue to hold.
- **Mutations** were already explicit — this just brings the read path into parity.
- **Wire format / GraphQL response shape** — the error is delivered through the existing `errors[]` channel using `QueryError::permission_denied`, the same variant the mutation path uses today.

## Test plan

- [x] `cargo test -p query` — 210/210 passing
- [x] `cargo test -p integration-test --test acp` — **197/197 passing** (was 196 — the new regression test bumps the count)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] New regression test [rust_acp_explicit_denial_on_single_doc_read](tools/integration-test/tests/acp/basic.rs) verifies both halves: browse query is silent, single-doc query errors with the requested doc ID in the message.

### Why Rust-only test

The new test is restricted to the Rust runtime (`#[tokio::test]` instead of `for_each_runtime!`) because Go DefraDB still returns empty results in this case — that's the upstream gap Backbone CI hit. Once Go gains parity the test can move to `for_each_runtime!`.

## Diff

8 files, 184 insertions, 11 deletions.