### PR TITLE
Use typed key structs in CRDT code

### DIFF
--- a/crates/crdt/src/composite.rs
+++ b/crates/crdt/src/composite.rs
@@ -11,7 +11,7 @@ use defra_core::{types::DocId, Error, Result};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::collections::HashMap;
-use storage::{Reader, ReaderWriter};
+use storage::{corekv::Key, keys::CRDTValueKey, Reader, ReaderWriter};
 
 /// Composite Delta - represents changes to multiple fields in a document
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -177,21 +177,23 @@ impl CompositeDAG {
 
     /// Build the value key for a field
     fn build_value_key(&self, field_name: &str) -> Vec<u8> {
-        let mut key = Vec::new();
-        key.extend_from_slice(b"/data/");
-        key.extend_from_slice(self.schema_version_id.as_bytes());
-        key.push(b'/');
-        key.extend_from_slice(self.doc_id.as_str().as_bytes());
-        key.push(b'/');
-        key.extend_from_slice(field_name.as_bytes());
-        key
+        CRDTValueKey::new(
+            self.schema_version_id.clone(),
+            self.doc_id.as_str().as_bytes().to_vec(),
+            field_name.to_string(),
+        )
+        .bytes()
     }
 
     /// Build the priority key for a field
     fn build_priority_key(&self, field_name: &str) -> Vec<u8> {
-        let mut key = self.build_value_key(field_name);
-        key.extend_from_slice(b"/priority");
-        key
+        CRDTValueKey::new(
+            self.schema_version_id.clone(),
+            self.doc_id.as_str().as_bytes().to_vec(),
+            field_name.to_string(),
+        )
+        .priority_key()
+        .bytes()
     }
 
     /// Get the current priority for a field (0 if not set)

--- a/crates/crdt/src/counter.rs
+++ b/crates/crdt/src/counter.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use defra_core::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
-use storage::{Reader, ReaderWriter};
+use storage::{corekv::Key, keys::CRDTValueKey, Reader, ReaderWriter};
 
 /// Numeric kind for counter values
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -231,22 +231,16 @@ impl Counter {
             return Err(Error::MergeError("field_name cannot be empty".into()));
         }
 
-        // Construct storage keys
-        let mut value_key = Vec::new();
-        value_key.extend_from_slice(b"/data/");
-        value_key.extend_from_slice(schema_version_id.as_bytes());
-        value_key.push(b'/');
-        value_key.extend_from_slice(doc_id);
-        value_key.push(b'/');
-        value_key.extend_from_slice(field_name.as_bytes());
-
-        // Nonce tracking prefix
-        let mut nonce_prefix = value_key.clone();
-        nonce_prefix.extend_from_slice(b"/nonces/");
+        let value_key = CRDTValueKey::new(
+            schema_version_id.clone(),
+            doc_id.to_vec(),
+            field_name.clone(),
+        );
+        let nonce_prefix = value_key.nonce_prefix();
 
         Ok(Self {
-            value_key,
-            nonce_prefix,
+            value_key: value_key.bytes(),
+            nonce_prefix: nonce_prefix.bytes(),
             schema_version_id,
             field_name,
             allow_decrement,

--- a/crates/crdt/src/lww.rs
+++ b/crates/crdt/src/lww.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use defra_core::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
-use storage::{Reader, ReaderWriter};
+use storage::{corekv::Key, keys::CRDTValueKey, Reader, ReaderWriter};
 use tracing::instrument;
 
 /// LWW Delta - represents a change to an LWW register
@@ -169,23 +169,16 @@ impl Lww {
             return Err(Error::MergeError("field_name cannot be empty".into()));
         }
 
-        // Construct storage keys
-        // Format: /data/<schema_version>/<doc_id>/<field_name>
-        let mut value_key = Vec::new();
-        value_key.extend_from_slice(b"/data/");
-        value_key.extend_from_slice(schema_version_id.as_bytes());
-        value_key.push(b'/');
-        value_key.extend_from_slice(doc_id);
-        value_key.push(b'/');
-        value_key.extend_from_slice(field_name.as_bytes());
-
-        // Priority key: value_key + "/priority"
-        let mut priority_key = value_key.clone();
-        priority_key.extend_from_slice(b"/priority");
+        let value_key = CRDTValueKey::new(
+            schema_version_id.clone(),
+            doc_id.to_vec(),
+            field_name.clone(),
+        );
+        let priority_key = value_key.priority_key();
 
         Ok(Self {
-            value_key,
-            priority_key,
+            value_key: value_key.bytes(),
+            priority_key: priority_key.bytes(),
             schema_version_id,
             field_name,
         })

--- a/crates/storage/src/keys/crdt.rs
+++ b/crates/storage/src/keys/crdt.rs
@@ -1,0 +1,226 @@
+use crate::corekv::Key;
+
+const DATA_PREFIX: &[u8] = b"/data/";
+const PRIORITY_SUFFIX: &[u8] = b"/priority";
+const NONCES_SUFFIX: &[u8] = b"/nonces/";
+
+/// CRDTValueKey: Stores a CRDT field value.
+///
+/// Structure: /data/[SchemaVersionID]/[DocID bytes]/[FieldName]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CRDTValueKey {
+    /// Schema version identifier.
+    pub schema_version_id: String,
+    /// Raw document identifier bytes.
+    pub doc_id: Vec<u8>,
+    /// Field name.
+    pub field_name: String,
+}
+
+impl CRDTValueKey {
+    /// Create a new CRDTValueKey.
+    pub fn new(
+        schema_version_id: impl Into<String>,
+        doc_id: impl Into<Vec<u8>>,
+        field_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version_id: schema_version_id.into(),
+            doc_id: doc_id.into(),
+            field_name: field_name.into(),
+        }
+    }
+
+    /// Create the corresponding priority key.
+    pub fn priority_key(&self) -> CRDTPriorityKey {
+        CRDTPriorityKey::new(
+            self.schema_version_id.clone(),
+            self.doc_id.clone(),
+            self.field_name.clone(),
+        )
+    }
+
+    /// Create a nonce key prefix for this field.
+    pub fn nonce_prefix(&self) -> CRDTNoncePrefix {
+        CRDTNoncePrefix::new(
+            self.schema_version_id.clone(),
+            self.doc_id.clone(),
+            self.field_name.clone(),
+        )
+    }
+}
+
+impl Key for CRDTValueKey {
+    fn bytes(&self) -> Vec<u8> {
+        let mut key = Vec::with_capacity(
+            DATA_PREFIX.len()
+                + self.schema_version_id.len()
+                + 1
+                + self.doc_id.len()
+                + 1
+                + self.field_name.len(),
+        );
+        key.extend_from_slice(DATA_PREFIX);
+        key.extend_from_slice(self.schema_version_id.as_bytes());
+        key.push(b'/');
+        key.extend_from_slice(&self.doc_id);
+        key.push(b'/');
+        key.extend_from_slice(self.field_name.as_bytes());
+        key
+    }
+
+    fn to_string(&self) -> String {
+        format!(
+            "/data/{}/{}/{}",
+            self.schema_version_id,
+            String::from_utf8_lossy(&self.doc_id),
+            self.field_name
+        )
+    }
+}
+
+/// CRDTPriorityKey: Stores CRDT field priority metadata.
+///
+/// Structure: /data/[SchemaVersionID]/[DocID bytes]/[FieldName]/priority
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CRDTPriorityKey {
+    /// Value key this priority metadata is associated with.
+    pub value_key: CRDTValueKey,
+}
+
+impl CRDTPriorityKey {
+    /// Create a new CRDTPriorityKey.
+    pub fn new(
+        schema_version_id: impl Into<String>,
+        doc_id: impl Into<Vec<u8>>,
+        field_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            value_key: CRDTValueKey::new(schema_version_id, doc_id, field_name),
+        }
+    }
+}
+
+impl Key for CRDTPriorityKey {
+    fn bytes(&self) -> Vec<u8> {
+        let mut key = self.value_key.bytes();
+        key.extend_from_slice(PRIORITY_SUFFIX);
+        key
+    }
+
+    fn to_string(&self) -> String {
+        format!("{}/priority", self.value_key.to_string())
+    }
+}
+
+/// CRDTNoncePrefix: Prefix for CRDT nonce-tracking keys.
+///
+/// Structure: /data/[SchemaVersionID]/[DocID bytes]/[FieldName]/nonces/
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CRDTNoncePrefix {
+    /// Value key this nonce prefix is associated with.
+    pub value_key: CRDTValueKey,
+}
+
+impl CRDTNoncePrefix {
+    /// Create a new CRDTNoncePrefix.
+    pub fn new(
+        schema_version_id: impl Into<String>,
+        doc_id: impl Into<Vec<u8>>,
+        field_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            value_key: CRDTValueKey::new(schema_version_id, doc_id, field_name),
+        }
+    }
+
+    /// Create a nonce key by appending the nonce bytes.
+    pub fn nonce_key(&self, nonce: i64) -> CRDTNonceKey {
+        CRDTNonceKey {
+            prefix: self.clone(),
+            nonce,
+        }
+    }
+}
+
+impl Key for CRDTNoncePrefix {
+    fn bytes(&self) -> Vec<u8> {
+        let mut key = self.value_key.bytes();
+        key.extend_from_slice(NONCES_SUFFIX);
+        key
+    }
+
+    fn to_string(&self) -> String {
+        format!("{}/nonces/", self.value_key.to_string())
+    }
+}
+
+/// CRDTNonceKey: Tracks an applied counter nonce.
+///
+/// Structure: /data/[SchemaVersionID]/[DocID bytes]/[FieldName]/nonces/[NonceBE]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CRDTNonceKey {
+    /// Prefix for the nonce-tracking keys.
+    pub prefix: CRDTNoncePrefix,
+    /// Nonce encoded as big-endian bytes.
+    pub nonce: i64,
+}
+
+impl Key for CRDTNonceKey {
+    fn bytes(&self) -> Vec<u8> {
+        let mut key = self.prefix.bytes();
+        key.extend_from_slice(&self.nonce.to_be_bytes());
+        key
+    }
+
+    fn to_string(&self) -> String {
+        format!("{:?}", self.bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_crdt_value_key_bytes_match_legacy_encoding() {
+        let key = CRDTValueKey::new("schema", b"doc-123".to_vec(), "field");
+
+        assert_eq!(key.bytes(), b"/data/schema/doc-123/field");
+        assert_eq!(key.to_string(), "/data/schema/doc-123/field");
+    }
+
+    #[test]
+    fn test_crdt_priority_key_bytes_match_legacy_encoding() {
+        let key = CRDTPriorityKey::new("schema", b"doc-123".to_vec(), "field");
+
+        assert_eq!(key.bytes(), b"/data/schema/doc-123/field/priority");
+        assert_eq!(key.to_string(), "/data/schema/doc-123/field/priority");
+    }
+
+    #[test]
+    fn test_crdt_nonce_prefix_and_key_bytes_match_legacy_encoding() {
+        let prefix = CRDTNoncePrefix::new("schema", b"doc-123".to_vec(), "field");
+        let key = prefix.nonce_key(42);
+
+        let mut expected = b"/data/schema/doc-123/field/nonces/".to_vec();
+        expected.extend_from_slice(&42i64.to_be_bytes());
+
+        assert_eq!(prefix.bytes(), b"/data/schema/doc-123/field/nonces/");
+        assert_eq!(key.bytes(), expected);
+    }
+
+    #[test]
+    fn test_crdt_value_key_builds_related_keys() {
+        let value_key = CRDTValueKey::new("schema", b"doc-123".to_vec(), "field");
+
+        assert_eq!(
+            value_key.priority_key().bytes(),
+            b"/data/schema/doc-123/field/priority"
+        );
+        assert_eq!(
+            value_key.nonce_prefix().bytes(),
+            b"/data/schema/doc-123/field/nonces/"
+        );
+    }
+}

--- a/crates/storage/src/keys/mod.rs
+++ b/crates/storage/src/keys/mod.rs
@@ -1,7 +1,7 @@
 /// Key hierarchy for DefraDB storage
 ///
-/// This module provides 29 key types organized across 6 stores:
-/// - Datastore (5 keys): Document and collection data
+/// This module provides 33 key types organized across 6 stores:
+/// - Datastore (9 keys): Document, collection, and CRDT data
 /// - Headstore (6 keys): Merkle tree heads, definitions, and priority indexes
 /// - Systemstore (11 keys): Metadata and configuration
 /// - Peerstore (4 keys): Peer and replication metadata
@@ -38,6 +38,7 @@
 /// let string = key.to_string(); // Debug representation
 /// ```
 pub mod blockstore;
+pub mod crdt;
 pub mod datastore;
 pub mod encstore;
 pub mod headstore;
@@ -47,6 +48,7 @@ pub mod utils;
 
 // Re-export commonly used types
 pub use blockstore::{BlockstoreKey, ToMergeIndexKey, MERGE_PREFIX};
+pub use crdt::{CRDTNonceKey, CRDTNoncePrefix, CRDTPriorityKey, CRDTValueKey};
 pub use datastore::{
     DataStoreKey, DatastoreSE, IndexDataStoreKey, IndexedField, PrimaryDataStoreKey, ViewCacheKey,
     DATASTORE_DOC_VERSION_FIELD_ID,
@@ -84,6 +86,11 @@ mod tests {
         let _: Box<dyn Key> = Box::new(IndexDataStoreKey::new(1, 2, vec![]));
         let _: Box<dyn Key> = Box::new(DatastoreSE::new("col", "idx", vec![], "doc"));
         let _: Box<dyn Key> = Box::new(ViewCacheKey::new(1, 5));
+        let _: Box<dyn Key> = Box::new(CRDTValueKey::new("schema", b"doc".to_vec(), "field"));
+        let _: Box<dyn Key> = Box::new(CRDTPriorityKey::new("schema", b"doc".to_vec(), "field"));
+        let _: Box<dyn Key> = Box::new(CRDTNoncePrefix::new("schema", b"doc".to_vec(), "field"));
+        let _: Box<dyn Key> =
+            Box::new(CRDTNoncePrefix::new("schema", b"doc".to_vec(), "field").nonce_key(1));
 
         // Headstore keys
         let cid = test_cid();
@@ -132,6 +139,10 @@ mod tests {
         let _d3 = IndexDataStoreKey::new(1, 2, vec![]);
         let _d4 = DatastoreSE::new("c", "i", vec![], "d");
         let _d5 = ViewCacheKey::new(1, 5);
+        let _d6 = CRDTValueKey::new("s", b"d".to_vec(), "f");
+        let _d7 = CRDTPriorityKey::new("s", b"d".to_vec(), "f");
+        let _d8 = CRDTNoncePrefix::new("s", b"d".to_vec(), "f");
+        let _d9 = CRDTNoncePrefix::new("s", b"d".to_vec(), "f").nonce_key(1);
 
         // Headstore: 6 keys
         let cid = test_cid();
@@ -168,6 +179,6 @@ mod tests {
         // Encstore: 1 key
         let _e1 = EncstoreKey::new(cid);
 
-        // Total: 5 + 6 + 11 + 4 + 2 + 1 = 29 active key types.
+        // Total: 9 + 6 + 11 + 4 + 2 + 1 = 33 active key types.
     }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -5,7 +5,7 @@
 /// - Multiple backend implementations (Memory, Redb)
 /// - MVCC transactions with snapshot isolation
 /// - Six specialized stores with namespace isolation (plus RootStore foundation)
-/// - 27 key types for hierarchical organization across 6 stores
+/// - 33 key types for hierarchical organization across 6 stores
 /// - Chunking support for large values (>1MB, up to 256MB)
 /// - Merge tracking for CRDT operations
 ///
@@ -67,7 +67,7 @@
 /// - Transaction callbacks
 ///
 /// ## Phase 2: Key Hierarchy ✅ (Complete)
-/// - 27 key types across 6 stores
+/// - 33 key types across 6 stores
 /// - Key encoding/decoding with CockroachDB-style varint
 /// - Hierarchical organization with prefixes
 ///


### PR DESCRIPTION
## Summary
- add typed CRDT key structs in storage for value, priority, and nonce-tracking keys
- replace manual CRDT key concatenation in lww, counter, and composite with the typed helpers
- preserve the existing `/data/<schema>/<doc>/<field>` byte encoding and add compatibility tests

## Testing
- cargo test -p storage keys:: --lib
- cargo test -p crdt
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- cargo test --workspace --exclude integration-test --exclude ffi-test
- cargo build -p cli --features iroh
