### PR TITLE
fix(identity): replace hand-rolled DER parser with k256/p256 mainline (#775)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5881,6 +5881,8 @@ dependencies = [
  "crypto",
  "defra-core",
  "hex",
+ "k256",
+ "p256",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/identity/Cargo.toml
+++ b/crates/identity/Cargo.toml
@@ -16,6 +16,10 @@ serde.workspace = true
 serde_json.workspace = true
 hex.workspace = true
 base64.workspace = true
+# ECDSA signature DER ↔ raw conversion, used by the JWT token layer.
+# Replaces a hand-rolled ASN.1 parser in `token/der.rs` (#775).
+k256.workspace = true
+p256 = "0.13"
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/identity/src/token/decoding.rs
+++ b/crates/identity/src/token/decoding.rs
@@ -86,7 +86,7 @@ pub(crate) fn decode_secp256k1(token: &str) -> Result<IdentityClaims> {
     let claims = decode_claims(jwt.payload)?;
     let public_key = decode_public_key_from_claims(&claims, KeyType::Secp256k1)?;
     let raw_signature = decode_signature(jwt.signature)?;
-    let der_signature = der::raw_to_der(&raw_signature)?;
+    let der_signature = der::k256_raw_to_der(&raw_signature)?;
 
     let signing_input = format!("{}.{}", jwt.header, jwt.payload);
     verify_signature(public_key.as_ref(), &signing_input, &der_signature)?;
@@ -99,8 +99,8 @@ pub(crate) fn decode_secp256r1(token: &str) -> Result<IdentityClaims> {
     let claims = decode_claims(jwt.payload)?;
     let public_key = decode_public_key_from_claims(&claims, KeyType::Secp256r1)?;
     let raw_signature = decode_signature(jwt.signature)?;
-    // ES256 JWT signature is raw R||S (64 bytes), convert to DER for verification
-    let der_signature = der::raw_to_der(&raw_signature)?;
+    // ES256 JWT signature is raw R||S (64 bytes), convert to DER for verification.
+    let der_signature = der::p256_raw_to_der(&raw_signature)?;
 
     let signing_input = format!("{}.{}", jwt.header, jwt.payload);
     verify_signature(public_key.as_ref(), &signing_input, &der_signature)?;

--- a/crates/identity/src/token/der.rs
+++ b/crates/identity/src/token/der.rs
@@ -1,256 +1,113 @@
-//! DER signature format conversion utilities.
+//! ECDSA signature DER ↔ raw conversion for JWT signatures.
+//!
+//! Delegates to `k256::ecdsa::Signature` and `p256::ecdsa::Signature` —
+//! the same upstream RustCrypto types used by the `crypto` crate. JWT
+//! wire format requires raw R||S (RFC 7518), while our crypto layer
+//! signs/verifies in DER, so the JWT layer needs to translate at the
+//! boundary.
+//!
+//! Previously this module was a hand-rolled ASN.1 parser (~250 lines).
+//! That parser was the highest-risk file in the crypto audit (#775)
+//! because manual DER parsing is a notorious vulnerability vector.
+//! `k256` and `p256` provide the same conversion via their mainline
+//! `from_der` / `to_der` / `to_bytes` / `from_slice` methods, which are
+//! the same code paths thousands of other Rust crypto users rely on.
+
+use k256::ecdsa::Signature as K256Signature;
+use p256::ecdsa::Signature as P256Signature;
 
 use crate::error::Error;
 use crate::Result;
 
-/// Convert DER-encoded ECDSA signature to raw R||S format (64 bytes).
-pub(crate) fn der_to_raw(der: &[u8]) -> Result<Vec<u8>> {
-    // DER format: 0x30 <len> 0x02 <r_len> <r> 0x02 <s_len> <s>
-    if der.len() < 8 {
-        return Err(Error::TokenEncoding("DER signature too short".to_string()));
-    }
-    if der[0] != 0x30 {
-        return Err(Error::TokenEncoding(
-            "invalid DER signature: expected SEQUENCE tag".to_string(),
-        ));
-    }
-
-    let mut pos: usize = 2;
-
-    if der[1] & 0x80 != 0 {
-        let len_bytes = (der[1] & 0x7f) as usize;
-        pos = pos
-            .checked_add(len_bytes)
-            .ok_or_else(|| Error::TokenEncoding("DER length field overflow".to_string()))?;
-    }
-
-    if pos >= der.len() {
-        return Err(Error::TokenEncoding(
-            "DER signature truncated: R tag position out of bounds".to_string(),
-        ));
-    }
-
-    if der[pos] != 0x02 {
-        return Err(Error::TokenEncoding(
-            "invalid DER signature: expected INTEGER tag for R".to_string(),
-        ));
-    }
-    pos += 1;
-
-    if pos >= der.len() {
-        return Err(Error::TokenEncoding(
-            "DER signature truncated: R length position out of bounds".to_string(),
-        ));
-    }
-    let r_len = der[pos] as usize;
-    pos += 1;
-
-    let r_start = pos;
-    let r_end = r_start
-        .checked_add(r_len)
-        .ok_or_else(|| Error::TokenEncoding("DER R length overflow".to_string()))?;
-
-    if r_end > der.len() {
-        return Err(Error::TokenEncoding(format!(
-            "DER signature truncated: R component extends beyond data (need {} bytes, have {})",
-            r_end,
-            der.len()
-        )));
-    }
-    pos = r_end;
-
-    if pos >= der.len() {
-        return Err(Error::TokenEncoding(
-            "DER signature truncated: S tag position out of bounds".to_string(),
-        ));
-    }
-
-    if der[pos] != 0x02 {
-        return Err(Error::TokenEncoding(
-            "invalid DER signature: expected INTEGER tag for S".to_string(),
-        ));
-    }
-    pos += 1;
-
-    if pos >= der.len() {
-        return Err(Error::TokenEncoding(
-            "DER signature truncated: S length position out of bounds".to_string(),
-        ));
-    }
-    let s_len = der[pos] as usize;
-    pos += 1;
-
-    let s_start = pos;
-    let s_end = s_start
-        .checked_add(s_len)
-        .ok_or_else(|| Error::TokenEncoding("DER S length overflow".to_string()))?;
-
-    if s_end > der.len() {
-        return Err(Error::TokenEncoding(format!(
-            "DER signature truncated: S component extends beyond data (need {} bytes, have {})",
-            s_end,
-            der.len()
-        )));
-    }
-
-    let mut r = &der[r_start..r_end];
-    let mut s = &der[s_start..s_end];
-
-    // Remove leading zeros (DER INTEGER padding)
-    while r.len() > 32 && r[0] == 0 {
-        r = &r[1..];
-    }
-    while s.len() > 32 && s[0] == 0 {
-        s = &s[1..];
-    }
-
-    let mut result = vec![0u8; 64];
-    let r_offset = 32 - r.len().min(32);
-    let s_offset = 32 - s.len().min(32);
-
-    result[r_offset..32].copy_from_slice(&r[..r.len().min(32)]);
-    result[32 + s_offset..64].copy_from_slice(&s[..s.len().min(32)]);
-
-    Ok(result)
+/// secp256k1 (ES256K) DER → raw R||S (64 bytes).
+pub(crate) fn k256_der_to_raw(der: &[u8]) -> Result<Vec<u8>> {
+    let sig = K256Signature::from_der(der)
+        .map_err(|e| Error::TokenEncoding(format!("invalid ES256K DER signature: {}", e)))?;
+    Ok(sig.to_bytes().to_vec())
 }
 
-/// Convert raw R||S signature (64 bytes) to DER-encoded ECDSA signature.
-pub(crate) fn raw_to_der(raw: &[u8]) -> Result<Vec<u8>> {
-    if raw.len() != 64 {
-        return Err(Error::TokenDecoding(format!(
-            "invalid raw signature length: expected 64, got {}",
-            raw.len()
-        )));
-    }
+/// secp256k1 (ES256K) raw R||S (64 bytes) → DER.
+pub(crate) fn k256_raw_to_der(raw: &[u8]) -> Result<Vec<u8>> {
+    let sig = K256Signature::from_slice(raw)
+        .map_err(|e| Error::TokenDecoding(format!("invalid ES256K raw signature: {}", e)))?;
+    Ok(sig.to_der().as_bytes().to_vec())
+}
 
-    let r = &raw[0..32];
-    let s = &raw[32..64];
+/// secp256r1 (ES256) DER → raw R||S (64 bytes).
+pub(crate) fn p256_der_to_raw(der: &[u8]) -> Result<Vec<u8>> {
+    let sig = P256Signature::from_der(der)
+        .map_err(|e| Error::TokenEncoding(format!("invalid ES256 DER signature: {}", e)))?;
+    Ok(sig.to_bytes().to_vec())
+}
 
-    fn encode_der_integer(bytes: &[u8]) -> Vec<u8> {
-        let mut start = 0;
-        while start < bytes.len() - 1 && bytes[start] == 0 {
-            start += 1;
-        }
-        let trimmed = &bytes[start..];
-
-        let mut result = Vec::new();
-        result.push(0x02); // INTEGER tag
-
-        // Add leading zero if high bit is set (to ensure positive number)
-        if trimmed[0] & 0x80 != 0 {
-            result.push((trimmed.len() + 1) as u8);
-            result.push(0x00);
-        } else {
-            result.push(trimmed.len() as u8);
-        }
-        result.extend_from_slice(trimmed);
-        result
-    }
-
-    let r_der = encode_der_integer(r);
-    let s_der = encode_der_integer(s);
-
-    let content_len = r_der.len() + s_der.len();
-    if content_len > 127 {
-        return Err(Error::TokenEncoding(format!(
-            "DER content length {} exceeds single-byte short form limit",
-            content_len
-        )));
-    }
-
-    let mut result = Vec::new();
-    result.push(0x30); // SEQUENCE tag
-    result.push(content_len as u8);
-    result.extend_from_slice(&r_der);
-    result.extend_from_slice(&s_der);
-
-    Ok(result)
+/// secp256r1 (ES256) raw R||S (64 bytes) → DER.
+pub(crate) fn p256_raw_to_der(raw: &[u8]) -> Result<Vec<u8>> {
+    let sig = P256Signature::from_slice(raw)
+        .map_err(|e| Error::TokenDecoding(format!("invalid ES256 raw signature: {}", e)))?;
+    Ok(sig.to_der().as_bytes().to_vec())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_der_to_raw_empty_input() {
-        let result = der_to_raw(&[]);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, Error::TokenEncoding(ref msg) if msg.contains("too short")));
+    /// A real ES256K signature produced by k256 in DER form, used as a
+    /// known-good fixture for round-trip tests.
+    fn k256_der_fixture() -> Vec<u8> {
+        use k256::ecdsa::{signature::Signer, SigningKey};
+        let sk = SigningKey::from_bytes(&[0x42u8; 32].into()).unwrap();
+        let sig: K256Signature = sk.sign(b"defradb-#775");
+        sig.to_der().as_bytes().to_vec()
+    }
+
+    fn p256_der_fixture() -> Vec<u8> {
+        use p256::ecdsa::{signature::Signer, SigningKey};
+        let sk = SigningKey::from_bytes(&[0x42u8; 32].into()).unwrap();
+        let sig: P256Signature = sk.sign(b"defradb-#775");
+        sig.to_der().as_bytes().to_vec()
     }
 
     #[test]
-    fn test_der_to_raw_wrong_tag() {
-        let result = der_to_raw(&[0x31, 0x40, 0x02, 0x20, 0x00, 0x00, 0x00, 0x00]);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, Error::TokenEncoding(ref msg) if msg.contains("SEQUENCE tag")));
+    fn k256_roundtrip() {
+        let der = k256_der_fixture();
+        let raw = k256_der_to_raw(&der).unwrap();
+        assert_eq!(raw.len(), 64);
+        let der2 = k256_raw_to_der(&raw).unwrap();
+        // DER may be re-canonicalized; converting back to raw must match.
+        assert_eq!(k256_der_to_raw(&der2).unwrap(), raw);
     }
 
     #[test]
-    fn test_der_to_raw_truncated_r() {
-        let result = der_to_raw(&[0x30, 0x44, 0x02, 0x20, 0x00, 0x00, 0x00, 0x00]);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, Error::TokenEncoding(ref msg) if msg.contains("truncated")));
+    fn p256_roundtrip() {
+        let der = p256_der_fixture();
+        let raw = p256_der_to_raw(&der).unwrap();
+        assert_eq!(raw.len(), 64);
+        let der2 = p256_raw_to_der(&raw).unwrap();
+        assert_eq!(p256_der_to_raw(&der2).unwrap(), raw);
     }
 
     #[test]
-    fn test_der_to_raw_missing_s_tag() {
-        let mut der = vec![0x30, 0x26];
-        der.push(0x02);
-        der.push(0x20);
-        der.extend_from_slice(&[0x00; 32]);
-
-        let result = der_to_raw(&der);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            matches!(err, Error::TokenEncoding(ref msg) if msg.contains("out of bounds") || msg.contains("truncated"))
-        );
+    fn k256_der_rejects_garbage() {
+        assert!(k256_der_to_raw(&[]).is_err());
+        assert!(k256_der_to_raw(&[0x30, 0x00]).is_err());
+        assert!(k256_der_to_raw(b"not der at all").is_err());
     }
 
     #[test]
-    fn test_der_to_raw_wrong_r_tag() {
-        let result = der_to_raw(&[0x30, 0x44, 0x03, 0x20, 0x00, 0x00, 0x00, 0x00]);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, Error::TokenEncoding(ref msg) if msg.contains("INTEGER tag for R")));
+    fn k256_raw_rejects_wrong_length() {
+        assert!(k256_raw_to_der(&[0u8; 63]).is_err());
+        assert!(k256_raw_to_der(&[0u8; 65]).is_err());
     }
 
     #[test]
-    fn test_raw_to_der_wrong_length() {
-        let result = raw_to_der(&[0u8; 63]);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, Error::TokenDecoding(ref msg) if msg.contains("expected 64")));
+    fn p256_der_rejects_garbage() {
+        assert!(p256_der_to_raw(&[]).is_err());
+        assert!(p256_der_to_raw(b"not der at all").is_err());
     }
 
     #[test]
-    fn test_der_roundtrip() {
-        // Create a valid raw signature (64 bytes)
-        let mut raw = vec![0u8; 64];
-        raw[0] = 0x12;
-        raw[31] = 0x34;
-        raw[32] = 0x56;
-        raw[63] = 0x78;
-
-        let der = raw_to_der(&raw).unwrap();
-        let recovered = der_to_raw(&der).unwrap();
-
-        assert_eq!(raw, recovered);
-    }
-
-    #[test]
-    fn test_der_roundtrip_with_high_bits() {
-        // Test with high bits set (requires leading zero in DER)
-        let mut raw = vec![0u8; 64];
-        raw[0] = 0xFF;
-        raw[32] = 0x80;
-
-        let der = raw_to_der(&raw).unwrap();
-        let recovered = der_to_raw(&der).unwrap();
-
-        assert_eq!(raw, recovered);
+    fn p256_raw_rejects_wrong_length() {
+        assert!(p256_raw_to_der(&[0u8; 63]).is_err());
+        assert!(p256_raw_to_der(&[0u8; 65]).is_err());
     }
 }

--- a/crates/identity/src/token/encoding.rs
+++ b/crates/identity/src/token/encoding.rs
@@ -50,7 +50,7 @@ pub(crate) fn encode_secp256k1<I: FullIdentity, T: Serialize>(
         .sign(signing_input.as_bytes())
         .map_err(|e| Error::TokenEncoding(format!("signing failed: {}", e)))?;
 
-    let raw_sig = der::der_to_raw(&signature)?;
+    let raw_sig = der::k256_der_to_raw(&signature)?;
     let sig_b64 = URL_SAFE_NO_PAD.encode(&raw_sig);
     Ok(format!("{}.{}", signing_input, sig_b64))
 }
@@ -65,8 +65,8 @@ pub(crate) fn encode_secp256r1<I: FullIdentity, T: Serialize>(
         .sign(signing_input.as_bytes())
         .map_err(|e| Error::TokenEncoding(format!("signing failed: {}", e)))?;
 
-    // ES256 JWT uses raw R||S (64 bytes), same as ES256K
-    let raw_sig = der::der_to_raw(&signature)?;
+    // ES256 JWT uses raw R||S (64 bytes), same as ES256K but on the P-256 curve.
+    let raw_sig = der::p256_der_to_raw(&signature)?;
     let sig_b64 = URL_SAFE_NO_PAD.encode(&raw_sig);
     Ok(format!("{}.{}", signing_input, sig_b64))
 }


### PR DESCRIPTION
## Summary

Addresses #775. [crates/identity/src/token/der.rs](crates/identity/src/token/der.rs) was a ~250-line hand-rolled ASN.1 DER parser converting ECDSA signatures between DER and raw R||S format for the JWT layer. Manual ASN.1 parsing is a notorious vulnerability vector and the audit flagged this as the highest-risk file in the identity crate.

This PR replaces the manual parser with `k256::ecdsa::Signature` and `p256::ecdsa::Signature` mainline `from_der` / `to_der` / `from_slice` / `to_bytes` calls — the same RustCrypto types the `crypto` crate already uses for signing and verification. The unsafe manual parser is eliminated entirely while the JWT wire format stays identical (raw R||S per RFC 7518) and zero call-site signatures change.

## Scope deviation from the issue

The issue text proposes a full migration to the `jwt-simple` crate, which would also replace [encoding.rs](crates/identity/src/token/encoding.rs) and [decoding.rs](crates/identity/src/token/decoding.rs). After investigation I deliberately scoped this PR smaller for three reasons:

1. **`jwt-simple` defaults to BoringSSL** (`boring` crate, native dep with CMake/perl build requirements). Even with `pure-rust` feature it pulls `superboring`, a non-trivial extra dep tree.
2. **Key-type bridging**. We'd need a shim from `crypto::keys::PublicKey`/`PrivateKey` traits to `jwt-simple`'s key trait hierarchy. Not hard but adds surface area.
3. **Token-format compat risk**. `jwt-simple` may add or require fields that diverge from our current claim shape — needs comprehensive round-trip tests against existing tokens before deletion of the manual implementation.

The actual security value the issue calls out is in **killing the hand-rolled ASN.1 parser**, which this PR achieves directly with battle-tested k256/p256 mainline calls — the same code paths thousands of other Rust crypto users rely on. A follow-up PR can do the full `jwt-simple` migration if desired; I'll add a comment to the issue with this rationale.

## What changes

- [crates/identity/Cargo.toml](crates/identity/Cargo.toml) — add `k256.workspace = true` and `p256 = \"0.13\"` as direct deps. Both were already in the transitive graph via `crypto`.
- [crates/identity/src/token/der.rs](crates/identity/src/token/der.rs) — rewrite as four thin wrappers (`k256_der_to_raw`, `k256_raw_to_der`, `p256_der_to_raw`, `p256_raw_to_der`) around `k256`/`p256` ECDSA types. ~250 lines → ~115 lines.
- [encoding.rs](crates/identity/src/token/encoding.rs) and [decoding.rs](crates/identity/src/token/decoding.rs) — call key-type-specific helpers instead of the old generic `der_to_raw` / `raw_to_der`.
- New unit tests use real signatures from `k256::ecdsa::SigningKey` and `p256::ecdsa::SigningKey` fixtures to verify round-trip + rejection of garbage and wrong-length inputs.

## Test plan

- [x] `cargo test -p identity` — **all 26 token unit tests + 8 doc tests passing**
- [x] `cargo test -p integration-test --test identity` — **56/56 passing** (covers token round-trip across ES256K, EdDSA, ES256, plus negative cases like expired/malformed/wrong-signer)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

## Diff

5 files, 89 insertions, 226 deletions. Net deletion of 137 lines plus the unsafe ASN.1 parser entirely.