### PR TITLE
fix(p2p): cap block count in CAR decoder to prevent memory DoS (#840)

### DIFF
--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -93,9 +93,18 @@ pub fn decode_car(data: &[u8]) -> Result<CarContents> {
     cursor = &cursor[header_len as usize..];
     let roots = decode_car_header(header_bytes)?;
 
-    // Read blocks
+    // Read blocks. Cap at CAR_MAX_BLOCKS to prevent a hostile peer from
+    // sending millions of tiny block headers that allocate unbounded memory
+    // before any downstream limit fires (#840).
     let mut blocks = Vec::new();
     while !cursor.is_empty() {
+        if blocks.len() >= CAR_MAX_BLOCKS {
+            return Err(Error::Codec(format!(
+                "CAR file exceeds maximum block count of {}",
+                CAR_MAX_BLOCKS
+            )));
+        }
+
         let section_len = read_varint(&mut cursor)?;
         if section_len as usize > cursor.len() {
             return Err(Error::Codec("CAR block section length exceeds data".into()));
@@ -470,5 +479,35 @@ mod tests {
 
         assert_eq!(collected.blocks.len(), depth);
         assert!(!collected.truncated());
+    }
+
+    #[test]
+    fn decode_car_rejects_block_count_exceeding_cap() {
+        let root = make_cid(b"root");
+        let blocks: Vec<(&Cid, &[u8])> = (0..CAR_MAX_BLOCKS + 1)
+            .map(|_| (&root, b"x".as_slice()))
+            .collect();
+        let encoded = encode_car(&[root], &blocks).unwrap();
+
+        let result = decode_car(&encoded);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("maximum block count"),
+            "expected block-count error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn decode_car_accepts_exactly_max_blocks() {
+        let root = make_cid(b"root");
+        let blocks: Vec<(&Cid, &[u8])> = (0..CAR_MAX_BLOCKS)
+            .map(|_| (&root, b"x".as_slice()))
+            .collect();
+        let encoded = encode_car(&[root], &blocks).unwrap();
+
+        let (roots, decoded) = decode_car(&encoded).unwrap();
+        assert_eq!(roots, vec![root]);
+        assert_eq!(decoded.len(), CAR_MAX_BLOCKS);
     }
 }


### PR DESCRIPTION
## Summary

Add a `CAR_MAX_BLOCKS` check inside `decode_car`'s loop to prevent a hostile peer from exhausting memory via millions of tiny block headers packed into a single CAR message.

## Why

`decode_car` iterated CAR blocks with no count limit. A 16 MiB CAR packed with ~400k trivial block entries (varint + CIDv1 + 1 byte) fits within the wire-size cap but the `Vec<(Cid, Vec<u8>)>` runtime representation is several multiples larger. With concurrent CAR fetches, an attacker can force multi-GB memory spikes.

The downstream `collect_exact_blocks` and `collect_recursive` already enforce `CAR_MAX_BLOCKS`, but only after `decode_car` has allocated the full Vec. Moving the cap into the decode loop closes the gap.

## Changes

- `crates/p2p/src/sync/car.rs` — add `blocks.len() >= CAR_MAX_BLOCKS` check before each push in the decode loop
- Two new unit tests:
  - `decode_car_rejects_block_count_exceeding_cap` — feeds CAR_MAX_BLOCKS+1 blocks, asserts error
  - `decode_car_accepts_exactly_max_blocks` — feeds exactly CAR_MAX_BLOCKS blocks, asserts success

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p --lib car` — all 10 CAR tests pass

Closes #840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)