### PR TITLE
chore(deps): bump criterion/thiserror/axum/tower/tonic majors (#652)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "sha2 0.10.9",
  "storage",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zanzibar",
@@ -358,16 +358,16 @@ dependencies = [
  "rand 0.9.2",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "sha3",
 ]
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1316,55 +1316,19 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "base64 0.22.1",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sha1",
- "sync_wrapper 1.0.2",
- "tokio",
- "tokio-tungstenite 0.24.0",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core 0.5.6",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -1376,8 +1340,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -1399,27 +1365,6 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1556,26 +1501,6 @@ checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1587,7 +1512,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1784,15 +1709,15 @@ dependencies = [
  "async-trait",
  "bytes",
  "cid 0.10.1",
- "criterion 0.5.1",
+ "criterion 0.6.0",
  "crypto",
  "defra-core",
- "lru 0.16.3",
+ "lru 0.16.4",
  "multihash 0.18.1",
  "parking_lot 0.12.5",
  "sha2 0.10.9",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2274,7 +2199,7 @@ dependencies = [
  "sourcehub",
  "storage",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-chrome",
@@ -2555,7 +2480,7 @@ version = "2026.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06938675df074ca7749a6d531c4706bcc339e842105e73b03a76d45bd860b349"
 dependencies = [
- "axum 0.8.8",
+ "axum 0.8.9",
  "bytes",
  "cfg-if",
  "commonware-codec",
@@ -2927,7 +2852,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -3057,39 +2982,35 @@ name = "crdt"
 version = "0.5.0"
 dependencies = [
  "async-trait",
- "criterion 0.5.1",
+ "criterion 0.6.0",
  "defra-core",
  "proptest",
  "serde",
  "serde_json",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot 0.5.0",
- "futures",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "tokio",
@@ -3231,7 +3152,7 @@ dependencies = [
  "serial_test",
  "sha2 0.10.9",
  "subtle",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "unsigned-varint 0.8.0",
  "x25519-dalek",
@@ -3534,7 +3455,7 @@ dependencies = [
  "cid 0.10.1",
  "futures",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -3584,7 +3505,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zeroize",
@@ -3637,7 +3558,7 @@ dependencies = [
  "document",
  "schema",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3674,7 +3595,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zeroize",
@@ -3690,7 +3611,7 @@ dependencies = [
  "identity",
  "serde",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -3706,7 +3627,7 @@ dependencies = [
  "schema",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -3765,7 +3686,7 @@ version = "0.5.0"
 dependencies = [
  "async-trait",
  "cid 0.10.1",
- "criterion 0.5.1",
+ "criterion 0.6.0",
  "libipld",
  "multibase",
  "multicodec",
@@ -3776,7 +3697,7 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "zeroize",
@@ -3809,7 +3730,7 @@ dependencies = [
  "acp",
  "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.9",
  "cid 0.10.1",
  "crypto",
  "defra-core",
@@ -3818,18 +3739,18 @@ dependencies = [
  "events",
  "futures",
  "hex",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "identity",
  "lens",
  "query",
  "schema",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
- "tower-http 0.5.2",
+ "tower 0.5.3",
+ "tower-http",
  "tracing",
  "urlencoding",
 ]
@@ -3841,7 +3762,7 @@ dependencies = [
  "acp",
  "anyhow",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.9",
  "blockstore",
  "db",
  "db-merge",
@@ -3892,7 +3813,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -4195,7 +4116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -4379,7 +4300,7 @@ dependencies = [
  "sourcehub",
  "storage",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -4538,7 +4459,7 @@ dependencies = [
  "bytes",
  "cid 0.10.1",
  "parking_lot 0.12.5",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -4674,7 +4595,7 @@ dependencies = [
  "sha2 0.10.9",
  "sourcehub",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-chrome",
@@ -4740,9 +4661,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fjall"
-version = "3.1.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cb1eb0cef3792900897b32c8282f6417bc978f6af46400a2f14bf0e649ae30"
+checksum = "b62b25b4d815ae178d7d9e4aa32ee59f072efd5431c736abede1e6ee13c8c453"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -5026,7 +4947,7 @@ checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags 2.11.0",
  "debugid",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5667,9 +5588,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5682,7 +5603,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -5709,7 +5629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.37",
  "rustls-pki-types",
@@ -5737,7 +5657,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5752,7 +5672,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -5772,7 +5692,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -5934,7 +5854,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -6029,7 +5949,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "rand 0.9.2",
@@ -6251,7 +6171,7 @@ dependencies = [
  "portmapper",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-webpki 0.103.11",
@@ -6474,11 +6394,11 @@ dependencies = [
  "hickory-resolver 0.25.2",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "iroh-base",
  "iroh-metrics 0.38.3",
- "lru 0.16.3",
+ "lru 0.16.4",
  "n0-error",
  "n0-future",
  "noq",
@@ -6574,17 +6494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6595,15 +6504,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -6797,7 +6697,7 @@ dependencies = [
  "keyring 3.6.3",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -6848,12 +6748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6872,7 +6766,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7489,14 +7383,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -7583,9 +7476,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -7607,9 +7500,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
-version = "3.1.0"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5fa40c207eed45c811085aaa1b0a25fead22e298e286081cd4b98785fe759b"
+checksum = "e447ac67ff6aef4ec07fc19e507b219336cbba90a697c0dbeb1bf51b91536b67"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -7619,7 +7512,7 @@ dependencies = [
  "log",
  "lz4_flex",
  "quick_cache",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "self_cell",
  "sfa",
  "tempfile",
@@ -7639,9 +7532,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
  "twox-hash",
 ]
@@ -7918,12 +7811,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "multistream-select"
@@ -8219,7 +8106,7 @@ dependencies = [
  "noq-proto",
  "noq-udp",
  "pin-project-lite",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -8245,7 +8132,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring 0.17.14",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -8845,14 +8732,16 @@ dependencies = [
  "defra-core",
  "hex",
  "identity",
- "prost 0.13.5",
+ "prost 0.14.3",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tonic 0.12.3",
- "tonic-build 0.12.3",
+ "tonic 0.14.5",
+ "tonic-build 0.14.5",
+ "tonic-prost",
+ "tonic-prost-build",
  "tracing",
 ]
 
@@ -8923,7 +8812,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -9151,11 +9040,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
 ]
 
@@ -9172,7 +9062,7 @@ dependencies = [
  "schema",
  "serde_json",
  "sqlparser",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -9206,7 +9096,7 @@ dependencies = [
  "md5",
  "pg_interval_2",
  "postgres-types",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rust_decimal",
  "rustls-pki-types",
  "ryu",
@@ -9764,9 +9654,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -9822,7 +9712,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap 0.8.3",
+ "multimap",
  "petgraph 0.6.5",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -9835,19 +9725,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
- "multimap 0.10.1",
- "once_cell",
- "petgraph 0.7.1",
+ "multimap",
+ "petgraph 0.8.3",
  "prettyplease 0.2.37",
- "prost 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.117",
  "tempfile",
@@ -9903,11 +9794,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.13.5",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -9938,6 +9829,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -9992,7 +9903,7 @@ dependencies = [
  "ciborium",
  "cid 0.10.1",
  "crdt",
- "criterion 0.5.1",
+ "criterion 0.6.0",
  "datastore",
  "db",
  "defra-core",
@@ -10011,7 +9922,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10057,7 +9968,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10074,7 +9985,7 @@ dependencies = [
  "serde",
  "serde_json",
  "storage",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -10138,7 +10049,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -10158,7 +10069,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring 0.17.14",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
@@ -10234,9 +10145,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -10511,7 +10422,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.5",
  "log",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "smallvec",
 ]
 
@@ -10617,7 +10528,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
@@ -10639,7 +10550,7 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
- "tower-http 0.6.8",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -10753,9 +10664,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -10866,12 +10777,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -11145,7 +11050,7 @@ dependencies = [
  "serde_ipld_dagcbor",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -11866,7 +11771,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "zanzibar",
@@ -12019,7 +11924,7 @@ dependencies = [
  "bm25",
  "chrono",
  "cid 0.10.1",
- "criterion 0.5.1",
+ "criterion 0.6.0",
  "defra-core",
  "document",
  "fjall",
@@ -12037,7 +11942,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -12645,18 +12550,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -12665,6 +12558,18 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -12847,50 +12752,28 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
- "socket2 0.5.10",
+ "socket2 0.6.3",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper 1.0.2",
- "tokio-stream",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -12911,14 +12794,12 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
  "quote",
  "syn 2.0.117",
 ]
@@ -12932,6 +12813,22 @@ dependencies = [
  "bytes",
  "prost 0.14.3",
  "tonic 0.14.5",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+dependencies = [
+ "prettyplease 0.2.37",
+ "proc-macro2",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "quote",
+ "syn 2.0.117",
+ "tempfile",
+ "tonic-build 0.14.5",
 ]
 
 [[package]]
@@ -12962,26 +12859,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "pin-project-lite",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -13003,6 +12886,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -13162,24 +13046,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -13193,6 +13059,22 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -13241,6 +13123,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"
@@ -13376,9 +13264,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -14996,7 +14884,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -15181,7 +15069,6 @@ version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
- "bindgen 0.72.1",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,14 +95,21 @@ postcard = { version = "1.0", features = ["alloc"] }
 
 # Storage
 redb = "2.4"
-fjall = "3"
-rocksdb = "0.22"
+fjall = "3.1.4"
+rocksdb = "0.24.0"
 
 # Cryptography
 ed25519-dalek = { version = "2.1", features = ["serde", "zeroize"] }
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { version = "1.23.0", features = ["v4"] }
 k256 = { version = "0.13", features = ["ecdsa", "serde"] }
 sha2 = { version = "0.10", features = ["asm"] }
+# Pinned to 0.8: rand 0.9 bumped rand_core to 0.9, but the stable
+# RustCrypto ecosystem (k256 0.13, p256 0.13, ed25519-dalek 2.1,
+# x25519-dalek 2.x, aes-gcm 0.10) still pins rand_core 0.6, so passing
+# rand 0.9's `OsRng` as an RNG argument to any of these crates fails with
+# trait-bound errors. rand_core-0.9-compatible releases exist only as
+# prereleases (ed25519-dalek 3.0-pre, k256 0.14-rc, …). Bump together
+# once those stabilize. Tracked in #652.
 rand = "0.8"
 aes-gcm = "0.10"
 hex = "0.4"
@@ -115,10 +122,15 @@ alloy-consensus = { version = "1", features = ["k256"] }
 alloy-eips = "1"
 alloy-signer = "1"
 alloy-signer-local = { version = "1", default-features = false }
-alloy-rlp = "0.3"
+alloy-rlp = "0.3.15"
 bs58 = "0.5"
 
 # IPLD
+# Pinned together: libipld 0.16 is the last release and internally pins
+# cid 0.10 / multihash 0.18. Bumping cid or multihash here would create
+# duplicate types across the IPLD API boundary, so the whole stack moves
+# together once we either drop libipld or migrate to its successor.
+# Tracked in #652.
 cid = { version = "0.10", features = ["serde"] }
 multihash = "0.18"
 multicodec = "0.1"
@@ -132,19 +144,21 @@ bm25 = "2.3"
 graphql-parser = "0.4"
 
 # HTTP
-axum = { version = "0.7", features = ["ws"] }
-tower = { version = "0.4", features = ["timeout", "limit"] }
-tower-http = { version = "0.5", features = ["cors", "trace"] }
-hyper = "1.0"
+axum = { version = "0.8.9", features = ["ws"] }
+tower = { version = "0.5", features = ["timeout", "limit"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+hyper = "1.9.0"
 
 # Error handling
-thiserror = "1.0"
+thiserror = "2"
 anyhow = "1.0"
 
 # gRPC (Orbis ring integration)
-tonic = "0.12"
-prost = "0.13"
-tonic-build = "0.12"
+tonic = "0.14"
+tonic-prost = "0.14"
+prost = "0.14"
+tonic-build = "0.14"
+tonic-prost-build = "0.14"
 
 # Bytes
 bytes = "1.5"
@@ -153,14 +167,14 @@ bytes = "1.5"
 tracing = "0.1"
 
 # Testing
-proptest = "1.4"
-criterion = { version = "0.5", features = ["async_tokio"] }
+proptest = "1.11.0"
+criterion = { version = "0.6", features = ["async_tokio"] }
 
 # Synchronization (non-poisoning locks)
 parking_lot = "0.12"
 
 # Caching
-lru = "0.16.3"
+lru = "0.16.4"
 
 # Async streams
 tokio-stream = "0.1"

--- a/crates/blockstore/benches/blockstore.rs
+++ b/crates/blockstore/benches/blockstore.rs
@@ -3,7 +3,8 @@ use std::sync::{Arc, OnceLock};
 
 use blockstore::{Blockstore, DefraBlockstore};
 use cid::Cid;
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use std::hint::black_box;
 use lru::LruCache;
 use multihash::MultihashGeneric;
 use sha2::{Digest, Sha256};

--- a/crates/blockstore/benches/blockstore.rs
+++ b/crates/blockstore/benches/blockstore.rs
@@ -4,10 +4,10 @@ use std::sync::{Arc, OnceLock};
 use blockstore::{Blockstore, DefraBlockstore};
 use cid::Cid;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use std::hint::black_box;
 use lru::LruCache;
 use multihash::MultihashGeneric;
 use sha2::{Digest, Sha256};
+use std::hint::black_box;
 use storage::backends::MemoryStore;
 
 fn runtime() -> &'static tokio::runtime::Runtime {

--- a/crates/crdt/benches/merge.rs
+++ b/crates/crdt/benches/merge.rs
@@ -2,7 +2,8 @@ use std::sync::OnceLock;
 
 use crdt::traits::{Context, ReplicatedData, ValueReader};
 use crdt::{decode_priority, encode_priority, Lww, LwwDelta};
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use std::hint::black_box;
 use defra_core::types::DocId;
 use storage::{MemoryStore, Store};
 

--- a/crates/crdt/benches/merge.rs
+++ b/crates/crdt/benches/merge.rs
@@ -3,8 +3,8 @@ use std::sync::OnceLock;
 use crdt::traits::{Context, ReplicatedData, ValueReader};
 use crdt::{decode_priority, encode_priority, Lww, LwwDelta};
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use std::hint::black_box;
 use defra_core::types::DocId;
+use std::hint::black_box;
 use storage::{MemoryStore, Store};
 
 fn runtime() -> &'static tokio::runtime::Runtime {

--- a/crates/defra-core/benches/block.rs
+++ b/crates/defra-core/benches/block.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
 use defra_core::block::generate_cid_from_bytes;
 use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
 

--- a/crates/defra-core/benches/block.rs
+++ b/crates/defra-core/benches/block.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::hint::black_box;
 use defra_core::block::generate_cid_from_bytes;
 use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
+use std::hint::black_box;
 
 fn lww_block() -> Block {
     Block::new(

--- a/crates/http/src/identity_extractor.rs
+++ b/crates/http/src/identity_extractor.rs
@@ -14,7 +14,6 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use std::future::Future;
 
 use identity::{from_token, verify_auth_token, Did, Identity, TokenIdentity};
 
@@ -254,28 +253,15 @@ where
 {
     type Rejection = IdentityExtractionError;
 
-    fn from_request_parts<'life0, 'life1, 'async_trait>(
-        parts: &'life0 mut Parts,
-        _state: &'life1 S,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Self, Self::Rejection>> + Send + 'async_trait>>
-    where
-        'life0: 'async_trait,
-        'life1: 'async_trait,
-        Self: 'async_trait,
-    {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         // If the auth middleware already parsed identity, reuse it.
         if let Some(mid) = parts.extensions.get::<MiddlewareIdentity>() {
-            let did = mid.0.clone();
-            return Box::pin(async move { Ok(ExtractIdentity(did)) });
+            return Ok(ExtractIdentity(mid.0.clone()));
         }
 
         // Fallback: parse from headers (for routes/tests without the middleware).
-        let result = parse_identity_from_headers(&parts.headers);
-
-        Box::pin(async move {
-            let did = result?;
-            Ok(ExtractIdentity(did))
-        })
+        let did = parse_identity_from_headers(&parts.headers)?;
+        Ok(ExtractIdentity(did))
     }
 }
 
@@ -375,64 +361,50 @@ where
 {
     type Rejection = IdentityExtractionError;
 
-    fn from_request_parts<'life0, 'life1, 'async_trait>(
-        parts: &'life0 mut Parts,
-        _state: &'life1 S,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Self, Self::Rejection>> + Send + 'async_trait>>
-    where
-        'life0: 'async_trait,
-        'life1: 'async_trait,
-        Self: 'async_trait,
-    {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         // Get the auth header value, returning error for malformed headers
-        let auth_result: Result<Option<String>, IdentityExtractionError> =
-            match parts.headers.get(AUTHORIZATION) {
-                Some(value) => match value.to_str() {
-                    Ok(s) => Ok(Some(s.to_string())),
-                    Err(_) => Err(IdentityExtractionError::InvalidToken(
+        let auth_value: Option<String> = match parts.headers.get(AUTHORIZATION) {
+            Some(value) => match value.to_str() {
+                Ok(s) => Some(s.to_string()),
+                Err(_) => {
+                    return Err(IdentityExtractionError::InvalidToken(
                         "Authorization header contains invalid characters".to_string(),
-                    )),
-                },
-                None => Ok(None),
-            };
-
-        // Check if request has an Authorization header with a token
-        let has_auth_token = match &auth_result {
-            Ok(Some(auth)) => {
-                let trimmed = auth
-                    .strip_prefix("Bearer ")
-                    .or_else(|| auth.strip_prefix("bearer "));
-                trimmed.map(|t| !t.trim().is_empty()).unwrap_or(false)
-            }
-            _ => false,
+                    ))
+                }
+            },
+            None => None,
         };
 
+        // Check if request has an Authorization header with a token
+        let has_auth_token = auth_value
+            .as_deref()
+            .and_then(|auth| {
+                auth.strip_prefix("Bearer ")
+                    .or_else(|| auth.strip_prefix("bearer "))
+            })
+            .map(|t| !t.trim().is_empty())
+            .unwrap_or(false);
+
         // Get Host header for audience verification (matches Go DefraDB behavior)
-        let host_result = extract_host_header(&parts.headers);
+        // For authenticated requests, require a valid Host header — this prevents
+        // token bypass via missing/malformed Host header.
+        let host = match extract_host_header(&parts.headers) {
+            HostHeaderResult::Valid(h) => h,
+            HostHeaderResult::Missing if has_auth_token => {
+                return Err(IdentityExtractionError::MissingHost(
+                    "Host header required for authenticated requests".to_string(),
+                ));
+            }
+            HostHeaderResult::Invalid if has_auth_token => {
+                return Err(IdentityExtractionError::MissingHost(
+                    "valid Host header required for authenticated requests".to_string(),
+                ));
+            }
+            // Anonymous requests don't need Host header
+            _ => String::new(),
+        };
 
-        Box::pin(async move {
-            let auth_value = auth_result?;
-
-            // For authenticated requests, require a valid Host header
-            // This prevents token bypass via missing/malformed Host header
-            let host = match host_result {
-                HostHeaderResult::Valid(h) => h,
-                HostHeaderResult::Missing if has_auth_token => {
-                    return Err(IdentityExtractionError::MissingHost(
-                        "Host header required for authenticated requests".to_string(),
-                    ));
-                }
-                HostHeaderResult::Invalid if has_auth_token => {
-                    return Err(IdentityExtractionError::MissingHost(
-                        "valid Host header required for authenticated requests".to_string(),
-                    ));
-                }
-                // Anonymous requests don't need Host header
-                _ => String::new(),
-            };
-
-            let result = extract_token_identity_from_auth_header(auth_value.as_deref(), &host)?;
-            Ok(ExtractTokenIdentity(result))
-        })
+        let result = extract_token_identity_from_auth_header(auth_value.as_deref(), &host)?;
+        Ok(ExtractTokenIdentity(result))
     }
 }

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -87,7 +87,10 @@ pub fn create_router_with_state(state: AppState) -> Router {
         .route("/{name}/truncate", delete(handlers::truncate_collection))
         .route("/{name}/document/{docID}", get(handlers::get_document))
         .route("/{name}/document/{docID}", patch(handlers::update_document))
-        .route("/{name}/document/{docID}", delete(handlers::delete_document))
+        .route(
+            "/{name}/document/{docID}",
+            delete(handlers::delete_document),
+        )
         // Go-compatible index routes (collection in path)
         .route("/{name}/indexes", get(handlers::index::go_list_indexes))
         .route("/{name}/indexes", post(handlers::index::go_create_index))

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -47,14 +47,14 @@ pub fn create_router_with_state(state: AppState) -> Router {
     let tx_routes = Router::new()
         .route("/", post(handlers::tx_begin))
         .route("/concurrent", post(handlers::tx_begin_concurrent))
-        .route("/:id", post(handlers::tx_commit))
-        .route("/:id", delete(handlers::tx_discard))
-        .route("/:id/lens", post(handlers::txn_ops::set_migration_in_txn))
+        .route("/{id}", post(handlers::tx_commit))
+        .route("/{id}", delete(handlers::tx_discard))
+        .route("/{id}/lens", post(handlers::txn_ops::set_migration_in_txn))
         .route(
-            "/:id/collections",
+            "/{id}/collections",
             get(handlers::txn_ops::get_collections_in_txn),
         )
-        .route("/:id/schema", post(handlers::txn_ops::add_schema_in_txn));
+        .route("/{id}/schema", post(handlers::txn_ops::add_schema_in_txn));
 
     // Collection routes (REST API)
     // Static routes must come before parametric `:name` routes
@@ -71,41 +71,41 @@ pub fn create_router_with_state(state: AppState) -> Router {
             get(handlers::get_all_collections).delete(handlers::delete_collection_versions),
         )
         .route("/migrations", post(handlers::lens::set_migration))
-        .route("/by-id/:id", get(handlers::find_collection_by_id))
+        .route("/by-id/{id}", get(handlers::find_collection_by_id))
         .route(
-            "/by-version/:id",
+            "/by-version/{id}",
             get(handlers::get_collection_by_version_id),
         )
         // Go-compatible list-all-indexes route (no path param)
         .route("/indexes", get(handlers::index::go_list_all_indexes))
         .route(
-            "/:name",
+            "/{name}",
             post(handlers::create_document).delete(handlers::delete_collection),
         )
-        .route("/:name/describe", get(handlers::describe_collection))
-        .route("/:name/exists", get(handlers::collection_exists))
-        .route("/:name/truncate", delete(handlers::truncate_collection))
-        .route("/:name/document/:docID", get(handlers::get_document))
-        .route("/:name/document/:docID", patch(handlers::update_document))
-        .route("/:name/document/:docID", delete(handlers::delete_document))
+        .route("/{name}/describe", get(handlers::describe_collection))
+        .route("/{name}/exists", get(handlers::collection_exists))
+        .route("/{name}/truncate", delete(handlers::truncate_collection))
+        .route("/{name}/document/{docID}", get(handlers::get_document))
+        .route("/{name}/document/{docID}", patch(handlers::update_document))
+        .route("/{name}/document/{docID}", delete(handlers::delete_document))
         // Go-compatible index routes (collection in path)
-        .route("/:name/indexes", get(handlers::index::go_list_indexes))
-        .route("/:name/indexes", post(handlers::index::go_create_index))
+        .route("/{name}/indexes", get(handlers::index::go_list_indexes))
+        .route("/{name}/indexes", post(handlers::index::go_create_index))
         .route(
-            "/:name/indexes/:index",
+            "/{name}/indexes/{index}",
             delete(handlers::index::go_delete_index),
         )
         // Go-compatible encrypted index routes
         .route(
-            "/:name/encrypted-indexes",
+            "/{name}/encrypted-indexes",
             get(handlers::encrypted_index::go_list_encrypted_indexes),
         )
         .route(
-            "/:name/encrypted-indexes",
+            "/{name}/encrypted-indexes",
             post(handlers::encrypted_index::go_add_encrypted_index),
         )
         .route(
-            "/:name/encrypted-indexes/:field",
+            "/{name}/encrypted-indexes/{field}",
             delete(handlers::encrypted_index::go_delete_encrypted_index),
         );
 
@@ -143,7 +143,7 @@ pub fn create_router_with_state(state: AppState) -> Router {
         .route("/status", get(handlers::acp::get_status))
         .route("/policy", post(handlers::acp::add_policy))
         .route("/policy", get(handlers::acp::list_policies))
-        .route("/policy/:id", get(handlers::acp::get_policy))
+        .route("/policy/{id}", get(handlers::acp::get_policy))
         .route(
             "/document/relationship",
             post(handlers::acp::add_doc_relationship),

--- a/crates/orbis/Cargo.toml
+++ b/crates/orbis/Cargo.toml
@@ -14,6 +14,7 @@ crypto = { path = "../crypto" }
 
 # gRPC
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 prost = { workspace = true }
 
 # Async runtime (dedicated runtime for sync bridge)
@@ -37,6 +38,7 @@ blst = "0.3"
 
 [build-dependencies]
 tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/orbis/build.rs
+++ b/crates/orbis/build.rs
@@ -1,4 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("proto/orbis.proto")?;
+    tonic_prost_build::configure().compile_protos(&["proto/orbis.proto"], &["proto"])?;
     Ok(())
 }

--- a/crates/query/benches/filter.rs
+++ b/crates/query/benches/filter.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
 use query::{DocumentMapping, Filter};
 use serde_json::{json, Value as JsonValue};
 

--- a/crates/query/benches/filter.rs
+++ b/crates/query/benches/filter.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::hint::black_box;
 use query::{DocumentMapping, Filter};
 use serde_json::{json, Value as JsonValue};
+use std::hint::black_box;
 
 fn make_mapping() -> DocumentMapping {
     let mut mapping = DocumentMapping::new();

--- a/crates/query/benches/groupby.rs
+++ b/crates/query/benches/groupby.rs
@@ -1,7 +1,8 @@
 use std::sync::OnceLock;
 
 use async_trait::async_trait;
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use std::hint::black_box;
 use query::mapper::GroupBy;
 use query::plan::{GroupAlias, GroupByNode};
 use query::{Doc, DocumentMapping, PlanNode};

--- a/crates/query/benches/groupby.rs
+++ b/crates/query/benches/groupby.rs
@@ -2,11 +2,11 @@ use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use std::hint::black_box;
 use query::mapper::GroupBy;
 use query::plan::{GroupAlias, GroupByNode};
 use query::{Doc, DocumentMapping, PlanNode};
 use serde_json::Value as JsonValue;
+use std::hint::black_box;
 
 const GROUP_INDEX: usize = 4;
 

--- a/crates/query/benches/parsing.rs
+++ b/crates/query/benches/parsing.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
 use query::query_parse::parse_request_with_variables;
 
 fn bench_parsing(c: &mut Criterion) {

--- a/crates/query/benches/parsing.rs
+++ b/crates/query/benches/parsing.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::hint::black_box;
 use query::query_parse::parse_request_with_variables;
+use std::hint::black_box;
 
 fn bench_parsing(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse");

--- a/crates/query/benches/planner.rs
+++ b/crates/query/benches/planner.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
 use query::mapper::Field;
 use query::{Filter, Planner, Select};
 use schema::{

--- a/crates/query/benches/planner.rs
+++ b/crates/query/benches/planner.rs
@@ -1,10 +1,10 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::hint::black_box;
 use query::mapper::Field;
 use query::{Filter, Planner, Select};
 use schema::{
     CollectionVersion, FieldDescription, FieldKind, IndexDescription, IndexedFieldDescription,
 };
+use std::hint::black_box;
 
 fn map<const N: usize>(
     entries: [(String, serde_json::Value); N],

--- a/crates/storage/benches/transaction.rs
+++ b/crates/storage/benches/transaction.rs
@@ -1,7 +1,8 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use std::hint::black_box;
 use storage::backends::RedbStore;
 use storage::corekv::{IterOptions, Reader, Store, Writer};
 use tempfile::TempDir;

--- a/tools/integration-test/tests/acp/link_collection.rs
+++ b/tools/integration-test/tests/acp/link_collection.rs
@@ -32,6 +32,7 @@
 //! - a policy that doesn't exist → `"policyID specified does not exist with acp"`
 //! - a resource name not on the policy → `"resource does not exist on the specified policy"`
 //! - a resource missing `read`/`update`/`delete` permission → `"resource is missing required permission on policy"`
+//!
 //! Error strings are Go-compatible so mixed Rust/Go deployments produce
 //! identical user-facing output.
 


### PR DESCRIPTION
## Summary

Workspace dependency bumps per #652.

## Bumped

- `criterion` 0.5 → 0.6. `criterion::black_box` is deprecated in 0.6; migrated 8 bench files to `std::hint::black_box`.
- `thiserror` 1 → 2. No source changes required.
- `axum` 0.7 → 0.8, `tower` 0.4 → 0.5, `tower-http` 0.5 → 0.6. Two downstream impacts in `defra-http`:
  1. `FromRequestParts` dropped `#[async_trait]` in favor of a real `async fn` method. The two hand-desugared impls in [crates/http/src/identity_extractor.rs](crates/http/src/identity_extractor.rs) were rewritten to the new form (net -~60 lines).
  2. axum 0.8 changed path-param syntax from `:name` to `{name}`. Migrated all 17 affected routes in [crates/http/src/router/routes.rs](crates/http/src/router/routes.rs).
- `tonic` 0.12 → 0.14, `prost` 0.13 → 0.14. The top-level `tonic_build::compile_protos` free function was removed in 0.14; prost codegen also split out into a separate `tonic-prost-build` crate. Updated [crates/orbis/build.rs](crates/orbis/build.rs) to `tonic_prost_build::configure().compile_protos(&[...], &[...])`, and added `tonic-prost-build` as a build-dep and `tonic-prost` as a runtime dep in [crates/orbis/Cargo.toml](crates/orbis/Cargo.toml) so the generated code can resolve `::tonic_prost`.

## Deferred (with explanatory comments in Cargo.toml)

- **`rand` 0.8 → 0.9.** Blocked by the stable RustCrypto ecosystem still pinning `rand_core = "0.6"` (`k256 0.13`, `p256 0.13`, `ed25519-dalek 2.x`, `x25519-dalek 2.x`, `aes-gcm 0.10`). Moving `rand` alone trips trait-bound mismatches at every `SigningKey::random(&mut OsRng)` and `StaticSecret::random_from_rng(OsRng)` call site in [crates/crypto/](crates/crypto/). Revisit once those crates ship `rand_core 0.9`-compatible stable releases (currently only prereleases: `ed25519-dalek 3.0-pre`, `k256 0.14-rc`, …).
- **IPLD stack (`cid` 0.10, `multihash` 0.18, `libipld` 0.16).** `libipld 0.16` is the last release on crates.io and internally pins `cid 0.10` / `multihash 0.18`. Bumping either in the workspace creates duplicate `Cid` / `MultihashGeneric` types across the IPLD API boundary. The whole stack has to move together once we drop or replace `libipld`.

Both deferrals are documented inline in [Cargo.toml](Cargo.toml) so the next person hitting these doesn't re-derive the pain.

## `libp2p` / `iroh` pinning

Unchanged, per the out-of-scope note in #652.

## Incidental

Fixed a pre-existing `clippy::doc_lazy_continuation` error in [tools/integration-test/tests/acp/link_collection.rs](tools/integration-test/tests/acp/link_collection.rs) that surfaces under newer clippy, so `cargo clippy --workspace --all-targets -- -D warnings` stays green on this branch.

Also filed #814 for a pre-existing build failure in the `storage` bench noticed during this work (missing `required-features = ["redb"]` on the `[[bench]]` entry) — not fixed here to keep this PR scoped.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test` passes
- [x] Rust-only integration tests green: `basic` (11), `query` (16), `acp` (105), `p2p` (15)
- [x] `cargo fmt --all` applied

Closes #652.