### PR TITLE
fix(db-blocks): reject secp256r1 for block signing to match Go (#849)

### DIFF
--- a/crates/db-blocks/src/lib.rs
+++ b/crates/db-blocks/src/lib.rs
@@ -59,18 +59,21 @@ pub(crate) fn compute_signature(
         return Ok(None);
     }
 
-    // Go's internal/core/block/signing.go:74-79 rejects any key type other
-    // than secp256k1 or Ed25519 with ErrUnsupportedKeyForSigning. Produce
-    // the same error so a Rust node never emits a signed block that a Go
-    // node would refuse to verify (signature.go:186-193).
-    if matches!(
-        signer.key_type,
-        defra_core::signing::SigningKeyType::Secp256r1
-    ) {
-        return Err(format!(
-            "unsupported key type for block signing: {} (only secp256k1 and ed25519 are supported, matching Go)",
-            signer.key_type
-        ));
+    // Only secp256k1, Ed25519, and BLS are supported for block signing.
+    // secp256k1 and Ed25519 match Go's internal/core/block/signing.go:74-79
+    // and signature.go:186-193. BLS is a Rust-specific extension wired
+    // through a remote signer (Orbis ring); the local-signing match below
+    // still rejects local BLS with a clearer error.
+    match signer.key_type {
+        defra_core::signing::SigningKeyType::Secp256k1
+        | defra_core::signing::SigningKeyType::Ed25519
+        | defra_core::signing::SigningKeyType::Bls => {}
+        other => {
+            return Err(format!(
+                "unsupported key type for signing. KeyType: {}",
+                other
+            ));
+        }
     }
 
     // Serialize the block (without signature) to get the bytes to sign

--- a/crates/db-blocks/src/lib.rs
+++ b/crates/db-blocks/src/lib.rs
@@ -59,6 +59,20 @@ pub(crate) fn compute_signature(
         return Ok(None);
     }
 
+    // Go's internal/core/block/signing.go:74-79 rejects any key type other
+    // than secp256k1 or Ed25519 with ErrUnsupportedKeyForSigning. Produce
+    // the same error so a Rust node never emits a signed block that a Go
+    // node would refuse to verify (signature.go:186-193).
+    if matches!(
+        signer.key_type,
+        defra_core::signing::SigningKeyType::Secp256r1
+    ) {
+        return Err(format!(
+            "unsupported key type for block signing: {} (only secp256k1 and ed25519 are supported, matching Go)",
+            signer.key_type
+        ));
+    }
+
     // Serialize the block (without signature) to get the bytes to sign
     let block_bytes = block
         .to_dag_cbor()
@@ -82,14 +96,6 @@ pub(crate) fn compute_signature(
                 let private_key =
                     crypto::Secp256k1PrivateKey::from_bytes(&signer.private_key_bytes)
                         .map_err(|e| format!("Failed to load secp256k1 private key: {}", e))?;
-                private_key
-                    .sign(&block_bytes)
-                    .map_err(|e| format!("Failed to sign block: {}", e))?
-            }
-            defra_core::signing::SigningKeyType::Secp256r1 => {
-                let private_key =
-                    crypto::Secp256r1PrivateKey::from_bytes(&signer.private_key_bytes)
-                        .map_err(|e| format!("Failed to load secp256r1 private key: {}", e))?;
                 private_key
                     .sign(&block_bytes)
                     .map_err(|e| format!("Failed to sign block: {}", e))?

--- a/crates/db-blocks/src/tests.rs
+++ b/crates/db-blocks/src/tests.rs
@@ -1,8 +1,7 @@
 use super::*;
 use blockstore::{Blockstore, DefraBlockstore};
-use crypto::keys::PublicKey;
+use crypto::keys::Key;
 use defra_core::encryption::EncryptionConfig;
-use defra_core::SignatureType;
 use std::sync::{Arc, Mutex};
 use storage::backends::MemoryStore;
 
@@ -135,11 +134,11 @@ fn test_compute_document_blocks_places_encryption_metadata_in_blockstore_entries
     );
 }
 
-struct TestRemoteSecp256r1Signer {
+struct LocalSecp256r1Signer {
     private_key: crypto::Secp256r1PrivateKey,
 }
 
-impl defra_core::signing::RemoteSigner for TestRemoteSecp256r1Signer {
+impl defra_core::signing::RemoteSigner for LocalSecp256r1Signer {
     fn sign_sync(
         &self,
         data: &[u8],
@@ -151,8 +150,44 @@ impl defra_core::signing::RemoteSigner for TestRemoteSecp256r1Signer {
     }
 }
 
+// Go's internal/core/block/signing.go:74-79 rejects any key type other than
+// secp256k1 or Ed25519 with ErrUnsupportedKeyForSigning. Rust must match so
+// that a Rust node cannot produce blocks a Go node will refuse to verify.
 #[test]
-fn test_compute_signature_supports_remote_secp256r1() {
+fn test_compute_signature_rejects_local_secp256r1_block_signing() {
+    let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
+    let public_key = private_key.public_key();
+
+    let block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc-1".to_vec(),
+            schema_version_id: "schema-v1".to_string(),
+            status: 1,
+            priority: 1,
+        }),
+        Vec::new(),
+        Vec::new(),
+    );
+
+    let signer = defra_core::signing::SigningConfig {
+        key_type: defra_core::signing::SigningKeyType::Secp256r1,
+        private_key_bytes: private_key.raw().to_vec(),
+        public_key_bytes: public_key.raw_owned(),
+        public_key_hex: hex::encode(public_key.raw()),
+        remote_signer: None,
+        signing_authorization: None,
+    };
+
+    let err = compute_signature(&block, &signer)
+        .expect_err("secp256r1 block signing must be rejected for Go parity");
+    assert!(
+        err.contains("secp256r1") || err.contains("ES256") || err.contains("secp256k1"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_compute_signature_rejects_remote_secp256r1_block_signing() {
     let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
     let public_key = private_key.public_key();
 
@@ -172,33 +207,20 @@ fn test_compute_signature_supports_remote_secp256r1() {
         private_key_bytes: Vec::new(),
         public_key_bytes: public_key.raw_owned(),
         public_key_hex: hex::encode(public_key.raw()),
-        remote_signer: Some(Arc::new(TestRemoteSecp256r1Signer { private_key })),
+        remote_signer: Some(Arc::new(LocalSecp256r1Signer { private_key })),
         signing_authorization: None,
     };
 
-    let (sig_cid, sig_cbor) = compute_signature(&block, &signer)
-        .expect("signature should succeed")
-        .expect("composite block should be signed");
-    assert!(!sig_cid.to_bytes().is_empty());
-
-    let signature = Signature::from_dag_cbor(&sig_cbor).expect("signature block should decode");
-    assert_eq!(signature.header.sig_type, SignatureType::ES256);
-    assert_eq!(
-        signature.header.identity,
-        signer.public_key_hex.as_bytes().to_vec()
+    let err = compute_signature(&block, &signer)
+        .expect_err("secp256r1 block signing must be rejected even when delegated to remote");
+    assert!(
+        err.contains("secp256r1") || err.contains("ES256") || err.contains("secp256k1"),
+        "unexpected error: {err}"
     );
-
-    let public_key = crypto::Secp256r1PublicKey::from_bytes(&signer.public_key_bytes)
-        .expect("public key should decode");
-    let signed_bytes = block.to_dag_cbor().expect("block should encode");
-    let valid = public_key
-        .verify(&signed_bytes, &signature.value)
-        .expect("verification should succeed");
-    assert!(valid, "remote secp256r1 signature should verify");
 }
 
 struct CapturingRemoteSigner {
-    private_key: crypto::Secp256r1PrivateKey,
+    private_key: crypto::Ed25519PrivateKey,
     seen_authorization: Arc<Mutex<Option<defra_core::signing::SigningAuthorization>>>,
 }
 
@@ -217,7 +239,7 @@ impl defra_core::signing::RemoteSigner for CapturingRemoteSigner {
 
 #[test]
 fn test_compute_signature_passes_signing_authorization_to_remote_signer() {
-    let private_key = crypto::generate_secp256r1().expect("should generate secp256r1 key");
+    let private_key = crypto::generate_ed25519().expect("should generate ed25519 key");
     let public_key = private_key.public_key();
     let seen_authorization = Arc::new(Mutex::new(None));
 
@@ -233,7 +255,7 @@ fn test_compute_signature_passes_signing_authorization_to_remote_signer() {
     );
 
     let signer = defra_core::signing::SigningConfig {
-        key_type: defra_core::signing::SigningKeyType::Secp256r1,
+        key_type: defra_core::signing::SigningKeyType::Ed25519,
         private_key_bytes: Vec::new(),
         public_key_bytes: public_key.raw_owned(),
         public_key_hex: hex::encode(public_key.raw()),


### PR DESCRIPTION
Resolves #849

## Summary

Rust was signing blocks with secp256r1 (both locally and via remote signer). Go's `internal/core/block/signing.go:74-79` rejects any key type other than secp256k1 or Ed25519 with `ErrUnsupportedKeyForSigning`, and `getPublicKeyFromSignature` at `signature.go:186-193` only accepts ES256K and EdDSA for verification. Any ES256-signed block a Rust node produced would be rejected by a Go peer, breaking cross-implementation replication.

Fix: reject secp256r1 at `compute_signature` so a Rust node never emits a block a Go node refuses to verify.

## Scope clarification

The filed issue described a signature-byte S-normalization gap. The audit found:
- Go's `ecdsa.SignASN1` uses a random nonce (`rand.Reader`), so byte-identical signatures between Rust (RFC 6979 deterministic) and Go are impossible regardless of `normalize_s`.
- The real parity gap is that Go refuses to sign or verify secp256r1 blocks at all.

Fixing the sign path is the minimum to guarantee a Rust node cannot produce a block a Go peer will reject.

Non-block secp256r1 paths (JWT tokens, DID generation, raw identity signing) are unchanged — those already interoperate fine.

## Test plan

- [x] `test_compute_signature_rejects_local_secp256r1_block_signing` — asserts local secp256r1 signing returns an error. Failed on main, passes with fix.
- [x] `test_compute_signature_rejects_remote_secp256r1_block_signing` — asserts remote-signer secp256r1 is also rejected (can't bypass by wrapping in a RemoteSigner).
- [x] `test_compute_signature_passes_signing_authorization_to_remote_signer` — switched from secp256r1 to Ed25519 so the authorization pass-through test still exercises remote signing.
- [x] `cargo test -p db-blocks` — all 8 tests pass.
- [x] `cargo test -p db-merge` — all 58 tests pass (verify path is unchanged).
- [x] `cargo clippy -p db-blocks -p db-merge -p defra-core --tests --no-deps -- -D warnings` — clean.
- [x] `cargo build --workspace` — clean.