### PR TITLE
feat(embedded): idempotent EmbeddedNode::shutdown API (#813)

### DIFF
--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -15,6 +15,7 @@ use anyhow::{anyhow, Context, Result};
 use p2p::sync::SyncConfig;
 #[cfg(feature = "iroh")]
 use p2p::P2PTransport;
+use tokio::sync::Notify;
 
 pub(crate) type EmbeddedBlockstore<S> = blockstore::DefraBlockstore<S>;
 pub(crate) type EmbeddedMergeHandler<S> = db_merge::AcpMergeHandler<S, EmbeddedBlockstore<S>>;
@@ -35,8 +36,12 @@ pub struct EmbeddedNode<S: storage::corekv::Store> {
     pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
     pub p2p: Option<Arc<ManagedP2PSystem>>,
     /// Idempotency guard for [`EmbeddedNode::shutdown`]. Set to `true`
-    /// by the first caller of `shutdown()`; subsequent calls are no-ops.
+    /// by the first caller of `shutdown()`.
     shutdown_started: AtomicBool,
+    /// Marks that shutdown work has finished.
+    shutdown_finished: AtomicBool,
+    /// Wakes concurrent shutdown callers once teardown is complete.
+    shutdown_notify: Notify,
 }
 
 impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
@@ -90,8 +95,8 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
     /// step is needed here.
     ///
     /// This method is **idempotent** — the first caller performs the
-    /// work, subsequent calls return immediately. Safe to call from
-    /// multiple tasks concurrently.
+    /// work, concurrent callers wait for that teardown to finish and
+    /// then return. Safe to call from multiple tasks concurrently.
     ///
     /// Embedded callers should `await` this before dropping the
     /// [`EmbeddedNode`] to ensure clean teardown:
@@ -101,9 +106,12 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
     /// drop(node);
     /// ```
     pub async fn shutdown(&self) {
-        // Idempotency guard. Swap to true and bail if another task
-        // already initiated shutdown.
+        // Idempotency guard. The first task performs shutdown. Any
+        // concurrent caller waits for shutdown to finish before
+        // returning so `shutdown().await` consistently means teardown
+        // has completed.
         if self.shutdown_started.swap(true, Ordering::SeqCst) {
+            self.wait_for_shutdown().await;
             return;
         }
 
@@ -121,6 +129,9 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
         if let Err(error) = self.database.close().await {
             tracing::warn!(error = %error, "EmbeddedNode::shutdown: database close returned an error");
         }
+
+        self.shutdown_finished.store(true, Ordering::SeqCst);
+        self.shutdown_notify.notify_waiters();
     }
 
     /// Returns true if [`EmbeddedNode::shutdown`] has been initiated.
@@ -130,6 +141,16 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
     /// operations when teardown is in progress.
     pub fn is_shutdown(&self) -> bool {
         self.shutdown_started.load(Ordering::SeqCst)
+    }
+
+    async fn wait_for_shutdown(&self) {
+        loop {
+            let notified = self.shutdown_notify.notified();
+            if self.shutdown_finished.load(Ordering::SeqCst) {
+                return;
+            }
+            notified.await;
+        }
     }
 }
 
@@ -402,5 +423,101 @@ where
         sourcehub_acp,
         p2p: p2p_setup.map(|setup| setup.system),
         shutdown_started: AtomicBool::new(false),
+        shutdown_finished: AtomicBool::new(false),
+        shutdown_notify: Notify::new(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    use async_trait::async_trait;
+
+    #[derive(Clone, Default)]
+    struct SlowCloseStore {
+        inner: storage::MemoryStore,
+        close_calls: Arc<AtomicUsize>,
+        close_started: Arc<Notify>,
+        close_finished: Arc<AtomicBool>,
+        allow_close: Arc<Notify>,
+    }
+
+    impl SlowCloseStore {
+        async fn wait_until_close_started(&self) {
+            loop {
+                let notified = self.close_started.notified();
+                if self.close_calls.load(Ordering::SeqCst) > 0 {
+                    return;
+                }
+                notified.await;
+            }
+        }
+    }
+
+    impl storage::corekv::private::Sealed for SlowCloseStore {}
+
+    #[async_trait]
+    impl storage::Store for SlowCloseStore {
+        async fn new_txn(&self, readonly: bool) -> storage::Result<Box<dyn storage::Txn>> {
+            self.inner.new_txn(readonly).await
+        }
+
+        async fn close(&self) -> storage::Result<()> {
+            self.close_calls.fetch_add(1, Ordering::SeqCst);
+            self.close_started.notify_waiters();
+            self.allow_close.notified().await;
+            let result = self.inner.close().await;
+            self.close_finished.store(true, Ordering::SeqCst);
+            result
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_shutdown_callers_wait_for_teardown_completion() -> Result<()> {
+        let store = Arc::new(SlowCloseStore::default());
+        let node = Arc::new(build_with_store(store.clone(), EmbeddedNodeConfig::default()).await?);
+
+        let first = {
+            let node = node.clone();
+            tokio::spawn(async move {
+                node.shutdown().await;
+            })
+        };
+
+        store.wait_until_close_started().await;
+
+        let second = {
+            let node = node.clone();
+            let store = store.clone();
+            tokio::spawn(async move {
+                node.shutdown().await;
+                assert!(
+                    store.close_finished.load(Ordering::SeqCst),
+                    "shutdown() returned before store close completed"
+                );
+            })
+        };
+
+        tokio::task::yield_now().await;
+        assert!(
+            !second.is_finished(),
+            "concurrent shutdown caller returned before teardown completed"
+        );
+
+        store.allow_close.notify_waiters();
+
+        first.await.expect("first shutdown task should not panic");
+        second.await.expect("second shutdown task should not panic");
+
+        assert_eq!(
+            store.close_calls.load(Ordering::SeqCst),
+            1,
+            "shutdown should only close the store once"
+        );
+        assert!(store.close_finished.load(Ordering::SeqCst));
+
+        Ok(())
+    }
 }

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::node_acp::{create_document_acp, create_nac_manager};
@@ -33,6 +34,9 @@ pub struct EmbeddedNode<S: storage::corekv::Store> {
     pub node_identity_did: Option<String>,
     pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
     pub p2p: Option<Arc<ManagedP2PSystem>>,
+    /// Idempotency guard for [`EmbeddedNode::shutdown`]. Set to `true`
+    /// by the first caller of `shutdown()`; subsequent calls are no-ops.
+    shutdown_started: AtomicBool,
 }
 
 impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
@@ -68,6 +72,64 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
         }
 
         Ok(())
+    }
+
+    /// Shut the node down cleanly.
+    ///
+    /// Order:
+    /// 1. **P2P transport** — closes the iroh endpoint or libp2p host
+    ///    gracefully and aborts the replication/merge background tasks.
+    ///    Addresses the `Endpoint dropped without calling Endpoint::close`
+    ///    iroh warning downstream embedders have been hitting.
+    /// 2. **Database** — close-guards future transactions (new `begin_txn`
+    ///    calls will return `Error::DatabaseClosed`) and closes the
+    ///    underlying store.
+    ///
+    /// The background downsample task is aborted by the `Drop` impl on
+    /// `BackgroundTasks` when the node itself is dropped, so no explicit
+    /// step is needed here.
+    ///
+    /// This method is **idempotent** — the first caller performs the
+    /// work, subsequent calls return immediately. Safe to call from
+    /// multiple tasks concurrently.
+    ///
+    /// Embedded callers should `await` this before dropping the
+    /// [`EmbeddedNode`] to ensure clean teardown:
+    ///
+    /// ```ignore
+    /// node.shutdown().await;
+    /// drop(node);
+    /// ```
+    pub async fn shutdown(&self) {
+        // Idempotency guard. Swap to true and bail if another task
+        // already initiated shutdown.
+        if self.shutdown_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        // 1. P2P first — stops inbound/outbound traffic and awaits the
+        //    transport's graceful close path (iroh Endpoint::close /
+        //    libp2p Host::shutdown).
+        if let Some(p2p) = &self.p2p {
+            p2p.shutdown().await;
+        }
+
+        // 2. Database — sets the is_closed flag and closes the store.
+        //    Log but don't propagate errors: shutdown should complete
+        //    even if the store close returns an I/O error, so embedders
+        //    can't be blocked from exiting by a closing store.
+        if let Err(error) = self.database.close().await {
+            tracing::warn!(error = %error, "EmbeddedNode::shutdown: database close returned an error");
+        }
+    }
+
+    /// Returns true if [`EmbeddedNode::shutdown`] has been initiated.
+    ///
+    /// Does not guarantee that shutdown has finished — just that it has
+    /// started. Useful for embedders that want to short-circuit pending
+    /// operations when teardown is in progress.
+    pub fn is_shutdown(&self) -> bool {
+        self.shutdown_started.load(Ordering::SeqCst)
     }
 }
 
@@ -339,5 +401,6 @@ where
         node_identity_did,
         sourcehub_acp,
         p2p: p2p_setup.map(|setup| setup.system),
+        shutdown_started: AtomicBool::new(false),
     })
 }

--- a/crates/embedded/tests/shutdown.rs
+++ b/crates/embedded/tests/shutdown.rs
@@ -1,0 +1,76 @@
+//! Regression tests for the EmbeddedNode::shutdown API (#813).
+//!
+//! Verifies:
+//! 1. `shutdown()` can be called and returns
+//! 2. After `shutdown()`, `is_shutdown()` reports true
+//! 3. `shutdown()` is idempotent — repeated calls are safe no-ops
+//! 4. After `shutdown()`, the database reports `is_closed() == true`
+
+use anyhow::Result;
+use embedded::NodeBuilder;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_reports_closed_database() -> Result<()> {
+    let node = NodeBuilder::default().build().await?;
+    assert!(!node.is_shutdown(), "fresh node should not report shutdown");
+    assert!(
+        !node.database.is_closed(),
+        "fresh database should not report closed"
+    );
+
+    node.shutdown().await;
+
+    assert!(
+        node.is_shutdown(),
+        "after shutdown(), is_shutdown() should return true"
+    );
+    assert!(
+        node.database.is_closed(),
+        "after shutdown(), database should report closed"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_is_idempotent() -> Result<()> {
+    let node = NodeBuilder::default().build().await?;
+
+    // First call does real work.
+    node.shutdown().await;
+    assert!(node.is_shutdown());
+    assert!(node.database.is_closed());
+
+    // Second and third calls must be safe no-ops.
+    node.shutdown().await;
+    node.shutdown().await;
+    assert!(node.is_shutdown());
+    assert!(node.database.is_closed());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_concurrent_calls_are_safe() -> Result<()> {
+    use std::sync::Arc;
+
+    let node = Arc::new(NodeBuilder::default().build().await?);
+
+    // Fire several concurrent shutdown() calls. They should all return
+    // without panicking, and the node should end up fully shut down.
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let n = node.clone();
+            tokio::spawn(async move { n.shutdown().await })
+        })
+        .collect();
+
+    for h in handles {
+        h.await.expect("shutdown task should not panic");
+    }
+
+    assert!(node.is_shutdown());
+    assert!(node.database.is_closed());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #813. Adds a public, idempotent `shutdown()` method on `EmbeddedNode` so embedders can await clean teardown before dropping the node, instead of relying on Drop behavior.

## Motivation

defra-agent-desktop and other downstream embedders have been relying on Drop for teardown, which produces iroh warnings like:

> `Endpoint dropped without calling Endpoint::close. Aborting ungracefully.`

…and leaves integration tests hanging. The underlying `ShutdownHandle::shutdown` machinery already existed — embedders just had no way to reach it through the public `EmbeddedNode` API.

## API

```rust
impl<S: Store + 'static> EmbeddedNode<S> {
    /// Shut the node down cleanly. Idempotent; safe to call concurrently.
    pub async fn shutdown(&self);

    /// Returns true if shutdown has been initiated.
    pub fn is_shutdown(&self) -> bool;
}
```

## Teardown order (per issue)

1. **P2P transport** — calls `ManagedP2PSystem::shutdown()` which invokes the pre-existing `ShutdownHandle::shutdown`:
   - **iroh**: `IrohTransport::shutdown()` closes the endpoint gracefully → resolves the `Endpoint dropped without calling Endpoint::close` warning
   - **libp2p**: aborts replication/merge tasks, then `P2PHostHandle::shutdown()`
   - Clears the signing identity store (already in `ShutdownHandle`)
2. **Database** — `db::DB::close()` sets the `is_closed` flag (future `begin_txn` calls return `Error::DatabaseClosed`) and closes the underlying store

The background downsample task is aborted by the existing `Drop` impl on `BackgroundTasks` when the node itself is dropped — no explicit step needed in `shutdown()`.

## Idempotency

An `AtomicBool shutdown_started` guard ensures the first call does real work and subsequent calls return immediately. Safe under concurrent invocation from multiple tasks.

## Tests

New [crates/embedded/tests/shutdown.rs](crates/embedded/tests/shutdown.rs) with three test cases:

- **`shutdown_reports_closed_database`** — post-shutdown state: `is_shutdown()` returns true, `database.is_closed()` returns true
- **`shutdown_is_idempotent`** — three sequential `shutdown()` calls converge on the same stable state with no panics
- **`shutdown_concurrent_calls_are_safe`** — 8 concurrent `shutdown()` invocations on a shared `Arc<EmbeddedNode>` all complete without panicking

## Test plan

- [x] `cargo test -p embedded --test shutdown` — 3/3 passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` applied

## Recommended usage

```rust
node.shutdown().await;
drop(node); // BackgroundTasks::Drop aborts the downsample task here
```