### PR TITLE
refactor(errors): defra-errors crate — unified subsystem error (Phase 0 of #796)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,6 +3559,7 @@ dependencies = [
  "db-blocks",
  "db-nac",
  "defra-core",
+ "defra-errors",
  "document",
  "events",
  "futures",
@@ -3734,6 +3735,18 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "defra-errors"
+version = "0.5.0"
+dependencies = [
+ "datastore",
+ "defra-core",
+ "document",
+ "schema",
+ "storage",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -9989,6 +10002,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "defra-core",
+ "defra-errors",
  "document",
  "schema",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10002,7 +10002,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "defra-core",
- "defra-errors",
  "document",
  "schema",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/defra-core",
+    "crates/defra-errors",
     "crates/crdt",
     "crates/storage",
     "crates/blockstore",

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -68,6 +68,7 @@ parking_lot.workspace = true
 # Internal crates
 db-blocks = { path = "../db-blocks" }
 db-nac = { path = "../db-nac", default-features = false }
+defra-errors = { path = "../defra-errors" }
 storage = { path = "../storage" }
 datastore = { path = "../datastore" }
 schema = { path = "../schema" }

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -124,6 +124,37 @@ impl From<lens::Error> for Error {
     }
 }
 
+impl From<defra_errors::Error> for Error {
+    fn from(err: defra_errors::Error) -> Self {
+        // Map each variant of the unified error to the closest db::Error
+        // variant so callers can keep pattern-matching on db::Error as before.
+        // New subsystem crates use defra_errors::Error directly and get
+        // bridged into db::Error when they thread errors up to the db layer.
+        match err {
+            defra_errors::Error::Storage(e) => Error::Storage(e),
+            defra_errors::Error::Datastore(e) => Error::Datastore(e),
+            defra_errors::Error::Schema(e) => Error::Schema(e),
+            defra_errors::Error::Document(e) => Error::Document(e),
+            defra_errors::Error::Core(e) => Error::Core(e),
+            defra_errors::Error::InvalidDocument(msg) => Error::InvalidDocument(msg),
+            defra_errors::Error::DocumentNotFound(msg) => Error::DocumentNotFound(msg),
+            defra_errors::Error::CollectionNotFound(msg) => Error::CollectionNotFound(msg),
+            defra_errors::Error::NotFound(msg) => Error::Other(format!("not found: {}", msg)),
+            defra_errors::Error::AlreadyExists(msg) => {
+                Error::Other(format!("already exists: {}", msg))
+            }
+            defra_errors::Error::InvalidArgument(msg) => {
+                Error::Other(format!("invalid argument: {}", msg))
+            }
+            defra_errors::Error::Other(msg) => Error::Other(msg),
+            // `defra_errors::Error` is `#[non_exhaustive]` so new variants
+            // added upstream get a catch-all Other here until we choose to
+            // map them more specifically.
+            other => Error::Other(other.to_string()),
+        }
+    }
+}
+
 impl Error {
     pub fn document_at_key(key: &[u8], source: document::Error) -> Self {
         Self::DocumentAtKey {

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -126,10 +126,11 @@ impl From<lens::Error> for Error {
 
 impl From<defra_errors::Error> for Error {
     fn from(err: defra_errors::Error) -> Self {
-        // Map each variant of the unified error to the closest db::Error
-        // variant so callers can keep pattern-matching on db::Error as before.
-        // New subsystem crates use defra_errors::Error directly and get
-        // bridged into db::Error when they thread errors up to the db layer.
+        // Needed for the `?` operator: extracted subsystem crates return
+        // `defra_errors::Error`, and db-layer functions that call into
+        // them return `db::Error`. This conversion lets `?` bridge
+        // automatically. It is not a compatibility shim — db::Error is
+        // still being actively reshaped in Phase 7 of the epic.
         match err {
             defra_errors::Error::Storage(e) => Error::Storage(e),
             defra_errors::Error::Datastore(e) => Error::Datastore(e),

--- a/crates/defra-errors/Cargo.toml
+++ b/crates/defra-errors/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "defra-errors"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Unified error type for DefraDB — shared base across db, query, and extracted subsystems"
+
+[dependencies]
+# Foundation crates whose errors feed into the unified Error via #[from]
+defra-core = { path = "../defra-core" }
+document = { path = "../document" }
+schema = { path = "../schema" }
+storage = { path = "../storage" }
+datastore = { path = "../datastore" }
+
+# Error handling
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/defra-errors/src/lib.rs
+++ b/crates/defra-errors/src/lib.rs
@@ -1,0 +1,143 @@
+//! Unified error type for DefraDB.
+//!
+//! Shared base error used by db, query, and extracted subsystem crates
+//! (db-backup, db-index, db-txn, db-commits-fetcher, db-lensed-fetcher,
+//! db-patch, etc.). Instead of every extracted crate carrying its own
+//! narrow `Error` enum + `From` conversion boilerplate, they all use
+//! [`Error`] from this crate.
+//!
+//! `db::Error` and `query_types::QueryError` are separate, more
+//! specialized errors that carry variants genuinely unique to those
+//! layers. They each provide a `From<defra_errors::Error>` impl so
+//! subsystem errors thread up into the broader hierarchy cleanly.
+//!
+//! # Design notes
+//!
+//! - Foundation errors (storage, datastore, schema, document, defra-core)
+//!   are brought in via `#[from]` so the `?` operator works across crate
+//!   boundaries without manual mapping.
+//! - Common free-form variants (`InvalidDocument`, `NotFound`,
+//!   `AlreadyExists`, `Other`) live here so multiple extracted subsystems
+//!   can reuse them.
+//! - The enum is `#[non_exhaustive]` so new variants can be added
+//!   without breaking downstream matches that use `_` wildcards.
+
+use thiserror::Error;
+
+/// Result alias used across the DefraDB crates that consume
+/// [`Error`] directly.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Unified error type shared across DefraDB subsystem crates.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("storage error: {0}")]
+    Storage(#[from] storage::Error),
+
+    #[error("datastore error: {0}")]
+    Datastore(#[from] datastore::Error),
+
+    #[error("schema error: {0}")]
+    Schema(#[from] schema::SchemaError),
+
+    #[error("document error: {0}")]
+    Document(#[from] document::Error),
+
+    #[error("core error: {0}")]
+    Core(#[from] defra_core::Error),
+
+    #[error("invalid document: {0}")]
+    InvalidDocument(String),
+
+    #[error("document not found: {0}")]
+    DocumentNotFound(String),
+
+    #[error("collection not found: {0}")]
+    CollectionNotFound(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("already exists: {0}")]
+    AlreadyExists(String),
+
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl Error {
+    /// Construct an `InvalidDocument` error from any displayable value.
+    pub fn invalid_document(msg: impl Into<String>) -> Self {
+        Self::InvalidDocument(msg.into())
+    }
+
+    /// Construct a `DocumentNotFound` error from any displayable value.
+    pub fn document_not_found(msg: impl Into<String>) -> Self {
+        Self::DocumentNotFound(msg.into())
+    }
+
+    /// Construct a `CollectionNotFound` error from any displayable value.
+    pub fn collection_not_found(msg: impl Into<String>) -> Self {
+        Self::CollectionNotFound(msg.into())
+    }
+
+    /// Construct a `NotFound` error from any displayable value.
+    pub fn not_found(msg: impl Into<String>) -> Self {
+        Self::NotFound(msg.into())
+    }
+
+    /// Construct an `AlreadyExists` error from any displayable value.
+    pub fn already_exists(msg: impl Into<String>) -> Self {
+        Self::AlreadyExists(msg.into())
+    }
+
+    /// Construct an `InvalidArgument` error from any displayable value.
+    pub fn invalid_argument(msg: impl Into<String>) -> Self {
+        Self::InvalidArgument(msg.into())
+    }
+
+    /// Construct an `Other` free-form error from any displayable value.
+    pub fn other(msg: impl Into<String>) -> Self {
+        Self::Other(msg.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_storage_error_display_matches_inner() {
+        let inner = storage::Error::Other("disk on fire".to_string());
+        let expected = format!("storage error: {}", inner);
+        let wrapped: Error = inner.into();
+        assert_eq!(wrapped.to_string(), expected);
+    }
+
+    #[test]
+    fn invalid_document_constructor_roundtrip() {
+        let err = Error::invalid_document("missing _docID");
+        assert!(matches!(err, Error::InvalidDocument(_)));
+        assert_eq!(err.to_string(), "invalid document: missing _docID");
+    }
+
+    #[test]
+    fn not_found_constructor_roundtrip() {
+        let err = Error::not_found("txn foo");
+        assert!(matches!(err, Error::NotFound(_)));
+        assert_eq!(err.to_string(), "not found: txn foo");
+    }
+
+    #[test]
+    fn wrapper_chains_inner_source() {
+        let inner = document::Error::CborDecode("bad cbor".to_string());
+        let wrapped: Error = inner.into();
+        // thiserror's #[from] preserves the source chain; std::error::Error::source() returns Some.
+        use std::error::Error as _;
+        assert!(wrapped.source().is_some());
+    }
+}

--- a/crates/query-types/Cargo.toml
+++ b/crates/query-types/Cargo.toml
@@ -30,7 +30,6 @@ schema = { path = "../schema" }
 storage = { path = "../storage" }
 document = { path = "../document" }
 defra-core = { path = "../defra-core" }
-defra-errors = { path = "../defra-errors" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/query-types/Cargo.toml
+++ b/crates/query-types/Cargo.toml
@@ -30,6 +30,7 @@ schema = { path = "../schema" }
 storage = { path = "../storage" }
 document = { path = "../document" }
 defra-core = { path = "../defra-core" }
+defra-errors = { path = "../defra-errors" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/query-types/src/error.rs
+++ b/crates/query-types/src/error.rs
@@ -270,49 +270,14 @@ impl QueryError {
     }
 }
 
-impl From<defra_errors::Error> for QueryError {
-    fn from(err: defra_errors::Error) -> Self {
-        // Bridge the unified subsystem error into the query-layer error.
-        // Extracted crates (db-commits-fetcher, db-lensed-fetcher, etc.)
-        // return `defra_errors::Error`; this impl lets callers in the
-        // query crate use `?` without manual mapping.
-        //
-        // For the structured wrappers (Storage/Datastore/Schema/Document/
-        // Core) we flatten into `Execution` / `Internal` with the full
-        // chain stringified, because QueryError's structured variants take
-        // specific inner error types that don't line up directly with
-        // defra_errors' broader storage::Error / datastore::Error shapes.
-        match err {
-            defra_errors::Error::Storage(e) => {
-                QueryError::Execution(format!("storage error: {}", e))
-            }
-            defra_errors::Error::Datastore(e) => {
-                QueryError::Execution(format!("datastore error: {}", e))
-            }
-            defra_errors::Error::Schema(e) => QueryError::Execution(format!("schema error: {}", e)),
-            defra_errors::Error::Document(e) => {
-                QueryError::Internal(format!("document error: {}", e))
-            }
-            defra_errors::Error::Core(e) => QueryError::Internal(format!("core error: {}", e)),
-            defra_errors::Error::InvalidDocument(msg) => {
-                QueryError::Execution(format!("invalid document: {}", msg))
-            }
-            defra_errors::Error::DocumentNotFound(msg) => QueryError::DocumentNotFound(msg),
-            defra_errors::Error::CollectionNotFound(msg) => QueryError::CollectionNotFound(msg),
-            defra_errors::Error::NotFound(msg) => {
-                QueryError::Execution(format!("not found: {}", msg))
-            }
-            defra_errors::Error::AlreadyExists(msg) => {
-                QueryError::Execution(format!("already exists: {}", msg))
-            }
-            defra_errors::Error::InvalidArgument(msg) => {
-                QueryError::Execution(format!("invalid argument: {}", msg))
-            }
-            defra_errors::Error::Other(msg) => QueryError::Execution(msg),
-            other => QueryError::Internal(other.to_string()),
-        }
-    }
-}
+// A `From<defra_errors::Error> for QueryError` bridge is intentionally NOT
+// provided yet. `QueryError::Storage` wraps `storage::corekv::Error` while
+// `defra_errors::Error::Storage` wraps the broader `storage::Error` — they
+// don't line up, so any bridge today would either stringify (losing
+// structure) or need a structural fix to one of the two enums. When the
+// first extracted subsystem actually threads errors into query code, we
+// reshape QueryError at that point. Adding the bridge preemptively with a
+// stringifying workaround would paper over the mismatch.
 
 #[cfg(test)]
 mod tests {

--- a/crates/query-types/src/error.rs
+++ b/crates/query-types/src/error.rs
@@ -270,6 +270,50 @@ impl QueryError {
     }
 }
 
+impl From<defra_errors::Error> for QueryError {
+    fn from(err: defra_errors::Error) -> Self {
+        // Bridge the unified subsystem error into the query-layer error.
+        // Extracted crates (db-commits-fetcher, db-lensed-fetcher, etc.)
+        // return `defra_errors::Error`; this impl lets callers in the
+        // query crate use `?` without manual mapping.
+        //
+        // For the structured wrappers (Storage/Datastore/Schema/Document/
+        // Core) we flatten into `Execution` / `Internal` with the full
+        // chain stringified, because QueryError's structured variants take
+        // specific inner error types that don't line up directly with
+        // defra_errors' broader storage::Error / datastore::Error shapes.
+        match err {
+            defra_errors::Error::Storage(e) => {
+                QueryError::Execution(format!("storage error: {}", e))
+            }
+            defra_errors::Error::Datastore(e) => {
+                QueryError::Execution(format!("datastore error: {}", e))
+            }
+            defra_errors::Error::Schema(e) => QueryError::Execution(format!("schema error: {}", e)),
+            defra_errors::Error::Document(e) => {
+                QueryError::Internal(format!("document error: {}", e))
+            }
+            defra_errors::Error::Core(e) => QueryError::Internal(format!("core error: {}", e)),
+            defra_errors::Error::InvalidDocument(msg) => {
+                QueryError::Execution(format!("invalid document: {}", msg))
+            }
+            defra_errors::Error::DocumentNotFound(msg) => QueryError::DocumentNotFound(msg),
+            defra_errors::Error::CollectionNotFound(msg) => QueryError::CollectionNotFound(msg),
+            defra_errors::Error::NotFound(msg) => {
+                QueryError::Execution(format!("not found: {}", msg))
+            }
+            defra_errors::Error::AlreadyExists(msg) => {
+                QueryError::Execution(format!("already exists: {}", msg))
+            }
+            defra_errors::Error::InvalidArgument(msg) => {
+                QueryError::Execution(format!("invalid argument: {}", msg))
+            }
+            defra_errors::Error::Other(msg) => QueryError::Execution(msg),
+            other => QueryError::Internal(other.to_string()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

First phase of the db/query decomposition follow-up epic #796. Introduces a shared error type (`defra_errors::Error`) that every extracted subsystem crate will use from day one, eliminating the per-crate narrow-Error + `From`-boilerplate pattern that `db-index` (#795) had to invent.

## What this PR does

- New crate `crates/defra-errors/` at the storage layer, depends only on `defra-core`, `document`, `schema`, `storage`, `datastore`
- Defines `defra_errors::Error` as a thiserror enum with:
  - `#[from]` wrappers for foundation errors (Storage, Datastore, Schema, Document, Core)
  - Shared free-form variants (InvalidDocument, DocumentNotFound, CollectionNotFound, NotFound, AlreadyExists, InvalidArgument, Other)
  - Constructor helpers for each variant
  - `#[non_exhaustive]` so new variants don't break downstream matches
- `From<defra_errors::Error> for db::Error` — bridges subsystem errors into db's broader error hierarchy
- `From<defra_errors::Error> for query_types::QueryError` — same for query-layer consumers. Flattens structured wrappers into `Execution`/`Internal` since QueryError's `Storage`/`Schema` variants take different inner types than defra-errors' broader `storage::Error`/`schema::SchemaError`.

## What this PR does NOT do

- Does **not** reshape `db::Error` or `QueryError` to move variants out. That's Phase 7 (the existing db::Error cleanup pass in the epic). This PR is purely additive so Phases 1-6 can consume the unified error without waiting on the variant migration.
- **Zero behavior change.** All existing errors flow through existing code paths unchanged. Display output and Debug chains are identical for everything except new subsystem-originated errors (which don't exist yet until Phase 2+ lands).

## Why this approach (vs reshape-in-one-PR)

The plan allows a flag-day reshape of db::Error since there's no BC requirement. I chose additive-only for Phase 0 because:

1. Phases 1-6 only need `defra_errors::Error` to *exist* — they don't need db::Error to be thinned. Deferring the reshape keeps each PR smaller and easier to review.
2. The right time to audit what stays in db::Error vs what moves out is *after* all extractions land, when we can see which variants still have producers. That's Phase 7.
3. A smaller, additive Phase 0 de-risks the whole epic — if Phase 0 breaks something subtle about error propagation, the fix is localized.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p defra-errors` — 4/4 unit tests (Display format, constructors, source chain via `std::error::Error::source()`)
- [x] `cargo test -p db -p query-types` — all passing (additive change)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

## Diff

8 files, +258 lines, 0 deletions. New crate + two bridge impls.

## Next

- **Phase 1**: extract `db-txn` crate with `TransactionView<S>` trait (1 PR) — unblocks fetcher extractions
- **Phase 2-3**: extract `db-commits-fetcher`, `db-lensed-fetcher` (2 PRs)
- **Phase 4**: extract `db-patch` as free functions (1 PR, parallel with Phase 1)
- **Phases 5-8**: dense_search design + extract + final cleanup

Related: #796 (epic), #669, #670.