### PR TITLE
Fix signing config private key zeroization

### DIFF
--- a/crates/cli/src/commands/start/run.rs
+++ b/crates/cli/src/commands/start/run.rs
@@ -173,6 +173,7 @@ impl Node {
             }
         }
 
+        defra_core::signing::clear_identity_store();
         info!("DefraDB node shutdown complete");
         Ok(())
     }

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -55,7 +55,10 @@ impl Node {
                 did.as_ref(),
                 defra_core::signing::SigningConfig {
                     key_type: identity.identity_key_type().to_string(),
-                    private_key_bytes: identity.private_key_bytes(),
+                    private_key_bytes:
+                        defra_core::signing::SigningConfig::private_key_bytes_from_vec(
+                            identity.private_key_bytes(),
+                        ),
                     public_key_bytes: identity.public_key_bytes(),
                     public_key_hex: hex::encode(identity.public_key_bytes()),
                     remote_signer: None,

--- a/crates/defra-core/src/signing.rs
+++ b/crates/defra-core/src/signing.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
+use zeroize::Zeroize;
 
 /// Remote signing delegate (e.g. Orbis, Secure Enclave host callbacks).
 ///
@@ -153,7 +154,7 @@ impl Clone for SigningConfig {
     fn clone(&self) -> Self {
         Self {
             key_type: self.key_type.clone(),
-            private_key_bytes: self.private_key_bytes.clone(),
+            private_key_bytes: Self::private_key_bytes_from_slice(&self.private_key_bytes),
             public_key_bytes: self.public_key_bytes.clone(),
             public_key_hex: self.public_key_hex.clone(),
             remote_signer: self.remote_signer.clone(),
@@ -162,7 +163,29 @@ impl Clone for SigningConfig {
     }
 }
 
+impl Drop for SigningConfig {
+    fn drop(&mut self) {
+        self.private_key_bytes.zeroize();
+    }
+}
+
 impl SigningConfig {
+    /// Copy private key bytes into an exactly sized allocation.
+    pub fn private_key_bytes_from_slice(bytes: &[u8]) -> Vec<u8> {
+        let mut exact = Vec::with_capacity(bytes.len());
+        exact.extend_from_slice(bytes);
+        exact
+    }
+
+    /// Normalize owned private key bytes to an exactly sized allocation.
+    pub fn private_key_bytes_from_vec(bytes: Vec<u8>) -> Vec<u8> {
+        if bytes.len() == bytes.capacity() {
+            bytes
+        } else {
+            Self::private_key_bytes_from_slice(&bytes)
+        }
+    }
+
     /// Returns true if this identity has locally exportable private key bytes.
     pub fn has_local_private_key(&self) -> bool {
         !self.private_key_bytes.is_empty()
@@ -285,7 +308,7 @@ pub fn resolve_signing_config_with_flag(
 /// Clear all stored identities (for node cleanup).
 pub fn clear_identity_store() {
     if let Ok(mut store) = identity_store().lock() {
-        store.clear();
+        drop(std::mem::take(&mut *store));
     }
 }
 
@@ -401,6 +424,18 @@ mod tests {
         assert_eq!(resolved, "did:key:remote");
 
         clear_identity_store();
+    }
+
+    #[test]
+    fn private_key_bytes_from_vec_shrinks_spare_capacity() {
+        let mut bytes = Vec::with_capacity(64);
+        bytes.extend_from_slice(&[1_u8, 2, 3, 4]);
+        assert_eq!(bytes.capacity(), 64);
+
+        let exact = SigningConfig::private_key_bytes_from_vec(bytes);
+
+        assert_eq!(exact, vec![1, 2, 3, 4]);
+        assert_eq!(exact.len(), exact.capacity());
     }
 }
 

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -210,6 +210,8 @@ impl ShutdownHandle {
                 }
             }
         }
+
+        defra_core::signing::clear_identity_store();
     }
 }
 

--- a/crates/embedded/src/node_identity.rs
+++ b/crates/embedded/src/node_identity.rs
@@ -50,7 +50,10 @@ pub(crate) fn create_node_identity(
                 &did_str,
                 defra_core::signing::SigningConfig {
                     key_type,
-                    private_key_bytes: raw_identity.private_key_bytes().to_vec(),
+                    private_key_bytes:
+                        defra_core::signing::SigningConfig::private_key_bytes_from_vec(
+                            raw_identity.private_key_bytes(),
+                        ),
                     public_key_bytes: raw_identity.public_key_bytes().to_vec(),
                     public_key_hex: hex::encode(raw_identity.public_key_bytes()),
                     remote_signer: None,

--- a/crates/ffi/src/acp/identity.rs
+++ b/crates/ffi/src/acp/identity.rs
@@ -307,7 +307,10 @@ pub extern "C" fn create_identity() -> FfiResult {
                 did.as_ref(),
                 defra_core::signing::SigningConfig {
                     key_type: "ed25519".to_string(),
-                    private_key_bytes: identity.private_key_bytes().to_vec(),
+                    private_key_bytes:
+                        defra_core::signing::SigningConfig::private_key_bytes_from_vec(
+                            identity.private_key_bytes(),
+                        ),
                     public_key_bytes: identity.public_key_bytes().to_vec(),
                     public_key_hex,
                     remote_signer: None,

--- a/crates/sourcehub/src/cosmos/cosmos_provider.rs
+++ b/crates/sourcehub/src/cosmos/cosmos_provider.rs
@@ -377,7 +377,9 @@ mod tests {
             &did,
             defra_core::signing::SigningConfig {
                 key_type: "secp256r1".to_string(),
-                private_key_bytes: raw_identity.private_key_bytes().to_vec(),
+                private_key_bytes: defra_core::signing::SigningConfig::private_key_bytes_from_vec(
+                    raw_identity.private_key_bytes(),
+                ),
                 public_key_bytes: raw_identity.public_key_bytes().to_vec(),
                 public_key_hex: hex::encode(raw_identity.public_key_bytes()),
                 remote_signer: None,

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -678,7 +678,9 @@ mod tests {
             &did,
             defra_core::signing::SigningConfig {
                 key_type: "secp256k1".to_string(),
-                private_key_bytes: raw_identity.private_key_bytes().to_vec(),
+                private_key_bytes: defra_core::signing::SigningConfig::private_key_bytes_from_vec(
+                    raw_identity.private_key_bytes(),
+                ),
                 public_key_bytes: raw_identity.public_key_bytes().to_vec(),
                 public_key_hex: hex::encode(raw_identity.public_key_bytes()),
                 remote_signer: None,


### PR DESCRIPTION
## Summary
- zeroize  on drop and clear the identity store by dropping stored configs
- normalize retained private key buffers to exact-size allocations during clone and construction
- clear the identity store on CLI and embedded shutdown paths

## Testing
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- cargo test --workspace --exclude integration-test --exclude ffi-test