### PR TITLE
fix(p2p): back off on rate-limited replicator pushes

### DIFF
--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -6,6 +6,9 @@ use thiserror::Error;
 /// Result type for P2P operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Error text used when the coordinator rejects a request due to peer backpressure.
+pub const RATE_LIMITED_MESSAGE: &str = "rate limited: too many requests, retry later";
+
 /// P2P error types.
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -341,6 +344,11 @@ impl Error {
             } if collection_id == "rate-limited"
         )
     }
+}
+
+/// Returns true when a peer reply carries the coordinator's explicit rate-limit signal.
+pub fn is_rate_limited_message(message: &str) -> bool {
+    message == RATE_LIMITED_MESSAGE
 }
 
 /// Convert a blockstore CID verification error into its P2P counterpart.

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -1,6 +1,7 @@
 //! Broadcasting local updates to the network.
 
 use std::collections::HashSet;
+use std::time::Duration;
 
 use acp::ReplicatedDocActorRelationships;
 use blockstore::Blockstore;
@@ -8,12 +9,39 @@ use bytes::Bytes;
 use cid::Cid;
 
 use super::SyncCoordinator;
-use crate::error::Result;
+use crate::error::{is_rate_limited_message, Result};
 use crate::message::PushLogRequest;
 use crate::signing::sign_with_transport;
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::BroadcastResult;
 use crate::transport::{P2PTransport, PeerId};
+
+const MAX_RATE_LIMITED_PUSH_ATTEMPTS: usize = 10;
+
+fn rate_limited_push_delay(attempt: usize) -> Duration {
+    #[cfg(test)]
+    {
+        match attempt {
+            1 => Duration::from_millis(1),
+            2 => Duration::from_millis(2),
+            3 => Duration::from_millis(4),
+            4 => Duration::from_millis(8),
+            _ => Duration::from_millis(10),
+        }
+    }
+
+    #[cfg(not(test))]
+    {
+        match attempt {
+            1 => Duration::from_millis(25),
+            2 => Duration::from_millis(50),
+            3 => Duration::from_millis(100),
+            4 => Duration::from_millis(200),
+            5 => Duration::from_millis(400),
+            _ => Duration::from_millis(500),
+        }
+    }
+}
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     async fn list_replicators_for_push(&self) -> Option<Vec<crate::replicator::ReplicatorInfo>> {
@@ -275,16 +303,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 let Ok(_permit) = semaphore.acquire().await else {
                     return;
                 };
-                if let Err(e) = transport
-                    .send_two_stream_request(&peer_id_clone, request)
-                    .await
-                {
-                    tracing::debug!(
-                        peer_id = %peer_id_clone,
-                        cid = %cid_clone,
-                        error = %e,
-                        "PushLog to replicator failed"
-                    );
+                let any_failed = Self::send_ordered_pushlogs_via_transport(
+                    &transport,
+                    &peer_id_clone,
+                    vec![(cid_clone, request)],
+                )
+                .await;
+                if any_failed {
                     Self::report_push_failure(
                         &failure_tx,
                         &peer_id_clone,
@@ -351,40 +376,426 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         requests: Vec<(Cid, PushLogRequest)>,
     ) -> bool {
         let mut any_failed = false;
-        for (cid, request) in requests {
-            match transport.send_two_stream_request(peer_id, request).await {
-                Ok(reply) if reply.err_message.is_some() => {
-                    tracing::warn!(
-                        peer_id = %peer_id,
-                        cid = %cid,
-                        error = %reply.err_message.as_deref().unwrap_or("unknown pushlog error"),
-                        "PushLog to replicator was rejected"
-                    );
-                    any_failed = true;
-                    break;
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    if e.is_connection_like() {
-                        tracing::debug!(
+        'requests: for (cid, request) in requests {
+            let mut rate_limited_attempts = 0;
+            loop {
+                match transport
+                    .send_two_stream_request(peer_id, request.clone())
+                    .await
+                {
+                    Ok(reply) => {
+                        let Some(error_message) = reply.err_message.as_deref() else {
+                            break;
+                        };
+
+                        if is_rate_limited_message(error_message) {
+                            rate_limited_attempts += 1;
+                            if rate_limited_attempts > MAX_RATE_LIMITED_PUSH_ATTEMPTS {
+                                tracing::warn!(
+                                    peer_id = %peer_id,
+                                    cid = %cid,
+                                    attempts = rate_limited_attempts,
+                                    "PushLog to replicator remained rate-limited; stopping ordered push"
+                                );
+                                any_failed = true;
+                                break 'requests;
+                            }
+
+                            let delay = rate_limited_push_delay(rate_limited_attempts);
+                            tracing::debug!(
+                                peer_id = %peer_id,
+                                cid = %cid,
+                                attempt = rate_limited_attempts,
+                                delay_ms = delay.as_millis(),
+                                "PushLog to replicator was rate-limited; backing off before retry"
+                            );
+                            tokio::time::sleep(delay).await;
+                            continue;
+                        }
+
+                        tracing::warn!(
                             peer_id = %peer_id,
                             cid = %cid,
-                            error = %e,
-                            "PushLog to replicator failed because the connection became unavailable; stopping replay for this peer"
+                            error = %error_message,
+                            "PushLog to replicator was rejected"
                         );
-                    } else {
+                        any_failed = true;
+                        break;
+                    }
+                    Err(e) => {
+                        if e.is_connection_like() {
+                            tracing::debug!(
+                                peer_id = %peer_id,
+                                cid = %cid,
+                                error = %e,
+                                "PushLog to replicator failed because the connection became unavailable; stopping replay for this peer"
+                            );
+                            any_failed = true;
+                            break 'requests;
+                        }
+
                         tracing::debug!(
                             peer_id = %peer_id,
                             cid = %cid,
                             error = %e,
                             "PushLog to replicator failed"
                         );
+                        any_failed = true;
+                        break;
                     }
-                    any_failed = true;
-                    break;
                 }
             }
         }
         any_failed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use cid::multihash::{Code, MultihashDigest};
+
+    use crate::error::{Result as P2PResult, RATE_LIMITED_MESSAGE};
+    use crate::message::{
+        BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
+        PushLogReply, PushSEArtifactsRequest,
+    };
+    use crate::topics::DefraTopic;
+    use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
+    use crate::{QueryId, ReplicatorInfo};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestTransport {
+        peer_id: PeerId,
+        pubkey: Vec<u8>,
+        replies: Arc<Mutex<VecDeque<PushLogReply>>>,
+        sent_cids: Arc<Mutex<Vec<Vec<u8>>>>,
+    }
+
+    impl TestTransport {
+        fn new(replies: Vec<PushLogReply>) -> Self {
+            Self {
+                peer_id: PeerId::new("local-peer".to_string()),
+                pubkey: vec![1, 2, 3],
+                replies: Arc::new(Mutex::new(VecDeque::from(replies))),
+                sent_cids: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn sent_cids(&self) -> Vec<Vec<u8>> {
+            self.sent_cids.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl P2PTransport for TestTransport {
+        type ResponseToken = ();
+
+        fn local_peer_id(&self) -> &PeerId {
+            &self.peer_id
+        }
+
+        fn local_public_key_proto(&self) -> &[u8] {
+            &self.pubkey
+        }
+
+        fn sign(&self, _data: &[u8]) -> P2PResult<Vec<u8>> {
+            Ok(vec![0])
+        }
+
+        async fn dial(&self, _peer_id: &PeerId, _addrs: Vec<PeerAddr>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn listen(&self, _addr: PeerAddr) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn connected_peers(&self) -> P2PResult<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn listen_addresses(&self) -> P2PResult<Vec<PeerAddr>> {
+            Ok(Vec::new())
+        }
+
+        async fn poll_until_connected(
+            &self,
+            _peer_id: &PeerId,
+            _timeout: Duration,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn peer_addresses(&self) -> P2PResult<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn subscribe(&self, _topic: DefraTopic) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn unsubscribe(&self, _topic: DefraTopic) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn publish(
+            &self,
+            _topic: DefraTopic,
+            _msg: PushLogBroadcast,
+        ) -> P2PResult<MessageId> {
+            Ok(MessageId::new("noop".to_string()))
+        }
+
+        async fn topic_peers(&self, _topic: DefraTopic) -> P2PResult<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn send_pushlog_response(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: PushLogReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_two_stream_request(
+            &self,
+            _peer_id: &PeerId,
+            req: PushLogRequest,
+        ) -> P2PResult<PushLogReply> {
+            self.sent_cids.lock().unwrap().push(req.cid.to_vec());
+            Ok(self
+                .replies
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| PushLogReply::success("ok")))
+        }
+
+        async fn send_two_stream_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: PushLogReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: DocSyncRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: DocSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: BranchableSyncRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: BranchableSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_request(&self, _peer_id: &PeerId, _root_cid: Cid) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_response(&self, _peer_id: &PeerId, _car_data: Vec<u8>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _car_data: Vec<u8>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: DocSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: BranchableSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_se_artifacts(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushSEArtifactsRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn sync_blocks(
+            &self,
+            _root: Cid,
+            _providers: Vec<PeerId>,
+            _missing: Vec<Cid>,
+        ) -> P2PResult<QueryId> {
+            Ok(QueryId(1))
+        }
+
+        async fn cancel_sync(&self, _query_id: QueryId) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn create_replicator(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn delete_replicator(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn list_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_replicator(&self, _peer_id: &PeerId) -> P2PResult<Option<ReplicatorInfo>> {
+            Ok(None)
+        }
+
+        async fn remove_replicator_collections(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> P2PResult<bool> {
+            Ok(false)
+        }
+
+        async fn shutdown(&self) -> P2PResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn ordered_pushlogs_retry_rate_limited_request_before_advancing() {
+        let transport = TestTransport::new(vec![
+            PushLogReply::error("first", RATE_LIMITED_MESSAGE),
+            PushLogReply::success("first"),
+            PushLogReply::success("second"),
+        ]);
+        let peer_id = PeerId::new("remote-peer".to_string());
+        let cid1 = Cid::new_v1(0x55, Code::Sha2_256.digest(b"cid-1"));
+        let cid2 = Cid::new_v1(0x55, Code::Sha2_256.digest(b"cid-2"));
+        let requests = vec![
+            (
+                cid1,
+                PushLogRequest::new(
+                    "doc-1".to_string(),
+                    Bytes::from(cid1.to_bytes()),
+                    "collection".to_string(),
+                    "creator".to_string(),
+                    Bytes::from_static(b"block-1"),
+                ),
+            ),
+            (
+                cid2,
+                PushLogRequest::new(
+                    "doc-1".to_string(),
+                    Bytes::from(cid2.to_bytes()),
+                    "collection".to_string(),
+                    "creator".to_string(),
+                    Bytes::from_static(b"block-2"),
+                ),
+            ),
+        ];
+
+        let any_failed =
+            SyncCoordinator::<
+                blockstore::DefraBlockstore<storage::backends::MemoryStore>,
+                TestTransport,
+            >::send_ordered_pushlogs_via_transport(&transport, &peer_id, requests)
+            .await;
+
+        assert!(!any_failed);
+        assert_eq!(
+            transport.sent_cids(),
+            vec![cid1.to_bytes(), cid1.to_bytes(), cid2.to_bytes()]
+        );
+    }
+
+    #[tokio::test]
+    async fn ordered_pushlogs_stop_after_bounded_rate_limit_retries() {
+        let transport = TestTransport::new(
+            std::iter::repeat_with(|| PushLogReply::error("first", RATE_LIMITED_MESSAGE))
+                .take(MAX_RATE_LIMITED_PUSH_ATTEMPTS + 2)
+                .collect(),
+        );
+        let peer_id = PeerId::new("remote-peer".to_string());
+        let cid1 = Cid::new_v1(0x55, Code::Sha2_256.digest(b"cid-1"));
+        let cid2 = Cid::new_v1(0x55, Code::Sha2_256.digest(b"cid-2"));
+        let requests = vec![
+            (
+                cid1,
+                PushLogRequest::new(
+                    "doc-1".to_string(),
+                    Bytes::from(cid1.to_bytes()),
+                    "collection".to_string(),
+                    "creator".to_string(),
+                    Bytes::from_static(b"block-1"),
+                ),
+            ),
+            (
+                cid2,
+                PushLogRequest::new(
+                    "doc-1".to_string(),
+                    Bytes::from(cid2.to_bytes()),
+                    "collection".to_string(),
+                    "creator".to_string(),
+                    Bytes::from_static(b"block-2"),
+                ),
+            ),
+        ];
+
+        let any_failed =
+            SyncCoordinator::<
+                blockstore::DefraBlockstore<storage::backends::MemoryStore>,
+                TestTransport,
+            >::send_ordered_pushlogs_via_transport(&transport, &peer_id, requests)
+            .await;
+
+        assert!(any_failed);
+        assert_eq!(
+            transport.sent_cids(),
+            vec![cid1.to_bytes(); MAX_RATE_LIMITED_PUSH_ATTEMPTS + 1]
+        );
     }
 }

--- a/crates/sourcehub/src/cosmos/cosmos_provider.rs
+++ b/crates/sourcehub/src/cosmos/cosmos_provider.rs
@@ -353,6 +353,7 @@ mod tests {
 
     #[test]
     fn resolve_cosmos_bearer_token_uses_request_token_for_remote_identity() {
+        let _guard = crate::signing_state_test_guard();
         let did = "did:key:zRemoteCosmosToken";
         let token = "delegated.jwt.token".to_string();
         defra_core::signing::clear_identity_store();
@@ -372,6 +373,7 @@ mod tests {
 
     #[test]
     fn resolve_cosmos_bearer_token_builds_local_secp256r1_token() {
+        let _guard = crate::signing_state_test_guard();
         let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
         let raw_identity =
             identity::RawIdentity::from_secp256r1(private_key).expect("identity should build");

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -649,6 +649,7 @@ mod tests {
 
     #[test]
     fn resolve_registered_or_passthrough_bearer_token_uses_request_token_for_remote_identity() {
+        let _guard = crate::signing_state_test_guard();
         let did = "did:key:zRemoteHubRsToken";
         let token = "device.jwt.token".to_string();
         defra_core::signing::clear_identity_store();
@@ -668,6 +669,7 @@ mod tests {
 
     #[test]
     fn resolve_registered_or_passthrough_bearer_token_builds_local_secp256k1_token() {
+        let _guard = crate::signing_state_test_guard();
         let private_key = crypto::generate_secp256k1().expect("should generate secp256k1 key");
         let raw_identity =
             identity::RawIdentity::from_secp256k1(private_key).expect("identity should build");

--- a/crates/sourcehub/src/lib.rs
+++ b/crates/sourcehub/src/lib.rs
@@ -12,3 +12,11 @@ pub use provider::{
     AcpLightClientStatus, ProviderError, ProviderPolicyInfo, SourceHubProvider, SubjectRef,
 };
 pub use tuning::AcpTuning;
+
+#[cfg(test)]
+pub(crate) fn signing_state_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+}


### PR DESCRIPTION
## Summary
- retry the same PushLog when a replicator explicitly replies with the rate-limit backpressure message instead of continuing through the rest of the DAG
- route single-block replicator pushes through the same ordered send path so rejected replies are handled consistently
- centralize the rate-limit reply string and add focused coordinator tests for bounded retry behavior

## Testing
- cargo test -p p2p --lib