### PR TITLE
fix(db-merge): replace unreachable!() with typed errors in merge dispatch

### DIFF
--- a/crates/db-merge/src/merge_handler/batch.rs
+++ b/crates/db-merge/src/merge_handler/batch.rs
@@ -416,7 +416,7 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMe
                     .await
             }
             CrdtDelta::CollectionSet(_) => Ok(MergeOutcome::terminal_skip("collection set delta")),
-            _ => unreachable!(),
+            other => Err(MergeError::UnsupportedDelta(format!("{other:?}"))),
         }
     }
 }

--- a/crates/db-merge/src/merge_handler/counter.rs
+++ b/crates/db-merge/src/merge_handler/counter.rs
@@ -368,7 +368,9 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 )
                 .map_err(|e| MergeError::MergeFailed(e.to_string()))
             }
-            _ => unreachable!(),
+            other => Err(MergeError::UnsupportedDelta(format!(
+                "unsupported NumericKind: {other:?}"
+            ))),
         }
     }
 
@@ -427,7 +429,10 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     None
                 }
             }
-            _ => unreachable!(),
+            other => {
+                tracing::warn!("Unsupported NumericKind: {other:?}");
+                None
+            }
         }
     }
 }

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -474,7 +474,7 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> Merg
                 tracing::debug!(cid = %cid, "CollectionSet delta - skipping");
                 Ok(MergeOutcome::terminal_skip("collection set delta"))
             }
-            _ => unreachable!(),
+            other => Err(MergeError::UnsupportedDelta(format!("{other:?}"))),
         }
     }
 


### PR DESCRIPTION
## Summary
- Closes #851
- Four match arms in `db-merge/merge_handler/` used `_ => unreachable!()` as a catch-all for `CrdtDelta` and `NumericKind` — both `#[non_exhaustive]` enums from external crates. If a new variant is added, the merge handler panics at runtime instead of returning a typed error. Replace all four with graceful `MergeError::UnsupportedDelta` returns (or `tracing::warn` + `None` for the value-read path).

## Test plan
- [x] `cargo test -p db-merge` — 58 tests pass, 0 fail.
- [x] `cargo clippy -p db-merge --tests --no-deps -- -D warnings` — clean.
- [x] No test for the wildcard arm itself: the arm is unreachable today (CBOR deserializer rejects unknown keys before dispatch). The fix is a forward-safety improvement, not a bug in current behavior. Adding a variant to trigger it would require modifying `defra-core`'s CrdtDelta enum, which is out of scope.