### PR TITLE
fix(defra-node): repair p2p feature compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,6 +3778,7 @@ dependencies = [
  "serde_json",
  "sourcehub",
  "storage",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -35,6 +35,7 @@ tracing.workspace = true
 async-trait = "0.1"
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 axum = { workspace = true, optional = true }
 reqwest = { version = "0.12", features = ["json"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -17,6 +17,8 @@ mod db_impls;
 pub mod dense_search;
 mod node_acp;
 #[cfg(feature = "p2p")]
+mod p2p_error;
+#[cfg(feature = "p2p")]
 mod p2p_handle;
 pub mod search_chunks;
 pub mod version;
@@ -41,6 +43,8 @@ pub use config::P2PConfig;
 pub use config::{DocumentAcpConfig, SourceHubConfig};
 pub use dense_search::{DenseHybridSearchHit, DenseHybridSearchRequest, DenseHybridSearchResponse};
 pub use events::EventName;
+#[cfg(feature = "p2p")]
+pub use p2p_error::{P2PError, P2PResult};
 pub use query::{QueryExecutor, QueryRequest, QueryResponse};
 
 #[cfg(all(feature = "http", feature = "p2p"))]
@@ -54,24 +58,13 @@ impl HttpP2PAdapter {
         "not supported by embedded defra-node HTTP adapter".to_string()
     }
 
-    fn map_embedded_error(error: embedded::P2PError) -> defra_http::router::P2PError {
+    fn map_p2p_error(error: P2PError) -> defra_http::router::P2PError {
         match error {
-            embedded::P2PError::InvalidInput(message) => {
-                defra_http::router::P2PError::InvalidInput(message)
-            }
-            embedded::P2PError::NotFound(message) => {
-                defra_http::router::P2PError::NotFound(message)
-            }
-            embedded::P2PError::Unsupported(message) => {
-                defra_http::router::P2PError::Unsupported(message)
-            }
-            embedded::P2PError::Transport(message) => {
-                defra_http::router::P2PError::Transport(message)
-            }
-            embedded::P2PError::Persistence(message) => {
-                defra_http::router::P2PError::Internal(message)
-            }
-            embedded::P2PError::Internal(message) => {
+            P2PError::InvalidInput(message) => defra_http::router::P2PError::InvalidInput(message),
+            P2PError::NotFound(message) => defra_http::router::P2PError::NotFound(message),
+            P2PError::Unsupported(message) => defra_http::router::P2PError::Unsupported(message),
+            P2PError::Transport(message) => defra_http::router::P2PError::Transport(message),
+            P2PError::Persistence(message) | P2PError::Internal(message) => {
                 defra_http::router::P2PError::Internal(message)
             }
         }
@@ -93,14 +86,14 @@ impl defra_http::P2POperations for HttpP2PAdapter {
         self.inner
             .connected_peers()
             .await
-            .map_err(Self::map_embedded_error)
+            .map_err(Self::map_p2p_error)
     }
 
     async fn connect_peer(&self, addr: &str) -> defra_http::router::P2PResult<()> {
         self.inner
             .connect_peer(addr)
             .await
-            .map_err(Self::map_embedded_error)
+            .map_err(Self::map_p2p_error)
     }
 
     async fn get_replicators(
@@ -124,7 +117,7 @@ impl defra_http::P2POperations for HttpP2PAdapter {
         self.inner
             .set_replicator(addr, collections)
             .await
-            .map_err(Self::map_embedded_error)
+            .map_err(Self::map_p2p_error)
     }
 
     async fn remove_replicator(
@@ -148,7 +141,7 @@ impl defra_http::P2POperations for HttpP2PAdapter {
             self.inner
                 .subscribe_collection(&collection)
                 .await
-                .map_err(Self::map_embedded_error)?;
+                .map_err(Self::map_p2p_error)?;
         }
         Ok(())
     }
@@ -182,6 +175,16 @@ impl defra_http::P2POperations for HttpP2PAdapter {
     async fn remove_documents(
         &self,
         _docs: Vec<defra_http::router::P2pDocumentRequest>,
+    ) -> defra_http::router::P2PResult<()> {
+        Err(defra_http::router::P2PError::Unsupported(
+            Self::unsupported(),
+        ))
+    }
+
+    async fn republish_document(
+        &self,
+        _collection_name: &str,
+        _doc_id: &str,
     ) -> defra_http::router::P2PResult<()> {
         Err(defra_http::router::P2PError::Unsupported(
             Self::unsupported(),
@@ -223,18 +226,14 @@ impl defra_http::P2POperations for HttpP2PAdapter {
 pub trait P2POps: Send + Sync {
     async fn local_peer_id(&self) -> String;
     async fn listen_addresses(&self) -> Vec<String>;
-    async fn connected_peers(&self) -> embedded::P2PResult<Vec<String>>;
-    async fn connect_peer(&self, addr: &str) -> embedded::P2PResult<()>;
-    async fn notify_network_change(&self) -> embedded::P2PResult<()>;
-    async fn subscribe_collection(&self, name: &str) -> embedded::P2PResult<()>;
+    async fn connected_peers(&self) -> P2PResult<Vec<String>>;
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()>;
+    async fn notify_network_change(&self) -> P2PResult<()>;
+    async fn subscribe_collection(&self, name: &str) -> P2PResult<()>;
     /// Set up push replication to a peer for the given collections.
     /// The peer address may be an endpoint ticket, `<node-id>@<ip>:<port>`,
     /// or just `<node-id>`.
-    async fn set_replicator(
-        &self,
-        peer_addr: &str,
-        collections: Vec<String>,
-    ) -> embedded::P2PResult<()>;
+    async fn set_replicator(&self, peer_addr: &str, collections: Vec<String>) -> P2PResult<()>;
 }
 
 /// Type-erased schema operations so we can store DB<S> without leaking the Store generic.
@@ -771,7 +770,9 @@ impl NodeBuilder {
 
     #[cfg(feature = "p2p")]
     async fn run_event_handler<B: blockstore::Blockstore + Send + Sync + 'static>(
-        mut events: tokio::sync::mpsc::Receiver<p2p::TransportEvent>,
+        mut events: tokio::sync::mpsc::Receiver<
+            p2p::TransportEvent<<p2p::iroh::IrohTransport as P2PTransport>::ResponseToken>,
+        >,
         coordinator: Arc<p2p::sync::SyncCoordinator<B, p2p::iroh::IrohTransport>>,
     ) {
         let semaphore = Arc::new(tokio::sync::Semaphore::new(32));

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -25,6 +25,8 @@ pub mod version;
 
 use std::path::PathBuf;
 use std::sync::Arc;
+#[cfg(feature = "p2p")]
+use std::sync::Mutex;
 
 #[cfg(feature = "p2p")]
 use p2p::P2PTransport;
@@ -258,6 +260,95 @@ pub struct EmbeddedNode {
     embedding_config: db::EmbeddingClientConfig,
     #[cfg(feature = "p2p")]
     p2p_ops: Option<Arc<dyn P2POps>>,
+    #[cfg(feature = "p2p")]
+    p2p_lifecycle: Option<P2PLifecycle>,
+}
+
+#[cfg(feature = "p2p")]
+struct P2PLifecycle {
+    inner: Mutex<Option<P2PLifecycleInner>>,
+}
+
+#[cfg(feature = "p2p")]
+struct P2PLifecycleInner {
+    transport: p2p::iroh::IrohTransport,
+    endpoint_task: tokio::task::JoinHandle<()>,
+    replication_task: tokio::task::JoinHandle<()>,
+    event_handler_task: tokio::task::JoinHandle<()>,
+    failure_recorder_task: tokio::task::JoinHandle<()>,
+    retry_loop_task: tokio::task::JoinHandle<()>,
+}
+
+#[cfg(feature = "p2p")]
+impl P2PLifecycle {
+    fn new(inner: P2PLifecycleInner) -> Self {
+        Self {
+            inner: Mutex::new(Some(inner)),
+        }
+    }
+
+    async fn shutdown(&self) {
+        let inner = match self.inner.lock() {
+            Ok(mut guard) => guard.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        };
+
+        if let Some(inner) = inner {
+            inner.shutdown().await;
+        }
+    }
+}
+
+#[cfg(feature = "p2p")]
+impl P2PLifecycleInner {
+    async fn shutdown(self) {
+        abort_background_task("iroh retry loop", self.retry_loop_task).await;
+
+        if let Err(error) = self.transport.shutdown().await {
+            tracing::debug!(%error, "Iroh transport shutdown returned an error");
+        }
+
+        await_endpoint_task(self.endpoint_task).await;
+        abort_background_task("iroh event handler", self.event_handler_task).await;
+        abort_background_task("iroh replication loop", self.replication_task).await;
+        abort_background_task("iroh failure recorder", self.failure_recorder_task).await;
+    }
+}
+
+#[cfg(feature = "p2p")]
+async fn await_endpoint_task(mut task: tokio::task::JoinHandle<()>) {
+    match tokio::time::timeout(std::time::Duration::from_secs(5), &mut task).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) if error.is_cancelled() => {
+            tracing::debug!("Iroh endpoint task was already cancelled");
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "Iroh endpoint task failed during shutdown");
+        }
+        Err(_) => {
+            tracing::warn!("Iroh endpoint task did not stop after graceful shutdown; aborting");
+            task.abort();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(1), task).await;
+        }
+    }
+}
+
+#[cfg(feature = "p2p")]
+async fn abort_background_task(task_name: &'static str, task: tokio::task::JoinHandle<()>) {
+    task.abort();
+    match tokio::time::timeout(std::time::Duration::from_secs(1), task).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) if error.is_cancelled() => {}
+        Ok(Err(error)) => {
+            tracing::debug!(task = task_name, %error, "P2P background task failed during shutdown");
+        }
+        Err(_) => {
+            tracing::debug!(
+                task = task_name,
+                "P2P background task did not stop after abort"
+            );
+        }
+    }
 }
 
 impl EmbeddedNode {
@@ -315,6 +406,14 @@ impl EmbeddedNode {
     #[cfg(feature = "p2p")]
     pub fn p2p_arc(&self) -> Option<Arc<dyn P2POps>> {
         self.p2p_ops.as_ref().map(Arc::clone)
+    }
+
+    /// Gracefully stop background services owned by this embedded node.
+    pub async fn shutdown(&self) {
+        #[cfg(feature = "p2p")]
+        if let Some(lifecycle) = &self.p2p_lifecycle {
+            lifecycle.shutdown().await;
+        }
     }
 }
 
@@ -639,13 +738,21 @@ impl NodeBuilder {
         let runner: Arc<dyn QueryExecutor> = Arc::new(query_runner);
         let schema_ops: Arc<dyn SchemaOps> = Arc::new(database.clone());
 
+        #[cfg(feature = "p2p")]
+        let (p2p_ops, p2p_lifecycle) = match p2p_result {
+            Some(result) => (Some(result.ops), result.lifecycle),
+            None => (None, None),
+        };
+
         Ok(EmbeddedNode {
             runner,
             event_bus,
             schema_ops,
             embedding_config,
             #[cfg(feature = "p2p")]
-            p2p_ops: p2p_result.map(|r| r.ops),
+            p2p_ops,
+            #[cfg(feature = "p2p")]
+            p2p_lifecycle,
         })
     }
 
@@ -667,7 +774,7 @@ impl NodeBuilder {
             bind_port: Some(config.port),
             bind_addr: config.bind_addr,
         };
-        let (command_tx, iroh_events, _task_handle) = p2p::iroh::spawn_endpoint(iroh_config)
+        let (command_tx, iroh_events, endpoint_task) = p2p::iroh::spawn_endpoint(iroh_config)
             .await
             .map_err(|e| anyhow::anyhow!("IROH endpoint spawn failed: {}", e))?;
 
@@ -701,7 +808,7 @@ impl NodeBuilder {
 
         // Failure channel (required by replication loop)
         let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
-        spawn_failure_recorder(store.clone(), failure_rx);
+        let failure_recorder_task = spawn_failure_recorder(store.clone(), failure_rx);
 
         let coordinator = Arc::new(coordinator);
 
@@ -725,7 +832,7 @@ impl NodeBuilder {
 
         // 9. Replication loop (transport-generic)
         let coord_for_repl = coordinator.clone();
-        tokio::spawn(async move {
+        let replication_task = tokio::spawn(async move {
             p2p::sync::ReplicationLoop::run(
                 coord_for_repl,
                 sync_events,
@@ -737,10 +844,11 @@ impl NodeBuilder {
 
         // 10. IROH event handler (events are already TransportEvent -- no conversion needed)
         let coord_for_events = coordinator.clone();
-        tokio::spawn(async move {
+        let event_handler_task = tokio::spawn(async move {
             Self::run_event_handler(iroh_events, coord_for_events).await;
         });
-        spawn_iroh_retry_loop(store.clone(), database.clone(), transport.clone());
+        let retry_loop_task =
+            spawn_iroh_retry_loop(store.clone(), database.clone(), transport.clone());
 
         // 11. Collection lookup (resolves names -> CIDs for gossip topics)
         let collection_lookup: Arc<dyn CollectionLookup> = database.clone();
@@ -751,14 +859,23 @@ impl NodeBuilder {
 
         let peer_id = transport.local_peer_id().to_string();
         tracing::info!(peer_id = %peer_id, "P2P started (IROH/QUIC)");
+        let ops_transport = transport.clone();
         let ops: Arc<dyn P2POps> = Arc::new(p2p_handle::P2PHandleImpl {
-            transport,
+            transport: ops_transport,
             coordinator,
             collection_lookup,
         });
 
         Ok(P2PSetupResult {
             ops,
+            lifecycle: Some(P2PLifecycle::new(P2PLifecycleInner {
+                transport,
+                endpoint_task,
+                replication_task,
+                event_handler_task,
+                failure_recorder_task,
+                retry_loop_task,
+            })),
             mutator,
             wire_document_acp: Some(Box::new(move |acp, strict| {
                 merge_handler_for_acp.set_document_acp(acp.clone());
@@ -930,6 +1047,7 @@ fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
 #[cfg(feature = "p2p")]
 struct P2PSetupResult {
     ops: Arc<dyn P2POps>,
+    lifecycle: Option<P2PLifecycle>,
     mutator: Arc<dyn query::DocMutator>,
     wire_document_acp: Option<WireDocumentAcpCallback>,
 }
@@ -1122,5 +1240,8 @@ mod p2p_tests {
         );
 
         wait_for_collection_len(&node1, "User", 1).await;
+
+        node0.shutdown().await;
+        node1.shutdown().await;
     }
 }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -675,7 +675,7 @@ impl NodeBuilder {
         let transport = p2p::iroh::IrohTransport::new(command_tx, secret_key);
 
         // 5. Blockstore for sync coordinator + merge handler
-        let sync_blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), false));
+        let sync_blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), true));
 
         // 6. Collection store (persists subscriptions)
         let collection_store: Arc<dyn p2p::sync::P2PCollectionStorage> =

--- a/crates/defra-node/src/p2p_error.rs
+++ b/crates/defra-node/src/p2p_error.rs
@@ -1,0 +1,65 @@
+use thiserror::Error;
+
+/// Error categories for defra-node P2P operations.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum P2PError {
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("unsupported operation: {0}")]
+    Unsupported(String),
+
+    #[error("transport error: {0}")]
+    Transport(String),
+
+    #[error("persistence error: {0}")]
+    Persistence(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+/// Convenience result alias for defra-node P2P operations.
+pub type P2PResult<T> = Result<T, P2PError>;
+
+impl P2PError {
+    pub fn invalid_input(message: impl Into<String>) -> Self {
+        Self::InvalidInput(message.into())
+    }
+
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::NotFound(message.into())
+    }
+
+    pub fn unsupported(message: impl Into<String>) -> Self {
+        Self::Unsupported(message.into())
+    }
+
+    pub fn transport(message: impl Into<String>) -> Self {
+        Self::Transport(message.into())
+    }
+
+    pub fn persistence(message: impl Into<String>) -> Self {
+        Self::Persistence(message.into())
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+}
+
+impl From<String> for P2PError {
+    fn from(message: String) -> Self {
+        Self::Internal(message)
+    }
+}
+
+impl From<&str> for P2PError {
+    fn from(message: &str) -> Self {
+        Self::Internal(message.to_string())
+    }
+}

--- a/crates/defra-node/src/p2p_handle.rs
+++ b/crates/defra-node/src/p2p_handle.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use p2p::P2PTransport;
 
 use crate::CollectionLookup;
+use crate::P2PError;
 use crate::P2POps;
+use crate::P2PResult;
 
 pub(crate) struct P2PHandleImpl<B: blockstore::Blockstore + Send + Sync + 'static> {
     pub(crate) transport: p2p::iroh::IrohTransport,
@@ -24,38 +26,37 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
         p2p::iroh::format_public_listen_addrs(self.transport.local_peer_id(), &raw_addrs)
     }
 
-    async fn connected_peers(&self) -> embedded::P2PResult<Vec<String>> {
+    async fn connected_peers(&self) -> P2PResult<Vec<String>> {
         self.transport
             .connected_peers()
             .await
             .map(|peers| peers.into_iter().map(|peer| peer.to_string()).collect())
-            .map_err(|error| {
-                embedded::P2PError::transport(format!("connected peers failed: {}", error))
-            })
+            .map_err(|error| P2PError::transport(format!("connected peers failed: {}", error)))
     }
 
-    async fn connect_peer(&self, addr: &str) -> embedded::P2PResult<()> {
+    async fn connect_peer(&self, addr: &str) -> P2PResult<()> {
         let (peer_id, addrs) = p2p::iroh::parse_public_peer_addr(addr)
-            .map_err(|error| embedded::P2PError::invalid_input(error.to_string()))?;
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
         self.transport
             .dial(&peer_id, addrs)
             .await
-            .map_err(|error| embedded::P2PError::transport(format!("dial failed: {}", error)))
+            .map_err(|error| P2PError::transport(format!("dial failed: {}", error)))
     }
 
-    async fn notify_network_change(&self) -> embedded::P2PResult<()> {
-        self.transport.network_change().await.map_err(|error| {
-            embedded::P2PError::transport(format!("network_change failed: {}", error))
-        })
+    async fn notify_network_change(&self) -> P2PResult<()> {
+        self.transport
+            .network_change()
+            .await
+            .map_err(|error| P2PError::transport(format!("network_change failed: {}", error)))
     }
 
-    async fn subscribe_collection(&self, name: &str) -> embedded::P2PResult<()> {
+    async fn subscribe_collection(&self, name: &str) -> P2PResult<()> {
         // Resolve collection name -> CID (gossip topics use CIDs, not names)
         let collection_id = self
             .collection_lookup
             .get_collection_id(name)
             .ok_or_else(|| {
-                embedded::P2PError::not_found(format!(
+                P2PError::not_found(format!(
                     "collection '{}' not found -- add schema before subscribing to P2P",
                     name
                 ))
@@ -69,18 +70,14 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
             .subscribe_collection(&collection_id)
             .await
             .map_err(|error| {
-                embedded::P2PError::transport(format!("subscribe collection failed: {}", error))
+                P2PError::transport(format!("subscribe collection failed: {}", error))
             })?;
         Ok(())
     }
 
-    async fn set_replicator(
-        &self,
-        peer_addr: &str,
-        collections: Vec<String>,
-    ) -> embedded::P2PResult<()> {
+    async fn set_replicator(&self, peer_addr: &str, collections: Vec<String>) -> P2PResult<()> {
         let (peer_id, addrs) = p2p::iroh::parse_public_peer_addr(peer_addr)
-            .map_err(|error| embedded::P2PError::invalid_input(error.to_string()))?;
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
         if !addrs.is_empty() || p2p::iroh::is_ticket_string(peer_addr) {
             self.connect_peer(peer_addr).await?;
         }
@@ -92,7 +89,7 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
                 .collection_lookup
                 .get_collection_id(name)
                 .ok_or_else(|| {
-                    embedded::P2PError::not_found(format!(
+                    P2PError::not_found(format!(
                         "collection '{}' not found for replicator setup",
                         name
                     ))
@@ -108,9 +105,7 @@ impl<B: blockstore::Blockstore + Send + Sync + 'static> P2POps for P2PHandleImpl
         self.coordinator
             .create_replicator(&peer_id, collection_cids, true)
             .await
-            .map_err(|error| {
-                embedded::P2PError::transport(format!("set replicator failed: {}", error))
-            })?;
+            .map_err(|error| P2PError::transport(format!("set replicator failed: {}", error)))?;
 
         tracing::info!(
             peer_id = %peer_id,

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -93,7 +93,6 @@ async fn run_event_loop(
         .is_err()
     {
         warn!("Event channel closed, cannot emit Listening event");
-        return;
     }
 
     loop {
@@ -138,6 +137,9 @@ async fn run_event_loop(
     }
     for (_, sync) in active_syncs.drain() {
         sync.abort_handle.abort();
+    }
+    if let Err(error) = gossip.shutdown().await {
+        debug!(%error, "Iroh gossip shutdown failed");
     }
     endpoint.close().await;
     info!("Iroh endpoint shut down");

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -100,15 +100,17 @@ pub(super) async fn handle_command(
             reply_msg,
             reply,
         } => {
-            let result = async {
-                protocols::write_message(&mut send_stream, &reply_msg).await?;
-                send_stream.finish().map_err(|e| {
-                    crate::error::Error::Transport(format!("failed to finish stream: {}", e))
-                })?;
-                Ok(())
-            }
-            .await;
-            let _ = reply.send(result);
+            tokio::spawn(async move {
+                let result = async {
+                    protocols::write_message(&mut send_stream, &reply_msg).await?;
+                    send_stream.finish().map_err(|e| {
+                        crate::error::Error::Transport(format!("failed to finish stream: {}", e))
+                    })?;
+                    Ok(())
+                }
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendTwoStreamRequest {
             peer_id,
@@ -116,15 +118,18 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let result = handle_request_response(
-                endpoint,
-                &peer_id,
-                protocols::ALPN_TWOSTREAM,
-                &request,
-                direct_addr,
-            )
-            .await;
-            let _ = reply.send(result);
+            let endpoint = endpoint.clone();
+            tokio::spawn(async move {
+                let result = handle_request_response(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_TWOSTREAM,
+                    &request,
+                    direct_addr,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendTwoStreamResponse {
             peer_id,
@@ -132,15 +137,18 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let result = handle_fire_and_forget(
-                endpoint,
-                &peer_id,
-                protocols::ALPN_TWOSTREAM,
-                &reply_msg,
-                direct_addr,
-            )
-            .await;
-            let _ = reply.send(result);
+            let endpoint = endpoint.clone();
+            tokio::spawn(async move {
+                let result = handle_fire_and_forget(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_TWOSTREAM,
+                    &reply_msg,
+                    direct_addr,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendDocSyncRequest {
             peer_id,
@@ -148,29 +156,33 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let result: crate::error::Result<crate::message::DocSyncReply> =
-                handle_request_response(
-                    endpoint,
-                    &peer_id,
-                    protocols::ALPN_DOCSYNC,
-                    &request,
-                    direct_addr,
-                )
-                .await;
-            match result {
-                Ok(doc_reply) => {
-                    let _ = event_tx
-                        .send(TransportEvent::DocSyncReply {
-                            peer_id,
-                            reply: doc_reply,
-                        })
-                        .await;
-                    let _ = reply.send(Ok(()));
+            let endpoint = endpoint.clone();
+            let event_tx = event_tx.clone();
+            tokio::spawn(async move {
+                let result: crate::error::Result<crate::message::DocSyncReply> =
+                    handle_request_response(
+                        &endpoint,
+                        &peer_id,
+                        protocols::ALPN_DOCSYNC,
+                        &request,
+                        direct_addr,
+                    )
+                    .await;
+                match result {
+                    Ok(doc_reply) => {
+                        let _ = event_tx
+                            .send(TransportEvent::DocSyncReply {
+                                peer_id,
+                                reply: doc_reply,
+                            })
+                            .await;
+                        let _ = reply.send(Ok(()));
+                    }
+                    Err(e) => {
+                        let _ = reply.send(Err(e));
+                    }
                 }
-                Err(e) => {
-                    let _ = reply.send(Err(e));
-                }
-            }
+            });
         }
         IrohCommand::SendBranchableSyncRequest {
             peer_id,
@@ -178,29 +190,33 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let result: crate::error::Result<crate::message::BranchableSyncReply> =
-                handle_request_response(
-                    endpoint,
-                    &peer_id,
-                    protocols::ALPN_BRANCHABLE,
-                    &request,
-                    direct_addr,
-                )
-                .await;
-            match result {
-                Ok(br_reply) => {
-                    let _ = event_tx
-                        .send(TransportEvent::BranchableSyncReply {
-                            peer_id,
-                            reply: br_reply,
-                        })
-                        .await;
-                    let _ = reply.send(Ok(()));
+            let endpoint = endpoint.clone();
+            let event_tx = event_tx.clone();
+            tokio::spawn(async move {
+                let result: crate::error::Result<crate::message::BranchableSyncReply> =
+                    handle_request_response(
+                        &endpoint,
+                        &peer_id,
+                        protocols::ALPN_BRANCHABLE,
+                        &request,
+                        direct_addr,
+                    )
+                    .await;
+                match result {
+                    Ok(br_reply) => {
+                        let _ = event_tx
+                            .send(TransportEvent::BranchableSyncReply {
+                                peer_id,
+                                reply: br_reply,
+                            })
+                            .await;
+                        let _ = reply.send(Ok(()));
+                    }
+                    Err(e) => {
+                        let _ = reply.send(Err(e));
+                    }
                 }
-                Err(e) => {
-                    let _ = reply.send(Err(e));
-                }
-            }
+            });
         }
         IrohCommand::SendDocSyncResponse {
             peer_id,
@@ -208,15 +224,18 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let result = handle_fire_and_forget(
-                endpoint,
-                &peer_id,
-                protocols::ALPN_DOCSYNC_RESP,
-                &reply_msg,
-                direct_addr,
-            )
-            .await;
-            let _ = reply.send(result);
+            let endpoint = endpoint.clone();
+            tokio::spawn(async move {
+                let result = handle_fire_and_forget(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_DOCSYNC_RESP,
+                    &reply_msg,
+                    direct_addr,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendBranchableSyncResponse {
             peer_id,
@@ -224,45 +243,52 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let result = handle_fire_and_forget(
-                endpoint,
-                &peer_id,
-                protocols::ALPN_BRANCHABLE_RESP,
-                &reply_msg,
-                direct_addr,
-            )
-            .await;
-            let _ = reply.send(result);
+            let endpoint = endpoint.clone();
+            tokio::spawn(async move {
+                let result = handle_fire_and_forget(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_BRANCHABLE_RESP,
+                    &reply_msg,
+                    direct_addr,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendDocSyncResponseToken {
             mut send_stream,
             reply_msg,
             reply,
         } => {
-            let result = async {
-                protocols::write_message(&mut send_stream, &reply_msg).await?;
-                send_stream.finish().map_err(|e| {
-                    crate::error::Error::Transport(format!("failed to finish stream: {}", e))
-                })?;
-                Ok(())
-            }
-            .await;
-            let _ = reply.send(result);
+            tokio::spawn(async move {
+                let result = async {
+                    protocols::write_message(&mut send_stream, &reply_msg).await?;
+                    send_stream.finish().map_err(|e| {
+                        crate::error::Error::Transport(format!("failed to finish stream: {}", e))
+                    })?;
+                    Ok(())
+                }
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendBranchableSyncResponseToken {
             mut send_stream,
             reply_msg,
             reply,
         } => {
-            let result = async {
-                protocols::write_message(&mut send_stream, &reply_msg).await?;
-                send_stream.finish().map_err(|e| {
-                    crate::error::Error::Transport(format!("failed to finish stream: {}", e))
-                })?;
-                Ok(())
-            }
-            .await;
-            let _ = reply.send(result);
+            tokio::spawn(async move {
+                let result = async {
+                    protocols::write_message(&mut send_stream, &reply_msg).await?;
+                    send_stream.finish().map_err(|e| {
+                        crate::error::Error::Transport(format!("failed to finish stream: {}", e))
+                    })?;
+                    Ok(())
+                }
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendCarRequest {
             peer_id,
@@ -271,15 +297,18 @@ pub(super) async fn handle_command(
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let request = CarFetchRequest::full_dag(root_cid);
-            let result = handle_fire_and_forget(
-                endpoint,
-                &peer_id,
-                protocols::ALPN_CAR,
-                &request,
-                direct_addr,
-            )
-            .await;
-            let _ = reply.send(result);
+            let endpoint = endpoint.clone();
+            tokio::spawn(async move {
+                let result = handle_fire_and_forget(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_CAR,
+                    &request,
+                    direct_addr,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendCarResponse {
             peer_id,
@@ -287,15 +316,18 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let result = handle_fire_and_forget(
-                endpoint,
-                &peer_id,
-                protocols::ALPN_CAR_RESP,
-                &car_data,
-                direct_addr,
-            )
-            .await;
-            let _ = reply.send(result);
+            let endpoint = endpoint.clone();
+            tokio::spawn(async move {
+                let result = handle_fire_and_forget(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_CAR_RESP,
+                    &car_data,
+                    direct_addr,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SendSEArtifacts {
             peer_id,
@@ -303,15 +335,18 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let result = handle_fire_and_forget(
-                endpoint,
-                &peer_id,
-                protocols::ALPN_SE,
-                &request,
-                direct_addr,
-            )
-            .await;
-            let _ = reply.send(result);
+            let endpoint = endpoint.clone();
+            tokio::spawn(async move {
+                let result = handle_fire_and_forget(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_SE,
+                    &request,
+                    direct_addr,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
         }
         IrohCommand::SyncBlocks {
             root,


### PR DESCRIPTION
## Summary
- add a local defra-node P2P error type instead of referencing the embedded crate
- update the IROH event handler receiver to the typed TransportEvent response token
- fill the missing embedded HTTP P2P adapter republish_document method

## Verification
- cargo check -p defra-node --features p2p,http --locked
- cargo test -p defra-node --test issue_729_get_for_update_warning