### PR TITLE
fix(crdt): remove counter nonce idempotency to match Go (#847)

### DIFF
--- a/crates/crdt/src/counter.rs
+++ b/crates/crdt/src/counter.rs
@@ -385,6 +385,11 @@ impl Counter {
     /// must be seeded from the document value to ensure correct accumulation.
     ///
     /// Returns true if seeding was performed, false if already initialized.
+    ///
+    /// NOTE: per #847, counter merge is unconditional and there is no nonce
+    /// tracking. Any future seed variant (e.g. Float32 once added by #848)
+    /// MUST NOT call a `mark_nonce(..)` helper — that would leak dead markers
+    /// into the datastore and reintroduce the dedup contract this PR removes.
     pub async fn seed_if_uninitialized_int64(
         &self,
         rw: &mut dyn ReaderWriter,

--- a/crates/crdt/src/counter.rs
+++ b/crates/crdt/src/counter.rs
@@ -1,9 +1,13 @@
 //! Counter CRDT implementation
 //!
-//! Supports increment and decrement operations with nonce-based idempotent delivery.
-//! Uses commutative addition with wrapping on overflow for Int64 (matching Go DefraDB),
-//! and IEEE-754 addition for Float64. This is not a traditional PN-Counter (which uses
-//! separate per-replica counters); instead it uses a single value with nonce tracking.
+//! Supports increment and decrement operations. Uses commutative addition with
+//! wrapping on overflow for Int64 (matching Go DefraDB), and IEEE-754 addition
+//! for Float64. This is not a traditional PN-Counter (which uses separate
+//! per-replica counters); instead it uses a single accumulated value.
+//!
+//! Merge is unconditional — idempotency is enforced upstream by the blockstore
+//! (`is_merged(cid)` / `get_unmerged()`) on every ingest path. Matches Go's
+//! counter Merge which also ignores the delta nonce.
 
 use crate::traits::{Context, Delta, MergeResult, ReplicatedData, ValueReader};
 use async_trait::async_trait;
@@ -188,8 +192,6 @@ impl Delta for CounterDelta {
 pub struct Counter {
     /// Storage key for the counter value
     value_key: Vec<u8>,
-    /// Storage key for tracking applied nonces
-    nonce_prefix: Vec<u8>,
     /// Schema version
     schema_version_id: String,
     /// Field name
@@ -236,57 +238,14 @@ impl Counter {
             doc_id.to_vec(),
             field_name.clone(),
         );
-        let nonce_prefix = value_key.nonce_prefix();
 
         Ok(Self {
             value_key: value_key.bytes(),
-            nonce_prefix: nonce_prefix.bytes(),
             schema_version_id,
             field_name,
             allow_decrement,
             kind,
         })
-    }
-
-    fn nonce_key(&self, nonce: i64) -> Vec<u8> {
-        let mut nonce_key = self.nonce_prefix.clone();
-        nonce_key.extend_from_slice(&nonce.to_be_bytes());
-        nonce_key
-    }
-
-    /// Check if a nonce has been applied
-    async fn has_nonce(&self, reader: &dyn Reader, nonce: i64) -> Result<bool> {
-        reader
-            .has(&self.nonce_key(nonce))
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))
-    }
-
-    /// Mark a nonce as applied
-    ///
-    async fn mark_nonce(&self, rw: &mut dyn ReaderWriter, nonce: i64) -> Result<()> {
-        let nonce_key = self.nonce_key(nonce);
-        rw.set(&nonce_key, &[1])
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))
-    }
-
-    /// Remove a nonce marker once block/CID-level merge dedup is durable.
-    ///
-    /// Returns `true` if a marker existed and was removed.
-    pub async fn clear_nonce(&self, rw: &mut dyn ReaderWriter, nonce: i64) -> Result<bool> {
-        let nonce_key = self.nonce_key(nonce);
-        let exists = rw
-            .has(&nonce_key)
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        if !exists {
-            return Ok(false);
-        }
-        rw.delete(&nonce_key)
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(true)
     }
 
     /// Get current value as i64
@@ -355,20 +314,15 @@ impl Counter {
             .map_err(|e| Error::Storage(e.to_string()))
     }
 
-    /// Apply an increment/decrement
+    /// Apply an increment/decrement.
     ///
-    /// # Crash Recovery Semantics
-    ///
-    /// Nonce marking and value updates are not atomic. To ensure safety:
-    /// - Nonce is marked FIRST, then value is updated
-    /// - If crash occurs after nonce but before value update: delta is lost (under-count)
-    /// - If crash occurred with old ordering (value then nonce): would double-count
-    ///
-    /// Under-counting on crash is safer than over-counting because:
-    /// 1. It's easier to detect missing deltas than duplicate applications
-    /// 2. Over-counting violates CRDT idempotency guarantees
-    ///
-    /// For true atomicity, use a Store implementation with transaction support.
+    /// Merge is unconditional: every delta that reaches this method is
+    /// applied. Per-delta idempotency is the blockstore's job via
+    /// `is_merged(cid)` / `get_unmerged()` on every ingest path (PushLog,
+    /// DAG traversal, crash recovery). Do not reintroduce a nonce-based
+    /// dedup check here — doing so causes Rust↔Go state divergence on
+    /// legitimate block retransmits (#847). The `delta.nonce` field
+    /// exists only so the resulting DAG block has a unique CID.
     async fn apply_delta(
         &self,
         rw: &mut dyn ReaderWriter,
@@ -383,11 +337,6 @@ impl Counter {
                 self.kind,
                 delta.kind()
             )));
-        }
-
-        // Check if nonce already applied (idempotency)
-        if !is_create && self.has_nonce(rw, delta.nonce).await? {
-            return Ok(MergeResult::SkippedAlreadyApplied { nonce: delta.nonce });
         }
 
         // Decode and validate based on kind BEFORE any state changes
@@ -420,10 +369,6 @@ impl Counter {
             }
         };
 
-        // Mark nonce FIRST to prevent double-counting on crash recovery
-        self.mark_nonce(rw, delta.nonce).await?;
-
-        // Then update value
         match new_value {
             NewValue::Int64(v) => self.set_int64(rw, v).await?,
             NewValue::Float64(v) => self.set_float64(rw, v).await?,
@@ -438,7 +383,6 @@ impl Counter {
     /// Local document creation stores counter values in the document layer but not
     /// in CRDT accumulation storage. Before merging a remote delta, the CRDT storage
     /// must be seeded from the document value to ensure correct accumulation.
-    /// Also marks nonce=0 as applied since the initial creation already accounts for it.
     ///
     /// Returns true if seeding was performed, false if already initialized.
     pub async fn seed_if_uninitialized_int64(
@@ -454,7 +398,6 @@ impl Counter {
             return Ok(false);
         }
         self.set_int64(rw, value).await?;
-        self.mark_nonce(rw, 0).await?;
         Ok(true)
     }
 
@@ -472,7 +415,6 @@ impl Counter {
             return Ok(false);
         }
         self.set_float64(rw, value).await?;
-        self.mark_nonce(rw, 0).await?;
         Ok(true)
     }
 

--- a/crates/crdt/src/traits.rs
+++ b/crates/crdt/src/traits.rs
@@ -16,8 +16,6 @@ pub enum MergeResult {
     RejectedLowerPriority { current: u64, incoming: u64 },
     /// Delta was rejected due to lexicographic tie-breaking (same priority, current value wins)
     RejectedTieBreak,
-    /// Delta was skipped because it was already applied (idempotency via nonce)
-    SkippedAlreadyApplied { nonce: i64 },
 }
 
 impl MergeResult {
@@ -32,11 +30,6 @@ impl MergeResult {
             self,
             MergeResult::RejectedLowerPriority { .. } | MergeResult::RejectedTieBreak
         )
-    }
-
-    /// Returns true if the delta was skipped due to idempotency
-    pub fn was_skipped(&self) -> bool {
-        matches!(self, MergeResult::SkippedAlreadyApplied { .. })
     }
 }
 

--- a/crates/crdt/tests/counter_tests.rs
+++ b/crates/crdt/tests/counter_tests.rs
@@ -64,8 +64,13 @@ async fn test_counter_increment() {
     txn.commit().await.unwrap();
 }
 
+/// Regression guard for #847. Counter merge must NOT dedupe by nonce — that
+/// job belongs to the blockstore's `is_merged(cid)` check. This test calls
+/// `merge` twice with the same delta directly, which is the exact scenario
+/// the blockstore would normally suppress; the counter must match Go's
+/// unconditional-apply behaviour if the blockstore ever doesn't.
 #[tokio::test]
-async fn test_counter_idempotency() {
+async fn test_counter_retransmit_applies_twice() {
     let store = MemoryStore::new();
     let counter = Counter::new(
         "v1".to_string(),
@@ -84,7 +89,6 @@ async fn test_counter_idempotency() {
 
     let mut txn = store.new_txn(false).await.unwrap();
 
-    // Apply same delta twice
     let delta = CounterDelta::new_int64(
         b"doc1".to_vec(),
         "count".to_string(),
@@ -95,60 +99,19 @@ async fn test_counter_idempotency() {
     )
     .unwrap();
 
-    counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-    counter.merge(&mut *txn, &ctx, &delta).await.unwrap(); // Should be ignored
+    // Apply the same delta twice. Both applications must succeed, and the
+    // accumulated value must be 10 — matching Go, where Merge ignores the
+    // delta nonce entirely.
+    let first = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
+    let second = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
+    assert_eq!(first, MergeResult::Applied);
+    assert_eq!(second, MergeResult::Applied);
 
-    // Should still be 5 (not 10)
     let value_bytes = counter.value(&*txn).await.unwrap();
     let value = i64::from_be_bytes(value_bytes.try_into().unwrap());
-    assert_eq!(value, 5);
+    assert_eq!(value, 10);
 
     txn.commit().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_counter_clear_nonce_removes_replay_marker() {
-    let store = MemoryStore::new();
-    let counter = Counter::new(
-        "v1".to_string(),
-        b"doc1",
-        "count".to_string(),
-        true,
-        NumericKind::Int64,
-    )
-    .unwrap();
-
-    let ctx = Context {
-        doc_id: DocId::new_unchecked("doc1"),
-        schema_version: "v1".to_string(),
-        is_create: false,
-    };
-
-    let mut txn = store.new_txn(false).await.unwrap();
-
-    let delta = CounterDelta::new_int64(
-        b"doc1".to_vec(),
-        "count".to_string(),
-        1,
-        1,
-        "v1".to_string(),
-        1,
-    )
-    .unwrap();
-    counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-
-    let replay_within_window = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-    assert!(matches!(
-        replay_within_window,
-        MergeResult::SkippedAlreadyApplied { nonce: 1 }
-    ));
-
-    assert!(counter.clear_nonce(&mut *txn, 1).await.unwrap());
-    assert!(!counter.clear_nonce(&mut *txn, 1).await.unwrap());
-
-    let value_bytes = counter.value(&*txn).await.unwrap();
-    let value = i64::from_be_bytes(value_bytes.try_into().unwrap());
-    assert_eq!(value, 1);
 }
 
 #[tokio::test]
@@ -565,48 +528,6 @@ async fn test_counter_merge_result_applied() {
 
     let result = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
     assert!(matches!(result, MergeResult::Applied));
-}
-
-#[tokio::test]
-async fn test_counter_merge_result_skipped_already_applied() {
-    let store = MemoryStore::new();
-    let counter = Counter::new(
-        "v1".to_string(),
-        b"doc1",
-        "count".to_string(),
-        true,
-        NumericKind::Int64,
-    )
-    .unwrap();
-
-    let ctx = Context {
-        doc_id: DocId::new_unchecked("doc1"),
-        schema_version: "v1".to_string(),
-        is_create: false,
-    };
-
-    let mut txn = store.new_txn(false).await.unwrap();
-
-    let delta = CounterDelta::new_int64(
-        b"doc1".to_vec(),
-        "count".to_string(),
-        10,
-        12345,
-        "v1".to_string(),
-        5,
-    )
-    .unwrap();
-
-    // First merge should apply
-    let result1 = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-    assert!(matches!(result1, MergeResult::Applied));
-
-    // Second merge with same nonce should be skipped
-    let result2 = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-    assert!(matches!(
-        result2,
-        MergeResult::SkippedAlreadyApplied { nonce: 12345 }
-    ));
 }
 
 #[tokio::test]

--- a/crates/crdt/tests/property_tests.rs
+++ b/crates/crdt/tests/property_tests.rs
@@ -522,8 +522,12 @@ mod counter_properties {
             });
         }
 
+        // Counter merge is unconditional — idempotency is the blockstore's
+        // job via is_merged(cid), not the CRDT's (#847). Property: applying
+        // a delta twice through counter.merge() must apply twice. This
+        // matches Go's counter.Merge behaviour.
         #[test]
-        fn test_counter_idempotence(
+        fn test_counter_double_apply_accumulates(
             increment in -1000i64..1000i64,
             nonce in 0..10000i64
         ) {
@@ -549,12 +553,13 @@ mod counter_properties {
                 let mut txn = store.new_txn(false).await.unwrap();
 
                 counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-                let val1 = counter.value(&*txn).await.ok();
+                let val1 = counter.value(&*txn).await.ok().map(|b| i64::from_be_bytes(b.try_into().unwrap()));
 
                 counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-                let val2 = counter.value(&*txn).await.ok();
+                let val2 = counter.value(&*txn).await.ok().map(|b| i64::from_be_bytes(b.try_into().unwrap()));
 
-                assert_eq!(val1, val2);
+                assert_eq!(val1, Some(increment.wrapping_mul(1)));
+                assert_eq!(val2, Some(increment.wrapping_mul(2)));
             });
         }
 
@@ -869,8 +874,12 @@ mod counter_properties {
         assert_eq!(value, 50);
     }
 
+    // Regression guard for #847. Counter merge must NOT dedupe by nonce —
+    // replaying the same delta accumulates, matching Go's counter.Merge
+    // which also ignores the delta nonce. The blockstore's is_merged(cid)
+    // filter is the single source of CRDT idempotency.
     #[tokio::test]
-    async fn test_counter_nonce_replay_protection() {
+    async fn test_counter_replayed_delta_accumulates() {
         let ctx = Context {
             doc_id: DocId::new_unchecked("doc1"),
             schema_version: "v1".to_string(),
@@ -904,7 +913,7 @@ mod counter_properties {
 
         let value_bytes = counter.value(&*txn).await.unwrap();
         let value = i64::from_be_bytes(value_bytes.try_into().unwrap());
-        assert_eq!(value, 100);
+        assert_eq!(value, 1000);
     }
 
     #[tokio::test]
@@ -1004,15 +1013,17 @@ mod float64_counter_properties {
             });
         }
 
+        // Float64 variant of test_counter_double_apply_accumulates (#847).
+        // Counter merge is unconditional; the blockstore dedups by CID.
         #[test]
-        fn test_float64_counter_idempotence(
+        fn test_float64_counter_double_apply_accumulates(
             increment in -1000.0f64..1000.0f64,
             nonce in 0..10000i64
         ) {
             prop_assume!(increment.is_finite());
 
             let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async {
+            let (val1, val2) = rt.block_on(async {
                 let ctx = Context {
                     doc_id: DocId::new_unchecked("doc1"),
                     schema_version: "v1".to_string(),
@@ -1033,13 +1044,16 @@ mod float64_counter_properties {
                 let mut txn = store.new_txn(false).await.unwrap();
 
                 counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-                let val1 = counter.value(&*txn).await.ok();
+                let val1 = counter.value(&*txn).await.ok().map(|b| f64::from_be_bytes(b.try_into().unwrap()));
 
                 counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-                let val2 = counter.value(&*txn).await.ok();
+                let val2 = counter.value(&*txn).await.ok().map(|b| f64::from_be_bytes(b.try_into().unwrap()));
 
-                assert_eq!(val1, val2);
+                (val1, val2)
             });
+
+            prop_assert_eq!(val1, Some(increment));
+            prop_assert_eq!(val2, Some(increment + increment));
         }
     }
 

--- a/crates/db-merge/src/merge_handler/batch.rs
+++ b/crates/db-merge/src/merge_handler/batch.rs
@@ -13,11 +13,11 @@ pub(crate) struct PendingPostCommitAction {
     pub action: Box<dyn CompositePostCommitAction>,
 }
 
-/// Field blocks that should be marked merged and have any transient replay state cleaned up
-/// once the surrounding batch transaction commits.
+/// Field blocks that should be marked merged in the blockstore once the
+/// surrounding batch transaction commits. The blockstore's merged-set is the
+/// single source of CRDT idempotency; see #847.
 pub(crate) struct PendingFieldBlockFinalization {
     pub cids: Vec<Cid>,
-    pub fallback_collection_id: Option<String>,
 }
 
 impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMergeHandler<S, B> {
@@ -213,11 +213,8 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMe
 
         let field_block_finalizations = pending_field_block_finalizations.into_inner().unwrap();
         for finalization in field_block_finalizations {
-            self.best_effort_finalize_linked_field_blocks(
-                &finalization.cids,
-                finalization.fallback_collection_id.as_deref(),
-            )
-            .await;
+            self.best_effort_finalize_linked_field_blocks(&finalization.cids)
+                .await;
         }
 
         // Emit all collected events
@@ -379,12 +376,7 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMe
                                 );
                                 e.into_inner()
                             })
-                            .push(PendingFieldBlockFinalization {
-                                cids: vec![*cid],
-                                fallback_collection_id: metadata
-                                    .collection_id
-                                    .map(ToOwned::to_owned),
-                            });
+                            .push(PendingFieldBlockFinalization { cids: vec![*cid] });
                         Ok(MergeOutcome::Merged)
                     }
                     Ok(_) => {
@@ -396,12 +388,7 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMe
                                 );
                                 e.into_inner()
                             })
-                            .push(PendingFieldBlockFinalization {
-                                cids: vec![*cid],
-                                fallback_collection_id: metadata
-                                    .collection_id
-                                    .map(ToOwned::to_owned),
-                            });
+                            .push(PendingFieldBlockFinalization { cids: vec![*cid] });
                         Ok(MergeOutcome::terminal_skip("rejected by CRDT"))
                     }
                     Err(e) => Err(e),

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -283,11 +283,8 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
 
                 txn.force_commit().await?;
 
-                self.best_effort_finalize_linked_field_blocks(
-                    &state.linked_field_cids,
-                    metadata.collection_id,
-                )
-                .await;
+                self.best_effort_finalize_linked_field_blocks(&state.linked_field_cids)
+                    .await;
 
                 {
                     let mut merged = self.merged_composites.lock().unwrap_or_else(|e| {
@@ -602,7 +599,6 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                         })
                         .push(PendingFieldBlockFinalization {
                             cids: state.linked_field_cids.clone(),
-                            fallback_collection_id: metadata.collection_id.map(ToOwned::to_owned),
                         });
                 }
 

--- a/crates/db-merge/src/merge_handler/counter.rs
+++ b/crates/db-merge/src/merge_handler/counter.rs
@@ -110,36 +110,16 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         };
 
         match result {
-            Ok(merge_result) => {
-                if merge_result.was_applied() {
-                    txn.force_commit().await?;
-                    self.best_effort_finalize_field_block_merge(cid, metadata.collection_id)
-                        .await;
-                    tracing::info!(
-                        cid = %cid,
-                        field_name = %payload.field_name,
-                        doc_id = %doc_id_str,
-                        "Counter delta merged successfully"
-                    );
-                    Ok(MergeOutcome::Merged)
-                } else {
-                    // Skipped (nonce already applied)
-                    if let Err(e) = txn.force_discard() {
-                        tracing::error!(
-                            cid = %cid,
-                            error = %e,
-                            "Failed to discard transaction after skip"
-                        );
-                    }
-                    tracing::debug!(
-                        cid = %cid,
-                        field_name = %payload.field_name,
-                        "Counter delta skipped (nonce already applied)"
-                    );
-                    self.best_effort_finalize_field_block_merge(cid, metadata.collection_id)
-                        .await;
-                    Ok(MergeOutcome::terminal_skip("nonce already applied"))
-                }
+            Ok(_merge_result) => {
+                txn.force_commit().await?;
+                self.best_effort_finalize_field_block_merge(cid).await;
+                tracing::info!(
+                    cid = %cid,
+                    field_name = %payload.field_name,
+                    doc_id = %doc_id_str,
+                    "Counter delta merged successfully"
+                );
+                Ok(MergeOutcome::Merged)
             }
             Err(e) => {
                 if let Err(discard_err) = txn.force_discard() {
@@ -258,19 +238,8 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         })
     }
 
-    pub(crate) async fn best_effort_finalize_field_block_merge(
-        &self,
-        cid: &Cid,
-        fallback_collection_id: Option<&str>,
-    ) {
-        if let Err(error) = finalize_linked_field_blocks(
-            &self.db,
-            &self.blockstore,
-            &[*cid],
-            fallback_collection_id,
-        )
-        .await
-        {
+    pub(crate) async fn best_effort_finalize_field_block_merge(&self, cid: &Cid) {
+        if let Err(error) = mark_field_blocks_merged(&self.blockstore, &[*cid]).await {
             tracing::warn!(
                 cid = %cid,
                 error = %error,
@@ -279,19 +248,12 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         }
     }
 
-    pub(crate) async fn best_effort_finalize_linked_field_blocks(
-        &self,
-        cids: &[Cid],
-        fallback_collection_id: Option<&str>,
-    ) {
+    pub(crate) async fn best_effort_finalize_linked_field_blocks(&self, cids: &[Cid]) {
         if cids.is_empty() {
             return;
         }
 
-        if let Err(error) =
-            finalize_linked_field_blocks(&self.db, &self.blockstore, cids, fallback_collection_id)
-                .await
-        {
+        if let Err(error) = mark_field_blocks_merged(&self.blockstore, cids).await {
             tracing::warn!(
                 count = cids.len(),
                 error = %error,
@@ -432,11 +394,16 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
     }
 }
 
-async fn finalize_linked_field_blocks<S: Store, B: blockstore::Blockstore + Send + Sync>(
-    db: &Arc<DB<S>>,
+/// Mark a batch of field-block CIDs as merged in the blockstore.
+///
+/// The blockstore's merged-set is the single source of truth for CRDT
+/// idempotency in Rust (matching Go). Every ingest path upstream — PushLog,
+/// DAG traversal, crash-recovery replay — gates on `is_merged(cid)` /
+/// `get_unmerged()` and skips blocks that are already merged. See #847 for
+/// the history of this contract.
+async fn mark_field_blocks_merged<B: blockstore::Blockstore + Send + Sync>(
     blockstore: &Arc<B>,
     cids: &[Cid],
-    fallback_collection_id: Option<&str>,
 ) -> Result<(), MergeError> {
     if cids.is_empty() {
         return Ok(());
@@ -446,85 +413,6 @@ async fn finalize_linked_field_blocks<S: Store, B: blockstore::Blockstore + Send
         .mark_batch_as_merged(cids)
         .await
         .map_err(|e| MergeError::Storage(e.to_string()))?;
-
-    for cid in cids {
-        cleanup_counter_nonce_for_cid(db, blockstore, cid, fallback_collection_id).await?;
-    }
-
-    Ok(())
-}
-
-async fn cleanup_counter_nonce_for_cid<S: Store, B: blockstore::Blockstore + Send + Sync>(
-    db: &Arc<DB<S>>,
-    blockstore: &Arc<B>,
-    cid: &Cid,
-    fallback_collection_id: Option<&str>,
-) -> Result<(), MergeError> {
-    let Some(block_data) = blockstore
-        .get(cid)
-        .await
-        .map_err(|e| MergeError::Storage(e.to_string()))?
-    else {
-        return Ok(());
-    };
-
-    let block =
-        Block::from_dag_cbor(&block_data).map_err(|e| MergeError::BlockDecode(e.to_string()))?;
-
-    let payload = match &block.delta {
-        CrdtDelta::Counter(payload) => payload,
-        _ => return Ok(()),
-    };
-
-    let collection = db
-        .find_collection_by_id(&payload.schema_version_id)?
-        .or(fallback_collection_id.and_then(|cid| db.find_collection_by_id(cid).ok().flatten()))
-        .ok_or_else(|| {
-            MergeError::MissingMetadata(format!(
-                "Collection not found for schema_version_id: {}",
-                payload.schema_version_id
-            ))
-        })?;
-
-    let field = collection
-        .schema()
-        .field_by_name(&payload.field_name)
-        .ok_or_else(|| {
-            MergeError::MissingMetadata(format!(
-                "Field '{}' not found in collection",
-                payload.field_name
-            ))
-        })?;
-
-    let numeric_kind = match &field.kind {
-        FieldKind::Scalar(ScalarKind::Int) => NumericKind::Int64,
-        FieldKind::Scalar(ScalarKind::Float32 | ScalarKind::Float64) => NumericKind::Float64,
-        other => {
-            return Err(MergeError::UnsupportedDelta(format!(
-                "Counter field '{}' has unsupported kind during cleanup: {:?}",
-                payload.field_name, other
-            )))
-        }
-    };
-
-    let counter = Counter::new(
-        payload.schema_version_id.clone(),
-        &payload.doc_id,
-        payload.field_name.clone(),
-        field.crdt_type.allows_decrement(),
-        numeric_kind,
-    )
-    .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
-
-    let txn = db.new_txn(false).await?;
-    {
-        let mut datastore = txn.datastore()?;
-        counter
-            .clear_nonce(&mut datastore, payload.nonce)
-            .await
-            .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
-    }
-    txn.force_commit().await?;
 
     Ok(())
 }

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1048,7 +1048,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn counter_merge_marks_cid_merged_and_clears_nonce_marker() {
+    async fn counter_merge_marks_cid_merged() {
         let (handler, blockstore) = make_handler_with_counter_schema().await;
         let mut doc = Document::new();
         doc.generate_and_set_doc_id().unwrap();
@@ -1089,29 +1089,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(outcome, MergeOutcome::Merged);
+        // The blockstore merged-set is the single source of CRDT idempotency
+        // (see #847). The counter merge path no longer keeps per-delta nonce
+        // markers, so there is nothing else to assert here.
         assert!(blockstore.is_merged(&cid).await.unwrap());
-
-        let counter = crdt::Counter::new(
-            payload.schema_version_id.clone(),
-            &payload.doc_id,
-            payload.field_name.clone(),
-            true,
-            crdt::NumericKind::Int64,
-        )
-        .unwrap();
-
-        let txn = handler.db.new_txn(true).await.unwrap();
-        let mut datastore = txn.datastore().unwrap();
-        let removed = counter
-            .clear_nonce(&mut datastore, payload.nonce)
-            .await
-            .unwrap();
-        let _ = txn.discard();
-
-        assert!(
-            !removed,
-            "nonce marker should be removed once the CID is finalized as merged"
-        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Remove nonce-based idempotency from Rust's counter CRDT merge path so it matches Go's unconditional-apply semantics (#847).
- Drop the dead `MergeResult::SkippedAlreadyApplied` variant and the `cleanup_counter_nonce_for_cid` helper that only existed to service the Rust-specific dedup layer.
- Flip 5 unit/property tests that were asserting the broken behaviour; add a direct regression guard for #847.

## Why

Go DefraDB's `counter.Merge` ignores the delta nonce entirely — nonces exist only so that emitted DAG blocks get unique CIDs. Rust was short-circuiting `apply_delta` when a nonce was already present in storage, which caused state divergence any time the same counter delta was legitimately re-delivered (pubsub republish, replicator retry, DAG resync after crash). Same network traffic, different state — a direct violation of `"same CRDT operations → same merged state"` (CLAUDE.md).

Idempotency for CRDT merge lives at the blockstore layer in both implementations. The merged-set markers (`is_merged(cid)` / `get_unmerged()`) filter already-merged blocks on every ingest path before they ever reach `counter.merge()`. The per-delta nonce check in Rust was belt-and-braces that turned into a divergence.

## Audit — block-CID dedup guarantee holds on every merge-reaching path

- **PushLog ingest** — `crates/p2p/src/sync/manager/process/pushlog.rs:77, 145` checks `blockstore.is_merged(cid)` before `process_block_inner`.
- **DAG traversal** — `crates/p2p/src/sync/manager/links.rs:92` skips merged subtrees.
- **Crash recovery replay** — `crates/p2p/src/sync/replication/recovery.rs:54` only replays from `get_unmerged()`.
- **Batch merge** — same `handle_block` path as PushLog, same guard.
- **Bitswap** — deposits blocks into the blockstore but does not itself call merge; merge happens when a later PushLog/DocSync references the block, with the same is_merged guard.

If a future ingest path is added that skips this guard, this fix would surface as a double-apply — that would be a separate bug, not a regression of this one. The blockstore's merged-set is the documented contract; counter merge now relies on it the same way every other CRDT type already does.

## Changes

- `crates/crdt/src/counter.rs` — strip `has_nonce`/`mark_nonce`/`clear_nonce`, the nonce-prefix field, the nonce-dedup branch in `apply_delta`, and the `mark_nonce(0)` calls in both seed functions. New doc comment on `Counter::merge` pointing at the blockstore-layer idempotency contract.
- `crates/crdt/src/traits.rs` — remove `MergeResult::SkippedAlreadyApplied` variant + `was_skipped()` helper. Enum remains `#[non_exhaustive]`.
- `crates/db-merge/src/merge_handler/counter.rs` — delete `cleanup_counter_nonce_for_cid` entirely (now zero callers). Rename `finalize_linked_field_blocks` → `mark_field_blocks_merged`; it's now a thin wrapper around `blockstore.mark_batch_as_merged` (the critical dedup step, unchanged). Best-effort wrappers drop the now-redundant `fallback_collection_id` argument.
- `crates/db-merge/src/merge_handler/batch.rs` — `PendingFieldBlockFinalization` loses the `fallback_collection_id` field.
- `crates/db-merge/src/merge_handler/composite.rs` — update construction sites.
- `crates/db-merge/src/merge_handler/mod.rs` — rename `counter_merge_marks_cid_merged_and_clears_nonce_marker` → `counter_merge_marks_cid_merged` and drop the clear-nonce assertion (no longer applies).

### Tests

- `crates/crdt/tests/counter_tests.rs`
  - **new**: `test_counter_retransmit_applies_twice` — direct regression guard. Merges the same delta twice via `counter.merge()` and asserts accumulation. Replaces `test_counter_idempotency` which asserted the broken behaviour.
  - **deleted**: `test_counter_clear_nonce_removes_replay_marker` (API gone).
  - **deleted**: `test_counter_merge_result_skipped_already_applied` (variant gone).
- `crates/crdt/tests/property_tests.rs`
  - **renamed/rewritten**: `test_counter_idempotence` → `test_counter_double_apply_accumulates`.
  - **renamed/rewritten**: `test_float64_counter_idempotence` → `test_float64_counter_double_apply_accumulates`.
  - **renamed/rewritten**: `test_counter_nonce_replay_protection` → `test_counter_replayed_delta_accumulates`.

## Storage / migration

Pre-existing nonce markers under `/data/{schema}/{doc}/{field}/nonces/...` remain on disk after this change. They are never read and never written again; they occupy a small amount of storage indefinitely. Acceptable because:

1. The keyspace is bounded by the number of counter deltas the node processed before this fix — not unbounded.
2. Correctness is unaffected — the old markers are simply ignored.
3. defradb.rs is at v1.0 RC1 and the nonce keyspace was never part of any documented external contract.

No migration script. `CRDTNoncePrefix` / `CRDTNonceKey` key types in `storage/src/keys/crdt.rs` are left in place — they're low-level byte-layout definitions, not behaviour, and leaving them keeps any on-disk nonce keys decodable if someone ever needs to inspect them.

## Out of scope

- **`CounterDelta::nonce` field**: stays. The DAG block layer still uses it for CID uniqueness, matching Go.
- **Dual-runtime integration test**: the unit tests directly cover the scenario #847 describes (apply the same delta twice; assert it accumulates, not dedupes). A Rust↔Go end-to-end convergence test would be valuable but requires fixture infrastructure for deterministic delta replay across the two binaries and isn't a blocker for this PR.
- **LWW / Composite / Collection CRDTs**: untouched. Their idempotency was already blockstore-layer only.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p crdt` — 27 property + unit tests pass, including the new regression guard
- [x] `cargo test -p db-merge` — 58 tests pass, including the renamed `counter_merge_marks_cid_merged`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test` — clean
- [ ] (CI) `cargo test -p integration-test --test basic` — counter sanity via the full stack
- [ ] (CI) `go_compat` matrix against the Go binary — cross-runtime parity check

Closes #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)