### PR TITLE
fix(crdt): remove counter nonce idempotency, match Go merge semantics

### DIFF
--- a/crates/crdt/src/counter.rs
+++ b/crates/crdt/src/counter.rs
@@ -1,9 +1,18 @@
 //! Counter CRDT implementation
 //!
-//! Supports increment and decrement operations with nonce-based idempotent delivery.
-//! Uses commutative addition with wrapping on overflow for Int64 (matching Go DefraDB),
-//! and IEEE-754 addition for Float64. This is not a traditional PN-Counter (which uses
-//! separate per-replica counters); instead it uses a single value with nonce tracking.
+//! Supports increment and decrement operations via commutative addition.
+//! Uses wrapping on overflow for Int64 (matching Go DefraDB) and IEEE-754
+//! addition for Float64.
+//!
+//! # Idempotency
+//!
+//! Counter merges are NOT idempotent — every delta that reaches `merge()`
+//! advances the value. This matches Go DefraDB
+//! (`internal/core/crdt/counter.go::Counter::Merge`) which ignores the
+//! `Nonce` field at merge time. `Nonce` exists on the delta solely to make
+//! each signed block's CID unique in the DAG; block-CID deduplication at
+//! the blockstore layer is the correct place to prevent double-application
+//! of the same delta across retransmits and crash recovery.
 
 use crate::traits::{Context, Delta, MergeResult, ReplicatedData, ValueReader};
 use async_trait::async_trait;
@@ -188,8 +197,6 @@ impl Delta for CounterDelta {
 pub struct Counter {
     /// Storage key for the counter value
     value_key: Vec<u8>,
-    /// Storage key for tracking applied nonces
-    nonce_prefix: Vec<u8>,
     /// Schema version
     schema_version_id: String,
     /// Field name
@@ -236,57 +243,14 @@ impl Counter {
             doc_id.to_vec(),
             field_name.clone(),
         );
-        let nonce_prefix = value_key.nonce_prefix();
 
         Ok(Self {
             value_key: value_key.bytes(),
-            nonce_prefix: nonce_prefix.bytes(),
             schema_version_id,
             field_name,
             allow_decrement,
             kind,
         })
-    }
-
-    fn nonce_key(&self, nonce: i64) -> Vec<u8> {
-        let mut nonce_key = self.nonce_prefix.clone();
-        nonce_key.extend_from_slice(&nonce.to_be_bytes());
-        nonce_key
-    }
-
-    /// Check if a nonce has been applied
-    async fn has_nonce(&self, reader: &dyn Reader, nonce: i64) -> Result<bool> {
-        reader
-            .has(&self.nonce_key(nonce))
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))
-    }
-
-    /// Mark a nonce as applied
-    ///
-    async fn mark_nonce(&self, rw: &mut dyn ReaderWriter, nonce: i64) -> Result<()> {
-        let nonce_key = self.nonce_key(nonce);
-        rw.set(&nonce_key, &[1])
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))
-    }
-
-    /// Remove a nonce marker once block/CID-level merge dedup is durable.
-    ///
-    /// Returns `true` if a marker existed and was removed.
-    pub async fn clear_nonce(&self, rw: &mut dyn ReaderWriter, nonce: i64) -> Result<bool> {
-        let nonce_key = self.nonce_key(nonce);
-        let exists = rw
-            .has(&nonce_key)
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        if !exists {
-            return Ok(false);
-        }
-        rw.delete(&nonce_key)
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))?;
-        Ok(true)
     }
 
     /// Get current value as i64
@@ -355,20 +319,11 @@ impl Counter {
             .map_err(|e| Error::Storage(e.to_string()))
     }
 
-    /// Apply an increment/decrement
+    /// Apply an increment/decrement.
     ///
-    /// # Crash Recovery Semantics
-    ///
-    /// Nonce marking and value updates are not atomic. To ensure safety:
-    /// - Nonce is marked FIRST, then value is updated
-    /// - If crash occurs after nonce but before value update: delta is lost (under-count)
-    /// - If crash occurred with old ordering (value then nonce): would double-count
-    ///
-    /// Under-counting on crash is safer than over-counting because:
-    /// 1. It's easier to detect missing deltas than duplicate applications
-    /// 2. Over-counting violates CRDT idempotency guarantees
-    ///
-    /// For true atomicity, use a Store implementation with transaction support.
+    /// Every call advances the value — merge is not idempotent. This matches
+    /// Go's `Counter.Merge` (see module docs). Duplicate-block suppression is
+    /// the blockstore's responsibility, not this crate's.
     async fn apply_delta(
         &self,
         rw: &mut dyn ReaderWriter,
@@ -383,11 +338,6 @@ impl Counter {
                 self.kind,
                 delta.kind()
             )));
-        }
-
-        // Check if nonce already applied (idempotency)
-        if !is_create && self.has_nonce(rw, delta.nonce).await? {
-            return Ok(MergeResult::SkippedAlreadyApplied { nonce: delta.nonce });
         }
 
         // Decode and validate based on kind BEFORE any state changes
@@ -420,10 +370,7 @@ impl Counter {
             }
         };
 
-        // Mark nonce FIRST to prevent double-counting on crash recovery
-        self.mark_nonce(rw, delta.nonce).await?;
-
-        // Then update value
+        // Update value. Nonce is not tracked — see module docs / #847.
         match new_value {
             NewValue::Int64(v) => self.set_int64(rw, v).await?,
             NewValue::Float64(v) => self.set_float64(rw, v).await?,
@@ -438,7 +385,6 @@ impl Counter {
     /// Local document creation stores counter values in the document layer but not
     /// in CRDT accumulation storage. Before merging a remote delta, the CRDT storage
     /// must be seeded from the document value to ensure correct accumulation.
-    /// Also marks nonce=0 as applied since the initial creation already accounts for it.
     ///
     /// Returns true if seeding was performed, false if already initialized.
     pub async fn seed_if_uninitialized_int64(
@@ -454,7 +400,6 @@ impl Counter {
             return Ok(false);
         }
         self.set_int64(rw, value).await?;
-        self.mark_nonce(rw, 0).await?;
         Ok(true)
     }
 
@@ -472,7 +417,6 @@ impl Counter {
             return Ok(false);
         }
         self.set_float64(rw, value).await?;
-        self.mark_nonce(rw, 0).await?;
         Ok(true)
     }
 

--- a/crates/crdt/src/traits.rs
+++ b/crates/crdt/src/traits.rs
@@ -16,8 +16,6 @@ pub enum MergeResult {
     RejectedLowerPriority { current: u64, incoming: u64 },
     /// Delta was rejected due to lexicographic tie-breaking (same priority, current value wins)
     RejectedTieBreak,
-    /// Delta was skipped because it was already applied (idempotency via nonce)
-    SkippedAlreadyApplied { nonce: i64 },
 }
 
 impl MergeResult {
@@ -32,11 +30,6 @@ impl MergeResult {
             self,
             MergeResult::RejectedLowerPriority { .. } | MergeResult::RejectedTieBreak
         )
-    }
-
-    /// Returns true if the delta was skipped due to idempotency
-    pub fn was_skipped(&self) -> bool {
-        matches!(self, MergeResult::SkippedAlreadyApplied { .. })
     }
 }
 

--- a/crates/crdt/tests/counter_tests.rs
+++ b/crates/crdt/tests/counter_tests.rs
@@ -65,93 +65,6 @@ async fn test_counter_increment() {
 }
 
 #[tokio::test]
-async fn test_counter_idempotency() {
-    let store = MemoryStore::new();
-    let counter = Counter::new(
-        "v1".to_string(),
-        b"doc1",
-        "count".to_string(),
-        true,
-        NumericKind::Int64,
-    )
-    .unwrap();
-
-    let ctx = Context {
-        doc_id: DocId::new_unchecked("doc1"),
-        schema_version: "v1".to_string(),
-        is_create: false,
-    };
-
-    let mut txn = store.new_txn(false).await.unwrap();
-
-    // Apply same delta twice
-    let delta = CounterDelta::new_int64(
-        b"doc1".to_vec(),
-        "count".to_string(),
-        10,
-        12345,
-        "v1".to_string(),
-        5,
-    )
-    .unwrap();
-
-    counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-    counter.merge(&mut *txn, &ctx, &delta).await.unwrap(); // Should be ignored
-
-    // Should still be 5 (not 10)
-    let value_bytes = counter.value(&*txn).await.unwrap();
-    let value = i64::from_be_bytes(value_bytes.try_into().unwrap());
-    assert_eq!(value, 5);
-
-    txn.commit().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_counter_clear_nonce_removes_replay_marker() {
-    let store = MemoryStore::new();
-    let counter = Counter::new(
-        "v1".to_string(),
-        b"doc1",
-        "count".to_string(),
-        true,
-        NumericKind::Int64,
-    )
-    .unwrap();
-
-    let ctx = Context {
-        doc_id: DocId::new_unchecked("doc1"),
-        schema_version: "v1".to_string(),
-        is_create: false,
-    };
-
-    let mut txn = store.new_txn(false).await.unwrap();
-
-    let delta = CounterDelta::new_int64(
-        b"doc1".to_vec(),
-        "count".to_string(),
-        1,
-        1,
-        "v1".to_string(),
-        1,
-    )
-    .unwrap();
-    counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-
-    let replay_within_window = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-    assert!(matches!(
-        replay_within_window,
-        MergeResult::SkippedAlreadyApplied { nonce: 1 }
-    ));
-
-    assert!(counter.clear_nonce(&mut *txn, 1).await.unwrap());
-    assert!(!counter.clear_nonce(&mut *txn, 1).await.unwrap());
-
-    let value_bytes = counter.value(&*txn).await.unwrap();
-    let value = i64::from_be_bytes(value_bytes.try_into().unwrap());
-    assert_eq!(value, 1);
-}
-
-#[tokio::test]
 async fn test_counter_decrement_not_allowed() {
     let store = MemoryStore::new();
     let counter = Counter::new(
@@ -568,48 +481,6 @@ async fn test_counter_merge_result_applied() {
 }
 
 #[tokio::test]
-async fn test_counter_merge_result_skipped_already_applied() {
-    let store = MemoryStore::new();
-    let counter = Counter::new(
-        "v1".to_string(),
-        b"doc1",
-        "count".to_string(),
-        true,
-        NumericKind::Int64,
-    )
-    .unwrap();
-
-    let ctx = Context {
-        doc_id: DocId::new_unchecked("doc1"),
-        schema_version: "v1".to_string(),
-        is_create: false,
-    };
-
-    let mut txn = store.new_txn(false).await.unwrap();
-
-    let delta = CounterDelta::new_int64(
-        b"doc1".to_vec(),
-        "count".to_string(),
-        10,
-        12345,
-        "v1".to_string(),
-        5,
-    )
-    .unwrap();
-
-    // First merge should apply
-    let result1 = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-    assert!(matches!(result1, MergeResult::Applied));
-
-    // Second merge with same nonce should be skipped
-    let result2 = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
-    assert!(matches!(
-        result2,
-        MergeResult::SkippedAlreadyApplied { nonce: 12345 }
-    ));
-}
-
-#[tokio::test]
 async fn test_counter_wrong_delta_type() {
     let store = MemoryStore::new();
     let counter = Counter::new(
@@ -760,4 +631,76 @@ fn test_counter_delta_validation_rejects_empty_values() {
         .unwrap_err()
         .to_string()
         .contains("schema_version_id"));
+}
+
+// Regression guard for issue #847.
+//
+// Go DefraDB's Counter.Merge (internal/core/crdt/counter.go:154-161) ignores
+// the Nonce field entirely — Nonce exists only to make the signed DAG block's
+// CID unique at delta-creation time. Every delta that reaches Merge is applied.
+//
+// The Rust implementation previously short-circuited merge when it saw a nonce
+// marker it had stored on a prior successful apply (counter.rs:389). That
+// diverges from Go: when the same CounterDelta reaches both implementations
+// twice (retransmit, DAG resync, crash recovery replay), Go advances the value
+// by 2x the increment and Rust stays at 1x. Two nodes observing identical
+// network traffic therefore disagree on the counter value — a CRDT convergence
+// violation.
+//
+// Fix: remove the nonce idempotency check so counter merge matches Go's
+// "apply every delta" semantics. Block-CID deduplication at the blockstore
+// layer is the correct place to enforce "do not process the same block twice".
+//
+// This test fails on the pre-fix code (final value 5, not 10) and passes
+// after the check is removed.
+#[tokio::test]
+async fn regression_847_counter_applies_delta_each_merge() {
+    let store = MemoryStore::new();
+    let counter = Counter::new(
+        "v1".to_string(),
+        b"doc1",
+        "count".to_string(),
+        true,
+        NumericKind::Int64,
+    )
+    .unwrap();
+
+    let ctx = Context {
+        doc_id: DocId::new_unchecked("doc1"),
+        schema_version: "v1".to_string(),
+        is_create: false,
+    };
+
+    let mut txn = store.new_txn(false).await.unwrap();
+
+    let delta = CounterDelta::new_int64(
+        b"doc1".to_vec(),
+        "count".to_string(),
+        10,
+        12345,
+        "v1".to_string(),
+        5,
+    )
+    .unwrap();
+
+    // Same delta delivered twice (e.g., retransmit or DAG resync).
+    let r1 = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
+    let r2 = counter.merge(&mut *txn, &ctx, &delta).await.unwrap();
+
+    assert_eq!(r1, MergeResult::Applied);
+    assert_eq!(
+        r2,
+        MergeResult::Applied,
+        "bug #847: second merge of an identical CounterDelta must be applied \
+         (matching Go). If this fails with SkippedAlreadyApplied, the nonce \
+         idempotency check has been reintroduced."
+    );
+
+    let value_bytes = counter.value(&*txn).await.unwrap();
+    let value = i64::from_be_bytes(value_bytes.try_into().unwrap());
+    assert_eq!(
+        value, 10,
+        "bug #847: two increments of 5 should produce 10, not 5 — Rust was \
+         silently skipping the second merge due to the nonce marker."
+    );
 }

--- a/crates/db-merge/src/merge_handler/counter.rs
+++ b/crates/db-merge/src/merge_handler/counter.rs
@@ -433,10 +433,10 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
 }
 
 async fn finalize_linked_field_blocks<S: Store, B: blockstore::Blockstore + Send + Sync>(
-    db: &Arc<DB<S>>,
+    _db: &Arc<DB<S>>,
     blockstore: &Arc<B>,
     cids: &[Cid],
-    fallback_collection_id: Option<&str>,
+    _fallback_collection_id: Option<&str>,
 ) -> Result<(), MergeError> {
     if cids.is_empty() {
         return Ok(());
@@ -447,84 +447,6 @@ async fn finalize_linked_field_blocks<S: Store, B: blockstore::Blockstore + Send
         .await
         .map_err(|e| MergeError::Storage(e.to_string()))?;
 
-    for cid in cids {
-        cleanup_counter_nonce_for_cid(db, blockstore, cid, fallback_collection_id).await?;
-    }
-
     Ok(())
 }
 
-async fn cleanup_counter_nonce_for_cid<S: Store, B: blockstore::Blockstore + Send + Sync>(
-    db: &Arc<DB<S>>,
-    blockstore: &Arc<B>,
-    cid: &Cid,
-    fallback_collection_id: Option<&str>,
-) -> Result<(), MergeError> {
-    let Some(block_data) = blockstore
-        .get(cid)
-        .await
-        .map_err(|e| MergeError::Storage(e.to_string()))?
-    else {
-        return Ok(());
-    };
-
-    let block =
-        Block::from_dag_cbor(&block_data).map_err(|e| MergeError::BlockDecode(e.to_string()))?;
-
-    let payload = match &block.delta {
-        CrdtDelta::Counter(payload) => payload,
-        _ => return Ok(()),
-    };
-
-    let collection = db
-        .find_collection_by_id(&payload.schema_version_id)?
-        .or(fallback_collection_id.and_then(|cid| db.find_collection_by_id(cid).ok().flatten()))
-        .ok_or_else(|| {
-            MergeError::MissingMetadata(format!(
-                "Collection not found for schema_version_id: {}",
-                payload.schema_version_id
-            ))
-        })?;
-
-    let field = collection
-        .schema()
-        .field_by_name(&payload.field_name)
-        .ok_or_else(|| {
-            MergeError::MissingMetadata(format!(
-                "Field '{}' not found in collection",
-                payload.field_name
-            ))
-        })?;
-
-    let numeric_kind = match &field.kind {
-        FieldKind::Scalar(ScalarKind::Int) => NumericKind::Int64,
-        FieldKind::Scalar(ScalarKind::Float32 | ScalarKind::Float64) => NumericKind::Float64,
-        other => {
-            return Err(MergeError::UnsupportedDelta(format!(
-                "Counter field '{}' has unsupported kind during cleanup: {:?}",
-                payload.field_name, other
-            )))
-        }
-    };
-
-    let counter = Counter::new(
-        payload.schema_version_id.clone(),
-        &payload.doc_id,
-        payload.field_name.clone(),
-        field.crdt_type.allows_decrement(),
-        numeric_kind,
-    )
-    .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
-
-    let txn = db.new_txn(false).await?;
-    {
-        let mut datastore = txn.datastore()?;
-        counter
-            .clear_nonce(&mut datastore, payload.nonce)
-            .await
-            .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
-    }
-    txn.force_commit().await?;
-
-    Ok(())
-}

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1048,7 +1048,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn counter_merge_marks_cid_merged_and_clears_nonce_marker() {
+    async fn counter_merge_marks_cid_merged() {
         let (handler, blockstore) = make_handler_with_counter_schema().await;
         let mut doc = Document::new();
         doc.generate_and_set_doc_id().unwrap();
@@ -1090,28 +1090,6 @@ mod tests {
             .unwrap();
         assert_eq!(outcome, MergeOutcome::Merged);
         assert!(blockstore.is_merged(&cid).await.unwrap());
-
-        let counter = crdt::Counter::new(
-            payload.schema_version_id.clone(),
-            &payload.doc_id,
-            payload.field_name.clone(),
-            true,
-            crdt::NumericKind::Int64,
-        )
-        .unwrap();
-
-        let txn = handler.db.new_txn(true).await.unwrap();
-        let mut datastore = txn.datastore().unwrap();
-        let removed = counter
-            .clear_nonce(&mut datastore, payload.nonce)
-            .await
-            .unwrap();
-        let _ = txn.discard();
-
-        assert!(
-            !removed,
-            "nonce marker should be removed once the CID is finalized as merged"
-        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Closes #847
- Go's `Counter.Merge` (`internal/core/crdt/counter.go:154-161`) ignores the Nonce field entirely — it exists only to make the signed DAG block's CID unique. Every delta that reaches Merge is applied unconditionally. Rust previously short-circuited when it saw a nonce marker from a prior apply — a convergence violation.
- Removed: `has_nonce` check in `apply_delta`, `mark_nonce` in `apply_delta` + `seed_if_uninitialized_*`, `clear_nonce` / `has_nonce` / `mark_nonce` / `nonce_key` methods, `nonce_prefix` field from `Counter` struct, `SkippedAlreadyApplied` variant + `was_skipped()` from `MergeResult`, `cleanup_counter_nonce_for_cid` in db-merge, old idempotency tests.
- Retained: `nonce` field on `CounterDelta` (wire compatibility — Go still serializes it for block CID uniqueness).
- Net: **-220 LOC**.

## Test plan
- [x] New test `regression_847_counter_applies_delta_each_merge` fails on `main` (value 5 / `SkippedAlreadyApplied`) and passes on this branch (value 10 / `Applied`).
- [x] `cargo test -p crdt --test counter_tests` — 20 tests pass, 0 fail.
- [x] `cargo test -p db-merge` — 58 tests pass, 0 fail.
- [x] `cargo clippy -p crdt -p db-merge --tests --no-deps -- -D warnings` — clean.