### PR TITLE
Reduce FFI collection wrapper boilerplate

### DIFF
--- a/crates/ffi/src/collection/mod.rs
+++ b/crates/ffi/src/collection/mod.rs
@@ -2,6 +2,10 @@
 //!
 //! This module exposes collection lifecycle and management functions
 //! that match Go's collection management behavior.
+//!
+//! The read/write wrappers are the current code-generation prototype for #692:
+//! they keep explicit `extern "C"` items for cbindgen, but share the repeated
+//! node/runtime/NAC/database prelude through `ffi_node_db_async_body!`.
 
 mod migration;
 mod purge;

--- a/crates/ffi/src/collection/read.rs
+++ b/crates/ffi/src/collection/read.rs
@@ -1,11 +1,5 @@
-use std::ffi::c_char;
-
+use crate::ffi_node_db_async_body;
 use acp::nac::NodePermission;
-
-use crate::helpers::{get_node_database, get_rt, require_c_str};
-use crate::nac_check::check_nac_for_node;
-use crate::types::FfiResult;
-use crate::{ffi_async, ffi_entry, try_ffi};
 
 /// Get a collection by name.
 ///
@@ -28,31 +22,26 @@ use crate::{ffi_async, ffi_entry, try_ffi};
 #[no_mangle]
 pub unsafe extern "C" fn get_collection_by_name(
     node_ptr: usize,
-    identity_did: *const c_char,
-    name: *const c_char,
-) -> FfiResult {
-    ffi_entry! {
-        let rt = try_ffi!(get_rt());
-        try_ffi!(check_nac_for_node(
-            rt,
-            node_ptr,
-            identity_did,
-            NodePermission::CollectionGet
-        ));
-        let name_str = try_ffi!(require_c_str(name, "name"));
-        let database = try_ffi!(get_node_database(node_ptr));
+    identity_did: *const std::ffi::c_char,
+    name: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionGet,
+        name => name_str: "name";
+        {
+        let collection = database
+            .get_collection(&name_str)
+            .map_err(|e| format!("failed to get collection: {}", e))?
+            .ok_or_else(|| format!("collection '{}' not found", name_str))?;
 
-        ffi_async!(rt, {
-            let collection = database
-                .get_collection(&name_str)
-                .map_err(|e| format!("failed to get collection: {}", e))?
-                .ok_or_else(|| format!("collection '{}' not found", name_str))?;
+        let json = serde_json::to_string(collection.schema())
+            .map_err(|e| format!("failed to serialize collection: {}", e))?;
 
-            let json = serde_json::to_string(collection.schema())
-                .map_err(|e| format!("failed to serialize collection: {}", e))?;
-
-            Ok(json)
-        })
+        Ok(json)
+    }
     }
 }
 
@@ -76,27 +65,22 @@ pub unsafe extern "C" fn get_collection_by_name(
 #[no_mangle]
 pub unsafe extern "C" fn has_collection(
     node_ptr: usize,
-    identity_did: *const c_char,
-    name: *const c_char,
-) -> FfiResult {
-    ffi_entry! {
-        let rt = try_ffi!(get_rt());
-        try_ffi!(check_nac_for_node(
-            rt,
-            node_ptr,
-            identity_did,
-            NodePermission::CollectionGet
-        ));
-        let name_str = try_ffi!(require_c_str(name, "name"));
-        let database = try_ffi!(get_node_database(node_ptr));
+    identity_did: *const std::ffi::c_char,
+    name: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionGet,
+        name => name_str: "name";
+        {
+        let exists = database
+            .has_collection(&name_str)
+            .map_err(|e| format!("failed to check collection: {}", e))?;
 
-        ffi_async!(rt, {
-            let exists = database
-                .has_collection(&name_str)
-                .map_err(|e| format!("failed to check collection: {}", e))?;
-
-            Ok(exists.to_string())
-        })
+        Ok(exists.to_string())
+    }
     }
 }
 
@@ -121,33 +105,28 @@ pub unsafe extern "C" fn has_collection(
 #[no_mangle]
 pub unsafe extern "C" fn find_collection_by_id(
     node_ptr: usize,
-    identity_did: *const c_char,
-    collection_id: *const c_char,
-) -> FfiResult {
-    ffi_entry! {
-        let rt = try_ffi!(get_rt());
-        try_ffi!(check_nac_for_node(
-            rt,
-            node_ptr,
-            identity_did,
-            NodePermission::CollectionGet
-        ));
-        let id_str = try_ffi!(require_c_str(collection_id, "collection_id"));
-        let database = try_ffi!(get_node_database(node_ptr));
+    identity_did: *const std::ffi::c_char,
+    collection_id: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionGet,
+        collection_id => id_str: "collection_id";
+        {
+        let collection = database
+            .find_collection_by_id(&id_str)
+            .map_err(|e| format!("failed to find collection: {}", e))?;
 
-        ffi_async!(rt, {
-            let collection = database
-                .find_collection_by_id(&id_str)
-                .map_err(|e| format!("failed to find collection: {}", e))?;
+        let json = match collection {
+            Some(c) => serde_json::to_string(c.schema())
+                .map_err(|e| format!("failed to serialize collection: {}", e))?,
+            None => "null".to_string(),
+        };
 
-            let json = match collection {
-                Some(c) => serde_json::to_string(c.schema())
-                    .map_err(|e| format!("failed to serialize collection: {}", e))?,
-                None => "null".to_string(),
-            };
-
-            Ok(json)
-        })
+        Ok(json)
+    }
     }
 }
 
@@ -171,34 +150,29 @@ pub unsafe extern "C" fn find_collection_by_id(
 #[no_mangle]
 pub unsafe extern "C" fn get_collection_by_version_id(
     node_ptr: usize,
-    identity_did: *const c_char,
-    version_id: *const c_char,
-) -> FfiResult {
-    ffi_entry! {
-        let rt = try_ffi!(get_rt());
-        try_ffi!(check_nac_for_node(
-            rt,
-            node_ptr,
-            identity_did,
-            NodePermission::CollectionGet
-        ));
-        let version_str = try_ffi!(require_c_str(version_id, "version_id"));
-        let database = try_ffi!(get_node_database(node_ptr));
+    identity_did: *const std::ffi::c_char,
+    version_id: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionGet,
+        version_id => version_str: "version_id";
+        {
+        let collection = database
+            .get_collection_by_version_id_full(&version_str)
+            .await
+            .map_err(|e| format!("failed to get collection: {}", e))?;
 
-        ffi_async!(rt, {
-            let collection = database
-                .get_collection_by_version_id_full(&version_str)
-                .await
-                .map_err(|e| format!("failed to get collection: {}", e))?;
+        let json = match collection {
+            Some(c) => serde_json::to_string(c.schema())
+                .map_err(|e| format!("failed to serialize collection: {}", e))?,
+            None => "null".to_string(),
+        };
 
-            let json = match collection {
-                Some(c) => serde_json::to_string(c.schema())
-                    .map_err(|e| format!("failed to serialize collection: {}", e))?,
-                None => "null".to_string(),
-            };
-
-            Ok(json)
-        })
+        Ok(json)
+    }
     }
 }
 

--- a/crates/ffi/src/collection/write.rs
+++ b/crates/ffi/src/collection/write.rs
@@ -1,11 +1,5 @@
-use std::ffi::c_char;
-
+use crate::ffi_node_db_async_body;
 use acp::nac::NodePermission;
-
-use crate::helpers::{get_node_database, get_rt, require_c_str};
-use crate::nac_check::check_nac_for_node;
-use crate::types::FfiResult;
-use crate::{ffi_async, ffi_entry, try_ffi};
 
 /// Delete a collection by name.
 ///
@@ -27,28 +21,23 @@ use crate::{ffi_async, ffi_entry, try_ffi};
 #[no_mangle]
 pub unsafe extern "C" fn delete_collection(
     node_ptr: usize,
-    identity_did: *const c_char,
-    name: *const c_char,
-) -> FfiResult {
-    ffi_entry! {
-        let rt = try_ffi!(get_rt());
-        try_ffi!(check_nac_for_node(
-            rt,
-            node_ptr,
-            identity_did,
-            NodePermission::CollectionPatch
-        ));
-        let name_str = try_ffi!(require_c_str(name, "name"));
-        let database = try_ffi!(get_node_database(node_ptr));
+    identity_did: *const std::ffi::c_char,
+    name: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionPatch,
+        name => name_str: "name";
+        {
+        database
+            .delete_collection(&name_str)
+            .await
+            .map_err(|e| format!("failed to delete collection: {}", e))?;
 
-        ffi_async!(rt, {
-            database
-                .delete_collection(&name_str)
-                .await
-                .map_err(|e| format!("failed to delete collection: {}", e))?;
-
-            Ok("{}".to_string())
-        })
+        Ok("{}".to_string())
+    }
     }
 }
 
@@ -73,28 +62,23 @@ pub unsafe extern "C" fn delete_collection(
 #[no_mangle]
 pub unsafe extern "C" fn set_active_collection_version(
     node_ptr: usize,
-    identity_did: *const c_char,
-    version_id: *const c_char,
-) -> FfiResult {
-    ffi_entry! {
-        let rt = try_ffi!(get_rt());
-        try_ffi!(check_nac_for_node(
-            rt,
-            node_ptr,
-            identity_did,
-            NodePermission::CollectionPatch
-        ));
-        let version_str = try_ffi!(require_c_str(version_id, "version_id"));
-        let database = try_ffi!(get_node_database(node_ptr));
+    identity_did: *const std::ffi::c_char,
+    version_id: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionPatch,
+        version_id => version_str: "version_id";
+        {
+        database
+            .set_active_collection_version(&version_str)
+            .await
+            .map_err(|e| format!("failed to set active collection version: {}", e))?;
 
-        ffi_async!(rt, {
-            database
-                .set_active_collection_version(&version_str)
-                .await
-                .map_err(|e| format!("failed to set active collection version: {}", e))?;
-
-            Ok("{}".to_string())
-        })
+        Ok("{}".to_string())
+    }
     }
 }
 
@@ -120,33 +104,28 @@ pub unsafe extern "C" fn set_active_collection_version(
 #[no_mangle]
 pub unsafe extern "C" fn patch_collection(
     node_ptr: usize,
-    identity_did: *const c_char,
-    collection_name: *const c_char,
-    patch: *const c_char,
-) -> FfiResult {
-    ffi_entry! {
-        let rt = try_ffi!(get_rt());
-        try_ffi!(check_nac_for_node(
-            rt,
-            node_ptr,
-            identity_did,
-            NodePermission::CollectionPatch
-        ));
-        let name_str = try_ffi!(require_c_str(collection_name, "collection_name"));
-        let patch_str = try_ffi!(require_c_str(patch, "patch"));
-        let database = try_ffi!(get_node_database(node_ptr));
+    identity_did: *const std::ffi::c_char,
+    collection_name: *const std::ffi::c_char,
+    patch: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionPatch,
+        collection_name => name_str: "collection_name",
+        patch => patch_str: "patch";
+        {
+        let updated_schema = database
+            .patch_collection(&name_str, &patch_str)
+            .await
+            .map_err(|e| format!("failed to patch collection: {}", e))?;
 
-        ffi_async!(rt, {
-            let updated_schema = database
-                .patch_collection(&name_str, &patch_str)
-                .await
-                .map_err(|e| format!("failed to patch collection: {}", e))?;
+        let json = serde_json::to_string(&updated_schema)
+            .map_err(|e| format!("failed to serialize updated schema: {}", e))?;
 
-            let json = serde_json::to_string(&updated_schema)
-                .map_err(|e| format!("failed to serialize updated schema: {}", e))?;
-
-            Ok(json)
-        })
+        Ok(json)
+    }
     }
 }
 
@@ -171,28 +150,23 @@ pub unsafe extern "C" fn patch_collection(
 #[no_mangle]
 pub unsafe extern "C" fn truncate_collection(
     node_ptr: usize,
-    identity_did: *const c_char,
-    name: *const c_char,
-) -> FfiResult {
-    ffi_entry! {
-        let rt = try_ffi!(get_rt());
-        try_ffi!(check_nac_for_node(
-            rt,
-            node_ptr,
-            identity_did,
-            NodePermission::CollectionTruncate
-        ));
-        let name_str = try_ffi!(require_c_str(name, "name"));
-        let database = try_ffi!(get_node_database(node_ptr));
+    identity_did: *const std::ffi::c_char,
+    name: *const std::ffi::c_char,
+) -> crate::types::FfiResult {
+    ffi_node_db_async_body! {
+        node = node_ptr,
+        identity = identity_did,
+        database = database,
+        permission = NodePermission::CollectionTruncate,
+        name => name_str: "name";
+        {
+        database
+            .truncate_collection(&name_str)
+            .await
+            .map_err(|e| format!("failed to truncate collection: {}", e))?;
 
-        ffi_async!(rt, {
-            database
-                .truncate_collection(&name_str)
-                .await
-                .map_err(|e| format!("failed to truncate collection: {}", e))?;
-
-            Ok("{}".to_string())
-        })
+        Ok("{}".to_string())
+    }
     }
 }
 

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -138,6 +138,46 @@ macro_rules! ffi_async_ok {
     }};
 }
 
+/// Expand the common `FfiResult` wrapper body for the
+/// node-permission-database async path.
+///
+/// The exported `extern "C"` function item stays explicit so cbindgen can keep
+/// emitting it in `defra.h`, while the repeated runtime / NAC / C-string /
+/// database prelude is shared in one place.
+#[macro_export]
+macro_rules! ffi_node_db_async_body {
+    (
+        node = $node_ptr:ident,
+        identity = $identity_did:ident,
+        database = $database:ident,
+        permission = $permission:expr
+        $(, $arg:ident => $parsed:ident : $arg_name:literal)*
+        $(,)?
+        ;
+        $body:block
+    ) => {
+        $crate::ffi_entry! {
+            let rt = $crate::try_ffi!($crate::helpers::get_rt());
+            $crate::try_ffi!($crate::nac_check::check_nac_for_node(
+                rt,
+                $node_ptr,
+                $identity_did,
+                $permission
+            ));
+            $(
+                let ffi_arg_ptr = $arg;
+                let ffi_arg_name = $arg_name;
+                let $parsed = $crate::try_ffi!(unsafe {
+                    $crate::helpers::require_c_str(ffi_arg_ptr, ffi_arg_name)
+                });
+            )*
+            let $database = $crate::try_ffi!($crate::helpers::get_node_database($node_ptr));
+
+            $crate::ffi_async!(rt, $body)
+        }
+    };
+}
+
 // Re-export FFI functions at crate root
 pub use acp::{
     add_dac_actor_relationship, add_dac_policy, add_nac_actor_relationship,


### PR DESCRIPTION
## Summary
- prototype wrapper boilerplate reduction for the collection read/write category in `crates/ffi`
- keep explicit `extern "C"` exports for cbindgen while sharing the node/database async wrapper body
- document the cbindgen constraint in the collection module comments

## Measurement
- 8 collection wrappers now share one common wrapper body pattern
- diff stat: 200 insertions, 208 deletions across 4 files
- regenerated `defra.h` has no diff from `HEAD`
- repeated runtime prelude count in `crates/ffi/src` dropped from 68 to 60
- repeated `get_node_database(node_ptr)` prelude count dropped from 24 to 16

## Verification
- `cargo test -p ffi`
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test --workspace --exclude integration-test --exclude ffi-test`

Closes #692