### PR TITLE
feat(p2p): improve iroh reconnect surfaces and ingress retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8846,6 +8846,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
+ "sha2 0.10.9",
  "storage",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8828,6 +8828,7 @@ dependencies = [
  "crypto",
  "defra-core",
  "futures",
+ "hex",
  "identity",
  "iroh",
  "iroh-bitswap",

--- a/crates/blockstore/src/error.rs
+++ b/crates/blockstore/src/error.rs
@@ -39,3 +39,12 @@ pub enum Error {
     #[error("internal error: {0}")]
     Internal(String),
 }
+
+impl Error {
+    /// Returns true when this error originates from a storage-layer transaction
+    /// conflict. Callers that want to retry safely should prefer this typed
+    /// check over matching on the stringified error chain.
+    pub fn is_txn_conflict(&self) -> bool {
+        matches!(self, Error::Storage(storage_err) if storage_err.is_txn_conflict())
+    }
+}

--- a/crates/cli/src/commands/client/p2p/replicator.rs
+++ b/crates/cli/src/commands/client/p2p/replicator.rs
@@ -178,28 +178,6 @@ fn extract_public_peer_id(addr: &str) -> Result<String> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::extract_public_peer_id;
-
-    #[test]
-    fn extract_public_peer_id_accepts_libp2p_multiaddr() {
-        let peer_id = "12D3KooWM111111111111111111111111111111111111111111111";
-        let addr = format!("/ip4/127.0.0.1/tcp/9000/p2p/{peer_id}");
-
-        assert_eq!(extract_public_peer_id(&addr).unwrap(), peer_id);
-    }
-
-    #[cfg(feature = "iroh")]
-    #[test]
-    fn extract_public_peer_id_accepts_iroh_public_addr() {
-        let peer_id = "ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6";
-        let addr = format!("127.0.0.1:9000/p2p/{peer_id}");
-
-        assert_eq!(extract_public_peer_id(&addr).unwrap(), peer_id);
-    }
-}
-
 impl P2pReplicatorDeleteArgs {
     /// Execute the replicator delete command
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
@@ -219,5 +197,27 @@ impl P2pReplicatorDeleteArgs {
             self.collection.join(", ")
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_public_peer_id;
+
+    #[test]
+    fn extract_public_peer_id_accepts_libp2p_multiaddr() {
+        let peer_id = "12D3KooWM111111111111111111111111111111111111111111111";
+        let addr = format!("/ip4/127.0.0.1/tcp/9000/p2p/{peer_id}");
+
+        assert_eq!(extract_public_peer_id(&addr).unwrap(), peer_id);
+    }
+
+    #[cfg(feature = "iroh")]
+    #[test]
+    fn extract_public_peer_id_accepts_iroh_public_addr() {
+        let peer_id = "ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6";
+        let addr = format!("127.0.0.1:9000/p2p/{peer_id}");
+
+        assert_eq!(extract_public_peer_id(&addr).unwrap(), peer_id);
     }
 }

--- a/crates/cli/src/commands/client/p2p/replicator.rs
+++ b/crates/cli/src/commands/client/p2p/replicator.rs
@@ -121,15 +121,8 @@ async fn build_explicit_replay_capabilities(
     let source_peer_id = local_info
         .first()
         .ok_or_else(|| Error::Server("local node has no P2P listen address".to_string()))
-        .and_then(|addr| {
-            p2p::parse_multiaddr_with_peer_id(addr)
-                .map(|parsed| parsed.peer_id.to_string())
-                .map_err(|e| Error::Server(e.to_string()))
-        })?;
-    let target_peer_id = p2p::parse_multiaddr_with_peer_id(address)
-        .map_err(|e| Error::Server(e.to_string()))?
-        .peer_id
-        .to_string();
+        .and_then(|addr| extract_public_peer_id(addr.as_str()))?;
+    let target_peer_id = extract_public_peer_id(address)?;
     let identity = raw_identity_from_key_bytes("replicator identity", identity_key_bytes)?;
     let collections_by_name = client.collection_versions().await?;
 
@@ -160,6 +153,51 @@ async fn build_explicit_replay_capabilities(
             })
         })
         .collect()
+}
+
+fn extract_public_peer_id(addr: &str) -> Result<String> {
+    if let Ok(parsed) = p2p::parse_multiaddr_with_peer_id(addr) {
+        return Ok(parsed.peer_id.to_string());
+    }
+
+    #[cfg(feature = "iroh")]
+    {
+        return p2p::iroh::parse_public_peer_addr(addr)
+            .map(|(peer_id, _)| peer_id.to_string())
+            .map_err(|e| Error::Server(e.to_string()));
+    }
+
+    #[cfg(not(feature = "iroh"))]
+    {
+        Err(Error::Server(
+            p2p::parse_multiaddr_with_peer_id(addr)
+                .err()
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "invalid peer address".to_string()),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_public_peer_id;
+
+    #[test]
+    fn extract_public_peer_id_accepts_libp2p_multiaddr() {
+        let peer_id = "12D3KooWM111111111111111111111111111111111111111111111";
+        let addr = format!("/ip4/127.0.0.1/tcp/9000/p2p/{peer_id}");
+
+        assert_eq!(extract_public_peer_id(&addr).unwrap(), peer_id);
+    }
+
+    #[cfg(feature = "iroh")]
+    #[test]
+    fn extract_public_peer_id_accepts_iroh_public_addr() {
+        let peer_id = "ae58ff8833241ac82d6ff7611046ed67b5072d142c588d0063e942d9a75502b6";
+        let addr = format!("127.0.0.1:9000/p2p/{peer_id}");
+
+        assert_eq!(extract_public_peer_id(&addr).unwrap(), peer_id);
+    }
 }
 
 impl P2pReplicatorDeleteArgs {

--- a/crates/cli/src/commands/client/p2p/replicator.rs
+++ b/crates/cli/src/commands/client/p2p/replicator.rs
@@ -206,7 +206,10 @@ mod tests {
 
     #[test]
     fn extract_public_peer_id_accepts_libp2p_multiaddr() {
-        let peer_id = "12D3KooWM111111111111111111111111111111111111111111111";
+        // Use a real libp2p PeerID — the multiaddr parser validates the
+        // multihash component, so the placeholder string used previously
+        // ("12D3KooWM1111...") fails before reaching extract_public_peer_id.
+        let peer_id = libp2p::PeerId::random().to_string();
         let addr = format!("/ip4/127.0.0.1/tcp/9000/p2p/{peer_id}");
 
         assert_eq!(extract_public_peer_id(&addr).unwrap(), peer_id);

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -10,7 +10,9 @@ use async_trait::async_trait;
 use blockstore::Blockstore;
 
 use defra_http::router::{P2PError, P2POperations, P2PResult, ReplicatorInfo};
-use p2p::iroh::{format_public_listen_addrs, parse_public_peer_addr, IrohTransport};
+use p2p::iroh::{
+    best_shareable_public_addr, format_public_listen_addrs, parse_public_peer_addr, IrohTransport,
+};
 use p2p::sync::IrohSyncCoordinator;
 use p2p::topics::DefraTopic;
 use p2p::P2PTransport;
@@ -66,6 +68,14 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             .listen_addresses()
             .await
             .map(|addrs| format_public_listen_addrs(self.transport.local_peer_id(), &addrs))
+            .map_err(|e| P2PError::Transport(e.to_string()))
+    }
+
+    async fn shareable_address(&self) -> P2PResult<Option<String>> {
+        self.transport
+            .listen_addresses()
+            .await
+            .map(|addrs| best_shareable_public_addr(self.transport.local_peer_id(), &addrs))
             .map_err(|e| P2PError::Transport(e.to_string()))
     }
 

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -111,6 +111,13 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
+    async fn notify_network_change(&self) -> P2PResult<()> {
+        self.transport
+            .network_change()
+            .await
+            .map_err(|e| P2PError::Transport(e.to_string()))
+    }
+
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         let p2p_infos = self
             .transport

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -288,6 +288,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
+    async fn notify_network_change(&self) -> P2PResult<()> {
+        Ok(())
+    }
+
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         let p2p_infos = self
             .handle

--- a/crates/db-backup/src/backup/mod.rs
+++ b/crates/db-backup/src/backup/mod.rs
@@ -32,16 +32,14 @@ pub fn classify_schema_fields(schema: &CollectionVersion) -> Vec<FieldInfo> {
         }
 
         match &field.kind {
-            FieldKind::Scalar(_) | FieldKind::ScalarArray(_) => {
-                if field.relation_name.is_none() {
-                    result.push(FieldInfo {
-                        name: field.name.clone(),
-                        is_relation: false,
-                        is_self_ref: false,
-                        is_array: field.kind.is_array(),
-                        is_primary: false,
-                    });
-                }
+            FieldKind::Scalar(_) | FieldKind::ScalarArray(_) if field.relation_name.is_none() => {
+                result.push(FieldInfo {
+                    name: field.name.clone(),
+                    is_relation: false,
+                    is_self_ref: false,
+                    is_array: field.kind.is_array(),
+                    is_primary: false,
+                });
             }
             FieldKind::SelfRef { is_array, .. } => {
                 result.push(FieldInfo {

--- a/crates/db-blocks/src/lib.rs
+++ b/crates/db-blocks/src/lib.rs
@@ -245,7 +245,7 @@ pub async fn get_all_field_heads(
     }
 
     // Sort by CID string representation to match Go's Block.New() sorting
-    entries.sort_by(|a, b| a.cid.to_bytes().cmp(&b.cid.to_bytes()));
+    entries.sort_by_key(|a| a.cid.to_bytes());
     Ok(entries)
 }
 
@@ -304,7 +304,7 @@ impl DocHeadsSnapshot {
 
         // Sort each field's entries by CID string to match Go's deterministic ordering.
         for entries in entries_by_field.values_mut() {
-            entries.sort_by(|a, b| a.cid.to_bytes().cmp(&b.cid.to_bytes()));
+            entries.sort_by_key(|a| a.cid.to_bytes());
         }
 
         Ok(Self {

--- a/crates/db-index/src/index_manager/mod.rs
+++ b/crates/db-index/src/index_manager/mod.rs
@@ -275,14 +275,10 @@ impl IndexManager {
         let key_bytes = seq_key.bytes();
 
         let current = match datastore.get(&key_bytes).await.map_err(Error::Storage)? {
-            Some(bytes) => {
-                if bytes.len() == 4 {
-                    u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
-                } else {
-                    0
-                }
+            Some(bytes) if bytes.len() == 4 => {
+                u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
             }
-            None => 0,
+            _ => 0,
         };
 
         let next_id = current + 1;

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -126,9 +126,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)>,
         )> = Vec::with_capacity(prepared_docs.len());
 
-        for ((doc, id_was_generated), blocks) in
-            prepared_docs.into_iter().zip(computed_blocks.into_iter())
-        {
+        for ((doc, id_was_generated), blocks) in prepared_docs.into_iter().zip(computed_blocks) {
             let doc_id = doc.id().cloned().ok_or_else(|| {
                 query::error::QueryError::execution("document should have ID after generation")
             })?;

--- a/crates/db/src/collection_ops/create.rs
+++ b/crates/db/src/collection_ops/create.rs
@@ -109,14 +109,10 @@ impl<S: Store> crate::database::DB<S> {
             let key_bytes = seq_key.bytes();
             let mut current: u32 =
                 match systemstore.get(&key_bytes).await.map_err(Error::Storage)? {
-                    Some(bytes) => {
-                        if bytes.len() == 4 {
-                            u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
-                        } else {
-                            0
-                        }
+                    Some(bytes) if bytes.len() == 4 => {
+                        u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]])
                     }
-                    None => 0,
+                    _ => 0,
                 };
             for idx in &mut schema.indexes {
                 current += 1;

--- a/crates/db/src/lensed_fetcher/migration.rs
+++ b/crates/db/src/lensed_fetcher/migration.rs
@@ -66,7 +66,8 @@ impl<S: Store> LensedDocFetcher<S> {
 
         let mut full_history: HashMap<String, CollectionHistoryLink> = HashMap::new();
 
-        // Add each version to the history
+        // First pass: build links with `previous` and `transform` from each
+        // version's stored `previous_version` pointer.
         for version in versions {
             let mut link = CollectionHistoryLink::new(&version.version_id, &version.collection_id);
 
@@ -79,6 +80,28 @@ impl<S: Store> LensedDocFetcher<S> {
             }
 
             full_history.insert(version.version_id.clone(), link);
+        }
+
+        // Second pass: backfill `next` so the targeted-history walk can
+        // traverse forward from older versions. Without this, a node whose
+        // collection sits at v1 cannot find a path to a doc that arrived at
+        // v2 — the previous-only graph is unreachable from v1.
+        // Mirrors the equivalent pass in `lensed_auto_commit_fetcher`.
+        let reverse_links: Vec<(String, String)> = full_history
+            .values()
+            .flat_map(|link| {
+                link.previous
+                    .iter()
+                    .map(|prev_id| (prev_id.clone(), link.version_id.clone()))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        for (parent_id, child_id) in reverse_links {
+            if let Some(parent_link) = full_history.get_mut(&parent_id) {
+                if !parent_link.next.contains(&child_id) {
+                    parent_link.next.push(child_id);
+                }
+            }
         }
 
         build_targeted_history(&full_history, target_version_id)

--- a/crates/db/src/versioned_fetcher.rs
+++ b/crates/db/src/versioned_fetcher.rs
@@ -429,13 +429,11 @@ impl<S: Store> VersionedFetcher<S> {
                         }
                     }
                 }
-                CrdtDelta::Composite(payload) => {
+                CrdtDelta::Composite(payload) if payload.priority >= max_composite_priority => {
                     // Track document status from composite blocks.
                     // The highest-priority composite determines the final status.
-                    if payload.priority >= max_composite_priority {
-                        max_composite_priority = payload.priority;
-                        is_deleted = payload.status == 2;
-                    }
+                    max_composite_priority = payload.priority;
+                    is_deleted = payload.status == 2;
                 }
                 _ => {
                     // Collection and schema definition deltas are not relevant for document reconstruction

--- a/crates/ffi/src/p2p/peer.rs
+++ b/crates/ffi/src/p2p/peer.rs
@@ -102,10 +102,13 @@ pub unsafe extern "C" fn p2p_notify_network_change(
                     None => return Err(FfiP2PError::no_p2p_system()),
                 };
 
-                let _ = p2p;
-                Err(FfiP2PError::unsupported(
-                    "notify_network_change is not part of the HTTP P2P operations surface",
-                ))
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .notify_network_change()
+                        .await
+                        .map_err(FfiP2PError::from)
+                })
             })
             .ok_or_else(FfiP2PError::invalid_node_handle)
             .and_then(|result| result);

--- a/crates/http/src/handlers/p2p/mod.rs
+++ b/crates/http/src/handlers/p2p/mod.rs
@@ -42,8 +42,8 @@ pub use collections::{
 };
 pub use documents::{add_documents, list_documents, remove_documents, sync_documents};
 pub use peers::{
-    active_peers, connect, connect_peer, get_info, list_peers, ConnectPeerRequest, P2pInfoResponse,
-    PeerInfo,
+    active_peers, connect, connect_peer, get_info, get_shareable_address, list_peers,
+    ConnectPeerRequest, P2pInfoResponse, PeerInfo, ShareableAddressResponse,
 };
 pub use replicators::{
     add_replicator, list_replicators, remove_replicator, ReplicatorDeleteRequest,

--- a/crates/http/src/handlers/p2p/peers.rs
+++ b/crates/http/src/handlers/p2p/peers.rs
@@ -17,6 +17,12 @@ use crate::validation::validate_multiaddr;
 /// endpoint tickets, raw endpoint ids, or `<endpoint-id>@<host>:<port>`.
 pub type P2pInfoResponse = Vec<String>;
 
+/// Response for the single best shareable P2P address.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShareableAddressResponse {
+    pub address: Option<String>,
+}
+
 /// Response for listing peers.
 #[derive(Debug, Clone, Serialize)]
 pub struct PeerInfo {
@@ -62,6 +68,23 @@ pub async fn get_info(
         .collect();
 
     Ok(Json(full_addrs))
+}
+
+/// Get the single best shareable P2P address, if available.
+///
+/// GET /api/v0/p2p/shareable-address
+///
+/// Requires `P2pPeerInfo` permission when NAC is enabled.
+pub async fn get_shareable_address(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+) -> Result<Json<ShareableAddressResponse>, HttpError> {
+    require_permission(&state, &identity, NodePermission::P2pPeerInfo).await?;
+
+    let p2p = state.require_p2p()?;
+    let address = p2p.shareable_address().await.map_err(map_p2p_internal)?;
+
+    Ok(Json(ShareableAddressResponse { address }))
 }
 
 /// List connected peers.
@@ -178,5 +201,14 @@ mod tests {
         assert!(json.contains("/ip4/127.0.0.1/tcp/9000"));
         // Verify it's an array, not an object
         assert!(json.starts_with('['));
+    }
+
+    #[test]
+    fn test_shareable_address_response_serialize() {
+        let response = ShareableAddressResponse {
+            address: Some("endpoint-ticket".to_string()),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert_eq!(json, r#"{"address":"endpoint-ticket"}"#);
     }
 }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -28,6 +28,7 @@
 //!
 //! ## P2P (requires P2POperations)
 //! - `GET /api/v0/p2p/info` - Get P2P node info
+//! - `GET /api/v0/p2p/shareable-address` - Get the single best shareable P2P address
 //! - `GET /api/v0/p2p/peers` - List connected peers
 //! - `POST /api/v0/p2p/peers` - Connect to peer
 //! - `GET /api/v0/p2p/replicator` - List replicators

--- a/crates/http/src/mock/p2p.rs
+++ b/crates/http/src/mock/p2p.rs
@@ -80,6 +80,10 @@ impl P2POperations for MockP2POperations {
         Ok(self.addresses.clone())
     }
 
+    async fn shareable_address(&self) -> P2PResult<Option<String>> {
+        Ok(self.addresses.first().cloned())
+    }
+
     async fn connected_peers(&self) -> P2PResult<Vec<String>> {
         Ok(self.peers.read().unwrap().clone())
     }
@@ -199,6 +203,10 @@ impl P2POperations for FailingMockP2POperations {
     }
 
     async fn listen_addresses(&self) -> P2PResult<Vec<String>> {
+        Err(P2PError::Internal(self.error.clone()))
+    }
+
+    async fn shareable_address(&self) -> P2PResult<Option<String>> {
         Err(P2PError::Internal(self.error.clone()))
     }
 

--- a/crates/http/src/mock/p2p.rs
+++ b/crates/http/src/mock/p2p.rs
@@ -95,6 +95,10 @@ impl P2POperations for MockP2POperations {
         Ok(())
     }
 
+    async fn notify_network_change(&self) -> P2PResult<()> {
+        Ok(())
+    }
+
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         Ok(self.replicators.read().unwrap().clone())
     }
@@ -203,6 +207,10 @@ impl P2POperations for FailingMockP2POperations {
     }
 
     async fn connect_peer(&self, _addr: &str) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
+    }
+
+    async fn notify_network_change(&self) -> P2PResult<()> {
         Err(P2PError::Internal(self.error.clone()))
     }
 

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -129,6 +129,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         // P2P
         // =====================================================================
         "/api/v0/p2p/info" => RoutePermission::Required(NodePermission::P2pPeerInfo),
+        "/api/v0/p2p/shareable-address" => RoutePermission::Required(NodePermission::P2pPeerInfo),
         "/api/v0/p2p/active-peers" => RoutePermission::Required(NodePermission::P2pPeerActive),
         "/api/v0/p2p/connect" => RoutePermission::Required(NodePermission::P2pPeerConnect),
         "/api/v0/p2p/peers" => match *method {

--- a/crates/http/src/route_permissions_tests.rs
+++ b/crates/http/src/route_permissions_tests.rs
@@ -122,6 +122,10 @@ mod tests {
             RoutePermission::Required(NodePermission::P2pPeerInfo)
         );
         assert_eq!(
+            route_permission("/api/v0/p2p/shareable-address", &Method::GET),
+            RoutePermission::Required(NodePermission::P2pPeerInfo)
+        );
+        assert_eq!(
             route_permission("/api/v0/p2p/replicators", &Method::GET),
             RoutePermission::Required(NodePermission::P2pReplicatorList)
         );

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -115,6 +115,10 @@ pub fn create_router_with_state(state: AppState) -> Router {
     // P2P routes
     let p2p_routes = Router::new()
         .route("/info", get(handlers::p2p::get_info))
+        .route(
+            "/shareable-address",
+            get(handlers::p2p::get_shareable_address),
+        )
         .route("/active-peers", get(handlers::p2p::active_peers)) // Go-compatible
         .route("/connect", post(handlers::p2p::connect)) // Go-compatible
         .route("/peers", get(handlers::p2p::list_peers))

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -56,6 +56,17 @@ pub trait P2POperations: Send + Sync {
     /// Get listening addresses.
     async fn listen_addresses(&self) -> P2PResult<Vec<String>>;
 
+    /// Get the single best address to share with another node, if available.
+    ///
+    /// This is a stronger contract than `listen_addresses()`: callers should not
+    /// need to guess which returned address is meant for remote sharing.
+    ///
+    /// Transports that do not have a clear shareable-address concept may return
+    /// `Ok(None)`.
+    async fn shareable_address(&self) -> P2PResult<Option<String>> {
+        Ok(None)
+    }
+
     /// Get connected peers.
     async fn connected_peers(&self) -> P2PResult<Vec<String>>;
 

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -62,6 +62,15 @@ pub trait P2POperations: Send + Sync {
     /// Connect to a peer at the given address.
     async fn connect_peer(&self, addr: &str) -> P2PResult<()>;
 
+    /// Notify the transport that local network conditions may have changed.
+    ///
+    /// Some transports, such as iroh, use this to refresh relay/direct
+    /// connectivity after interface changes. Transports that do not require
+    /// explicit handling may treat this as a no-op.
+    async fn notify_network_change(&self) -> P2PResult<()> {
+        Ok(())
+    }
+
     /// Get all replicators.
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>>;
 

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -213,6 +213,7 @@ impl Server {
     ///
     /// When P2P operations are configured, the server enables additional endpoints:
     /// - `GET /api/v0/p2p/info` - Get P2P node info (peer ID, addresses)
+    /// - `GET /api/v0/p2p/shareable-address` - Get the single best shareable P2P address
     /// - `GET /api/v0/p2p/peers` - List connected peers
     /// - `POST /api/v0/p2p/peers` - Connect to a peer
     /// - And other P2P management endpoints

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -158,6 +158,13 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
+    async fn notify_network_change(&self) -> P2PResult<()> {
+        self.transport
+            .network_change()
+            .await
+            .map_err(|error| P2PError::transport(error.to_string()))
+    }
+
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         let p2p_infos = self
             .transport

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -11,7 +11,9 @@ use crate::{
     P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo, ReplicatorPushOptions,
 };
 
-use p2p::iroh::{format_public_listen_addrs, parse_public_peer_addr, IrohTransport};
+use p2p::iroh::{
+    best_shareable_public_addr, format_public_listen_addrs, parse_public_peer_addr, IrohTransport,
+};
 use p2p::sync::IrohSyncCoordinator;
 use p2p::topics::DefraTopic;
 use p2p::P2PTransport;
@@ -106,6 +108,14 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             .listen_addresses()
             .await
             .map(|addrs| format_public_listen_addrs(self.transport.local_peer_id(), &addrs))
+            .map_err(|error| P2PError::transport(error.to_string()))
+    }
+
+    async fn shareable_address(&self) -> P2PResult<Option<String>> {
+        self.transport
+            .listen_addresses()
+            .await
+            .map(|addrs| best_shareable_public_addr(self.transport.local_peer_id(), &addrs))
             .map_err(|error| P2PError::transport(error.to_string()))
     }
 

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -171,6 +171,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
+    async fn notify_network_change(&self) -> P2PResult<()> {
+        Ok(())
+    }
+
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
         let p2p_infos = self
             .handle

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -36,6 +36,7 @@ serde_bytes = { workspace = true }
 postcard = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
+sha2 = { workspace = true }
 
 # UUID for message IDs
 uuid = { workspace = true }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -35,6 +35,7 @@ serde_cbor = { workspace = true }
 serde_bytes = { workspace = true }
 postcard = { workspace = true }
 base64 = { workspace = true }
+hex = { workspace = true }
 
 # UUID for message IDs
 uuid = { workspace = true }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -33,6 +33,7 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }
 serde_bytes = { workspace = true }
+postcard = { workspace = true }
 base64 = { workspace = true }
 
 # UUID for message IDs
@@ -64,14 +65,13 @@ iroh = { workspace = true, optional = true }
 iroh-gossip = { workspace = true, optional = true }
 iroh-blobs = { workspace = true, optional = true }
 iroh-tickets = { workspace = true, optional = true }
-postcard = { workspace = true, optional = true }
 rand = { version = "0.9", optional = true }
 blake3 = { version = "1", optional = true }
 
 [features]
 default = []
 test-utils = []
-iroh-transport = ["dep:iroh", "dep:iroh-gossip", "dep:iroh-blobs", "dep:iroh-tickets", "dep:postcard", "dep:rand", "dep:blake3"]
+iroh-transport = ["dep:iroh", "dep:iroh-gossip", "dep:iroh-blobs", "dep:iroh-tickets", "dep:rand", "dep:blake3"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -150,6 +150,12 @@ pub enum Error {
     #[error("blockstore error: {0}")]
     BlockstoreError(String),
 
+    /// Blockstore operation failed because of a retriable storage-layer
+    /// transaction conflict. Kept distinct from `BlockstoreError` so retry
+    /// logic can match on a typed variant instead of a string suffix.
+    #[error("blockstore transaction conflict")]
+    BlockstoreTxnConflict,
+
     /// Failed to send response.
     #[error("failed to send response: {0}")]
     ResponseSend(String),
@@ -244,11 +250,31 @@ pub enum Error {
 }
 
 impl Error {
+    /// Suffix that storage surfaces in stringified transaction-conflict errors.
+    ///
+    /// Used only as a fallback for legacy call sites that still construct
+    /// `BlockstoreError`/`Storage` from an already-stringified error chain.
+    /// New call sites should flow typed `blockstore::Error` /
+    /// `storage::corekv::Error` values through `Error::from_blockstore`
+    /// instead, which preserves `BlockstoreTxnConflict` without relying on
+    /// wording stability.
     const TXN_CONFLICT_SUFFIX: &str = "transaction conflict. Please retry";
+
+    /// Convert a typed blockstore error into the nearest P2P error,
+    /// preserving the retriable transaction-conflict signal instead of
+    /// stringifying it away.
+    pub fn from_blockstore(err: blockstore::Error) -> Self {
+        if err.is_txn_conflict() {
+            Error::BlockstoreTxnConflict
+        } else {
+            Error::BlockstoreError(err.to_string())
+        }
+    }
 
     /// Returns true if this error represents a storage-layer transaction conflict.
     pub fn is_txn_conflict(&self) -> bool {
         match self {
+            Error::BlockstoreTxnConflict => true,
             Error::BlockstoreError(msg) | Error::Storage(msg) => {
                 msg.ends_with(Self::TXN_CONFLICT_SUFFIX)
             }
@@ -320,6 +346,8 @@ mod tests {
 
     #[test]
     fn txn_conflict_detection_matches_wrapped_storage_messages() {
+        // Legacy stringified variants: retained so any caller that still
+        // builds errors by stringifying stays retriable.
         let blockstore_error =
             Error::BlockstoreError("storage error: transaction conflict. Please retry".into());
         let storage_error = Error::Storage("transaction conflict. Please retry".into());
@@ -328,6 +356,32 @@ mod tests {
         assert!(storage_error.is_txn_conflict());
         assert!(blockstore_error.is_retriable());
         assert!(storage_error.is_retriable());
+    }
+
+    #[test]
+    fn txn_conflict_detection_matches_typed_variant() {
+        let typed = Error::BlockstoreTxnConflict;
+        assert!(typed.is_txn_conflict());
+        assert!(typed.is_retriable());
+    }
+
+    #[test]
+    fn from_blockstore_preserves_typed_txn_conflict() {
+        let conflict = blockstore::Error::Storage(storage::corekv::Error::TxnConflict);
+        assert!(conflict.is_txn_conflict());
+        let p2p_err = Error::from_blockstore(conflict);
+        assert!(matches!(p2p_err, Error::BlockstoreTxnConflict));
+        assert!(p2p_err.is_retriable());
+    }
+
+    #[test]
+    fn from_blockstore_non_conflict_keeps_stringified_message() {
+        let other = blockstore::Error::NotFound("missing".into());
+        let p2p_err = Error::from_blockstore(other);
+        match p2p_err {
+            Error::BlockstoreError(msg) => assert!(msg.contains("missing")),
+            other => panic!("expected BlockstoreError, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/p2p/src/host/p2p_host/protocols.rs
+++ b/crates/p2p/src/host/p2p_host/protocols.rs
@@ -172,11 +172,24 @@ impl<S: Store> P2PHost<S> {
                         }
                     }
                     Err(e) => {
+                        let payload_info =
+                            crate::message::PushLogBroadcast::inspect_gossip_payload(&message.data);
+                        let sample = crate::sync::GossipDecodeFailureSample {
+                            transport: crate::sync::GossipTransport::Libp2p,
+                            peer_id: propagation_source.to_string(),
+                            topic: topic.clone(),
+                            message_size: message.data.len(),
+                            error: e.clone(),
+                            payload_prefix_hex: payload_info.payload_prefix_hex,
+                            payload_shape_hint: payload_info.payload_shape_hint,
+                            occurrences: 0,
+                        };
                         // Exponential-backoff sampling: warn on the
                         // 1st, 2nd, 4th, 8th... occurrence; remainder at
                         // debug. Shared process-global counter with the
                         // iroh transport (issue #858).
-                        let count = crate::sync::record_gossip_decode_failure();
+                        let count =
+                            crate::sync::record_gossip_decode_failure_sample(sample.clone());
                         if count == 1 || count.is_power_of_two() {
                             warn!(
                                 peer_id = %propagation_source,
@@ -184,6 +197,8 @@ impl<S: Store> P2PHost<S> {
                                 message_size = message.data.len(),
                                 total_failures = count,
                                 error = %e,
+                                payload_prefix = %sample.payload_prefix_hex,
+                                payload_shape = %sample.payload_shape_hint,
                                 "Failed to decode gossipsub message as PushLogBroadcast or PushLogRequest"
                             );
                         } else {
@@ -193,6 +208,8 @@ impl<S: Store> P2PHost<S> {
                                 message_size = message.data.len(),
                                 total_failures = count,
                                 error = %e,
+                                payload_prefix = %sample.payload_prefix_hex,
+                                payload_shape = %sample.payload_shape_hint,
                                 "Failed to decode gossipsub message"
                             );
                         }

--- a/crates/p2p/src/host/p2p_host/protocols.rs
+++ b/crates/p2p/src/host/p2p_host/protocols.rs
@@ -139,18 +139,19 @@ impl<S: Store> P2PHost<S> {
                     message_id, topic, propagation_source
                 );
 
-                // Decode the message payload.
-                // Rust-to-Rust sends PushLogBroadcast (no MetaData).
-                // Go-to-Rust sends PushLogRequest (with MetaData).
-                // Try PushLogBroadcast first, then fall back to PushLogRequest.
-                let broadcast =
-                    serde_cbor::from_slice::<PushLogBroadcast>(&message.data).or_else(|_| {
-                        serde_cbor::from_slice::<PushLogRequest>(&message.data)
-                            .map(|req| PushLogBroadcast::from_request(&req))
-                    });
-
-                match broadcast {
-                    Ok(broadcast) => {
+                match PushLogBroadcast::decode_gossip_payload(&message.data) {
+                    Ok((broadcast, encoding)) => {
+                        if encoding != crate::message::PushLogGossipPayloadEncoding::CborBroadcast
+                            && encoding != crate::message::PushLogGossipPayloadEncoding::CborRequest
+                        {
+                            debug!(
+                                peer_id = %propagation_source,
+                                topic = %topic,
+                                message_size = message.data.len(),
+                                ?encoding,
+                                "Decoded libp2p gossip payload via compatibility fallback"
+                            );
+                        }
                         if self
                             .event_tx
                             .send(HostEvent::GossipMessage {

--- a/crates/p2p/src/host/p2p_host/protocols.rs
+++ b/crates/p2p/src/host/p2p_host/protocols.rs
@@ -180,7 +180,7 @@ impl<S: Store> P2PHost<S> {
                             topic: topic.clone(),
                             message_size: message.data.len(),
                             error: e.clone(),
-                            payload_prefix_hex: payload_info.payload_prefix_hex,
+                            payload_fingerprint: payload_info.payload_fingerprint,
                             payload_shape_hint: payload_info.payload_shape_hint,
                             occurrences: 0,
                         };
@@ -197,7 +197,7 @@ impl<S: Store> P2PHost<S> {
                                 message_size = message.data.len(),
                                 total_failures = count,
                                 error = %e,
-                                payload_prefix = %sample.payload_prefix_hex,
+                                payload_fingerprint = %sample.payload_fingerprint,
                                 payload_shape = %sample.payload_shape_hint,
                                 "Failed to decode gossipsub message as PushLogBroadcast or PushLogRequest"
                             );
@@ -208,7 +208,7 @@ impl<S: Store> P2PHost<S> {
                                 message_size = message.data.len(),
                                 total_failures = count,
                                 error = %e,
-                                payload_prefix = %sample.payload_prefix_hex,
+                                payload_fingerprint = %sample.payload_fingerprint,
                                 payload_shape = %sample.payload_shape_hint,
                                 "Failed to decode gossipsub message"
                             );

--- a/crates/p2p/src/iroh/addr.rs
+++ b/crates/p2p/src/iroh/addr.rs
@@ -116,6 +116,17 @@ pub fn format_public_listen_addrs(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> V
     formatted
 }
 
+/// Select the best public iroh address to share with another node.
+///
+/// This prefers endpoint tickets, then direct connectable addresses, and skips
+/// the bare endpoint ID fallback because callers asked for a concrete address
+/// rather than an identity-only hint.
+pub fn best_shareable_public_addr(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> Option<String> {
+    format_public_listen_addrs(peer_id, raw_addrs)
+        .into_iter()
+        .find(|addr| is_ticket_string(addr) || addr.contains("/p2p/"))
+}
+
 /// Build an [`EndpointAddr`] from a peer id and a list of dial hints.
 pub fn endpoint_addr_from_parts(peer_id: &PeerId, addrs: &[PeerAddr]) -> Result<EndpointAddr> {
     let endpoint_id = parse_endpoint_id(peer_id)?;
@@ -236,5 +247,53 @@ mod tests {
             format_public_listen_addrs(&peer_id, &[PeerAddr::new("127.0.0.1:9999".to_string())]);
 
         assert_eq!(formatted, vec![direct, peer_id.to_string()]);
+    }
+
+    #[test]
+    fn best_shareable_public_addr_prefers_ticket() {
+        let peer_id = PeerId::new(endpoint_id().to_string());
+        let ticket = EndpointTicket::from(
+            EndpointAddr::new(endpoint_id()).with_ip_addr("127.0.0.1:9999".parse().unwrap()),
+        )
+        .to_string();
+
+        let selected = best_shareable_public_addr(
+            &peer_id,
+            &[
+                PeerAddr::new(format!("iroh://{}", peer_id)),
+                PeerAddr::new("127.0.0.1:9999".to_string()),
+                PeerAddr::new(ticket.clone()),
+            ],
+        );
+
+        assert_eq!(selected, Some(ticket));
+    }
+
+    #[test]
+    fn best_shareable_public_addr_falls_back_to_direct_addr() {
+        let peer_id = PeerId::new(endpoint_id().to_string());
+
+        let selected = best_shareable_public_addr(
+            &peer_id,
+            &[
+                PeerAddr::new(format!("iroh://{}", peer_id)),
+                PeerAddr::new("127.0.0.1:9999".to_string()),
+            ],
+        );
+
+        assert_eq!(
+            selected,
+            Some(format!("127.0.0.1:9999/p2p/{}", peer_id.as_str()))
+        );
+    }
+
+    #[test]
+    fn best_shareable_public_addr_skips_identity_only_fallback() {
+        let peer_id = PeerId::new(endpoint_id().to_string());
+
+        let selected =
+            best_shareable_public_addr(&peer_id, &[PeerAddr::new(format!("iroh://{}", peer_id))]);
+
+        assert_eq!(selected, None);
     }
 }

--- a/crates/p2p/src/iroh/addr.rs
+++ b/crates/p2p/src/iroh/addr.rs
@@ -72,10 +72,10 @@ pub fn parse_public_peer_addr(addr: &str) -> Result<(PeerId, Vec<PeerAddr>)> {
 
 /// Render raw iroh endpoint listen addresses into stable, connectable public strings.
 ///
-/// The returned list prefers endpoint tickets first because they carry the
-/// most complete dial hints and stay valid across interface churn. Direct
-/// addresses are included after tickets, followed by a bare endpoint ID as a
-/// stable identity-only reference.
+/// The returned list keeps direct addresses first for compatibility with
+/// existing callers that treat the first entry as a multiaddr-like dial
+/// address. Endpoint tickets are included after direct addresses, followed by
+/// a bare endpoint ID as a stable identity-only reference.
 pub fn format_public_listen_addrs(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> Vec<String> {
     let mut direct = Vec::new();
     let mut tickets = Vec::new();
@@ -103,10 +103,10 @@ pub fn format_public_listen_addrs(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> V
         }
     }
 
-    let mut formatted = tickets;
-    for addr in direct {
-        if !formatted.contains(&addr) {
-            formatted.push(addr);
+    let mut formatted = direct;
+    for ticket in tickets {
+        if !formatted.contains(&ticket) {
+            formatted.push(ticket);
         }
     }
     if !formatted.contains(&peer_id.to_string()) {
@@ -122,9 +122,12 @@ pub fn format_public_listen_addrs(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> V
 /// the bare endpoint ID fallback because callers asked for a concrete address
 /// rather than an identity-only hint.
 pub fn best_shareable_public_addr(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> Option<String> {
-    format_public_listen_addrs(peer_id, raw_addrs)
-        .into_iter()
-        .find(|addr| is_ticket_string(addr) || addr.contains("/p2p/"))
+    let formatted = format_public_listen_addrs(peer_id, raw_addrs);
+    formatted
+        .iter()
+        .find(|addr| is_ticket_string(addr))
+        .cloned()
+        .or_else(|| formatted.into_iter().find(|addr| addr.contains("/p2p/")))
 }
 
 /// Build an [`EndpointAddr`] from a peer id and a list of dial hints.
@@ -217,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn format_public_addresses_prefers_ticket_before_direct_addrs() {
+    fn format_public_addresses_preserve_direct_first_for_legacy_callers() {
         let peer_id = PeerId::new(endpoint_id().to_string());
         let ticket = EndpointTicket::from(
             EndpointAddr::new(endpoint_id()).with_ip_addr("127.0.0.1:9999".parse().unwrap()),
@@ -233,8 +236,9 @@ mod tests {
             ],
         );
 
-        assert_eq!(formatted[0], ticket);
+        assert_eq!(formatted[0], direct);
         assert!(formatted.contains(&direct));
+        assert!(formatted.contains(&ticket));
         assert!(formatted.contains(&peer_id.to_string()));
     }
 

--- a/crates/p2p/src/iroh/addr.rs
+++ b/crates/p2p/src/iroh/addr.rs
@@ -72,9 +72,10 @@ pub fn parse_public_peer_addr(addr: &str) -> Result<(PeerId, Vec<PeerAddr>)> {
 
 /// Render raw iroh endpoint listen addresses into stable, connectable public strings.
 ///
-/// The returned list prefers directly dialable addresses first so existing callers can
-/// connect with the first entry. A bare endpoint ID is still included last as a stable
-/// identity-only reference.
+/// The returned list prefers endpoint tickets first because they carry the
+/// most complete dial hints and stay valid across interface churn. Direct
+/// addresses are included after tickets, followed by a bare endpoint ID as a
+/// stable identity-only reference.
 pub fn format_public_listen_addrs(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> Vec<String> {
     let mut direct = Vec::new();
     let mut tickets = Vec::new();
@@ -102,10 +103,10 @@ pub fn format_public_listen_addrs(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> V
         }
     }
 
-    let mut formatted = direct;
-    for ticket in tickets {
-        if !formatted.contains(&ticket) {
-            formatted.push(ticket);
+    let mut formatted = tickets;
+    for addr in direct {
+        if !formatted.contains(&addr) {
+            formatted.push(addr);
         }
     }
     if !formatted.contains(&peer_id.to_string()) {
@@ -205,12 +206,13 @@ mod tests {
     }
 
     #[test]
-    fn format_public_addresses_keeps_legacy_id_and_ticket() {
+    fn format_public_addresses_prefers_ticket_before_direct_addrs() {
         let peer_id = PeerId::new(endpoint_id().to_string());
         let ticket = EndpointTicket::from(
             EndpointAddr::new(endpoint_id()).with_ip_addr("127.0.0.1:9999".parse().unwrap()),
         )
         .to_string();
+        let direct = format!("127.0.0.1:9999/p2p/{peer_id}");
         let formatted = format_public_listen_addrs(
             &peer_id,
             &[
@@ -220,8 +222,19 @@ mod tests {
             ],
         );
 
-        assert_eq!(formatted[0], format!("127.0.0.1:9999/p2p/{peer_id}"));
-        assert!(formatted.contains(&ticket));
+        assert_eq!(formatted[0], ticket);
+        assert!(formatted.contains(&direct));
         assert!(formatted.contains(&peer_id.to_string()));
+    }
+
+    #[test]
+    fn format_public_addresses_without_ticket_still_return_direct_addrs() {
+        let peer_id = PeerId::new(endpoint_id().to_string());
+        let direct = format!("127.0.0.1:9999/p2p/{peer_id}");
+
+        let formatted =
+            format_public_listen_addrs(&peer_id, &[PeerAddr::new("127.0.0.1:9999".to_string())]);
+
+        assert_eq!(formatted, vec![direct, peer_id.to_string()]);
     }
 }

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -563,7 +563,7 @@ pub(super) async fn handle_subscribe(
                                     topic: topic_str_clone.clone(),
                                     message_size: msg.content.len(),
                                     error: e.clone(),
-                                    payload_prefix_hex: payload_info.payload_prefix_hex,
+                                    payload_fingerprint: payload_info.payload_fingerprint,
                                     payload_shape_hint: payload_info.payload_shape_hint,
                                     occurrences: 0,
                                 };
@@ -581,7 +581,7 @@ pub(super) async fn handle_subscribe(
                                         message_size = msg.content.len(),
                                         total_failures = count,
                                         error = %e,
-                                        payload_prefix = %sample.payload_prefix_hex,
+                                        payload_fingerprint = %sample.payload_fingerprint,
                                         payload_shape = %sample.payload_shape_hint,
                                         "Failed to decode Iroh gossip message as PushLogBroadcast or PushLogRequest"
                                     );
@@ -592,7 +592,7 @@ pub(super) async fn handle_subscribe(
                                         message_size = msg.content.len(),
                                         total_failures = count,
                                         error = %e,
-                                        payload_prefix = %sample.payload_prefix_hex,
+                                        payload_fingerprint = %sample.payload_fingerprint,
                                         payload_shape = %sample.payload_shape_hint,
                                         "Failed to decode Iroh gossip message"
                                     );

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -552,12 +552,28 @@ pub(super) async fn handle_subscribe(
                                 }
                             }
                             Err(e) => {
+                                let payload_info =
+                                    crate::message::PushLogBroadcast::inspect_gossip_payload(
+                                        &msg.content,
+                                    );
+                                let sender_peer_id = endpoint_id_to_peer_id(&msg.delivered_from);
+                                let sample = crate::sync::GossipDecodeFailureSample {
+                                    transport: crate::sync::GossipTransport::Iroh,
+                                    peer_id: sender_peer_id.to_string(),
+                                    topic: topic_str_clone.clone(),
+                                    message_size: msg.content.len(),
+                                    error: e.clone(),
+                                    payload_prefix_hex: payload_info.payload_prefix_hex,
+                                    payload_shape_hint: payload_info.payload_shape_hint,
+                                    occurrences: 0,
+                                };
                                 // Exponential-backoff sampling: warn on the
                                 // 1st, 2nd, 4th, 8th... occurrence; remainder
                                 // at debug. Counter is process-global and
                                 // surfaced via SyncDiagnostics (issue #858).
-                                let count = crate::sync::record_gossip_decode_failure();
-                                let sender_peer_id = endpoint_id_to_peer_id(&msg.delivered_from);
+                                let count = crate::sync::record_gossip_decode_failure_sample(
+                                    sample.clone(),
+                                );
                                 if count == 1 || count.is_power_of_two() {
                                     warn!(
                                         peer_id = %sender_peer_id,
@@ -565,6 +581,8 @@ pub(super) async fn handle_subscribe(
                                         message_size = msg.content.len(),
                                         total_failures = count,
                                         error = %e,
+                                        payload_prefix = %sample.payload_prefix_hex,
+                                        payload_shape = %sample.payload_shape_hint,
                                         "Failed to decode Iroh gossip message as PushLogBroadcast or PushLogRequest"
                                     );
                                 } else {
@@ -574,6 +592,8 @@ pub(super) async fn handle_subscribe(
                                         message_size = msg.content.len(),
                                         total_failures = count,
                                         error = %e,
+                                        payload_prefix = %sample.payload_prefix_hex,
+                                        payload_shape = %sample.payload_shape_hint,
                                         "Failed to decode Iroh gossip message"
                                     );
                                 }

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -523,10 +523,19 @@ pub(super) async fn handle_subscribe(
             match result {
                 Ok(event) => match event {
                     iroh_gossip::api::Event::Received(msg) => {
-                        match postcard::from_bytes::<crate::message::PushLogBroadcast>(&msg.content)
+                        match crate::message::PushLogBroadcast::decode_gossip_payload(&msg.content)
                         {
-                            Ok(broadcast) => {
+                            Ok((broadcast, encoding)) => {
                                 let sender_peer_id = endpoint_id_to_peer_id(&msg.delivered_from);
+                                if encoding != crate::message::PushLogGossipPayloadEncoding::PostcardBroadcast {
+                                    debug!(
+                                        peer_id = %sender_peer_id,
+                                        topic = %topic_str_clone,
+                                        message_size = msg.content.len(),
+                                        ?encoding,
+                                        "Decoded Iroh gossip message via compatibility fallback"
+                                    );
+                                }
                                 let msg_id = MessageId::new(uuid::Uuid::new_v4().to_string());
                                 if event_tx
                                     .send(TransportEvent::GossipMessage {
@@ -556,8 +565,7 @@ pub(super) async fn handle_subscribe(
                                         message_size = msg.content.len(),
                                         total_failures = count,
                                         error = %e,
-                                        "Failed to decode gossip message \
-                                         (version skew or malformed sender?)"
+                                        "Failed to decode Iroh gossip message as PushLogBroadcast or PushLogRequest"
                                     );
                                 } else {
                                     debug!(
@@ -566,7 +574,7 @@ pub(super) async fn handle_subscribe(
                                         message_size = msg.content.len(),
                                         total_failures = count,
                                         error = %e,
-                                        "Failed to decode gossip message"
+                                        "Failed to decode Iroh gossip message"
                                     );
                                 }
                             }

--- a/crates/p2p/src/iroh/mod.rs
+++ b/crates/p2p/src/iroh/mod.rs
@@ -23,8 +23,8 @@ mod secret_key;
 mod transport;
 
 pub use addr::{
-    endpoint_addr_from_parts, endpoint_ticket_string, format_public_listen_addrs, is_ticket_string,
-    parse_public_peer_addr,
+    best_shareable_public_addr, endpoint_addr_from_parts, endpoint_ticket_string,
+    format_public_listen_addrs, is_ticket_string, parse_public_peer_addr,
 };
 pub use config::{IrohDiscoveryConfig, IrohRelayModeConfig};
 pub use endpoint::spawn_endpoint;

--- a/crates/p2p/src/message/mod.rs
+++ b/crates/p2p/src/message/mod.rs
@@ -42,7 +42,7 @@ pub use car::CarFetchRequest;
 pub use docsync::{DocSyncItem, DocSyncReply, DocSyncRequest, MAX_DOC_IDS};
 pub use identity::{IdentityRequest, IdentityResponse};
 pub use metadata::MetaData;
-pub use pushlog::{PushLogBroadcast, PushLogReply, PushLogRequest};
+pub use pushlog::{PushLogBroadcast, PushLogGossipPayloadEncoding, PushLogReply, PushLogRequest};
 pub use se::{
     PushSEArtifactsReply, PushSEArtifactsRequest, QuerySEArtifactsReply, QuerySEArtifactsRequest,
     SEArtifact, SEFieldQuery,

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -289,6 +289,82 @@ pub enum PushLogGossipPayloadEncoding {
     CborBroadcast,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PushLogGossipPayloadDebugInfo {
+    pub payload_prefix_hex: String,
+    pub payload_shape_hint: String,
+}
+
+const GOSSIP_PAYLOAD_PREFIX_BYTES: usize = 24;
+const GOSSIP_TEXT_PREFIX_CHARS: usize = 48;
+
+fn truncated_text_prefix(text: &str) -> String {
+    let mut prefix = String::new();
+    let mut chars = text.chars();
+    for _ in 0..GOSSIP_TEXT_PREFIX_CHARS {
+        match chars.next() {
+            Some(ch) => prefix.push(ch),
+            None => return prefix,
+        }
+    }
+    if chars.next().is_some() {
+        prefix.push_str("...");
+    }
+    prefix
+}
+
+fn describe_cbor_value(value: &serde_cbor::Value) -> String {
+    match value {
+        serde_cbor::Value::Map(entries) => {
+            let keys: Vec<String> = entries
+                .iter()
+                .filter_map(|(key, _)| match key {
+                    serde_cbor::Value::Text(text) => Some(text.clone()),
+                    _ => None,
+                })
+                .take(10)
+                .collect();
+            if keys.is_empty() {
+                format!("cbor_map(len={})", entries.len())
+            } else {
+                format!("cbor_map(keys=[{}])", keys.join(","))
+            }
+        }
+        serde_cbor::Value::Array(items) => format!("cbor_array(len={})", items.len()),
+        serde_cbor::Value::Bytes(bytes) => format!("cbor_bytes(len={})", bytes.len()),
+        serde_cbor::Value::Text(text) => {
+            format!("cbor_text(prefix={:?})", truncated_text_prefix(text))
+        }
+        serde_cbor::Value::Tag(tag, _) => format!("cbor_tag({tag})"),
+        serde_cbor::Value::Bool(value) => format!("cbor_bool({value})"),
+        serde_cbor::Value::Null => "cbor_null".to_string(),
+        serde_cbor::Value::Integer(_) => "cbor_integer".to_string(),
+        serde_cbor::Value::Float(_) => "cbor_float".to_string(),
+        _ => "cbor_scalar".to_string(),
+    }
+}
+
+fn describe_gossip_payload_shape(payload: &[u8]) -> String {
+    if payload.is_empty() {
+        return "empty".to_string();
+    }
+
+    if let Ok(value) = serde_cbor::from_slice::<serde_cbor::Value>(payload) {
+        return describe_cbor_value(&value);
+    }
+
+    if payload
+        .iter()
+        .all(|byte| byte.is_ascii_graphic() || byte.is_ascii_whitespace())
+    {
+        if let Ok(text) = std::str::from_utf8(payload) {
+            return format!("utf8_text(prefix={:?})", truncated_text_prefix(text));
+        }
+    }
+
+    format!("opaque_binary(first_byte=0x{:02x})", payload[0])
+}
+
 impl PushLogBroadcast {
     /// Create a new PushLogBroadcast.
     pub fn new(
@@ -357,5 +433,51 @@ impl PushLogBroadcast {
                     .map(|broadcast| (broadcast, PushLogGossipPayloadEncoding::CborBroadcast))
             })
             .map_err(|error| error.to_string())
+    }
+
+    pub(crate) fn inspect_gossip_payload(payload: &[u8]) -> PushLogGossipPayloadDebugInfo {
+        PushLogGossipPayloadDebugInfo {
+            payload_prefix_hex: hex::encode(
+                &payload[..payload.len().min(GOSSIP_PAYLOAD_PREFIX_BYTES)],
+            ),
+            payload_shape_hint: describe_gossip_payload_shape(payload),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inspect_gossip_payload_identifies_cbor_request_shape() {
+        let payload = serde_cbor::to_vec(&PushLogRequest::new(
+            "doc-1".to_string(),
+            Bytes::from_static(&[1, 2, 3]),
+            "collection-1".to_string(),
+            "creator-1".to_string(),
+            Bytes::from_static(&[4, 5, 6]),
+        ))
+        .expect("request should encode");
+
+        let info = PushLogBroadcast::inspect_gossip_payload(&payload);
+        assert!(info.payload_shape_hint.starts_with("cbor_map("));
+        assert!(info.payload_shape_hint.contains("DocID"));
+        assert!(info.payload_shape_hint.contains("CollectionID"));
+        assert!(!info.payload_prefix_hex.is_empty());
+    }
+
+    #[test]
+    fn inspect_gossip_payload_identifies_utf8_text_shape() {
+        let info = PushLogBroadcast::inspect_gossip_payload(b"hello from some other producer");
+        assert!(info.payload_shape_hint.starts_with("utf8_text("));
+        assert!(!info.payload_prefix_hex.is_empty());
+    }
+
+    #[test]
+    fn inspect_gossip_payload_identifies_opaque_binary_shape() {
+        let info = PushLogBroadcast::inspect_gossip_payload(&[0xff, 0x00, 0x01, 0x02]);
+        assert_eq!(info.payload_shape_hint, "opaque_binary(first_byte=0xff)");
+        assert_eq!(info.payload_prefix_hex, "ff000102");
     }
 }

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -274,11 +274,16 @@ pub struct PushLogBroadcast {
     pub block: Bytes,
 
     /// Optional local-ACP actor relationship snapshot for this document.
-    #[serde(
-        rename = "ACPActorRelationships",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    ///
+    /// Unlike `PushLogRequest`, this field is NOT tagged with
+    /// `skip_serializing_if = "Option::is_none"`. Iroh gossip publishes this
+    /// struct via `postcard::to_allocvec`, and postcard is a non-self-describing
+    /// format: a trailing Option that the serializer skips leaves the
+    /// deserializer reading past end-of-input. Always emitting the Option
+    /// discriminator keeps postcard round-trips intact; CBOR consumers remain
+    /// compatible because a `None` is encoded as CBOR null and the `default`
+    /// attribute makes the field still optional on decode.
+    #[serde(rename = "ACPActorRelationships", default)]
     pub acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
 }
 
@@ -485,5 +490,33 @@ mod tests {
         let info = PushLogBroadcast::inspect_gossip_payload(&[0xff, 0x00, 0x01, 0x02]);
         assert_eq!(info.payload_shape_hint, "opaque_binary(first_byte=0xff)");
         assert_eq!(info.payload_fingerprint, "0c252d844a815f83");
+    }
+
+    #[test]
+    fn postcard_round_trip_without_acp_relationships() {
+        // Regression: iroh gossip publishes PushLogBroadcast via postcard. If
+        // the acp_actor_relationships field is `skip_serializing_if`d when
+        // `None`, postcard runs off the end of the buffer on decode because
+        // postcard is a non-self-describing format. Non-ACP updates were
+        // silently dropped on the receiver before this check.
+        let broadcast = PushLogBroadcast::new(
+            "bae-eabce396-ddf9-5a76-85ac-ade4e4205de9".to_string(),
+            Bytes::from_static(&[0xaa; 38]),
+            "bafyreiabcdefghijklmnopqrstuvwxyz123456789012345678".to_string(),
+            "12D3KooWExamplePeerIdForTestingOnly0000000000000".to_string(),
+            Bytes::from_static(&[0xbb; 128]),
+            None,
+        );
+
+        let encoded = postcard::to_allocvec(&broadcast).expect("postcard encode");
+        let decoded: PushLogBroadcast =
+            postcard::from_bytes(&encoded).expect("postcard round trip");
+        assert_eq!(decoded, broadcast);
+        assert!(decoded.acp_actor_relationships.is_none());
+
+        let (via_decode_gossip, encoding) =
+            PushLogBroadcast::decode_gossip_payload(&encoded).expect("decode via gossip path");
+        assert_eq!(encoding, PushLogGossipPayloadEncoding::PostcardBroadcast);
+        assert_eq!(via_decode_gossip, broadcast);
     }
 }

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -2,6 +2,7 @@
 
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use acp::ReplicatedDocActorRelationships;
 
@@ -291,12 +292,12 @@ pub enum PushLogGossipPayloadEncoding {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PushLogGossipPayloadDebugInfo {
-    pub payload_prefix_hex: String,
+    pub payload_fingerprint: String,
     pub payload_shape_hint: String,
 }
 
-const GOSSIP_PAYLOAD_PREFIX_BYTES: usize = 24;
 const GOSSIP_TEXT_PREFIX_CHARS: usize = 48;
+const GOSSIP_PAYLOAD_FINGERPRINT_BYTES: usize = 8;
 
 fn truncated_text_prefix(text: &str) -> String {
     let mut prefix = String::new();
@@ -436,10 +437,9 @@ impl PushLogBroadcast {
     }
 
     pub(crate) fn inspect_gossip_payload(payload: &[u8]) -> PushLogGossipPayloadDebugInfo {
+        let digest = Sha256::digest(payload);
         PushLogGossipPayloadDebugInfo {
-            payload_prefix_hex: hex::encode(
-                &payload[..payload.len().min(GOSSIP_PAYLOAD_PREFIX_BYTES)],
-            ),
+            payload_fingerprint: hex::encode(&digest[..GOSSIP_PAYLOAD_FINGERPRINT_BYTES]),
             payload_shape_hint: describe_gossip_payload_shape(payload),
         }
     }
@@ -464,20 +464,26 @@ mod tests {
         assert!(info.payload_shape_hint.starts_with("cbor_map("));
         assert!(info.payload_shape_hint.contains("DocID"));
         assert!(info.payload_shape_hint.contains("CollectionID"));
-        assert!(!info.payload_prefix_hex.is_empty());
+        assert_eq!(
+            info.payload_fingerprint.len(),
+            GOSSIP_PAYLOAD_FINGERPRINT_BYTES * 2
+        );
     }
 
     #[test]
     fn inspect_gossip_payload_identifies_utf8_text_shape() {
         let info = PushLogBroadcast::inspect_gossip_payload(b"hello from some other producer");
         assert!(info.payload_shape_hint.starts_with("utf8_text("));
-        assert!(!info.payload_prefix_hex.is_empty());
+        assert_eq!(
+            info.payload_fingerprint.len(),
+            GOSSIP_PAYLOAD_FINGERPRINT_BYTES * 2
+        );
     }
 
     #[test]
     fn inspect_gossip_payload_identifies_opaque_binary_shape() {
         let info = PushLogBroadcast::inspect_gossip_payload(&[0xff, 0x00, 0x01, 0x02]);
         assert_eq!(info.payload_shape_hint, "opaque_binary(first_byte=0xff)");
-        assert_eq!(info.payload_prefix_hex, "ff000102");
+        assert_eq!(info.payload_fingerprint, "0c252d844a815f83");
     }
 }

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -323,8 +323,8 @@ fn describe_cbor_value(value: &serde_cbor::Value) -> String {
     match value {
         serde_cbor::Value::Map(entries) => {
             let keys: Vec<String> = entries
-                .iter()
-                .filter_map(|(key, _)| match key {
+                .keys()
+                .filter_map(|key| match key {
                     serde_cbor::Value::Text(text) => Some(text.clone()),
                     _ => None,
                 })

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -281,6 +281,14 @@ pub struct PushLogBroadcast {
     pub acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
 }
 
+/// Encoding variant accepted when decoding gossip payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushLogGossipPayloadEncoding {
+    PostcardBroadcast,
+    CborRequest,
+    CborBroadcast,
+}
+
 impl PushLogBroadcast {
     /// Create a new PushLogBroadcast.
     pub fn new(
@@ -324,5 +332,30 @@ impl PushLogBroadcast {
         );
         request.acp_actor_relationships = self.acp_actor_relationships.clone();
         request
+    }
+
+    /// Decode a gossip payload using the set of encodings accepted across P2P transports.
+    ///
+    /// We prefer the native Iroh wire encoding first, then fall back to request-shaped
+    /// payloads and the legacy CBOR variants accepted by libp2p.
+    pub fn decode_gossip_payload(
+        payload: &[u8],
+    ) -> Result<(Self, PushLogGossipPayloadEncoding), String> {
+        if let Ok(broadcast) = postcard::from_bytes::<Self>(payload) {
+            return Ok((broadcast, PushLogGossipPayloadEncoding::PostcardBroadcast));
+        }
+
+        serde_cbor::from_slice::<PushLogRequest>(payload)
+            .map(|request| {
+                (
+                    Self::from_request(&request),
+                    PushLogGossipPayloadEncoding::CborRequest,
+                )
+            })
+            .or_else(|_| {
+                serde_cbor::from_slice::<Self>(payload)
+                    .map(|broadcast| (broadcast, PushLogGossipPayloadEncoding::CborBroadcast))
+            })
+            .map_err(|error| error.to_string())
     }
 }

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -3,10 +3,11 @@
 //! Verifies that DocSync and BranchableSync handlers enforce access checks
 //! in Controlled mode before processing requests.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use blockstore::DefraBlockstore;
+use blockstore::{Blockstore, DefraBlockstore, Error as BlockstoreError};
 use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
 use storage::backends::MemoryStore;
@@ -14,7 +15,9 @@ use tokio::time::timeout;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Error;
-use crate::message::{BranchableSyncRequest, DocSyncRequest, MetaData, PushLogRequest};
+use crate::message::{
+    BranchableSyncRequest, DocSyncRequest, MetaData, PushLogBroadcast, PushLogRequest,
+};
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
 use crate::sync::head_provider::NoOpHeadProvider;
@@ -48,6 +51,29 @@ fn create_test_coordinator(
     let broadcaster = Broadcaster::new(transport.clone());
     let store = Arc::new(MemoryStore::new());
     let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    create_test_coordinator_with_blockstore(
+        access_mode,
+        replicators,
+        peer_state,
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore,
+    )
+}
+
+fn create_test_coordinator_with_blockstore<B: Blockstore + 'static>(
+    access_mode: AccessMode,
+    replicators: Arc<ReplicatorRegistry>,
+    peer_state: Arc<PeerStateTracker>,
+    transport: NoopTransport,
+    local_peer_id: String,
+    broadcaster: Broadcaster<NoopTransport>,
+    blockstore: Arc<B>,
+) -> (
+    SyncCoordinator<B, NoopTransport>,
+    tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
+) {
     let (manager, events) = SyncManager::new(blockstore, peer_state.clone(), SyncConfig::default());
 
     let coordinator = SyncCoordinator {
@@ -81,6 +107,95 @@ fn create_test_coordinator(
     };
 
     (coordinator, events)
+}
+
+struct ConflictOnceBlockstore {
+    inner: TestBlockstore,
+    remaining_put_conflicts: AtomicUsize,
+    put_attempts: AtomicUsize,
+}
+
+impl ConflictOnceBlockstore {
+    fn new() -> Self {
+        let store = Arc::new(MemoryStore::new());
+        Self {
+            inner: DefraBlockstore::new(store, true),
+            remaining_put_conflicts: AtomicUsize::new(1),
+            put_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn put_attempts(&self) -> usize {
+        self.put_attempts.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Blockstore for ConflictOnceBlockstore {
+    async fn get(&self, cid: &Cid) -> blockstore::Result<Option<bytes::Bytes>> {
+        self.inner.get(cid).await
+    }
+
+    async fn put(&self, cid: &Cid, data: &[u8]) -> blockstore::Result<()> {
+        self.put_attempts.fetch_add(1, Ordering::SeqCst);
+        if self
+            .remaining_put_conflicts
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                if remaining > 0 {
+                    Some(remaining - 1)
+                } else {
+                    None
+                }
+            })
+            .is_ok()
+        {
+            return Err(BlockstoreError::Storage(
+                storage::corekv::Error::TxnConflict,
+            ));
+        }
+
+        self.inner.put(cid, data).await
+    }
+
+    async fn put_many(&self, blocks: &[(&Cid, &[u8])]) -> blockstore::Result<()> {
+        self.inner.put_many(blocks).await
+    }
+
+    async fn has(&self, cid: &Cid) -> blockstore::Result<bool> {
+        self.inner.has(cid).await
+    }
+
+    async fn delete(&self, cid: &Cid) -> blockstore::Result<()> {
+        self.inner.delete(cid).await
+    }
+
+    async fn get_size(&self, cid: &Cid) -> blockstore::Result<Option<usize>> {
+        self.inner.get_size(cid).await
+    }
+
+    async fn all_cids(&self) -> blockstore::Result<Vec<Cid>> {
+        self.inner.all_cids().await
+    }
+
+    fn hash_on_read(&self, enabled: bool) {
+        self.inner.hash_on_read(enabled);
+    }
+
+    async fn is_merged(&self, cid: &Cid) -> blockstore::Result<bool> {
+        self.inner.is_merged(cid).await
+    }
+
+    async fn mark_as_merged(&self, cid: &Cid) -> blockstore::Result<()> {
+        self.inner.mark_as_merged(cid).await
+    }
+
+    async fn mark_batch_as_merged(&self, cids: &[Cid]) -> blockstore::Result<()> {
+        self.inner.mark_batch_as_merged(cids).await
+    }
+
+    async fn get_unmerged(&self) -> blockstore::Result<Vec<Cid>> {
+        self.inner.get_unmerged().await
+    }
 }
 
 #[derive(Clone)]
@@ -351,6 +466,15 @@ fn pushlog_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
         peer_id,
         request: pushlog_request(collection_id),
         token: (),
+    }
+}
+
+fn gossip_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
+    TransportEvent::GossipMessage {
+        propagation_source: peer_id,
+        message_id: MessageId::new("gossip".to_string()),
+        topic: collection_id.to_string(),
+        message: PushLogBroadcast::from_request(&pushlog_request(collection_id)),
     }
 }
 
@@ -695,5 +819,73 @@ async fn two_stream_authenticated_explicit_replicator_is_marked_explicit_replica
             );
         }
         other => panic!("expected BlockReceived, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn pushlog_retries_transient_transaction_conflicts_without_sync_error() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let blockstore = Arc::new(ConflictOnceBlockstore::new());
+
+    let (coordinator, mut events) = create_test_coordinator_with_blockstore(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore.clone(),
+    );
+
+    let peer = random_peer_id();
+    coordinator
+        .handle_transport_event(pushlog_event(peer.clone(), "collection1"))
+        .await
+        .unwrap();
+
+    assert_eq!(blockstore.put_attempts(), 2);
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived { sender_peer, .. } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+        }
+        other => panic!("expected BlockReceived after retry, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn gossip_retries_transient_transaction_conflicts_without_sync_error() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let blockstore = Arc::new(ConflictOnceBlockstore::new());
+
+    let (coordinator, mut events) = create_test_coordinator_with_blockstore(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore.clone(),
+    );
+
+    let peer = random_peer_id();
+    coordinator
+        .handle_transport_event(gossip_event(peer.clone(), "collection1"))
+        .await
+        .unwrap();
+
+    assert_eq!(blockstore.put_attempts(), 2);
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived { sender_peer, .. } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+        }
+        other => panic!("expected BlockReceived after gossip retry, got {:?}", other),
     }
 }

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -8,6 +8,7 @@ use super::super::SyncCoordinator;
 use crate::error::Result;
 use crate::message::BranchableSyncReply;
 use crate::signing::sign_with_transport;
+use crate::sync::manager::links::find_all_missing_links;
 use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
@@ -129,18 +130,44 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             match Cid::try_from(head_bytes.as_slice()) {
                 Ok(cid) => {
                     tracing::trace!(cid = %cid, "Parsed collection head CID");
-                    match self.manager.blockstore().has(&cid).await {
-                        Ok(true) => {
-                            tracing::debug!(cid = %cid, "Already have block");
-                        }
-                        Ok(false) => {
-                            tracing::debug!(cid = %cid, "Need to fetch block");
-                            cids_to_fetch.push(cid);
-                        }
+                    // Having the head block locally does NOT imply we have its
+                    // ancestors. The head can land via gossip for a single
+                    // commit while earlier collection commits (other docs)
+                    // remain missing. Walk the local DAG and skip the fetch
+                    // only when no descendants are missing.
+                    let needs_fetch = match self.manager.blockstore().has(&cid).await {
+                        Ok(true) => match self.manager.blockstore().get(&cid).await {
+                            Ok(Some(data)) => {
+                                match find_all_missing_links(
+                                    self.manager.blockstore().as_ref(),
+                                    &data,
+                                )
+                                .await
+                                {
+                                    Ok(missing) => !missing.is_empty(),
+                                    Err(e) => {
+                                        tracing::debug!(
+                                            cid = %cid,
+                                            error = %e,
+                                            "Failed to walk DAG; falling back to fetch"
+                                        );
+                                        true
+                                    }
+                                }
+                            }
+                            _ => true,
+                        },
+                        Ok(false) => true,
                         Err(e) => {
                             tracing::warn!(cid = %cid, error = %e, "Error checking block");
-                            cids_to_fetch.push(cid);
+                            true
                         }
+                    };
+                    if needs_fetch {
+                        tracing::debug!(cid = %cid, "Need to fetch DAG");
+                        cids_to_fetch.push(cid);
+                    } else {
+                        tracing::debug!(cid = %cid, "Already have block and full DAG");
                     }
                 }
                 Err(e) => {

--- a/crates/p2p/src/sync/manager/diagnostics.rs
+++ b/crates/p2p/src/sync/manager/diagnostics.rs
@@ -9,7 +9,15 @@
 //! because the libp2p and iroh gossip paths run in the transport layer and do
 //! not have direct access to a `SyncManager`.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    collections::VecDeque,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        LazyLock,
+    },
+};
+
+use parking_lot::Mutex;
 
 /// Process-global counter of gossip payload decode failures.
 ///
@@ -18,6 +26,43 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// `SyncDiagnostics::snapshot()` so tests see the same number across all
 /// managers in the process.
 static GOSSIP_DECODE_FAILURES: AtomicU64 = AtomicU64::new(0);
+static RECENT_GOSSIP_DECODE_FAILURES: LazyLock<Mutex<VecDeque<GossipDecodeFailureSample>>> =
+    LazyLock::new(|| Mutex::new(VecDeque::with_capacity(GOSSIP_DECODE_FAILURE_SAMPLE_LIMIT)));
+
+const GOSSIP_DECODE_FAILURE_SAMPLE_LIMIT: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GossipTransport {
+    Iroh,
+    Libp2p,
+}
+
+impl GossipTransport {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Iroh => "iroh",
+            Self::Libp2p => "libp2p",
+        }
+    }
+}
+
+impl std::fmt::Display for GossipTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GossipDecodeFailureSample {
+    pub transport: GossipTransport,
+    pub peer_id: String,
+    pub topic: String,
+    pub message_size: usize,
+    pub error: String,
+    pub payload_prefix_hex: String,
+    pub payload_shape_hint: String,
+    pub occurrences: u64,
+}
 
 /// Record a gossip payload decode failure and return the new total count.
 ///
@@ -30,6 +75,36 @@ static GOSSIP_DECODE_FAILURES: AtomicU64 = AtomicU64::new(0);
 /// rather than synthesizing failures.
 pub(crate) fn record_gossip_decode_failure() -> u64 {
     GOSSIP_DECODE_FAILURES.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+/// Record a gossip payload decode failure and retain a deduplicated sample.
+pub(crate) fn record_gossip_decode_failure_sample(mut sample: GossipDecodeFailureSample) -> u64 {
+    let total = record_gossip_decode_failure();
+    let mut recent = RECENT_GOSSIP_DECODE_FAILURES.lock();
+
+    if let Some(index) = recent.iter().position(|existing| {
+        existing.transport == sample.transport
+            && existing.peer_id == sample.peer_id
+            && existing.topic == sample.topic
+            && existing.payload_prefix_hex == sample.payload_prefix_hex
+            && existing.payload_shape_hint == sample.payload_shape_hint
+    }) {
+        let mut existing = recent
+            .remove(index)
+            .expect("matched gossip decode failure sample should exist");
+        existing.message_size = sample.message_size;
+        existing.error = sample.error;
+        existing.occurrences += 1;
+        recent.push_back(existing);
+    } else {
+        sample.occurrences = 1;
+        recent.push_back(sample);
+        while recent.len() > GOSSIP_DECODE_FAILURE_SAMPLE_LIMIT {
+            recent.pop_front();
+        }
+    }
+
+    total
 }
 
 #[derive(Debug, Default)]
@@ -50,6 +125,9 @@ pub struct SyncDiagnosticsSnapshot {
     pub pending_dag_expired: u64,
     /// Process-global; see [`record_gossip_decode_failure`].
     pub gossip_decode_failures: u64,
+    /// Process-global recent samples captured by
+    /// [`record_gossip_decode_failure_sample`].
+    pub recent_gossip_decode_failures: Vec<GossipDecodeFailureSample>,
 }
 
 impl SyncDiagnostics {
@@ -61,6 +139,11 @@ impl SyncDiagnostics {
             pending_dag_resolved: self.pending_dag_resolved.load(Ordering::Relaxed),
             pending_dag_expired: self.pending_dag_expired.load(Ordering::Relaxed),
             gossip_decode_failures: GOSSIP_DECODE_FAILURES.load(Ordering::Relaxed),
+            recent_gossip_decode_failures: RECENT_GOSSIP_DECODE_FAILURES
+                .lock()
+                .iter()
+                .cloned()
+                .collect(),
         }
     }
 
@@ -126,6 +209,32 @@ mod tests {
         let second = record_gossip_decode_failure();
         assert_eq!(second, first + 1);
         assert!(SyncDiagnostics::default().snapshot().gossip_decode_failures >= second);
+    }
+
+    #[test]
+    fn record_gossip_decode_failure_sample_surfaces_recent_metadata() {
+        let topic = format!("topic-{}", uuid::Uuid::new_v4());
+        let prefix = format!("deadbeef-{}", uuid::Uuid::new_v4());
+        let sample = GossipDecodeFailureSample {
+            transport: GossipTransport::Iroh,
+            peer_id: "peer-123".to_string(),
+            topic: topic.clone(),
+            message_size: 128,
+            error: "Hit the end of buffer".to_string(),
+            payload_prefix_hex: prefix.clone(),
+            payload_shape_hint: "cbor_map(keys=[Unexpected])".to_string(),
+            occurrences: 0,
+        };
+
+        let total = record_gossip_decode_failure_sample(sample);
+        let snapshot = SyncDiagnostics::default().snapshot();
+        assert!(snapshot.gossip_decode_failures >= total);
+        assert!(snapshot.recent_gossip_decode_failures.iter().any(|entry| {
+            entry.transport == GossipTransport::Iroh
+                && entry.topic == topic
+                && entry.payload_prefix_hex == prefix
+                && entry.occurrences >= 1
+        }));
     }
 
     #[test]

--- a/crates/p2p/src/sync/manager/diagnostics.rs
+++ b/crates/p2p/src/sync/manager/diagnostics.rs
@@ -59,7 +59,7 @@ pub struct GossipDecodeFailureSample {
     pub topic: String,
     pub message_size: usize,
     pub error: String,
-    pub payload_prefix_hex: String,
+    pub payload_fingerprint: String,
     pub payload_shape_hint: String,
     pub occurrences: u64,
 }
@@ -86,7 +86,7 @@ pub(crate) fn record_gossip_decode_failure_sample(mut sample: GossipDecodeFailur
         existing.transport == sample.transport
             && existing.peer_id == sample.peer_id
             && existing.topic == sample.topic
-            && existing.payload_prefix_hex == sample.payload_prefix_hex
+            && existing.payload_fingerprint == sample.payload_fingerprint
             && existing.payload_shape_hint == sample.payload_shape_hint
     }) {
         let mut existing = recent
@@ -221,7 +221,7 @@ mod tests {
             topic: topic.clone(),
             message_size: 128,
             error: "Hit the end of buffer".to_string(),
-            payload_prefix_hex: prefix.clone(),
+            payload_fingerprint: prefix.clone(),
             payload_shape_hint: "cbor_map(keys=[Unexpected])".to_string(),
             occurrences: 0,
         };
@@ -232,7 +232,7 @@ mod tests {
         assert!(snapshot.recent_gossip_decode_failures.iter().any(|entry| {
             entry.transport == GossipTransport::Iroh
                 && entry.topic == topic
-                && entry.payload_prefix_hex == prefix
+                && entry.payload_fingerprint == prefix
                 && entry.occurrences >= 1
         }));
     }

--- a/crates/p2p/src/sync/manager/mod.rs
+++ b/crates/p2p/src/sync/manager/mod.rs
@@ -23,7 +23,9 @@ pub use config::{
     SyncConfig, DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
     DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
 };
-pub(crate) use diagnostics::record_gossip_decode_failure;
-pub use diagnostics::{SyncDiagnostics, SyncDiagnosticsSnapshot};
+pub(crate) use diagnostics::record_gossip_decode_failure_sample;
+pub use diagnostics::{
+    GossipDecodeFailureSample, GossipTransport, SyncDiagnostics, SyncDiagnosticsSnapshot,
+};
 pub use events::SyncEvent;
 pub use process::SyncManager;

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -286,7 +286,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                     error = %e,
                     "Failed to load root block from blockstore"
                 );
-                return Err(Error::BlockstoreError(e.to_string()));
+                return Err(Error::from_blockstore(e));
             }
         };
 

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -1,7 +1,7 @@
 //! PushLog processing and block storage.
 
 use std::collections::HashSet;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use cid::Cid;
 
@@ -16,7 +16,64 @@ use crate::ExplicitReplayAuthorization;
 
 use super::SyncManager;
 
+const MAX_RETRIABLE_PUSHLOG_ATTEMPTS: usize = 4;
+
+fn retriable_pushlog_delay(attempt: usize) -> Duration {
+    match attempt {
+        1 => Duration::from_millis(10),
+        2 => Duration::from_millis(25),
+        _ => Duration::from_millis(50),
+    }
+}
+
 impl<B: Blockstore + 'static> SyncManager<B> {
+    async fn retry_retriable_pushlog_op<T, F, Fut>(
+        &self,
+        cid: &Cid,
+        op_name: &'static str,
+        mut op: F,
+    ) -> Result<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        let mut attempt = 1;
+        loop {
+            match op().await {
+                Ok(value) => return Ok(value),
+                Err(error) if error.is_retriable() && attempt < MAX_RETRIABLE_PUSHLOG_ATTEMPTS => {
+                    tracing::debug!(
+                        cid = %cid,
+                        op_name,
+                        attempt,
+                        max_attempts = MAX_RETRIABLE_PUSHLOG_ATTEMPTS,
+                        error = %error,
+                        "Retryable PushLog storage operation failed; backing off and retrying"
+                    );
+                    tokio::time::sleep(retriable_pushlog_delay(attempt)).await;
+                    attempt += 1;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    async fn emit_sync_error(&self, cid: &Cid, error: &Error) -> Result<()> {
+        if self
+            .event_tx
+            .send(SyncEvent::SyncError {
+                cid: *cid,
+                error: error.to_string(),
+            })
+            .await
+            .is_err()
+        {
+            tracing::warn!(?cid, "Failed to send SyncError event - receiver dropped");
+            return Err(Error::ChannelSend);
+        }
+        Ok(())
+    }
+
     /// Process an incoming PushLog broadcast.
     ///
     /// This is the main entry point for handling sync messages from the network.
@@ -74,7 +131,15 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 }
 
                 // Now check if block is already merged
-                match self.blockstore.is_merged(&cid).await {
+                match self
+                    .retry_retriable_pushlog_op(&cid, "post_wait_is_merged", || async {
+                        self.blockstore
+                            .is_merged(&cid)
+                            .await
+                            .map_err(|e| Error::BlockstoreError(e.to_string()))
+                    })
+                    .await
+                {
                     Ok(true) => {
                         // Already merged by the other task
                         if self
@@ -109,23 +174,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         .await
                     }
                     Err(e) => {
-                        if self
-                            .event_tx
-                            .send(SyncEvent::SyncError {
-                                cid,
-                                error: e.to_string(),
-                            })
-                            .await
-                            .is_err()
-                        {
-                            tracing::warn!(
-                                ?cid,
-                                "Failed to send SyncError event - receiver dropped"
-                            );
-                            // Return channel error since we can't notify caller of the blockstore error
-                            return Err(Error::ChannelSend);
-                        }
-                        Err(Error::BlockstoreError(e.to_string()))
+                        self.emit_sync_error(&cid, &e).await?;
+                        Err(e)
                     }
                 }
             }
@@ -142,7 +192,15 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
     ) -> Result<()> {
         // Check if already merged
-        match self.blockstore.is_merged(cid).await {
+        match self
+            .retry_retriable_pushlog_op(cid, "is_merged", || async {
+                self.blockstore
+                    .is_merged(cid)
+                    .await
+                    .map_err(|e| Error::BlockstoreError(e.to_string()))
+            })
+            .await
+        {
             Ok(true) => {
                 tracing::debug!(cid = %cid, doc_id = %msg.doc_id, "Block already merged, skipping");
                 if self
@@ -168,19 +226,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 // Not merged, continue processing
             }
             Err(e) => {
-                if self
-                    .event_tx
-                    .send(SyncEvent::SyncError {
-                        cid: *cid,
-                        error: e.to_string(),
-                    })
-                    .await
-                    .is_err()
-                {
-                    tracing::warn!(?cid, "Failed to send SyncError event - receiver dropped");
-                    return Err(Error::ChannelSend);
-                }
-                return Err(Error::BlockstoreError(e.to_string()));
+                self.emit_sync_error(cid, &e).await?;
+                return Err(e);
             }
         }
 
@@ -196,20 +243,17 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         }
 
         // Store the block (marked as unmerged in P2P mode)
-        if let Err(e) = self.blockstore.put(cid, &msg.block).await {
-            if self
-                .event_tx
-                .send(SyncEvent::SyncError {
-                    cid: *cid,
-                    error: e.to_string(),
-                })
-                .await
-                .is_err()
-            {
-                tracing::warn!(?cid, "Failed to send SyncError event - receiver dropped");
-                return Err(Error::ChannelSend);
-            }
-            return Err(Error::BlockstoreError(e.to_string()));
+        if let Err(e) = self
+            .retry_retriable_pushlog_op(cid, "put_block", || async {
+                self.blockstore
+                    .put(cid, &msg.block)
+                    .await
+                    .map_err(|e| Error::BlockstoreError(e.to_string()))
+            })
+            .await
+        {
+            self.emit_sync_error(cid, &e).await?;
+            return Err(e);
         }
 
         tracing::debug!(
@@ -272,7 +316,12 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 return Err(Error::ChannelSend);
             }
 
-            match self.retry_pending_dags_waiting_on(cid).await {
+            match self
+                .retry_retriable_pushlog_op(cid, "retry_pending_dags_waiting_on", || {
+                    self.retry_pending_dags_waiting_on(cid)
+                })
+                .await
+            {
                 Ok(completed_roots) => {
                     if !completed_roots.is_empty() {
                         tracing::info!(

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -136,7 +136,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         self.blockstore
                             .is_merged(&cid)
                             .await
-                            .map_err(|e| Error::BlockstoreError(e.to_string()))
+                            .map_err(Error::from_blockstore)
                     })
                     .await
                 {
@@ -197,7 +197,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 self.blockstore
                     .is_merged(cid)
                     .await
-                    .map_err(|e| Error::BlockstoreError(e.to_string()))
+                    .map_err(Error::from_blockstore)
             })
             .await
         {
@@ -248,7 +248,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 self.blockstore
                     .put(cid, &msg.block)
                     .await
-                    .map_err(|e| Error::BlockstoreError(e.to_string()))
+                    .map_err(Error::from_blockstore)
             })
             .await
         {
@@ -316,12 +316,13 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 return Err(Error::ChannelSend);
             }
 
-            match self
-                .retry_retriable_pushlog_op(cid, "retry_pending_dags_waiting_on", || {
-                    self.retry_pending_dags_waiting_on(cid)
-                })
-                .await
-            {
+            // Not wrapped in retry_retriable_pushlog_op: the inner blockstore
+            // reads already propagate typed `BlockstoreTxnConflict` via
+            // `Error::from_blockstore`, and those are the only retriable errors
+            // surfaced here. DAG-traversal failures (missing links, bitswap
+            // timeouts, channel-send) are terminal in this context, so an outer
+            // retry would not make progress.
+            match self.retry_pending_dags_waiting_on(cid).await {
                 Ok(completed_roots) => {
                     if !completed_roots.is_empty() {
                         tracing::info!(

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -30,11 +30,11 @@ pub use coordinator::{
 };
 pub use dag_sync::{DagSync, DagSyncConfig, DagSyncState, NeedsFetchData, SyncPlan};
 pub use head_provider::{DocumentHeadProvider, NoOpHeadProvider};
-pub(crate) use manager::record_gossip_decode_failure;
+pub(crate) use manager::record_gossip_decode_failure_sample;
 pub use manager::{
-    SyncConfig, SyncDiagnostics, SyncDiagnosticsSnapshot, SyncEvent, SyncManager,
-    DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
-    DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
+    GossipDecodeFailureSample, GossipTransport, SyncConfig, SyncDiagnostics,
+    SyncDiagnosticsSnapshot, SyncEvent, SyncManager, DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
+    DEFAULT_MAX_CONCURRENT_PUSH_TASKS, DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
 };
 pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
 pub use peer_state::{PeerStateTracker, PeerStats};

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -358,7 +358,7 @@ where
 
     // Collect CIDs to mark as merged
     let mut merged_cids = Vec::new();
-    for (block, result) in merge_blocks.iter().zip(batch_results.into_iter()) {
+    for (block, result) in merge_blocks.iter().zip(batch_results) {
         match result {
             Ok(MergeOutcome::Merged) => {
                 merged_cids.push(block.cid);

--- a/crates/p2p/tests/message_tests.rs
+++ b/crates/p2p/tests/message_tests.rs
@@ -1,13 +1,20 @@
 //! Tests for the wire message types module.
 
+use acp::{ReplicatedActorRelationship, ReplicatedDocActorRelationships};
 use bytes::Bytes;
-use p2p::message::{Message, MetaData, PushLogBroadcast, PushLogReply, PushLogRequest};
+use p2p::message::{
+    Message, MetaData, PushLogBroadcast, PushLogGossipPayloadEncoding, PushLogReply, PushLogRequest,
+};
 use p2p::protocol::MESSAGE_VERSION;
 
 fn encode_with_ciborium<T: serde::Serialize>(value: &T) -> Vec<u8> {
     let mut bytes = Vec::new();
     ciborium::into_writer(value, &mut bytes).expect("failed to encode with ciborium");
     bytes
+}
+
+fn encode_with_postcard<T: serde::Serialize>(value: &T) -> Vec<u8> {
+    postcard::to_allocvec(value).expect("failed to encode with postcard")
 }
 
 fn decode_with_ciborium<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
@@ -17,6 +24,17 @@ fn decode_with_ciborium<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> T {
 fn has_text_key(map: &[(ciborium::Value, ciborium::Value)], key: &str) -> bool {
     map.iter()
         .any(|(candidate, _)| candidate == &ciborium::Value::Text(key.to_string()))
+}
+
+fn sample_actor_relationships() -> ReplicatedDocActorRelationships {
+    ReplicatedDocActorRelationships {
+        policy_id: "policy-1".to_string(),
+        resource_name: "documents".to_string(),
+        relationships: vec![ReplicatedActorRelationship {
+            relation: "reader".to_string(),
+            actor: "did:key:z6Mkexample".to_string(),
+        }],
+    }
 }
 
 #[test]
@@ -381,4 +399,61 @@ fn test_pushlog_broadcast_to_request() {
     assert_eq!(request.block, broadcast.block);
     // Request should have default metadata
     assert_eq!(request.metadata.version, MESSAGE_VERSION);
+}
+
+#[test]
+fn test_decode_gossip_payload_from_postcard_broadcast() {
+    let broadcast = PushLogBroadcast::new(
+        "doc-postcard-broadcast".to_string(),
+        Bytes::from(vec![1, 2, 3, 4]),
+        "collection-postcard-broadcast".to_string(),
+        "creator-postcard-broadcast".to_string(),
+        Bytes::from(vec![5, 6, 7, 8]),
+        Some(sample_actor_relationships()),
+    );
+
+    let encoded = encode_with_postcard(&broadcast);
+    let (decoded, encoding) =
+        PushLogBroadcast::decode_gossip_payload(&encoded).expect("decode failed");
+
+    assert_eq!(encoding, PushLogGossipPayloadEncoding::PostcardBroadcast);
+    assert_eq!(decoded, broadcast);
+}
+
+#[test]
+fn test_decode_gossip_payload_from_cbor_broadcast() {
+    let broadcast = PushLogBroadcast::new(
+        "doc-cbor-broadcast".to_string(),
+        Bytes::from(vec![10, 20, 30]),
+        "collection-cbor-broadcast".to_string(),
+        "creator-cbor-broadcast".to_string(),
+        Bytes::from(vec![40, 50, 60]),
+        None,
+    );
+
+    let encoded = encode_with_ciborium(&broadcast);
+    let (decoded, encoding) =
+        PushLogBroadcast::decode_gossip_payload(&encoded).expect("decode failed");
+
+    assert_eq!(encoding, PushLogGossipPayloadEncoding::CborBroadcast);
+    assert_eq!(decoded, broadcast);
+}
+
+#[test]
+fn test_decode_gossip_payload_from_cbor_request() {
+    let mut request = PushLogRequest::new(
+        "doc-cbor-request".to_string(),
+        Bytes::from(vec![11, 22, 33]),
+        "collection-cbor-request".to_string(),
+        "creator-cbor-request".to_string(),
+        Bytes::from(vec![44, 55, 66]),
+    );
+    request.acp_actor_relationships = Some(sample_actor_relationships());
+
+    let encoded = encode_with_ciborium(&request);
+    let (decoded, encoding) =
+        PushLogBroadcast::decode_gossip_payload(&encoded).expect("decode failed");
+
+    assert_eq!(encoding, PushLogGossipPayloadEncoding::CborRequest);
+    assert_eq!(decoded, PushLogBroadcast::from_request(&request));
 }

--- a/crates/query-plan/src/planner/index_selection/filter_to_scan.rs
+++ b/crates/query-plan/src/planner/index_selection/filter_to_scan.rs
@@ -108,22 +108,18 @@ pub fn filter_to_index_scan(
         }
 
         match cond.op {
-            FilterOp::Eq => {
-                if !has_eq {
-                    if let ConditionValue::Single(v) = &cond.value {
-                        has_eq = true;
-                        eq_value = Some(v.clone());
-                        eq_json_path = cond.json_path.clone();
-                    }
+            FilterOp::Eq if !has_eq => {
+                if let ConditionValue::Single(v) = &cond.value {
+                    has_eq = true;
+                    eq_value = Some(v.clone());
+                    eq_json_path = cond.json_path.clone();
                 }
             }
-            FilterOp::In => {
-                if !has_in {
-                    if let ConditionValue::Multiple(vs) = &cond.value {
-                        has_in = true;
-                        in_values = Some(vs.clone());
-                        in_json_path = cond.json_path.clone();
-                    }
+            FilterOp::In if !has_in => {
+                if let ConditionValue::Multiple(vs) = &cond.value {
+                    has_in = true;
+                    in_values = Some(vs.clone());
+                    in_json_path = cond.json_path.clone();
                 }
             }
             FilterOp::Gt => {

--- a/crates/query/src/runner/commits_height.rs
+++ b/crates/query/src/runner/commits_height.rs
@@ -106,10 +106,10 @@ fn extract_commits_height_range_from_conditions(
                     ));
                 }
             }
-            Some(crate::mapper::FilterOp::Or | crate::mapper::FilterOp::Not) => {
-                if logical_value_contains_top_level_height(value) {
-                    return HeightRangeExtraction::Unsupported;
-                }
+            Some(crate::mapper::FilterOp::Or | crate::mapper::FilterOp::Not)
+                if logical_value_contains_top_level_height(value) =>
+            {
+                return HeightRangeExtraction::Unsupported;
             }
             _ => {}
         }

--- a/crates/query/src/runner/query/relation_aggregate.rs
+++ b/crates/query/src/runner/query/relation_aggregate.rs
@@ -446,15 +446,15 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                                     crate::mapper::FilterOp::parse(op_str)
                                                 {
                                                     match op {
-                                                        crate::mapper::FilterOp::Eq => {
-                                                            if value != expected {
-                                                                return false;
-                                                            }
+                                                        crate::mapper::FilterOp::Eq
+                                                            if value != expected =>
+                                                        {
+                                                            return false;
                                                         }
-                                                        crate::mapper::FilterOp::Ne => {
-                                                            if value == expected {
-                                                                return false;
-                                                            }
+                                                        crate::mapper::FilterOp::Ne
+                                                            if value == expected =>
+                                                        {
+                                                            return false;
                                                         }
                                                         crate::mapper::FilterOp::Gt => {
                                                             let v = value.as_f64().unwrap_or(0.0);

--- a/crates/storage/src/backends/shared.rs
+++ b/crates/storage/src/backends/shared.rs
@@ -107,6 +107,7 @@ impl CallbackManager {
             + self.on_discard_async.lock().len()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn counts(&self) -> CallbackCounts {
         CallbackCounts {
             on_success: self.on_success.lock().len(),

--- a/tools/ffi-test/src/commands/run.rs
+++ b/tools/ffi-test/src/commands/run.rs
@@ -136,11 +136,9 @@ async fn run_multiple_packages(
         match result {
             Ok(result) => {
                 // Calculate pass rate
-                let pass_rate = if result.summary.total > 0 {
-                    result.summary.passed * 100 / result.summary.total
-                } else {
-                    100
-                };
+                let pass_rate = (result.summary.passed * 100)
+                    .checked_div(result.summary.total)
+                    .unwrap_or(100);
 
                 // Format the rate with color
                 let rate_str = if pass_rate == 100 {
@@ -214,11 +212,9 @@ async fn run_multiple_packages(
 
     // Print totals
     println!("{}", "─".repeat(84));
-    let grand_pass_rate = if grand_total.total > 0 {
-        grand_total.passed * 100 / grand_total.total
-    } else {
-        100
-    };
+    let grand_pass_rate = (grand_total.passed * 100)
+        .checked_div(grand_total.total)
+        .unwrap_or(100);
 
     let grand_rate_str = if grand_pass_rate == 100 {
         format!("{}%", grand_pass_rate).green().bold()

--- a/tools/ffi-test/src/commands/status.rs
+++ b/tools/ffi-test/src/commands/status.rs
@@ -169,11 +169,7 @@ async fn show_current_worktree(depth: usize, filter: Option<&str>) -> Result<()>
         }
 
         let total = total_pass + total_fail + total_skip;
-        let pass_rate = if total > 0 {
-            total_pass * 100 / total
-        } else {
-            100
-        };
+        let pass_rate = (total_pass * 100).checked_div(total).unwrap_or(100);
 
         // Pre-pad rate text before coloring (ANSI codes break {:>N} alignment)
         let rate_str = if total == 0 {
@@ -237,11 +233,7 @@ async fn show_current_worktree(depth: usize, filter: Option<&str>) -> Result<()>
     }
 
     let grand_total = grand_pass + grand_fail + grand_skip;
-    let pass_rate = if grand_total > 0 {
-        grand_pass * 100 / grand_total
-    } else {
-        100
-    };
+    let pass_rate = (grand_pass * 100).checked_div(grand_total).unwrap_or(100);
 
     // Pre-pad rate text before coloring (ANSI codes break {:>N} alignment)
     let rate_str = if pass_rate == 100 {
@@ -319,16 +311,8 @@ async fn show_all_worktrees() -> Result<()> {
             }
 
             let total = total_pass + total_fail + total_skip;
-            let pass_pct = if total > 0 {
-                total_pass * 100 / total
-            } else {
-                0
-            };
-            let fail_pct = if total > 0 {
-                total_fail * 100 / total
-            } else {
-                0
-            };
+            let pass_pct = (total_pass * 100).checked_div(total).unwrap_or(0);
+            let fail_pct = (total_fail * 100).checked_div(total).unwrap_or(0);
 
             println!(
                 "  Tests: {} passed ({}%), {} failed ({}%), {} skipped ({} total, {} packages)",

--- a/tools/ffi-test/src/report.rs
+++ b/tools/ffi-test/src/report.rs
@@ -95,7 +95,7 @@ async fn enforce_retention(branch: &str, package: &str) -> Result<()> {
     }
 
     // Sort by timestamp, newest first
-    reports.sort_by(|a, b| b.1.cmp(&a.1));
+    reports.sort_by_key(|r| std::cmp::Reverse(r.1));
 
     // Delete oldest reports beyond retention count
     for (path, _) in reports.into_iter().skip(REPORT_RETENTION_COUNT) {
@@ -226,7 +226,7 @@ pub async fn load_for_diff(branch: &str, package: &str, count: usize) -> Result<
     }
 
     // Sort by timestamp, newest first
-    reports_with_ts.sort_by(|a, b| b.1.cmp(&a.1));
+    reports_with_ts.sort_by_key(|r| std::cmp::Reverse(r.1));
 
     Ok(reports_with_ts
         .into_iter()


### PR DESCRIPTION
## Summary
- add `notify_network_change` to the public `P2POperations` surface with a transport-neutral default no-op
- wire the real Iroh `network_change()` call through the P2P adapters and FFI/mobile entrypoint
- expose a dedicated public `shareable_address` API and `/api/v0/p2p/shareable-address` endpoint so callers can ask for the single best address instead of inferring from `listen_addresses()`
- prefer Iroh endpoint tickets for shareable-address selection while preserving direct-address fallback when tickets are unavailable
- retry transient pushlog blockstore transaction conflicts before surfacing `SyncError`, reducing noisy failures on the Iroh ingress path
- accept compatible gossip payload encodings across transports so Iroh can decode current postcard broadcasts plus CBOR gossip payloads already tolerated on the libp2p side
- cover the retry path, shareable-address selection, and gossip payload compatibility with targeted regression tests

## Testing
- `cargo check -p defra-http -p defra-p2p-adapter`
- `cargo check -p ffi --features iroh`
- `cargo check -p cli --features iroh`
- `cargo test -p p2p --features iroh-transport format_public_addresses --lib`
- `cargo test -p p2p --features iroh-transport best_shareable_public_addr --lib`
- `cargo test -p p2p transient_transaction_conflicts --lib`
- `cargo test -p p2p gossip_payload --test message_tests`
- `cargo test -p defra-http p2p_routes --lib`
- `cargo check -p defra-http -p defra-p2p-adapter -p cli -p ffi --features ffi/iroh,cli/iroh`

## Issues
Closes #873
Closes #874
Closes #875
Refs #876
