### PR TITLE
feat(embedded, defra-node): log selected storage backend at startup (#637)

### DIFF
--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -435,6 +435,11 @@ impl NodeBuilder {
 
             match self.storage_backend {
                 StorageBackend::Redb => {
+                    tracing::info!(
+                        storage_backend = "redb",
+                        data_path = %path.display(),
+                        "embedded node starting"
+                    );
                     let store = Arc::new(
                         storage::RedbStore::open(path.to_str().ok_or_else(|| {
                             anyhow::anyhow!("data_path contains non-UTF8 characters")
@@ -458,6 +463,11 @@ impl NodeBuilder {
                 }
                 #[cfg(feature = "rocksdb")]
                 StorageBackend::RocksDb => {
+                    tracing::info!(
+                        storage_backend = "rocksdb",
+                        data_path = %path.display(),
+                        "embedded node starting"
+                    );
                     let store = Arc::new(
                         storage::RocksDbStore::open(&path)
                             .map_err(|e| anyhow::anyhow!("failed to open rocksdb store: {}", e))?,
@@ -486,6 +496,10 @@ impl NodeBuilder {
                 }
             }
         } else {
+            tracing::info!(
+                storage_backend = "memory",
+                "embedded node starting (ephemeral, no data_path)"
+            );
             let store = Arc::new(storage::MemoryStore::new());
             let acp_store: Arc<dyn acp::AcpStore> = Arc::new(acp::MemoryAcpStore::new());
 

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -136,6 +136,12 @@ impl NodeBuilder {
                 }
             }
 
+            tracing::info!(
+                storage_backend = "redb",
+                data_path = %path.display(),
+                "embedded node starting"
+            );
+
             let redb = storage::RedbStore::open(
                 path.to_str()
                     .ok_or_else(|| anyhow!("data path contains non-UTF-8 characters"))?,
@@ -144,6 +150,10 @@ impl NodeBuilder {
 
             (Arc::new(EmbeddedStore::Redb(redb)), Persistence::Persistent)
         } else {
+            tracing::info!(
+                storage_backend = "memory",
+                "embedded node starting (ephemeral, no data_path)"
+            );
             (
                 Arc::new(EmbeddedStore::Memory(storage::MemoryStore::new())),
                 Persistence::Memory,


### PR DESCRIPTION
## Summary

Closes #637. Adds an `info!` log line at embedded node startup identifying the storage backend and data path.

## The problem

Before this PR, `EmbeddedNode::build()` emitted no log line identifying which storage backend was active. A production incident described in the issue saw a binary built without the `rocksdb` feature silently fall through to redb, creating a fresh `data.redb` file beside an existing `data.rocksdb/` directory and making ~830MB of historical data invisible. Diagnosis required SSH-ing into the host and inspecting filesystem timestamps — the service logs gave nothing.

## The change

Both node-builder paths now emit a tracing `info!` line at startup:

```
INFO embedded node starting storage_backend=rocksdb data_path=/var/lib/defra
```

Added to:

- [crates/defra-node/src/lib.rs](crates/defra-node/src/lib.rs) — 3 sites (Redb, RocksDb, Memory) in `NodeBuilder::build`
- [crates/embedded/src/node.rs](crates/embedded/src/node.rs) — 2 sites (Redb, Memory) in `NodeBuilder::build`

The CLI path (`crates/cli/src/commands/start/node.rs`) already logs this for Memory/Redb/Fjall/RocksDB datastores and needs no change.

## Test plan

- `cargo check --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all` applied

This is an additive observability change — zero behavior delta beyond the new log lines.