### PR TITLE
fix(p2p): reduce sync retry noise and handle retriable failures

### DIFF
--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -20,6 +20,20 @@ use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
 use crate::config::{Config, LogFormat, LogLevel, LogOutput};
 use crate::error::{Error, Result};
 
+fn with_default_transport_noise_filters(filter: EnvFilter) -> EnvFilter {
+    filter
+        .add_directive(
+            "iroh_quinn_proto::connection=error"
+                .parse()
+                .expect("valid tracing directive"),
+        )
+        .add_directive(
+            "noq_proto::connection=error"
+                .parse()
+                .expect("valid tracing directive"),
+        )
+}
+
 pub struct LoggingHandle {
     #[cfg(feature = "profiling")]
     profiling: Option<ProfilingTrace>,
@@ -65,8 +79,9 @@ pub fn init(config: &Config, enable_profiling: bool) -> Result<LoggingHandle> {
         LogLevel::Fatal => Level::ERROR,
     };
 
-    let filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level.to_string()));
+    let filter = with_default_transport_noise_filters(
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level.to_string())),
+    );
 
     let builder = fmt::layer()
         .with_target(true)

--- a/crates/defra-node/src/bin/coding-session-bench.rs
+++ b/crates/defra-node/src/bin/coding-session-bench.rs
@@ -178,7 +178,17 @@ mod rocksdb_runner {
         }
 
         let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+            .add_directive(
+                "iroh_quinn_proto::connection=error"
+                    .parse()
+                    .expect("valid tracing directive"),
+            )
+            .add_directive(
+                "noq_proto::connection=error"
+                    .parse()
+                    .expect("valid tracing directive"),
+            );
         let _ = tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_target(true)

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -799,8 +799,10 @@ impl NodeBuilder {
             let coord = coordinator.clone();
             tokio::spawn(async move {
                 if let Err(e) = coord.handle_transport_event(event).await {
-                    if e.to_string().contains("rate-limited") {
+                    if e.is_rate_limited() {
                         tracing::debug!(error = %e, "P2P rate-limited");
+                    } else if e.is_retriable() {
+                        tracing::warn!(error = %e, "P2P transport event failed after retries");
                     } else {
                         tracing::error!(error = %e, "P2P event handler error");
                     }
@@ -982,11 +984,20 @@ mod p2p_tests {
     fn init_tracing() {
         static INIT: Once = Once::new();
         INIT.call_once(|| {
-            let _ = tracing_subscriber::fmt()
-                .with_env_filter(
-                    tracing_subscriber::EnvFilter::from_default_env()
-                        .add_directive(tracing::Level::INFO.into()),
+            let filter = tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into())
+                .add_directive(
+                    "iroh_quinn_proto::connection=error"
+                        .parse()
+                        .expect("valid tracing directive"),
                 )
+                .add_directive(
+                    "noq_proto::connection=error"
+                        .parse()
+                        .expect("valid tracing directive"),
+                );
+            let _ = tracing_subscriber::fmt()
+                .with_env_filter(filter)
                 .with_test_writer()
                 .try_init();
         });

--- a/crates/ffi/src/profiling.rs
+++ b/crates/ffi/src/profiling.rs
@@ -16,6 +16,20 @@ fn guard_slot() -> &'static Mutex<Option<FlushGuard>> {
     PROFILING_GUARD.get_or_init(|| Mutex::new(None))
 }
 
+fn with_default_transport_noise_filters(filter: EnvFilter) -> EnvFilter {
+    filter
+        .add_directive(
+            "iroh_quinn_proto::connection=error"
+                .parse()
+                .expect("valid tracing directive"),
+        )
+        .add_directive(
+            "noq_proto::connection=error"
+                .parse()
+                .expect("valid tracing directive"),
+        )
+}
+
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn defra_profiling_start(output_path: *const c_char) -> FfiResult {
@@ -41,8 +55,9 @@ pub extern "C" fn defra_profiling_start(output_path: *const c_char) -> FfiResult
             }
         };
 
-        let filter =
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        let filter = with_default_transport_noise_filters(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        );
         let (chrome_layer, flush_guard) = ChromeLayerBuilder::new()
             .writer(file)
             .include_args(true)

--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -243,6 +243,36 @@ pub enum Error {
     HeadProvider(String),
 }
 
+impl Error {
+    const TXN_CONFLICT_SUFFIX: &str = "transaction conflict. Please retry";
+
+    /// Returns true if this error represents a storage-layer transaction conflict.
+    pub fn is_txn_conflict(&self) -> bool {
+        match self {
+            Error::BlockstoreError(msg) | Error::Storage(msg) => {
+                msg.ends_with(Self::TXN_CONFLICT_SUFFIX)
+            }
+            _ => false,
+        }
+    }
+
+    /// Returns true if retrying the operation may succeed without changing inputs.
+    pub fn is_retriable(&self) -> bool {
+        self.is_txn_conflict()
+    }
+
+    /// Returns true if this is the coordinator's synthetic rate-limit rejection.
+    pub fn is_rate_limited(&self) -> bool {
+        matches!(
+            self,
+            Error::AccessDenied {
+                collection_id,
+                ..
+            } if collection_id == "rate-limited"
+        )
+    }
+}
+
 /// Convert a blockstore CID verification error into its P2P counterpart.
 ///
 /// Called at each P2P block ingestion boundary so callers get typed errors
@@ -281,5 +311,37 @@ impl From<libp2p::TransportError<io::Error>> for Error {
 impl From<libp2p::multiaddr::Error> for Error {
     fn from(e: libp2p::multiaddr::Error) -> Self {
         Error::InvalidMultiaddr(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn txn_conflict_detection_matches_wrapped_storage_messages() {
+        let blockstore_error =
+            Error::BlockstoreError("storage error: transaction conflict. Please retry".into());
+        let storage_error = Error::Storage("transaction conflict. Please retry".into());
+
+        assert!(blockstore_error.is_txn_conflict());
+        assert!(storage_error.is_txn_conflict());
+        assert!(blockstore_error.is_retriable());
+        assert!(storage_error.is_retriable());
+    }
+
+    #[test]
+    fn rate_limited_detection_is_typed() {
+        let rate_limited = Error::AccessDenied {
+            peer_id: "peer-1".into(),
+            collection_id: "rate-limited".into(),
+        };
+        let ordinary_denial = Error::AccessDenied {
+            peer_id: "peer-1".into(),
+            collection_id: "users".into(),
+        };
+
+        assert!(rate_limited.is_rate_limited());
+        assert!(!ordinary_denial.is_rate_limited());
     }
 }

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -548,8 +548,12 @@ pub(super) async fn handle_subscribe(
                                 // at debug. Counter is process-global and
                                 // surfaced via SyncDiagnostics (issue #858).
                                 let count = crate::sync::record_gossip_decode_failure();
+                                let sender_peer_id = endpoint_id_to_peer_id(&msg.delivered_from);
                                 if count == 1 || count.is_power_of_two() {
                                     warn!(
+                                        peer_id = %sender_peer_id,
+                                        topic = %topic_str_clone,
+                                        message_size = msg.content.len(),
                                         total_failures = count,
                                         error = %e,
                                         "Failed to decode gossip message \
@@ -557,6 +561,9 @@ pub(super) async fn handle_subscribe(
                                     );
                                 } else {
                                     debug!(
+                                        peer_id = %sender_peer_id,
+                                        topic = %topic_str_clone,
+                                        message_size = msg.content.len(),
                                         total_failures = count,
                                         error = %e,
                                         "Failed to decode gossip message"

--- a/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
@@ -9,6 +9,62 @@ use crate::error::Result;
 use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    async fn retry_pending_root_after_bitswap(
+        &self,
+        query_id: crate::QueryId,
+        root_cid: Cid,
+    ) -> Result<()> {
+        match self.manager.retry_pending_dag(&root_cid).await {
+            Ok(true) => {
+                tracing::debug!(
+                    query_id = query_id.0,
+                    root_cid = %root_cid,
+                    "Pending DAG completed after Bitswap activity"
+                );
+            }
+            Ok(false) => {
+                let missing = self.manager.pending_dag_missing(&root_cid);
+                if !missing.is_empty() {
+                    let mut providers: Vec<PeerId> = self
+                        .access
+                        .peer_state
+                        .connected_peers()
+                        .into_iter()
+                        .map(PeerId::new)
+                        .collect();
+                    if let Some(source) = self.manager.pending_dag_source_peer(&root_cid) {
+                        let source_transport_id = PeerId::new(source);
+                        if !providers.contains(&source_transport_id) {
+                            providers.push(source_transport_id);
+                        }
+                    }
+                    if let Err(e) = self
+                        .runtime
+                        .transport
+                        .sync_blocks(root_cid, providers, missing)
+                        .await
+                    {
+                        tracing::warn!(
+                            query_id = query_id.0,
+                            root_cid = %root_cid,
+                            error = %e,
+                            "Failed to start Bitswap fetch for remaining child blocks"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    query_id = query_id.0,
+                    root_cid = %root_cid,
+                    error = %e,
+                    "Failed to retry pending DAG"
+                );
+            }
+        }
+        Ok(())
+    }
+
     pub(super) async fn handle_bitswap_block_received(
         &self,
         query_id: crate::QueryId,
@@ -47,6 +103,17 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 return Err(e);
             }
         }
+
+        let completed_roots = self.manager.retry_pending_dags_waiting_on(&cid).await?;
+        if !completed_roots.is_empty() {
+            tracing::debug!(
+                query_id = query_id.0,
+                received_cid = %cid,
+                completed_count = completed_roots.len(),
+                completed_roots = ?completed_roots,
+                "Bitswap block completed pending DAGs waiting on this CID"
+            );
+        }
         Ok(())
     }
 
@@ -56,78 +123,509 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         success: bool,
         error: Option<String>,
     ) -> Result<()> {
-        // Per-completion bookkeeping is debug: the coordinator receives one of
-        // these per DAG fetch, and success=true only means "the transport task
-        // exited", not "blocks were merged" (see issue #858).
-        tracing::debug!(
-            query_id = query_id.0,
-            success = success,
-            error = ?error,
-            "Bitswap fetch completed"
-        );
+        let Some(root_cid) = self.manager.take_query_root(query_id) else {
+            tracing::debug!(
+                query_id = query_id.0,
+                "Bitswap fetch completed for unknown query, ignoring"
+            );
+            return Ok(());
+        };
 
-        if !success {
+        if success {
+            tracing::debug!(
+                query_id = query_id.0,
+                root_cid = %root_cid,
+                "Bitswap fetch completed"
+            );
+            self.manager.clear_pending_dag_fetch_failures(&root_cid);
+        } else {
             if let Some(ref err) = error {
-                tracing::warn!(
-                    query_id = query_id.0,
-                    error = %err,
-                    "Bitswap fetch failed after exhausting providers; retrying pending DAGs"
-                );
-            }
-        }
-
-        let pending_dags: Vec<Cid> = self.manager.pending_dag_cids();
-        for root_cid in pending_dags {
-            match self.manager.retry_pending_dag(&root_cid).await {
-                Ok(true) => {
-                    // Counter bump happens inside retry_pending_dag on success;
-                    // this log is the coordinator-side trace of that signal.
+                if let Some(snapshot) = self
+                    .manager
+                    .record_pending_dag_fetch_failure(&root_cid, err)
+                {
+                    let sampled_warn =
+                        snapshot.fetch_failures == 1 || snapshot.fetch_failures.is_power_of_two();
+                    if sampled_warn {
+                        tracing::warn!(
+                            query_id = query_id.0,
+                            root_cid = %root_cid,
+                            doc_id = %snapshot.doc_id,
+                            collection_id = %snapshot.collection_id,
+                            source_peer = ?snapshot.source_peer,
+                            missing_count = snapshot.missing_count,
+                            fetch_failures = snapshot.fetch_failures,
+                            error = %err,
+                            "Bitswap fetch failed after exhausting providers; pending DAG remains unresolved"
+                        );
+                    } else {
+                        tracing::debug!(
+                            query_id = query_id.0,
+                            root_cid = %root_cid,
+                            doc_id = %snapshot.doc_id,
+                            collection_id = %snapshot.collection_id,
+                            source_peer = ?snapshot.source_peer,
+                            missing_count = snapshot.missing_count,
+                            fetch_failures = snapshot.fetch_failures,
+                            error = %err,
+                            "Bitswap fetch failed after exhausting providers; pending DAG remains unresolved"
+                        );
+                    }
+                } else {
                     tracing::debug!(
                         query_id = query_id.0,
                         root_cid = %root_cid,
-                        "Pending DAG completed after Bitswap fetch"
-                    );
-                }
-                Ok(false) => {
-                    let missing = self.manager.pending_dag_missing(&root_cid);
-                    if !missing.is_empty() {
-                        let mut providers: Vec<PeerId> = self
-                            .access
-                            .peer_state
-                            .connected_peers()
-                            .into_iter()
-                            .map(PeerId::new)
-                            .collect();
-                        if let Some(source) = self.manager.pending_dag_source_peer(&root_cid) {
-                            let source_transport_id = PeerId::new(source);
-                            if !providers.contains(&source_transport_id) {
-                                providers.push(source_transport_id);
-                            }
-                        }
-                        if let Err(e) = self
-                            .runtime
-                            .transport
-                            .sync_blocks(root_cid, providers, missing)
-                            .await
-                        {
-                            tracing::warn!(
-                                root_cid = %root_cid,
-                                error = %e,
-                                "Failed to start Bitswap fetch for child blocks"
-                            );
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        query_id = query_id.0,
-                        root_cid = %root_cid,
-                        error = %e,
-                        "Failed to retry pending DAG"
+                        error = %err,
+                        "Bitswap fetch failed after exhausting providers for unknown pending DAG"
                     );
                 }
             }
         }
+
+        self.retry_pending_root_after_bitswap(query_id, root_cid)
+            .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use blockstore::DefraBlockstore;
+    use bytes::Bytes;
+    use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use storage::backends::MemoryStore;
+
+    use crate::error::Result as P2PResult;
+    use crate::message::{
+        BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
+        PushLogReply, PushLogRequest, PushSEArtifactsRequest,
+    };
+    use crate::sync::{SyncConfig, SyncCoordinator, SyncEvent};
+    use crate::topics::DefraTopic;
+    use crate::transport::{MessageId, P2PTransport, PeerAddr};
+    use crate::{QueryId, ReplicatorInfo};
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct SyncCall {
+        root: Cid,
+        providers: Vec<PeerId>,
+        missing: Vec<Cid>,
+    }
+
+    #[derive(Clone)]
+    struct TestTransport {
+        peer_id: PeerId,
+        pubkey: Vec<u8>,
+        sync_calls: Arc<Mutex<Vec<SyncCall>>>,
+    }
+
+    impl TestTransport {
+        fn new() -> Self {
+            Self {
+                peer_id: PeerId::new("local-peer".to_string()),
+                pubkey: vec![1, 2, 3],
+                sync_calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn sync_calls(&self) -> Vec<SyncCall> {
+            self.sync_calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl P2PTransport for TestTransport {
+        type ResponseToken = ();
+
+        fn local_peer_id(&self) -> &PeerId {
+            &self.peer_id
+        }
+
+        fn local_public_key_proto(&self) -> &[u8] {
+            &self.pubkey
+        }
+
+        fn sign(&self, _data: &[u8]) -> P2PResult<Vec<u8>> {
+            Ok(vec![0])
+        }
+
+        async fn dial(&self, _peer_id: &PeerId, _addrs: Vec<PeerAddr>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn listen(&self, _addr: PeerAddr) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn connected_peers(&self) -> P2PResult<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn listen_addresses(&self) -> P2PResult<Vec<PeerAddr>> {
+            Ok(Vec::new())
+        }
+
+        async fn poll_until_connected(
+            &self,
+            _peer_id: &PeerId,
+            _timeout: Duration,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn peer_addresses(&self) -> P2PResult<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn subscribe(&self, _topic: DefraTopic) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn unsubscribe(&self, _topic: DefraTopic) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn publish(
+            &self,
+            _topic: DefraTopic,
+            _msg: PushLogBroadcast,
+        ) -> P2PResult<MessageId> {
+            Ok(MessageId::new("noop".to_string()))
+        }
+
+        async fn topic_peers(&self, _topic: DefraTopic) -> P2PResult<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn send_pushlog_response(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: PushLogReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_two_stream_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushLogRequest,
+        ) -> P2PResult<PushLogReply> {
+            Ok(PushLogReply::success("noop"))
+        }
+
+        async fn send_two_stream_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: PushLogReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: DocSyncRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: DocSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: BranchableSyncRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: BranchableSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_request(&self, _peer_id: &PeerId, _root_cid: Cid) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_response(&self, _peer_id: &PeerId, _car_data: Vec<u8>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _car_data: Vec<u8>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: DocSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: BranchableSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_se_artifacts(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushSEArtifactsRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn sync_blocks(
+            &self,
+            root: Cid,
+            providers: Vec<PeerId>,
+            missing: Vec<Cid>,
+        ) -> P2PResult<QueryId> {
+            self.sync_calls.lock().unwrap().push(SyncCall {
+                root,
+                providers,
+                missing,
+            });
+            Ok(QueryId(999))
+        }
+
+        async fn cancel_sync(&self, _query_id: QueryId) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn create_replicator(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn delete_replicator(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn list_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_replicator(&self, _peer_id: &PeerId) -> P2PResult<Option<ReplicatorInfo>> {
+            Ok(None)
+        }
+
+        async fn remove_replicator_collections(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> P2PResult<bool> {
+            Ok(false)
+        }
+
+        async fn shutdown(&self) -> P2PResult<()> {
+            Ok(())
+        }
+    }
+
+    fn create_lww_block(field_name: &str) -> (Cid, Vec<u8>) {
+        let block = Block::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: b"doc123".to_vec(),
+                field_name: field_name.to_string(),
+                priority: 1,
+                schema_version_id: "schema1".to_string(),
+                data: b"value".to_vec(),
+            }),
+            vec![],
+            vec![],
+        );
+        let bytes = block.to_dag_cbor().expect("encode lww block");
+        let cid = block.generate_cid().expect("generate lww cid");
+        (cid, bytes)
+    }
+
+    fn create_composite_block(doc_id: &str, field_name: &str, field_cid: Cid) -> (Cid, Vec<u8>) {
+        let block = Block::new(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                doc_id: doc_id.as_bytes().to_vec(),
+                schema_version_id: "schema1".to_string(),
+                priority: 1,
+                status: 1,
+            }),
+            vec![],
+            vec![DAGLink::new(field_name, field_cid)],
+        );
+        let bytes = block.to_dag_cbor().expect("encode composite block");
+        let cid = block.generate_cid().expect("generate composite cid");
+        (cid, bytes)
+    }
+
+    fn make_broadcast(
+        doc_id: &str,
+        cid: Cid,
+        block: Vec<u8>,
+        collection_id: &str,
+    ) -> PushLogBroadcast {
+        PushLogBroadcast::new(
+            doc_id.to_string(),
+            Bytes::from(cid.to_bytes()),
+            collection_id.to_string(),
+            "creator1".to_string(),
+            Bytes::from(block),
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn bitswap_block_received_retries_only_waiting_dags() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = TestTransport::new();
+        let (coordinator, mut events) =
+            SyncCoordinator::new(transport, blockstore, SyncConfig::default())
+                .await
+                .expect("coordinator");
+
+        let (field_cid, field_block) = create_lww_block("name");
+        let (root_cid, root_block) = create_composite_block("doc123", "name", field_cid);
+
+        coordinator
+            .manager()
+            .process_pushlog(
+                &make_broadcast("doc123", root_cid, root_block, "collection1"),
+                Some("peer-1"),
+                false,
+                None,
+            )
+            .await
+            .expect("root pushlog");
+
+        match events.try_recv().expect("DagNeedsFetch event") {
+            SyncEvent::DagNeedsFetch {
+                root_cid: event_root,
+                ..
+            } => {
+                assert_eq!(event_root, root_cid);
+            }
+            other => panic!("expected DagNeedsFetch, got {:?}", other),
+        }
+
+        coordinator
+            .handle_bitswap_block_received(QueryId(42), field_cid, field_block)
+            .await
+            .expect("bitswap block received");
+
+        match tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("event")
+            .expect("channel open")
+        {
+            SyncEvent::DagReady {
+                root_cid: event_root,
+                doc_id,
+                ..
+            } => {
+                assert_eq!(event_root, root_cid);
+                assert_eq!(doc_id, "doc123");
+            }
+            other => panic!("expected DagReady, got {:?}", other),
+        }
+
+        assert_eq!(coordinator.manager().pending_dag_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn bitswap_complete_retries_only_its_registered_root() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = TestTransport::new();
+        let transport_handle = transport.clone();
+        let (coordinator, mut events) =
+            SyncCoordinator::new(transport, blockstore, SyncConfig::default())
+                .await
+                .expect("coordinator");
+
+        let (field1_cid, _field1_block) = create_lww_block("name");
+        let (field2_cid, _field2_block) = create_lww_block("age");
+        let (root1_cid, root1_block) = create_composite_block("doc1", "name", field1_cid);
+        let (root2_cid, root2_block) = create_composite_block("doc2", "age", field2_cid);
+
+        coordinator
+            .manager()
+            .process_pushlog(
+                &make_broadcast("doc1", root1_cid, root1_block, "collection1"),
+                Some("peer-1"),
+                false,
+                None,
+            )
+            .await
+            .expect("first pending root");
+        coordinator
+            .manager()
+            .process_pushlog(
+                &make_broadcast("doc2", root2_cid, root2_block, "collection2"),
+                Some("peer-2"),
+                false,
+                None,
+            )
+            .await
+            .expect("second pending root");
+
+        for _ in 0..2 {
+            let _ = events.try_recv().expect("DagNeedsFetch event");
+        }
+
+        let query_id = QueryId(7);
+        coordinator.manager().register_query(query_id, root1_cid);
+        coordinator
+            .handle_bitswap_complete(
+                query_id,
+                false,
+                Some("selective CAR fetch failed".to_string()),
+            )
+            .await
+            .expect("bitswap complete");
+
+        let sync_calls = transport_handle.sync_calls();
+        assert_eq!(sync_calls.len(), 1, "only one pending root should retry");
+        assert_eq!(sync_calls[0].root, root1_cid);
+        assert_eq!(sync_calls[0].missing, vec![field1_cid]);
+        assert_eq!(
+            sync_calls[0].providers,
+            vec![PeerId::new("peer-1".to_string())]
+        );
+        assert_eq!(coordinator.manager().pending_dag_attempts(&root1_cid), 1);
+        assert_eq!(coordinator.manager().pending_dag_attempts(&root2_cid), 0);
+
+        coordinator
+            .handle_bitswap_complete(QueryId(9999), false, Some("ignored".to_string()))
+            .await
+            .expect("unknown query is ignored");
+        assert_eq!(
+            transport_handle.sync_calls().len(),
+            1,
+            "unknown query should not trigger another retry"
+        );
     }
 }

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -8,6 +8,7 @@ mod gossip;
 mod pushlog;
 
 use blockstore::Blockstore;
+use std::time::Duration;
 
 use super::SyncCoordinator;
 use crate::error::{Error, Result};
@@ -16,8 +17,42 @@ use crate::signing::sign_with_transport;
 use crate::transport::{P2PTransport, PeerId, TransportEvent};
 
 const RATE_LIMITED_MSG: &str = "rate limited: too many requests, retry later";
+const MAX_RETRIABLE_EVENT_ATTEMPTS: usize = 4;
+
+fn retriable_event_delay(attempt: usize) -> Duration {
+    match attempt {
+        1 => Duration::from_millis(10),
+        2 => Duration::from_millis(25),
+        _ => Duration::from_millis(50),
+    }
+}
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    async fn retry_retriable_event<F, Fut>(&self, event_kind: &'static str, mut op: F) -> Result<()>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<()>>,
+    {
+        let mut attempt = 1;
+        loop {
+            match op().await {
+                Ok(()) => return Ok(()),
+                Err(error) if error.is_retriable() && attempt < MAX_RETRIABLE_EVENT_ATTEMPTS => {
+                    tracing::debug!(
+                        event_kind,
+                        attempt,
+                        max_attempts = MAX_RETRIABLE_EVENT_ATTEMPTS,
+                        error = %error,
+                        "Retryable transport event failed; backing off and retrying"
+                    );
+                    tokio::time::sleep(retriable_event_delay(attempt)).await;
+                    attempt += 1;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
     fn handle_peer_connected(&self, peer_id: PeerId) {
         tracing::debug!(peer_id = %peer_id, "Peer connected");
         self.access.peer_state.peer_connected(peer_id.as_str());
@@ -246,8 +281,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 cid,
                 data,
             } => {
-                self.handle_bitswap_block_received(query_id, cid, data)
-                    .await?;
+                self.retry_retriable_event("bitswap_block_received", || {
+                    self.handle_bitswap_block_received(query_id, cid, data.clone())
+                })
+                .await?;
             }
             TransportEvent::BitswapComplete {
                 query_id,
@@ -310,8 +347,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 root_cid,
                 car_data,
             } => {
-                self.handle_car_fetch_response(peer_id, root_cid, car_data)
-                    .await?;
+                self.retry_retriable_event("car_fetch_response", || {
+                    self.handle_car_fetch_response(peer_id.clone(), root_cid, car_data.clone())
+                })
+                .await?;
             }
             other => {
                 let _ = other;

--- a/crates/p2p/src/sync/manager/pending.rs
+++ b/crates/p2p/src/sync/manager/pending.rs
@@ -49,4 +49,9 @@ pub struct PendingDag {
     /// Surfaced in diagnostic logs so the single aggregated WARN on terminal
     /// failure can carry an attempt count without scraping intermediate noise.
     pub attempts: u32,
+    /// Number of Bitswap/CAR fetch rounds that exhausted providers without
+    /// yielding a complete DAG for this root.
+    pub fetch_failures: u32,
+    /// Most recent provider-exhaustion error for this root, if any.
+    pub last_fetch_error: Option<String>,
 }

--- a/crates/p2p/src/sync/manager/process/bitswap.rs
+++ b/crates/p2p/src/sync/manager/process/bitswap.rs
@@ -19,6 +19,11 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         self.query_to_root.write().insert(query_id, root_cid);
     }
 
+    /// Remove and return the root CID associated with a Bitswap query.
+    pub fn take_query_root(&self, query_id: QueryId) -> Option<Cid> {
+        self.query_to_root.write().remove(&query_id)
+    }
+
     /// Handle Bitswap query completion.
     ///
     /// Called when a Bitswap sync completes (success or failure).

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -13,6 +13,15 @@ use crate::sync::manager::pending::{PendingDag, MAX_PENDING_DAGS, PENDING_DAG_TT
 
 use super::SyncManager;
 
+#[derive(Debug, Clone)]
+pub struct PendingDagFetchFailure {
+    pub doc_id: String,
+    pub collection_id: String,
+    pub source_peer: Option<String>,
+    pub missing_count: usize,
+    pub fetch_failures: u32,
+}
+
 impl<B: Blockstore + 'static> SyncManager<B> {
     /// Get the pending DAGs count (for testing/monitoring).
     pub fn pending_dag_count(&self) -> usize {
@@ -50,6 +59,34 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             .read()
             .get(root_cid)
             .and_then(|dag| dag.source_peer.clone())
+    }
+
+    /// Record a provider-exhaustion failure for a pending DAG and return a
+    /// snapshot suitable for rate-limited logging.
+    pub fn record_pending_dag_fetch_failure(
+        &self,
+        root_cid: &Cid,
+        error: &str,
+    ) -> Option<PendingDagFetchFailure> {
+        let mut pending = self.pending_dags.write();
+        let dag = pending.get_mut(root_cid)?;
+        dag.fetch_failures = dag.fetch_failures.saturating_add(1);
+        dag.last_fetch_error = Some(error.to_string());
+        Some(PendingDagFetchFailure {
+            doc_id: dag.doc_id.clone(),
+            collection_id: dag.collection_id.clone(),
+            source_peer: dag.source_peer.clone(),
+            missing_count: dag.missing.len(),
+            fetch_failures: dag.fetch_failures,
+        })
+    }
+
+    /// Clear the remembered fetch-failure state for a pending DAG.
+    pub fn clear_pending_dag_fetch_failures(&self, root_cid: &Cid) {
+        if let Some(dag) = self.pending_dags.write().get_mut(root_cid) {
+            dag.fetch_failures = 0;
+            dag.last_fetch_error = None;
+        }
     }
 
     /// Retry pending DAGs that were waiting on `cid`.
@@ -118,22 +155,26 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         if !self.insert_pending_dag(
             root_cid,
             PendingDag {
-                doc_id,
+                doc_id: doc_id.clone(),
                 // DocSync protocol doesn't include collection_id or creator.
                 // The merge handler will extract these from the block data.
                 collection_id: String::new(),
                 creator: String::new(),
                 missing: std::iter::once(root_cid).collect(),
-                source_peer: Some(source_peer),
+                source_peer: Some(source_peer.clone()),
                 is_explicit_replicator: false,
                 explicit_replay_authorization: None,
                 acp_actor_relationships: None,
                 inserted_at: Instant::now(),
                 attempts: 0,
+                fetch_failures: 0,
+                last_fetch_error: None,
             },
         ) {
             tracing::warn!(
                 cid = %root_cid,
+                doc_id = %doc_id,
+                source_peer = %source_peer,
                 max = MAX_PENDING_DAGS,
                 "Pending DAGs at capacity, dropping DocSync registration"
             );
@@ -161,19 +202,23 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             root_cid,
             PendingDag {
                 doc_id: String::new(),
-                collection_id,
+                collection_id: collection_id.clone(),
                 creator: String::new(),
                 missing: std::iter::once(root_cid).collect(),
-                source_peer: Some(source_peer),
+                source_peer: Some(source_peer.clone()),
                 is_explicit_replicator: false,
                 explicit_replay_authorization: None,
                 acp_actor_relationships: None,
                 inserted_at: Instant::now(),
                 attempts: 0,
+                fetch_failures: 0,
+                last_fetch_error: None,
             },
         ) {
             tracing::warn!(
                 cid = %root_cid,
+                collection_id = %collection_id,
+                source_peer = %source_peer,
                 max = MAX_PENDING_DAGS,
                 "Pending DAGs at capacity, dropping branchable DAG registration"
             );
@@ -213,7 +258,12 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             tracing::warn!(
                 root_cid = %root_cid,
                 doc_id = %info.doc_id,
+                collection_id = %info.collection_id,
+                source_peer = ?info.source_peer,
+                missing_count = info.missing.len(),
                 attempts = info.attempts,
+                fetch_failures = info.fetch_failures,
+                last_fetch_error = ?info.last_fetch_error,
                 age_secs = info.inserted_at.elapsed().as_secs(),
                 "Pending DAG expired (TTL exceeded), dropping"
             );

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -326,6 +326,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                                 acp_actor_relationships: msg.acp_actor_relationships.clone(),
                                 inserted_at: now,
                                 attempts: 0,
+                                fetch_failures: 0,
+                                last_fetch_error: None,
                             },
                         );
                         true
@@ -336,6 +338,10 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 if !inserted {
                     tracing::warn!(
                         cid = %cid,
+                        doc_id = %msg.doc_id,
+                        collection_id = %msg.collection_id,
+                        source_peer = ?sender_peer,
+                        missing_count = missing.len(),
                         max = MAX_PENDING_DAGS,
                         "Pending DAGs at capacity, dropping PushLog DAG registration"
                     );


### PR DESCRIPTION
## Summary
- add typed retriable and transaction-conflict detection, then retry retriable CAR and Bitswap ingest failures with bounded backoff
- scope Bitswap retries to the affected pending DAGs, track pending DAG fetch failures, and log terminal unresolved state without warn-plus-debug duplication
- add peer/topic/message-size context to gossip decode failures and filter upstream MultipathNotNegotiated transport noise in the tracing subscribers this repo owns

## Testing
- cargo fmt --all
- cargo test -p p2p bitswap_
- cargo test -p p2p detection_
- cargo check -p cli -p ffi -p defra-node

Fixes #870