### PR TITLE
Unify BasicTxn callback storage

### DIFF
--- a/crates/datastore/src/txn.rs
+++ b/crates/datastore/src/txn.rs
@@ -26,6 +26,24 @@ enum TxnState {
     Discarded,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TxnCallbackPhase {
+    Success,
+    Error,
+    Discard,
+}
+
+enum RegisteredCallback {
+    Sync {
+        phase: TxnCallbackPhase,
+        callback: TxnCallback,
+    },
+    Async {
+        phase: TxnCallbackPhase,
+        callback: AsyncCallback,
+    },
+}
+
 /// BasicTxn wraps a corekv transaction with DefraDB-specific functionality.
 ///
 /// This matches Go's BasicTxn in internal/datastore/txn.go, providing:
@@ -37,14 +55,7 @@ pub struct BasicTxn {
     id: u64,
     readonly: bool,
     state: TxnState,
-
-    success_fns: Vec<TxnCallback>,
-    error_fns: Vec<TxnCallback>,
-    discard_fns: Vec<TxnCallback>,
-
-    success_async_fns: Vec<AsyncCallback>,
-    error_async_fns: Vec<AsyncCallback>,
-    discard_async_fns: Vec<AsyncCallback>,
+    callbacks: Vec<RegisteredCallback>,
 }
 
 impl BasicTxn {
@@ -65,12 +76,7 @@ impl BasicTxn {
             id,
             readonly,
             state: TxnState::Active,
-            success_fns: Vec::new(),
-            error_fns: Vec::new(),
-            discard_fns: Vec::new(),
-            success_async_fns: Vec::new(),
-            error_async_fns: Vec::new(),
-            discard_async_fns: Vec::new(),
+            callbacks: Vec::new(),
         }
     }
 
@@ -121,32 +127,83 @@ impl BasicTxn {
 
     /// Register a callback to be called on successful commit.
     pub fn on_success(&mut self, callback: TxnCallback) {
-        self.success_fns.push(callback);
+        self.callbacks.push(RegisteredCallback::Sync {
+            phase: TxnCallbackPhase::Success,
+            callback,
+        });
     }
 
     /// Register a callback to be called on commit error.
     pub fn on_error(&mut self, callback: TxnCallback) {
-        self.error_fns.push(callback);
+        self.callbacks.push(RegisteredCallback::Sync {
+            phase: TxnCallbackPhase::Error,
+            callback,
+        });
     }
 
     /// Register a callback to be called on discard.
     pub fn on_discard(&mut self, callback: TxnCallback) {
-        self.discard_fns.push(callback);
+        self.callbacks.push(RegisteredCallback::Sync {
+            phase: TxnCallbackPhase::Discard,
+            callback,
+        });
     }
 
     /// Register an async callback to be called on successful commit.
     pub fn on_success_async(&mut self, callback: AsyncCallback) {
-        self.success_async_fns.push(callback);
+        self.callbacks.push(RegisteredCallback::Async {
+            phase: TxnCallbackPhase::Success,
+            callback,
+        });
     }
 
     /// Register an async callback to be called on commit error.
     pub fn on_error_async(&mut self, callback: AsyncCallback) {
-        self.error_async_fns.push(callback);
+        self.callbacks.push(RegisteredCallback::Async {
+            phase: TxnCallbackPhase::Error,
+            callback,
+        });
     }
 
     /// Register an async callback to be called on discard.
     pub fn on_discard_async(&mut self, callback: AsyncCallback) {
-        self.discard_async_fns.push(callback);
+        self.callbacks.push(RegisteredCallback::Async {
+            phase: TxnCallbackPhase::Discard,
+            callback,
+        });
+    }
+
+    fn split_callbacks(
+        callbacks: Vec<RegisteredCallback>,
+        phase: TxnCallbackPhase,
+    ) -> (
+        Vec<TxnCallback>,
+        Vec<AsyncCallback>,
+        Vec<RegisteredCallback>,
+    ) {
+        let mut retained = Vec::with_capacity(callbacks.len());
+        let mut sync_callbacks = Vec::new();
+        let mut async_callbacks = Vec::new();
+
+        for callback in callbacks {
+            match callback {
+                RegisteredCallback::Sync {
+                    phase: callback_phase,
+                    callback,
+                } if callback_phase == phase => {
+                    sync_callbacks.push(callback);
+                }
+                RegisteredCallback::Async {
+                    phase: callback_phase,
+                    callback,
+                } if callback_phase == phase => {
+                    async_callbacks.push(callback);
+                }
+                callback => retained.push(callback),
+            }
+        }
+
+        (sync_callbacks, async_callbacks, retained)
     }
 
     /// Commit the transaction.
@@ -171,6 +228,7 @@ impl BasicTxn {
         // Extract the underlying transaction
         // The SharedTxn holds it in an Arc<RwLock<Box<dyn Txn>>>
         // We need to get ownership to call commit
+        let callbacks = std::mem::take(&mut self.callbacks);
         let shared = Arc::try_unwrap(self.shared_txn).map_err(|_| {
             Error::Storage(storage::corekv::Error::Other(
                 "Cannot commit: transaction still has references".into(),
@@ -180,12 +238,13 @@ impl BasicTxn {
         let txn = shared.into_txn();
         let result = txn.commit().await;
 
-        let (sync_fns, async_fns) = if result.is_ok() {
+        let (sync_fns, async_fns, retained_callbacks) = if result.is_ok() {
             self.state = TxnState::Committed;
-            (self.success_fns, self.success_async_fns)
+            Self::split_callbacks(callbacks, TxnCallbackPhase::Success)
         } else {
-            (self.error_fns, self.error_async_fns)
+            Self::split_callbacks(callbacks, TxnCallbackPhase::Error)
         };
+        self.callbacks = retained_callbacks;
 
         // Callbacks run directly so the runtime's panic strategy stays explicit:
         // unwind propagates in dev/test, and release aborts the process.
@@ -226,6 +285,7 @@ impl BasicTxn {
         }
 
         // Extract and discard the underlying transaction
+        let callbacks = std::mem::take(&mut self.callbacks);
         let shared = Arc::try_unwrap(self.shared_txn).map_err(|_| Error::TxnStillInUse)?;
 
         let txn = shared.into_txn();
@@ -236,14 +296,17 @@ impl BasicTxn {
         // Async discard callbacks are spawned and run directly. On native
         // targets a panic in the task follows the runtime panic strategy.
         let txn_id = self.id;
-        if !self.discard_async_fns.is_empty() {
-            let callback_count = self.discard_async_fns.len();
+        let (discard_fns, discard_async_fns, retained_callbacks) =
+            Self::split_callbacks(callbacks, TxnCallbackPhase::Discard);
+        self.callbacks = retained_callbacks;
+        if !discard_async_fns.is_empty() {
+            let callback_count = discard_async_fns.len();
             tracing::debug!(
                 txn_id = txn_id,
                 count = callback_count,
                 "Spawning async discard callbacks in background"
             );
-            for callback in self.discard_async_fns {
+            for callback in discard_async_fns {
                 #[cfg(not(target_arch = "wasm32"))]
                 tokio::spawn(async move {
                     callback().await;
@@ -258,7 +321,7 @@ impl BasicTxn {
             }
         }
 
-        for callback in self.discard_fns {
+        for callback in discard_fns {
             callback();
         }
 

--- a/crates/datastore/tests/txn_tests.rs
+++ b/crates/datastore/tests/txn_tests.rs
@@ -4,6 +4,7 @@ use datastore::BasicTxn;
 use futures::FutureExt;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
+use std::sync::Mutex;
 use storage::backends::MemoryStore;
 
 #[tokio::test]
@@ -312,6 +313,45 @@ async fn test_basic_txn_async_success_callback() {
 }
 
 #[tokio::test]
+async fn test_basic_txn_mixed_success_callbacks_preserve_execution_order() {
+    let store = MemoryStore::new();
+    let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+    let execution_order = Arc::new(Mutex::new(Vec::new()));
+
+    let order = execution_order.clone();
+    txn.on_success(Box::new(move || {
+        order.lock().unwrap().push("sync-1");
+    }));
+
+    let order = execution_order.clone();
+    txn.on_success_async(Box::new(move || {
+        Box::pin(async move {
+            order.lock().unwrap().push("async-1");
+        })
+    }));
+
+    let order = execution_order.clone();
+    txn.on_success(Box::new(move || {
+        order.lock().unwrap().push("sync-2");
+    }));
+
+    let order = execution_order.clone();
+    txn.on_success_async(Box::new(move || {
+        Box::pin(async move {
+            order.lock().unwrap().push("async-2");
+        })
+    }));
+
+    txn.commit().await.unwrap();
+
+    assert_eq!(
+        *execution_order.lock().unwrap(),
+        vec!["async-1", "async-2", "sync-1", "sync-2"]
+    );
+}
+
+#[tokio::test]
 async fn test_basic_txn_async_discard_callback() {
     use std::time::Duration;
 
@@ -332,6 +372,29 @@ async fn test_basic_txn_async_discard_callback() {
         .await
         .expect("Timeout waiting for async callback")
         .expect("Failed to receive from callback");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_basic_txn_discard_spawns_async_callbacks_before_sync_callbacks() {
+    use std::time::Duration;
+
+    let store = MemoryStore::new();
+    let mut txn = BasicTxn::new(&store, 1, false).await.unwrap();
+
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    txn.on_discard_async(Box::new(move || {
+        Box::pin(async move {
+            started_tx.send(()).unwrap();
+        })
+    }));
+
+    txn.on_discard(Box::new(move || {
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("async discard callback should be spawned before sync discard callback runs");
+    }));
+
+    txn.discard().unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- replace BasicTxn's six callback vectors with a single internal callback registry keyed by phase and sync/async kind
- preserve the existing public registration API and the existing execution semantics for commit/discard callbacks
- add mixed callback ordering tests to pin async-before-sync execution and discard spawn ordering

## Testing
- cargo test -p datastore
- cargo fmt --all -- --check
- cargo test --workspace --exclude integration-test --exclude ffi-test
- CARGO_TARGET_DIR=target/clippy-issue684 cargo clippy --all -- -D warnings