### PR TITLE
fix(embedded): preserve peer connection ordering in p2p event loops

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -13,6 +13,18 @@ use p2p::P2PTransport;
 
 type WireDocumentAcp = Option<Box<dyn FnOnce(Arc<dyn acp::DocumentACP>)>>;
 
+fn transport_event_requires_inline_ordering<ResponseToken>(
+    event: &p2p::TransportEvent<ResponseToken>,
+) -> bool {
+    matches!(
+        event,
+        p2p::TransportEvent::PeerConnected(_)
+            | p2p::TransportEvent::PeerDisconnected(_)
+            | p2p::TransportEvent::PeerSubscribed { .. }
+            | p2p::TransportEvent::PeerUnsubscribed { .. }
+    )
+}
+
 pub(super) struct P2PSetup {
     pub(super) host_handle: Option<p2p::P2PHostHandle>,
     pub(super) p2p_tasks: Option<P2PTasks>,
@@ -228,10 +240,20 @@ impl Node {
                     _ => {}
                 }
 
+                let transport_event = p2p::convert_host_event(event);
+                if transport_event_requires_inline_ordering(&transport_event) {
+                    if let Err(e) = coordinator_for_events
+                        .handle_transport_event(transport_event)
+                        .await
+                    {
+                        error!("Failed to handle host event: {}", e);
+                    }
+                    continue;
+                }
+
                 let permit = semaphore.clone().acquire_owned().await.unwrap();
                 let coord = coordinator_for_events.clone();
                 tokio::spawn(async move {
-                    let transport_event = p2p::convert_host_event(event);
                     if let Err(e) = coord.handle_transport_event(transport_event).await {
                         error!("Failed to handle host event: {}", e);
                     }
@@ -537,6 +559,13 @@ impl Node {
                         ));
                     }
                     _ => {}
+                }
+
+                if transport_event_requires_inline_ordering(&event) {
+                    if let Err(e) = coordinator_for_events.handle_transport_event(event).await {
+                        error!("Failed to handle iroh event: {}", e);
+                    }
+                    continue;
                 }
 
                 let permit = semaphore.clone().acquire_owned().await.unwrap();

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -13,18 +13,6 @@ use p2p::P2PTransport;
 
 type WireDocumentAcp = Option<Box<dyn FnOnce(Arc<dyn acp::DocumentACP>)>>;
 
-fn transport_event_requires_inline_ordering<ResponseToken>(
-    event: &p2p::TransportEvent<ResponseToken>,
-) -> bool {
-    matches!(
-        event,
-        p2p::TransportEvent::PeerConnected(_)
-            | p2p::TransportEvent::PeerDisconnected(_)
-            | p2p::TransportEvent::PeerSubscribed { .. }
-            | p2p::TransportEvent::PeerUnsubscribed { .. }
-    )
-}
-
 pub(super) struct P2PSetup {
     pub(super) host_handle: Option<p2p::P2PHostHandle>,
     pub(super) p2p_tasks: Option<P2PTasks>,
@@ -241,7 +229,7 @@ impl Node {
                 }
 
                 let transport_event = p2p::convert_host_event(event);
-                if transport_event_requires_inline_ordering(&transport_event) {
+                if transport_event.requires_inline_ordering() {
                     if let Err(e) = coordinator_for_events
                         .handle_transport_event(transport_event)
                         .await
@@ -561,7 +549,7 @@ impl Node {
                     _ => {}
                 }
 
-                if transport_event_requires_inline_ordering(&event) {
+                if event.requires_inline_ordering() {
                     if let Err(e) = coordinator_for_events.handle_transport_event(event).await {
                         error!("Failed to handle iroh event: {}", e);
                     }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -795,7 +795,7 @@ impl NodeBuilder {
     ) {
         let semaphore = Arc::new(tokio::sync::Semaphore::new(32));
         while let Some(event) = events.recv().await {
-            if transport_event_requires_inline_ordering(&event) {
+            if event.requires_inline_ordering() {
                 if let Err(e) = coordinator.handle_transport_event(event).await {
                     if e.is_rate_limited() {
                         tracing::debug!(error = %e, "P2P rate-limited");
@@ -823,18 +823,6 @@ impl NodeBuilder {
                 drop(permit);
             });
         }
-    }
-
-    fn transport_event_requires_inline_ordering<ResponseToken>(
-        event: &p2p::TransportEvent<ResponseToken>,
-    ) -> bool {
-        matches!(
-            event,
-            p2p::TransportEvent::PeerConnected(_)
-                | p2p::TransportEvent::PeerDisconnected(_)
-                | p2p::TransportEvent::PeerSubscribed { .. }
-                | p2p::TransportEvent::PeerUnsubscribed { .. }
-        )
     }
 }
 

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -795,6 +795,19 @@ impl NodeBuilder {
     ) {
         let semaphore = Arc::new(tokio::sync::Semaphore::new(32));
         while let Some(event) = events.recv().await {
+            if transport_event_requires_inline_ordering(&event) {
+                if let Err(e) = coordinator.handle_transport_event(event).await {
+                    if e.is_rate_limited() {
+                        tracing::debug!(error = %e, "P2P rate-limited");
+                    } else if e.is_retriable() {
+                        tracing::warn!(error = %e, "P2P transport event failed after retries");
+                    } else {
+                        tracing::error!(error = %e, "P2P event handler error");
+                    }
+                }
+                continue;
+            }
+
             let permit = semaphore.clone().acquire_owned().await.unwrap();
             let coord = coordinator.clone();
             tokio::spawn(async move {
@@ -810,6 +823,18 @@ impl NodeBuilder {
                 drop(permit);
             });
         }
+    }
+
+    fn transport_event_requires_inline_ordering<ResponseToken>(
+        event: &p2p::TransportEvent<ResponseToken>,
+    ) -> bool {
+        matches!(
+            event,
+            p2p::TransportEvent::PeerConnected(_)
+                | p2p::TransportEvent::PeerDisconnected(_)
+                | p2p::TransportEvent::PeerSubscribed { .. }
+                | p2p::TransportEvent::PeerUnsubscribed { .. }
+        )
     }
 }
 

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -54,13 +54,18 @@ pub(crate) fn spawn_libp2p_event_handler<B: blockstore::Blockstore + 'static>(
                 _ => {}
             }
 
+            let transport_event = p2p::convert_host_event(event);
+            if transport_event_requires_inline_ordering(&transport_event) {
+                if let Err(error) = coordinator.handle_transport_event(transport_event).await {
+                    tracing::error!(error = %error, "error handling libp2p event");
+                }
+                continue;
+            }
+
             let permit = semaphore.clone().acquire_owned().await.unwrap();
             let coordinator = coordinator.clone();
             tokio::spawn(async move {
-                if let Err(error) = coordinator
-                    .handle_transport_event(p2p::convert_host_event(event))
-                    .await
-                {
+                if let Err(error) = coordinator.handle_transport_event(transport_event).await {
                     tracing::error!(error = %error, "error handling libp2p event");
                 }
                 drop(permit);
@@ -102,6 +107,13 @@ pub(crate) fn spawn_iroh_event_handler<B: blockstore::Blockstore + 'static>(
                 _ => {}
             }
 
+            if transport_event_requires_inline_ordering(&event) {
+                if let Err(error) = coordinator.handle_transport_event(event).await {
+                    tracing::error!(error = %error, "error handling iroh event");
+                }
+                continue;
+            }
+
             let permit = semaphore.clone().acquire_owned().await.unwrap();
             let coordinator = coordinator.clone();
             tokio::spawn(async move {
@@ -112,6 +124,18 @@ pub(crate) fn spawn_iroh_event_handler<B: blockstore::Blockstore + 'static>(
             });
         }
     })
+}
+
+fn transport_event_requires_inline_ordering<ResponseToken>(
+    event: &p2p::TransportEvent<ResponseToken>,
+) -> bool {
+    matches!(
+        event,
+        p2p::TransportEvent::PeerConnected(_)
+            | p2p::TransportEvent::PeerDisconnected(_)
+            | p2p::TransportEvent::PeerSubscribed { .. }
+            | p2p::TransportEvent::PeerUnsubscribed { .. }
+    )
 }
 
 pub(crate) fn spawn_replication_loop<B, T, S>(
@@ -372,4 +396,65 @@ pub(crate) fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transport_event_requires_inline_ordering;
+
+    #[test]
+    fn transport_control_plane_events_preserve_ordering() {
+        let peer = p2p::transport::PeerId::new("peer".to_string());
+        let topic = "topic".to_string();
+
+        assert!(transport_event_requires_inline_ordering(
+            &p2p::TransportEvent::<()>::PeerConnected(peer.clone())
+        ));
+        assert!(transport_event_requires_inline_ordering(
+            &p2p::TransportEvent::<()>::PeerDisconnected(peer.clone())
+        ));
+        assert!(transport_event_requires_inline_ordering(
+            &p2p::TransportEvent::<()>::PeerSubscribed {
+                peer_id: peer.clone(),
+                topic: topic.clone(),
+            }
+        ));
+        assert!(transport_event_requires_inline_ordering(
+            &p2p::TransportEvent::<()>::PeerUnsubscribed {
+                peer_id: peer,
+                topic,
+            }
+        ));
+    }
+
+    #[test]
+    fn transport_data_plane_events_remain_parallelizable() {
+        let peer = p2p::transport::PeerId::new("peer".to_string());
+        let cid = cid::Cid::try_from("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku")
+            .expect("valid cid");
+        let message = p2p::message::PushLogBroadcast {
+            cid: cid.to_bytes().into(),
+            creator: "creator".to_string(),
+            doc_id: "doc".to_string(),
+            collection_id: "collection".to_string(),
+            block: bytes::Bytes::from_static(b"block"),
+            acp_actor_relationships: None,
+        };
+
+        assert!(!transport_event_requires_inline_ordering(
+            &p2p::TransportEvent::<()>::GossipMessage {
+                propagation_source: peer.clone(),
+                message_id: p2p::transport::MessageId::new("msg".to_string()),
+                topic: "topic".to_string(),
+                message,
+            }
+        ));
+        assert!(!transport_event_requires_inline_ordering(
+            &p2p::TransportEvent::<()>::BitswapBlockReceived {
+                query_id: p2p::QueryId(1),
+                cid,
+                data: vec![1, 2, 3],
+            }
+        ));
+    }
 }

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -55,7 +55,7 @@ pub(crate) fn spawn_libp2p_event_handler<B: blockstore::Blockstore + 'static>(
             }
 
             let transport_event = p2p::convert_host_event(event);
-            if transport_event_requires_inline_ordering(&transport_event) {
+            if transport_event.requires_inline_ordering() {
                 if let Err(error) = coordinator.handle_transport_event(transport_event).await {
                     tracing::error!(error = %error, "error handling libp2p event");
                 }
@@ -107,7 +107,7 @@ pub(crate) fn spawn_iroh_event_handler<B: blockstore::Blockstore + 'static>(
                 _ => {}
             }
 
-            if transport_event_requires_inline_ordering(&event) {
+            if event.requires_inline_ordering() {
                 if let Err(error) = coordinator.handle_transport_event(event).await {
                     tracing::error!(error = %error, "error handling iroh event");
                 }
@@ -124,18 +124,6 @@ pub(crate) fn spawn_iroh_event_handler<B: blockstore::Blockstore + 'static>(
             });
         }
     })
-}
-
-fn transport_event_requires_inline_ordering<ResponseToken>(
-    event: &p2p::TransportEvent<ResponseToken>,
-) -> bool {
-    matches!(
-        event,
-        p2p::TransportEvent::PeerConnected(_)
-            | p2p::TransportEvent::PeerDisconnected(_)
-            | p2p::TransportEvent::PeerSubscribed { .. }
-            | p2p::TransportEvent::PeerUnsubscribed { .. }
-    )
 }
 
 pub(crate) fn spawn_replication_loop<B, T, S>(
@@ -396,65 +384,4 @@ pub(crate) fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
             }
         }
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::transport_event_requires_inline_ordering;
-
-    #[test]
-    fn transport_control_plane_events_preserve_ordering() {
-        let peer = p2p::transport::PeerId::new("peer".to_string());
-        let topic = "topic".to_string();
-
-        assert!(transport_event_requires_inline_ordering(
-            &p2p::TransportEvent::<()>::PeerConnected(peer.clone())
-        ));
-        assert!(transport_event_requires_inline_ordering(
-            &p2p::TransportEvent::<()>::PeerDisconnected(peer.clone())
-        ));
-        assert!(transport_event_requires_inline_ordering(
-            &p2p::TransportEvent::<()>::PeerSubscribed {
-                peer_id: peer.clone(),
-                topic: topic.clone(),
-            }
-        ));
-        assert!(transport_event_requires_inline_ordering(
-            &p2p::TransportEvent::<()>::PeerUnsubscribed {
-                peer_id: peer,
-                topic,
-            }
-        ));
-    }
-
-    #[test]
-    fn transport_data_plane_events_remain_parallelizable() {
-        let peer = p2p::transport::PeerId::new("peer".to_string());
-        let cid = cid::Cid::try_from("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku")
-            .expect("valid cid");
-        let message = p2p::message::PushLogBroadcast {
-            cid: cid.to_bytes().into(),
-            creator: "creator".to_string(),
-            doc_id: "doc".to_string(),
-            collection_id: "collection".to_string(),
-            block: bytes::Bytes::from_static(b"block"),
-            acp_actor_relationships: None,
-        };
-
-        assert!(!transport_event_requires_inline_ordering(
-            &p2p::TransportEvent::<()>::GossipMessage {
-                propagation_source: peer.clone(),
-                message_id: p2p::transport::MessageId::new("msg".to_string()),
-                topic: "topic".to_string(),
-                message,
-            }
-        ));
-        assert!(!transport_event_requires_inline_ordering(
-            &p2p::TransportEvent::<()>::BitswapBlockReceived {
-                query_id: p2p::QueryId(1),
-                cid,
-                data: vec![1, 2, 3],
-            }
-        ));
-    }
 }

--- a/crates/p2p/src/transport.rs
+++ b/crates/p2p/src/transport.rs
@@ -196,6 +196,20 @@ pub enum TransportEvent<ResponseToken> {
     Listening(PeerAddr),
 }
 
+impl<ResponseToken> TransportEvent<ResponseToken> {
+    /// Returns true when this event mutates peer/subscription state that must
+    /// be observed before later data-plane events from the same transport.
+    pub fn requires_inline_ordering(&self) -> bool {
+        matches!(
+            self,
+            Self::PeerConnected(_)
+                | Self::PeerDisconnected(_)
+                | Self::PeerSubscribed { .. }
+                | Self::PeerUnsubscribed { .. }
+        )
+    }
+}
+
 /// Trait abstracting the P2P transport layer.
 ///
 /// The sync coordinator is generic over this trait, allowing different transport
@@ -323,4 +337,62 @@ pub trait P2PTransport: Clone + Send + Sync + 'static {
     // ---- Lifecycle ----
 
     async fn shutdown(&self) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use cid::Cid;
+
+    use super::{MessageId, PeerId, TransportEvent};
+    use crate::message::PushLogBroadcast;
+    use crate::QueryId;
+
+    #[test]
+    fn control_plane_events_require_inline_ordering() {
+        let peer = PeerId::new("peer".to_string());
+        let topic = "topic".to_string();
+
+        assert!(TransportEvent::<()>::PeerConnected(peer.clone()).requires_inline_ordering());
+        assert!(TransportEvent::<()>::PeerDisconnected(peer.clone()).requires_inline_ordering());
+        assert!(TransportEvent::<()>::PeerSubscribed {
+            peer_id: peer.clone(),
+            topic: topic.clone(),
+        }
+        .requires_inline_ordering());
+        assert!(TransportEvent::<()>::PeerUnsubscribed {
+            peer_id: peer,
+            topic,
+        }
+        .requires_inline_ordering());
+    }
+
+    #[test]
+    fn data_plane_events_do_not_require_inline_ordering() {
+        let peer = PeerId::new("peer".to_string());
+        let cid =
+            Cid::try_from("bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku").unwrap();
+        let message = PushLogBroadcast {
+            doc_id: "doc".to_string(),
+            cid: cid.to_bytes().into(),
+            collection_id: "collection".to_string(),
+            creator: "creator".to_string(),
+            block: Bytes::from_static(b"block"),
+            acp_actor_relationships: None,
+        };
+
+        assert!(!TransportEvent::<()>::GossipMessage {
+            propagation_source: peer.clone(),
+            message_id: MessageId::new("msg".to_string()),
+            topic: "topic".to_string(),
+            message,
+        }
+        .requires_inline_ordering());
+        assert!(!TransportEvent::<()>::BitswapBlockReceived {
+            query_id: QueryId(1),
+            cid,
+            data: vec![1, 2, 3],
+        }
+        .requires_inline_ordering());
+    }
 }


### PR DESCRIPTION
## Summary
- process peer connection and subscription lifecycle events inline in the embedded, CLI, and defra-node P2P event loops
- keep data-plane events concurrent so normal throughput is unchanged
- add targeted embedded tests covering which transport events must preserve ordering

## Why
The defra-agent desktop live soak harness was failing on the first turn with repeated:
- `Access denied: peer is not a replicator for this collection`
- `Dropping GossipSub message from unauthorized peer`
- downstream Bitswap exhaustion for the missing DAG

The root cause was an ordering race in runtime event dispatch: the transport emits `PeerConnected` before gossip ingress, but several runtime event handlers spawned every transport event into independent tasks. That allowed a gossip `PushLogBroadcast` to be authorized before the corresponding `PeerConnected` event had updated `peer_state`, so the connected-peer fallback in coordinator access control never fired.

This change restores the missing guarantee by handling peer lifecycle events inline before parallelizing message work across all current SyncCoordinator runtime consumers.
