### PR TITLE
fix(p2p): inline MetaData fields in all request types, fixing CBOR map encoding

### DIFF
--- a/crates/p2p/src/host/p2p_host/two_stream.rs
+++ b/crates/p2p/src/host/p2p_host/two_stream.rs
@@ -159,10 +159,9 @@ impl<S: Store> P2PHost<S> {
                         Some(request.peer_id.clone()),
                         None,
                     ) {
-                        Ok(token) => crate::message::IdentityResponse::success(
-                            &request.message_id,
-                            token,
-                        ),
+                        Ok(token) => {
+                            crate::message::IdentityResponse::success(&request.message_id, token)
+                        }
                         Err(error) => crate::message::IdentityResponse::error(
                             &request.message_id,
                             &format!("failed to generate identity token: {error}"),

--- a/crates/p2p/src/host/p2p_host/two_stream.rs
+++ b/crates/p2p/src/host/p2p_host/two_stream.rs
@@ -47,7 +47,7 @@ impl<S: Store> P2PHost<S> {
                 let is_explicit_replicator = explicit_replay_authorization.is_some();
                 info!(
                     peer_id = %peer_id,
-                    message_id = %request.metadata.message_id,
+                    message_id = %request.message_id,
                     doc_id = %request.doc_id,
                     "Host received PushLog request via two-stream protocol"
                 );
@@ -73,7 +73,7 @@ impl<S: Store> P2PHost<S> {
             TwoStreamEvent::DocSyncRequest { peer_id, request } => {
                 info!(
                     peer_id = %peer_id,
-                    message_id = %request.metadata.message_id,
+                    message_id = %request.message_id,
                     doc_ids = ?request.doc_ids,
                     "Host received DocSync request via two-stream protocol"
                 );
@@ -115,7 +115,7 @@ impl<S: Store> P2PHost<S> {
             TwoStreamEvent::BranchableSyncRequest { peer_id, request } => {
                 info!(
                     peer_id = %peer_id,
-                    message_id = %request.metadata.message_id,
+                    message_id = %request.message_id,
                     collection_id = %request.collection_id,
                     "Host received BranchableSync request via two-stream protocol"
                 );
@@ -160,16 +160,16 @@ impl<S: Store> P2PHost<S> {
                         None,
                     ) {
                         Ok(token) => crate::message::IdentityResponse::success(
-                            &request.metadata.message_id,
+                            &request.message_id,
                             token,
                         ),
                         Err(error) => crate::message::IdentityResponse::error(
-                            &request.metadata.message_id,
+                            &request.message_id,
                             &format!("failed to generate identity token: {error}"),
                         ),
                     },
                     None => crate::message::IdentityResponse::error(
-                        &request.metadata.message_id,
+                        &request.message_id,
                         "node identity is not configured",
                     ),
                 };

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -138,7 +138,7 @@ pub(super) async fn handle_command(
             let pending_pushlog_replies = pending_pushlog_replies.clone();
             let task = tokio::spawn(async move {
                 let result = async move {
-                    let message_id = request.metadata.message_id.clone();
+                    let message_id = request.message_id.clone();
                     let (reply_tx, reply_rx) = oneshot::channel();
                     pending_pushlog_replies
                         .lock()

--- a/crates/p2p/src/message/branchable.rs
+++ b/crates/p2p/src/message/branchable.rs
@@ -3,18 +3,47 @@
 use serde::{Deserialize, Serialize};
 
 use super::cbor::{nullable_bytes, optional_bytes, vec_of_bytes};
-use super::metadata::MetaData;
 use super::traits::Message;
 
 /// Branchable collection sync request.
 ///
 /// Sent to peers to ask for their head CIDs for a branchable collection.
 /// Uses two-stream protocol (same transport as DocSync).
+///
+/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// indefinite-length maps when flatten is used (CBOR major type 0xbf).
+/// Go's fxamacker/cbor produces definite-length maps, causing signature
+/// verification to fail. Instead, we duplicate the fields for wire compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BranchableSyncRequest {
-    /// Message metadata.
-    #[serde(flatten)]
-    pub metadata: MetaData,
+    /// DefraDB message version.
+    #[serde(rename = "Version")]
+    pub version: String,
+
+    /// Unique message identifier. Responses use the same ID as the request.
+    #[serde(rename = "MessageID")]
+    pub message_id: String,
+
+    /// ID of the sender (PeerID when using libp2p).
+    #[serde(rename = "SenderID")]
+    pub sender_id: String,
+
+    /// Public key of the node that created the message.
+    #[serde(rename = "Pubkey", with = "nullable_bytes")]
+    pub pubkey: Vec<u8>,
+
+    /// Signature for message authentication.
+    #[serde(
+        rename = "Signature",
+        skip_serializing_if = "Option::is_none",
+        default,
+        with = "optional_bytes"
+    )]
+    pub signature: Option<Vec<u8>>,
+
+    /// Error message if something went wrong.
+    #[serde(rename = "ErrMessage", skip_serializing_if = "Option::is_none")]
+    pub err_message: Option<String>,
 
     /// Collection ID to sync.
     #[serde(rename = "CollectionID")]
@@ -25,7 +54,12 @@ impl BranchableSyncRequest {
     /// Create a new BranchableSyncRequest.
     pub fn new(collection_id: String) -> Self {
         Self {
-            metadata: MetaData::new(),
+            version: crate::protocol::MESSAGE_VERSION.to_string(),
+            message_id: String::new(),
+            sender_id: String::new(),
+            pubkey: Vec::new(),
+            signature: None,
+            err_message: None,
             collection_id,
         }
     }
@@ -33,47 +67,47 @@ impl BranchableSyncRequest {
 
 impl Message for BranchableSyncRequest {
     fn version(&self) -> &str {
-        &self.metadata.version
+        &self.version
     }
 
     fn set_version(&mut self, version: String) {
-        self.metadata.version = version;
+        self.version = version;
     }
 
     fn message_id(&self) -> &str {
-        &self.metadata.message_id
+        &self.message_id
     }
 
     fn set_message_id(&mut self, id: String) {
-        self.metadata.message_id = id;
+        self.message_id = id;
     }
 
     fn sender_id(&self) -> &str {
-        &self.metadata.sender_id
+        &self.sender_id
     }
 
     fn set_sender_id(&mut self, id: String) {
-        self.metadata.sender_id = id;
+        self.sender_id = id;
     }
 
     fn pubkey(&self) -> &[u8] {
-        &self.metadata.pubkey
+        &self.pubkey
     }
 
     fn set_pubkey(&mut self, pubkey: Vec<u8>) {
-        self.metadata.pubkey = pubkey;
+        self.pubkey = pubkey;
     }
 
     fn signature(&self) -> Option<&[u8]> {
-        self.metadata.signature.as_deref()
+        self.signature.as_deref()
     }
 
     fn set_signature(&mut self, signature: Option<Vec<u8>>) {
-        self.metadata.signature = signature;
+        self.signature = signature;
     }
 
     fn err_message(&self) -> Option<&str> {
-        self.metadata.err_message.as_deref()
+        self.err_message.as_deref()
     }
 }
 

--- a/crates/p2p/src/message/docsync.rs
+++ b/crates/p2p/src/message/docsync.rs
@@ -3,7 +3,6 @@
 use serde::{Deserialize, Serialize};
 
 use super::cbor::{nullable_bytes, optional_bytes, vec_of_bytes};
-use super::metadata::MetaData;
 use super::traits::Message;
 
 /// Maximum number of document IDs allowed in a single DocSyncRequest.
@@ -16,11 +15,41 @@ pub const MAX_DOC_IDS: usize = 1000;
 ///
 /// This is used when a node wants to sync specific documents from the network.
 /// Unlike replicator sync (push-based), DocSync is pull-based.
+///
+/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// indefinite-length maps when flatten is used (CBOR major type 0xbf).
+/// Go's fxamacker/cbor produces definite-length maps, causing signature
+/// verification to fail. Instead, we duplicate the fields for wire compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DocSyncRequest {
-    /// Message metadata.
-    #[serde(flatten)]
-    pub metadata: MetaData,
+    /// DefraDB message version.
+    #[serde(rename = "Version")]
+    pub version: String,
+
+    /// Unique message identifier. Responses use the same ID as the request.
+    #[serde(rename = "MessageID")]
+    pub message_id: String,
+
+    /// ID of the sender (PeerID when using libp2p).
+    #[serde(rename = "SenderID")]
+    pub sender_id: String,
+
+    /// Public key of the node that created the message.
+    #[serde(rename = "Pubkey", with = "nullable_bytes")]
+    pub pubkey: Vec<u8>,
+
+    /// Signature for message authentication.
+    #[serde(
+        rename = "Signature",
+        skip_serializing_if = "Option::is_none",
+        default,
+        with = "optional_bytes"
+    )]
+    pub signature: Option<Vec<u8>>,
+
+    /// Error message if something went wrong.
+    #[serde(rename = "ErrMessage", skip_serializing_if = "Option::is_none")]
+    pub err_message: Option<String>,
 
     /// Document IDs to sync.
     #[serde(rename = "DocIDs")]
@@ -31,7 +60,12 @@ impl DocSyncRequest {
     /// Create a new DocSyncRequest.
     pub fn new(doc_ids: Vec<String>) -> Self {
         Self {
-            metadata: MetaData::new(),
+            version: crate::protocol::MESSAGE_VERSION.to_string(),
+            message_id: String::new(),
+            sender_id: String::new(),
+            pubkey: Vec::new(),
+            signature: None,
+            err_message: None,
             doc_ids,
         }
     }
@@ -39,47 +73,47 @@ impl DocSyncRequest {
 
 impl Message for DocSyncRequest {
     fn version(&self) -> &str {
-        &self.metadata.version
+        &self.version
     }
 
     fn set_version(&mut self, version: String) {
-        self.metadata.version = version;
+        self.version = version;
     }
 
     fn message_id(&self) -> &str {
-        &self.metadata.message_id
+        &self.message_id
     }
 
     fn set_message_id(&mut self, id: String) {
-        self.metadata.message_id = id;
+        self.message_id = id;
     }
 
     fn sender_id(&self) -> &str {
-        &self.metadata.sender_id
+        &self.sender_id
     }
 
     fn set_sender_id(&mut self, id: String) {
-        self.metadata.sender_id = id;
+        self.sender_id = id;
     }
 
     fn pubkey(&self) -> &[u8] {
-        &self.metadata.pubkey
+        &self.pubkey
     }
 
     fn set_pubkey(&mut self, pubkey: Vec<u8>) {
-        self.metadata.pubkey = pubkey;
+        self.pubkey = pubkey;
     }
 
     fn signature(&self) -> Option<&[u8]> {
-        self.metadata.signature.as_deref()
+        self.signature.as_deref()
     }
 
     fn set_signature(&mut self, signature: Option<Vec<u8>>) {
-        self.metadata.signature = signature;
+        self.signature = signature;
     }
 
     fn err_message(&self) -> Option<&str> {
-        self.metadata.err_message.as_deref()
+        self.err_message.as_deref()
     }
 }
 

--- a/crates/p2p/src/message/identity.rs
+++ b/crates/p2p/src/message/identity.rs
@@ -1,13 +1,32 @@
 use serde::{Deserialize, Serialize};
 
 use super::cbor::{nullable_bytes, optional_bytes};
-use super::metadata::MetaData;
 use super::traits::Message;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdentityRequest {
-    #[serde(flatten)]
-    pub metadata: MetaData,
+    #[serde(rename = "Version")]
+    pub version: String,
+
+    #[serde(rename = "MessageID")]
+    pub message_id: String,
+
+    #[serde(rename = "SenderID")]
+    pub sender_id: String,
+
+    #[serde(rename = "Pubkey", with = "nullable_bytes")]
+    pub pubkey: Vec<u8>,
+
+    #[serde(
+        rename = "Signature",
+        skip_serializing_if = "Option::is_none",
+        default,
+        with = "optional_bytes"
+    )]
+    pub signature: Option<Vec<u8>>,
+
+    #[serde(rename = "ErrMessage", skip_serializing_if = "Option::is_none")]
+    pub err_message: Option<String>,
 
     #[serde(rename = "PeerID")]
     pub peer_id: String,
@@ -16,7 +35,12 @@ pub struct IdentityRequest {
 impl IdentityRequest {
     pub fn new(peer_id: String) -> Self {
         Self {
-            metadata: MetaData::new(),
+            version: crate::protocol::MESSAGE_VERSION.to_string(),
+            message_id: String::new(),
+            sender_id: String::new(),
+            pubkey: Vec::new(),
+            signature: None,
+            err_message: None,
             peer_id,
         }
     }
@@ -24,47 +48,47 @@ impl IdentityRequest {
 
 impl Message for IdentityRequest {
     fn version(&self) -> &str {
-        &self.metadata.version
+        &self.version
     }
 
     fn set_version(&mut self, version: String) {
-        self.metadata.version = version;
+        self.version = version;
     }
 
     fn message_id(&self) -> &str {
-        &self.metadata.message_id
+        &self.message_id
     }
 
     fn set_message_id(&mut self, id: String) {
-        self.metadata.message_id = id;
+        self.message_id = id;
     }
 
     fn sender_id(&self) -> &str {
-        &self.metadata.sender_id
+        &self.sender_id
     }
 
     fn set_sender_id(&mut self, id: String) {
-        self.metadata.sender_id = id;
+        self.sender_id = id;
     }
 
     fn pubkey(&self) -> &[u8] {
-        &self.metadata.pubkey
+        &self.pubkey
     }
 
     fn set_pubkey(&mut self, pubkey: Vec<u8>) {
-        self.metadata.pubkey = pubkey;
+        self.pubkey = pubkey;
     }
 
     fn signature(&self) -> Option<&[u8]> {
-        self.metadata.signature.as_deref()
+        self.signature.as_deref()
     }
 
     fn set_signature(&mut self, signature: Option<Vec<u8>>) {
-        self.metadata.signature = signature;
+        self.signature = signature;
     }
 
     fn err_message(&self) -> Option<&str> {
-        self.metadata.err_message.as_deref()
+        self.err_message.as_deref()
     }
 }
 

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -7,18 +7,47 @@ use sha2::{Digest, Sha256};
 use acp::ReplicatedDocActorRelationships;
 
 use super::cbor::{nullable_bytes, optional_bytes};
-use super::metadata::MetaData;
 use super::traits::Message;
 use crate::protocol::MESSAGE_VERSION;
 
 /// PushLog request message for sending resource updates to peer nodes.
 ///
 /// This is the primary message type for CRDT synchronization between nodes.
+///
+/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// indefinite-length maps when flatten is used (CBOR major type 0xbf).
+/// Go's fxamacker/cbor produces definite-length maps, causing signature
+/// verification to fail. Instead, we duplicate the fields for wire compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PushLogRequest {
-    /// Message metadata.
-    #[serde(flatten)]
-    pub metadata: MetaData,
+    /// DefraDB message version.
+    #[serde(rename = "Version")]
+    pub version: String,
+
+    /// Unique message identifier. Responses use the same ID as the request.
+    #[serde(rename = "MessageID")]
+    pub message_id: String,
+
+    /// ID of the sender (PeerID when using libp2p).
+    #[serde(rename = "SenderID")]
+    pub sender_id: String,
+
+    /// Public key of the node that created the message.
+    #[serde(rename = "Pubkey", with = "nullable_bytes")]
+    pub pubkey: Vec<u8>,
+
+    /// Signature for message authentication.
+    #[serde(
+        rename = "Signature",
+        skip_serializing_if = "Option::is_none",
+        default,
+        with = "optional_bytes"
+    )]
+    pub signature: Option<Vec<u8>>,
+
+    /// Error message if something went wrong.
+    #[serde(rename = "ErrMessage", skip_serializing_if = "Option::is_none")]
+    pub err_message: Option<String>,
 
     /// Document ID being updated.
     #[serde(rename = "DocID")]
@@ -69,7 +98,12 @@ impl PushLogRequest {
         block: Bytes,
     ) -> Self {
         Self {
-            metadata: MetaData::new(),
+            version: crate::protocol::MESSAGE_VERSION.to_string(),
+            message_id: String::new(),
+            sender_id: String::new(),
+            pubkey: Vec::new(),
+            signature: None,
+            err_message: None,
             doc_id,
             cid,
             collection_id,
@@ -83,47 +117,47 @@ impl PushLogRequest {
 
 impl Message for PushLogRequest {
     fn version(&self) -> &str {
-        &self.metadata.version
+        &self.version
     }
 
     fn set_version(&mut self, version: String) {
-        self.metadata.version = version;
+        self.version = version;
     }
 
     fn message_id(&self) -> &str {
-        &self.metadata.message_id
+        &self.message_id
     }
 
     fn set_message_id(&mut self, id: String) {
-        self.metadata.message_id = id;
+        self.message_id = id;
     }
 
     fn sender_id(&self) -> &str {
-        &self.metadata.sender_id
+        &self.sender_id
     }
 
     fn set_sender_id(&mut self, id: String) {
-        self.metadata.sender_id = id;
+        self.sender_id = id;
     }
 
     fn pubkey(&self) -> &[u8] {
-        &self.metadata.pubkey
+        &self.pubkey
     }
 
     fn set_pubkey(&mut self, pubkey: Vec<u8>) {
-        self.metadata.pubkey = pubkey;
+        self.pubkey = pubkey;
     }
 
     fn signature(&self) -> Option<&[u8]> {
-        self.metadata.signature.as_deref()
+        self.signature.as_deref()
     }
 
     fn set_signature(&mut self, signature: Option<Vec<u8>>) {
-        self.metadata.signature = signature;
+        self.signature = signature;
     }
 
     fn err_message(&self) -> Option<&str> {
-        self.metadata.err_message.as_deref()
+        self.err_message.as_deref()
     }
 }
 

--- a/crates/p2p/src/message/se.rs
+++ b/crates/p2p/src/message/se.rs
@@ -6,7 +6,6 @@
 use serde::{Deserialize, Serialize};
 
 use super::cbor::{nullable_bytes, optional_bytes};
-use super::metadata::MetaData;
 use super::traits::Message;
 use crate::protocol::MESSAGE_VERSION;
 
@@ -51,11 +50,41 @@ impl SEFieldQuery {
 /// the actual data values.
 ///
 /// Matches Go's QuerySEArtifactsRequest.
+///
+/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// indefinite-length maps when flatten is used (CBOR major type 0xbf).
+/// Go's fxamacker/cbor produces definite-length maps, causing signature
+/// verification to fail. Instead, we duplicate the fields for wire compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuerySEArtifactsRequest {
-    /// Message metadata.
-    #[serde(flatten)]
-    pub metadata: MetaData,
+    /// DefraDB message version.
+    #[serde(rename = "Version")]
+    pub version: String,
+
+    /// Unique message identifier. Responses use the same ID as the request.
+    #[serde(rename = "MessageID")]
+    pub message_id: String,
+
+    /// ID of the sender (PeerID when using libp2p).
+    #[serde(rename = "SenderID")]
+    pub sender_id: String,
+
+    /// Public key of the node that created the message.
+    #[serde(rename = "Pubkey", with = "nullable_bytes")]
+    pub pubkey: Vec<u8>,
+
+    /// Signature for message authentication.
+    #[serde(
+        rename = "Signature",
+        skip_serializing_if = "Option::is_none",
+        default,
+        with = "optional_bytes"
+    )]
+    pub signature: Option<Vec<u8>>,
+
+    /// Error message if something went wrong.
+    #[serde(rename = "ErrMessage", skip_serializing_if = "Option::is_none")]
+    pub err_message: Option<String>,
 
     /// Collection identifier.
     #[serde(rename = "CollectionID")]
@@ -70,7 +99,12 @@ impl QuerySEArtifactsRequest {
     /// Create a new QuerySEArtifactsRequest.
     pub fn new(collection_id: impl Into<String>, queries: Vec<SEFieldQuery>) -> Self {
         Self {
-            metadata: MetaData::new(),
+            version: crate::protocol::MESSAGE_VERSION.to_string(),
+            message_id: String::new(),
+            sender_id: String::new(),
+            pubkey: Vec::new(),
+            signature: None,
+            err_message: None,
             collection_id: collection_id.into(),
             queries,
         }
@@ -79,47 +113,47 @@ impl QuerySEArtifactsRequest {
 
 impl Message for QuerySEArtifactsRequest {
     fn version(&self) -> &str {
-        &self.metadata.version
+        &self.version
     }
 
     fn set_version(&mut self, version: String) {
-        self.metadata.version = version;
+        self.version = version;
     }
 
     fn message_id(&self) -> &str {
-        &self.metadata.message_id
+        &self.message_id
     }
 
     fn set_message_id(&mut self, id: String) {
-        self.metadata.message_id = id;
+        self.message_id = id;
     }
 
     fn sender_id(&self) -> &str {
-        &self.metadata.sender_id
+        &self.sender_id
     }
 
     fn set_sender_id(&mut self, id: String) {
-        self.metadata.sender_id = id;
+        self.sender_id = id;
     }
 
     fn pubkey(&self) -> &[u8] {
-        &self.metadata.pubkey
+        &self.pubkey
     }
 
     fn set_pubkey(&mut self, pubkey: Vec<u8>) {
-        self.metadata.pubkey = pubkey;
+        self.pubkey = pubkey;
     }
 
     fn signature(&self) -> Option<&[u8]> {
-        self.metadata.signature.as_deref()
+        self.signature.as_deref()
     }
 
     fn set_signature(&mut self, signature: Option<Vec<u8>>) {
-        self.metadata.signature = signature;
+        self.signature = signature;
     }
 
     fn err_message(&self) -> Option<&str> {
-        self.metadata.err_message.as_deref()
+        self.err_message.as_deref()
     }
 }
 
@@ -275,11 +309,41 @@ impl SEArtifact {
 /// The replicator stores them for later querying.
 ///
 /// Matches Go's PushSEArtifactsRequest.
+///
+/// Note: We don't use `#[serde(flatten)]` because serde_cbor produces
+/// indefinite-length maps when flatten is used (CBOR major type 0xbf).
+/// Go's fxamacker/cbor produces definite-length maps, causing signature
+/// verification to fail. Instead, we duplicate the fields for wire compatibility.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PushSEArtifactsRequest {
-    /// Message metadata.
-    #[serde(flatten)]
-    pub metadata: MetaData,
+    /// DefraDB message version.
+    #[serde(rename = "Version")]
+    pub version: String,
+
+    /// Unique message identifier. Responses use the same ID as the request.
+    #[serde(rename = "MessageID")]
+    pub message_id: String,
+
+    /// ID of the sender (PeerID when using libp2p).
+    #[serde(rename = "SenderID")]
+    pub sender_id: String,
+
+    /// Public key of the node that created the message.
+    #[serde(rename = "Pubkey", with = "nullable_bytes")]
+    pub pubkey: Vec<u8>,
+
+    /// Signature for message authentication.
+    #[serde(
+        rename = "Signature",
+        skip_serializing_if = "Option::is_none",
+        default,
+        with = "optional_bytes"
+    )]
+    pub signature: Option<Vec<u8>>,
+
+    /// Error message if something went wrong.
+    #[serde(rename = "ErrMessage", skip_serializing_if = "Option::is_none")]
+    pub err_message: Option<String>,
 
     /// Collection identifier.
     #[serde(rename = "CollectionID")]
@@ -294,7 +358,12 @@ impl PushSEArtifactsRequest {
     /// Create a new PushSEArtifactsRequest.
     pub fn new(collection_id: impl Into<String>, artifacts: Vec<SEArtifact>) -> Self {
         Self {
-            metadata: MetaData::new(),
+            version: crate::protocol::MESSAGE_VERSION.to_string(),
+            message_id: String::new(),
+            sender_id: String::new(),
+            pubkey: Vec::new(),
+            signature: None,
+            err_message: None,
             collection_id: collection_id.into(),
             artifacts,
         }
@@ -303,47 +372,47 @@ impl PushSEArtifactsRequest {
 
 impl Message for PushSEArtifactsRequest {
     fn version(&self) -> &str {
-        &self.metadata.version
+        &self.version
     }
 
     fn set_version(&mut self, version: String) {
-        self.metadata.version = version;
+        self.version = version;
     }
 
     fn message_id(&self) -> &str {
-        &self.metadata.message_id
+        &self.message_id
     }
 
     fn set_message_id(&mut self, id: String) {
-        self.metadata.message_id = id;
+        self.message_id = id;
     }
 
     fn sender_id(&self) -> &str {
-        &self.metadata.sender_id
+        &self.sender_id
     }
 
     fn set_sender_id(&mut self, id: String) {
-        self.metadata.sender_id = id;
+        self.sender_id = id;
     }
 
     fn pubkey(&self) -> &[u8] {
-        &self.metadata.pubkey
+        &self.pubkey
     }
 
     fn set_pubkey(&mut self, pubkey: Vec<u8>) {
-        self.metadata.pubkey = pubkey;
+        self.pubkey = pubkey;
     }
 
     fn signature(&self) -> Option<&[u8]> {
-        self.metadata.signature.as_deref()
+        self.signature.as_deref()
     }
 
     fn set_signature(&mut self, signature: Option<Vec<u8>>) {
-        self.metadata.signature = signature;
+        self.signature = signature;
     }
 
     fn err_message(&self) -> Option<&str> {
-        self.metadata.err_message.as_deref()
+        self.err_message.as_deref()
     }
 }
 

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -15,9 +15,7 @@ use tokio::time::timeout;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Error;
-use crate::message::{
-    BranchableSyncRequest, DocSyncRequest, MetaData, PushLogBroadcast, PushLogRequest,
-};
+use crate::message::{BranchableSyncRequest, DocSyncRequest, PushLogBroadcast, PushLogRequest};
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
 use crate::sync::head_provider::NoOpHeadProvider;
@@ -509,10 +507,7 @@ impl P2PTransport for NoopTransport {
 fn doc_sync_event(peer_id: PeerId) -> TransportEvent<()> {
     TransportEvent::DocSyncRequest {
         peer_id,
-        request: DocSyncRequest {
-            metadata: MetaData::new(),
-            doc_ids: vec!["doc1".to_string()],
-        },
+        request: DocSyncRequest::new(vec!["doc1".to_string()]),
         token: None,
     }
 }
@@ -520,10 +515,7 @@ fn doc_sync_event(peer_id: PeerId) -> TransportEvent<()> {
 fn branchable_sync_event(peer_id: PeerId, collection_id: &str) -> TransportEvent<()> {
     TransportEvent::BranchableSyncRequest {
         peer_id,
-        request: BranchableSyncRequest {
-            metadata: MetaData::new(),
-            collection_id: collection_id.to_string(),
-        },
+        request: BranchableSyncRequest::new(collection_id.to_string()),
         token: None,
     }
 }

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -86,11 +86,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .send_branchable_sync_reply(
                 &peer_id,
                 token,
-                BranchableSyncReply::success(
-                    &request.message_id,
-                    &request.collection_id,
-                    heads,
-                ),
+                BranchableSyncReply::success(&request.message_id, &request.collection_id, heads),
             )
             .await
         {

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -87,7 +87,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 &peer_id,
                 token,
                 BranchableSyncReply::success(
-                    &request.metadata.message_id,
+                    &request.message_id,
                     &request.collection_id,
                     heads,
                 ),

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -69,7 +69,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         tracing::debug!(
             peer_id = %peer_id,
             doc_ids = ?request.doc_ids,
-            message_id = %request.metadata.message_id,
+            message_id = %request.message_id,
             "Received DocSync request"
         );
 
@@ -115,7 +115,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .send_doc_sync_reply(
                 &peer_id,
                 token,
-                DocSyncReply::success(&request.metadata.message_id, results),
+                DocSyncReply::success(&request.message_id, results),
             )
             .await
         {

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -35,7 +35,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 "Rejecting PushLog request from unauthorized peer"
             );
             let reply = PushLogReply::error(
-                &request.metadata.message_id,
+                &request.message_id,
                 &format!(
                     "access denied: not authorized for collection {}",
                     request.collection_id
@@ -73,7 +73,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     error = %e,
                     "Failed to parse CID from PushLog request - sending error response"
                 );
-                let reply = PushLogReply::error(&request.metadata.message_id, &error_msg);
+                let reply = PushLogReply::error(&request.message_id, &error_msg);
                 if let Err(send_err) = self
                     .runtime
                     .transport
@@ -115,8 +115,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         let reply = match &process_result {
-            Ok(()) => PushLogReply::success(&request.metadata.message_id),
-            Err(e) => PushLogReply::error(&request.metadata.message_id, &e.to_string()),
+            Ok(()) => PushLogReply::success(&request.message_id),
+            Err(e) => PushLogReply::error(&request.message_id, &e.to_string()),
         };
 
         if let Err(e) = self
@@ -154,7 +154,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             peer_id = %peer_id,
             doc_id = %request.doc_id,
             collection_id = %request.collection_id,
-            message_id = %request.metadata.message_id,
+            message_id = %request.message_id,
             "Received PushLog request via two-stream protocol (Go compatibility)"
         );
 
@@ -181,7 +181,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 "Rejecting two-stream request from unauthorized peer"
             );
             let mut reply = PushLogReply::error(
-                &request.metadata.message_id,
+                &request.message_id,
                 &format!(
                     "access denied: not authorized for collection {}",
                     request.collection_id
@@ -208,7 +208,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     error = %e,
                     "Failed to parse CID from two-stream request - sending error response"
                 );
-                let mut reply = PushLogReply::error(&request.metadata.message_id, &error_msg);
+                let mut reply = PushLogReply::error(&request.message_id, &error_msg);
                 if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
                     tracing::error!(error = %sign_err, "Failed to sign invalid CID response");
                 }
@@ -231,8 +231,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .await;
 
         let mut reply = match &process_result {
-            Ok(()) => PushLogReply::success(&request.metadata.message_id),
-            Err(e) => PushLogReply::error(&request.metadata.message_id, &e.to_string()),
+            Ok(()) => PushLogReply::success(&request.message_id),
+            Err(e) => PushLogReply::error(&request.message_id, &e.to_string()),
         };
 
         if let Err(e) = sign_with_transport(&self.runtime.transport, &mut reply) {

--- a/crates/p2p/src/two_stream/handler/branchable_se.rs
+++ b/crates/p2p/src/two_stream/handler/branchable_se.rs
@@ -17,7 +17,7 @@ impl TwoStreamHandler {
         peer_id: PeerId,
         request: BranchableSyncRequest,
     ) -> Result<()> {
-        let message_id = request.metadata.message_id.clone();
+        let message_id = request.message_id.clone();
 
         let mut stream = self
             .control
@@ -86,7 +86,7 @@ impl TwoStreamHandler {
         peer_id: PeerId,
         request: PushSEArtifactsRequest,
     ) -> Result<()> {
-        let message_id = request.metadata.message_id.clone();
+        let message_id = request.message_id.clone();
         let artifacts_count = request.artifacts.len();
 
         let mut stream = self

--- a/crates/p2p/src/two_stream/handler/doc_sync.rs
+++ b/crates/p2p/src/two_stream/handler/doc_sync.rs
@@ -19,7 +19,7 @@ impl TwoStreamHandler {
         peer_id: PeerId,
         request: DocSyncRequest,
     ) -> Result<DocSyncReply> {
-        let message_id = request.metadata.message_id.clone();
+        let message_id = request.message_id.clone();
 
         // Create response channel
         let (tx, rx) = tokio::sync::oneshot::channel();
@@ -93,7 +93,7 @@ impl TwoStreamHandler {
         peer_id: PeerId,
         request: DocSyncRequest,
     ) -> Result<()> {
-        let message_id = request.metadata.message_id.clone();
+        let message_id = request.message_id.clone();
 
         // Open stream and send request
         let mut stream = self

--- a/crates/p2p/src/two_stream/handler/identity.rs
+++ b/crates/p2p/src/two_stream/handler/identity.rs
@@ -13,7 +13,7 @@ impl TwoStreamHandler {
         peer_id: PeerId,
         request: IdentityRequest,
     ) -> Result<IdentityResponse> {
-        let message_id = request.metadata.message_id.clone();
+        let message_id = request.message_id.clone();
         let (tx, rx) = oneshot::channel();
 
         {

--- a/crates/p2p/src/two_stream/handler/inbound.rs
+++ b/crates/p2p/src/two_stream/handler/inbound.rs
@@ -63,7 +63,7 @@ impl TwoStreamHandler {
             ensure_transport_sender(&peer_id, &request)?;
             tracing::info!(
                 peer_id = %peer_id,
-                message_id = %request.metadata.message_id,
+                message_id = %request.message_id,
                 doc_id = %request.doc_id,
                 "Successfully read PushLog request on two-stream protocol"
             );
@@ -76,7 +76,7 @@ impl TwoStreamHandler {
             ensure_transport_sender(&peer_id, &request)?;
             tracing::info!(
                 peer_id = %peer_id,
-                message_id = %request.metadata.message_id,
+                message_id = %request.message_id,
                 doc_ids = ?request.doc_ids,
                 "Successfully read DocSync request on two-stream protocol"
             );
@@ -89,7 +89,7 @@ impl TwoStreamHandler {
             ensure_transport_sender(&peer_id, &request)?;
             tracing::info!(
                 peer_id = %peer_id,
-                message_id = %request.metadata.message_id,
+                message_id = %request.message_id,
                 collection_id = %request.collection_id,
                 "Successfully read BranchableSync request on two-stream protocol"
             );
@@ -102,7 +102,7 @@ impl TwoStreamHandler {
             ensure_transport_sender(&peer_id, &request)?;
             tracing::info!(
                 peer_id = %peer_id,
-                message_id = %request.metadata.message_id,
+                message_id = %request.message_id,
                 requester = %request.peer_id,
                 "Successfully read Identity request on two-stream protocol"
             );

--- a/crates/p2p/src/two_stream/handler/mod.rs
+++ b/crates/p2p/src/two_stream/handler/mod.rs
@@ -123,11 +123,11 @@ impl TwoStreamHandler {
 
     /// Create a success reply for a request.
     pub fn success_reply(request: &PushLogRequest) -> PushLogReply {
-        PushLogReply::success(&request.metadata.message_id)
+        PushLogReply::success(&request.message_id)
     }
 
     /// Create an error reply for a request.
     pub fn error_reply(request: &PushLogRequest, error: &str) -> PushLogReply {
-        PushLogReply::error(&request.metadata.message_id, error)
+        PushLogReply::error(&request.message_id, error)
     }
 }

--- a/crates/p2p/src/two_stream/handler/pushlog.rs
+++ b/crates/p2p/src/two_stream/handler/pushlog.rs
@@ -21,7 +21,7 @@ impl TwoStreamHandler {
         peer_id: PeerId,
         request: PushLogRequest,
     ) -> Result<(String, oneshot::Receiver<PushLogReply>)> {
-        let message_id = request.metadata.message_id.clone();
+        let message_id = request.message_id.clone();
 
         // Create response channel
         let (tx, rx) = oneshot::channel();

--- a/crates/p2p/src/two_stream/mod.rs
+++ b/crates/p2p/src/two_stream/mod.rs
@@ -44,7 +44,7 @@ mod tests {
 
         let reply = TwoStreamHandler::success_reply(&request);
         // PushLogReply has flat fields (no metadata struct) for CBOR wire compatibility
-        assert_eq!(reply.message_id, request.metadata.message_id);
+        assert_eq!(reply.message_id, request.message_id);
         assert!(reply.err_message.is_none());
     }
 
@@ -60,7 +60,7 @@ mod tests {
 
         let reply = TwoStreamHandler::error_reply(&request, "test error");
         // PushLogReply has flat fields (no metadata struct) for CBOR wire compatibility
-        assert_eq!(reply.message_id, request.metadata.message_id);
+        assert_eq!(reply.message_id, request.message_id);
         assert_eq!(reply.err_message, Some("test error".to_string()));
     }
 }

--- a/crates/p2p/tests/host_tests.rs
+++ b/crates/p2p/tests/host_tests.rs
@@ -63,7 +63,7 @@ async fn send_two_stream_request_and_capture_flag(
                 is_explicit_replicator,
                 ..
             } => {
-                let mut reply = PushLogReply::success(&request.metadata.message_id);
+                let mut reply = PushLogReply::success(&request.message_id);
                 sign_message(receiver_handle.keypair(), &mut reply).unwrap();
                 receiver_handle
                     .send_two_stream_response(peer_id, reply)

--- a/crates/p2p/tests/message_tests.rs
+++ b/crates/p2p/tests/message_tests.rs
@@ -103,12 +103,12 @@ fn test_message_trait_accessors_pushlog_request() {
         Bytes::from(vec![30, 40]),
     );
 
-    // Set metadata fields via the embedded metadata struct
-    request.metadata.message_id = "test-msg-id".to_string();
-    request.metadata.sender_id = "sender-peer-id".to_string();
-    request.metadata.pubkey = vec![1, 2, 3, 4, 5];
-    request.metadata.signature = Some(vec![6, 7, 8, 9]);
-    request.metadata.err_message = Some("test error".to_string());
+    // Set metadata fields directly on the struct
+    request.message_id = "test-msg-id".to_string();
+    request.sender_id = "sender-peer-id".to_string();
+    request.pubkey = vec![1, 2, 3, 4, 5];
+    request.signature = Some(vec![6, 7, 8, 9]);
+    request.err_message = Some("test error".to_string());
 
     // Test trait accessors
     assert_eq!(request.version(), MESSAGE_VERSION);
@@ -118,8 +118,8 @@ fn test_message_trait_accessors_pushlog_request() {
     assert_eq!(request.signature(), Some(&[6u8, 7, 8, 9][..]));
     assert_eq!(request.err_message(), Some("test error"));
 
-    // Test mutable access via metadata field
-    request.metadata.message_id = "new-msg-id".to_string();
+    // Test mutable access via direct field
+    request.message_id = "new-msg-id".to_string();
     assert_eq!(request.message_id(), "new-msg-id");
 }
 
@@ -398,7 +398,87 @@ fn test_pushlog_broadcast_to_request() {
     assert_eq!(request.creator, broadcast.creator);
     assert_eq!(request.block, broadcast.block);
     // Request should have default metadata
-    assert_eq!(request.metadata.version, MESSAGE_VERSION);
+    assert_eq!(request.version, MESSAGE_VERSION);
+}
+
+// Regression guard for issue #827.
+//
+// `#[serde(flatten)]` on MetaData causes serde_cbor to emit an indefinite-
+// length CBOR map (major type 5, additional info 31 = byte 0xbf) instead of
+// a definite-length map (0xa0–0xb7 for 0–23 entries). Go's fxamacker/cbor
+// emits definite maps. Since both sides re-serialize for signature
+// verification, the byte mismatch breaks Rust↔Go interop.
+//
+// The fix inlines MetaData fields (same as PushLogReply already does).
+// These tests fail on pre-fix code (first byte = 0xbf) and pass after.
+mod regression_827 {
+    use bytes::Bytes;
+    use p2p::message::*;
+
+    fn assert_definite_cbor_map(type_name: &str, bytes: &[u8]) {
+        assert!(
+            !bytes.is_empty(),
+            "{type_name}: serialization produced empty output"
+        );
+        assert_ne!(
+            bytes[0], 0xbf,
+            "{type_name}: CBOR map must be definite-length (not 0xbf indefinite). \
+             If this fails, #[serde(flatten)] has been reintroduced on MetaData."
+        );
+        let major = bytes[0] >> 5;
+        assert_eq!(
+            major, 5,
+            "{type_name}: expected CBOR map (major type 5), got major type {major}"
+        );
+    }
+
+    #[test]
+    fn pushlog_request_definite_map() {
+        let req = PushLogRequest::new(
+            "doc".into(),
+            Bytes::from(vec![1]),
+            "col".into(),
+            "creator".into(),
+            Bytes::from(vec![2]),
+        );
+        let bytes = serde_cbor::to_vec(&req).unwrap();
+        assert_definite_cbor_map("PushLogRequest", &bytes);
+    }
+
+    #[test]
+    fn docsync_request_definite_map() {
+        let req = DocSyncRequest::new(vec!["doc1".into()]);
+        let bytes = serde_cbor::to_vec(&req).unwrap();
+        assert_definite_cbor_map("DocSyncRequest", &bytes);
+    }
+
+    #[test]
+    fn branchable_request_definite_map() {
+        let req = BranchableSyncRequest::new("col1".into());
+        let bytes = serde_cbor::to_vec(&req).unwrap();
+        assert_definite_cbor_map("BranchableSyncRequest", &bytes);
+    }
+
+    #[test]
+    fn identity_request_definite_map() {
+        let req = IdentityRequest::new("peer1".into());
+        let bytes = serde_cbor::to_vec(&req).unwrap();
+        assert_definite_cbor_map("IdentityRequest", &bytes);
+    }
+
+    #[test]
+    fn query_se_request_definite_map() {
+        let req = QuerySEArtifactsRequest::new("col1", vec![]);
+        let bytes = serde_cbor::to_vec(&req).unwrap();
+        assert_definite_cbor_map("QuerySEArtifactsRequest", &bytes);
+    }
+
+    #[test]
+    fn push_se_request_definite_map() {
+        let req = PushSEArtifactsRequest::new("col1", vec![]);
+        let bytes = serde_cbor::to_vec(&req).unwrap();
+        assert_definite_cbor_map("PushSEArtifactsRequest", &bytes);
+    }
 }
 
 #[test]

--- a/crates/p2p/tests/signing_tests.rs
+++ b/crates/p2p/tests/signing_tests.rs
@@ -24,28 +24,28 @@ fn test_sign_message_sets_all_fields() {
     let mut msg = create_test_message();
 
     // Before signing, metadata should have defaults
-    assert!(msg.metadata.message_id.is_empty());
-    assert!(msg.metadata.sender_id.is_empty());
-    assert!(msg.metadata.pubkey.is_empty());
-    assert!(msg.metadata.signature.is_none());
+    assert!(msg.message_id.is_empty());
+    assert!(msg.sender_id.is_empty());
+    assert!(msg.pubkey.is_empty());
+    assert!(msg.signature.is_none());
 
     // Sign the message
     sign_message(&keypair, &mut msg).expect("signing should succeed");
 
     // After signing, all fields should be populated
-    assert!(!msg.metadata.message_id.is_empty());
-    assert_eq!(msg.metadata.version, MESSAGE_VERSION);
-    assert!(!msg.metadata.sender_id.is_empty());
-    assert!(!msg.metadata.pubkey.is_empty());
-    assert!(msg.metadata.signature.is_some());
+    assert!(!msg.message_id.is_empty());
+    assert_eq!(msg.version, MESSAGE_VERSION);
+    assert!(!msg.sender_id.is_empty());
+    assert!(!msg.pubkey.is_empty());
+    assert!(msg.signature.is_some());
 
     // Verify sender_id matches keypair's peer ID
     let expected_peer_id = keypair.public().to_peer_id().to_string();
-    assert_eq!(msg.metadata.sender_id, expected_peer_id);
+    assert_eq!(msg.sender_id, expected_peer_id);
 
     // Verify pubkey matches keypair's public key
     let expected_pubkey = keypair.public().encode_protobuf();
-    assert_eq!(msg.metadata.pubkey, expected_pubkey);
+    assert_eq!(msg.pubkey, expected_pubkey);
 }
 
 #[test]
@@ -90,7 +90,7 @@ fn test_verify_wrong_signature_fails() {
     sign_message(&keypair, &mut msg).expect("signing should succeed");
 
     // Replace signature with garbage
-    msg.metadata.signature = Some(vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    msg.signature = Some(vec![0xDE, 0xAD, 0xBE, 0xEF]);
 
     // Verify should fail
     let result = verify_message(&msg);
@@ -112,7 +112,7 @@ fn test_verify_pubkey_mismatch_fails() {
     sign_message(&keypair1, &mut msg).expect("signing should succeed");
 
     // Replace sender_id with keypair2's peer ID (but keep keypair1's pubkey and signature)
-    msg.metadata.sender_id = keypair2.public().to_peer_id().to_string();
+    msg.sender_id = keypair2.public().to_peer_id().to_string();
 
     // Verify should fail because pubkey doesn't match sender_id
     let result = verify_message(&msg);
@@ -131,13 +131,13 @@ fn test_sign_preserves_existing_message_id() {
 
     // Set a custom message ID before signing
     let custom_id = "custom-message-id-123".to_string();
-    msg.metadata.message_id = custom_id.clone();
+    msg.message_id = custom_id.clone();
 
     // Sign the message
     sign_message(&keypair, &mut msg).expect("signing should succeed");
 
     // Message ID should be preserved
-    assert_eq!(msg.metadata.message_id, custom_id);
+    assert_eq!(msg.message_id, custom_id);
 }
 
 #[test]
@@ -146,10 +146,10 @@ fn test_verify_missing_signature_fails() {
     let mut msg = create_test_message();
 
     // Partially populate metadata without signature
-    msg.metadata.message_id = Uuid::new_v4().to_string();
-    msg.metadata.version = MESSAGE_VERSION.to_string();
-    msg.metadata.sender_id = keypair.public().to_peer_id().to_string();
-    msg.metadata.pubkey = keypair.public().encode_protobuf();
+    msg.message_id = Uuid::new_v4().to_string();
+    msg.version = MESSAGE_VERSION.to_string();
+    msg.sender_id = keypair.public().to_peer_id().to_string();
+    msg.pubkey = keypair.public().encode_protobuf();
     // Intentionally leave signature as None
 
     // Verify should fail due to missing signature
@@ -171,12 +171,12 @@ fn test_sign_message_cloned() {
     let signed = sign_message_cloned(&keypair, &original).expect("signing should succeed");
 
     // Original should be unchanged
-    assert!(original.metadata.message_id.is_empty());
-    assert!(original.metadata.signature.is_none());
+    assert!(original.message_id.is_empty());
+    assert!(original.signature.is_none());
 
     // Signed copy should have all fields populated
-    assert!(!signed.metadata.message_id.is_empty());
-    assert!(signed.metadata.signature.is_some());
+    assert!(!signed.message_id.is_empty());
+    assert!(signed.signature.is_some());
 
     // Signed copy should verify
     verify_message(&signed).expect("verification should succeed");
@@ -192,14 +192,14 @@ fn test_different_keypairs_produce_different_signatures() {
 
     // Set same message ID for comparison
     let msg_id = "same-msg-id".to_string();
-    msg1.metadata.message_id = msg_id.clone();
-    msg2.metadata.message_id = msg_id;
+    msg1.message_id = msg_id.clone();
+    msg2.message_id = msg_id;
 
     sign_message(&keypair1, &mut msg1).expect("signing should succeed");
     sign_message(&keypair2, &mut msg2).expect("signing should succeed");
 
     // Signatures should be different
-    assert_ne!(msg1.metadata.signature, msg2.metadata.signature);
+    assert_ne!(msg1.signature, msg2.signature);
 
     // Both should verify with their own keypairs
     verify_message(&msg1).expect("msg1 should verify");
@@ -214,7 +214,7 @@ fn test_uuid_format() {
     sign_message(&keypair, &mut msg).expect("signing should succeed");
 
     // Verify message_id is a valid UUID format
-    let uuid_result = Uuid::parse_str(&msg.metadata.message_id);
+    let uuid_result = Uuid::parse_str(&msg.message_id);
     assert!(
         uuid_result.is_ok(),
         "message_id should be valid UUID format"


### PR DESCRIPTION
## Summary
- Closes #827
- `#[serde(flatten)]` on `MetaData` causes `serde_cbor` to emit indefinite-length CBOR maps (`0xbf`). Go's `fxamacker/cbor` emits definite-length maps. Both sides re-serialize for signature verification, so the byte mismatch breaks **all** Rust↔Go signed request traffic.
- Inlined the 6 MetaData fields (Version, MessageID, SenderID, Pubkey, Signature, ErrMessage) on all 6 request types: `PushLogRequest`, `DocSyncRequest`, `BranchableSyncRequest`, `IdentityRequest`, `QuerySEArtifactsRequest`, `PushSEArtifactsRequest`. This matches the pattern already used by every `*Reply` type.
- Updated all `.metadata.field` references across 13 handler/test files (two-stream dispatch, coordinator event handlers, signing tests, host tests, access tests).
- Added 6 regression tests (one per type) that assert the first CBOR byte is a definite-length map marker, not `0xbf`. All 6 fail on `main` and pass on this branch.

## Test plan
- [x] 6 new regression tests in `regression_827` module fail on `main` (byte `0xbf`) and pass on this branch.
- [x] Full `cargo test -p p2p` — 247 tests pass, 0 fail.
- [x] `cargo clippy -p p2p --tests --no-deps -- -D warnings` — clean.