### PR TITLE
fix(db-merge): derive secp256k1 peer DIDs via crypto crate (#852)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1_der"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
+
+[[package]]
 name = "async-broadcast"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7093,9 +7099,11 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
 dependencies = [
+ "asn1_der",
  "bs58",
  "ed25519-dalek 2.2.0",
  "hkdf",
+ "k256",
  "multihash 0.19.3",
  "quick-protobuf",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ ciborium = "0.2"
 
 # P2P networking
 # Note: Using 0.53 to match iroh-bitswap's dependency
-libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "relay"] }
+libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "relay", "secp256k1"] }
 iroh-bitswap = { git = "https://github.com/sourcenetwork/beetle", branch = "main" }
 libp2p-stream = "0.1.0-alpha.1"
 multiaddr = "0.18"

--- a/crates/db-merge/src/peer_identity.rs
+++ b/crates/db-merge/src/peer_identity.rs
@@ -12,7 +12,11 @@
 //! # Supported Key Types
 //!
 //! - Ed25519 (most common for libp2p)
-//! - secp256k1 (used by some networks)
+//! - secp256k1 (used by some networks, common with Go peers)
+//!
+//! Both key types have short public keys that libp2p inlines into the PeerId
+//! under the 42-byte identity-hash threshold, so `peer_id_to_did` can recover
+//! the key material from the PeerId alone.
 
 use crypto::keys::PublicKey as _;
 use crypto::{create_did_key, KeyType, Secp256k1PublicKey};
@@ -63,9 +67,10 @@ pub enum PeerIdentityError {
 /// let did = peer_id_to_did(&peer_id)?;
 /// ```
 pub fn peer_id_to_did(peer_id: &PeerId) -> Result<Did, PeerIdentityError> {
-    // Try to extract the public key from the PeerId
-    // Note: This only works for PeerIds that contain an inline public key
-    // (which is the case for Ed25519 keys used by most libp2p implementations)
+    // Works for PeerIds that inline their public key. Ed25519 (36-byte
+    // protobuf) and secp256k1 (37-byte protobuf) both fit under libp2p's
+    // 42-byte identity-hash threshold, so inline decoding is the common
+    // case for both supported key types.
     let public_key = PublicKey::try_decode_protobuf(&peer_id.to_bytes()[2..])
         .map_err(|e| PeerIdentityError::KeyExtraction(e.to_string()))?;
 
@@ -157,7 +162,26 @@ pub fn create_peer_to_did_mapper() -> impl Fn(&str) -> Option<Did> + Send + Sync
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libp2p::identity::Keypair;
+    use libp2p::identity::{secp256k1, Keypair};
+
+    // Known secp256k1 fixture that Go's `crypto.NewPublicKey(...).DID()`
+    // produces for the same 32-byte private key. Mirrors the constants in
+    // crates/crypto/tests/go_compat_keys.rs so this test exercises the
+    // full extraction pipeline (libp2p protobuf → compressed 33 bytes →
+    // crypto::Secp256k1PublicKey → uncompressed 65 bytes → DID).
+    const GO_SECP256K1_PRIVATE_KEY: [u8; 32] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e,
+        0x1f, 0x20,
+    ];
+    const GO_SECP256K1_DID: &str =
+        "did:key:z7r8or8ecagY9LD87s54K2arcXmgmw6bUhyvq83RrnB2hJiUb2ug5YGAk1ZUaimewnoLL1ZGzXuTCnWRSrRZgR3v2PLPH";
+
+    fn libp2p_keypair_from_go_fixture() -> Keypair {
+        let mut sk_bytes = GO_SECP256K1_PRIVATE_KEY;
+        let sk = secp256k1::SecretKey::try_from_bytes(&mut sk_bytes).unwrap();
+        secp256k1::Keypair::from(sk).into()
+    }
 
     // Go's defradb/crypto/keys.go:276-282 derives the secp256k1 DID from
     // the uncompressed SEC1 public key. `crypto::Secp256k1PublicKey::did`
@@ -179,9 +203,11 @@ mod tests {
             did_from_peer_id, did_from_public_key,
             "peer_id and public_key conversions must agree"
         );
+        // Go produces the uncompressed secp256k1 DID with the base58btc
+        // `z7r8` prefix (multicodec 0xe7 + 65-byte uncompressed point).
         assert!(
-            did_from_peer_id.as_str().starts_with("did:key:z"),
-            "secp256k1 DID must start with did:key:z, got {}",
+            did_from_peer_id.as_str().starts_with("did:key:z7r8"),
+            "secp256k1 DID must start with did:key:z7r8, got {}",
             did_from_peer_id.as_str()
         );
 
@@ -192,6 +218,29 @@ mod tests {
         assert_eq!(kt, crypto::KeyType::Secp256k1);
         assert_eq!(bytes.len(), 65);
         assert_eq!(bytes[0], 0x04);
+    }
+
+    // Exercises the full libp2p-side extraction against a fixture that
+    // matches `crates/crypto/tests/go_compat_keys.rs::test_secp256k1_did_matches_go`.
+    // Rust must produce the same DID Go produces for the same 32-byte
+    // private key when routed through libp2p's protobuf encoding.
+    #[test]
+    fn test_secp256k1_public_key_to_did_matches_go_fixture() {
+        let kp = libp2p_keypair_from_go_fixture();
+        let did = public_key_to_did(&kp.public()).expect("secp256k1 DID conversion must succeed");
+        assert_eq!(
+            did.as_str(),
+            GO_SECP256K1_DID,
+            "libp2p secp256k1 path must produce the same DID Go produces for the fixture key"
+        );
+    }
+
+    #[test]
+    fn test_secp256k1_peer_id_to_did_matches_go_fixture() {
+        let kp = libp2p_keypair_from_go_fixture();
+        let peer_id = PeerId::from_public_key(&kp.public());
+        let did = peer_id_to_did(&peer_id).expect("secp256k1 DID conversion must succeed");
+        assert_eq!(did.as_str(), GO_SECP256K1_DID);
     }
 
     #[test]

--- a/crates/db-merge/src/peer_identity.rs
+++ b/crates/db-merge/src/peer_identity.rs
@@ -14,7 +14,8 @@
 //! - Ed25519 (most common for libp2p)
 //! - secp256k1 (used by some networks)
 
-use crypto::{create_did_key, KeyType};
+use crypto::keys::PublicKey as _;
+use crypto::{create_did_key, KeyType, Secp256k1PublicKey};
 use identity::Did;
 use libp2p::identity::PublicKey;
 use libp2p::PeerId;
@@ -84,33 +85,43 @@ pub fn peer_id_to_did(peer_id: &PeerId) -> Result<Did, PeerIdentityError> {
 ///
 /// The corresponding DID, or an error if the key type is unsupported.
 pub fn public_key_to_did(public_key: &PublicKey) -> Result<Did, PeerIdentityError> {
-    let (key_type, key_bytes) = match public_key.key_type() {
+    let did_string = match public_key.key_type() {
         libp2p::identity::KeyType::Ed25519 => {
             let encoded = public_key.encode_protobuf();
-            // Ed25519 protobuf encoding: type (1 byte) + length (1 byte) + key (32 bytes)
-            // We need just the raw 32-byte key
+            // libp2p protobuf PublicKey for Ed25519:
+            //   0x08 0x01       (field 1, KeyType = Ed25519)
+            //   0x12 0x20       (field 2, Data length 32)
+            //   <32 raw bytes>
             if encoded.len() < 36 {
                 return Err(PeerIdentityError::KeyExtraction(
                     "Ed25519 key too short".to_string(),
                 ));
             }
-            (KeyType::Ed25519, encoded[4..36].to_vec())
+            create_did_key(KeyType::Ed25519, &encoded[4..36])
+                .map_err(|e| PeerIdentityError::DidCreation(e.to_string()))?
         }
         libp2p::identity::KeyType::Secp256k1 => {
+            // Go's defradb/crypto/keys.go:276-282 derives the secp256k1 DID
+            // from the uncompressed SEC1 public key (65 bytes, 0x04 prefix).
+            // libp2p hands us the compressed 33-byte form via protobuf, so
+            // route through crypto::Secp256k1PublicKey which decompresses
+            // the point and reuses the same createDIDKey encoding Go uses.
             let encoded = public_key.encode_protobuf();
-            // secp256k1 protobuf encoding varies, extract the key portion
-            // The format is: type varint + data
-            if encoded.len() < 35 {
+            // libp2p protobuf PublicKey for secp256k1:
+            //   0x08 0x02       (field 1, KeyType = Secp256k1)
+            //   0x12 0x21       (field 2, Data length 33)
+            //   <33 compressed SEC1 bytes>
+            if encoded.len() < 37 {
                 return Err(PeerIdentityError::KeyExtraction(
                     "secp256k1 key too short".to_string(),
                 ));
             }
-            // For secp256k1, we need uncompressed format (65 bytes) for DID
-            // libp2p uses compressed format (33 bytes), need to expand
-            // For now, return error - this needs proper implementation
-            return Err(PeerIdentityError::UnsupportedKeyType(
-                "secp256k1 DID conversion requires uncompressed key expansion".to_string(),
-            ));
+            let compressed = &encoded[4..37];
+            let crypto_key = Secp256k1PublicKey::from_bytes(compressed)
+                .map_err(|e| PeerIdentityError::KeyExtraction(e.to_string()))?;
+            crypto_key
+                .did()
+                .map_err(|e| PeerIdentityError::DidCreation(e.to_string()))?
         }
         other => {
             return Err(PeerIdentityError::UnsupportedKeyType(format!(
@@ -119,9 +130,6 @@ pub fn public_key_to_did(public_key: &PublicKey) -> Result<Did, PeerIdentityErro
             )));
         }
     };
-
-    let did_string = create_did_key(key_type, &key_bytes)
-        .map_err(|e| PeerIdentityError::DidCreation(e.to_string()))?;
 
     Did::new(did_string).map_err(PeerIdentityError::DidParse)
 }
@@ -150,6 +158,61 @@ pub fn create_peer_to_did_mapper() -> impl Fn(&str) -> Option<Did> + Send + Sync
 mod tests {
     use super::*;
     use libp2p::identity::Keypair;
+
+    // Go's defradb/crypto/keys.go:276-282 derives the secp256k1 DID from
+    // the uncompressed SEC1 public key. `crypto::Secp256k1PublicKey::did`
+    // already does the equivalent. Peer-identity conversion must produce
+    // the same DID starting from libp2p's compressed key so Rust and Go
+    // agree on the DID for the same peer.
+    #[test]
+    fn test_secp256k1_peer_to_did_matches_crypto_did() {
+        let libp2p_keypair = Keypair::generate_secp256k1();
+        let libp2p_pk = libp2p_keypair.public();
+        let peer_id = PeerId::from_public_key(&libp2p_pk);
+
+        let did_from_peer_id =
+            peer_id_to_did(&peer_id).expect("secp256k1 peer_id must convert to did");
+        let did_from_public_key =
+            public_key_to_did(&libp2p_pk).expect("secp256k1 public key must convert to did");
+
+        assert_eq!(
+            did_from_peer_id, did_from_public_key,
+            "peer_id and public_key conversions must agree"
+        );
+        assert!(
+            did_from_peer_id.as_str().starts_with("did:key:z"),
+            "secp256k1 DID must start with did:key:z, got {}",
+            did_from_peer_id.as_str()
+        );
+
+        // Sanity: parsing the DID back must round-trip to a secp256k1
+        // key type with uncompressed SEC1 bytes (65 bytes starting 0x04).
+        let (kt, bytes) =
+            crypto::parse_did_key(did_from_peer_id.as_str()).expect("DID must round-trip");
+        assert_eq!(kt, crypto::KeyType::Secp256k1);
+        assert_eq!(bytes.len(), 65);
+        assert_eq!(bytes[0], 0x04);
+    }
+
+    #[test]
+    fn test_secp256k1_peer_to_did_is_deterministic() {
+        let libp2p_keypair = Keypair::generate_secp256k1();
+        let peer_id = PeerId::from_public_key(&libp2p_keypair.public());
+
+        let did1 = peer_id_to_did(&peer_id).unwrap();
+        let did2 = peer_id_to_did(&peer_id).unwrap();
+        assert_eq!(did1, did2);
+    }
+
+    #[test]
+    fn test_secp256k1_mapper_function() {
+        let libp2p_keypair = Keypair::generate_secp256k1();
+        let peer_id = PeerId::from_public_key(&libp2p_keypair.public());
+
+        let mapper = create_peer_to_did_mapper();
+        let did = mapper(&peer_id.to_string()).expect("secp256k1 peer must map to DID");
+        assert!(did.as_str().starts_with("did:key:z"));
+    }
 
     #[test]
     fn test_ed25519_peer_to_did() {


### PR DESCRIPTION
Resolves #852

## Summary

`public_key_to_did` for secp256k1 peers returned `UnsupportedKeyType("secp256k1 DID conversion requires uncompressed key expansion")` — blocking any ACP lookup keyed on a secp256k1-authenticated peer. Go supports both Ed25519 and secp256k1 and derives the DID from the uncompressed SEC1 public key (`defradb/crypto/keys.go:276-282`).

Fix: extract the compressed 33-byte key from libp2p's protobuf (`encoded[4..37]`), construct a `crypto::Secp256k1PublicKey` (which already decompresses the point to 65 bytes), and delegate to its `did()` — the same path already byte-parity-tested against Go in `crates/crypto/tests/go_compat_keys.rs::test_secp256k1_did_matches_go`.

Also enables the `secp256k1` feature on the workspace `libp2p` dependency; without it libp2p cannot even decode secp256k1 keys, so the existing match arm was effectively unreachable from real peer traffic.

## Test plan

- [x] `test_secp256k1_peer_to_did_matches_crypto_did` — constructs a libp2p secp256k1 keypair, runs it through `peer_id_to_did` and `public_key_to_did`, asserts they agree, start with `did:key:z`, and round-trip via `parse_did_key` back to `(Secp256k1, 65 uncompressed bytes, 0x04 prefix)`. Failed on main (`UnsupportedKeyType(...)`), passes with fix.
- [x] `test_secp256k1_peer_to_did_is_deterministic` — same peer → same DID across calls.
- [x] `test_secp256k1_mapper_function` — closure from `create_peer_to_did_mapper` maps a secp256k1 peer ID string to a DID.
- [x] Existing Ed25519 tests still pass.
- [x] `cargo test -p db-merge --lib peer_identity` — 8/8.
- [x] `cargo clippy -p db-merge --tests --no-deps -- -D warnings` — clean.
- [x] `cargo build --workspace` — clean.
