### PR TITLE
feat(defra-node): expose collection patching and migration (#859)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,7 @@ dependencies = [
  "defra-http",
  "events",
  "identity",
+ "lens",
  "p2p",
  "query",
  "reqwest 0.12.28",

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -29,6 +29,7 @@ sourcehub = { path = "../sourcehub" }
 identity = { path = "../identity" }
 defra-core = { path = "../defra-core" }
 schema = { path = "../schema" }
+lens = { path = "../lens" }
 tokio.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -2,6 +2,9 @@
 
 use std::sync::Arc;
 
+use lens::{LensConfig, TransformId};
+use schema::CollectionVersion;
+
 use crate::SchemaOps;
 
 #[async_trait::async_trait]
@@ -14,7 +17,7 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
             .map_err(|e| anyhow::anyhow!("schema validation error: {}", e))?;
 
         for collection in collections {
-            self.create_collection(collection)
+            db::DB::create_collection(self, collection)
                 .await
                 .map_err(|e| anyhow::anyhow!("create collection error: {}", e))?;
         }
@@ -22,8 +25,7 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
     }
 
     async fn add_view(&self, source_query: &str, target_sdl: &str) -> anyhow::Result<()> {
-        let known_types: std::collections::HashSet<String> = self
-            .list_collections()
+        let known_types: std::collections::HashSet<String> = db::DB::list_collections(self)
             .unwrap_or_default()
             .into_iter()
             .collect();
@@ -83,6 +85,54 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
         }
 
         Ok(())
+    }
+
+    async fn patch_collection(
+        &self,
+        collection_name: &str,
+        patch: &str,
+    ) -> anyhow::Result<CollectionVersion> {
+        db::DB::patch_collection(self, collection_name, patch)
+            .await
+            .map_err(anyhow::Error::new)
+    }
+
+    async fn set_active_collection_version(&self, version_id: &str) -> anyhow::Result<()> {
+        db::DB::set_active_collection_version(self, version_id)
+            .await
+            .map_err(anyhow::Error::new)
+    }
+
+    async fn set_migration(&self, config: LensConfig) -> anyhow::Result<TransformId> {
+        db::DB::set_migration(self, config)
+            .await
+            .map_err(anyhow::Error::new)
+    }
+
+    fn list_collections(&self) -> anyhow::Result<Vec<String>> {
+        db::DB::list_collections(self).map_err(anyhow::Error::new)
+    }
+
+    fn get_collection(&self, name: &str) -> anyhow::Result<Option<CollectionVersion>> {
+        Ok(db::DB::get_collection(self, name)
+            .map_err(anyhow::Error::new)?
+            .map(|collection| collection.schema().clone()))
+    }
+
+    async fn get_collection_by_version_id(
+        &self,
+        version_id: &str,
+    ) -> anyhow::Result<Option<CollectionVersion>> {
+        Ok(db::DB::get_collection_by_version_id_full(self, version_id)
+            .await
+            .map_err(anyhow::Error::new)?
+            .map(|collection| collection.schema().clone()))
+    }
+
+    async fn get_all_collection_versions(&self) -> anyhow::Result<Vec<CollectionVersion>> {
+        db::DB::get_all_collection_versions(self)
+            .await
+            .map_err(anyhow::Error::new)
     }
 }
 

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -45,9 +45,11 @@ pub use config::P2PConfig;
 pub use config::{DocumentAcpConfig, SourceHubConfig};
 pub use dense_search::{DenseHybridSearchHit, DenseHybridSearchRequest, DenseHybridSearchResponse};
 pub use events::EventName;
+pub use lens::{LensConfig, LensModule, TransformId};
 #[cfg(feature = "p2p")]
 pub use p2p_error::{P2PError, P2PResult};
 pub use query::{QueryExecutor, QueryRequest, QueryResponse};
+pub use schema::CollectionVersion;
 
 #[cfg(all(feature = "http", feature = "p2p"))]
 struct HttpP2PAdapter {
@@ -243,6 +245,20 @@ pub trait P2POps: Send + Sync {
 trait SchemaOps: Send + Sync {
     async fn add_schema(&self, sdl: &str) -> anyhow::Result<()>;
     async fn add_view(&self, source_query: &str, target_sdl: &str) -> anyhow::Result<()>;
+    async fn patch_collection(
+        &self,
+        collection_name: &str,
+        patch: &str,
+    ) -> anyhow::Result<CollectionVersion>;
+    async fn set_active_collection_version(&self, version_id: &str) -> anyhow::Result<()>;
+    async fn set_migration(&self, config: LensConfig) -> anyhow::Result<TransformId>;
+    fn list_collections(&self) -> anyhow::Result<Vec<String>>;
+    fn get_collection(&self, name: &str) -> anyhow::Result<Option<CollectionVersion>>;
+    async fn get_collection_by_version_id(
+        &self,
+        version_id: &str,
+    ) -> anyhow::Result<Option<CollectionVersion>>;
+    async fn get_all_collection_versions(&self) -> anyhow::Result<Vec<CollectionVersion>>;
 }
 
 /// Type-erased collection lookup for resolving names to CIDs.
@@ -374,6 +390,78 @@ impl EmbeddedNode {
     /// like `@downsample` that are forward-declared for future defradb.rs support).
     pub async fn add_view(&self, source_query: &str, target_sdl: &str) -> anyhow::Result<()> {
         self.schema_ops.add_view(source_query, target_sdl).await
+    }
+
+    /// Apply a JSON Patch (RFC 6902) to an existing collection's schema.
+    ///
+    /// Returns the updated [`CollectionVersion`] (with a new `version_id`). The
+    /// prior version is deactivated and the patched version is activated, unless
+    /// the patch is a metadata-only or in-place change (see [`db::DB::patch_collection`]).
+    ///
+    /// `collection_name` may be a collection name, version ID, or variant; the
+    /// underlying implementation falls back to version-ID lookup if name lookup fails.
+    pub async fn patch_collection(
+        &self,
+        collection_name: &str,
+        patch: &str,
+    ) -> anyhow::Result<CollectionVersion> {
+        self.schema_ops
+            .patch_collection(collection_name, patch)
+            .await
+    }
+
+    /// Activate a specific collection version by its `version_id`.
+    ///
+    /// Deactivates sibling versions of the same collection and updates the
+    /// collection-name pointer to resolve to this version. If migrations are
+    /// registered, documents are reindexed through them.
+    pub async fn set_active_collection_version(&self, version_id: &str) -> anyhow::Result<()> {
+        self.schema_ops
+            .set_active_collection_version(version_id)
+            .await
+    }
+
+    /// Register a Lens migration between two collection versions.
+    ///
+    /// Returns the content-addressed [`TransformId`] of the stored transform.
+    /// Placeholder versions are created if the source or destination are not
+    /// yet materialized, allowing migrations to be registered ahead of patches.
+    pub async fn set_migration(&self, config: LensConfig) -> anyhow::Result<TransformId> {
+        self.schema_ops.set_migration(config).await
+    }
+
+    /// List the names of every active collection known to the node.
+    ///
+    /// Useful for idempotent schema-bootstrap flows that need to decide whether
+    /// to call [`Self::add_schema`] (create) or [`Self::patch_collection`] (evolve).
+    pub fn list_collections(&self) -> anyhow::Result<Vec<String>> {
+        self.schema_ops.list_collections()
+    }
+
+    /// Fetch the active schema definition for a collection by name.
+    ///
+    /// Returns `Ok(None)` if no active collection with that name exists.
+    pub fn get_collection(&self, name: &str) -> anyhow::Result<Option<CollectionVersion>> {
+        self.schema_ops.get_collection(name)
+    }
+
+    /// Fetch a collection schema by its version ID, including inactive versions.
+    ///
+    /// Searches both the in-memory cache (active versions) and the underlying
+    /// systemstore (all stored versions), so callers can inspect the history
+    /// of a patched collection.
+    pub async fn get_collection_by_version_id(
+        &self,
+        version_id: &str,
+    ) -> anyhow::Result<Option<CollectionVersion>> {
+        self.schema_ops
+            .get_collection_by_version_id(version_id)
+            .await
+    }
+
+    /// Return every collection version known to the node, active and inactive.
+    pub async fn get_all_collection_versions(&self) -> anyhow::Result<Vec<CollectionVersion>> {
+        self.schema_ops.get_all_collection_versions().await
     }
 
     /// Subscribe to DefraDB events.

--- a/crates/defra-node/tests/issue_859_schema_migration.rs
+++ b/crates/defra-node/tests/issue_859_schema_migration.rs
@@ -1,0 +1,239 @@
+//! Tests for issue #859: collection patching, schema migration, and
+//! introspection exposed through [`EmbeddedNode`].
+
+use anyhow::{Context, Result};
+use defra_node::{EmbeddedNode, LensConfig, LensModule};
+
+const USER_SDL: &str = r#"
+type User {
+    name: String
+    age: Int
+}
+"#;
+
+// Minimal valid WebAssembly module — just the 4-byte `\0asm` magic plus the
+// 4-byte version (`1`). Wasmtime accepts this as an empty module, which is
+// all we need to prove [`EmbeddedNode::set_migration`] wires through to the
+// underlying lens store.
+const EMPTY_WASM: &[u8] = &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+
+#[tokio::test(flavor = "current_thread")]
+async fn list_collections_reports_added_schema() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+
+    assert!(node.list_collections()?.is_empty());
+
+    node.add_schema(USER_SDL).await?;
+
+    let names = node.list_collections()?;
+    assert_eq!(names, vec!["User".to_string()]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_collection_returns_active_schema() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(USER_SDL).await?;
+
+    let collection = node
+        .get_collection("User")?
+        .context("User collection should exist")?;
+    assert_eq!(collection.name, "User");
+    assert!(collection.is_active);
+    assert!(collection.fields.iter().any(|f| f.name == "name"));
+    assert!(collection.fields.iter().any(|f| f.name == "age"));
+
+    assert!(node.get_collection("NotAType")?.is_none());
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn patch_collection_adds_field_and_bumps_version() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(USER_SDL).await?;
+
+    let original = node
+        .get_collection("User")?
+        .context("User should exist after add_schema")?;
+
+    let patch = r#"[
+        {"op": "add", "path": "/User/Fields/-", "value": {"Name": "email", "Kind": 11}}
+    ]"#;
+    let patched = node.patch_collection("User", patch).await?;
+
+    assert_ne!(patched.version_id, original.version_id);
+    assert!(patched.fields.iter().any(|f| f.name == "email"));
+
+    let current = node
+        .get_collection("User")?
+        .context("User should still exist after patch")?;
+    assert_eq!(current.version_id, patched.version_id);
+    assert!(current.fields.iter().any(|f| f.name == "email"));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn patch_collection_chained_evolutions_produce_distinct_versions() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(USER_SDL).await?;
+
+    let v0 = node
+        .get_collection("User")?
+        .context("User should exist")?
+        .version_id;
+
+    let v1 = node
+        .patch_collection(
+            "User",
+            r#"[{"op":"add","path":"/User/Fields/-","value":{"Name":"email","Kind":11}}]"#,
+        )
+        .await?
+        .version_id;
+    let v2 = node
+        .patch_collection(
+            "User",
+            r#"[{"op":"add","path":"/User/Fields/-","value":{"Name":"phone","Kind":11}}]"#,
+        )
+        .await?
+        .version_id;
+
+    assert_ne!(v0, v1);
+    assert_ne!(v1, v2);
+    assert_ne!(v0, v2);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_collection_by_version_id_finds_prior_and_new() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(USER_SDL).await?;
+
+    let original_version = node
+        .get_collection("User")?
+        .context("User should exist")?
+        .version_id;
+
+    let patch = r#"[
+        {"op": "add", "path": "/User/Fields/-", "value": {"Name": "email", "Kind": 11}}
+    ]"#;
+    let patched = node.patch_collection("User", patch).await?;
+
+    let by_new = node
+        .get_collection_by_version_id(&patched.version_id)
+        .await?
+        .context("new version should be retrievable")?;
+    assert_eq!(by_new.version_id, patched.version_id);
+
+    let by_old = node
+        .get_collection_by_version_id(&original_version)
+        .await?
+        .context("old version should still be retrievable")?;
+    assert_eq!(by_old.version_id, original_version);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn get_all_collection_versions_returns_history() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(USER_SDL).await?;
+
+    let initial = node.get_all_collection_versions().await?;
+    assert_eq!(initial.len(), 1);
+
+    let patch = r#"[
+        {"op": "add", "path": "/User/Fields/-", "value": {"Name": "email", "Kind": 11}}
+    ]"#;
+    node.patch_collection("User", patch).await?;
+
+    let after_patch = node.get_all_collection_versions().await?;
+    assert!(
+        after_patch.len() >= 2,
+        "expected at least two versions after patching, got {}",
+        after_patch.len()
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn set_active_collection_version_round_trips_to_original() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(USER_SDL).await?;
+
+    let original_version = node
+        .get_collection("User")?
+        .context("User should exist")?
+        .version_id;
+
+    let patch = r#"[
+        {"op": "add", "path": "/User/Fields/-", "value": {"Name": "email", "Kind": 11}}
+    ]"#;
+    let patched = node.patch_collection("User", patch).await?;
+    assert_ne!(patched.version_id, original_version);
+    assert_eq!(
+        node.get_collection("User")?
+            .context("User should exist")?
+            .version_id,
+        patched.version_id,
+    );
+
+    node.set_active_collection_version(&original_version)
+        .await?;
+    assert_eq!(
+        node.get_collection("User")?
+            .context("User should exist")?
+            .version_id,
+        original_version,
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn set_migration_registers_lens_between_versions() -> Result<()> {
+    let node = EmbeddedNode::builder().build().await?;
+    node.add_schema(USER_SDL).await?;
+
+    let original_version = node
+        .get_collection("User")?
+        .context("User should exist")?
+        .version_id;
+
+    let patch = r#"[
+        {"op": "add", "path": "/User/Fields/-", "value": {"Name": "email", "Kind": 11}}
+    ]"#;
+    let patched = node.patch_collection("User", patch).await?;
+
+    let module = LensModule::from_bytes(EMPTY_WASM.to_vec());
+    let config = LensConfig::new(&original_version, &patched.version_id, module);
+
+    let transform_id = node.set_migration(config).await?;
+    assert!(
+        !transform_id.0.is_empty(),
+        "transform id should be a non-empty CID"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn introspection_supports_idempotent_schema_ensure() -> Result<()> {
+    // Demonstrates the idempotent bootstrap pattern the issue calls out:
+    // the application checks whether a collection exists before falling
+    // back to add_schema. Running twice must not error.
+    let node = EmbeddedNode::builder().build().await?;
+
+    ensure_user_schema(&node).await?;
+    ensure_user_schema(&node).await?;
+
+    assert_eq!(node.list_collections()?, vec!["User".to_string()]);
+    Ok(())
+}
+
+async fn ensure_user_schema(node: &EmbeddedNode) -> Result<()> {
+    if node.get_collection("User")?.is_none() {
+        node.add_schema(USER_SDL).await?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Exposes schema-evolution APIs from `EmbeddedNode`: `patch_collection`, `set_active_collection_version`, `set_migration`, and introspection helpers (`list_collections`, `get_collection`, `get_collection_by_version_id`, `get_all_collection_versions`).
- Re-exports `CollectionVersion`, `LensConfig`, `LensModule`, and `TransformId` from `defra-node` so embedders don't pull in the inner `schema`/`lens` crates directly.
- Adds 9 tests covering add → patch → introspect → migrate → revert flows, plus the idempotent `ensure_schema` pattern called out in the issue.

## Why

Closes #859. Downstream embedded users (see defra-agent#40) need to reconcile schema drift on long-lived local stores. `add_schema` alone can only create collections, so stale persisted definitions (e.g. a `ToolServiceRegistry.tools` relation that no longer exists in the desired SDL) require out-of-band operator steps. With `patch_collection` + introspection, an application can detect divergence and evolve the schema itself.

## Test plan

- [x] `cargo test -p defra-node` (14 existing + 9 new) — all pass
- [x] `cargo clippy --all -- -D warnings` (the exact CI invocation) — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo check --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)