### PR TITLE
Reduce P2P replay noise and improve iroh retry recovery

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -594,7 +594,6 @@ impl Node {
 
         let retry_store = store.clone();
         let retry_pusher = doc_pusher.clone();
-        let retry_transport = transport.clone();
         let retry_loop_task = tokio::spawn(async move {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -612,10 +612,8 @@ impl Node {
                         continue;
                     }
                     let peer_id = p2p::transport::PeerId::new(peer_id_str.clone());
-                    let connected = retry_transport.connected_peers().await.unwrap_or_default();
-                    if !connected.iter().any(|p| p.as_str() == peer_id.as_str()) {
-                        continue;
-                    }
+                    // Iroh request-response can reconnect on demand, so don't
+                    // gate retries on the peer-map snapshot.
                     let docs = match peerstore.get_retry_doc_ids(&peer_id_str).await {
                         Ok(d) => d,
                         Err(_) => continue,

--- a/crates/db-merge/src/broadcast_mutator/broadcast.rs
+++ b/crates/db-merge/src/broadcast_mutator/broadcast.rs
@@ -9,6 +9,14 @@ use db_blocks::BlockResult;
 
 pub(crate) const BROADCAST_MAX_RETRIES: u32 = 10;
 
+fn is_expected_fire_and_forget_failure(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("insufficientpeers")
+        || lower.contains("channel send error")
+        || lower.contains("channel receive error")
+        || p2p::error::Error::is_connection_loss_reason(&lower)
+}
+
 pub(crate) fn broadcast_retry_delay_ms(
     err_str: &str,
     connected_peers: usize,
@@ -36,10 +44,17 @@ async fn connected_peer_count<B: Blockstore + 'static, T: P2PTransport>(
 /// Log broadcast failures at error level for observability in fire-and-forget paths.
 pub(crate) fn log_broadcast_failure(status: &BroadcastStatus) {
     if let BroadcastStatus::Failed(err) = status {
-        tracing::error!(
-            error = %err,
-            "Fire-and-forget broadcast failed — document committed locally but NOT replicated"
-        );
+        if is_expected_fire_and_forget_failure(err) {
+            tracing::warn!(
+                error = %err,
+                "Fire-and-forget broadcast could not reach peers; document committed locally but was not replicated"
+            );
+        } else {
+            tracing::error!(
+                error = %err,
+                "Fire-and-forget broadcast failed — document committed locally but NOT replicated"
+            );
+        }
     }
 }
 

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -179,6 +179,7 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
 
             if !requests.is_empty() {
                 let push_h = handle.clone();
+                let total_blocks = requests.len();
                 let permit = replay_semaphore
                     .clone()
                     .acquire_owned()
@@ -186,25 +187,45 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
                     .map_err(|_| "replay semaphore closed before scheduling push".to_string())?;
                 push_handles.push(tokio::spawn(async move {
                     let _permit = permit;
+                    let mut completed_blocks = 0usize;
                     for req in requests {
                         let cid = req.cid.clone();
                         match push_h.send_two_stream_request(peer_id, req).await {
                             Ok(reply) if reply.err_message.is_some() => {
                                 tracing::warn!(
                                     peer_id = %peer_id,
+                                    completed_blocks,
+                                    total_blocks,
                                     cid_len = cid.len(),
                                     error = %reply.err_message.as_deref().unwrap_or("unknown pushlog error"),
-                                    "Existing document replay PushLog was rejected"
+                                    "Existing document replay PushLog was rejected; stopping replay for this document"
                                 );
+                                break;
                             }
-                            Ok(_) => {}
+                            Ok(_) => {
+                                completed_blocks += 1;
+                            }
                             Err(e) => {
-                                tracing::warn!(
-                                    peer_id = %peer_id,
-                                    cid_len = cid.len(),
-                                    error = %e,
-                                    "Existing document replay PushLog failed"
-                                );
+                                if e.is_connection_like() {
+                                    tracing::debug!(
+                                        peer_id = %peer_id,
+                                        completed_blocks,
+                                        total_blocks,
+                                        cid_len = cid.len(),
+                                        error = %e,
+                                        "Existing document replay stopped because the connection became unavailable"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        peer_id = %peer_id,
+                                        completed_blocks,
+                                        total_blocks,
+                                        cid_len = cid.len(),
+                                        error = %e,
+                                        "Existing document replay PushLog failed; stopping replay for this document"
+                                    );
+                                }
+                                break;
                             }
                         }
                     }

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -172,6 +172,7 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
             if !requests.is_empty() {
                 let t = transport.clone();
                 let pid = peer_id.clone();
+                let total_blocks = requests.len();
                 let permit = replay_semaphore
                     .clone()
                     .acquire_owned()
@@ -179,25 +180,45 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
                     .map_err(|_| "replay semaphore closed before scheduling push".to_string())?;
                 push_handles.push(tokio::spawn(async move {
                     let _permit = permit;
+                    let mut completed_blocks = 0usize;
                     for req in requests {
                         let cid = req.cid.clone();
                         match t.send_two_stream_request(&pid, req).await {
                             Ok(reply) if reply.err_message.is_some() => {
                                 tracing::warn!(
                                     peer_id = %pid,
+                                    completed_blocks,
+                                    total_blocks,
                                     cid_len = cid.len(),
                                     error = %reply.err_message.as_deref().unwrap_or("unknown pushlog error"),
-                                    "Existing document replay PushLog was rejected"
+                                    "Existing document replay PushLog was rejected; stopping replay for this document"
                                 );
+                                break;
                             }
-                            Ok(_) => {}
+                            Ok(_) => {
+                                completed_blocks += 1;
+                            }
                             Err(e) => {
-                                tracing::warn!(
-                                    peer_id = %pid,
-                                    cid_len = cid.len(),
-                                    error = %e,
-                                    "Existing document replay PushLog failed"
-                                );
+                                if e.is_connection_like() {
+                                    tracing::debug!(
+                                        peer_id = %pid,
+                                        completed_blocks,
+                                        total_blocks,
+                                        cid_len = cid.len(),
+                                        error = %e,
+                                        "Existing document replay stopped because the connection became unavailable"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        peer_id = %pid,
+                                        completed_blocks,
+                                        total_blocks,
+                                        cid_len = cid.len(),
+                                        error = %e,
+                                        "Existing document replay PushLog failed; stopping replay for this document"
+                                    );
+                                }
+                                break;
                             }
                         }
                     }
@@ -370,7 +391,7 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
         .await
         .map_err(|e| format!("headstore iterator: {}", e))?;
 
-    let mut any_failed = false;
+    let mut successful_blocks = 0usize;
     while let Some(pair) = iter
         .next()
         .await
@@ -403,21 +424,37 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
             );
 
             if p2p::signing::sign_with_transport(transport, &mut request).is_err() {
-                any_failed = true;
-                continue;
+                return Err(format!(
+                    "failed to sign replay block after {successful_blocks} successful block(s)"
+                ));
             }
 
             match transport.send_two_stream_request(peer_id, request).await {
-                Ok(reply) if reply.err_message.is_some() => any_failed = true,
-                Ok(_) => {}
-                Err(_) => any_failed = true,
+                Ok(reply) if reply.err_message.is_some() => {
+                    return Err(format!(
+                        "peer rejected replay after {successful_blocks} successful block(s): {}",
+                        reply
+                            .err_message
+                            .as_deref()
+                            .unwrap_or("unknown pushlog error")
+                    ));
+                }
+                Ok(_) => {
+                    successful_blocks += 1;
+                }
+                Err(error) => {
+                    let prefix = if error.is_connection_like() {
+                        "transport became unavailable"
+                    } else {
+                        "replay push failed"
+                    };
+                    return Err(format!(
+                        "{prefix} after {successful_blocks} successful block(s): {error}"
+                    ));
+                }
             }
         }
     }
 
-    if any_failed {
-        Err("some pushes failed".to_string())
-    } else {
-        Ok(())
-    }
+    Ok(())
 }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -883,16 +883,9 @@ fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
                 }
 
                 let peer_id = p2p::transport::PeerId::new(peer_id_str.clone());
-                let connected = match transport.connected_peers().await {
-                    Ok(peers) => peers,
-                    Err(error) => {
-                        tracing::debug!(error = %error, "failed to load connected peers for retry");
-                        continue;
-                    }
-                };
-                if !connected.contains(&peer_id) {
-                    continue;
-                }
+                // Iroh request-response can reconnect on demand, so don't
+                // suppress retries based on the peer-map's current
+                // connected_peers snapshot.
 
                 let docs = match peerstore.get_retry_doc_ids(&peer_id_str).await {
                     Ok(docs) => docs,

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -335,10 +335,9 @@ pub(crate) fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
                 }
 
                 let peer_id = p2p::transport::PeerId::new(peer_id_str.clone());
-                let connected = transport.connected_peers().await.unwrap_or_default();
-                if !connected.contains(&peer_id) {
-                    continue;
-                }
+                // Iroh request-response reconnects on demand. The peer-map-backed
+                // connected_peers snapshot is not authoritative enough to gate
+                // retries here, so let the transport attempt the replay.
 
                 let docs = match peerstore.get_retry_doc_ids(&peer_id_str).await {
                     Ok(docs) => docs,

--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -287,6 +287,50 @@ impl Error {
         self.is_txn_conflict()
     }
 
+    /// Returns true if the error looks like a transport/connection teardown signal.
+    ///
+    /// This is intentionally broader than a single enum variant because iroh and
+    /// libp2p surface many disconnect cases through stringified transport errors.
+    pub fn is_connection_like(&self) -> bool {
+        match self {
+            Error::ConnectionClosed
+            | Error::ChannelSend
+            | Error::ChannelReceive
+            | Error::ResponseTimeout
+            | Error::ConnectionTimeout(_) => true,
+            Error::Dial(msg)
+            | Error::Transport(msg)
+            | Error::Codec(msg)
+            | Error::ProtocolNegotiation(msg)
+            | Error::Noise(msg)
+            | Error::Swarm(msg)
+            | Error::ResponseSend(msg) => Self::is_connection_loss_reason(msg),
+            Error::Io(err) => Self::is_connection_loss_reason(&err.to_string()),
+            Error::StreamOpen { reason, .. } | Error::StreamWrite { reason, .. } => {
+                Self::is_connection_loss_reason(reason)
+            }
+            _ => false,
+        }
+    }
+
+    /// Best-effort classifier for common disconnect / teardown reasons surfaced
+    /// as transport strings.
+    pub fn is_connection_loss_reason(reason: &str) -> bool {
+        let lower = reason.to_ascii_lowercase();
+        lower == "closed"
+            || lower.ends_with(": closed")
+            || lower.contains("connection lost")
+            || lower.contains("connection closed")
+            || lower.contains("connection reset")
+            || lower.contains("stream reset")
+            || lower.contains("broken pipe")
+            || lower.contains("peer closed")
+            || lower.contains("aborted by peer")
+            || lower.contains("closed during the handshake")
+            || lower.contains("timed out waiting for peer")
+            || lower.contains("endpoint closed")
+    }
+
     /// Returns true if this is the coordinator's synthetic rate-limit rejection.
     pub fn is_rate_limited(&self) -> bool {
         matches!(
@@ -397,5 +441,20 @@ mod tests {
 
         assert!(rate_limited.is_rate_limited());
         assert!(!ordinary_denial.is_rate_limited());
+    }
+
+    #[test]
+    fn connection_like_detection_matches_common_transport_failures() {
+        assert!(Error::ChannelSend.is_connection_like());
+        assert!(Error::ChannelReceive.is_connection_like());
+        assert!(Error::Dial("closed".into()).is_connection_like());
+        assert!(Error::Codec("failed to read length: connection lost".into()).is_connection_like());
+        assert!(Error::Transport("peer closed stream".into()).is_connection_like());
+        assert!(Error::ResponseSend("broken pipe".into()).is_connection_like());
+        assert!(!Error::AccessDenied {
+            peer_id: "peer-1".into(),
+            collection_id: "users".into(),
+        }
+        .is_connection_like());
     }
 }

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -149,13 +149,14 @@ pub(super) async fn try_fetch_from_provider(
 ) -> bool {
     // Per-provider CAR failures log at debug — the caller aggregates per-DAG
     // outcomes into a single WARN via BitswapComplete (see issue #858).
-    let endpoint_id = match parse_endpoint_id(provider) {
-        Ok(id) => id,
-        Err(e) => {
-            debug!(provider = %provider, error = %e, "CAR fetch: invalid provider peer ID");
-            return false;
-        }
-    };
+    if let Err(error) = parse_endpoint_id(provider) {
+        debug!(
+            provider = %provider,
+            error = %error,
+            "CAR fetch: invalid provider peer ID"
+        );
+        return false;
+    }
 
     let connection = match connect_with_direct_addr_fallback(
         endpoint,

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -18,6 +18,49 @@ use super::protocols;
 /// needs time to process the request before replying.
 pub(super) const REQUEST_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+fn endpoint_addr(
+    endpoint_id: iroh::EndpointId,
+    direct_addr: Option<std::net::SocketAddr>,
+) -> EndpointAddr {
+    let mut addr = EndpointAddr::from(endpoint_id);
+    if let Some(sa) = direct_addr {
+        addr = addr.with_ip_addr(sa);
+    }
+    addr
+}
+
+async fn connect_with_direct_addr_fallback(
+    endpoint: &Endpoint,
+    peer_id: &PeerId,
+    alpn: &[u8],
+    direct_addr: Option<std::net::SocketAddr>,
+) -> crate::error::Result<iroh::endpoint::Connection> {
+    let endpoint_id = parse_endpoint_id(peer_id)?;
+
+    if let Some(sa) = direct_addr {
+        match endpoint
+            .connect(endpoint_addr(endpoint_id, Some(sa)), alpn)
+            .await
+        {
+            Ok(connection) => return Ok(connection),
+            Err(error) => {
+                debug!(
+                    peer_id = %peer_id,
+                    direct_addr = %sa,
+                    alpn = %String::from_utf8_lossy(alpn),
+                    error = %error,
+                    "Direct iroh dial failed, retrying without cached direct address"
+                );
+            }
+        }
+    }
+
+    endpoint
+        .connect(endpoint_addr(endpoint_id, None), alpn)
+        .await
+        .map_err(|e| crate::error::Error::Dial(e.to_string()))
+}
+
 /// Send a request and wait for a response (bidirectional stream).
 ///
 /// `direct_addr` is an optional cached socket address for the peer; when provided it is
@@ -33,16 +76,8 @@ where
     Req: serde::Serialize,
     Resp: serde::de::DeserializeOwned,
 {
-    let endpoint_id = parse_endpoint_id(peer_id)?;
-    let mut addr = EndpointAddr::from(endpoint_id);
-    if let Some(sa) = direct_addr {
-        addr = addr.with_ip_addr(sa);
-    }
-
-    let connection = endpoint
-        .connect(addr, alpn)
-        .await
-        .map_err(|e| crate::error::Error::Dial(e.to_string()))?;
+    let connection =
+        connect_with_direct_addr_fallback(endpoint, peer_id, alpn, direct_addr).await?;
 
     let (mut send, mut recv) = connection
         .open_bi()
@@ -82,16 +117,8 @@ pub(super) async fn handle_fire_and_forget<T: serde::Serialize>(
     msg: &T,
     direct_addr: Option<std::net::SocketAddr>,
 ) -> crate::error::Result<()> {
-    let endpoint_id = parse_endpoint_id(peer_id)?;
-    let mut addr = EndpointAddr::from(endpoint_id);
-    if let Some(sa) = direct_addr {
-        addr = addr.with_ip_addr(sa);
-    }
-
-    let connection = endpoint
-        .connect(addr, alpn)
-        .await
-        .map_err(|e| crate::error::Error::Dial(e.to_string()))?;
+    let connection =
+        connect_with_direct_addr_fallback(endpoint, peer_id, alpn, direct_addr).await?;
 
     let (mut send, mut recv) = connection
         .open_bi()
@@ -130,11 +157,14 @@ pub(super) async fn try_fetch_from_provider(
         }
     };
 
-    let mut addr = EndpointAddr::from(endpoint_id);
-    if let Some(sa) = direct_addr {
-        addr = addr.with_ip_addr(sa);
-    }
-    let connection = match endpoint.connect(addr, protocols::ALPN_CAR).await {
+    let connection = match connect_with_direct_addr_fallback(
+        endpoint,
+        provider,
+        protocols::ALPN_CAR,
+        direct_addr,
+    )
+    .await
+    {
         Ok(conn) => conn,
         Err(e) => {
             debug!(

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -33,7 +33,20 @@ pub(super) async fn handle_incoming(
         Ok(accepting) => match accepting.await {
             Ok(conn) => conn,
             Err(e) => {
-                warn!("Failed to complete connection handshake: {}", e);
+                let error_msg = e.to_string();
+                if crate::error::Error::is_connection_loss_reason(&error_msg) {
+                    debug!(
+                        remote_addr = ?remote_addr,
+                        error = %error_msg,
+                        "Incoming connection handshake ended before completion"
+                    );
+                } else {
+                    warn!(
+                        remote_addr = ?remote_addr,
+                        error = %error_msg,
+                        "Failed to complete connection handshake"
+                    );
+                }
                 return;
             }
         },

--- a/crates/p2p/src/sync/broadcaster.rs
+++ b/crates/p2p/src/sync/broadcaster.rs
@@ -122,13 +122,23 @@ impl<T: P2PTransport> Broadcaster<T> {
                 })
             }
             (Err(doc_err), Err(col_err)) => {
-                tracing::error!(
-                    doc_id = %broadcast.doc_id,
-                    collection_id = %broadcast.collection_id,
-                    doc_error = %doc_err,
-                    collection_error = %col_err,
-                    "Failed to broadcast to both topics"
-                );
+                if doc_err.is_connection_like() && col_err.is_connection_like() {
+                    tracing::warn!(
+                        doc_id = %broadcast.doc_id,
+                        collection_id = %broadcast.collection_id,
+                        doc_error = %doc_err,
+                        collection_error = %col_err,
+                        "Broadcast to both topics failed because the transport was unavailable"
+                    );
+                } else {
+                    tracing::error!(
+                        doc_id = %broadcast.doc_id,
+                        collection_id = %broadcast.collection_id,
+                        doc_error = %doc_err,
+                        collection_error = %col_err,
+                        "Failed to broadcast to both topics"
+                    );
+                }
                 Err(Error::GossipSubPublish(format!(
                     "failed to publish to both topics: doc={}, collection={}",
                     doc_err, col_err

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -20,7 +20,14 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         match self.runtime.transport.list_replicators().await {
             Ok(replicators) => Some(replicators),
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to get replicators for push");
+                if e.is_connection_like() {
+                    tracing::debug!(
+                        error = %e,
+                        "Skipping replicator push because the transport is unavailable"
+                    );
+                } else {
+                    tracing::warn!(error = %e, "Failed to get replicators for push");
+                }
                 None
             }
         }
@@ -345,16 +352,27 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         "PushLog to replicator was rejected"
                     );
                     any_failed = true;
+                    break;
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    tracing::debug!(
-                        peer_id = %peer_id,
-                        cid = %cid,
-                        error = %e,
-                        "PushLog to replicator failed"
-                    );
+                    if e.is_connection_like() {
+                        tracing::debug!(
+                            peer_id = %peer_id,
+                            cid = %cid,
+                            error = %e,
+                            "PushLog to replicator failed because the connection became unavailable; stopping replay for this peer"
+                        );
+                    } else {
+                        tracing::debug!(
+                            peer_id = %peer_id,
+                            cid = %cid,
+                            error = %e,
+                            "PushLog to replicator failed"
+                        );
+                    }
                     any_failed = true;
+                    break;
                 }
             }
         }

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -254,11 +254,19 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 .send_pushlog_response(token, reply)
                 .await
             {
-                tracing::warn!(
-                    peer_id = %peer_id,
-                    error = %e,
-                    "Failed to send two-stream response via token"
-                );
+                if e.is_connection_like() {
+                    tracing::debug!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Peer disconnected before the two-stream response could be sent via token"
+                    );
+                } else {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Failed to send two-stream response via token"
+                    );
+                }
             }
         } else if let Err(e) = self
             .runtime
@@ -266,11 +274,19 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .send_two_stream_response(peer_id, reply)
             .await
         {
-            tracing::warn!(
-                peer_id = %peer_id,
-                error = %e,
-                "Failed to send two-stream response"
-            );
+            if e.is_connection_like() {
+                tracing::debug!(
+                    peer_id = %peer_id,
+                    error = %e,
+                    "Peer disconnected before the fallback two-stream response could be sent"
+                );
+            } else {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    error = %e,
+                    "Failed to send two-stream response"
+                );
+            }
         }
     }
 }

--- a/crates/p2p/src/sync/manager/links.rs
+++ b/crates/p2p/src/sync/manager/links.rs
@@ -10,42 +10,6 @@ use blockstore::Blockstore;
 
 use crate::error::{Error, Result};
 
-/// Find missing blocks by extracting links from the block data (one level).
-///
-/// This parses the block's IPLD structure and checks which linked CIDs
-/// are not present in the blockstore.
-pub async fn find_missing_links<B: Blockstore>(
-    blockstore: &B,
-    block_data: &[u8],
-) -> Result<Vec<Cid>> {
-    extract_references(blockstore, block_data).await
-}
-
-/// Extract IPLD references from block data and check which are missing.
-async fn extract_references<B: Blockstore>(blockstore: &B, block_data: &[u8]) -> Result<Vec<Cid>> {
-    let refs = extract_ipld_links(block_data)?;
-
-    let mut missing = Vec::new();
-    for link_cid in refs {
-        match blockstore.has(&link_cid).await {
-            Ok(true) => {}
-            Ok(false) => {
-                missing.push(link_cid);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    cid = %link_cid,
-                    error = %e,
-                    "Failed to check if block exists, treating as missing"
-                );
-                missing.push(link_cid);
-            }
-        }
-    }
-
-    Ok(missing)
-}
-
 /// Parse IPLD block data and return all referenced CIDs.
 fn extract_ipld_links(block_data: &[u8]) -> Result<Vec<Cid>> {
     use libipld::multihash::{Code, MultihashDigest};

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -10,7 +10,7 @@ use blockstore::{verify_block_cid, Blockstore};
 use crate::error::{Error, Result};
 use crate::message::PushLogBroadcast;
 use crate::sync::manager::events::SyncEvent;
-use crate::sync::manager::links::find_missing_links;
+use crate::sync::manager::links::find_all_missing_links;
 use crate::sync::manager::pending::{PendingDag, MAX_PENDING_DAGS, PENDING_DAG_TTL};
 use crate::ExplicitReplayAuthorization;
 
@@ -84,7 +84,8 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// 2. Acquire process queue lock (serialize concurrent syncs for same CID)
     /// 3. Check if already merged
     /// 4. Store block in blockstore (marked as unmerged)
-    /// 5. Emit BlockReceived event for database layer to merge
+    /// 5. Emit BlockReceived only once the full reachable DAG is locally present,
+    ///    otherwise emit DagNeedsFetch for the missing descendants
     ///
     /// # Go Compatibility
     ///
@@ -260,11 +261,13 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             ?cid,
             doc_id = %msg.doc_id,
             collection_id = %msg.collection_id,
-            "Block stored, checking for missing links"
+            "Block stored, checking DAG for missing links"
         );
 
-        // Check for missing linked blocks
-        let missing = match find_missing_links(self.blockstore.as_ref(), &msg.block).await {
+        // Check for missing linked blocks at every depth of the reachable DAG.
+        // A single-level check can incorrectly declare Collection -> Composite
+        // roots complete while nested field blocks are still missing locally.
+        let missing = match find_all_missing_links(self.blockstore.as_ref(), &msg.block).await {
             Ok(m) => m,
             Err(e) => {
                 // Block parsing failed - emit error event and propagate error
@@ -452,5 +455,140 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         }
 
         providers.into_iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use blockstore::DefraBlockstore;
+    use bytes::Bytes;
+    use defra_core::{
+        Block, CollectionDeltaPayload, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload,
+    };
+    use storage::backends::MemoryStore;
+
+    use crate::sync::{PeerStateTracker, SyncConfig};
+
+    fn create_lww_block(field_name: &str) -> (Cid, Vec<u8>) {
+        let block = Block::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: b"doc123".to_vec(),
+                field_name: field_name.to_string(),
+                priority: 1,
+                schema_version_id: "schema1".to_string(),
+                data: b"value".to_vec(),
+            }),
+            vec![],
+            vec![],
+        );
+        let bytes = block.to_dag_cbor().expect("encode lww block");
+        let cid = block.generate_cid().expect("generate lww cid");
+        (cid, bytes)
+    }
+
+    fn create_composite_block(doc_id: &str, field_name: &str, field_cid: Cid) -> (Cid, Vec<u8>) {
+        let block = Block::new(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                doc_id: doc_id.as_bytes().to_vec(),
+                schema_version_id: "schema1".to_string(),
+                priority: 1,
+                status: 1,
+            }),
+            vec![],
+            vec![DAGLink::new(field_name, field_cid)],
+        );
+        let bytes = block.to_dag_cbor().expect("encode composite block");
+        let cid = block.generate_cid().expect("generate composite cid");
+        (cid, bytes)
+    }
+
+    fn create_collection_block(
+        schema_version_id: &str,
+        doc_id: &str,
+        composite_cid: Cid,
+    ) -> (Cid, Vec<u8>) {
+        let block = Block::new(
+            CrdtDelta::Collection(CollectionDeltaPayload {
+                schema_version_id: schema_version_id.to_string(),
+                priority: 1,
+            }),
+            vec![],
+            vec![DAGLink::new(doc_id, composite_cid)],
+        );
+        let bytes = block.to_dag_cbor().expect("encode collection block");
+        let cid = block.generate_cid().expect("generate collection cid");
+        (cid, bytes)
+    }
+
+    fn make_broadcast(
+        doc_id: &str,
+        cid: Cid,
+        block: Vec<u8>,
+        collection_id: &str,
+    ) -> PushLogBroadcast {
+        PushLogBroadcast::new(
+            doc_id.to_string(),
+            Bytes::from(cid.to_bytes()),
+            collection_id.to_string(),
+            "creator1".to_string(),
+            Bytes::from(block),
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn process_pushlog_tracks_nested_missing_links_before_merge() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, mut events) =
+            SyncManager::new(blockstore.clone(), peer_state, SyncConfig::default());
+
+        let (field_cid, _field_block) = create_lww_block("name");
+        let (composite_cid, composite_block) = create_composite_block("doc123", "name", field_cid);
+        blockstore
+            .put(&composite_cid, &composite_block)
+            .await
+            .expect("store composite block");
+
+        let (collection_cid, collection_block) =
+            create_collection_block("schema1", "doc123", composite_cid);
+
+        manager
+            .process_pushlog(
+                &make_broadcast("doc123", collection_cid, collection_block, "collection1"),
+                Some("peer-1"),
+                false,
+                None,
+            )
+            .await
+            .expect("process pushlog");
+
+        match events.try_recv().expect("DagNeedsFetch event") {
+            SyncEvent::DagNeedsFetch {
+                root_cid,
+                missing,
+                doc_id,
+                collection_id,
+                sender_peer,
+                ..
+            } => {
+                assert_eq!(root_cid, collection_cid);
+                assert_eq!(missing, vec![field_cid]);
+                assert_eq!(doc_id, "doc123");
+                assert_eq!(collection_id, "collection1");
+                assert_eq!(sender_peer.as_deref(), Some("peer-1"));
+            }
+            other => panic!("expected DagNeedsFetch, got {:?}", other),
+        }
+
+        assert_eq!(manager.pending_dag_count(), 1);
+        assert_eq!(
+            manager.pending_dag_missing(&collection_cid),
+            vec![field_cid]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- reduce noisy P2P log spam for expected disconnect, shutdown, and transport-unavailable paths
- make iroh request/response and CAR fetches retry without a stale cached direct address before giving up
- stop replay loops after the first connection-class failure and let iroh retry loops attempt reconnects instead of trusting connected_peers() snapshots

## Testing
- cargo fmt
- cargo test -p p2p connection_like_detection_matches_common_transport_failures -- --nocapture
- cargo test -p db-merge --lib --no-run
- cargo test -p defra-node --lib --no-run

Refs #885