### PR TITLE
fix(db): drop get_for_update datastore before txn discard

### DIFF
--- a/crates/db/src/auto_commit_mutator/read.rs
+++ b/crates/db/src/auto_commit_mutator/read.rs
@@ -13,19 +13,29 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
-        // Get the datastore
-        let datastore = txn.datastore().map_err(|e| {
-            query::error::QueryError::execution(format!(
-                "failed to get datastore for collection '{}': {}",
-                collection_name, e
-            ))
-        })?;
+        // Scope the datastore + run the check inside an inner block, then
+        // explicitly drop the datastore NamespaceView before calling
+        // `txn.discard()`. BasicTxn::discard() does Arc::try_unwrap on the
+        // inner SharedTxn; any outstanding NamespaceView clone causes the
+        // unwrap to fail with `TxnStillInUse` and spam the logs. Explicit
+        // drop here makes the Arc refcount unambiguously 1 at the discard
+        // point regardless of async state-machine layout (#821).
+        let result = {
+            let datastore = txn.datastore().map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to get datastore for collection '{}': {}",
+                    collection_name, e
+                ))
+            })?;
 
-        // Execute the check
-        let result = collection
-            .exists_with_datastore(&datastore, doc_id)
-            .await
-            .map_err(|e| query::error::QueryError::execution(format!("exists error: {}", e)));
+            let r = collection
+                .exists_with_datastore(&datastore, doc_id)
+                .await
+                .map_err(|e| query::error::QueryError::execution(format!("exists error: {}", e)));
+
+            drop(datastore);
+            r
+        };
 
         // Discard the read-only transaction
         if let Err(e) = txn.discard() {
@@ -51,7 +61,12 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
-        // Scope the datastore so the read-only transaction can be cleanly discarded.
+        // See exists_impl — explicit drop(datastore) before txn.discard()
+        // to guarantee the SharedTxn Arc refcount is 1 at the discard
+        // point. Without this, BasicTxn::discard() can fail with
+        // TxnStillInUse under certain async runtime schedules and spam
+        // "Failed to discard read-only transaction after get_for_update"
+        // warnings (#821).
         let result = {
             let datastore = txn.datastore().map_err(|e| {
                 query::error::QueryError::execution(format!(
@@ -60,13 +75,15 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 ))
             })?;
 
-            // Execute the fetch
-            collection
+            let r = collection
                 .get_with_datastore(&datastore, doc_id)
                 .await
                 .map_err(|e| {
                     query::error::QueryError::execution(format!("get_for_update error: {}", e))
-                })
+                });
+
+            drop(datastore);
+            r
         };
 
         // Discard the read-only transaction


### PR DESCRIPTION
## Summary
- explicitly drop the read-only transaction datastore `NamespaceView` before `txn.discard()` in `exists_impl`
- do the same in `get_for_update_impl` to avoid `TxnStillInUse` warnings after `get_for_update`
- keeps the existing warning path for genuinely failed discards

Closes #821.

## Prior unmerged fix
After fetching `origin`, there was already a remote branch named `fix/get-for-update-discard-warn` with the same intended fix:

- commit: `1f28fe0d`
- author date: `2026-04-15T16:35:41+07:00` (`2026-04-15T02:35:41-07:00` Pacific)
- subject: `fix(db): explicit drop of datastore NamespaceView before read-only txn discard (#821)`

That branch had not been merged into `main` when this worktree was created. This PR carries that fix forward on a fresh issue branch based on current `origin/main`.

## Tests
- `cargo test -p defra-node --test issue_729_get_for_update_warning embedded_upsert_does_not_warn_when_discarding_get_for_update_txn -- --exact --nocapture`
- `cargo test -p db`
