### PR TITLE
docs(p2p): fix misleading security model comment in bitswap/access.rs

### DIFF
--- a/crates/p2p/src/bitswap/access.rs
+++ b/crates/p2p/src/bitswap/access.rs
@@ -3,19 +3,33 @@
 //! This module provides access control primitives:
 //! - `AccessMode`: Controls whether access control is enabled (Open vs Controlled)
 //!
-//! # Security Model
+//! # Security Model (current state)
 //!
-//! Access control is enforced at the **SyncCoordinator level**, not at the Bitswap level.
-//! The SyncCoordinator checks access on incoming PushLog and GossipSub messages before
-//! blocks are stored. This means:
+//! Access control today is enforced **only on the ingress path** via the
+//! SyncCoordinator: incoming PushLog and GossipSub messages are checked against
+//! the `ReplicatorRegistry` before blocks are stored. This means unauthorized
+//! peers cannot push blocks *into* this node.
 //!
-//! 1. Unauthorized peers cannot push blocks to this node
-//! 2. Bitswap inherently only serves blocks that passed the coordinator's access check
-//! 3. Per-collection authorization is enforced (a replicator for collection A cannot
-//!    access collection B)
+//! **The egress path via Bitswap is not filtered.** Once a block is in the
+//! blockstore — however it got there — it is served to any connected peer that
+//! requests it via Bitswap. The `BitswapStoreAdapter::get(&self, cid: &Cid)`
+//! signature (`crates/p2p/src/bitswap/store.rs`) has no peer context, so a
+//! per-peer access check cannot be expressed at this layer today.
 //!
-//! This follows the Go DefraDB security model where each replicator is authorized
-//! per-collection.
+//! **This diverges from Go DefraDB.** Go wires Bitswap with
+//! `bitswap.WithPeerBlockRequestFilter(p.hasAccess)` (`go-p2p/peer.go:146`),
+//! so every incoming block request is filtered per (peer, CID) against the
+//! replicator registry. Go denies block fetches from peers that are not
+//! authorized for the collection that owns the CID.
+//!
+//! In practice this means that in a Rust node running `AccessMode::Controlled`,
+//! any peer that can open a libp2p connection can fetch any stored block,
+//! regardless of their authorization for the owning collection. ACP-encrypted
+//! collections still protect plaintext confidentiality, but ciphertext and
+//! block-existence signals leak to all connected peers.
+//!
+//! See issue #830 for the tracking fix (adding a per-peer request filter to
+//! Rust's Bitswap integration to restore parity with Go).
 
 /// Access control mode for P2P synchronization.
 ///


### PR DESCRIPTION
## Summary
- Fixes #836
- The `bitswap/access.rs` module doc claimed Bitswap only serves blocks that passed the coordinator's access check, and that the design matches Go. Both claims are false today — the SyncCoordinator gates ingress only, and the iroh-bitswap `Store::get` signature has no peer context. Go wires `WithPeerBlockRequestFilter(p.hasAccess)` at `go-p2p/peer.go:146`; Rust has no equivalent.
- Rewrite the comment to accurately describe current behavior, cite the code paths on both sides, and reference #830 for the tracking fix.

## Test plan
- [x] Doc-only change (`//!` module comment). No behavior, no API, no tests.
- [x] Claim verification: confirmed `WithPeerBlockRequestFilter` present in Go at `go-p2p/peer.go:146`; confirmed absent in Rust (`behaviour.rs:240-241, 325-326` uses `BitswapConfig::default()`); confirmed `BitswapStoreAdapter::get` at `crates/p2p/src/bitswap/store.rs:67` has no peer parameter.