### PR TITLE
perf(query): parallelize ACP checks in PermissionFilterNode (#519)

### DIFF
--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -3,6 +3,7 @@
 //! This node wraps a source node and filters out documents that the
 //! identity context doesn't have permission to read.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use acp::{DocumentACP, DocumentPermission, Identity};
@@ -10,7 +11,7 @@ use async_trait::async_trait;
 use identity::Did;
 
 use crate::document::DocumentMapping;
-use crate::error::Result;
+use crate::error::{QueryError, Result};
 use crate::planner::{Doc, PlanNode};
 use crate::txn::check_doc_access_with_overlay;
 
@@ -40,6 +41,18 @@ pub struct PermissionFilterNode {
 
     /// Document mapping from source
     document_mapping: DocumentMapping,
+
+    /// Doc IDs the caller explicitly requested (e.g., via
+    /// `_docID: { _eq: "..." }` or `docID: "..."`). When non-empty and
+    /// at least one of these is denied, `next()` returns a
+    /// `permission_denied` error after the source is exhausted instead
+    /// of silently returning fewer results — matching Go's behavior and
+    /// closing the read-side gap reported in #551.
+    requested_doc_ids: HashSet<String>,
+
+    /// Subset of `requested_doc_ids` that were emitted by the source
+    /// but failed the read-permission check.
+    denied_requested_ids: Vec<String>,
 }
 
 impl PermissionFilterNode {
@@ -67,7 +80,20 @@ impl PermissionFilterNode {
             resource_name: resource_name.into(),
             current_doc: Doc::default(),
             document_mapping,
+            requested_doc_ids: HashSet::new(),
+            denied_requested_ids: Vec::new(),
         }
+    }
+
+    /// Mark a set of document IDs as explicitly requested by the caller.
+    ///
+    /// When any of these IDs are emitted by the source but denied by ACP,
+    /// `next()` will return a `permission_denied` error after the source is
+    /// drained instead of silently filtering them out. Browse queries
+    /// (no explicit doc IDs) keep the existing filter-only semantics.
+    pub fn with_requested_doc_ids(mut self, doc_ids: Vec<String>) -> Self {
+        self.requested_doc_ids = doc_ids.into_iter().collect();
+        self
     }
 
     /// Create from an optional DID for backward compatibility.
@@ -129,6 +155,19 @@ impl PlanNode for PermissionFilterNode {
         loop {
             // Get next document from source
             if !self.source.next().await? {
+                // Source drained. If the caller explicitly asked for
+                // specific doc IDs and any of those were denied by ACP,
+                // surface that as an explicit permission-denied error
+                // instead of silently returning fewer results (#551).
+                if !self.denied_requested_ids.is_empty() {
+                    let mut ids = std::mem::take(&mut self.denied_requested_ids);
+                    ids.sort();
+                    ids.dedup();
+                    return Err(QueryError::permission_denied(format!(
+                        "read denied for doc_id(s): {}",
+                        ids.join(", ")
+                    )));
+                }
                 return Ok(false);
             }
 
@@ -151,6 +190,12 @@ impl PlanNode for PermissionFilterNode {
             if self.has_read_permission(&doc_id).await? {
                 self.current_doc = doc.deep_clone();
                 return Ok(true);
+            }
+
+            // Denied. If this doc was explicitly requested by ID, remember
+            // it so we can surface an error after the source is drained.
+            if self.requested_doc_ids.contains(&doc_id) {
+                self.denied_requested_ids.push(doc_id);
             }
 
             // No permission, continue to next document

--- a/crates/query/src/plan/permission_filter.rs
+++ b/crates/query/src/plan/permission_filter.rs
@@ -3,7 +3,7 @@
 //! This node wraps a source node and filters out documents that the
 //! identity context doesn't have permission to read.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 use acp::{DocumentACP, DocumentPermission, Identity};
@@ -53,6 +53,12 @@ pub struct PermissionFilterNode {
     /// Subset of `requested_doc_ids` that were emitted by the source
     /// but failed the read-permission check.
     denied_requested_ids: Vec<String>,
+
+    /// Queue of permitted documents, populated in `start()` after the
+    /// source is fully drained and all ACP checks are dispatched in
+    /// parallel via `futures::future::try_join_all`. `next()` simply
+    /// pops from the front (#519).
+    permitted_docs: VecDeque<Doc>,
 }
 
 impl PermissionFilterNode {
@@ -82,6 +88,7 @@ impl PermissionFilterNode {
             document_mapping,
             requested_doc_ids: HashSet::new(),
             denied_requested_ids: Vec::new(),
+            permitted_docs: VecDeque::new(),
         }
     }
 
@@ -148,58 +155,87 @@ impl PlanNode for PermissionFilterNode {
     }
 
     async fn start(&mut self) -> Result<()> {
-        self.source.start().await
-    }
+        self.source.start().await?;
 
-    async fn next(&mut self) -> Result<bool> {
-        loop {
-            // Get next document from source
-            if !self.source.next().await? {
-                // Source drained. If the caller explicitly asked for
-                // specific doc IDs and any of those were denied by ACP,
-                // surface that as an explicit permission-denied error
-                // instead of silently returning fewer results (#551).
-                if !self.denied_requested_ids.is_empty() {
-                    let mut ids = std::mem::take(&mut self.denied_requested_ids);
-                    ids.sort();
-                    ids.dedup();
-                    return Err(QueryError::permission_denied(format!(
-                        "read denied for doc_id(s): {}",
-                        ids.join(", ")
-                    )));
-                }
-                return Ok(false);
-            }
+        // Drain the source eagerly and dispatch all ACP checks in parallel
+        // (#519). Previously this filter awaited each `has_read_permission`
+        // call serially in `next()`, which on remote backends like SourceHub
+        // (gRPC, ~50–100ms per check) made a 1000-doc result set serialize
+        // into 50–100s of pure wait time.
+        //
+        // Why drain-and-parallelize: the upstream ScanNode already
+        // materializes the full document set in `init()` via `Vec<Doc>`,
+        // so the "streaming" of `PlanNode::next()` is fictional at the
+        // bottom of the plan tree. Capturing full per-query parallelism
+        // here is a one-file change with zero planner contract impact.
+        // If/when scans ever become true streams, this should evolve to
+        // a `FuturesUnordered`-based sliding window with bounded
+        // concurrency (textbook async best practice for I/O parallelism).
 
+        let docid_index = self.document_mapping.first_index_of_name("_docID");
+
+        // Phase 1: drain the source into (doc_id, doc) pairs.
+        let mut pending: Vec<(String, Doc)> = Vec::new();
+        while self.source.next().await? {
             let doc = self.source.value();
-
-            // Child join scan mappings may place `_docID` at a non-zero index to keep
-            // schema fields aligned for FK lookups, so resolve it from the mapping
-            // instead of assuming Doc field index 0.
-            let doc_id = match self
-                .document_mapping
-                .first_index_of_name("_docID")
+            let doc_id = match docid_index
                 .and_then(|index| doc.get(index))
                 .and_then(|value| value.as_str())
             {
                 Some(id) => id.to_string(),
+                // Docs without a `_docID` mapping cannot be ACP-checked
+                // and were silently skipped in the previous serial loop;
+                // preserve that behavior.
                 None => continue,
             };
+            pending.push((doc_id, doc.deep_clone()));
+        }
 
-            // Check read permission
-            if self.has_read_permission(&doc_id).await? {
-                self.current_doc = doc.deep_clone();
-                return Ok(true);
-            }
+        if pending.is_empty() {
+            return Ok(());
+        }
 
-            // Denied. If this doc was explicitly requested by ID, remember
-            // it so we can surface an error after the source is drained.
-            if self.requested_doc_ids.contains(&doc_id) {
+        // Phase 2: dispatch every read-permission check concurrently.
+        // `has_read_permission` borrows `&self`; the borrow checker is
+        // happy because we don't mutate `self` until after the join.
+        let checks = pending
+            .iter()
+            .map(|(doc_id, _)| self.has_read_permission(doc_id));
+        let decisions = futures::future::try_join_all(checks).await?;
+
+        // Phase 3: walk results, queue permitted docs, track denied
+        // explicit-id requests for the #551 error path.
+        for ((doc_id, doc), allowed) in pending.into_iter().zip(decisions) {
+            if allowed {
+                self.permitted_docs.push_back(doc);
+            } else if self.requested_doc_ids.contains(&doc_id) {
                 self.denied_requested_ids.push(doc_id);
             }
-
-            // No permission, continue to next document
         }
+
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<bool> {
+        if let Some(doc) = self.permitted_docs.pop_front() {
+            self.current_doc = doc;
+            return Ok(true);
+        }
+
+        // Queue drained. If the caller explicitly asked for specific
+        // doc IDs and any were denied by ACP, surface a permission-denied
+        // error instead of silently returning fewer results (#551).
+        if !self.denied_requested_ids.is_empty() {
+            let mut ids = std::mem::take(&mut self.denied_requested_ids);
+            ids.sort();
+            ids.dedup();
+            return Err(QueryError::permission_denied(format!(
+                "read denied for doc_id(s): {}",
+                ids.join(", ")
+            )));
+        }
+
+        Ok(false)
     }
 
     fn value(&self) -> &Doc {

--- a/crates/query/src/planner/builder/mod.rs
+++ b/crates/query/src/planner/builder/mod.rs
@@ -150,19 +150,31 @@ impl Planner {
     }
 
     /// Conditionally wrap a plan with a PermissionFilterNode if the collection has an ACP policy.
+    ///
+    /// `requested_doc_ids` should be passed when the caller targets specific
+    /// documents by ID (e.g. via `_docID: { _eq: "..." }`); the filter then
+    /// surfaces an explicit permission-denied error when any of those IDs are
+    /// filtered out, instead of silently returning fewer results (#551).
     pub(super) fn maybe_wrap_with_acp_filter(
         &self,
         plan: Box<dyn PlanNode>,
         collection: &CollectionVersion,
+        requested_doc_ids: Option<&[String]>,
     ) -> Box<dyn PlanNode> {
         if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
-            Box::new(PermissionFilterNode::from_optional_did(
+            let mut node = PermissionFilterNode::from_optional_did(
                 plan,
                 acp.clone(),
                 self.identity_did.clone(),
                 &policy.id,
                 &policy.resource_name,
-            ))
+            );
+            if let Some(ids) = requested_doc_ids {
+                if !ids.is_empty() {
+                    node = node.with_requested_doc_ids(ids.to_vec());
+                }
+            }
+            Box::new(node)
         } else {
             plan
         }
@@ -575,7 +587,7 @@ impl Planner {
 
         // Insert ACP permission filter for the root collection (if ACP-protected).
         // Position: after Select/joins/similarity but before GroupBy/Aggregates/OrderBy/Limit.
-        plan = self.maybe_wrap_with_acp_filter(plan, &collection);
+        plan = self.maybe_wrap_with_acp_filter(plan, &collection, select.doc_ids.as_deref());
 
         // Apply GroupBy/OrderBy/Limit (or just OrderBy/Aggregates/Limit without GROUP BY)
         plan = self.apply_groupby_ordering_limit(

--- a/crates/query/src/planner/joins/aggregate_joins.rs
+++ b/crates/query/src/planner/joins/aggregate_joins.rs
@@ -454,7 +454,8 @@ impl Planner {
                     }
 
                     // Insert ACP permission filter for the aggregate child collection (if ACP-protected).
-                    child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+                    child_plan =
+                        self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
                     // Set up child mapping in parent for TypeJoin (after sub-join modifications)
                     mapping.set_child_at(effective_relation_index, child_scan_mapping.clone());

--- a/crates/query/src/planner/joins/filter_relation.rs
+++ b/crates/query/src/planner/joins/filter_relation.rs
@@ -85,7 +85,7 @@ impl Planner {
         let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
 
         // Insert ACP permission filter for the child collection (if ACP-protected).
-        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
         // Find the other side of the relation
         let target_relation_field = if let Some(rel_name) = &relation_field.relation_name {

--- a/crates/query/src/planner/joins/mod.rs
+++ b/crates/query/src/planner/joins/mod.rs
@@ -1046,7 +1046,7 @@ impl Planner {
             }
 
             // Insert ACP permission filter for the child collection (if ACP-protected).
-            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
             // Update parent mapping with the final child mapping (after sub-joins)
             // This ensures the nested relation mappings are included

--- a/crates/query/src/planner/joins/multi_level.rs
+++ b/crates/query/src/planner/joins/multi_level.rs
@@ -102,7 +102,7 @@ impl Planner {
             let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
 
             // Insert ACP permission filter for the child collection (if ACP-protected).
-            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+            child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
             // Find the other side of the relation
             let target_relation_field = if let Some(rel_name) = &relation_field.relation_name {
@@ -226,7 +226,7 @@ impl Planner {
         let mut child_plan: Box<dyn PlanNode> = Box::new(child_scan);
 
         // Insert ACP permission filter for the child collection (if ACP-protected).
-        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection);
+        child_plan = self.maybe_wrap_with_acp_filter(child_plan, &target_collection, None);
 
         // Add sub-joins for remaining path levels within the child plan
         if path.len() > 1 {

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -271,13 +271,22 @@ pub(crate) fn build_plan(
     // Insert ACP permission filter after Select, before OrderBy/Limit/Aggregates.
     // This ensures aggregates (count, average, etc.) operate on filtered documents.
     if let Some(acf) = acp_filter {
-        plan = Box::new(PermissionFilterNode::new(
+        let mut filter_node = PermissionFilterNode::new(
             plan,
             acf.acp,
             acf.identity,
             acf.policy_id,
             acf.resource_name,
-        ));
+        );
+        // If the caller asked for specific docs by ID, surface an explicit
+        // permission-denied error when any of them are filtered out
+        // (#551 — Backbone parity for read-side denial shape).
+        if let Some(ref doc_ids) = select.doc_ids {
+            if !doc_ids.is_empty() {
+                filter_node = filter_node.with_requested_doc_ids(doc_ids.clone());
+            }
+        }
+        plan = Box::new(filter_node);
     }
 
     // Check if we have GROUP BY

--- a/tools/integration-test/tests/acp/basic.rs
+++ b/tools/integration-test/tests/acp/basic.rs
@@ -77,3 +77,109 @@ async fn acp_basic_test(cluster: TestCluster) {
 }
 
 for_each_runtime!(acp_basic, acp_basic_test, .with_acp_local());
+
+/// Regression test for #551 — single-doc reads against an ACP-protected
+/// document by a user without permission must surface an explicit
+/// permission-denied GraphQL error, not a silent empty result.
+///
+/// Browse queries (no explicit doc ID) keep the existing filter-only
+/// semantics; only explicit `User(docID: "...")` lookups error.
+///
+/// Rust-only: Go DefraDB still returns empty results in this case, which
+/// is the upstream gap Backbone CI hit. Once Go gains the same behavior
+/// this test can move to `for_each_runtime!`.
+#[tokio::test]
+async fn rust_acp_explicit_denial_on_single_doc_read() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_acp_local()
+        .build()
+        .await
+        .expect("build rust cluster with local acp");
+    acp_explicit_denial_on_single_doc_read_test(cluster).await;
+}
+
+async fn acp_explicit_denial_on_single_doc_read_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let binary_path = node.binary_path().to_path_buf();
+
+    let alice = generate_identity(&binary_path).expect("generate Alice");
+    let bob = generate_identity(&binary_path).expect("generate Bob");
+
+    let policy_result = node
+        .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+        .expect("add policy");
+    let policy_id = policy_result["PolicyID"]
+        .as_str()
+        .or_else(|| policy_result["policyID"].as_str())
+        .expect("missing PolicyID");
+
+    let schema = users_schema_with_policy(policy_id);
+    node.schema_add_with_identity(&schema, &alice.private_key_hex)
+        .expect("add schema");
+
+    let data = node
+        .query_with_identity(
+            r#"mutation { add_User(input: {name: "Secret", age: 42}) { _docID name } }"#,
+            &alice.private_key_hex,
+        )
+        .expect("create protected doc");
+    let doc_id = data["add_User"][0]["_docID"]
+        .as_str()
+        .expect("missing _docID")
+        .to_string();
+
+    // Browse query: still silently filtered (Bob sees an empty array).
+    let browse_result = node
+        .query_with_identity("query { User { _docID name } }", &bob.private_key_hex)
+        .expect("Bob browse query failed");
+    let browse_users = browse_result["User"]
+        .as_array()
+        .expect("browse result not array");
+    assert_eq!(
+        browse_users.len(),
+        0,
+        "browse queries should still silently filter denied docs"
+    );
+
+    // Explicit single-doc query: must surface an error mentioning the denied doc ID.
+    // Different runtimes wrap denial errors differently — accept either an Err from
+    // the client or an `errors[]` field in the JSON response.
+    let single_doc_query = format!(r#"query {{ User(docID: "{}") {{ _docID name }} }}"#, doc_id);
+    let single_doc_result = node.query_with_identity(&single_doc_query, &bob.private_key_hex);
+
+    let denial_message = match &single_doc_result {
+        Err(err) => err.to_string(),
+        Ok(value) => {
+            // Some HTTP layers surface GraphQL errors as a 200 response with
+            // an `errors[]` field; check both shapes.
+            let errors = value
+                .get("errors")
+                .and_then(|v| v.as_array())
+                .filter(|arr| !arr.is_empty());
+            match errors {
+                Some(arr) => arr
+                    .iter()
+                    .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("; "),
+                None => panic!(
+                    "expected explicit permission-denied error for single-doc read, got: {}",
+                    serde_json::to_string_pretty(value).unwrap()
+                ),
+            }
+        }
+    };
+
+    assert!(
+        denial_message.to_lowercase().contains("denied")
+            || denial_message.to_lowercase().contains("permission"),
+        "denial message should mention permission/denied, got: {}",
+        denial_message
+    );
+    assert!(
+        denial_message.contains(&doc_id),
+        "denial message should reference the requested doc id, got: {}",
+        denial_message
+    );
+}


### PR DESCRIPTION
## Summary

Closes #519. Stops the query executor from serializing on per-document ACP checks.

Previously [PermissionFilterNode::next()](crates/query/src/plan/permission_filter.rs) awaited each `has_read_permission` call before advancing to the next doc. With remote backends like SourceHub (gRPC, ~50–100ms per check), a 1000-doc result set serialized into 50–100s of pure wait time. This PR drains the source eagerly in `start()`, dispatches every read-permission check concurrently via `futures::future::try_join_all`, and serves permitted docs from a pre-built `VecDeque` in `next()`.

## Design choice

Three options were on the table; this PR implements **drain-and-parallelize**:

- **A — drain in start(), parallelize all (this PR)** ✅ Single-file diff, full per-query parallelism, zero planner contract change. Matches the fact that ScanNode already materializes `Vec<Doc>` in `init()` — the \"streaming\" of `PlanNode::next()` is fictional at the bottom of the plan tree.
- **B — page-batched dispatch in next()** — Halfway house. Useful only if a future ScanNode actually starts streaming. Adds complexity without payoff today.
- **C — `FuturesUnordered` with in-flight cap** — Textbook async best-practice for I/O parallelism. But it requires wrapping `PlanNode` sources as `Stream`s, a planner-wide refactor. Noted inline as the future evolution path if/when scans become true streams.

## What changes

Single file: [crates/query/src/plan/permission_filter.rs](crates/query/src/plan/permission_filter.rs)

- Add `permitted_docs: VecDeque<Doc>` field
- Rewrite `start()`: drain source → collect `(doc_id, doc)` pairs → dispatch all `has_read_permission` calls via `futures::future::try_join_all` → walk decisions, queue permitted, track denied explicit-id requests
- Rewrite `next()`: pop from queue; if empty and any explicit-id request was denied, return `permission_denied` error (preserves #551 semantics)
- Inline comment documenting the streaming-evolution path

Net: +74/-38 lines in one file.

## Layering on PR #785 (#551)

This PR is based on `fix/acp-read-denial-error` (PR #785) because it builds on the `requested_doc_ids` / `denied_requested_ids` machinery from #551. When #785 merges, this branch rebases cleanly. If this merges first, #785 needs a trivial rebase.

## Test plan

- [x] `cargo test -p query` — 210/210 passing
- [x] `cargo test -p integration-test --test acp` — **197/197 passing**, including:
  - `basic::rust_acp_basic` — browse-query silent filtering still works
  - `basic::rust_acp_explicit_denial_on_single_doc_read` (from #785) — single-doc denial still errors
  - `multi_identity::*`, `relationship::*`, `p2p::*` — multi-actor scenarios still pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

## Perf characterization

The latency hotspot is the SourceHub gRPC layer, not exercised by local tests. Functional correctness verified end-to-end. Expected order-of-magnitude speedup on real SourceHub deployments: a query yielding N docs goes from O(N × RTT) to O(RTT), bounded only by gRPC channel concurrency.
