### PR TITLE
Handle issues #806 and #807: typed signing config cleanup

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -302,7 +302,7 @@ impl StartArgs {
         defra_core::signing::store_identity(
             &signer_did,
             defra_core::signing::SigningConfig {
-                key_type: "bls".to_string(),
+                key_type: defra_core::signing::SigningKeyType::Bls,
                 private_key_bytes: vec![],
                 public_key_bytes,
                 public_key_hex,

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -54,7 +54,23 @@ impl Node {
             defra_core::signing::store_identity(
                 did.as_ref(),
                 defra_core::signing::SigningConfig {
-                    key_type: identity.identity_key_type().to_string(),
+                    key_type: match identity.identity_key_type() {
+                        identity::IdentityKeyType::Ed25519 => {
+                            defra_core::signing::SigningKeyType::Ed25519
+                        }
+                        identity::IdentityKeyType::Secp256k1 => {
+                            defra_core::signing::SigningKeyType::Secp256k1
+                        }
+                        identity::IdentityKeyType::Secp256r1 => {
+                            defra_core::signing::SigningKeyType::Secp256r1
+                        }
+                        other => {
+                            return Err(Error::InvalidIdentity(format!(
+                                "unsupported identity key type for node signing: {}",
+                                other
+                            )))
+                        }
+                    },
                     private_key_bytes: identity.private_key_bytes(),
                     public_key_bytes: identity.public_key_bytes(),
                     public_key_hex: hex::encode(identity.public_key_bytes()),

--- a/crates/crypto/src/batch.rs
+++ b/crates/crypto/src/batch.rs
@@ -47,8 +47,8 @@ pub struct BatchSignature {
 pub fn sign_batch(cids: &[Cid], config: &SigningConfig) -> Result<BatchSignature, BatchSignError> {
     let root = compute_merkle_root(cids).ok_or(BatchSignError::MissingKey)?;
 
-    let (sig_type, sig_bytes) = match config.key_type.as_str() {
-        "ed25519" => {
+    let (sig_type, sig_bytes) = match config.key_type {
+        defra_core::signing::SigningKeyType::Ed25519 => {
             let key = Ed25519PrivateKey::from_bytes(&config.private_key_bytes).map_err(|e| {
                 BatchSignError::SigningFailed(format!("invalid ed25519 key: {}", e))
             })?;
@@ -57,7 +57,7 @@ pub fn sign_batch(cids: &[Cid], config: &SigningConfig) -> Result<BatchSignature
             })?;
             ("EdDSA".to_string(), sig)
         }
-        "secp256k1" => {
+        defra_core::signing::SigningKeyType::Secp256k1 => {
             let key = Secp256k1PrivateKey::from_bytes(&config.private_key_bytes).map_err(|e| {
                 BatchSignError::SigningFailed(format!("invalid secp256k1 key: {}", e))
             })?;
@@ -65,6 +65,12 @@ pub fn sign_batch(cids: &[Cid], config: &SigningConfig) -> Result<BatchSignature
                 BatchSignError::SigningFailed(format!("secp256k1 sign failed: {}", e))
             })?;
             ("ES256K".to_string(), sig)
+        }
+        defra_core::signing::SigningKeyType::Secp256r1
+        | defra_core::signing::SigningKeyType::Bls => {
+            return Err(BatchSignError::UnsupportedKeyType(
+                config.key_type.to_string(),
+            ))
         }
         other => return Err(BatchSignError::UnsupportedKeyType(other.to_string())),
     };
@@ -144,7 +150,7 @@ mod tests {
         let private_key = crate::keys::generation::generate_ed25519().unwrap();
         let public_key = private_key.public_key();
         SigningConfig {
-            key_type: "ed25519".to_string(),
+            key_type: defra_core::signing::SigningKeyType::Ed25519,
             private_key_bytes: private_key.raw_owned(),
             public_key_bytes: public_key.raw_owned(),
             public_key_hex: public_key.to_hex_string(),
@@ -157,7 +163,7 @@ mod tests {
         let private_key = crate::keys::generation::generate_secp256k1().unwrap();
         let public_key = private_key.public_key();
         SigningConfig {
-            key_type: "secp256k1".to_string(),
+            key_type: defra_core::signing::SigningKeyType::Secp256k1,
             private_key_bytes: private_key.raw_owned(),
             public_key_bytes: public_key.raw_owned(),
             public_key_hex: public_key.to_hex_string(),

--- a/crates/db-blocks/src/lib.rs
+++ b/crates/db-blocks/src/lib.rs
@@ -66,19 +66,19 @@ pub(crate) fn compute_signature(
 
     // Determine signature type and sign. Remote signers can back any supported
     // key type so mobile/TEE and Orbis-backed identities use the same path.
-    let sig_type = signer.signature_type()?;
+    let sig_type: defra_core::block::SignatureType = signer.key_type.into();
     let sig_bytes = if let Some(remote) = signer.remote_signer.as_ref() {
         remote.sign_sync(&block_bytes, signer.signing_authorization.as_ref())?
     } else {
-        match signer.key_type.as_str() {
-            "ed25519" => {
+        match signer.key_type {
+            defra_core::signing::SigningKeyType::Ed25519 => {
                 let private_key = crypto::Ed25519PrivateKey::from_bytes(&signer.private_key_bytes)
                     .map_err(|e| format!("Failed to load Ed25519 private key: {}", e))?;
                 private_key
                     .sign(&block_bytes)
                     .map_err(|e| format!("Failed to sign block: {}", e))?
             }
-            "secp256k1" => {
+            defra_core::signing::SigningKeyType::Secp256k1 => {
                 let private_key =
                     crypto::Secp256k1PrivateKey::from_bytes(&signer.private_key_bytes)
                         .map_err(|e| format!("Failed to load secp256k1 private key: {}", e))?;
@@ -86,7 +86,7 @@ pub(crate) fn compute_signature(
                     .sign(&block_bytes)
                     .map_err(|e| format!("Failed to sign block: {}", e))?
             }
-            "secp256r1" => {
+            defra_core::signing::SigningKeyType::Secp256r1 => {
                 let private_key =
                     crypto::Secp256r1PrivateKey::from_bytes(&signer.private_key_bytes)
                         .map_err(|e| format!("Failed to load secp256r1 private key: {}", e))?;
@@ -94,10 +94,12 @@ pub(crate) fn compute_signature(
                     .sign(&block_bytes)
                     .map_err(|e| format!("Failed to sign block: {}", e))?
             }
-            "bls" => {
+            defra_core::signing::SigningKeyType::Bls => {
                 return Err("BLS signing requires a remote signer".to_string());
             }
-            other => return Err(format!("Unsupported key type for signing: {}", other)),
+            other => {
+                return Err(format!("Unsupported key type for signing: {}", other));
+            }
         }
     };
 

--- a/crates/db-blocks/src/tests.rs
+++ b/crates/db-blocks/src/tests.rs
@@ -168,7 +168,7 @@ fn test_compute_signature_supports_remote_secp256r1() {
     );
 
     let signer = defra_core::signing::SigningConfig {
-        key_type: "secp256r1".to_string(),
+        key_type: defra_core::signing::SigningKeyType::Secp256r1,
         private_key_bytes: Vec::new(),
         public_key_bytes: public_key.raw_owned(),
         public_key_hex: hex::encode(public_key.raw()),
@@ -233,7 +233,7 @@ fn test_compute_signature_passes_signing_authorization_to_remote_signer() {
     );
 
     let signer = defra_core::signing::SigningConfig {
-        key_type: "secp256r1".to_string(),
+        key_type: defra_core::signing::SigningKeyType::Secp256r1,
         private_key_bytes: Vec::new(),
         public_key_bytes: public_key.raw_owned(),
         public_key_hex: hex::encode(public_key.raw()),

--- a/crates/defra-core/src/signing.rs
+++ b/crates/defra-core/src/signing.rs
@@ -113,13 +113,6 @@ impl PartialEq<&str> for SigningKeyType {
     }
 }
 
-/// Backward-compat: allow constructing from a `String` (panics on invalid).
-impl From<String> for SigningKeyType {
-    fn from(s: String) -> Self {
-        s.parse().unwrap_or_else(|e: String| panic!("{e}"))
-    }
-}
-
 /// Backward-compat: allow converting to String for callers that need it.
 impl From<SigningKeyType> for String {
     fn from(kt: SigningKeyType) -> Self {
@@ -135,8 +128,8 @@ impl From<SigningKeyType> for crate::block::SignatureType {
 
 /// Signing configuration containing key material for block signing.
 pub struct SigningConfig {
-    /// Key type: "ed25519", "secp256k1", "secp256r1", or "bls"
-    pub key_type: String,
+    /// Signing key type.
+    pub key_type: SigningKeyType,
     /// Raw private key bytes (empty for remote signers like Orbis)
     pub private_key_bytes: Vec<u8>,
     /// Raw public key bytes (for identity in signature header)
@@ -152,7 +145,7 @@ pub struct SigningConfig {
 impl Clone for SigningConfig {
     fn clone(&self) -> Self {
         Self {
-            key_type: self.key_type.clone(),
+            key_type: self.key_type,
             private_key_bytes: self.private_key_bytes.clone(),
             public_key_bytes: self.public_key_bytes.clone(),
             public_key_hex: self.public_key_hex.clone(),
@@ -171,22 +164,6 @@ impl SigningConfig {
     /// Returns true if this identity can sign by delegating to a remote signer.
     pub fn has_remote_signer(&self) -> bool {
         self.remote_signer.is_some()
-    }
-
-    /// Map the identity key type to a block signature type.
-    pub fn signature_type(&self) -> Result<crate::block::SignatureType, String> {
-        match self.key_type.as_str() {
-            "ed25519" => Ok(crate::block::SignatureType::EdDSA),
-            "secp256k1" => Ok(crate::block::SignatureType::ES256K),
-            "secp256r1" => Ok(crate::block::SignatureType::ES256),
-            "bls" => Ok(crate::block::SignatureType::BLS),
-            other => Err(format!("unsupported signing key type: {}", other)),
-        }
-    }
-
-    /// Parse the key type string into a `SigningKeyType` enum.
-    pub fn signing_key_type(&self) -> Result<SigningKeyType, String> {
-        self.key_type.parse()
     }
 }
 
@@ -335,7 +312,7 @@ mod tests {
 
     fn make_config(label: &str) -> SigningConfig {
         SigningConfig {
-            key_type: label.to_string(),
+            key_type: SigningKeyType::Secp256k1,
             private_key_bytes: vec![],
             public_key_bytes: vec![],
             public_key_hex: label.to_string(),
@@ -388,7 +365,7 @@ mod tests {
         store_identity(
             "did:key:remote",
             SigningConfig {
-                key_type: "bls".to_string(),
+                key_type: SigningKeyType::Bls,
                 private_key_bytes: vec![],
                 public_key_bytes: vec![],
                 public_key_hex: "remote".to_string(),
@@ -401,6 +378,12 @@ mod tests {
         assert_eq!(resolved, "did:key:remote");
 
         clear_identity_store();
+    }
+
+    #[test]
+    fn signing_key_type_from_str_rejects_invalid_values() {
+        let error = "invalid".parse::<SigningKeyType>().unwrap_err();
+        assert_eq!(error, "unsupported signing key type: invalid");
     }
 }
 

--- a/crates/embedded/src/node_identity.rs
+++ b/crates/embedded/src/node_identity.rs
@@ -41,9 +41,9 @@ pub(crate) fn create_node_identity(
                 .map_err(|error| anyhow!("failed to derive node DID: {error}"))?;
             let did_str = did.to_string();
             let key_type = match key {
-                Some(SigningKey::Ed25519(_)) => "ed25519".to_string(),
-                Some(SigningKey::Secp256r1(_)) => "secp256r1".to_string(),
-                _ => "secp256k1".to_string(),
+                Some(SigningKey::Ed25519(_)) => defra_core::signing::SigningKeyType::Ed25519,
+                Some(SigningKey::Secp256r1(_)) => defra_core::signing::SigningKeyType::Secp256r1,
+                _ => defra_core::signing::SigningKeyType::Secp256k1,
             };
 
             defra_core::signing::store_identity(
@@ -95,25 +95,28 @@ pub(crate) fn create_node_identity(
 pub(crate) fn raw_identity_from_stored_config(
     config: &defra_core::signing::SigningConfig,
 ) -> Result<identity::RawIdentity> {
-    match config.key_type.as_str() {
-        "ed25519" => {
+    match config.key_type {
+        defra_core::signing::SigningKeyType::Ed25519 => {
             let private_key = crypto::Ed25519PrivateKey::from_bytes(&config.private_key_bytes)
                 .map_err(|error| anyhow!("failed to load stored ed25519 key: {error}"))?;
             identity::RawIdentity::from_ed25519(private_key)
                 .map_err(|error| anyhow!("failed to create stored ed25519 identity: {error}"))
         }
-        "secp256k1" => {
+        defra_core::signing::SigningKeyType::Secp256k1 => {
             let private_key = crypto::Secp256k1PrivateKey::from_bytes(&config.private_key_bytes)
                 .map_err(|error| anyhow!("failed to load stored secp256k1 key: {error}"))?;
             identity::RawIdentity::from_secp256k1(private_key)
                 .map_err(|error| anyhow!("failed to create stored secp256k1 identity: {error}"))
         }
-        "secp256r1" => {
+        defra_core::signing::SigningKeyType::Secp256r1 => {
             let private_key = crypto::Secp256r1PrivateKey::from_bytes(&config.private_key_bytes)
                 .map_err(|error| anyhow!("failed to load stored secp256r1 key: {error}"))?;
             identity::RawIdentity::from_secp256r1(private_key)
                 .map_err(|error| anyhow!("failed to create stored secp256r1 identity: {error}"))
         }
+        defra_core::signing::SigningKeyType::Bls => Err(anyhow!(
+            "stored identity bls cannot be used as a node identity"
+        )),
         other => Err(anyhow!(
             "stored identity {} cannot be used as a node identity",
             other

--- a/crates/ffi/src/acp/identity.rs
+++ b/crates/ffi/src/acp/identity.rs
@@ -8,7 +8,8 @@ use crate::types::{c_str_to_string, DefraRemoteSignCallback, FfiResult};
 use crate::{ffi_async, ffi_entry, try_ffi};
 
 use super::identity_ops::{
-    decode_and_validate_public_key, store_remote_identity, validate_public_key_bytes,
+    decode_and_validate_public_key, parse_signing_key_type, store_remote_identity,
+    validate_public_key_bytes,
 };
 
 /// Get the node's identity (DID).
@@ -75,6 +76,7 @@ pub extern "C" fn RegisterIdentity(
                 unsafe { c_str_to_string(public_key_hex) }.ok_or("invalid public_key_hex parameter")?;
             let key_type_str =
                 unsafe { c_str_to_string(key_type) }.unwrap_or_else(|| "secp256k1".to_string());
+            let signing_key_type = parse_signing_key_type(&key_type_str)?;
 
             let private_key_bytes =
                 hex::decode(&priv_hex).map_err(|e| format!("invalid private key hex: {}", e))?;
@@ -86,7 +88,7 @@ pub extern "C" fn RegisterIdentity(
             defra_core::signing::store_identity(
                 &did_str,
                 defra_core::signing::SigningConfig {
-                    key_type: key_type_str,
+                    key_type: signing_key_type,
                     private_key_bytes,
                     public_key_bytes,
                     public_key_hex: pub_hex,
@@ -129,15 +131,16 @@ pub extern "C" fn register_remote_identity(
                 unsafe { c_str_to_string(public_key_hex) }.ok_or("invalid public_key_hex parameter")?;
             let key_type_str =
                 unsafe { c_str_to_string(key_type) }.unwrap_or_else(|| "secp256r1".to_string());
+            let signing_key_type = parse_signing_key_type(&key_type_str)?;
 
             let public_key_bytes =
-                decode_and_validate_public_key(&did_str, &pub_hex, &key_type_str)?;
+                decode_and_validate_public_key(&did_str, &pub_hex, signing_key_type)?;
 
             store_remote_identity(
                 did_str,
                 public_key_bytes,
                 pub_hex,
-                key_type_str,
+                signing_key_type,
                 signer_handle,
                 callback,
             )
@@ -183,19 +186,20 @@ pub extern "C" fn register_remote_identity_bytes(
             }
             let key_type_str =
                 unsafe { c_str_to_string(key_type) }.unwrap_or_else(|| "secp256r1".to_string());
+            let signing_key_type = parse_signing_key_type(&key_type_str)?;
             // SAFETY: `public_key_ptr` is non-null and `public_key_len` is
             // bounded (checked above). The caller guarantees the pointer is
             // valid for `public_key_len` bytes.
             let public_key_bytes =
                 unsafe { std::slice::from_raw_parts(public_key_ptr, public_key_len) }.to_vec();
 
-            validate_public_key_bytes(&did_str, &public_key_bytes, &key_type_str)?;
+            validate_public_key_bytes(&did_str, &public_key_bytes, signing_key_type)?;
 
             store_remote_identity(
                 did_str,
                 public_key_bytes.clone(),
                 hex::encode(&public_key_bytes),
-                key_type_str,
+                signing_key_type,
                 signer_handle,
                 callback,
             )
@@ -306,7 +310,7 @@ pub extern "C" fn create_identity() -> FfiResult {
             defra_core::signing::store_identity(
                 did.as_ref(),
                 defra_core::signing::SigningConfig {
-                    key_type: "ed25519".to_string(),
+                    key_type: defra_core::signing::SigningKeyType::Ed25519,
                     private_key_bytes: identity.private_key_bytes().to_vec(),
                     public_key_bytes: identity.public_key_bytes().to_vec(),
                     public_key_hex,
@@ -473,7 +477,10 @@ mod tests {
         }
 
         let config = defra_core::signing::get_identity(&did).expect("identity should be stored");
-        assert_eq!(config.key_type, "secp256r1");
+        assert_eq!(
+            config.key_type,
+            defra_core::signing::SigningKeyType::Secp256r1
+        );
         assert!(config.private_key_bytes.is_empty());
         assert!(config.remote_signer.is_some());
 
@@ -523,10 +530,32 @@ mod tests {
         }
 
         let config = defra_core::signing::get_identity(&did).expect("identity should be stored");
-        assert_eq!(config.key_type, "secp256r1");
+        assert_eq!(
+            config.key_type,
+            defra_core::signing::SigningKeyType::Secp256r1
+        );
         assert_eq!(config.public_key_bytes, public_key_bytes);
         assert_eq!(config.public_key_hex, hex::encode(public_key_bytes));
         assert!(config.remote_signer.is_some());
+    }
+
+    #[test]
+    fn test_register_remote_identity_rejects_invalid_key_type() {
+        let did_c = CString::new("did:key:zInvalid").unwrap();
+        let pub_c = CString::new("abcd").unwrap();
+        let key_type_c = CString::new("not-a-key").unwrap();
+
+        let result = register_remote_identity(
+            did_c.as_ptr(),
+            pub_c.as_ptr(),
+            key_type_c.as_ptr(),
+            1,
+            test_remote_sign_callback,
+        );
+        assert_eq!(result.status, 1);
+        let error = unsafe { CStr::from_ptr(result.error).to_string_lossy().into_owned() };
+        assert_eq!(error, "unsupported signing key type: not-a-key");
+        unsafe { crate::types::defra_free_string(result.error) };
     }
 
     #[test]

--- a/crates/ffi/src/acp/identity_ops.rs
+++ b/crates/ffi/src/acp/identity_ops.rs
@@ -56,20 +56,28 @@ impl defra_core::signing::RemoteSigner for FfiRemoteSigner {
     }
 }
 
-pub(crate) fn parse_crypto_key_type(key_type: &str) -> Result<crypto::KeyType, String> {
+pub(crate) fn parse_signing_key_type(
+    key_type: &str,
+) -> Result<defra_core::signing::SigningKeyType, String> {
+    key_type.parse()
+}
+
+pub(crate) fn parse_crypto_key_type(
+    key_type: defra_core::signing::SigningKeyType,
+) -> Result<crypto::KeyType, String> {
     match key_type {
-        "ed25519" => Ok(crypto::KeyType::Ed25519),
-        "secp256k1" => Ok(crypto::KeyType::Secp256k1),
-        "secp256r1" => Ok(crypto::KeyType::Secp256r1),
-        "bls" => Ok(crypto::KeyType::Bls12381),
-        other => Err(format!("unsupported key type: {}", other)),
+        defra_core::signing::SigningKeyType::Ed25519 => Ok(crypto::KeyType::Ed25519),
+        defra_core::signing::SigningKeyType::Secp256k1 => Ok(crypto::KeyType::Secp256k1),
+        defra_core::signing::SigningKeyType::Secp256r1 => Ok(crypto::KeyType::Secp256r1),
+        defra_core::signing::SigningKeyType::Bls => Ok(crypto::KeyType::Bls12381),
+        other => Err(format!("unsupported signing key type: {}", other)),
     }
 }
 
 pub(crate) fn decode_and_validate_public_key(
     did: &str,
     public_key_hex: &str,
-    key_type: &str,
+    key_type: defra_core::signing::SigningKeyType,
 ) -> Result<Vec<u8>, String> {
     let public_key_bytes = hex::decode(public_key_hex)
         .map_err(|error| format!("invalid public key hex: {}", error))?;
@@ -81,7 +89,7 @@ pub(crate) fn decode_and_validate_public_key(
 pub(crate) fn validate_public_key_bytes(
     did: &str,
     public_key_bytes: &[u8],
-    key_type: &str,
+    key_type: defra_core::signing::SigningKeyType,
 ) -> Result<(), String> {
     let crypto_key_type = parse_crypto_key_type(key_type)?;
 
@@ -105,14 +113,14 @@ pub(crate) fn store_remote_identity(
     did: String,
     public_key_bytes: Vec<u8>,
     public_key_hex: String,
-    key_type: String,
+    key_type: defra_core::signing::SigningKeyType,
     signer_handle: usize,
     callback: DefraRemoteSignCallback,
 ) -> Result<String, String> {
     let signer = Arc::new(FfiRemoteSigner {
         did: CString::new(did.clone())
             .map_err(|_| "did contains an embedded null byte".to_string())?,
-        key_type: CString::new(key_type.clone())
+        key_type: CString::new(key_type.to_string())
             .map_err(|_| "key_type contains an embedded null byte".to_string())?,
         signer_handle,
         callback,

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -147,11 +147,21 @@ fn resolve_embedded_config(
             };
             let key_type = unsafe { c_str_to_string(options.signing_key_type) }
                 .unwrap_or_else(|| "secp256k1".to_string());
+            let signing_key_type: defra_core::signing::SigningKeyType = key_type.parse()?;
 
-            Some(match key_type.as_str() {
-                "secp256k1" => embedded::SigningKey::Secp256k1(key_bytes),
-                "secp256r1" => embedded::SigningKey::Secp256r1(key_bytes),
-                "ed25519" => embedded::SigningKey::Ed25519(key_bytes),
+            Some(match signing_key_type {
+                defra_core::signing::SigningKeyType::Secp256k1 => {
+                    embedded::SigningKey::Secp256k1(key_bytes)
+                }
+                defra_core::signing::SigningKeyType::Secp256r1 => {
+                    embedded::SigningKey::Secp256r1(key_bytes)
+                }
+                defra_core::signing::SigningKeyType::Ed25519 => {
+                    embedded::SigningKey::Ed25519(key_bytes)
+                }
+                defra_core::signing::SigningKeyType::Bls => {
+                    return Err("unsupported signing key type: bls".to_string())
+                }
                 other => return Err(format!("unsupported signing key type: {}", other)),
             })
         } else {

--- a/crates/sourcehub/src/cosmos/cosmos_provider.rs
+++ b/crates/sourcehub/src/cosmos/cosmos_provider.rs
@@ -98,10 +98,15 @@ fn resolve_cosmos_bearer_token(
         return Ok(defra_core::signing::get_request_bearer_token(did));
     }
 
-    let key_type: crypto::KeyType = match signing_config.key_type.as_str() {
-        "ed25519" => crypto::KeyType::Ed25519,
-        "secp256k1" => crypto::KeyType::Secp256k1,
-        "secp256r1" => crypto::KeyType::Secp256r1,
+    let key_type: crypto::KeyType = match signing_config.key_type {
+        defra_core::signing::SigningKeyType::Ed25519 => crypto::KeyType::Ed25519,
+        defra_core::signing::SigningKeyType::Secp256k1 => crypto::KeyType::Secp256k1,
+        defra_core::signing::SigningKeyType::Secp256r1 => crypto::KeyType::Secp256r1,
+        defra_core::signing::SigningKeyType::Bls => {
+            return Err(ProviderError::Config(
+                "unsupported key type: bls".to_string(),
+            ))
+        }
         other => {
             return Err(ProviderError::Config(format!(
                 "unsupported key type: {}",
@@ -336,7 +341,7 @@ mod tests {
         defra_core::signing::store_identity(
             did,
             defra_core::signing::SigningConfig {
-                key_type: "secp256r1".to_string(),
+                key_type: defra_core::signing::SigningKeyType::Secp256r1,
                 private_key_bytes: Vec::new(),
                 public_key_bytes,
                 public_key_hex,
@@ -376,7 +381,7 @@ mod tests {
         defra_core::signing::store_identity(
             &did,
             defra_core::signing::SigningConfig {
-                key_type: "secp256r1".to_string(),
+                key_type: defra_core::signing::SigningKeyType::Secp256r1,
                 private_key_bytes: raw_identity.private_key_bytes().to_vec(),
                 public_key_bytes: raw_identity.public_key_bytes().to_vec(),
                 public_key_hex: hex::encode(raw_identity.public_key_bytes()),

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -637,7 +637,7 @@ mod tests {
         defra_core::signing::store_identity(
             did,
             defra_core::signing::SigningConfig {
-                key_type: "secp256r1".to_string(),
+                key_type: defra_core::signing::SigningKeyType::Secp256r1,
                 private_key_bytes: Vec::new(),
                 public_key_bytes,
                 public_key_hex,
@@ -677,7 +677,7 @@ mod tests {
         defra_core::signing::store_identity(
             &did,
             defra_core::signing::SigningConfig {
-                key_type: "secp256k1".to_string(),
+                key_type: defra_core::signing::SigningKeyType::Secp256k1,
                 private_key_bytes: raw_identity.private_key_bytes().to_vec(),
                 public_key_bytes: raw_identity.public_key_bytes().to_vec(),
                 public_key_hex: hex::encode(raw_identity.public_key_bytes()),

--- a/crates/sourcehub/src/hub_rs/provider_commands.rs
+++ b/crates/sourcehub/src/hub_rs/provider_commands.rs
@@ -67,7 +67,9 @@ pub(crate) fn resolve_registered_or_passthrough_bearer_token(
     use k256::ecdsa::SigningKey;
 
     if let Some(signing_config) = defra_core::signing::get_identity(did) {
-        if signing_config.has_local_private_key() && signing_config.key_type == "secp256k1" {
+        if signing_config.has_local_private_key()
+            && signing_config.key_type == defra_core::signing::SigningKeyType::Secp256k1
+        {
             let key = SigningKey::from_slice(&signing_config.private_key_bytes).map_err(|e| {
                 crate::provider::ProviderError::Config(format!("invalid signing key: {}", e))
             })?;


### PR DESCRIPTION
## Summary
- change `defra_core::signing::SigningConfig.key_type` from `String` to `SigningKeyType`
- remove the panic-prone `From<String>` conversion and push key-type parsing to FFI/config boundaries
- update signing consumers to use the enum directly and add invalid-key-type coverage for FFI registration

## Testing
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- cargo test --workspace --exclude integration-test --exclude ffi-test
- cargo build -p cli --features iroh

Closes #806
Closes #807
