### PR TITLE
refactor(db): remove dead Error variants (Phase 7 of #796)

### DIFF
--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -16,9 +16,6 @@ pub enum Error {
     #[error("document error: {0}")]
     Document(#[from] document::Error),
 
-    #[error("core error: {0}")]
-    Core(#[from] defra_core::Error),
-
     #[error("failed to deserialize document at key {key:?}: {source}")]
     DocumentAtKey {
         key: String,
@@ -57,9 +54,6 @@ pub enum Error {
 
     #[error("explicit transaction must use force_commit/force_discard")]
     ExplicitTxnMustUseForce,
-
-    #[error("unsupported transaction type")]
-    UnsupportedTxnType,
 
     #[error("serialization error: {0}")]
     Serialization(String),


### PR DESCRIPTION
## Summary

Phase 7 of #796: audit db::Error for variants with zero producers after the decomposition wave and remove them.

## What was dead

Two variants had zero direct constructors and zero From-trigger sites anywhere in the workspace:

- `Core(#[from] defra_core::Error)` — no `defra_core::Error` references in db outside error.rs itself, so this From impl is never exercised
- `UnsupportedTxnType` — no direct constructors, no helper method

Both removed.

## What was NOT dead (but looked suspicious)

During the audit I initially flagged several variants as candidates for removal because a naive grep for `Error::VariantName` turned up zero matches:

- `CollectionSchemaJson` — actually constructed via `Error::collection_schema_json()` helper (22+ sites across patch, schema_loader, txn, collection_ops, migration)
- `DocumentAtKey` — constructed via `Error::document_at_key()` helper (2 sites in collection/)
- `LensConfigJson` — constructed via `Error::lens_config_json()` helper (3 sites in migration/)
- `TextDecode` — constructed via `Error::text_decode()` helper (3 sites)
- `JsonPatch` — triggered via `?` on `json_patch::JsonPatchError` in patch/ module

These variants stay because their helper constructors are load-bearing.

## Why the thinning is small

The epic originally estimated db::Error could shrink meaningfully. The reality is that most of db::Error's 34 variants are actually used — the variant list grew organically as needed, not via speculative catch-alls. Only 2 variants turned out to be genuinely dead.

Net: -6 lines, 34 → 32 variants.

## Test plan

- `cargo check --workspace` clean
- `cargo test -p db` — all passing
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all` applied

Related: #796 (epic).