### PR TITLE
chore(deny): document rationale for each ignored advisory (#705)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,16 +2,61 @@
 # Some ignored crates live in tools/ (excluded from CI workspace) so may not match
 unused-ignored-advisory = "warn"
 ignore = [
-    # Unmaintained transitive dependencies - acceptable for now
-    "RUSTSEC-2024-0388",  # derivative
-    "RUSTSEC-2025-0057",  # fxhash
-    "RUSTSEC-2024-0384",  # instant
-    "RUSTSEC-2024-0387",  # opentelemetry_api
-    "RUSTSEC-2024-0436",  # paste
-    "RUSTSEC-2024-0370",  # proc-macro-error
-    "RUSTSEC-2025-0134",  # rustls-pemfile
-    "RUSTSEC-2021-0127",  # serde_cbor
-    "RUSTSEC-2024-0320",  # wasmtime related
+    # ------------------------------------------------------------------
+    # Unmaintained crates pulled in via upstream ecosystems we don't
+    # control. Each entry documents the pulling path and the condition
+    # under which it can be removed. Narrowed as part of #705.
+    # ------------------------------------------------------------------
+
+    # derivative — unmaintained. Pulled by iroh-bitswap (beetle repo).
+    # Removable when iroh is dropped per CLAUDE.md strategy (libp2p is
+    # the main transport), at which point beetle can be removed.
+    "RUSTSEC-2024-0388",
+
+    # fxhash — unmaintained. Pulled by bm25 2.3.x (full-text search).
+    # Our direct bm25 dep is already pinned to the latest workspace
+    # version; upstream bm25 would need to switch its internal hasher
+    # (e.g. to ahash) before this can be removed.
+    "RUSTSEC-2025-0057",
+
+    # instant — unmaintained. Pulled by libp2p 0.53. Newer libp2p
+    # releases replaced it with web-time. Removable when we bump libp2p
+    # — currently pinned to 0.53 to match iroh-bitswap's dep pin.
+    "RUSTSEC-2024-0384",
+
+    # opentelemetry_api — unmaintained. Pulled by iroh-metrics
+    # (beetle repo). Removable alongside iroh when we drop the iroh
+    # transport.
+    "RUSTSEC-2024-0387",
+
+    # paste — unmaintained. Pulled by alloy-primitives (backbone repo,
+    # ACP light client). Removable when alloy migrates off paste; our
+    # direct alloy pin is already at the latest workspace version.
+    "RUSTSEC-2024-0436",
+
+    # proc-macro-error — unmaintained. Pulled by multihash-derive 0.8,
+    # which is pinned to multihash 0.18 by libipld 0.16. The whole IPLD
+    # stack moves together; tracked in #652.
+    "RUSTSEC-2024-0370",
+
+    # rustls-pemfile 1.x — unmaintained (2.x is current). Pulled by
+    # reqwest 0.11 inside iroh-metrics (beetle repo). Our direct reqwest
+    # deps (db-search, defra-node) already use reqwest 0.12 and pull
+    # rustls-pemfile 2.x; the 1.x copy is purely from the iroh path and
+    # will disappear when iroh does.
+    "RUSTSEC-2025-0134",
+
+    # serde_cbor — unmaintained. Used directly by db, storage, and p2p
+    # for wire-format CBOR. Replacing with ciborium is a workspace-wide
+    # refactor that touches P2P wire format — out of scope for #705 and
+    # deliberately tracked as future work.
+    "RUSTSEC-2021-0127",
+
+    # wasmtime-related — belt-and-braces ignore after the wasmtime 41
+    # upgrade (which remediated RUSTSEC-2025-0046 / 0118 / 2026-0006).
+    # Retained until the upstream advisory is retracted for recent
+    # wasmtime releases.
+    "RUSTSEC-2024-0320",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Closes #705. Audits each ignored advisory in [deny.toml](deny.toml) and replaces the terse one-line `# <crate>` comments with structured per-advisory blocks documenting:

1. Why the crate is unmaintained
2. Which dep path pulls it in (beetle/iroh, libp2p 0.53, bm25, alloy, libipld 0.16, wasmtime, etc.)
3. The specific condition under which the ignore can be removed

## Audit findings

Every ignored advisory is still load-bearing — each references a crate still in the dep tree, locked by an upstream constraint we don't directly control:

| Advisory | Crate | Pulling path | Removable when |
|---|---|---|---|
| 2024-0388 | derivative | iroh-bitswap → beetle | iroh is dropped |
| 2025-0057 | fxhash | bm25 2.3.x | upstream bm25 switches hasher |
| 2024-0384 | instant | libp2p 0.53 | libp2p bumped past 0.53 |
| 2024-0387 | opentelemetry_api | iroh-metrics → beetle | iroh is dropped |
| 2024-0436 | paste | alloy-primitives → backbone | alloy migrates off paste |
| 2024-0370 | proc-macro-error | multihash-derive 0.8 | IPLD stack bump (#652) |
| 2025-0134 | rustls-pemfile 1.x | reqwest 0.11 → iroh-metrics | iroh is dropped |
| 2021-0127 | serde_cbor | db/storage/p2p direct | replace with ciborium (workspace-wide P2P wire-format refactor, future work) |
| 2024-0320 | wasmtime-related | belt-and-braces after wasmtime 41 upgrade | upstream advisory retracted |

**Five of nine** advisories are directly tied to iroh/beetle and will drop automatically when the iroh transport is removed (per CLAUDE.md strategy — libp2p is the main transport). Another (`proc-macro-error`) is gated on the IPLD stack bump already tracked in #652.

## What this PR does NOT do

- Does **not** remove any advisories. Every ignored one is still load-bearing.
- Does **not** upgrade deps or replace crates. Those are tracked as follow-ups:
  - Iroh removal (CLAUDE.md strategic direction)
  - #652 IPLD stack bump
  - Future "replace serde_cbor with ciborium" workspace refactor
- Does **not** touch the licenses / bans / sources sections.

## Test plan

- `deny.toml` is consumed by `cargo deny check` in CI. No Rust code touched.
- The changes are pure comment additions inside the `ignore` array; structure is unchanged.