### PR TITLE
refactor(schema): move definition_validation from db to schema crate (#669 slice)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4371,6 +4371,7 @@ dependencies = [
  "libp2p",
  "p2p",
  "query",
+ "schema",
  "serde",
  "serde_bytes",
  "serde_ipld_dagcbor",

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -84,7 +84,7 @@ impl<S: Store + 'static> SchemaAdapter<S> {
         let collections = query::parse_sdl_with_known_types(sdl, known_types)
             .map_err(|e| format!("failed to parse SDL: {}", e))?;
 
-        db::definition_validation::validate_new_collections(&collections)
+        schema::definition_validation::validate_new_collections(&collections)
             .map_err(|e| format!("failed to validate schema: {}", e))?;
 
         // #746: validate every @policy directive against the ACP store

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -61,7 +61,8 @@ pub(crate) mod collection_snapshot;
 mod commit_priority_index;
 pub(crate) mod commits_fetcher;
 pub mod database;
-pub mod definition_validation;
+// Definition validation moved to the `schema` crate (was #791 substitute
+// slice) — see `schema::definition_validation`.
 // dense_search and embedding extracted to standalone db-search crate (Phase 6 of #796).
 pub use db_search as dense_search;
 pub(crate) mod doc_fetcher;

--- a/crates/db/src/patch/mod.rs
+++ b/crates/db/src/patch/mod.rs
@@ -212,7 +212,7 @@ impl<S: Store> crate::database::DB<S> {
                 .cloned()
                 .chain(std::iter::once(new_schema.clone()))
                 .collect();
-            crate::definition_validation::validate_collection_changes(
+            schema::definition_validation::validate_collection_changes(
                 &all_existing,
                 &new_collections,
             )

--- a/crates/db/src/patch/store.rs
+++ b/crates/db/src/patch/store.rs
@@ -42,7 +42,7 @@ impl<S: Store> crate::database::DB<S> {
             .cloned()
             .chain(std::iter::once(new_schema.clone()))
             .collect();
-        crate::definition_validation::validate_collection_changes(&all_existing, &new_collections)
+        schema::definition_validation::validate_collection_changes(&all_existing, &new_collections)
             .map_err(Error::InvalidPatch)?;
 
         // Also run schema-level validation for checks not covered by definition validators

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -401,7 +401,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let collections = query::parse_sdl_with_known_types(sdl, known_types)
             .map_err(|e| Error::Other(format!("failed to parse SDL: {}", e)))?;
 
-        crate::definition_validation::validate_new_collections(&collections)
+        schema::definition_validation::validate_new_collections(&collections)
             .map_err(|e| Error::Other(format!("failed to validate schema: {}", e)))?;
 
         let mut finalized = Vec::new();

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -10,7 +10,7 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
         let collections =
             query::parse_sdl(sdl).map_err(|e| anyhow::anyhow!("SDL parse error: {}", e))?;
 
-        db::definition_validation::validate_new_collections(&collections)
+        schema::definition_validation::validate_new_collections(&collections)
             .map_err(|e| anyhow::anyhow!("schema validation error: {}", e))?;
 
         for collection in collections {

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -21,6 +21,7 @@ identity = { path = "../identity" }
 lens = { path = "../lens" }
 p2p = { path = "../p2p" }
 query = { path = "../query" }
+schema = { path = "../schema" }
 sourcehub = { path = "../sourcehub" }
 storage = { path = "../storage" }
 

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -55,7 +55,7 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
     pub async fn add_schema(&self, sdl: &str) -> Result<()> {
         let collections =
             query::parse_sdl(sdl).map_err(|error| anyhow!("SDL parse error: {error}"))?;
-        db::definition_validation::validate_new_collections(&collections)
+        schema::definition_validation::validate_new_collections(&collections)
             .map_err(|error| anyhow!("schema validation error: {error}"))?;
 
         for collection in collections {

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -395,7 +395,7 @@ pub extern "C" fn defra_mobile_ensure_schema(
                 }
             }
 
-            db::definition_validation::validate_new_collections(&to_create)
+            schema::definition_validation::validate_new_collections(&to_create)
                 .map_err(|error| format!("failed to validate schema: {}", error))?;
 
             let mut created = Vec::new();

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn add_schema(
                 .map_err(|e| format!("failed to parse schema: {}", e))?;
 
             // Run global validators (embedding type checks, etc.)
-            db::definition_validation::validate_new_collections(&collections)
+            schema::definition_validation::validate_new_collections(&collections)
                 .map_err(|e| format!("failed to validate schema: {}", e))?;
 
             // Validate policies on collections before creating them
@@ -146,7 +146,7 @@ pub unsafe extern "C" fn add_schema_in_txn(
             let collections = query::parse_sdl_with_known_types(&schema_str, known_types)
                 .map_err(|e| format!("failed to parse schema: {}", e))?;
 
-            db::definition_validation::validate_new_collections(&collections)
+            schema::definition_validation::validate_new_collections(&collections)
                 .map_err(|e| format!("failed to validate schema: {}", e))?;
 
             for collection in &collections {

--- a/crates/schema/src/definition_validation/global_validators.rs
+++ b/crates/schema/src/definition_validation/global_validators.rs
@@ -2,7 +2,7 @@
 
 use super::helpers::*;
 use super::DefinitionState;
-use schema::ORPHAN_COLLECTION_ID;
+use crate::ORPHAN_COLLECTION_ID;
 
 /// Matches Go's validateCollectionNameUnique.
 pub(super) fn validate_collection_name_unique(

--- a/crates/schema/src/definition_validation/helpers.rs
+++ b/crates/schema/src/definition_validation/helpers.rs
@@ -1,6 +1,6 @@
 //! Helper functions for definition validation formatting and type checks.
 
-use schema::{CType, FieldKind, ScalarKind};
+use crate::{CType, FieldKind, ScalarKind};
 
 /// Check if a CRDT type is supported as a user-specified field type.
 /// Matches Go's IsSupportedFieldCType: only None, LwwRegister, PnCounter, PCounter.
@@ -17,7 +17,7 @@ pub(super) fn is_crdt_type_supported(crdt: CType) -> bool {
 pub(super) fn is_valid_embedding_kind(kind: &FieldKind) -> bool {
     matches!(
         kind,
-        FieldKind::ScalarArray(schema::ScalarArrayKind::Float32Array)
+        FieldKind::ScalarArray(crate::ScalarArrayKind::Float32Array)
     )
 }
 
@@ -45,7 +45,6 @@ pub(super) fn format_crdt_type(crdt: CType) -> String {
         CType::PnCounter => "pncounter".to_string(),
         CType::PCounter => "pcounter".to_string(),
         CType::Unknown(_) => "unknown".to_string(),
-        _ => String::new(),
     }
 }
 
@@ -63,24 +62,21 @@ pub(super) fn format_field_kind(kind: &FieldKind) -> String {
             ScalarKind::String => "String".to_string(),
             ScalarKind::Blob => "Blob".to_string(),
             ScalarKind::Json => "JSON".to_string(),
-            _ => String::new(),
         },
         FieldKind::ScalarArray(a) => match a {
-            schema::ScalarArrayKind::BoolArray => "[Boolean!]".to_string(),
-            schema::ScalarArrayKind::IntArray => "[Int!]".to_string(),
-            schema::ScalarArrayKind::Float64Array => "[Float64!]".to_string(),
-            schema::ScalarArrayKind::Float32Array => "[Float32!]".to_string(),
-            schema::ScalarArrayKind::StringArray => "[String!]".to_string(),
-            schema::ScalarArrayKind::NillableBoolArray => "[Boolean]".to_string(),
-            schema::ScalarArrayKind::NillableIntArray => "[Int]".to_string(),
-            schema::ScalarArrayKind::NillableFloat64Array => "[Float64]".to_string(),
-            schema::ScalarArrayKind::NillableFloat32Array => "[Float32]".to_string(),
-            schema::ScalarArrayKind::NillableStringArray => "[String]".to_string(),
-            _ => String::new(),
+            crate::ScalarArrayKind::BoolArray => "[Boolean!]".to_string(),
+            crate::ScalarArrayKind::IntArray => "[Int!]".to_string(),
+            crate::ScalarArrayKind::Float64Array => "[Float64!]".to_string(),
+            crate::ScalarArrayKind::Float32Array => "[Float32!]".to_string(),
+            crate::ScalarArrayKind::StringArray => "[String!]".to_string(),
+            crate::ScalarArrayKind::NillableBoolArray => "[Boolean]".to_string(),
+            crate::ScalarArrayKind::NillableIntArray => "[Int]".to_string(),
+            crate::ScalarArrayKind::NillableFloat64Array => "[Float64]".to_string(),
+            crate::ScalarArrayKind::NillableFloat32Array => "[Float32]".to_string(),
+            crate::ScalarArrayKind::NillableStringArray => "[String]".to_string(),
         },
         FieldKind::Relation { .. } | FieldKind::SelfRef { .. } | FieldKind::Named { .. } => {
             "Object".to_string()
         }
-        _ => unreachable!(),
     }
 }

--- a/crates/schema/src/definition_validation/mod.rs
+++ b/crates/schema/src/definition_validation/mod.rs
@@ -10,7 +10,7 @@ mod update_validators;
 use global_validators::*;
 use update_validators::*;
 
-use schema::CollectionVersion;
+use crate::CollectionVersion;
 use std::collections::HashMap;
 
 /// Snapshot of all collection versions for validation.

--- a/crates/schema/src/definition_validation/update_validators.rs
+++ b/crates/schema/src/definition_validation/update_validators.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use schema::CollectionVersion;
+use crate::CollectionVersion;
 
 use super::DefinitionState;
 
@@ -222,7 +222,7 @@ pub(super) fn validate_field_not_mutated(
             }
         };
 
-        let old_fields_by_id: HashMap<&str, &schema::FieldDescription> =
+        let old_fields_by_id: HashMap<&str, &crate::FieldDescription> =
             old_col.fields.iter().map(|f| (f.id.as_str(), f)).collect();
 
         for new_field in &new_col.fields {

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -19,6 +19,8 @@ mod relation;
 mod source;
 mod validation;
 
+pub mod definition_validation;
+
 pub use cid::{
     generate_collection_block_full, generate_collection_block_full_with_query,
     generate_collection_cid, generate_collection_cid_full, generate_collection_cid_full_with_query,


### PR DESCRIPTION
## Summary

Sub-slice of #669. Moves `crates/db/src/definition_validation/` (~947 LOC) into `crates/schema/src/definition_validation/`.

## Pivot from #791

The originally-planned follow-up slice #791 (`db-migration` extraction) turned out to be blocked: the migration subsystem adds methods to `DB<S>` via `impl<S: Store> DB<S>` blocks, and Rust's orphan rule prevents those from moving to an external crate without a significant API break or trait-seam refactor. Same constraint blocks `downsample/` and `patch/`, which I had also earmarked as easy wins.

This PR takes the *actually* easy slice instead: `definition_validation/`. It has:
- Zero `impl DB<S>` blocks
- Zero `use crate::` imports outside the module (no coupling to `crate::txn`, `crate::error`, etc.)
- Only touches types already defined in `schema` (`CollectionVersion`, `FieldKind`, `CType`, `ScalarKind`, `ORPHAN_COLLECTION_ID`)

So rather than making a new crate, the module is **moved into the `schema` crate** where it conceptually belongs. `schema` already has a `validation` module for single-collection SDL validation; `definition_validation` handles multi-collection patch validation, which is a natural sibling.

## What changes

- `crates/db/src/definition_validation/` → `crates/schema/src/definition_validation/`
- `schema/src/lib.rs` adds `pub mod definition_validation`
- `db/src/lib.rs` drops `pub mod definition_validation`
- 8 call-site rewrites from `db::definition_validation::*` → `schema::definition_validation::*`:
  - `cli/src/schema_adapter.rs`
  - `defra-node/src/db_impls.rs`
  - `embedded/src/node.rs`
  - `ffi/src/mobile.rs`, `ffi/src/schema.rs` (×2)
  - `db/src/patch/mod.rs`, `db/src/patch/store.rs`, `db/src/txn_registry.rs` (internal)
- `embedded/Cargo.toml` adds `schema` dep (the other callers already had it)
- Cleaned up 4 dead `_` wildcard arms in `helpers.rs` — they existed because the match was over external non-exhaustive enums; now that the enums are crate-local they're exhaustive and the wildcards are dead code

Net: −947 LOC from db, +947 in schema (same content). db crate is now ~22.9K LOC down from 23.8K.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied
- [x] `cargo test -p integration-test --test query` — 27/27 passing (schema validation is exercised in query tests)

## Note on #791

#791 (db-migration extraction) is blocked by the orphan rule as described above. I'll update #669 with an honest status — the three "easy wins" I flagged in my earlier scope comment (backup, downsample, migration) turn out to be one easy win (backup, done in #793), one impossible (downsample, blocked), and one impossible (migration, blocked). Further db decomposition will need trait-seam refactors first.

Related: #669 (parent), #793 (db-backup), #788 (query-plan parallel extraction).