### PR TITLE
fix(p2p): record authenticated gossip peers before access checks

### DIFF
--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -730,6 +730,68 @@ async fn pushlog_connected_peer_is_not_marked_explicit_replicator() {
 }
 
 #[tokio::test]
+async fn gossip_controlled_mode_allows_authenticated_sender_without_prior_peer_connected() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let peer = random_peer_id();
+
+    let (coordinator, mut events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state.clone());
+
+    coordinator
+        .handle_transport_event(gossip_event(peer.clone(), "collection1"))
+        .await
+        .unwrap();
+
+    assert!(
+        peer_state.is_connected(peer.as_str()),
+        "authenticated gossip sender should be tracked as connected before access checks"
+    );
+
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived {
+            sender_peer,
+            is_explicit_replicator,
+            ..
+        } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+            assert!(
+                !is_explicit_replicator,
+                "authenticated gossip sender must not gain explicit replicator trust"
+            );
+        }
+        other => panic!("expected BlockReceived, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn peer_subscribed_event_marks_peer_connected() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let peer = random_peer_id();
+
+    let (coordinator, _events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state.clone());
+
+    coordinator
+        .handle_transport_event(TransportEvent::PeerSubscribed {
+            peer_id: peer.clone(),
+            topic: "collection1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        peer_state.is_connected(peer.as_str()),
+        "peer subscription should establish connected state for access checks"
+    );
+    assert_eq!(
+        peer_state.peers_for_collection("collection1"),
+        vec![peer.as_str().to_string()]
+    );
+}
+
+#[tokio::test]
 async fn pushlog_registered_replicator_is_marked_explicit_replicator() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());

--- a/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
@@ -23,6 +23,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             "Received GossipSub message"
         );
 
+        // Gossip delivery already identifies the sending peer at the transport
+        // layer. Record that authenticated liveness before checking access so
+        // iroh gossip messages don't race ahead of PeerConnected bookkeeping.
+        self.access
+            .peer_state
+            .peer_connected(propagation_source.as_str());
+
         // Access control check
         if let Err(e) = self
             .check_access_str(propagation_source.as_str(), &message.collection_id)

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -66,6 +66,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     fn handle_peer_subscribed(&self, peer_id: PeerId, topic: String) {
         tracing::debug!(peer_id = %peer_id, topic = %topic, "Peer subscribed to topic");
+        // iroh gossip neighbors can appear before the coordinator has observed a
+        // direct PeerConnected event. Treat an authenticated subscription event
+        // as proof that the peer is live so subsequent access checks use a
+        // consistent view of peer connectivity.
+        self.access.peer_state.peer_connected(peer_id.as_str());
         self.access
             .peer_state
             .peer_subscribed(peer_id.as_str(), topic);


### PR DESCRIPTION
## Summary
- record authenticated gossip senders as connected before coordinator access checks run
- treat peer subscription events as connected for the same coordinator peer-state invariant
- add regression coverage for controlled-mode gossip ingress and peer-subscription ordering

## Testing
- cargo test -p p2p access_tests -- --nocapture