### PR TITLE
fix(storage): gate transaction bench behind the redb feature (#814)

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -78,6 +78,7 @@ tempfile = "3.8"
 [[bench]]
 name = "transaction"
 harness = false
+required-features = ["redb"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Closes #814. Adds `required-features = [\"redb\"]` to the `[[bench]]` table in [crates/storage/Cargo.toml](crates/storage/Cargo.toml) so `cargo build --benches -p storage` with default features skips the bench instead of failing with 37 unresolved-import / type-inference errors.

## Why

The bench was added without a `required-features` declaration. It imports `storage::backends::RedbStore`, which only exists when the `redb` feature is enabled. The default feature set is `[\"rocksdb\"]`, so default builds don't have `RedbStore` — hence the errors.

This is Cargo's standard pattern for feature-gated bench binaries.

## Test plan

- [x] `cargo build --benches -p storage` — clean (skips the bench)
- [x] `cargo build --benches -p storage --features redb` — clean (builds and runs it)