### PR TITLE
Avoid CID string allocation in block sorting

### DIFF
--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -8,7 +8,7 @@ use multicodec::Codec;
 use multihash::MultihashGeneric;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::sync::{LazyLock, OnceLock};
+use std::sync::LazyLock;
 
 use crate::{Error, Result};
 
@@ -80,7 +80,7 @@ impl Block {
     pub fn new(delta: CrdtDelta, heads: Vec<Cid>, links: Vec<DAGLink>) -> Self {
         // Sort and normalize heads
         let mut sorted_heads = heads;
-        sorted_heads.sort_by_cached_key(|a| a.to_string());
+        sorted_heads.sort_unstable();
         let heads = if sorted_heads.is_empty() {
             None
         } else {
@@ -196,9 +196,6 @@ pub struct DAGLink {
 
     /// CID of the linked block
     pub link: Cid,
-
-    #[serde(skip)]
-    sort_key: OnceLock<String>,
 }
 
 impl DAGLink {
@@ -207,12 +204,7 @@ impl DAGLink {
         Self {
             name: name.into(),
             link,
-            sort_key: OnceLock::new(),
         }
-    }
-
-    fn sort_key(&self) -> &str {
-        self.sort_key.get_or_init(|| self.link.to_string())
     }
 }
 
@@ -232,8 +224,9 @@ impl PartialOrd for DAGLink {
 
 impl Ord for DAGLink {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // Sort by link CID multibase string (matching Go's strings.Compare)
-        self.sort_key().cmp(other.sort_key())
+        // DefraDB block links are CIDv1 DAG-CBOR SHA2-256 values, so native CID ordering
+        // matches the prior multibase string ordering without allocating.
+        self.link.cmp(&other.link)
     }
 }
 

--- a/crates/defra-core/tests/block_tests.rs
+++ b/crates/defra-core/tests/block_tests.rs
@@ -393,7 +393,30 @@ fn test_block_new_sorts_links_by_cid_string() {
 }
 
 #[test]
-fn test_dag_link_equality_ignores_sort_cache_state() {
+fn test_cid_order_matches_string_order_for_block_sort_inputs() {
+    let mut sorted_by_cid = vec![
+        test_cid(),
+        test_cid2(),
+        Cid::from_str(GO_LWW_SIMPLE_CID).unwrap(),
+        Cid::from_str(GO_LWW_HIGH_PRIORITY_CID).unwrap(),
+        Cid::from_str(GO_COUNTER_CID).unwrap(),
+        Cid::from_str(GO_COMPOSITE_ACTIVE_CID).unwrap(),
+        Cid::from_str(GO_COMPOSITE_DELETED_CID).unwrap(),
+        Cid::from_str(GO_COLLECTION_CID).unwrap(),
+        Cid::from_str(GO_LWW_DELETION_CID).unwrap(),
+        Cid::from_str(GO_BLOCK_WITH_ONE_HEAD_CID).unwrap(),
+        Cid::from_str(GO_COMPOSITE_BLOCK_WITH_LINKS_CID).unwrap(),
+    ];
+    let mut sorted_by_string = sorted_by_cid.clone();
+
+    sorted_by_cid.sort_unstable();
+    sorted_by_string.sort_by_cached_key(|cid| cid.to_string());
+
+    assert_eq!(sorted_by_cid, sorted_by_string);
+}
+
+#[test]
+fn test_dag_link_equality_is_unaffected_by_sorting() {
     let link = DAGLink::new("field", test_cid());
     let mut sorted = [link.clone()];
     sorted.sort();


### PR DESCRIPTION
## Summary
- replace string-based head sorting in `Block::new` with direct `Cid` ordering
- remove the cached DAG link string sort key and compare links by `Cid` directly
- add a regression test that proves direct CID ordering matches the previous string ordering for representative block CIDs

## Testing
- cargo test -p defra-core
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- cargo test --workspace --exclude integration-test --exclude ffi-test

Closes #672