### PR TITLE
Reduce QueryRunner capability option plumbing

### DIFF
--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -709,7 +709,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         // ACP filtering: check read permission for each commit's document.
         // _commits must enforce the same ACP rules as regular document queries.
-        if let Some(ref acp) = self.acp {
+        {
             use acp::{DocumentPermission, Identity};
 
             let identity = Identity::from(caller_identity.clone());
@@ -749,7 +749,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     let mut any_granted = false;
                     for &(policy_id, resource_name) in &policies {
                         match crate::txn::check_doc_access_with_overlay(
-                            acp.as_ref(),
+                            self.acp.as_ref(),
                             &identity,
                             DocumentPermission::Read,
                             policy_id,

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -75,13 +75,12 @@ async fn check_nac<F: DocFetcher + 'static, R: crate::txn::TransactionRegistry>(
     identity: &Option<Did>,
     parsed: &ParsedOperation,
 ) -> Option<QueryResponse> {
-    let nac = runner.nac.as_ref()?;
     let did = match identity {
         Some(d) => d.clone(),
         None => Did::wildcard(),
     };
     let permission = permission_for_operation(parsed);
-    if !nac.check_permission(&did, permission).await {
+    if !runner.nac.check_permission(&did, permission).await {
         return Some(QueryResponse::success(serde_json::json!({})));
     }
     None

--- a/crates/query/src/runner/explain/execute.rs
+++ b/crates/query/src/runner/explain/execute.rs
@@ -258,7 +258,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             let collections: Vec<CollectionVersion> =
                 collections_map.values().map(|c| (**c).clone()).collect();
 
-            let mut planner = Planner::new(collections).with_fetcher(Arc::new(fetcher_arc));
+            let mut planner = Planner::new(collections)
+                .with_fetcher(Arc::new(fetcher_arc))
+                .with_acp(self.acp.clone(), caller_identity.clone());
             if let Some(ref lens_store) = self.lens_store {
                 planner = planner.with_lens_store(lens_store.clone());
             }
@@ -266,10 +268,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             let mut plan = plan_result.plan;
 
             // Wrap with permission filter if needed (explain path)
-            if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+            if let Some(ref policy) = collection.policy {
                 plan = Box::new(PermissionFilterNode::new(
                     plan,
-                    acp.clone(),
+                    self.acp.clone(),
                     Identity::from(caller_identity),
                     &policy.id,
                     &policy.resource_name,
@@ -328,17 +330,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             let _doc_count = plan_docs.len();
 
             // Build ACP filter config if collection has policy and ACP is configured
-            let acp_filter =
-                if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
-                    Some(plan::AcpFilter {
-                        acp: acp.clone(),
-                        identity: Identity::from(caller_identity),
-                        policy_id: policy.id.clone(),
-                        resource_name: policy.resource_name.clone(),
-                    })
-                } else {
-                    None
-                };
+            let acp_filter = collection.policy.as_ref().map(|policy| plan::AcpFilter {
+                acp: self.acp.clone(),
+                identity: Identity::from(caller_identity),
+                policy_id: policy.id.clone(),
+                resource_name: policy.resource_name.clone(),
+            });
 
             // Build the plan (ACP filter is inserted inside, after Select but before aggregates)
             let mut plan = plan::build_plan(

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -39,7 +39,7 @@ mod query;
 mod version;
 
 use acp::nac::NodePermission;
-use acp::DocumentACP;
+use acp::{DocumentACP, Identity as AcpIdentity, ReplicatedActorRelationship};
 use async_trait::async_trait;
 use identity::Did;
 use schema::CollectionVersion;
@@ -73,6 +73,96 @@ pub trait NacChecker: Send + Sync {
     async fn check_permission(&self, identity: &Did, permission: NodePermission) -> bool;
 }
 
+struct NoOpNacChecker;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl NacChecker for NoOpNacChecker {
+    async fn check_permission(&self, _identity: &Did, _permission: NodePermission) -> bool {
+        true
+    }
+}
+
+struct NoOpDocumentAcp;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl DocumentACP for NoOpDocumentAcp {
+    async fn register_doc_object(
+        &self,
+        _identity: &Did,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<()> {
+        Ok(())
+    }
+
+    async fn is_doc_registered(
+        &self,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<bool> {
+        Ok(false)
+    }
+
+    async fn check_doc_access(
+        &self,
+        _identity: &AcpIdentity,
+        _permission: acp::DocumentPermission,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_actor_relationship(
+        &self,
+        _requestor: &Did,
+        _target: &Did,
+        _policy_id: &str,
+        _collection_id: &str,
+        _doc_id: &str,
+        _relation: &str,
+        _managing_relations: &[String],
+    ) -> acp::Result<bool> {
+        Ok(false)
+    }
+
+    async fn delete_actor_relationship(
+        &self,
+        _requestor: &Did,
+        _target: &Did,
+        _policy_id: &str,
+        _collection_id: &str,
+        _doc_id: &str,
+        _relation: &str,
+        _managing_relations: &[String],
+    ) -> acp::Result<bool> {
+        Ok(false)
+    }
+
+    async fn export_actor_relationships(
+        &self,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<Vec<ReplicatedActorRelationship>> {
+        Ok(Vec::new())
+    }
+
+    async fn unregister_doc_object(
+        &self,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<()> {
+        Ok(())
+    }
+}
+
 /// Query runner that executes GraphQL queries against storage.
 pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRegistry> {
     /// Document fetcher for storage access (used for non-transactional queries)
@@ -83,8 +173,11 @@ pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRe
     pub(crate) registry: Arc<R>,
     /// Document mutator for mutation operations (optional)
     pub(crate) mutator: Option<Arc<dyn DocMutator>>,
-    /// Document ACP for permission checks (optional)
-    pub(crate) acp: Option<Arc<dyn DocumentACP>>,
+    /// Document ACP for permission checks.
+    ///
+    /// Defaults to a no-op ACP implementation that allows access and treats
+    /// documents as unregistered, matching the "ACP not configured" behavior.
+    pub(crate) acp: Arc<dyn DocumentACP>,
     /// Default identity for ACP permission checks.
     ///
     /// Used when a request doesn't include an explicit identity (e.g., no bearer token).
@@ -92,8 +185,10 @@ pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRe
     pub(crate) default_identity: Option<Did>,
     /// Optional lens transform store for view queries with transforms
     pub(crate) lens_store: Option<Arc<dyn lens::TransformStore>>,
-    /// Optional NAC checker for query-level enforcement.
-    pub(crate) nac: Option<Arc<dyn NacChecker>>,
+    /// NAC checker for query-level enforcement.
+    ///
+    /// Defaults to a no-op checker that allows every request.
+    pub(crate) nac: Arc<dyn NacChecker>,
     /// Query execution timeout in seconds (0 = no timeout). Default: 30.
     pub(crate) query_timeout: u64,
 }
@@ -109,10 +204,10 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             collection_provider: Arc::new(StaticCollectionProvider::new(collections)),
             registry: Arc::new(NoOpTransactionRegistry),
             mutator: None,
-            acp: None,
+            acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             lens_store: None,
-            nac: None,
+            nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
         }
     }
@@ -127,10 +222,10 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             collection_provider: provider,
             registry: Arc::new(NoOpTransactionRegistry),
             mutator: None,
-            acp: None,
+            acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             lens_store: None,
-            nac: None,
+            nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
         }
     }
@@ -147,10 +242,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_provider: Arc::new(StaticCollectionProvider::new(collections)),
             registry: Arc::new(registry),
             mutator: None,
-            acp: None,
+            acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             lens_store: None,
-            nac: None,
+            nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
         }
     }
@@ -170,10 +265,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_provider: provider,
             registry: Arc::new(registry),
             mutator: None,
-            acp: None,
+            acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             lens_store: None,
-            nac: None,
+            nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
         }
     }
@@ -192,10 +287,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collection_provider: provider,
             registry,
             mutator: None,
-            acp: None,
+            acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
             lens_store: None,
-            nac: None,
+            nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
         }
     }
@@ -213,7 +308,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// When set, queries will filter results based on the identity's permissions.
     /// Collections with a policy will have ACP enforced; others are unaffected.
     pub fn with_acp(mut self, acp: Arc<dyn DocumentACP>) -> Self {
-        self.acp = Some(acp);
+        self.acp = acp;
         self
     }
 
@@ -228,7 +323,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// When set, queries will be checked against NAC permissions before execution.
     /// Denied operations return a GraphQL error (HTTP 200) matching Go behavior.
     pub fn with_nac(mut self, nac: Arc<dyn NacChecker>) -> Self {
-        self.nac = Some(nac);
+        self.nac = nac;
         self
     }
 

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -291,7 +291,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // This matches Go's behavior where GQL mutations on invisible documents return
         // empty results, while mutations on visible-but-unauthorized documents return errors.
         let mut acp_filtered_doc_ids: Option<Vec<String>> = None;
-        if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+        if let Some(ref policy) = collection.policy {
             match mutation.mutation_type {
                 MutationType::Update | MutationType::Upsert => {
                     if let Some(ref doc_ids) = doc_ids_for_check {
@@ -300,7 +300,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         for doc_id in doc_ids {
                             // Phase 1: Check if the identity can read the document
                             let can_read = crate::txn::check_doc_access_with_overlay(
-                                acp.as_ref(),
+                                self.acp.as_ref(),
                                 &identity_for_acp,
                                 DocumentPermission::Read,
                                 &policy.id,
@@ -317,7 +317,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
                             // Phase 2: Check if the identity can update the document
                             let can_update = crate::txn::check_doc_access_with_overlay(
-                                acp.as_ref(),
+                                self.acp.as_ref(),
                                 &identity_for_acp,
                                 DocumentPermission::Update,
                                 &policy.id,
@@ -344,7 +344,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         for doc_id in doc_ids {
                             // Phase 1: Check if the identity can read the document
                             let can_read = crate::txn::check_doc_access_with_overlay(
-                                acp.as_ref(),
+                                self.acp.as_ref(),
                                 &identity_for_acp,
                                 DocumentPermission::Read,
                                 &policy.id,
@@ -361,7 +361,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
                             // Phase 2: Check if the identity can delete the document
                             let can_delete = crate::txn::check_doc_access_with_overlay(
-                                acp.as_ref(),
+                                self.acp.as_ref(),
                                 &identity_for_acp,
                                 DocumentPermission::Delete,
                                 &policy.id,
@@ -429,11 +429,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         resource = ?collection.policy.as_ref().map(|p| p.resource_name.clone()),
                         "create mutation entering remote signer authorization path"
                     );
-                    if let (Some(acp), Some(identity_did), Some(policy)) = (
-                        self.acp.as_ref(),
-                        caller_identity.as_ref(),
-                        collection.policy.as_ref(),
-                    ) {
+                    if let (Some(identity_did), Some(policy)) =
+                        (caller_identity.as_ref(), collection.policy.as_ref())
+                    {
                         tracing::info!(
                             actor_did = %identity_did,
                             policy_id = %policy.id,
@@ -442,7 +440,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             permission = "writer",
                             "create mutation requesting access decision"
                         );
-                        let decision_id = acp
+                        let decision_id = self
+                            .acp
                             .create_access_decision(
                                 &Identity::from(identity_did.clone()),
                                 &policy.id,
@@ -484,7 +483,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     } else {
                         tracing::warn!(
                             collection = %mutation.collection_name,
-                            has_acp = self.acp.is_some(),
+                            has_acp = true,
                             has_caller_identity = caller_identity.is_some(),
                             has_policy = collection.policy.is_some(),
                             "create mutation skipped remote signer authorization due to missing prerequisites"
@@ -613,7 +612,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Execute the plan.
         // When ACP is active, wrap DocumentNotFound errors to match Go's generic message
         // (security best practice: don't reveal whether document exists vs unauthorized).
-        let has_acp = self.acp.is_some() && collection.policy.is_some();
+        let has_acp = collection.policy.is_some();
         let map_doc_not_found = |e: QueryError| -> QueryError {
             if has_acp {
                 match &e {
@@ -670,14 +669,14 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             mutation.mutation_type,
             MutationType::Create | MutationType::Upsert
         ) {
-            if let (Some(ref acp), Some(ref policy), Some(ref identity_did)) =
-                (&self.acp, &collection.policy, &caller_identity)
+            if let (Some(ref policy), Some(ref identity_did)) =
+                (&collection.policy, &caller_identity)
             {
                 for result in &results {
                     if let Some(doc_id) = result.get("_docID").and_then(|v| v.as_str()) {
                         // Check if document is already registered (for upsert of existing doc)
                         let is_registered = crate::txn::is_doc_registered_with_overlay(
-                            acp.as_ref(),
+                            self.acp.as_ref(),
                             &policy.id,
                             &policy.resource_name,
                             doc_id,
@@ -704,7 +703,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                     );
                                 deferred_acp_mutations
                                     .schedule_register_doc_object(
-                                        acp.clone(),
+                                        self.acp.clone(),
                                         identity_did.clone(),
                                         policy.id.clone(),
                                         policy.resource_name.clone(),
@@ -714,7 +713,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                     .map_err(QueryError::execution)?;
                             } else {
                                 let acp_registration_start = Instant::now();
-                                acp.register_doc_object(
+                                self.acp
+                                    .register_doc_object(
                                     identity_did,
                                     &policy.id,
                                     &policy.resource_name,
@@ -744,7 +744,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // For DELETE operations: unregister deleted docs from ACP
         // This cleans up ACP state to prevent orphaned registrations
         if matches!(mutation.mutation_type, MutationType::Delete) {
-            if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+            if let Some(ref policy) = collection.policy {
                 let request_bearer_token = caller_identity
                     .as_ref()
                     .and_then(|did| defra_core::signing::get_request_bearer_token(did.as_str()));
@@ -757,7 +757,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             crate::txn::current_deferred_acp_mutations()
                         {
                             if let Err(err) = deferred_acp_mutations.schedule_unregister_doc_object(
-                                acp.clone(),
+                                self.acp.clone(),
                                 policy.id.clone(),
                                 policy.resource_name.clone(),
                                 doc_id.to_string(),
@@ -771,7 +771,8 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                     "Failed to defer ACP unregister for deleted document"
                                 );
                             }
-                        } else if let Err(e) = acp
+                        } else if let Err(e) = self
+                            .acp
                             .unregister_doc_object(&policy.id, &policy.resource_name, doc_id)
                             .await
                         {

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -38,15 +38,15 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Convert storage documents to values for aggregation
         let mut plan_docs = documents_to_plan_docs(&docs, &mapping)?;
 
-        // Apply ACP filtering if collection has a policy and ACP is configured
-        if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+        // Apply ACP filtering when the collection is policy-backed.
+        if let Some(ref policy) = collection.policy {
             let acp_identity = Identity::from(identity);
             let mut filtered = Vec::with_capacity(plan_docs.len());
             for doc in plan_docs {
                 if let Some(doc_id_val) = doc.get(0) {
                     if let Some(doc_id) = doc_id_val.as_str() {
                         let has_access = crate::txn::check_doc_access_with_overlay(
-                            acp.as_ref(),
+                            self.acp.as_ref(),
                             &acp_identity,
                             DocumentPermission::Read,
                             &policy.id,
@@ -266,10 +266,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let collections: Vec<CollectionVersion> =
             collections_map.values().map(|c| (**c).clone()).collect();
 
-        let mut planner = Planner::new(collections).with_fetcher(Arc::new(fetcher_arc));
-        if let Some(ref acp) = self.acp {
-            planner = planner.with_acp(acp.clone(), identity);
-        }
+        let mut planner = Planner::new(collections)
+            .with_fetcher(Arc::new(fetcher_arc))
+            .with_acp(self.acp.clone(), identity);
         if let Some(ref lens_store) = self.lens_store {
             planner = planner.with_lens_store(lens_store.clone());
         }

--- a/crates/query/src/runner/query/nested.rs
+++ b/crates/query/src/runner/query/nested.rs
@@ -62,12 +62,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         profile.precompute_fulltext_elapsed = precompute_fulltext_start.elapsed();
 
         let plan_build_start = Instant::now();
-        let mut planner = Planner::new(collections).with_fetcher(Arc::new(fetcher_arc));
+        let mut planner = Planner::new(collections)
+            .with_fetcher(Arc::new(fetcher_arc))
+            .with_acp(self.acp.clone(), identity);
         if !fts_scores.is_empty() {
             planner = planner.with_fts_scores(fts_scores);
-        }
-        if let Some(ref acp) = self.acp {
-            planner = planner.with_acp(acp.clone(), identity);
         }
         if let Some(ref lens_store) = self.lens_store {
             planner = planner.with_lens_store(lens_store.clone());

--- a/crates/query/src/runner/query/select.rs
+++ b/crates/query/src/runner/query/select.rs
@@ -365,8 +365,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         };
 
         // Apply ACP filtering: remove document IDs the caller cannot read.
-        let filtered_ids =
-            Self::filter_ids_by_acp(&matching_ids, &self.acp, &collection, caller_identity).await;
+        let filtered_ids = Self::filter_ids_by_acp(
+            &matching_ids,
+            self.acp.as_ref(),
+            &collection,
+            caller_identity,
+        )
+        .await;
 
         Ok(serde_json::json!([{"docIDs": filtered_ids}]))
     }
@@ -377,13 +382,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Fail-closed: any ACP check error results in the document being excluded.
     async fn filter_ids_by_acp(
         doc_ids: &[String],
-        acp: &Option<std::sync::Arc<dyn DocumentACP>>,
+        acp: &dyn DocumentACP,
         collection: &schema::CollectionVersion,
         caller_identity: Option<Did>,
     ) -> Vec<String> {
-        let (acp, policy) = match (acp, &collection.policy) {
-            (Some(acp), Some(policy)) => (acp, policy),
-            _ => return doc_ids.to_vec(),
+        let policy = match &collection.policy {
+            Some(policy) => policy,
+            None => return doc_ids.to_vec(),
         };
 
         let identity = Identity::from(caller_identity);
@@ -391,7 +396,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         for doc_id in doc_ids {
             let has_access = crate::txn::check_doc_access_with_overlay(
-                acp.as_ref(),
+                acp,
                 &identity,
                 DocumentPermission::Read,
                 &policy.id,

--- a/crates/query/src/runner/query/simple.rs
+++ b/crates/query/src/runner/query/simple.rs
@@ -109,24 +109,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             documents_to_plan_docs(&docs, &mapping)?
         };
 
-        // Build ACP filter config if collection has policy and ACP is configured
-        let acp_filter = if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy)
-        {
-            Some(plan::AcpFilter {
-                acp: acp.clone(),
-                identity: Identity::from(identity),
-                policy_id: policy.id.clone(),
-                resource_name: policy.resource_name.clone(),
-            })
-        } else {
-            if collection.policy.is_some() && self.acp.is_none() {
-                tracing::warn!(
-                    collection = %collection.name,
-                    "Collection has ACP policy but QueryRunner has no ACP configured - ACP enforcement is DISABLED"
-                );
-            }
-            None
-        };
+        // Build ACP filter config when the collection is policy-backed.
+        let acp_filter = collection.policy.as_ref().map(|policy| plan::AcpFilter {
+            acp: self.acp.clone(),
+            identity: Identity::from(identity),
+            policy_id: policy.id.clone(),
+            resource_name: policy.resource_name.clone(),
+        });
 
         // Build and execute the plan (ACP filter is inserted inside, after Select but before aggregates)
         let mut plan =

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -70,7 +70,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Apply ACP filtering: check read permission for each reconstructed document.
         // CID-based time-travel queries must enforce the same ACP rules as regular queries.
         // Documents the caller lacks read permission for are silently excluded (Go behavior).
-        let documents = if let (Some(ref acp), Some(ref policy)) = (&self.acp, &collection.policy) {
+        let documents = if let Some(ref policy) = collection.policy {
             let identity = Identity::from(caller_identity);
             let mut permitted = Vec::with_capacity(documents.len());
             for doc in documents {
@@ -79,7 +79,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     None => continue,
                 };
                 match crate::txn::check_doc_access_with_overlay(
-                    acp.as_ref(),
+                    self.acp.as_ref(),
                     &identity,
                     DocumentPermission::Read,
                     &policy.id,


### PR DESCRIPTION
## Summary
- replace optional ACP and NAC wiring in `QueryRunner` with explicit no-op defaults
- simplify query, mutation, explain, commit, and version paths to rely on those defaults instead of hot-path `Option` branching
- keep `default_identity: Option<Did>` unchanged and preserve existing lens-store/mutator behavior

## Testing
- cargo test -p query
- cargo test -p integration-test --test basic -- --test-threads=1 --skip ::go_
- cargo test -p integration-test --test query --test acp --test nac -- --test-threads=1 --skip ::go_
- cargo test --workspace --exclude integration-test --exclude ffi-test
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings

Closes #677