### PR TITLE
refactor(blockstore): use multihash Code::Sha2_256 instead of 0x12 literal (#811)

### DIFF
--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -48,6 +48,7 @@ pub use verify::verify_block_cid;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use cid::multihash::Code;
 use cid::Cid;
 use lru::LruCache;
 use parking_lot::Mutex;
@@ -152,28 +153,24 @@ impl<S: Store + 'static> DefraBlockstore<S> {
         let code = mh.code();
 
         // Compute hash based on the multihash code
-        match code {
-            0x12 => {
-                // SHA2-256
-                let mut hasher = Sha256::new();
-                hasher.update(data);
-                let computed_digest = hasher.finalize();
+        if code == u64::from(Code::Sha2_256) {
+            let mut hasher = Sha256::new();
+            hasher.update(data);
+            let computed_digest = hasher.finalize();
 
-                if mh.digest() != computed_digest.as_slice() {
-                    return Err(Error::HashMismatch {
-                        cid: cid.to_string(),
-                    });
-                }
-                Ok(())
+            if mh.digest() != computed_digest.as_slice() {
+                return Err(Error::HashMismatch {
+                    cid: cid.to_string(),
+                });
             }
-            _ => {
-                tracing::warn!(
-                    hash_code = code,
-                    cid = %cid,
-                    "Hash verification skipped: unsupported hash algorithm"
-                );
-                Ok(())
-            }
+            Ok(())
+        } else {
+            tracing::warn!(
+                hash_code = code,
+                cid = %cid,
+                "Hash verification skipped: unsupported hash algorithm"
+            );
+            Ok(())
         }
     }
 }

--- a/crates/blockstore/src/verify.rs
+++ b/crates/blockstore/src/verify.rs
@@ -3,12 +3,11 @@
 //! Only SHA2-256 (multihash code 0x12) is accepted for P2P blocks. Any other
 //! hash algorithm is rejected to prevent bypass via unsupported algorithm codes.
 
+use cid::multihash::Code;
 use cid::Cid;
 use sha2::{Digest, Sha256};
 
 use crate::error::{Error, Result};
-
-const SHA2_256_CODE: u64 = 0x12;
 
 /// Verify that `data` hashes to the digest encoded in `cid`.
 ///
@@ -20,7 +19,7 @@ pub fn verify_block_cid(cid: &Cid, data: &[u8]) -> Result<()> {
     let mh = cid.hash();
     let code = mh.code();
 
-    if code != SHA2_256_CODE {
+    if code != u64::from(Code::Sha2_256) {
         return Err(Error::UnsupportedHashAlgorithm {
             code,
             cid: cid.to_string(),


### PR DESCRIPTION
## Summary

Closes #811. Replaces two SHA2-256 magic hex literals in security-critical verification paths with the named multihash crate constant.

## Changes

- **[crates/blockstore/src/verify.rs](crates/blockstore/src/verify.rs)** — remove the local `SHA2_256_CODE: u64 = 0x12` constant, use `u64::from(Code::Sha2_256)` directly in the algorithm check inside `verify_block_cid`.
- **[crates/blockstore/src/lib.rs](crates/blockstore/src/lib.rs)** — replace the bare `0x12 => ...` match arm in `BlockstoreImpl::verify_hash` with an `if code == u64::from(Code::Sha2_256)` check.

The multihash crate already sits in blockstore's dep graph (via `cid`) and its test module already imports `cid::multihash::{Code, MultihashDigest}`. Pulling the algorithm code from the registry constant instead of a bare hex literal makes the intent self-documenting, removes the need for a reader to look up what `0x12` means, and would catch a future codec registry shift at compile time instead of silently producing a stale comparison.

## Behavior

Identical. `Code::Sha2_256 as u64 == 0x12`. Existing verify tests pass unchanged:

- `verify::tests::valid_block_passes`
- `verify::tests::tampered_data_fails`
- `verify::tests::unsupported_algorithm_fails`

## Test plan

- `cargo test -p blockstore verify` — 3/3 passing
- `cargo clippy -p blockstore --all-targets -- -D warnings` clean
- `cargo fmt --all` applied