### PR TITLE
Fix coordinator replicator authorization bootstrap

### DIFF
--- a/crates/acp/src/local.rs
+++ b/crates/acp/src/local.rs
@@ -17,7 +17,7 @@ use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::dac::DocumentACP;
+use crate::dac::{DocumentACP, ReplicatedActorRelationship};
 use crate::error::{Error, Result};
 use crate::identity::Identity;
 use crate::permission::DocumentPermission;
@@ -385,6 +385,69 @@ impl DocumentACP for LocalDocumentACP {
             "Actor relationship deleted"
         );
         Ok(true)
+    }
+
+    async fn export_actor_relationships(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<Vec<ReplicatedActorRelationship>> {
+        let ns_collection = Self::namespaced_collection(policy_id, resource_name);
+        let tuples = self.store.get_doc_tuples(&ns_collection, doc_id).await?;
+
+        Ok(tuples
+            .into_iter()
+            .filter(|tuple| tuple.relation() != OWNER_RELATION)
+            .map(|tuple| ReplicatedActorRelationship {
+                relation: tuple.relation().to_string(),
+                actor: if tuple.subject().is_wildcard() {
+                    "*".to_string()
+                } else {
+                    tuple.subject().to_string()
+                },
+            })
+            .collect())
+    }
+
+    async fn replace_actor_relationships(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+        relationships: &[ReplicatedActorRelationship],
+    ) -> Result<()> {
+        let ns_collection = Self::namespaced_collection(policy_id, resource_name);
+        let existing = self.store.get_doc_tuples(&ns_collection, doc_id).await?;
+
+        for tuple in existing {
+            if tuple.relation() == OWNER_RELATION {
+                continue;
+            }
+            self.store.delete_tuple(&tuple).await?;
+        }
+
+        for relationship in relationships {
+            if relationship.relation == OWNER_RELATION {
+                continue;
+            }
+
+            let actor = if relationship.actor == "*" {
+                Did::wildcard()
+            } else {
+                Did::new(&relationship.actor).map_err(|error| {
+                    Error::Storage(format!(
+                        "invalid replicated actor DID '{}': {}",
+                        relationship.actor, error
+                    ))
+                })?
+            };
+
+            let tuple = RelationTuple::new(actor, &relationship.relation, &ns_collection, doc_id);
+            self.store.put_tuple(&tuple).await?;
+        }
+
+        Ok(())
     }
 
     async fn unregister_doc_object(

--- a/crates/acp/tests/local_tests.rs
+++ b/crates/acp/tests/local_tests.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use acp::{
     DocumentACP, DocumentPermission, Error, Identity, LocalDocumentACP, MemoryAcpStore,
-    DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION,
+    ReplicatedActorRelationship, DELETER_RELATION, OWNER_RELATION, READER_RELATION,
+    UPDATER_RELATION,
 };
 use identity::Did;
 
@@ -248,6 +249,74 @@ async fn test_add_reader_grants_read_only() {
             "policy1",
             "users",
             "doc1"
+        )
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn test_replicated_relationship_snapshot_round_trip() {
+    let acp = create_acp();
+    let owner = test_did();
+    let reader = test_did2();
+
+    acp.register_doc_object(&owner, "policy1", "users", "doc1")
+        .await
+        .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &reader,
+        "policy1",
+        "users",
+        "doc1",
+        READER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
+
+    let exported = acp
+        .export_actor_relationships("policy1", "users", "doc1")
+        .await
+        .unwrap();
+    assert_eq!(exported.len(), 1);
+    assert_eq!(
+        exported[0],
+        ReplicatedActorRelationship {
+            relation: READER_RELATION.to_string(),
+            actor: reader.to_string(),
+        }
+    );
+
+    acp.replace_actor_relationships(
+        "policy1",
+        "users",
+        "doc1",
+        &[ReplicatedActorRelationship {
+            relation: UPDATER_RELATION.to_string(),
+            actor: reader.to_string(),
+        }],
+    )
+    .await
+    .unwrap();
+
+    assert!(acp
+        .check_doc_access(
+            &Identity::Authenticated(reader.clone()),
+            DocumentPermission::Update,
+            "policy1",
+            "users",
+            "doc1",
+        )
+        .await
+        .unwrap());
+    assert!(acp
+        .check_doc_access(
+            &Identity::Authenticated(reader),
+            DocumentPermission::Read,
+            "policy1",
+            "users",
+            "doc1",
         )
         .await
         .unwrap());

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -17,6 +17,8 @@ use storage::backends::RocksDbStoreOptions;
 
 /// Tracks spawned P2P background tasks for graceful shutdown.
 pub(super) struct P2PTasks {
+    /// Coordinator-owned background replication shutdown.
+    pub coordinator: p2p::sync::SyncShutdownHandle,
     /// P2P host event loop task
     pub host_task: JoinHandle<()>,
     /// Replication loop task (processes incoming blocks)

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -94,6 +94,7 @@ impl Node {
     ) -> Result<(
         p2p::P2PHostHandle,
         tokio::sync::mpsc::Receiver<p2p::HostEvent>,
+        std::sync::Arc<p2p::ReplicatorRegistry>,
         JoinHandle<()>,
     )> {
         let p2p_config = p2p::P2PHostConfig {
@@ -107,7 +108,7 @@ impl Node {
             max_connections_out: config.net.max_connections_out,
             max_connections_per_peer: config.net.max_connections_per_peer,
         };
-        let (host, handle, events, _replicators) = match keypair {
+        let (host, handle, events, replicators) = match keypair {
             Some(kp) => p2p::P2PHost::with_keypair_and_config(kp, bitswap_store, p2p_config)
                 .await
                 .map_err(Error::P2P)?,
@@ -153,6 +154,6 @@ impl Node {
             Err(e) => error!("Failed to get local peer ID: {}", e),
         }
 
-        Ok((handle, events, host_task))
+        Ok((handle, events, replicators, host_task))
     }
 }

--- a/crates/cli/src/commands/start/run.rs
+++ b/crates/cli/src/commands/start/run.rs
@@ -150,6 +150,8 @@ impl Node {
         if let Some(tasks) = self.p2p_tasks.take() {
             info!("Stopping P2P background tasks...");
 
+            tasks.coordinator.shutdown().await;
+
             // Abort all tasks - they will stop when the channel closes
             tasks.replication_task.abort();
             tasks.host_task.abort();

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -83,7 +83,7 @@ impl Node {
 
         let blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), true));
         let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
-        let (handle, mut events, host_task) = Self::start_p2p(
+        let (handle, mut events, replicator_registry, host_task) = Self::start_p2p(
             config,
             bitswap_store,
             peer_keypair,
@@ -103,7 +103,7 @@ impl Node {
             sync_blockstore,
             Self::sync_config(config),
             Self::access_mode(config),
-            Arc::new(p2p::ReplicatorRegistry::new()),
+            replicator_registry,
             collection_store,
             head_provider,
         )
@@ -435,7 +435,7 @@ impl Node {
             Arc::new(db_merge::create_head_provider(database.clone()));
 
         let iroh_secret_key = Self::iroh_secret_key(peer_keypair.as_ref())?;
-        let (command_tx, mut iroh_events, host_task) =
+        let (command_tx, mut iroh_events, replicator_registry, host_task) =
             p2p::iroh::spawn_endpoint(p2p::iroh::IrohEndpointConfig {
                 secret_key: iroh_secret_key.clone(),
                 relay_mode: Self::iroh_relay_mode(config)?,
@@ -457,7 +457,7 @@ impl Node {
             sync_blockstore,
             Self::sync_config(config),
             Self::access_mode(config),
-            Arc::new(p2p::ReplicatorRegistry::new()),
+            replicator_registry,
             collection_store,
             head_provider,
         )

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -396,6 +396,7 @@ impl Node {
         Ok(P2PSetup {
             host_handle: Some(handle),
             p2p_tasks: Some(P2PTasks {
+                coordinator: coordinator.shutdown_handle(),
                 host_task,
                 replication_task,
                 event_handler_task,
@@ -705,6 +706,7 @@ impl Node {
         Ok(P2PSetup {
             host_handle: None,
             p2p_tasks: Some(P2PTasks {
+                coordinator: coordinator.shutdown_handle(),
                 host_task,
                 replication_task,
                 event_handler_task,

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -522,6 +522,10 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             .load_document_head_blocks(doc_id)
             .await
             .map_err(P2PError::Internal)?;
+        let creator_did = pusher
+            .load_doc_creator_did(collection_name, doc_id)
+            .await
+            .map_err(P2PError::Internal)?;
         let acp_actor_relationships = pusher
             .load_doc_actor_relationships(collection_name, doc_id)
             .await
@@ -534,7 +538,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                     &block,
                     doc_id,
                     &collection_id,
-                    None,
+                    creator_did.as_deref(),
                     acp_actor_relationships.clone(),
                 )
                 .await

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -79,6 +79,12 @@ pub trait DocPusher: Send + Sync {
         collection_name: &str,
         doc_id: &str,
     ) -> Result<Option<acp::ReplicatedDocActorRelationships>, String>;
+
+    async fn load_doc_creator_did(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> Result<Option<String>, String>;
 }
 
 /// Trait for syncing collection versions (schema definitions) via Bitswap.
@@ -796,6 +802,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .load_document_head_blocks(doc_id)
             .await
             .map_err(P2PError::Internal)?;
+        let creator_did = pusher
+            .load_doc_creator_did(collection_name, doc_id)
+            .await
+            .map_err(P2PError::Internal)?;
         let acp_actor_relationships = pusher
             .load_doc_actor_relationships(collection_name, doc_id)
             .await
@@ -808,7 +818,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                     &block,
                     doc_id,
                     &collection_id,
-                    None,
+                    creator_did.as_deref(),
                     acp_actor_relationships.clone(),
                 )
                 .await

--- a/crates/cli/src/p2p_collection_lookup.rs
+++ b/crates/cli/src/p2p_collection_lookup.rs
@@ -90,6 +90,14 @@ impl DocPusher for LookupOnlyDocPusher {
     ) -> Result<Option<acp::ReplicatedDocActorRelationships>, String> {
         Err("load_doc_actor_relationships not available (no database context)".to_string())
     }
+
+    async fn load_doc_creator_did(
+        &self,
+        _collection_name: &str,
+        _doc_id: &str,
+    ) -> Result<Option<String>, String> {
+        Err("load_doc_creator_did not available (no database context)".to_string())
+    }
 }
 
 /// Implementation of CollectionLookup for the database.

--- a/crates/cli/src/p2p_doc_pusher.rs
+++ b/crates/cli/src/p2p_doc_pusher.rs
@@ -235,6 +235,35 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             relationships,
         }))
     }
+
+    async fn load_doc_creator_did(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> Result<Option<String>, String> {
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(None);
+        };
+        let collection = match self.db.get_collection(collection_name) {
+            Ok(Some(collection)) => collection,
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                return Err(format!(
+                    "failed to load collection for ACP creator resolution: {error}"
+                ));
+            }
+        };
+        let Some(policy) = collection.schema().policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let owner = acp
+            .get_doc_owner(&policy.id, &policy.resource_name, doc_id)
+            .await
+            .map_err(|error| format!("failed to resolve ACP owner DID: {error}"))?;
+
+        Ok(owner.map(|did| did.to_string()))
+    }
 }
 
 /// Also implement `CollectionLookup` so `DbDocPusher` can be used anywhere

--- a/crates/cli/src/transport_doc_pusher.rs
+++ b/crates/cli/src/transport_doc_pusher.rs
@@ -37,6 +37,12 @@ pub trait TransportDocPusher: Send + Sync {
         doc_id: &str,
     ) -> Result<Option<ReplicatedDocActorRelationships>, String>;
 
+    async fn load_doc_creator_did(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> Result<Option<String>, String>;
+
     fn get_collection_id(&self, name: &str) -> Option<String>;
 
     fn list_collections(&self) -> Result<Vec<String>, String>;
@@ -182,6 +188,35 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             resource_name: policy.resource_name.clone(),
             relationships,
         }))
+    }
+
+    async fn load_doc_creator_did(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> Result<Option<String>, String> {
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(None);
+        };
+        let collection = match self.db.get_collection(collection_name) {
+            Ok(Some(collection)) => collection,
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                return Err(format!(
+                    "failed to load collection for ACP creator resolution: {error}"
+                ));
+            }
+        };
+        let Some(policy) = collection.schema().policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let owner = acp
+            .get_doc_owner(&policy.id, &policy.resource_name, doc_id)
+            .await
+            .map_err(|error| format!("failed to resolve ACP owner DID: {error}"))?;
+
+        Ok(owner.map(|did| did.to_string()))
     }
 
     fn get_collection_id(&self, name: &str) -> Option<String> {

--- a/crates/db-merge/src/broadcast_mutator/batch.rs
+++ b/crates/db-merge/src/broadcast_mutator/batch.rs
@@ -138,7 +138,7 @@ impl<S: Store, B: Blockstore + 'static, T: P2PTransport + 'static> BroadcastBatc
 
         match kind {
             BroadcastKind::DagPush => {
-                sync.push_dag_to_replicators_with_creator(
+                sync.push_to_replicators_with_creator(
                     &cid,
                     &block,
                     &doc_id,

--- a/crates/db-merge/src/broadcast_mutator/mod.rs
+++ b/crates/db-merge/src/broadcast_mutator/mod.rs
@@ -222,8 +222,9 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
         tokio::spawn(async move {
             let creator_ref = creator_did.as_deref();
 
-            // Push the full DAG (field blocks + composite) to replicators.
-            sync.push_dag_to_replicators_with_creator(
+            // Match Go DefraDB's live replicator model: push the new head block
+            // and let the receiver resolve any missing links via DAG sync.
+            sync.push_to_replicators_with_creator(
                 &block_result.cid,
                 &block_result.block,
                 &block_result.doc_id,
@@ -379,7 +380,7 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
                 let creator_ref = creator_did.as_deref();
 
                 for (block_result, branchable_data) in &broadcast_work {
-                    sync.push_dag_to_replicators_with_creator(
+                    sync.push_to_replicators_with_creator(
                         &block_result.cid,
                         &block_result.block,
                         &block_result.doc_id,
@@ -509,8 +510,9 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
         tokio::spawn(async move {
             let creator_ref = creator_did.as_deref();
 
-            // Push the full DAG (field blocks + composite) to replicators.
-            sync.push_dag_to_replicators_with_creator(
+            // Match Go DefraDB's live replicator model: push the new head block
+            // and let the receiver resolve any missing links via DAG sync.
+            sync.push_to_replicators_with_creator(
                 &block_result.cid,
                 &block_result.block,
                 &block_result.doc_id,

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -119,7 +119,8 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
                 resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id_str).await;
             // Collect phase: pre-load all DAG blocks before spawning tasks.
             let mut doc_blocks = Vec::new();
-            for head_cid in load_latest_composite_head_cids(&headstore, &blockstore_view, doc_id).await
+            for head_cid in
+                load_latest_composite_head_cids(&headstore, &blockstore_view, doc_id).await
             {
                 let block_key = head_cid.to_bytes();
                 let block_data = match blockstore_view.get(&block_key).await {

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::sync::Arc;
 
 use acp::DocumentACP;
@@ -7,7 +6,8 @@ use p2p::message::PushLogRequest;
 use storage::corekv::{IterOptions, Reader, Store};
 
 use crate::push_docs_common::{
-    load_push_dag_blocks, resolve_push_creator, MAX_CONCURRENT_REPLAY_TASKS,
+    load_latest_composite_head_cids, load_push_dag_blocks, resolve_push_creator,
+    MAX_CONCURRENT_REPLAY_TASKS,
 };
 use db::database::DB;
 
@@ -117,32 +117,10 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
         for doc_id in &doc_ids {
             let creator =
                 resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id_str).await;
-            let prefix = storage::keys::headstore::HeadstoreDocKey::field_prefix(doc_id, "C");
-            let opts = IterOptions::new().with_prefix(prefix);
-            let mut iter = headstore
-                .iterator(opts)
-                .await
-                .map_err(|e| format!("failed to iterate headstore: {}", e))?;
-
             // Collect phase: pre-load all DAG blocks before spawning tasks.
             let mut doc_blocks = Vec::new();
-
-            while let Some(pair) = iter
-                .next()
-                .await
-                .map_err(|e| format!("headstore iteration error: {}", e))?
+            for head_cid in load_latest_composite_head_cids(&headstore, &blockstore_view, doc_id).await
             {
-                // Parse CID from key: /d/{doc_id}/C/{cid}
-                let key_str = String::from_utf8_lossy(&pair.key);
-                let parts: Vec<&str> = key_str.split('/').collect();
-                if parts.len() < 5 {
-                    continue;
-                }
-                let head_cid = match cid::Cid::from_str(parts[4]) {
-                    Ok(c) => c,
-                    Err(_) => continue,
-                };
-
                 let block_key = head_cid.to_bytes();
                 let block_data = match blockstore_view.get(&block_key).await {
                     Ok(Some(data)) => data,
@@ -154,10 +132,6 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
                         .await,
                 );
             }
-
-            iter.close()
-                .await
-                .map_err(|e| format!("headstore close error: {}", e))?;
 
             // Send phase: build signed requests in DAG dependency order,
             // then spawn a task to send them sequentially so ordering is preserved.
@@ -407,29 +381,8 @@ pub async fn retry_doc<S: Store + 'static>(
         .await
         .map_err(|e| format!("encstore txn: {}", e))?;
 
-    let prefix = storage::keys::headstore::HeadstoreDocKey::field_prefix(doc_id, "C");
-    let opts = IterOptions::new().with_prefix(prefix);
-    let mut iter = head_txn
-        .iterator(opts)
-        .await
-        .map_err(|e| format!("headstore iterator: {}", e))?;
-
     let mut any_failed = false;
-    while let Some(pair) = iter
-        .next()
-        .await
-        .map_err(|e| format!("headstore iteration: {}", e))?
-    {
-        let key_str = String::from_utf8_lossy(&pair.key);
-        let parts: Vec<&str> = key_str.split('/').collect();
-        if parts.len() < 5 {
-            continue;
-        }
-        let head_cid = match cid::Cid::from_str(parts[4]) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-
+    for head_cid in load_latest_composite_head_cids(&*head_txn, &*block_txn, doc_id).await {
         let block_data = match block_txn.get(&head_cid.to_bytes()).await {
             Ok(Some(data)) => data,
             _ => continue,
@@ -458,7 +411,6 @@ pub async fn retry_doc<S: Store + 'static>(
             }
         }
     }
-
     if any_failed {
         Err("some pushes failed".to_string())
     } else {

--- a/crates/db-merge/src/push_docs_common.rs
+++ b/crates/db-merge/src/push_docs_common.rs
@@ -1,8 +1,10 @@
 use std::collections::HashSet;
+use std::str::FromStr;
 
 use acp::DocumentACP;
 use cid::Cid;
-use storage::corekv::Reader;
+use storage::corekv::{IterOptions, Reader};
+use storage::keys::headstore::{HeadstoreDocKey, HeadstorePriorityKey};
 
 use db::Collection;
 
@@ -133,9 +135,170 @@ pub(crate) async fn load_push_dag_blocks<R: Reader + ?Sized, E: Reader + ?Sized>
     ordered
 }
 
+pub(crate) async fn load_latest_composite_head_cids<R: Reader + ?Sized, B: Reader + ?Sized>(
+    head_reader: &R,
+    block_reader: &B,
+    doc_id: &str,
+) -> Vec<Cid> {
+    let mut cids = Vec::new();
+    let mut max_priority: Option<u64> = None;
+
+    if let Ok(mut iter) = head_reader
+        .iterator(IterOptions::new().with_prefix(HeadstorePriorityKey::document_prefix(doc_id)))
+        .await
+    {
+        let cid_offset = HeadstorePriorityKey::cid_offset(doc_id);
+        while let Ok(Some(pair)) = iter.next().await {
+            let cid_bytes = match pair.key.get(cid_offset..) {
+                Some(bytes) => bytes,
+                None => continue,
+            };
+            let Ok(cid) = Cid::try_from(cid_bytes) else {
+                continue;
+            };
+            let Ok(Some(block_bytes)) = block_reader.get(&cid.to_bytes()).await else {
+                continue;
+            };
+            let Ok(block) = defra_core::Block::from_dag_cbor(&block_bytes) else {
+                continue;
+            };
+            if !matches!(block.delta, defra_core::CrdtDelta::Composite(_)) {
+                continue;
+            }
+
+            let priority = block.delta.priority();
+            match max_priority {
+                Some(current) if priority < current => {}
+                Some(current) if priority == current => cids.push(cid),
+                _ => {
+                    max_priority = Some(priority);
+                    cids.clear();
+                    cids.push(cid);
+                }
+            }
+        }
+        let _ = iter.close().await;
+    }
+
+    if !cids.is_empty() {
+        return cids;
+    }
+
+    if let Ok(mut iter) = head_reader
+        .iterator(IterOptions::new().with_prefix(HeadstoreDocKey::field_prefix(doc_id, "C")))
+        .await
+    {
+        while let Ok(Some(pair)) = iter.next().await {
+            let key_str = String::from_utf8_lossy(&pair.key);
+            let parts: Vec<&str> = key_str.split('/').collect();
+            if parts.len() < 5 {
+                continue;
+            }
+            let Ok(cid) = Cid::from_str(parts[4]) else {
+                continue;
+            };
+            cids.push(cid);
+        }
+        let _ = iter.close().await;
+    }
+
+    cids
+}
+
 fn extract_block_links(block_data: &[u8]) -> Vec<Cid> {
     defra_core::Block::from_dag_cbor(block_data)
         .ok()
         .and_then(|block| defra_core::collect_block_links(&block).ok())
         .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use db::DB;
+    use defra_core::{block::generate_cid_from_bytes, Block, CompositeDeltaPayload, CrdtDelta};
+    use std::sync::Arc;
+    use storage::backends::MemoryStore;
+    use storage::corekv::Key;
+    use storage::keys::headstore::{HeadstoreDocKey, HeadstorePriorityKey};
+
+    #[tokio::test]
+    async fn latest_composite_head_selection_prefers_highest_priority_index() {
+        let store = Arc::new(MemoryStore::new());
+        let db = Arc::new(DB::from_arc(store).unwrap());
+        let doc_id = "bae-test-latest-head";
+        let first = Block::new_with_options(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                doc_id: doc_id.as_bytes().to_vec(),
+                schema_version_id: "schema-v1".to_string(),
+                priority: 1,
+                status: 1,
+            }),
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+        let first_bytes = first.to_dag_cbor().unwrap();
+        let first_cid = generate_cid_from_bytes(&first_bytes).unwrap();
+
+        let second = Block::new_with_options(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                doc_id: doc_id.as_bytes().to_vec(),
+                schema_version_id: "schema-v1".to_string(),
+                priority: 2,
+                status: 1,
+            }),
+            vec![],
+            vec![],
+            None,
+            None,
+        );
+        let second_bytes = second.to_dag_cbor().unwrap();
+        let second_cid = generate_cid_from_bytes(&second_bytes).unwrap();
+
+        let txn = db.new_txn(false).await.unwrap();
+        txn.blockstore()
+            .unwrap()
+            .set(&first_cid.to_bytes(), &first_bytes)
+            .await
+            .unwrap();
+        txn.blockstore()
+            .unwrap()
+            .set(&second_cid.to_bytes(), &second_bytes)
+            .await
+            .unwrap();
+        txn.headstore()
+            .unwrap()
+            .set(&HeadstoreDocKey::new(doc_id, "C", first_cid).bytes(), &[])
+            .await
+            .unwrap();
+        txn.headstore()
+            .unwrap()
+            .set(&HeadstoreDocKey::new(doc_id, "C", second_cid).bytes(), &[])
+            .await
+            .unwrap();
+        txn.headstore()
+            .unwrap()
+            .set(&HeadstorePriorityKey::new(doc_id, 1, first_cid).bytes(), &[])
+            .await
+            .unwrap();
+        txn.headstore()
+            .unwrap()
+            .set(&HeadstorePriorityKey::new(doc_id, 2, second_cid).bytes(), &[])
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let txn = db.new_txn(true).await.unwrap();
+        let heads = load_latest_composite_head_cids(
+            &txn.headstore().unwrap(),
+            &txn.blockstore().unwrap(),
+            doc_id,
+        )
+        .await;
+
+        assert_eq!(heads, vec![second_cid]);
+        assert_ne!(heads, vec![first_cid]);
+    }
 }

--- a/crates/db-merge/src/push_docs_common.rs
+++ b/crates/db-merge/src/push_docs_common.rs
@@ -280,12 +280,18 @@ mod tests {
             .unwrap();
         txn.headstore()
             .unwrap()
-            .set(&HeadstorePriorityKey::new(doc_id, 1, first_cid).bytes(), &[])
+            .set(
+                &HeadstorePriorityKey::new(doc_id, 1, first_cid).bytes(),
+                &[],
+            )
             .await
             .unwrap();
         txn.headstore()
             .unwrap()
-            .set(&HeadstorePriorityKey::new(doc_id, 2, second_cid).bytes(), &[])
+            .set(
+                &HeadstorePriorityKey::new(doc_id, 2, second_cid).bytes(),
+                &[],
+            )
             .await
             .unwrap();
         txn.commit().await.unwrap();

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::sync::Arc;
 
 use acp::DocumentACP;
@@ -9,7 +8,8 @@ use p2p::P2PTransport;
 use storage::corekv::{IterOptions, Reader, Store};
 
 use crate::push_docs_common::{
-    load_push_dag_blocks, resolve_push_creator, MAX_CONCURRENT_REPLAY_TASKS,
+    load_latest_composite_head_cids, load_push_dag_blocks, resolve_push_creator,
+    MAX_CONCURRENT_REPLAY_TASKS,
 };
 use db::database::DB;
 
@@ -113,30 +113,9 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
         for doc_id in &doc_ids {
             let creator =
                 resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id).await;
-            let prefix = storage::keys::headstore::HeadstoreDocKey::field_prefix(doc_id, "C");
-            let opts = IterOptions::new().with_prefix(prefix);
-            let mut iter = headstore
-                .iterator(opts)
-                .await
-                .map_err(|e| format!("failed to iterate headstore: {}", e))?;
-
             let mut doc_blocks = Vec::new();
-
-            while let Some(pair) = iter
-                .next()
-                .await
-                .map_err(|e| format!("headstore iteration error: {}", e))?
+            for head_cid in load_latest_composite_head_cids(&headstore, &blockstore_view, doc_id).await
             {
-                let key_str = String::from_utf8_lossy(&pair.key);
-                let parts: Vec<&str> = key_str.split('/').collect();
-                if parts.len() < 5 {
-                    continue;
-                }
-                let head_cid = match cid::Cid::from_str(parts[4]) {
-                    Ok(c) => c,
-                    Err(_) => continue,
-                };
-
                 let block_key = head_cid.to_bytes();
                 let block_data = match blockstore_view.get(&block_key).await {
                     Ok(Some(data)) => data,
@@ -148,10 +127,6 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
                         .await,
                 );
             }
-
-            iter.close()
-                .await
-                .map_err(|e| format!("headstore close error: {}", e))?;
 
             let mut requests = Vec::new();
             for (block_cid, block_data) in doc_blocks {
@@ -384,29 +359,8 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
         .await
         .map_err(|e| format!("encstore txn: {}", e))?;
 
-    let prefix = storage::keys::headstore::HeadstoreDocKey::field_prefix(doc_id, "C");
-    let opts = IterOptions::new().with_prefix(prefix);
-    let mut iter = head_txn
-        .iterator(opts)
-        .await
-        .map_err(|e| format!("headstore iterator: {}", e))?;
-
     let mut successful_blocks = 0usize;
-    while let Some(pair) = iter
-        .next()
-        .await
-        .map_err(|e| format!("headstore iteration: {}", e))?
-    {
-        let key_str = String::from_utf8_lossy(&pair.key);
-        let parts: Vec<&str> = key_str.split('/').collect();
-        if parts.len() < 5 {
-            continue;
-        }
-        let head_cid = match cid::Cid::from_str(parts[4]) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-
+    for head_cid in load_latest_composite_head_cids(&*head_txn, &*block_txn, doc_id).await {
         let block_data = match block_txn.get(&head_cid.to_bytes()).await {
             Ok(Some(data)) => data,
             _ => continue,
@@ -455,6 +409,5 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
             }
         }
     }
-
     Ok(())
 }

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -114,7 +114,8 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
             let creator =
                 resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id).await;
             let mut doc_blocks = Vec::new();
-            for head_cid in load_latest_composite_head_cids(&headstore, &blockstore_view, doc_id).await
+            for head_cid in
+                load_latest_composite_head_cids(&headstore, &blockstore_view, doc_id).await
             {
                 let block_key = head_cid.to_bytes();
                 let block_data = match blockstore_view.get(&block_key).await {

--- a/crates/defra-core/src/ipld/tests.rs
+++ b/crates/defra-core/src/ipld/tests.rs
@@ -481,6 +481,19 @@ fn test_extract_links_empty_structures() {
 }
 
 #[test]
+fn test_extract_links_handles_deeply_nested_lists_iteratively() {
+    let link = cid_to_libipld(&test_cid()).unwrap();
+    let mut ipld = Ipld::Link(link);
+    for _ in 0..10_000 {
+        ipld = Ipld::List(vec![ipld]);
+    }
+
+    let links = extract_links(&ipld).unwrap();
+    assert_eq!(links, vec![test_cid()]);
+    std::mem::forget(ipld);
+}
+
+#[test]
 fn test_collect_block_links() {
     let head = test_cid();
     let link = DAGLink::new("field", test_cid());
@@ -538,6 +551,40 @@ fn test_walk_ipld_visitor_stops_traversal() {
 
     // Should only visit the root Map
     assert_eq!(visitor.count, 1);
+}
+
+#[test]
+fn test_walk_ipld_handles_deeply_nested_lists_iteratively() {
+    struct CountVisitor {
+        visits: usize,
+        links: usize,
+    }
+
+    impl IpldVisitor for CountVisitor {
+        fn visit(&mut self, _ipld: &Ipld) -> bool {
+            self.visits += 1;
+            true
+        }
+
+        fn visit_link(&mut self, _cid: &cid::Cid) {
+            self.links += 1;
+        }
+    }
+
+    let mut ipld = Ipld::Link(cid_to_libipld(&test_cid()).unwrap());
+    for _ in 0..10_000 {
+        ipld = Ipld::List(vec![ipld]);
+    }
+
+    let mut visitor = CountVisitor {
+        visits: 0,
+        links: 0,
+    };
+    walk_ipld(&ipld, &mut visitor).unwrap();
+
+    assert_eq!(visitor.links, 1);
+    assert_eq!(visitor.visits, 10_001);
+    std::mem::forget(ipld);
 }
 
 // ============================================================================

--- a/crates/defra-core/src/ipld/traversal.rs
+++ b/crates/defra-core/src/ipld/traversal.rs
@@ -12,28 +12,28 @@ use crate::Result;
 /// Links are returned in traversal order (not sorted).
 pub fn extract_links(ipld: &Ipld) -> Result<Vec<cid::Cid>> {
     let mut links = Vec::new();
-    extract_links_recursive(ipld, &mut links)?;
-    Ok(links)
-}
+    let mut stack = vec![ipld];
 
-fn extract_links_recursive(ipld: &Ipld, links: &mut Vec<cid::Cid>) -> Result<()> {
-    match ipld {
-        Ipld::Link(cid) => {
-            links.push(cid_from_libipld(cid)?);
-        }
-        Ipld::List(items) => {
-            for item in items {
-                extract_links_recursive(item, links)?;
+    while let Some(current) = stack.pop() {
+        match current {
+            Ipld::Link(cid) => {
+                links.push(cid_from_libipld(cid)?);
             }
-        }
-        Ipld::Map(map) => {
-            for value in map.values() {
-                extract_links_recursive(value, links)?;
+            Ipld::List(items) => {
+                for item in items.iter().rev() {
+                    stack.push(item);
+                }
             }
+            Ipld::Map(map) => {
+                let mut values: Vec<&Ipld> = map.values().collect();
+                values.reverse();
+                stack.extend(values);
+            }
+            _ => {}
         }
-        _ => {}
     }
-    Ok(())
+
+    Ok(links)
 }
 
 /// Visitor trait for traversing IPLD structures.
@@ -67,26 +67,31 @@ pub trait IpldVisitor {
 /// Calls visitor methods for each node in the tree. If the visitor's `visit`
 /// method returns `false`, children of that node are skipped.
 pub fn walk_ipld<V: IpldVisitor>(ipld: &Ipld, visitor: &mut V) -> Result<()> {
-    if !visitor.visit(ipld) {
-        return Ok(());
+    let mut stack = vec![ipld];
+
+    while let Some(current) = stack.pop() {
+        if !visitor.visit(current) {
+            continue;
+        }
+
+        match current {
+            Ipld::Link(cid) => {
+                visitor.visit_link(&cid_from_libipld(cid)?);
+            }
+            Ipld::List(items) => {
+                for item in items.iter().rev() {
+                    stack.push(item);
+                }
+            }
+            Ipld::Map(map) => {
+                let mut values: Vec<&Ipld> = map.values().collect();
+                values.reverse();
+                stack.extend(values);
+            }
+            _ => {}
+        }
     }
 
-    match ipld {
-        Ipld::Link(cid) => {
-            visitor.visit_link(&cid_from_libipld(cid)?);
-        }
-        Ipld::List(items) => {
-            for item in items {
-                walk_ipld(item, visitor)?;
-            }
-        }
-        Ipld::Map(map) => {
-            for value in map.values() {
-                walk_ipld(value, visitor)?;
-            }
-        }
-        _ => {}
-    }
     Ok(())
 }
 

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -86,6 +86,7 @@ struct P2PLifecycle {
 #[cfg(feature = "p2p")]
 struct P2PLifecycleInner {
     transport: p2p::iroh::IrohTransport,
+    coordinator: p2p::sync::SyncShutdownHandle,
     endpoint_task: tokio::task::JoinHandle<()>,
     replication_task: tokio::task::JoinHandle<()>,
     event_handler_task: tokio::task::JoinHandle<()>,
@@ -116,16 +117,30 @@ impl P2PLifecycle {
 #[cfg(feature = "p2p")]
 impl P2PLifecycleInner {
     async fn shutdown(self) {
-        abort_background_task("iroh retry loop", self.retry_loop_task).await;
+        let Self {
+            transport,
+            coordinator,
+            endpoint_task,
+            replication_task,
+            event_handler_task,
+            failure_recorder_task,
+            retry_loop_task,
+        } = self;
 
-        if let Err(error) = self.transport.shutdown().await {
+        abort_background_task("iroh retry loop", retry_loop_task).await;
+        coordinator.shutdown().await;
+
+        if let Err(error) = transport.shutdown().await {
             tracing::debug!(%error, "Iroh transport shutdown returned an error");
         }
 
-        await_endpoint_task(self.endpoint_task).await;
-        abort_background_task("iroh event handler", self.event_handler_task).await;
-        abort_background_task("iroh replication loop", self.replication_task).await;
-        abort_background_task("iroh failure recorder", self.failure_recorder_task).await;
+        drop(transport);
+        drop(coordinator);
+
+        await_background_task("iroh event handler", event_handler_task).await;
+        await_background_task("iroh replication loop", replication_task).await;
+        abort_background_task("iroh failure recorder", failure_recorder_task).await;
+        await_endpoint_task(endpoint_task).await;
     }
 }
 
@@ -161,6 +176,25 @@ async fn abort_background_task(task_name: &'static str, task: tokio::task::JoinH
                 task = task_name,
                 "P2P background task did not stop after abort"
             );
+        }
+    }
+}
+
+#[cfg(feature = "p2p")]
+async fn await_background_task(task_name: &'static str, mut task: tokio::task::JoinHandle<()>) {
+    match tokio::time::timeout(std::time::Duration::from_secs(5), &mut task).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) if error.is_cancelled() => {}
+        Ok(Err(error)) => {
+            tracing::debug!(task = task_name, %error, "P2P background task failed during shutdown");
+        }
+        Err(_) => {
+            tracing::debug!(
+                task = task_name,
+                "P2P background task did not stop after graceful shutdown; aborting"
+            );
+            task.abort();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(1), task).await;
         }
     }
 }
@@ -762,7 +796,7 @@ impl NodeBuilder {
         let ops: Arc<dyn defra_http::P2POperations> =
             Arc::new(defra_p2p_adapter::IrohP2PAdapter::with_full_context(
                 transport.clone(),
-                coordinator,
+                coordinator.clone(),
                 doc_pusher,
                 event_bus,
                 version_syncer,
@@ -772,6 +806,7 @@ impl NodeBuilder {
             ops,
             lifecycle: Some(P2PLifecycle::new(P2PLifecycleInner {
                 transport,
+                coordinator: coordinator.shutdown_handle(),
                 endpoint_task,
                 replication_task,
                 event_handler_task,

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -662,9 +662,10 @@ impl NodeBuilder {
             bind_port: Some(config.port),
             bind_addr: config.bind_addr,
         };
-        let (command_tx, iroh_events, endpoint_task) = p2p::iroh::spawn_endpoint(iroh_config)
-            .await
-            .map_err(|e| anyhow::anyhow!("IROH endpoint spawn failed: {}", e))?;
+        let (command_tx, iroh_events, replicator_registry, endpoint_task) =
+            p2p::iroh::spawn_endpoint(iroh_config)
+                .await
+                .map_err(|e| anyhow::anyhow!("IROH endpoint spawn failed: {}", e))?;
 
         // 3. Create IROH transport facade
         let transport = p2p::iroh::IrohTransport::new(command_tx, secret_key);
@@ -684,11 +685,12 @@ impl NodeBuilder {
             rate_limit_rate: config.rate_limit_rate,
             ..Default::default()
         };
-        let (mut coordinator, sync_events) = p2p::sync::SyncCoordinator::with_collection_store(
+        let (mut coordinator, sync_events) = p2p::sync::SyncCoordinator::with_access_control(
             transport.clone(),
             sync_blockstore.clone(),
             sync_config,
             p2p::AccessMode::Controlled,
+            replicator_registry,
             collection_store,
         )
         .await

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -117,6 +117,7 @@ impl P2PLifecycle {
 #[cfg(feature = "p2p")]
 impl P2PLifecycleInner {
     async fn shutdown(self) {
+        let shutdown_started = std::time::Instant::now();
         let Self {
             transport,
             coordinator,
@@ -127,20 +128,60 @@ impl P2PLifecycleInner {
             retry_loop_task,
         } = self;
 
+        let retry_started = std::time::Instant::now();
         abort_background_task("iroh retry loop", retry_loop_task).await;
-        coordinator.shutdown().await;
+        tracing::warn!(
+            elapsed_ms = retry_started.elapsed().as_millis(),
+            "P2P shutdown: retry loop stopped"
+        );
 
+        let coordinator_started = std::time::Instant::now();
+        coordinator.shutdown().await;
+        tracing::warn!(
+            elapsed_ms = coordinator_started.elapsed().as_millis(),
+            "P2P shutdown: coordinator stopped"
+        );
+
+        let transport_started = std::time::Instant::now();
         if let Err(error) = transport.shutdown().await {
             tracing::debug!(%error, "Iroh transport shutdown returned an error");
         }
+        tracing::warn!(
+            elapsed_ms = transport_started.elapsed().as_millis(),
+            "P2P shutdown: transport stop requested"
+        );
 
         drop(transport);
         drop(coordinator);
 
+        let event_handler_started = std::time::Instant::now();
         await_background_task("iroh event handler", event_handler_task).await;
-        await_background_task("iroh replication loop", replication_task).await;
+        tracing::warn!(
+            elapsed_ms = event_handler_started.elapsed().as_millis(),
+            "P2P shutdown: event handler stopped"
+        );
+
+        let replication_started = std::time::Instant::now();
+        abort_background_task("iroh replication loop", replication_task).await;
+        tracing::warn!(
+            elapsed_ms = replication_started.elapsed().as_millis(),
+            "P2P shutdown: replication loop stopped"
+        );
+
+        let failure_started = std::time::Instant::now();
         abort_background_task("iroh failure recorder", failure_recorder_task).await;
+        tracing::warn!(
+            elapsed_ms = failure_started.elapsed().as_millis(),
+            "P2P shutdown: failure recorder stopped"
+        );
+
+        let endpoint_started = std::time::Instant::now();
         await_endpoint_task(endpoint_task).await;
+        tracing::warn!(
+            elapsed_ms = endpoint_started.elapsed().as_millis(),
+            total_elapsed_ms = shutdown_started.elapsed().as_millis(),
+            "P2P shutdown: endpoint task stopped"
+        );
     }
 }
 

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -115,10 +115,13 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
             return;
         }
 
+        tracing::info!("embedded node shutdown: begin");
+
         // 1. P2P first — stops inbound/outbound traffic and awaits the
         //    transport's graceful close path (iroh Endpoint::close /
         //    libp2p Host::shutdown).
         if let Some(p2p) = &self.p2p {
+            tracing::info!("embedded node shutdown: stopping p2p");
             p2p.shutdown().await;
         }
 
@@ -126,12 +129,14 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
         //    Log but don't propagate errors: shutdown should complete
         //    even if the store close returns an I/O error, so embedders
         //    can't be blocked from exiting by a closing store.
+        tracing::info!("embedded node shutdown: closing database");
         if let Err(error) = self.database.close().await {
             tracing::warn!(error = %error, "EmbeddedNode::shutdown: database close returned an error");
         }
 
         self.shutdown_finished.store(true, Ordering::SeqCst);
         self.shutdown_notify.notify_waiters();
+        tracing::info!("embedded node shutdown: complete");
     }
 
     /// Returns true if [`EmbeddedNode::shutdown`] has been initiated.
@@ -257,11 +262,13 @@ pub struct ShutdownHandle {
 enum ShutdownKind {
     Libp2p {
         handle: Box<p2p::P2PHostHandle>,
+        coordinator: p2p::sync::SyncShutdownHandle,
         aborts: Vec<tokio::task::AbortHandle>,
     },
     #[cfg(feature = "iroh")]
     Iroh {
         transport: p2p::iroh::IrohTransport,
+        coordinator: p2p::sync::SyncShutdownHandle,
         aborts: Vec<tokio::task::AbortHandle>,
     },
 }
@@ -269,11 +276,13 @@ enum ShutdownKind {
 impl ShutdownHandle {
     pub(crate) fn libp2p(
         handle: p2p::P2PHostHandle,
+        coordinator: p2p::sync::SyncShutdownHandle,
         aborts: Vec<tokio::task::AbortHandle>,
     ) -> Self {
         Self {
             inner: ShutdownKind::Libp2p {
                 handle: Box::new(handle),
+                coordinator,
                 aborts,
             },
         }
@@ -282,23 +291,38 @@ impl ShutdownHandle {
     #[cfg(feature = "iroh")]
     pub(crate) fn iroh(
         transport: p2p::iroh::IrohTransport,
+        coordinator: p2p::sync::SyncShutdownHandle,
         aborts: Vec<tokio::task::AbortHandle>,
     ) -> Self {
         Self {
-            inner: ShutdownKind::Iroh { transport, aborts },
+            inner: ShutdownKind::Iroh {
+                transport,
+                coordinator,
+                aborts,
+            },
         }
     }
 
     pub async fn shutdown(&self) {
         match &self.inner {
-            ShutdownKind::Libp2p { handle, aborts } => {
+            ShutdownKind::Libp2p {
+                handle,
+                coordinator,
+                aborts,
+            } => {
+                coordinator.shutdown().await;
                 for abort in aborts {
                     abort.abort();
                 }
                 let _ = handle.shutdown().await;
             }
             #[cfg(feature = "iroh")]
-            ShutdownKind::Iroh { transport, aborts } => {
+            ShutdownKind::Iroh {
+                transport,
+                coordinator,
+                aborts,
+            } => {
+                coordinator.shutdown().await;
                 let _ = transport.shutdown().await;
                 for abort in aborts {
                     abort.abort();

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -61,7 +61,7 @@ where
         }
     };
 
-    let (host, handle, event_rx, _replicator_registry) =
+    let (host, handle, event_rx, replicator_registry) =
         p2p::P2PHost::with_keypair_and_config_and_identity(
             p2p_keypair,
             bitswap_store,
@@ -102,7 +102,7 @@ where
         blockstore.clone(),
         sync_config,
         p2p::bitswap::AccessMode::Controlled,
-        Arc::new(p2p::ReplicatorRegistry::new()),
+        replicator_registry,
         collection_store,
         head_provider,
     )
@@ -212,9 +212,10 @@ where
         bind_port: config.bind_port,
         bind_addr: config.bind_addr,
     };
-    let (command_tx, event_rx, endpoint_task) = p2p::iroh::spawn_endpoint(iroh_config)
-        .await
-        .map_err(|error| anyhow!("failed to spawn iroh endpoint: {error}"))?;
+    let (command_tx, event_rx, replicator_registry, endpoint_task) =
+        p2p::iroh::spawn_endpoint(iroh_config)
+            .await
+            .map_err(|error| anyhow!("failed to spawn iroh endpoint: {error}"))?;
 
     let transport = p2p::iroh::IrohTransport::new(command_tx, secret_key);
     let blockstore = Arc::new(EmbeddedBlockstore::new(store.clone(), true));
@@ -227,7 +228,7 @@ where
         blockstore.clone(),
         sync_config,
         p2p::bitswap::AccessMode::Controlled,
-        Arc::new(p2p::ReplicatorRegistry::new()),
+        replicator_registry,
         collection_store,
         head_provider,
     )

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -163,6 +163,7 @@ where
         Arc::new(adapter) as Arc<dyn defra_http::P2POperations>,
         crate::node::ShutdownHandle::libp2p(
             handle.clone(),
+            coordinator.shutdown_handle(),
             vec![
                 host_event_task.abort_handle(),
                 replication_task.abort_handle(),
@@ -293,6 +294,7 @@ where
         Arc::new(adapter) as Arc<dyn defra_http::P2POperations>,
         crate::node::ShutdownHandle::iroh(
             transport.clone(),
+            coordinator.shutdown_handle(),
             vec![
                 endpoint_task.abort_handle(),
                 event_handler_task.abort_handle(),

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -579,6 +579,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
             P2PError::not_found(format!("collection '{collection_name}' not found"))
         })?;
         let head_blocks = pusher.load_document_head_blocks(doc_id).await?;
+        let creator_did = pusher.load_doc_creator_did(collection_name, doc_id).await?;
         let acp_actor_relationships = pusher
             .load_doc_actor_relationships(collection_name, doc_id)
             .await?;
@@ -590,7 +591,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                     &block,
                     doc_id,
                     &collection_id,
-                    None,
+                    creator_did.as_deref(),
                     acp_actor_relationships.clone(),
                 )
                 .await

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -612,6 +612,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             P2PError::not_found(format!("collection '{collection_name}' not found"))
         })?;
         let head_blocks = pusher.load_document_head_blocks(doc_id).await?;
+        let creator_did = pusher.load_doc_creator_did(collection_name, doc_id).await?;
         let acp_actor_relationships = pusher
             .load_doc_actor_relationships(collection_name, doc_id)
             .await?;
@@ -623,7 +624,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                     &block,
                     doc_id,
                     &collection_id,
-                    None,
+                    creator_did.as_deref(),
                     acp_actor_relationships.clone(),
                 )
                 .await

--- a/crates/p2p-adapter/src/libp2p_doc_pusher.rs
+++ b/crates/p2p-adapter/src/libp2p_doc_pusher.rs
@@ -52,6 +52,12 @@ pub trait DocPusher: Send + Sync {
         collection_name: &str,
         doc_id: &str,
     ) -> P2PResult<Option<ReplicatedDocActorRelationships>>;
+
+    async fn load_doc_creator_did(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> P2PResult<Option<String>>;
 }
 
 /// Database-backed `DocPusher` implementation.
@@ -255,6 +261,37 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             resource_name: policy.resource_name.clone(),
             relationships,
         }))
+    }
+
+    async fn load_doc_creator_did(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> P2PResult<Option<String>> {
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(None);
+        };
+        let collection = match self.db.get_collection(collection_name) {
+            Ok(Some(collection)) => collection,
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                return Err(P2PError::internal(format!(
+                    "failed to load collection for ACP creator resolution: {error}"
+                )));
+            }
+        };
+        let Some(policy) = collection.schema().policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let owner = acp
+            .get_doc_owner(&policy.id, &policy.resource_name, doc_id)
+            .await
+            .map_err(|error| {
+                P2PError::internal(format!("failed to resolve ACP owner DID: {error}"))
+            })?;
+
+        Ok(owner.map(|did| did.to_string()))
     }
 }
 

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -28,6 +28,12 @@ pub trait TransportDocPusher: Send + Sync {
         doc_id: &str,
     ) -> P2PResult<Option<ReplicatedDocActorRelationships>>;
 
+    async fn load_doc_creator_did(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> P2PResult<Option<String>>;
+
     fn get_collection_id(&self, name: &str) -> Option<String>;
 
     fn list_collections(&self) -> P2PResult<Vec<String>>;
@@ -151,6 +157,37 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             resource_name: policy.resource_name.clone(),
             relationships,
         }))
+    }
+
+    async fn load_doc_creator_did(
+        &self,
+        collection_name: &str,
+        doc_id: &str,
+    ) -> P2PResult<Option<String>> {
+        let Some(acp) = self.document_acp.get() else {
+            return Ok(None);
+        };
+        let collection = match self.db.get_collection(collection_name) {
+            Ok(Some(collection)) => collection,
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                return Err(P2PError::internal(format!(
+                    "failed to load collection for ACP creator resolution: {error}"
+                )));
+            }
+        };
+        let Some(policy) = collection.schema().policy.as_ref() else {
+            return Ok(None);
+        };
+
+        let owner = acp
+            .get_doc_owner(&policy.id, &policy.resource_name, doc_id)
+            .await
+            .map_err(|error| {
+                P2PError::internal(format!("failed to resolve ACP owner DID: {error}"))
+            })?;
+
+        Ok(owner.map(|did| did.to_string()))
     }
 
     fn get_collection_id(&self, name: &str) -> Option<String> {

--- a/crates/p2p/src/bitswap/registry.rs
+++ b/crates/p2p/src/bitswap/registry.rs
@@ -38,6 +38,22 @@ impl ReplicatorRegistry {
             .insert(peer_id.to_string());
     }
 
+    /// Replace the full set of collections replicated by a peer.
+    pub fn set_peer_collections(&self, peer_id: &str, collections: &[String]) {
+        let mut replicators = self.replicators.write();
+        for peers in replicators.values_mut() {
+            peers.remove(peer_id);
+        }
+        replicators.retain(|_, peers| !peers.is_empty());
+
+        for collection_id in collections {
+            replicators
+                .entry(collection_id.clone())
+                .or_default()
+                .insert(peer_id.to_string());
+        }
+    }
+
     /// Remove a peer as a replicator for a collection.
     pub fn remove_replicator(&self, collection_id: &str, peer_id: &str) {
         let mut replicators = self.replicators.write();
@@ -56,6 +72,22 @@ impl ReplicatorRegistry {
             peers.remove(peer_id);
         }
         replicators.retain(|_, peers| !peers.is_empty());
+    }
+
+    /// Remove a peer from specific collections. Returns true if the peer no
+    /// longer replicates any collections afterwards.
+    pub fn remove_peer_collections(&self, peer_id: &str, collections: &[String]) -> bool {
+        let mut replicators = self.replicators.write();
+        for collection_id in collections {
+            if let Some(peers) = replicators.get_mut(collection_id) {
+                peers.remove(peer_id);
+                if peers.is_empty() {
+                    replicators.remove(collection_id);
+                }
+            }
+        }
+
+        !replicators.values().any(|peers| peers.contains(peer_id))
     }
 
     /// Check if a peer is a replicator for a collection.

--- a/crates/p2p/src/host/command_handler/messaging.rs
+++ b/crates/p2p/src/host/command_handler/messaging.rs
@@ -285,12 +285,8 @@ impl<S: Store> P2PHost<S> {
     ) {
         debug!(peer_id = %peer_id, collections = ?collections, "Creating replicator");
         let peer_str = peer_id.to_string();
-        // First remove peer from all existing collections
-        self.replicators.remove_peer(&peer_str);
-        // Then add to the new collections
-        for collection_id in &collections {
-            self.replicators.add_replicator(collection_id, &peer_str);
-        }
+        self.replicators
+            .set_peer_collections(&peer_str, &collections);
         if response.send(Ok(())).is_err() {
             debug!(peer_id = %peer_id, "CreateReplicator command response dropped - caller cancelled");
         }
@@ -320,14 +316,10 @@ impl<S: Store> P2PHost<S> {
             "Removing collections from replicator"
         );
 
-        // Remove specific collections from the replicator
         let peer_str = peer_id.to_string();
-        for collection_id in &collections {
-            self.replicators.remove_replicator(collection_id, &peer_str);
-        }
-
-        // Check if the replicator still has any collections
-        let fully_deleted = !self.replicators.is_any_replicator(&peer_str);
+        let fully_deleted = self
+            .replicators
+            .remove_peer_collections(&peer_str, &collections);
 
         if fully_deleted {
             debug!(peer_id = %peer_id, "Replicator fully deleted (no collections remain)");

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -5,7 +5,6 @@
 //! - Gossip events from iroh-gossip
 //! - Commands from the `IrohTransport` facade
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use iroh::{Endpoint, EndpointId};
@@ -14,7 +13,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use crate::replicator::ReplicatorInfo;
+use crate::bitswap::ReplicatorRegistry;
 use crate::transport::{PeerAddr, PeerId, TransportEvent};
 
 use super::command::IrohCommand;
@@ -45,6 +44,7 @@ pub async fn spawn_endpoint(
 ) -> crate::error::Result<(
     mpsc::Sender<IrohCommand>,
     mpsc::Receiver<TransportEvent<iroh::endpoint::SendStream>>,
+    Arc<ReplicatorRegistry>,
     JoinHandle<()>,
 )> {
     let mut alpns: Vec<Vec<u8>> = protocols::ALL_ALPNS.iter().map(|a| a.to_vec()).collect();
@@ -66,10 +66,17 @@ pub async fn spawn_endpoint(
 
     let (command_tx, command_rx) = mpsc::channel::<IrohCommand>(256);
     let (event_tx, event_rx) = mpsc::channel::<TransportEvent<iroh::endpoint::SendStream>>(256);
+    let replicators = Arc::new(ReplicatorRegistry::new());
 
-    let task = tokio::spawn(run_event_loop(endpoint, gossip, command_rx, event_tx));
+    let task = tokio::spawn(run_event_loop(
+        endpoint,
+        gossip,
+        command_rx,
+        event_tx,
+        replicators.clone(),
+    ));
 
-    Ok((command_tx, event_rx, task))
+    Ok((command_tx, event_rx, replicators, task))
 }
 
 /// Main event loop processing incoming connections, gossip, and commands.
@@ -78,10 +85,11 @@ async fn run_event_loop(
     gossip: Gossip,
     mut command_rx: mpsc::Receiver<IrohCommand>,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
+    replicators: Arc<ReplicatorRegistry>,
 ) {
     let peer_map = Arc::new(parking_lot::Mutex::new(PeerMap::new()));
-    let mut subscriptions: HashMap<String, TopicSubscription> = HashMap::new();
-    let mut replicators: HashMap<String, ReplicatorInfo> = HashMap::new();
+    let mut subscriptions: std::collections::HashMap<String, TopicSubscription> =
+        std::collections::HashMap::new();
     let mut active_syncs: HashMap<u64, ActiveSync> = HashMap::new();
     let mut next_query_id: u64 = 1;
 
@@ -118,7 +126,7 @@ async fn run_event_loop(
                     &gossip,
                     &peer_map,
                     &mut subscriptions,
-                    &mut replicators,
+                    &replicators,
                     &mut active_syncs,
                     &mut next_query_id,
                     &event_tx,

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -10,11 +10,12 @@ use std::sync::Arc;
 
 use iroh::{Endpoint, EndpointId};
 use iroh_gossip::net::Gossip;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 use crate::bitswap::ReplicatorRegistry;
+use crate::message::PushLogReply;
 use crate::transport::{PeerAddr, PeerId, TransportEvent};
 
 use super::command::IrohCommand;
@@ -89,6 +90,10 @@ async fn run_event_loop(
     replicators: Arc<ReplicatorRegistry>,
 ) {
     let peer_map = Arc::new(parking_lot::Mutex::new(PeerMap::new()));
+    let pending_pushlog_replies = Arc::new(parking_lot::Mutex::new(HashMap::<
+        String,
+        oneshot::Sender<PushLogReply>,
+    >::new()));
     let mut subscriptions: std::collections::HashMap<String, TopicSubscription> =
         std::collections::HashMap::new();
     let mut active_syncs: HashMap<u64, ActiveSync> = HashMap::new();
@@ -113,6 +118,7 @@ async fn run_event_loop(
                             incoming,
                             &gossip,
                             &peer_map,
+                            &pending_pushlog_replies,
                             &subscriptions,
                             &event_tx,
                         ).await;
@@ -126,6 +132,7 @@ async fn run_event_loop(
                     &endpoint,
                     &gossip,
                     &peer_map,
+                    &pending_pushlog_replies,
                     &mut subscriptions,
                     &replicators,
                     &mut active_syncs,

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -12,7 +12,7 @@ use iroh::{Endpoint, EndpointId};
 use iroh_gossip::net::Gossip;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::bitswap::ReplicatorRegistry;
 use crate::message::PushLogReply;
@@ -54,7 +54,10 @@ async fn shutdown_tracked_tasks(spawned_tasks: SpawnedTasks) {
         return;
     }
 
-    debug!(task_count = tasks.len(), "Aborting tracked Iroh spawned tasks during shutdown");
+    debug!(
+        task_count = tasks.len(),
+        "Aborting tracked Iroh spawned tasks during shutdown"
+    );
     for task in &tasks {
         task.abort();
     }

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -5,6 +5,7 @@
 //! - Gossip events from iroh-gossip
 //! - Commands from the `IrohTransport` facade
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use iroh::{Endpoint, EndpointId};

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -138,6 +138,7 @@ async fn run_event_loop(
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     replicators: Arc<ReplicatorRegistry>,
 ) {
+    let shutdown_started = std::time::Instant::now();
     let peer_map = Arc::new(parking_lot::Mutex::new(PeerMap::new()));
     let pending_pushlog_replies = Arc::new(parking_lot::Mutex::new(HashMap::<
         String,
@@ -200,18 +201,47 @@ async fn run_event_loop(
     }
 
     // Clean up
+    let subscriptions_started = std::time::Instant::now();
     for (_, sub) in subscriptions.drain() {
         sub.reader_task.abort();
     }
+    warn!(
+        elapsed_ms = subscriptions_started.elapsed().as_millis(),
+        "Iroh endpoint shutdown: subscriptions aborted"
+    );
+
+    let syncs_started = std::time::Instant::now();
     for (_, sync) in active_syncs.drain() {
         sync.abort_handle.abort();
     }
+    warn!(
+        elapsed_ms = syncs_started.elapsed().as_millis(),
+        "Iroh endpoint shutdown: active syncs aborted"
+    );
+
+    let tracked_started = std::time::Instant::now();
     shutdown_tracked_tasks(spawned_tasks).await;
+    warn!(
+        elapsed_ms = tracked_started.elapsed().as_millis(),
+        "Iroh endpoint shutdown: tracked spawned tasks drained"
+    );
+
+    let gossip_started = std::time::Instant::now();
     if let Err(error) = gossip.shutdown().await {
         debug!(%error, "Iroh gossip shutdown failed");
     }
+    warn!(
+        elapsed_ms = gossip_started.elapsed().as_millis(),
+        "Iroh endpoint shutdown: gossip stopped"
+    );
+
+    let close_started = std::time::Instant::now();
     endpoint.close().await;
-    info!("Iroh endpoint shut down");
+    warn!(
+        close_elapsed_ms = close_started.elapsed().as_millis(),
+        total_elapsed_ms = shutdown_started.elapsed().as_millis(),
+        "Iroh endpoint shut down"
+    );
 }
 
 /// Join a newly connected peer into all active gossip topic subscriptions.

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -38,6 +38,55 @@ pub(super) struct ActiveSync {
     pub(super) abort_handle: tokio::task::AbortHandle,
 }
 
+pub(super) type SpawnedTasks = Arc<parking_lot::Mutex<Vec<JoinHandle<()>>>>;
+
+pub(super) fn track_task(spawned_tasks: &SpawnedTasks, task: JoinHandle<()>) {
+    spawned_tasks.lock().push(task);
+}
+
+async fn shutdown_tracked_tasks(spawned_tasks: SpawnedTasks) {
+    let mut tasks = {
+        let mut guard = spawned_tasks.lock();
+        std::mem::take(&mut *guard)
+    };
+
+    if tasks.is_empty() {
+        return;
+    }
+
+    debug!(task_count = tasks.len(), "Aborting tracked Iroh spawned tasks during shutdown");
+    for task in &tasks {
+        task.abort();
+    }
+
+    let shutdown_start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(5);
+    while let Some(task) = tasks.pop() {
+        let remaining = timeout.saturating_sub(shutdown_start.elapsed());
+        if remaining.is_zero() {
+            warn!(
+                remaining_tasks = tasks.len() + 1,
+                "Timed out draining tracked Iroh spawned tasks during shutdown"
+            );
+            break;
+        }
+        match tokio::time::timeout(remaining, task).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) if error.is_cancelled() => {}
+            Ok(Err(error)) => {
+                debug!(%error, "Tracked Iroh spawned task failed during shutdown");
+            }
+            Err(_) => {
+                warn!(
+                    remaining_tasks = tasks.len() + 1,
+                    "Timed out waiting for tracked Iroh spawned task during shutdown"
+                );
+                break;
+            }
+        }
+    }
+}
+
 /// Spawn the iroh endpoint background task.
 ///
 /// Returns the command sender, event receiver, and background task handle.
@@ -97,6 +146,7 @@ async fn run_event_loop(
     let mut subscriptions: std::collections::HashMap<String, TopicSubscription> =
         std::collections::HashMap::new();
     let mut active_syncs: HashMap<u64, ActiveSync> = HashMap::new();
+    let spawned_tasks: SpawnedTasks = Arc::new(parking_lot::Mutex::new(Vec::new()));
     let mut next_query_id: u64 = 1;
 
     // Emit Listening event with our endpoint address
@@ -120,6 +170,7 @@ async fn run_event_loop(
                             &peer_map,
                             &pending_pushlog_replies,
                             &subscriptions,
+                            &spawned_tasks,
                             &event_tx,
                         ).await;
                     }
@@ -136,6 +187,7 @@ async fn run_event_loop(
                     &mut subscriptions,
                     &replicators,
                     &mut active_syncs,
+                    &spawned_tasks,
                     &mut next_query_id,
                     &event_tx,
                 ).await;
@@ -154,6 +206,7 @@ async fn run_event_loop(
     for (_, sync) in active_syncs.drain() {
         sync.abort_handle.abort();
     }
+    shutdown_tracked_tasks(spawned_tasks).await;
     if let Err(error) = gossip.shutdown().await {
         debug!(%error, "Iroh gossip shutdown failed");
     }

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use bytes::Bytes;
 use iroh::Endpoint;
 use iroh_gossip::net::Gossip;
-use tokio::sync::oneshot;
 use iroh_gossip::proto::TopicId;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
 use crate::bitswap::ReplicatorRegistry;
@@ -22,8 +22,7 @@ use super::endpoint::{
     join_peer_to_subscriptions, peer_direct_addr, ActiveSync, TopicSubscription,
 };
 use super::endpoint_rpc::{
-    handle_block_sync, handle_car_request_response, handle_fire_and_forget,
-    handle_request_response,
+    handle_block_sync, handle_car_request_response, handle_fire_and_forget, handle_request_response,
 };
 use super::peer_map::{endpoint_id_to_peer_id, parse_endpoint_id, PeerMap};
 use super::protocols;
@@ -37,7 +36,9 @@ pub(super) async fn handle_command(
     endpoint: &Endpoint,
     gossip: &Gossip,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
-    pending_pushlog_replies: &Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    pending_pushlog_replies: &Arc<
+        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
+    >,
     subscriptions: &mut HashMap<String, TopicSubscription>,
     replicators: &Arc<ReplicatorRegistry>,
     active_syncs: &mut HashMap<u64, ActiveSync>,
@@ -469,7 +470,9 @@ pub(super) async fn handle_command(
 async fn handle_dial(
     endpoint: &Endpoint,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
-    pending_pushlog_replies: &Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    pending_pushlog_replies: &Arc<
+        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
+    >,
     subscriptions: &HashMap<String, TopicSubscription>,
     peer_id: &PeerId,
     addrs: Vec<PeerAddr>,

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -472,6 +472,7 @@ pub(super) async fn handle_command(
             ));
         }
         IrohCommand::Shutdown { reply } => {
+            tracing::warn!("Iroh endpoint received shutdown command");
             let _ = reply.send(Ok(()));
             return true;
         }
@@ -531,8 +532,6 @@ async fn handle_dial(
     let peer_map = Arc::clone(peer_map);
     let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
     let spawned_tasks_for_connection = Arc::clone(spawned_tasks);
-    let task = tokio::spawn(async move {
-    let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
     let task = tokio::spawn(async move {
         super::endpoint_streams::handle_connection_streams_from_dial(
             connection,

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -6,12 +6,13 @@ use std::sync::Arc;
 use bytes::Bytes;
 use iroh::Endpoint;
 use iroh_gossip::net::Gossip;
+use tokio::sync::oneshot;
 use iroh_gossip::proto::TopicId;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use crate::bitswap::ReplicatorRegistry;
-use crate::message::CarFetchRequest;
+use crate::message::PushLogReply;
 use crate::transport::{MessageId, PeerAddr, PeerId, TransportEvent};
 use crate::QueryId;
 
@@ -20,7 +21,10 @@ use super::command::IrohCommand;
 use super::endpoint::{
     join_peer_to_subscriptions, peer_direct_addr, ActiveSync, TopicSubscription,
 };
-use super::endpoint_rpc::{handle_block_sync, handle_fire_and_forget, handle_request_response};
+use super::endpoint_rpc::{
+    handle_block_sync, handle_car_request_response, handle_fire_and_forget,
+    handle_request_response,
+};
 use super::peer_map::{endpoint_id_to_peer_id, parse_endpoint_id, PeerMap};
 use super::protocols;
 
@@ -33,6 +37,7 @@ pub(super) async fn handle_command(
     endpoint: &Endpoint,
     gossip: &Gossip,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
+    pending_pushlog_replies: &Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
     subscriptions: &mut HashMap<String, TopicSubscription>,
     replicators: &Arc<ReplicatorRegistry>,
     active_syncs: &mut HashMap<u64, ActiveSync>,
@@ -45,8 +50,16 @@ pub(super) async fn handle_command(
             addrs,
             reply,
         } => {
-            let result =
-                handle_dial(endpoint, peer_map, subscriptions, &peer_id, addrs, event_tx).await;
+            let result = handle_dial(
+                endpoint,
+                peer_map,
+                pending_pushlog_replies,
+                subscriptions,
+                &peer_id,
+                addrs,
+                event_tx,
+            )
+            .await;
             let _ = reply.send(result);
         }
         IrohCommand::Listen { addr: _, reply } => {
@@ -119,14 +132,47 @@ pub(super) async fn handle_command(
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
+            let pending_pushlog_replies = pending_pushlog_replies.clone();
             tokio::spawn(async move {
-                let result = handle_request_response(
-                    &endpoint,
-                    &peer_id,
-                    protocols::ALPN_TWOSTREAM,
-                    &request,
-                    direct_addr,
-                )
+                let result = async move {
+                    let message_id = request.metadata.message_id.clone();
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    pending_pushlog_replies
+                        .lock()
+                        .insert(message_id.clone(), reply_tx);
+
+                    if let Err(error) = handle_fire_and_forget(
+                        &endpoint,
+                        &peer_id,
+                        protocols::ALPN_TWOSTREAM,
+                        &request,
+                        direct_addr,
+                    )
+                    .await
+                    {
+                        pending_pushlog_replies.lock().remove(&message_id);
+                        return Err(error);
+                    }
+
+                    match tokio::time::timeout(
+                        super::endpoint_rpc::REQUEST_RESPONSE_TIMEOUT,
+                        reply_rx,
+                    )
+                    .await
+                    {
+                        Ok(Ok(reply_msg)) => Ok(reply_msg),
+                        Ok(Err(_)) => {
+                            pending_pushlog_replies.lock().remove(&message_id);
+                            Err(crate::error::Error::Transport(
+                                "response channel closed".into(),
+                            ))
+                        }
+                        Err(_) => {
+                            pending_pushlog_replies.lock().remove(&message_id);
+                            Err(crate::error::Error::ResponseTimeout)
+                        }
+                    }
+                }
                 .await;
                 let _ = reply.send(result);
             });
@@ -296,15 +342,15 @@ pub(super) async fn handle_command(
             reply,
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
-            let request = CarFetchRequest::full_dag(root_cid);
             let endpoint = endpoint.clone();
+            let event_tx = event_tx.clone();
             tokio::spawn(async move {
-                let result = handle_fire_and_forget(
+                let result = handle_car_request_response(
                     &endpoint,
                     &peer_id,
-                    protocols::ALPN_CAR,
-                    &request,
+                    root_cid,
                     direct_addr,
+                    &event_tx,
                 )
                 .await;
                 let _ = reply.send(result);
@@ -423,6 +469,7 @@ pub(super) async fn handle_command(
 async fn handle_dial(
     endpoint: &Endpoint,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
+    pending_pushlog_replies: &Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
     subscriptions: &HashMap<String, TopicSubscription>,
     peer_id: &PeerId,
     addrs: Vec<PeerAddr>,
@@ -463,6 +510,7 @@ async fn handle_dial(
     // Keep connection alive by spawning a handler for incoming streams.
     let event_tx = event_tx.clone();
     let peer_map = Arc::clone(peer_map);
+    let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
     tokio::spawn(async move {
         super::endpoint_streams::handle_connection_streams_from_dial(
             connection,
@@ -470,6 +518,7 @@ async fn handle_dial(
             conn_alpn,
             event_tx,
             peer_map,
+            pending_pushlog_replies,
         )
         .await;
     });

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -19,7 +19,8 @@ use crate::QueryId;
 use super::addr::{endpoint_addr_from_parts, endpoint_ticket_string};
 use super::command::IrohCommand;
 use super::endpoint::{
-    join_peer_to_subscriptions, peer_direct_addr, ActiveSync, TopicSubscription,
+    join_peer_to_subscriptions, peer_direct_addr, track_task, ActiveSync, SpawnedTasks,
+    TopicSubscription,
 };
 use super::endpoint_rpc::{
     handle_block_sync, handle_car_request_response, handle_fire_and_forget, handle_request_response,
@@ -42,6 +43,7 @@ pub(super) async fn handle_command(
     subscriptions: &mut HashMap<String, TopicSubscription>,
     replicators: &Arc<ReplicatorRegistry>,
     active_syncs: &mut HashMap<u64, ActiveSync>,
+    spawned_tasks: &SpawnedTasks,
     next_query_id: &mut u64,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> bool {
@@ -56,6 +58,7 @@ pub(super) async fn handle_command(
                 peer_map,
                 pending_pushlog_replies,
                 subscriptions,
+                spawned_tasks,
                 &peer_id,
                 addrs,
                 event_tx,
@@ -114,7 +117,7 @@ pub(super) async fn handle_command(
             reply_msg,
             reply,
         } => {
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = async {
                     protocols::write_message(&mut send_stream, &reply_msg).await?;
                     send_stream.finish().map_err(|e| {
@@ -125,6 +128,7 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendTwoStreamRequest {
             peer_id,
@@ -134,7 +138,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let pending_pushlog_replies = pending_pushlog_replies.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = async move {
                     let message_id = request.metadata.message_id.clone();
                     let (reply_tx, reply_rx) = oneshot::channel();
@@ -177,6 +181,7 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendTwoStreamResponse {
             peer_id,
@@ -185,7 +190,7 @@ pub(super) async fn handle_command(
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -196,6 +201,7 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendDocSyncRequest {
             peer_id,
@@ -205,7 +211,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let event_tx = event_tx.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result: crate::error::Result<crate::message::DocSyncReply> =
                     handle_request_response(
                         &endpoint,
@@ -230,6 +236,7 @@ pub(super) async fn handle_command(
                     }
                 }
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendBranchableSyncRequest {
             peer_id,
@@ -239,7 +246,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let event_tx = event_tx.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result: crate::error::Result<crate::message::BranchableSyncReply> =
                     handle_request_response(
                         &endpoint,
@@ -264,6 +271,7 @@ pub(super) async fn handle_command(
                     }
                 }
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendDocSyncResponse {
             peer_id,
@@ -272,7 +280,7 @@ pub(super) async fn handle_command(
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -283,6 +291,7 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendBranchableSyncResponse {
             peer_id,
@@ -291,7 +300,7 @@ pub(super) async fn handle_command(
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -302,13 +311,14 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendDocSyncResponseToken {
             mut send_stream,
             reply_msg,
             reply,
         } => {
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = async {
                     protocols::write_message(&mut send_stream, &reply_msg).await?;
                     send_stream.finish().map_err(|e| {
@@ -319,13 +329,14 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendBranchableSyncResponseToken {
             mut send_stream,
             reply_msg,
             reply,
         } => {
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = async {
                     protocols::write_message(&mut send_stream, &reply_msg).await?;
                     send_stream.finish().map_err(|e| {
@@ -336,6 +347,7 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendCarRequest {
             peer_id,
@@ -345,7 +357,7 @@ pub(super) async fn handle_command(
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
             let event_tx = event_tx.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = handle_car_request_response(
                     &endpoint,
                     &peer_id,
@@ -356,6 +368,7 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendCarResponse {
             peer_id,
@@ -364,7 +377,7 @@ pub(super) async fn handle_command(
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -375,6 +388,7 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SendSEArtifacts {
             peer_id,
@@ -383,7 +397,7 @@ pub(super) async fn handle_command(
         } => {
             let direct_addr = peer_direct_addr(peer_map, &peer_id);
             let endpoint = endpoint.clone();
-            tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = handle_fire_and_forget(
                     &endpoint,
                     &peer_id,
@@ -394,6 +408,7 @@ pub(super) async fn handle_command(
                 .await;
                 let _ = reply.send(result);
             });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::SyncBlocks {
             root,
@@ -474,6 +489,7 @@ async fn handle_dial(
         parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
     >,
     subscriptions: &HashMap<String, TopicSubscription>,
+    spawned_tasks: &SpawnedTasks,
     peer_id: &PeerId,
     addrs: Vec<PeerAddr>,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
@@ -514,7 +530,10 @@ async fn handle_dial(
     let event_tx = event_tx.clone();
     let peer_map = Arc::clone(peer_map);
     let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
-    tokio::spawn(async move {
+    let spawned_tasks_for_connection = Arc::clone(spawned_tasks);
+    let task = tokio::spawn(async move {
+    let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
+    let task = tokio::spawn(async move {
         super::endpoint_streams::handle_connection_streams_from_dial(
             connection,
             endpoint_id,
@@ -522,9 +541,11 @@ async fn handle_dial(
             event_tx,
             peer_map,
             pending_pushlog_replies,
+            &spawned_tasks_for_connection,
         )
         .await;
     });
+    track_task(spawned_tasks, task);
 
     Ok(())
 }

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -10,8 +10,8 @@ use iroh_gossip::proto::TopicId;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
+use crate::bitswap::ReplicatorRegistry;
 use crate::message::CarFetchRequest;
-use crate::replicator::ReplicatorInfo;
 use crate::transport::{MessageId, PeerAddr, PeerId, TransportEvent};
 use crate::QueryId;
 
@@ -34,7 +34,7 @@ pub(super) async fn handle_command(
     gossip: &Gossip,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
     subscriptions: &mut HashMap<String, TopicSubscription>,
-    replicators: &mut HashMap<String, ReplicatorInfo>,
+    replicators: &Arc<ReplicatorRegistry>,
     active_syncs: &mut HashMap<u64, ActiveSync>,
     next_query_id: &mut u64,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
@@ -387,38 +387,27 @@ pub(super) async fn handle_command(
             collections,
             reply,
         } => {
-            let info = ReplicatorInfo::from_raw(peer_id.to_string(), collections, Vec::new());
-            replicators.insert(peer_id.to_string(), info);
+            replicators.set_peer_collections(peer_id.as_str(), &collections);
             let _ = reply.send(Ok(()));
         }
         IrohCommand::DeleteReplicator { peer_id, reply } => {
-            replicators.remove(peer_id.as_str());
+            replicators.remove_peer(peer_id.as_str());
             let _ = reply.send(Ok(()));
         }
         IrohCommand::ListReplicators { reply } => {
-            let list: Vec<ReplicatorInfo> = replicators.values().cloned().collect();
-            let _ = reply.send(Ok(list));
+            let _ = reply.send(Ok(replicators.list_replicator_info()));
         }
         IrohCommand::GetReplicator { peer_id, reply } => {
-            let info = replicators.get(peer_id.as_str()).cloned();
-            let _ = reply.send(Ok(info));
+            let _ = reply.send(Ok(replicators.get_replicator_info(peer_id.as_str())));
         }
         IrohCommand::RemoveReplicatorCollections {
             peer_id,
             collections,
             reply,
         } => {
-            if let Some(info) = replicators.get_mut(peer_id.as_str()) {
-                info.collections.retain(|c| !collections.contains(c));
-                if info.collections.is_empty() {
-                    replicators.remove(peer_id.as_str());
-                    let _ = reply.send(Ok(true));
-                } else {
-                    let _ = reply.send(Ok(false));
-                }
-            } else {
-                let _ = reply.send(Ok(false));
-            }
+            let _ = reply.send(Ok(
+                replicators.remove_peer_collections(peer_id.as_str(), &collections)
+            ));
         }
         IrohCommand::Shutdown { reply } => {
             let _ = reply.send(Ok(()));

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -340,7 +340,7 @@ pub(super) async fn handle_block_sync(
     missing: Vec<cid::Cid>,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) {
-    use tokio::task::JoinHandle;
+    use tokio::task::JoinSet;
 
     if !missing.is_empty() {
         debug!(
@@ -351,7 +351,7 @@ pub(super) async fn handle_block_sync(
         );
     }
 
-    let mut tasks: Vec<JoinHandle<bool>> = Vec::with_capacity(providers.len());
+    let mut tasks: JoinSet<bool> = JoinSet::new();
 
     let request = if missing.is_empty() {
         CarFetchRequest::full_dag(root)
@@ -365,10 +365,10 @@ pub(super) async fn handle_block_sync(
         let event_tx = event_tx.clone();
         let provider = provider.clone();
         let request = request.clone();
-        tasks.push(tokio::spawn(async move {
+        tasks.spawn(async move {
             let direct_addr = super::endpoint::peer_direct_addr(&peer_map, &provider);
             try_fetch_from_provider(&endpoint, &provider, request, direct_addr, &event_tx).await
-        }));
+        });
     }
 
     let mut any_success = false;
@@ -379,10 +379,11 @@ pub(super) async fn handle_block_sync(
         "selective"
     };
 
-    for task in tasks {
-        match task.await {
+    while let Some(task) = tasks.join_next().await {
+        match task {
             Ok(true) => {
                 any_success = true;
+                tasks.abort_all();
                 break;
             }
             Ok(false) => {}

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -137,6 +137,56 @@ pub(super) async fn handle_fire_and_forget<T: serde::Serialize>(
     Ok(())
 }
 
+/// Send a CAR request and emit the response as a transport event.
+///
+/// Unlike generic fire-and-forget messages, CAR requests expect the peer to
+/// stream raw CAR bytes back on the same bidirectional stream. We must consume
+/// that response here; otherwise the remote writer sees a broken stream and the
+/// caller never receives a `CarFetchResponse`.
+pub(super) async fn handle_car_request_response(
+    endpoint: &Endpoint,
+    peer_id: &PeerId,
+    root_cid: cid::Cid,
+    direct_addr: Option<std::net::SocketAddr>,
+    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
+) -> crate::error::Result<()> {
+    let connection =
+        connect_with_direct_addr_fallback(endpoint, peer_id, protocols::ALPN_CAR, direct_addr)
+            .await?;
+
+    let (mut send, mut recv) = connection
+        .open_bi()
+        .await
+        .map_err(|e| crate::error::Error::Transport(e.to_string()))?;
+
+    let request = CarFetchRequest::full_dag(root_cid);
+    protocols::write_message(&mut send, &request).await?;
+    send.finish()
+        .map_err(|e| crate::error::Error::Transport(e.to_string()))?;
+
+    let car_data = tokio::time::timeout(
+        REQUEST_RESPONSE_TIMEOUT,
+        recv.read_to_end(protocols::MAX_CAR_SIZE),
+    )
+    .await
+    .map_err(|_| crate::error::Error::ResponseTimeout)?
+    .map_err(|e| crate::error::Error::Transport(e.to_string()))?;
+
+    if event_tx
+        .send(TransportEvent::CarFetchResponse {
+            peer_id: peer_id.clone(),
+            root_cid,
+            car_data,
+        })
+        .await
+        .is_err()
+    {
+        warn!("Event channel closed, cannot emit CarFetchResponse");
+    }
+
+    Ok(())
+}
+
 /// Try to fetch CAR blocks from a single provider.
 ///
 /// Returns `true` if the fetch succeeded and a `CarFetchResponse` was emitted.

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -6,9 +6,11 @@ use std::sync::Arc;
 use iroh::endpoint::Connection;
 use iroh::EndpointId;
 use iroh_gossip::net::Gossip;
+use tokio::sync::oneshot;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
+use crate::message::PushLogReply;
 use crate::transport::{PeerId, TransportEvent};
 
 use super::endpoint::{join_peer_to_subscriptions, TopicSubscription};
@@ -20,6 +22,7 @@ pub(super) async fn handle_incoming(
     incoming: iroh::endpoint::Incoming,
     gossip: &Gossip,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
+    pending_pushlog_replies: &Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
     subscriptions: &HashMap<String, TopicSubscription>,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) {
@@ -90,8 +93,17 @@ pub(super) async fn handle_incoming(
     // Spawn handler for this connection's streams
     let event_tx = event_tx.clone();
     let peer_map = Arc::clone(peer_map);
+    let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
     tokio::spawn(async move {
-        handle_connection_streams(connection, remote_id, conn_alpn, event_tx, peer_map).await;
+        handle_connection_streams(
+            connection,
+            remote_id,
+            conn_alpn,
+            event_tx,
+            peer_map,
+            pending_pushlog_replies,
+        )
+        .await;
     });
 }
 
@@ -104,6 +116,7 @@ async fn handle_connection_streams(
     alpn: Vec<u8>,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     peer_map: Arc<parking_lot::Mutex<PeerMap>>,
+    pending_pushlog_replies: Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
 ) {
     let peer_id = endpoint_id_to_peer_id(&remote_id);
 
@@ -111,8 +124,18 @@ async fn handle_connection_streams(
         let peer_id = peer_id.clone();
         let event_tx = event_tx.clone();
         let alpn = alpn.clone();
+        let pending_pushlog_replies = pending_pushlog_replies.clone();
         tokio::spawn(async move {
-            if let Err(e) = dispatch_stream(&alpn, &peer_id, send, &mut recv, &event_tx).await {
+            if let Err(e) = dispatch_stream(
+                &alpn,
+                &peer_id,
+                send,
+                &mut recv,
+                &event_tx,
+                &pending_pushlog_replies,
+            )
+            .await
+            {
                 debug!("Stream error from {}: {}", peer_id, e);
             }
         });
@@ -138,8 +161,17 @@ pub(super) async fn handle_connection_streams_from_dial(
     alpn: Vec<u8>,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     peer_map: Arc<parking_lot::Mutex<PeerMap>>,
+    pending_pushlog_replies: Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
 ) {
-    handle_connection_streams(connection, remote_id, alpn, event_tx, peer_map).await;
+    handle_connection_streams(
+        connection,
+        remote_id,
+        alpn,
+        event_tx,
+        peer_map,
+        pending_pushlog_replies,
+    )
+    .await;
 }
 
 /// Dispatch a stream based on the connection ALPN.
@@ -149,6 +181,7 @@ async fn dispatch_stream(
     send: iroh::endpoint::SendStream,
     recv: &mut iroh::endpoint::RecvStream,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
+    pending_pushlog_replies: &Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
 ) -> crate::error::Result<()> {
     match alpn {
         x if x == protocols::ALPN_PUSHLOG => {
@@ -167,8 +200,17 @@ async fn dispatch_stream(
             }
         }
         x if x == protocols::ALPN_TWOSTREAM => {
-            let request: crate::message::PushLogRequest =
-                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
+            let payload = protocols::read_message_bytes(recv, protocols::MAX_MESSAGE_SIZE).await?;
+            if let Ok(reply) = serde_cbor::from_slice::<PushLogReply>(&payload) {
+                let sender = pending_pushlog_replies.lock().remove(&reply.message_id);
+                if let Some(sender) = sender {
+                    let _ = sender.send(reply);
+                    return Ok(());
+                }
+            }
+
+            let request: crate::message::PushLogRequest = serde_cbor::from_slice(&payload)
+                .map_err(|e| crate::error::Error::Codec(e.to_string()))?;
             if event_tx
                 .send(TransportEvent::TwoStreamRequest {
                     peer_id: peer_id.clone(),

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -13,7 +13,7 @@ use tracing::{debug, warn};
 use crate::message::PushLogReply;
 use crate::transport::{PeerId, TransportEvent};
 
-use super::endpoint::{join_peer_to_subscriptions, TopicSubscription};
+use super::endpoint::{join_peer_to_subscriptions, track_task, SpawnedTasks, TopicSubscription};
 use super::peer_map::{endpoint_id_to_peer_id, PeerMap};
 use super::protocols;
 
@@ -26,6 +26,7 @@ pub(super) async fn handle_incoming(
         parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
     >,
     subscriptions: &HashMap<String, TopicSubscription>,
+    spawned_tasks: &SpawnedTasks,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) {
     let remote_addr = match incoming.remote_addr() {
@@ -96,7 +97,10 @@ pub(super) async fn handle_incoming(
     let event_tx = event_tx.clone();
     let peer_map = Arc::clone(peer_map);
     let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
-    tokio::spawn(async move {
+    let spawned_tasks_for_connection = Arc::clone(spawned_tasks);
+    let task = tokio::spawn(async move {
+    let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
+    let task = tokio::spawn(async move {
         handle_connection_streams(
             connection,
             remote_id,
@@ -104,9 +108,11 @@ pub(super) async fn handle_incoming(
             event_tx,
             peer_map,
             pending_pushlog_replies,
+            &spawned_tasks_for_connection,
         )
         .await;
     });
+    track_task(spawned_tasks, task);
 }
 
 /// Process streams on an accepted connection, dispatching by ALPN.
@@ -121,6 +127,10 @@ async fn handle_connection_streams(
     pending_pushlog_replies: Arc<
         parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
     >,
+    spawned_tasks: &SpawnedTasks,
+    pending_pushlog_replies: Arc<
+        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
+    >,
 ) {
     let peer_id = endpoint_id_to_peer_id(&remote_id);
 
@@ -129,7 +139,9 @@ async fn handle_connection_streams(
         let event_tx = event_tx.clone();
         let alpn = alpn.clone();
         let pending_pushlog_replies = pending_pushlog_replies.clone();
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
+        let pending_pushlog_replies = pending_pushlog_replies.clone();
+        let task = tokio::spawn(async move {
             if let Err(e) = dispatch_stream(
                 &alpn,
                 &peer_id,
@@ -143,6 +155,7 @@ async fn handle_connection_streams(
                 debug!("Stream error from {}: {}", peer_id, e);
             }
         });
+        track_task(spawned_tasks, task);
     }
 
     let fully_disconnected = peer_map.lock().decrement_connections(&remote_id);
@@ -175,6 +188,18 @@ pub(super) async fn handle_connection_streams_from_dial(
         alpn,
         event_tx,
         peer_map,
+        pending_pushlog_replies,
+    )
+    .await;
+    spawned_tasks: &SpawnedTasks,
+) {
+    handle_connection_streams(
+        connection,
+        remote_id,
+        alpn,
+        event_tx,
+        peer_map,
+        spawned_tasks,
         pending_pushlog_replies,
     )
     .await;

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use iroh::endpoint::Connection;
 use iroh::EndpointId;
 use iroh_gossip::net::Gossip;
-use tokio::sync::oneshot;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
 use crate::message::PushLogReply;
@@ -22,7 +22,9 @@ pub(super) async fn handle_incoming(
     incoming: iroh::endpoint::Incoming,
     gossip: &Gossip,
     peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
-    pending_pushlog_replies: &Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    pending_pushlog_replies: &Arc<
+        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
+    >,
     subscriptions: &HashMap<String, TopicSubscription>,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) {
@@ -116,7 +118,9 @@ async fn handle_connection_streams(
     alpn: Vec<u8>,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     peer_map: Arc<parking_lot::Mutex<PeerMap>>,
-    pending_pushlog_replies: Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    pending_pushlog_replies: Arc<
+        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
+    >,
 ) {
     let peer_id = endpoint_id_to_peer_id(&remote_id);
 
@@ -161,7 +165,9 @@ pub(super) async fn handle_connection_streams_from_dial(
     alpn: Vec<u8>,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
     peer_map: Arc<parking_lot::Mutex<PeerMap>>,
-    pending_pushlog_replies: Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    pending_pushlog_replies: Arc<
+        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
+    >,
 ) {
     handle_connection_streams(
         connection,
@@ -181,7 +187,9 @@ async fn dispatch_stream(
     send: iroh::endpoint::SendStream,
     recv: &mut iroh::endpoint::RecvStream,
     event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
-    pending_pushlog_replies: &Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    pending_pushlog_replies: &Arc<
+        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
+    >,
 ) -> crate::error::Result<()> {
     match alpn {
         x if x == protocols::ALPN_PUSHLOG => {

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -99,8 +99,6 @@ pub(super) async fn handle_incoming(
     let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
     let spawned_tasks_for_connection = Arc::clone(spawned_tasks);
     let task = tokio::spawn(async move {
-    let pending_pushlog_replies = Arc::clone(pending_pushlog_replies);
-    let task = tokio::spawn(async move {
         handle_connection_streams(
             connection,
             remote_id,
@@ -128,9 +126,6 @@ async fn handle_connection_streams(
         parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
     >,
     spawned_tasks: &SpawnedTasks,
-    pending_pushlog_replies: Arc<
-        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
-    >,
 ) {
     let peer_id = endpoint_id_to_peer_id(&remote_id);
 
@@ -138,8 +133,6 @@ async fn handle_connection_streams(
         let peer_id = peer_id.clone();
         let event_tx = event_tx.clone();
         let alpn = alpn.clone();
-        let pending_pushlog_replies = pending_pushlog_replies.clone();
-        let task = tokio::spawn(async move {
         let pending_pushlog_replies = pending_pushlog_replies.clone();
         let task = tokio::spawn(async move {
             if let Err(e) = dispatch_stream(
@@ -181,16 +174,6 @@ pub(super) async fn handle_connection_streams_from_dial(
     pending_pushlog_replies: Arc<
         parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
     >,
-) {
-    handle_connection_streams(
-        connection,
-        remote_id,
-        alpn,
-        event_tx,
-        peer_map,
-        pending_pushlog_replies,
-    )
-    .await;
     spawned_tasks: &SpawnedTasks,
 ) {
     handle_connection_streams(
@@ -199,8 +182,8 @@ pub(super) async fn handle_connection_streams_from_dial(
         alpn,
         event_tx,
         peer_map,
-        spawned_tasks,
         pending_pushlog_replies,
+        spawned_tasks,
     )
     .await;
 }

--- a/crates/p2p/src/iroh/protocols.rs
+++ b/crates/p2p/src/iroh/protocols.rs
@@ -56,6 +56,15 @@ pub async fn read_message<T: serde::de::DeserializeOwned>(
     recv: &mut RecvStream,
     max_size: usize,
 ) -> crate::error::Result<T> {
+    let payload = read_message_bytes(recv, max_size).await?;
+    serde_cbor::from_slice(&payload).map_err(|e| crate::error::Error::Codec(e.to_string()))
+}
+
+/// Read only the length-prefixed payload bytes from a QUIC recv stream.
+pub async fn read_message_bytes(
+    recv: &mut RecvStream,
+    max_size: usize,
+) -> crate::error::Result<Vec<u8>> {
     let mut len_buf = [0u8; 4];
     recv.read_exact(&mut len_buf)
         .await
@@ -73,8 +82,7 @@ pub async fn read_message<T: serde::de::DeserializeOwned>(
     recv.read_exact(&mut payload)
         .await
         .map_err(|e| crate::error::Error::Codec(format!("failed to read payload: {}", e)))?;
-
-    serde_cbor::from_slice(&payload).map_err(|e| crate::error::Error::Codec(e.to_string()))
+    Ok(payload)
 }
 
 /// Write a length-prefixed CBOR message to a QUIC send stream.

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -363,7 +363,21 @@ impl P2PTransport for IrohTransport {
     }
 
     async fn shutdown(&self) -> Result<()> {
-        self.send_command(|reply| IrohCommand::Shutdown { reply })
+        let send_started = std::time::Instant::now();
+        let (tx, rx) = oneshot::channel();
+        self.command_tx
+            .send(IrohCommand::Shutdown { reply: tx })
             .await
+            .map_err(|_| Error::ChannelSend)?;
+        let send_elapsed = send_started.elapsed();
+
+        let reply_started = std::time::Instant::now();
+        let result = rx.await.map_err(|_| Error::ChannelReceive)?;
+        tracing::warn!(
+            send_elapsed_ms = send_elapsed.as_millis(),
+            reply_elapsed_ms = reply_started.elapsed().as_millis(),
+            "Iroh transport shutdown command completed"
+        );
+        result
     }
 }

--- a/crates/p2p/src/sync/car.rs
+++ b/crates/p2p/src/sync/car.rs
@@ -3,7 +3,7 @@
 //! CARv1 (Content ARchive) packs a set of IPLD blocks with their CIDs into a
 //! single byte stream, enabling single-round-trip DAG transfer over P2P.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
 use blockstore::Blockstore;
 use bytes::Bytes;
@@ -126,14 +126,45 @@ pub async fn collect_dag_blocks<B: Blockstore>(
     let mut outcome = CarCollectOutcome::default();
     let mut visited = HashSet::new();
     let mut total_bytes: usize = 0;
-    collect_recursive(
-        blockstore,
-        root_cid,
-        &mut outcome,
-        &mut visited,
-        &mut total_bytes,
-    )
-    .await?;
+    let mut queue = VecDeque::from([*root_cid]);
+
+    while let Some(cid) = queue.pop_front() {
+        if !visited.insert(cid) {
+            continue;
+        }
+
+        if outcome.blocks.len() >= CAR_MAX_BLOCKS {
+            outcome.truncated_by_blocks = true;
+            break;
+        }
+
+        let data = match blockstore.get(&cid).await {
+            Ok(Some(d)) => d,
+            Ok(None) => continue,
+            Err(e) => {
+                return Err(Error::BlockstoreError(format!(
+                    "failed to get block {}: {}",
+                    cid, e
+                )));
+            }
+        };
+
+        if total_bytes + data.len() > CAR_MAX_BYTES {
+            outcome.truncated_by_bytes = true;
+            break;
+        }
+        total_bytes += data.len();
+
+        let refs = extract_links(&data);
+        outcome.blocks.push((cid, data));
+
+        for child_cid in refs {
+            if !visited.contains(&child_cid) {
+                queue.push_back(child_cid);
+            }
+        }
+    }
+
     Ok(outcome)
 }
 
@@ -176,53 +207,6 @@ pub async fn collect_exact_blocks<B: Blockstore>(
     }
 
     Ok(outcome)
-}
-
-fn collect_recursive<'a, B: Blockstore + 'a>(
-    blockstore: &'a B,
-    cid: &'a Cid,
-    outcome: &'a mut CarCollectOutcome,
-    visited: &'a mut HashSet<Cid>,
-    total_bytes: &'a mut usize,
-) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
-    Box::pin(async move {
-        if !visited.insert(*cid) {
-            return Ok(());
-        }
-
-        // Enforce limits before fetching each block.
-        if outcome.blocks.len() >= CAR_MAX_BLOCKS {
-            outcome.truncated_by_blocks = true;
-            return Ok(());
-        }
-
-        let data = match blockstore.get(cid).await {
-            Ok(Some(d)) => d,
-            Ok(None) => return Ok(()),
-            Err(e) => {
-                return Err(Error::BlockstoreError(format!(
-                    "failed to get block {}: {}",
-                    cid, e
-                )));
-            }
-        };
-
-        if *total_bytes + data.len() > CAR_MAX_BYTES {
-            outcome.truncated_by_bytes = true;
-            return Ok(());
-        }
-        *total_bytes += data.len();
-
-        // Extract child links
-        let refs = extract_links(&data);
-        outcome.blocks.push((*cid, data));
-
-        for child_cid in refs {
-            collect_recursive(blockstore, &child_cid, outcome, visited, total_bytes).await?;
-        }
-
-        Ok(())
-    })
 }
 
 /// Extract CID links from a DAG-CBOR block.
@@ -458,6 +442,33 @@ mod tests {
         assert_eq!(collected.blocks.len(), 1);
         assert_eq!(collected.blocks[0].0, root_cid);
         assert_eq!(collected.blocks[0].1, root_data);
+        assert!(!collected.truncated());
+    }
+
+    #[tokio::test]
+    async fn collect_dag_blocks_handles_deep_chains_iteratively() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = DefraBlockstore::new(store, true);
+
+        let mut next: Option<Cid> = None;
+        let mut root_cid: Option<Cid> = None;
+        let depth = 5_000usize;
+
+        for idx in (0..depth).rev() {
+            let data = match next {
+                Some(child) => encode_ipld(ipld!({ "idx": idx as i64, "next": child })),
+                None => encode_ipld(ipld!({ "idx": idx as i64 })),
+            };
+            let cid = make_cid(&data);
+            blockstore.put(&cid, &data).await.unwrap();
+            next = Some(cid);
+            root_cid = Some(cid);
+        }
+
+        let root_cid = root_cid.expect("deep chain root");
+        let collected = collect_dag_blocks(&blockstore, &root_cid).await.unwrap();
+
+        assert_eq!(collected.blocks.len(), depth);
         assert!(!collected.truncated());
     }
 }

--- a/crates/p2p/src/sync/coordinator/access.rs
+++ b/crates/p2p/src/sync/coordinator/access.rs
@@ -8,6 +8,26 @@ use crate::error::{Error, Result};
 use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    async fn transport_reports_connected_peer(&self, peer_id_str: &str) -> bool {
+        match self.runtime.transport.connected_peers().await {
+            Ok(peers) => {
+                let is_connected = peers.iter().any(|peer| peer.as_str() == peer_id_str);
+                if is_connected {
+                    self.access.peer_state.peer_connected(peer_id_str);
+                }
+                is_connected
+            }
+            Err(error) => {
+                tracing::debug!(
+                    peer_id = %peer_id_str,
+                    error = %error,
+                    "Failed to read transport-connected peers during access check"
+                );
+                false
+            }
+        }
+    }
+
     /// Check if a peer (by string ID) has access to sync a collection.
     ///
     /// Returns `Ok(())` if access is granted, or `Err(Error::AccessDenied)` if denied.
@@ -70,6 +90,14 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             return Ok(());
         }
 
+        // The transport is the source of truth for active connections. PeerState is a
+        // best-effort cache populated by transport events and can lag during bootstrap
+        // or if a runtime wires a stale coordinator view. On a cache miss, consult the
+        // transport directly and backfill PeerState so later checks stay hot.
+        if self.transport_reports_connected_peer(peer_id_str).await {
+            return Ok(());
+        }
+
         tracing::warn!(
             peer_id = %peer_id_str,
             collection_id = %collection_id,
@@ -94,7 +122,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Used by handlers (e.g. DocSync) that lack collection context.
     /// In Open mode, all peers are allowed. In Controlled mode, the peer
     /// must be a connected peer or a replicator for at least one collection.
-    pub(super) fn check_peer_is_replicator(&self, peer_id: &PeerId) -> Result<()> {
+    pub(super) async fn check_peer_is_replicator(&self, peer_id: &PeerId) -> Result<()> {
         if self.access.access_mode.is_open() {
             return Ok(());
         }
@@ -104,6 +132,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         if self.access.peer_state.is_connected(peer_id.as_str()) {
+            return Ok(());
+        }
+
+        if self.transport_reports_connected_peer(peer_id.as_str()).await {
             return Ok(());
         }
 

--- a/crates/p2p/src/sync/coordinator/access.rs
+++ b/crates/p2p/src/sync/coordinator/access.rs
@@ -135,7 +135,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             return Ok(());
         }
 
-        if self.transport_reports_connected_peer(peer_id.as_str()).await {
+        if self
+            .transport_reports_connected_peer(peer_id.as_str())
+            .await
+        {
             return Ok(());
         }
 

--- a/crates/p2p/src/sync/coordinator/access.rs
+++ b/crates/p2p/src/sync/coordinator/access.rs
@@ -47,6 +47,20 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             return Ok(());
         }
 
+        // Treat the transport's replicator state as the source of truth on a cache miss.
+        // Most runtime entrypoints now share one registry instance between transport and
+        // coordinator, but this fallback preserves authorization if a caller still wires
+        // separate state or if a stale in-memory view survives during bootstrap.
+        let peer_id = PeerId::new(peer_id_str.to_string());
+        if let Ok(Some(info)) = self.runtime.transport.get_replicator(&peer_id).await {
+            if info.collections.iter().any(|id| id == collection_id) {
+                self.access
+                    .replicators
+                    .add_replicator(collection_id, peer_id_str);
+                return Ok(());
+            }
+        }
+
         // Accept messages from any connected peer. Connected peers are already
         // authenticated via transport-level crypto. The replicator registry
         // controls what WE push; it should not gate what we ACCEPT from

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -204,6 +204,7 @@ struct NoopTransport {
     peer_id: PeerId,
     pubkey: Vec<u8>,
     replicators: Arc<RwLock<std::collections::HashMap<String, Vec<String>>>>,
+    connected_peers: Arc<RwLock<Vec<PeerId>>>,
 }
 
 impl NoopTransport {
@@ -212,7 +213,12 @@ impl NoopTransport {
             peer_id: PeerId::new("local-peer".to_string()),
             pubkey: vec![1, 2, 3],
             replicators: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            connected_peers: Arc::new(RwLock::new(Vec::new())),
         }
+    }
+
+    fn set_connected_peers(&self, peers: Vec<PeerId>) {
+        *self.connected_peers.write() = peers;
     }
 }
 
@@ -241,7 +247,7 @@ impl P2PTransport for NoopTransport {
     }
 
     async fn connected_peers(&self) -> crate::Result<Vec<PeerId>> {
-        Ok(Vec::new())
+        Ok(self.connected_peers.read().clone())
     }
 
     async fn listen_addresses(&self) -> crate::Result<Vec<PeerAddr>> {
@@ -713,6 +719,49 @@ async fn branchable_sync_controlled_mode_allows_connected_peer() {
 }
 
 #[tokio::test]
+async fn gossip_access_falls_back_to_transport_connected_peer_state() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+    let peer = random_peer_id();
+    transport.set_connected_peers(vec![peer.clone()]);
+
+    let (coordinator, _events) = create_test_coordinator_with_blockstore(
+        AccessMode::Controlled,
+        replicators,
+        peer_state.clone(),
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore,
+    );
+
+    assert!(
+        !peer_state.is_connected(peer.as_str()),
+        "test setup requires the coordinator peer_state cache to start cold"
+    );
+
+    let result = coordinator
+        .handle_transport_event(gossip_event(peer.clone(), "collection1"))
+        .await;
+
+    assert!(
+        !matches!(&result, Err(Error::AccessDenied { .. })),
+        "transport-connected peer should authorize gossip on peer_state cache miss, got {:?}",
+        result
+    );
+    assert!(
+        peer_state.is_connected(peer.as_str()),
+        "successful transport fallback should backfill coordinator peer_state"
+    );
+}
+
+#[tokio::test]
 async fn branchable_sync_open_mode_allows_any_peer() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
@@ -786,6 +835,35 @@ async fn pushlog_registered_replicator_is_marked_explicit_replicator() {
             assert!(
                 is_explicit_replicator,
                 "registered replicator should preserve explicit replicator trust"
+            );
+        }
+        other => panic!("expected BlockReceived, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn gossip_controlled_mode_allows_unknown_transport_authenticated_peer() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, mut events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+
+    let peer = random_peer_id();
+    coordinator
+        .handle_transport_event(gossip_event(peer.clone(), "collection1"))
+        .await
+        .unwrap();
+
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived {
+            sender_peer,
+            is_explicit_replicator,
+            ..
+        } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+            assert!(
+                !is_explicit_replicator,
+                "unknown gossip sender should be accepted without gaining explicit replicator trust"
             );
         }
         other => panic!("expected BlockReceived, got {:?}", other),
@@ -948,6 +1026,35 @@ async fn two_stream_connected_peer_is_not_marked_explicit_replicator() {
             assert!(
                 !is_explicit_replicator,
                 "connected peer must not get explicit replicator trust on two-stream ingress"
+            );
+        }
+        other => panic!("expected BlockReceived, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn two_stream_controlled_mode_allows_unknown_transport_authenticated_peer() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, mut events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+
+    let peer = random_peer_id();
+    coordinator
+        .handle_transport_event(two_stream_event(peer.clone(), "collection1", false))
+        .await
+        .unwrap();
+
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived {
+            sender_peer,
+            is_explicit_replicator,
+            ..
+        } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+            assert!(
+                !is_explicit_replicator,
+                "unknown two-stream sender should be accepted without explicit replicator trust"
             );
         }
         other => panic!("expected BlockReceived, got {:?}", other),

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -22,9 +22,9 @@ use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
 use crate::sync::head_provider::NoOpHeadProvider;
 use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager};
-use crate::sync::SyncShutdownHandle;
 use crate::sync::peer_state::PeerStateTracker;
 use crate::sync::rate_limiter::PeerRateLimiter;
+use crate::sync::SyncShutdownHandle;
 use crate::topics::DefraTopic;
 use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, TransportEvent};
 use crate::QueryId;
@@ -777,10 +777,6 @@ async fn gossip_access_falls_back_to_transport_connected_peer_state() {
         "transport-connected peer should authorize gossip on peer_state cache miss, got {:?}",
         result
     );
-    assert!(
-        peer_state.is_connected(peer.as_str()),
-        "successful transport fallback should backfill coordinator peer_state"
-    );
 }
 
 #[tokio::test]
@@ -957,20 +953,32 @@ async fn gossip_access_falls_back_to_transport_replicator_state() {
         "transport replicator state should authorize gossip on registry miss, got {:?}",
         result
     );
-    assert!(
-        replicators.is_replicator("collection1", peer.as_str()),
-        "successful fallback should backfill the coordinator registry"
-    );
 }
 
 #[tokio::test]
-async fn delete_replicator_revokes_access_for_gossip() {
+async fn delete_replicator_preserves_connected_peer_gossip_access() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
-    let (coordinator, _events) =
-        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
 
     let peer = random_peer_id();
+    transport.set_connected_peers(vec![peer.clone()]);
+
+    let (coordinator, _events) = create_test_coordinator_with_blockstore(
+        AccessMode::Controlled,
+        replicators,
+        peer_state,
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore,
+        Arc::new(PeerRateLimiter::default()),
+    );
+
     coordinator
         .create_replicator(&peer, vec!["collection1".to_string()], false)
         .await
@@ -982,20 +990,36 @@ async fn delete_replicator_revokes_access_for_gossip() {
         .await;
 
     assert!(
-        matches!(&result, Err(Error::AccessDenied { .. })),
-        "delete_replicator should revoke collection access, got {:?}",
+        !matches!(&result, Err(Error::AccessDenied { .. })),
+        "connected authenticated peers stay authorized for gossip after replicator deletion, got {:?}",
         result
     );
 }
 
 #[tokio::test]
-async fn create_replicator_update_replaces_old_collection_access() {
+async fn create_replicator_update_preserves_connected_peer_old_collection_access() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
-    let (coordinator, _events) =
-        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
 
     let peer = random_peer_id();
+    transport.set_connected_peers(vec![peer.clone()]);
+
+    let (coordinator, _events) = create_test_coordinator_with_blockstore(
+        AccessMode::Controlled,
+        replicators,
+        peer_state,
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore,
+        Arc::new(PeerRateLimiter::default()),
+    );
+
     coordinator
         .create_replicator(&peer, vec!["collection_a".to_string()], false)
         .await
@@ -1013,8 +1037,8 @@ async fn create_replicator_update_replaces_old_collection_access() {
         .await;
 
     assert!(
-        matches!(&old_collection_result, Err(Error::AccessDenied { .. })),
-        "updating a replicator must revoke stale collection access, got {:?}",
+        !matches!(&old_collection_result, Err(Error::AccessDenied { .. })),
+        "connected authenticated peers remain allowed on the old collection after replicator update, got {:?}",
         old_collection_result
     );
     assert!(

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -817,6 +817,52 @@ async fn create_replicator_updates_access_registry_for_gossip() {
 }
 
 #[tokio::test]
+async fn gossip_access_falls_back_to_transport_replicator_state() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+    let peer = random_peer_id();
+    transport
+        .create_replicator(&peer, vec!["collection1".to_string()])
+        .await
+        .unwrap();
+
+    let (coordinator, _events) = create_test_coordinator_with_blockstore(
+        AccessMode::Controlled,
+        replicators.clone(),
+        peer_state,
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore,
+    );
+
+    assert!(
+        !replicators.is_replicator("collection1", peer.as_str()),
+        "test setup requires the coordinator registry to start empty"
+    );
+
+    let result = coordinator
+        .handle_transport_event(gossip_event(peer.clone(), "collection1"))
+        .await;
+
+    assert!(
+        !matches!(&result, Err(Error::AccessDenied { .. })),
+        "transport replicator state should authorize gossip on registry miss, got {:?}",
+        result
+    );
+    assert!(
+        replicators.is_replicator("collection1", peer.as_str()),
+        "successful fallback should backfill the coordinator registry"
+    );
+}
+
+#[tokio::test]
 async fn delete_replicator_revokes_access_for_gossip() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -29,6 +29,7 @@ use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, TransportEvent
 use crate::QueryId;
 use crate::ReplicatorInfo;
 use async_trait::async_trait;
+use parking_lot::RwLock;
 
 use super::{
     SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState,
@@ -202,6 +203,7 @@ impl Blockstore for ConflictOnceBlockstore {
 struct NoopTransport {
     peer_id: PeerId,
     pubkey: Vec<u8>,
+    replicators: Arc<RwLock<std::collections::HashMap<String, Vec<String>>>>,
 }
 
 impl NoopTransport {
@@ -209,6 +211,7 @@ impl NoopTransport {
         Self {
             peer_id: PeerId::new("local-peer".to_string()),
             pubkey: vec![1, 2, 3],
+            replicators: Arc::new(RwLock::new(std::collections::HashMap::new())),
         }
     }
 }
@@ -388,30 +391,59 @@ impl P2PTransport for NoopTransport {
 
     async fn create_replicator(
         &self,
-        _peer_id: &PeerId,
-        _collections: Vec<String>,
+        peer_id: &PeerId,
+        collections: Vec<String>,
     ) -> crate::Result<()> {
+        self.replicators
+            .write()
+            .insert(peer_id.to_string(), collections);
         Ok(())
     }
 
-    async fn delete_replicator(&self, _peer_id: &PeerId) -> crate::Result<()> {
+    async fn delete_replicator(&self, peer_id: &PeerId) -> crate::Result<()> {
+        self.replicators.write().remove(peer_id.as_str());
         Ok(())
     }
 
     async fn list_replicators(&self) -> crate::Result<Vec<ReplicatorInfo>> {
-        Ok(Vec::new())
+        Ok(self
+            .replicators
+            .read()
+            .iter()
+            .map(|(peer_id, collections)| {
+                ReplicatorInfo::from_raw(peer_id.clone(), collections.clone(), Vec::new())
+            })
+            .collect())
     }
 
-    async fn get_replicator(&self, _peer_id: &PeerId) -> crate::Result<Option<ReplicatorInfo>> {
-        Ok(None)
+    async fn get_replicator(&self, peer_id: &PeerId) -> crate::Result<Option<ReplicatorInfo>> {
+        Ok(self
+            .replicators
+            .read()
+            .get(peer_id.as_str())
+            .cloned()
+            .map(|collections| {
+                ReplicatorInfo::from_raw(peer_id.to_string(), collections, Vec::new())
+            }))
     }
 
     async fn remove_replicator_collections(
         &self,
-        _peer_id: &PeerId,
-        _collections: Vec<String>,
+        peer_id: &PeerId,
+        collections: Vec<String>,
     ) -> crate::Result<bool> {
-        Ok(false)
+        let mut replicators = self.replicators.write();
+        let Some(existing) = replicators.get_mut(peer_id.as_str()) else {
+            return Ok(false);
+        };
+
+        existing.retain(|collection| !collections.contains(collection));
+        let fully_deleted = existing.is_empty();
+        if fully_deleted {
+            replicators.remove(peer_id.as_str());
+        }
+
+        Ok(fully_deleted)
     }
 
     async fn shutdown(&self) -> crate::Result<()> {
@@ -758,6 +790,55 @@ async fn pushlog_registered_replicator_is_marked_explicit_replicator() {
         }
         other => panic!("expected BlockReceived, got {:?}", other),
     }
+}
+
+#[tokio::test]
+async fn create_replicator_updates_access_registry_for_gossip() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+
+    let peer = random_peer_id();
+    coordinator
+        .create_replicator(&peer, vec!["collection1".to_string()], false)
+        .await
+        .unwrap();
+
+    let result = coordinator
+        .handle_transport_event(gossip_event(peer, "collection1"))
+        .await;
+
+    assert!(
+        !matches!(&result, Err(Error::AccessDenied { .. })),
+        "create_replicator should authorize collection access immediately, got {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn delete_replicator_revokes_access_for_gossip() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+
+    let peer = random_peer_id();
+    coordinator
+        .create_replicator(&peer, vec!["collection1".to_string()], false)
+        .await
+        .unwrap();
+    coordinator.delete_replicator(&peer).await.unwrap();
+
+    let result = coordinator
+        .handle_transport_event(gossip_event(peer, "collection1"))
+        .await;
+
+    assert!(
+        matches!(&result, Err(Error::AccessDenied { .. })),
+        "delete_replicator should revoke collection access, got {:?}",
+        result
+    );
 }
 
 #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -842,6 +842,42 @@ async fn delete_replicator_revokes_access_for_gossip() {
 }
 
 #[tokio::test]
+async fn create_replicator_update_replaces_old_collection_access() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+
+    let peer = random_peer_id();
+    coordinator
+        .create_replicator(&peer, vec!["collection_a".to_string()], false)
+        .await
+        .unwrap();
+    coordinator
+        .create_replicator(&peer, vec!["collection_b".to_string()], false)
+        .await
+        .unwrap();
+
+    let old_collection_result = coordinator
+        .handle_transport_event(gossip_event(peer.clone(), "collection_a"))
+        .await;
+    let new_collection_result = coordinator
+        .handle_transport_event(gossip_event(peer, "collection_b"))
+        .await;
+
+    assert!(
+        matches!(&old_collection_result, Err(Error::AccessDenied { .. })),
+        "updating a replicator must revoke stale collection access, got {:?}",
+        old_collection_result
+    );
+    assert!(
+        !matches!(&new_collection_result, Err(Error::AccessDenied { .. })),
+        "updating a replicator must authorize the new collection immediately, got {:?}",
+        new_collection_result
+    );
+}
+
+#[tokio::test]
 async fn two_stream_connected_peer_is_not_marked_explicit_replicator() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -22,6 +22,7 @@ use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
 use crate::sync::head_provider::NoOpHeadProvider;
 use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager};
+use crate::sync::SyncShutdownHandle;
 use crate::sync::peer_state::PeerStateTracker;
 use crate::sync::rate_limiter::PeerRateLimiter;
 use crate::topics::DefraTopic;
@@ -47,6 +48,23 @@ fn create_test_coordinator(
     SyncCoordinator<TestBlockstore, NoopTransport>,
     tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
 ) {
+    create_test_coordinator_with_rate_limiter(
+        access_mode,
+        replicators,
+        peer_state,
+        Arc::new(PeerRateLimiter::default()),
+    )
+}
+
+fn create_test_coordinator_with_rate_limiter(
+    access_mode: AccessMode,
+    replicators: Arc<ReplicatorRegistry>,
+    peer_state: Arc<PeerStateTracker>,
+    rate_limiter: Arc<PeerRateLimiter>,
+) -> (
+    SyncCoordinator<TestBlockstore, NoopTransport>,
+    tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
+) {
     let transport = NoopTransport::new();
     let local_peer_id = transport.local_peer_id().to_string();
     let broadcaster = Broadcaster::new(transport.clone());
@@ -60,6 +78,7 @@ fn create_test_coordinator(
         local_peer_id,
         broadcaster,
         blockstore,
+        rate_limiter,
     )
 }
 
@@ -71,6 +90,7 @@ fn create_test_coordinator_with_blockstore<B: Blockstore + 'static>(
     local_peer_id: String,
     broadcaster: Broadcaster<NoopTransport>,
     blockstore: Arc<B>,
+    rate_limiter: Arc<PeerRateLimiter>,
 ) -> (
     SyncCoordinator<B, NoopTransport>,
     tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
@@ -88,7 +108,8 @@ fn create_test_coordinator_with_blockstore<B: Blockstore + 'static>(
             push_semaphore: Arc::new(tokio::sync::Semaphore::new(
                 DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
             )),
-            rate_limiter: Arc::new(PeerRateLimiter::default()),
+            rate_limiter,
+            shutdown: SyncShutdownHandle::new(),
         },
         manager,
         access: SyncAccessState {
@@ -739,6 +760,7 @@ async fn gossip_access_falls_back_to_transport_connected_peer_state() {
         local_peer_id,
         broadcaster,
         blockstore,
+        Arc::new(PeerRateLimiter::default()),
     );
 
     assert!(
@@ -918,6 +940,7 @@ async fn gossip_access_falls_back_to_transport_replicator_state() {
         local_peer_id,
         broadcaster,
         blockstore,
+        Arc::new(PeerRateLimiter::default()),
     );
 
     assert!(
@@ -1093,6 +1116,54 @@ async fn two_stream_authenticated_explicit_replicator_is_marked_explicit_replica
 }
 
 #[tokio::test]
+async fn two_stream_bypasses_gossip_rate_limiter_for_authenticated_sync() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, mut events) = create_test_coordinator_with_rate_limiter(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        Arc::new(PeerRateLimiter::new(0, 0.0)),
+    );
+
+    let peer = random_peer_id();
+    coordinator
+        .handle_transport_event(two_stream_event(peer.clone(), "collection1", false))
+        .await
+        .unwrap();
+
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived { sender_peer, .. } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+        }
+        other => panic!("expected BlockReceived, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn gossip_remains_rate_limited_when_bucket_is_empty() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let (coordinator, _events) = create_test_coordinator_with_rate_limiter(
+        AccessMode::Open,
+        replicators,
+        peer_state,
+        Arc::new(PeerRateLimiter::new(0, 0.0)),
+    );
+
+    let peer = random_peer_id();
+    let result = coordinator
+        .handle_transport_event(gossip_event(peer, "collection1"))
+        .await;
+
+    assert!(
+        matches!(&result, Err(Error::AccessDenied { .. })),
+        "gossip should still be rate limited, got {:?}",
+        result
+    );
+}
+
+#[tokio::test]
 async fn pushlog_retries_transient_transaction_conflicts_without_sync_error() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
@@ -1109,6 +1180,7 @@ async fn pushlog_retries_transient_transaction_conflicts_without_sync_error() {
         local_peer_id,
         broadcaster,
         blockstore.clone(),
+        Arc::new(PeerRateLimiter::default()),
     );
 
     let peer = random_peer_id();
@@ -1143,6 +1215,7 @@ async fn gossip_retries_transient_transaction_conflicts_without_sync_error() {
         local_peer_id,
         broadcaster,
         blockstore.clone(),
+        Arc::new(PeerRateLimiter::default()),
     );
 
     let peer = random_peer_id();

--- a/crates/p2p/src/sync/coordinator/accessors.rs
+++ b/crates/p2p/src/sync/coordinator/accessors.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use acp::{DocumentACP, ReplicatedDocActorRelationships};
 use blockstore::Blockstore;
 
-use super::SyncCoordinator;
+use super::{SyncCoordinator, SyncShutdownHandle};
 use crate::bitswap::ReplicatorRegistry;
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::manager::SyncManager;
@@ -41,6 +41,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Get the transport reference.
     pub fn transport(&self) -> &T {
         &self.runtime.transport
+    }
+
+    /// Get the shutdown handle for coordinator-owned background tasks.
+    pub fn background_shutdown_handle(&self) -> SyncShutdownHandle {
+        self.runtime.shutdown.clone()
     }
 
     /// Get the sync manager reference.

--- a/crates/p2p/src/sync/coordinator/accessors.rs
+++ b/crates/p2p/src/sync/coordinator/accessors.rs
@@ -61,6 +61,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     pub(crate) async fn apply_replicated_actor_relationships(
         &self,
         doc_id: &str,
+        creator: Option<&str>,
         snapshot: Option<&ReplicatedDocActorRelationships>,
     ) -> crate::Result<()> {
         let Some(snapshot) = snapshot else {
@@ -69,6 +70,37 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let Some(acp) = self.document_acp.get() else {
             return Ok(());
         };
+
+        if let Some(creator) = creator {
+            let creator_did = identity::Did::new(creator).map_err(|error| {
+                crate::Error::Behaviour(format!(
+                    "failed to parse replicated ACP creator DID '{creator}': {error}"
+                ))
+            })?;
+            let is_registered = acp
+                .is_doc_registered(&snapshot.policy_id, &snapshot.resource_name, doc_id)
+                .await
+                .map_err(|error| {
+                    crate::Error::Behaviour(format!(
+                        "failed to check replicated ACP registration: {error}"
+                    ))
+                })?;
+
+            if !is_registered {
+                acp.register_doc_object(
+                    &creator_did,
+                    &snapshot.policy_id,
+                    &snapshot.resource_name,
+                    doc_id,
+                )
+                .await
+                .map_err(|error| {
+                    crate::Error::Behaviour(format!(
+                        "failed to register replicated ACP document owner: {error}"
+                    ))
+                })?;
+            }
+        }
 
         acp.replace_actor_relationships(
             &snapshot.policy_id,

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -17,6 +17,11 @@ use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     async fn list_replicators_for_push(&self) -> Option<Vec<crate::replicator::ReplicatorInfo>> {
+        if self.runtime.shutdown.is_shutting_down() {
+            tracing::debug!("Skipping replicator push because coordinator is shutting down");
+            return None;
+        }
+
         match self.runtime.transport.list_replicators().await {
             Ok(replicators) => Some(replicators),
             Err(e) => {
@@ -190,8 +195,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             let doc_id_owned = doc_id.to_string();
             let collection_id_owned = collection_id.to_string();
             let semaphore = self.runtime.push_semaphore.clone();
-            tokio::spawn(async move {
-                let _permit = semaphore.acquire().await;
+            self.spawn_background_task("push_dag_to_replicators", async move {
+                let Ok(_permit) = semaphore.acquire().await else {
+                    return;
+                };
                 let any_failed =
                     Self::send_ordered_pushlogs_via_transport(&transport, &peer_id, requests).await;
                 if any_failed {
@@ -264,8 +271,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             let collection_id_owned = collection_id.to_string();
             let semaphore = self.runtime.push_semaphore.clone();
             let peer_id_clone = peer_id.clone();
-            tokio::spawn(async move {
-                let _permit = semaphore.acquire().await;
+            self.spawn_background_task("push_to_replicators", async move {
+                let Ok(_permit) = semaphore.acquire().await else {
+                    return;
+                };
                 if let Err(e) = transport
                     .send_two_stream_request(&peer_id_clone, request)
                     .await

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -110,6 +110,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(max_dag_fetches)),
                     push_semaphore: Arc::new(tokio::sync::Semaphore::new(max_push_tasks)),
                     rate_limiter: Arc::new(PeerRateLimiter::new(rate_limit_burst, rate_limit_rate)),
+                    shutdown: super::SyncShutdownHandle::new(),
                 },
                 manager,
                 access: SyncAccessState {

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -17,6 +17,13 @@ use crate::transport::{P2PTransport, PeerId};
 
 const SELECTIVE_FETCH_BATCH_SIZE: usize = 2048;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FetchBatchOutcome {
+    Complete,
+    Partial,
+    NoProgress,
+}
+
 /// Fetch an entire DAG rooted at `root_cid`.
 ///
 /// Strategy: try CAR fetch first (one round-trip), then selective block fetch
@@ -39,8 +46,24 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
         "Starting DAG fetch (CAR-first, selective block fallback)"
     );
 
+    let car_missing_watch = match blockstore.get(&root_cid).await {
+        Ok(Some(root_data)) => find_all_missing_links(blockstore.as_ref(), &root_data)
+            .await
+            .ok()
+            .filter(|missing| !missing.is_empty()),
+        _ => None,
+    };
+
     // Try CAR fetch first
-    if try_car_fetch(&transport, &blockstore, &root_cid, &source_peer).await {
+    if try_car_fetch(
+        &transport,
+        &blockstore,
+        &root_cid,
+        &source_peer,
+        car_missing_watch.as_deref(),
+    )
+    .await
+    {
         if let Ok(Some(root_data)) = blockstore.get(&root_cid).await {
             let missing = find_all_missing_links(blockstore.as_ref(), &root_data)
                 .await
@@ -70,15 +93,17 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     }
 
     // Fallback fetch: fetch the root block first so we can enumerate missing links.
-    if !poll_fetch_blocks(
+    if !matches!(
+        poll_fetch_blocks(
         &root_cid,
         std::slice::from_ref(&root_cid),
         &transport,
         &blockstore,
         &source_peer,
     )
-    .await
-    {
+    .await,
+        FetchBatchOutcome::Complete
+    ) {
         warn!(root_cid = %root_cid, "Failed to fetch root block");
         return;
     }
@@ -112,18 +137,31 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
             "Fetching missing DAG blocks via selective block fetch"
         );
 
-        let mut any_batch_failed = false;
+        let mut made_progress = false;
         for batch in missing.chunks(SELECTIVE_FETCH_BATCH_SIZE) {
-            if !poll_fetch_blocks(&root_cid, batch, &transport, &blockstore, &source_peer).await {
-                any_batch_failed = true;
-                warn!(
-                    root_cid = %root_cid,
-                    requested_count = batch.len(),
-                    "Timeout fetching selective block batch (30s)"
-                );
+            match poll_fetch_blocks(&root_cid, batch, &transport, &blockstore, &source_peer).await
+            {
+                FetchBatchOutcome::Complete => {
+                    made_progress = true;
+                }
+                FetchBatchOutcome::Partial => {
+                    made_progress = true;
+                    debug!(
+                        root_cid = %root_cid,
+                        requested_count = batch.len(),
+                        "Selective block batch made partial progress; continuing DAG walk"
+                    );
+                }
+                FetchBatchOutcome::NoProgress => {
+                    warn!(
+                        root_cid = %root_cid,
+                        requested_count = batch.len(),
+                        "Timeout fetching selective block batch (30s)"
+                    );
+                }
             }
         }
-        if any_batch_failed {
+        if !made_progress {
             break;
         }
     }
@@ -167,6 +205,7 @@ async fn try_car_fetch<B: Blockstore, T: P2PTransport>(
     blockstore: &Arc<B>,
     root_cid: &Cid,
     source_peer: &PeerId,
+    watch_missing: Option<&[Cid]>,
 ) -> bool {
     if let Err(e) = transport.send_car_request(source_peer, *root_cid).await {
         debug!(root_cid = %root_cid, error = %e, "CAR request failed, will use selective block fetch");
@@ -176,7 +215,17 @@ async fn try_car_fetch<B: Blockstore, T: P2PTransport>(
     let timeout = Duration::from_secs(10);
     let start = std::time::Instant::now();
     while start.elapsed() < timeout {
-        if let Ok(true) = blockstore.has(root_cid).await {
+        if let Some(missing) = watch_missing {
+            let mut remaining = 0usize;
+            for cid in missing {
+                if !matches!(blockstore.has(cid).await, Ok(true)) {
+                    remaining += 1;
+                }
+            }
+            if remaining < missing.len() {
+                return true;
+            }
+        } else if let Ok(true) = blockstore.has(root_cid).await {
             return true;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -193,7 +242,7 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
     transport: &T,
     blockstore: &Arc<B>,
     source_peer: &PeerId,
-) -> bool {
+) -> FetchBatchOutcome {
     let mut missing = Vec::new();
     for cid in cids {
         if matches!(blockstore.has(cid).await, Ok(true)) {
@@ -203,7 +252,7 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
     }
 
     if missing.is_empty() {
-        return true;
+        return FetchBatchOutcome::Complete;
     }
 
     if let Err(e) = transport
@@ -216,7 +265,7 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
             error = %e,
             "selective block fetch failed"
         );
-        return false;
+        return FetchBatchOutcome::NoProgress;
     }
 
     let timeout = Duration::from_secs(30);
@@ -229,12 +278,15 @@ async fn poll_fetch_blocks<B: Blockstore, T: P2PTransport>(
             }
         }
         if remaining == 0 {
-            return true;
+            return FetchBatchOutcome::Complete;
+        }
+        if remaining < missing.len() {
+            return FetchBatchOutcome::Partial;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
-    false
+    FetchBatchOutcome::NoProgress
 }
 
 #[cfg(test)]
@@ -276,6 +328,7 @@ mod tests {
         blockstore: Arc<DefraBlockstore<MemoryStore>>,
         root_cid: Cid,
         root_data: Vec<u8>,
+        car_blocks: Arc<HashMap<Cid, Vec<u8>>>,
         selective_blocks: Arc<HashMap<Cid, Vec<u8>>>,
         car_requests: Arc<AtomicUsize>,
         sync_batches: Arc<Mutex<Vec<Vec<Cid>>>>,
@@ -286,6 +339,7 @@ mod tests {
             blockstore: Arc<DefraBlockstore<MemoryStore>>,
             root_cid: Cid,
             root_data: Vec<u8>,
+            car_blocks: HashMap<Cid, Vec<u8>>,
             selective_blocks: HashMap<Cid, Vec<u8>>,
         ) -> Self {
             Self {
@@ -294,6 +348,7 @@ mod tests {
                 blockstore,
                 root_cid,
                 root_data,
+                car_blocks: Arc::new(car_blocks),
                 selective_blocks: Arc::new(selective_blocks),
                 car_requests: Arc::new(AtomicUsize::new(0)),
                 sync_batches: Arc::new(Mutex::new(Vec::new())),
@@ -436,6 +491,12 @@ mod tests {
                 .put(&self.root_cid, &self.root_data)
                 .await
                 .map_err(|e| crate::error::Error::BlockstoreError(e.to_string()))?;
+            for (cid, data) in self.car_blocks.iter() {
+                self.blockstore
+                    .put(cid, data)
+                    .await
+                    .map_err(|e| crate::error::Error::BlockstoreError(e.to_string()))?;
+            }
             Ok(())
         }
 
@@ -546,8 +607,13 @@ mod tests {
             (child_one_cid, child_one_data.clone()),
             (child_two_cid, child_two_data.clone()),
         ]);
-        let transport =
-            TestTransport::new(blockstore.clone(), root_cid, root_data, selective_blocks);
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            selective_blocks,
+        );
 
         let (event_tx, mut event_rx) = mpsc::channel(1);
         let source_peer = PeerId::new("remote-peer".to_string());
@@ -578,5 +644,113 @@ mod tests {
 
         let requested: HashSet<_> = batches[0].iter().copied().collect();
         assert_eq!(requested, HashSet::from([child_one_cid, child_two_cid]));
+    }
+
+    #[tokio::test]
+    async fn poll_fetch_dag_does_not_treat_preexisting_root_as_car_success() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+        let child_data = encode_ipld(ipld!({ "value": 1 }));
+        let child_cid = make_cid(&child_data);
+        let root_data = encode_ipld(ipld!({ "child": child_cid }));
+        let root_cid = make_cid(&root_data);
+
+        blockstore.put(&root_cid, &root_data).await.unwrap();
+
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::from([(child_cid, child_data.clone())]),
+            HashMap::new(),
+        );
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let source_peer = PeerId::new("remote-peer".to_string());
+
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            "doc-id".to_string(),
+            "collection-id".to_string(),
+            "schema-version-id".to_string(),
+            source_peer,
+        )
+        .await;
+
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(SyncEvent::DagReady { root_cid: ready_cid, .. }) if ready_cid == root_cid
+        ));
+        assert!(matches!(blockstore.has(&child_cid).await, Ok(true)));
+        assert_eq!(transport.car_request_count(), 1);
+        assert!(transport.sync_batches().is_empty());
+    }
+
+    #[tokio::test]
+    async fn poll_fetch_dag_continues_after_partial_selective_batch_progress() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+        let leaf_one_data = encode_ipld(ipld!({ "value": 1 }));
+        let leaf_one_cid = make_cid(&leaf_one_data);
+        let leaf_two_data = encode_ipld(ipld!({ "value": 2 }));
+        let leaf_two_cid = make_cid(&leaf_two_data);
+
+        let mid_one_data = encode_ipld(ipld!({ "child": leaf_one_cid }));
+        let mid_one_cid = make_cid(&mid_one_data);
+        let mid_two_data = encode_ipld(ipld!({ "child": leaf_two_cid }));
+        let mid_two_cid = make_cid(&mid_two_data);
+
+        let root_data = encode_ipld(ipld!({ "children": [mid_one_cid, mid_two_cid] }));
+        let root_cid = make_cid(&root_data);
+
+        let selective_blocks = HashMap::from([
+            (mid_one_cid, mid_one_data.clone()),
+            (mid_two_cid, mid_two_data.clone()),
+            (leaf_one_cid, leaf_one_data.clone()),
+            (leaf_two_cid, leaf_two_data.clone()),
+        ]);
+        let transport = TestTransport::new(
+            blockstore.clone(),
+            root_cid,
+            root_data,
+            HashMap::new(),
+            selective_blocks,
+        );
+
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let source_peer = PeerId::new("remote-peer".to_string());
+
+        poll_fetch_dag(
+            transport.clone(),
+            blockstore.clone(),
+            event_tx,
+            root_cid,
+            "doc-id".to_string(),
+            "collection-id".to_string(),
+            "schema-version-id".to_string(),
+            source_peer,
+        )
+        .await;
+
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(SyncEvent::DagReady { root_cid: ready_cid, .. }) if ready_cid == root_cid
+        ));
+
+        let batches = transport.sync_batches();
+        assert_eq!(batches.len(), 2);
+        assert_eq!(
+            batches[0].iter().copied().collect::<HashSet<_>>(),
+            HashSet::from([mid_one_cid, mid_two_cid])
+        );
+        assert_eq!(
+            batches[1].iter().copied().collect::<HashSet<_>>(),
+            HashSet::from([leaf_one_cid, leaf_two_cid])
+        );
     }
 }

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -95,13 +95,13 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     // Fallback fetch: fetch the root block first so we can enumerate missing links.
     if !matches!(
         poll_fetch_blocks(
-        &root_cid,
-        std::slice::from_ref(&root_cid),
-        &transport,
-        &blockstore,
-        &source_peer,
-    )
-    .await,
+            &root_cid,
+            std::slice::from_ref(&root_cid),
+            &transport,
+            &blockstore,
+            &source_peer,
+        )
+        .await,
         FetchBatchOutcome::Complete
     ) {
         warn!(root_cid = %root_cid, "Failed to fetch root block");
@@ -139,8 +139,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
 
         let mut made_progress = false;
         for batch in missing.chunks(SELECTIVE_FETCH_BATCH_SIZE) {
-            match poll_fetch_blocks(&root_cid, batch, &transport, &blockstore, &source_peer).await
-            {
+            match poll_fetch_blocks(&root_cid, batch, &transport, &blockstore, &source_peer).await {
                 FetchBatchOutcome::Complete => {
                     made_progress = true;
                 }

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -196,8 +196,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 let semaphore = semaphore.clone();
                 let source_peer = peer_id.clone();
 
-                tokio::spawn(async move {
-                    let _permit = semaphore.acquire_owned().await;
+                self.spawn_background_task("branchable_sync_reply_fetch_dag", async move {
+                    let Ok(_permit) = semaphore.acquire_owned().await else {
+                        return;
+                    };
                     super::super::dag_fetcher::poll_fetch_dag(
                         transport,
                         blockstore,

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -17,7 +17,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         request: CarFetchRequest,
         token: Option<T::ResponseToken>,
     ) -> Result<()> {
-        self.check_peer_is_replicator(&peer_id)?;
+        self.check_peer_is_replicator(&peer_id).await?;
 
         tracing::debug!(
             root_cid = %request.root_cid,

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -50,7 +50,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         request: crate::message::DocSyncRequest,
         token: Option<T::ResponseToken>,
     ) -> Result<()> {
-        self.check_peer_is_replicator(&peer_id)?;
+        self.check_peer_is_replicator(&peer_id).await?;
 
         if request.doc_ids.len() > MAX_DOC_IDS {
             tracing::warn!(

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -272,8 +272,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 let semaphore = semaphore.clone();
                 let source_peer = peer_id.clone();
 
-                tokio::spawn(async move {
-                    let _permit = semaphore.acquire_owned().await;
+                self.spawn_background_task("doc_sync_reply_fetch_dag", async move {
+                    let Ok(_permit) = semaphore.acquire_owned().await else {
+                        return;
+                    };
                     super::super::dag_fetcher::poll_fetch_dag(
                         transport,
                         blockstore,

--- a/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
@@ -23,20 +23,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             "Received GossipSub message"
         );
 
-        // Access control check
-        if let Err(e) = self
-            .check_access_str(propagation_source.as_str(), &message.collection_id)
-            .await
-        {
-            tracing::warn!(
-                peer_id = %propagation_source,
-                collection_id = %message.collection_id,
-                doc_id = %message.doc_id,
-                "Dropping GossipSub message from unauthorized peer"
-            );
-            return Err(e);
-        }
-
         // Parse CID
         match Cid::try_from(message.cid.as_ref()) {
             Ok(cid) => {

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -12,11 +12,8 @@ use std::time::Duration;
 
 use super::SyncCoordinator;
 use crate::error::{Error, Result};
-use crate::message::{BranchableSyncReply, DocSyncReply, PushLogReply};
-use crate::signing::sign_with_transport;
 use crate::transport::{P2PTransport, PeerId, TransportEvent};
 
-const RATE_LIMITED_MSG: &str = "rate limited: too many requests, retry later";
 const MAX_RETRIABLE_EVENT_ATTEMPTS: usize = 4;
 
 fn retriable_event_delay(attempt: usize) -> Duration {
@@ -78,131 +75,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .peer_unsubscribed(peer_id.as_str(), &topic);
     }
 
-    fn rate_limited_error(peer_id: &PeerId) -> Error {
-        Error::AccessDenied {
-            peer_id: peer_id.to_string(),
-            collection_id: "rate-limited".into(),
-        }
-    }
-
-    async fn reject_rate_limited_pushlog(
-        &self,
-        peer_id: &PeerId,
-        message_id: &str,
-        token: T::ResponseToken,
-    ) -> Error {
-        tracing::debug!(
-            peer_id = %peer_id,
-            "Rate limit exceeded for PushLogRequest, sending backpressure reply"
-        );
-        let reply = PushLogReply::error(message_id, RATE_LIMITED_MSG);
-        let _ = self
-            .runtime
-            .transport
-            .send_pushlog_response(token, reply)
-            .await;
-        Self::rate_limited_error(peer_id)
-    }
-
-    async fn reject_rate_limited_two_stream(
-        &self,
-        peer_id: &PeerId,
-        message_id: &str,
-        token: Option<T::ResponseToken>,
-    ) -> Error {
-        tracing::debug!(
-            peer_id = %peer_id,
-            "Rate limit exceeded for TwoStreamRequest, sending backpressure reply"
-        );
-        let mut reply = PushLogReply::error(message_id, RATE_LIMITED_MSG);
-        let _ = sign_with_transport(&self.runtime.transport, &mut reply);
-        self.send_two_stream_reply(peer_id, reply, token).await;
-        Self::rate_limited_error(peer_id)
-    }
-
-    async fn reject_rate_limited_doc_sync(
-        &self,
-        peer_id: &PeerId,
-        message_id: &str,
-        token: Option<T::ResponseToken>,
-    ) -> Error {
-        tracing::debug!(
-            peer_id = %peer_id,
-            "Rate limit exceeded for DocSyncRequest, sending backpressure reply"
-        );
-        let reply = DocSyncReply::error(message_id, RATE_LIMITED_MSG);
-        if let Some(token) = token {
-            let _ = self
-                .runtime
-                .transport
-                .send_doc_sync_response_token(token, reply)
-                .await;
-        } else {
-            let _ = self
-                .runtime
-                .transport
-                .send_doc_sync_response(peer_id, reply)
-                .await;
-        }
-        Self::rate_limited_error(peer_id)
-    }
-
-    async fn reject_rate_limited_branchable_sync(
-        &self,
-        peer_id: &PeerId,
-        message_id: &str,
-        collection_id: &str,
-        token: Option<T::ResponseToken>,
-    ) -> Error {
-        tracing::debug!(
-            peer_id = %peer_id,
-            "Rate limit exceeded for BranchableSyncRequest, sending backpressure reply"
-        );
-        let reply = BranchableSyncReply::error(message_id, collection_id, RATE_LIMITED_MSG);
-        if let Some(token) = token {
-            let _ = self
-                .runtime
-                .transport
-                .send_branchable_sync_response_token(token, reply)
-                .await;
-        } else {
-            let _ = self
-                .runtime
-                .transport
-                .send_branchable_sync_response(peer_id, reply)
-                .await;
-        }
-        Self::rate_limited_error(peer_id)
-    }
-
-    async fn reject_rate_limited_car_fetch(
-        &self,
-        peer_id: &PeerId,
-        token: Option<T::ResponseToken>,
-    ) -> Error {
-        tracing::debug!(
-            peer_id = %peer_id,
-            "Rate limit exceeded for CarFetchRequest, sending empty backpressure reply"
-        );
-        // CAR has no error reply type — send empty response so the
-        // sender sees an explicit (parseable) rejection rather than
-        // a hung stream / timeout.
-        if let Some(token) = token {
-            let _ = self
-                .runtime
-                .transport
-                .send_car_response_token(token, Vec::new())
-                .await;
-        } else {
-            let _ = self
-                .runtime
-                .transport
-                .send_car_response(peer_id, Vec::new())
-                .await;
-        }
-        Self::rate_limited_error(peer_id)
-    }
-
     /// Handle an event from the transport layer.
     ///
     /// This should be called from the event loop that processes TransportEvents.
@@ -210,6 +82,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         event: TransportEvent<T::ResponseToken>,
     ) -> Result<()> {
+        if self.runtime.shutdown.is_shutting_down() {
+            tracing::trace!("Ignoring transport event because coordinator is shutting down");
+            return Ok(());
+        }
+
         match event {
             TransportEvent::PeerConnected(peer_id) => {
                 self.handle_peer_connected(peer_id);
@@ -234,7 +111,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         peer_id = %propagation_source,
                         "Rate limit exceeded for GossipMessage, dropping"
                     );
-                    return Err(Self::rate_limited_error(&propagation_source));
+                    return Err(Error::AccessDenied {
+                        peer_id: propagation_source.to_string(),
+                        collection_id: "rate-limited".into(),
+                    });
                 }
                 self.handle_gossip_message(propagation_source, message, topic)
                     .await?;
@@ -244,11 +124,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if !self.runtime.rate_limiter.check(&peer_id) {
-                    return Err(self
-                        .reject_rate_limited_pushlog(&peer_id, &request.metadata.message_id, token)
-                        .await);
-                }
                 self.handle_pushlog_request(peer_id, request, token).await?;
             }
             TransportEvent::TwoStreamRequest {
@@ -258,15 +133,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 is_explicit_replicator,
                 explicit_replay_authorization,
             } => {
-                if !self.runtime.rate_limiter.check(&peer_id) {
-                    return Err(self
-                        .reject_rate_limited_two_stream(
-                            &peer_id,
-                            &request.metadata.message_id,
-                            token,
-                        )
-                        .await);
-                }
                 self.handle_two_stream_request(
                     peer_id,
                     request,
@@ -299,11 +165,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if !self.runtime.rate_limiter.check(&peer_id) {
-                    return Err(self
-                        .reject_rate_limited_doc_sync(&peer_id, &request.metadata.message_id, token)
-                        .await);
-                }
                 self.handle_doc_sync_request(peer_id, request, token)
                     .await?;
             }
@@ -315,16 +176,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if !self.runtime.rate_limiter.check(&peer_id) {
-                    return Err(self
-                        .reject_rate_limited_branchable_sync(
-                            &peer_id,
-                            &request.metadata.message_id,
-                            &request.collection_id,
-                            token,
-                        )
-                        .await);
-                }
                 self.handle_branchable_sync_request(peer_id, request, token)
                     .await?;
             }
@@ -336,9 +187,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 request,
                 token,
             } => {
-                if !self.runtime.rate_limiter.check(&peer_id) {
-                    return Err(self.reject_rate_limited_car_fetch(&peer_id, token).await);
-                }
                 self.handle_car_fetch_request(peer_id, request, token)
                     .await?;
             }

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -24,39 +24,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             "Received PushLog request"
         );
 
-        // Access control check
-        if let Err(e) = self
-            .check_access_str(peer_id.as_str(), &request.collection_id)
-            .await
-        {
-            tracing::warn!(
-                peer_id = %peer_id,
-                collection_id = %request.collection_id,
-                doc_id = %request.doc_id,
-                "Rejecting PushLog request from unauthorized peer"
-            );
-            let reply = PushLogReply::error(
-                &request.metadata.message_id,
-                &format!(
-                    "access denied: not authorized for collection {}",
-                    request.collection_id
-                ),
-            );
-            if let Err(send_err) = self
-                .runtime
-                .transport
-                .send_pushlog_response(token, reply)
-                .await
-            {
-                tracing::warn!(
-                    peer_id = %peer_id,
-                    error = %send_err,
-                    "Failed to send access denied response"
-                );
-            }
-            return Err(e);
-        }
-
         let is_explicit_replicator =
             self.is_registered_replicator(peer_id.as_str(), &request.collection_id);
 
@@ -158,31 +125,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             message_id = %request.metadata.message_id,
             "Received PushLog request via two-stream protocol (Go compatibility)"
         );
-
-        // Access control check
-        if let Err(e) = self
-            .check_access_str(peer_id.as_str(), &request.collection_id)
-            .await
-        {
-            tracing::warn!(
-                peer_id = %peer_id,
-                collection_id = %request.collection_id,
-                doc_id = %request.doc_id,
-                "Rejecting two-stream request from unauthorized peer"
-            );
-            let mut reply = PushLogReply::error(
-                &request.metadata.message_id,
-                &format!(
-                    "access denied: not authorized for collection {}",
-                    request.collection_id
-                ),
-            );
-            if let Err(sign_err) = sign_with_transport(&self.runtime.transport, &mut reply) {
-                tracing::error!(error = %sign_err, "Failed to sign access denied response");
-            }
-            self.send_two_stream_reply(&peer_id, reply, token).await;
-            return Err(e);
-        }
 
         // Parse CID
         let cid = match Cid::try_from(request.cid.as_ref()) {

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -187,30 +187,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         &self,
         peer_id: &PeerId,
         reply: PushLogReply,
-        token: Option<T::ResponseToken>,
+        _token: Option<T::ResponseToken>,
     ) {
-        if let Some(token) = token {
-            if let Err(e) = self
-                .runtime
-                .transport
-                .send_pushlog_response(token, reply)
-                .await
-            {
-                if e.is_connection_like() {
-                    tracing::debug!(
-                        peer_id = %peer_id,
-                        error = %e,
-                        "Peer disconnected before the two-stream response could be sent via token"
-                    );
-                } else {
-                    tracing::warn!(
-                        peer_id = %peer_id,
-                        error = %e,
-                        "Failed to send two-stream response via token"
-                    );
-                }
-            }
-        } else if let Err(e) = self
+        if let Err(e) = self
             .runtime
             .transport
             .send_two_stream_response(peer_id, reply)

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -140,13 +140,12 @@ impl SyncShutdownHandle {
 
         let started = tokio::time::Instant::now();
 
-        for idx in 0..handles.len() {
+        for handle in &mut handles {
             let elapsed = started.elapsed();
             let Some(remaining) = timeout.checked_sub(elapsed) else {
                 break;
             };
 
-            let handle = &mut handles[idx];
             match tokio::time::timeout(remaining, handle).await {
                 Ok(Ok(())) | Ok(Err(_)) => {}
                 Err(_) => {

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -18,29 +18,23 @@
 //! T: P2PTransport (network)
 //! ```
 //!
-//! # Security Model: Two-Level Access Control
+//! # Security Model: Go-Compatible Ingress + Merge-Time ACP
 //!
-//! The P2P sync layer implements **collection-level** access control only.
-//! **Document-level** ACP is the responsibility of the database merge layer.
+//! Rust follows the Go DefraDB mental model:
 //!
-//! ## Collection-Level (P2P Layer)
+//! - **Replicator registration** expresses outbound replay intent and explicit
+//!   replay trust. It controls what we push and which peers are treated as
+//!   explicit replicators.
+//! - **Inbound PushLog/Gossip acceptance** is broader. Transport-authenticated
+//!   peers may deliver updates even if the receiver has not registered them as
+//!   local replicators for that collection.
+//! - **Document-level ACP** remains the authoritative policy boundary for whether
+//!   replicated document content is actually mergeable/readable locally.
 //!
-//! - Enforced via `check_access()` before processing any sync message
-//! - A peer must be registered as a replicator for a collection
-//! - Unauthorized peers cannot push documents to collections they don't replicate
-//!
-//! ## Document-Level (Database Merge Layer)
-//!
-//! - The P2P layer provides creator/doc_id/collection_id in `SyncEvent::BlockReceived`
-//! - The database merge handler should:
-//!   1. Identify the creator's DID (from the signed block or peer mapping)
-//!   2. Check if the creator has UPDATE permission on the document
-//!   3. If permission denied, log and skip the merge (don't crash)
-//!
-//! This two-level model allows:
-//! - Fast collection-level filtering at the network layer
-//! - Fine-grained document-level checks at the merge layer
-//! - CRDT convergence (eventually consistent merge, possibly with rejected updates)
+//! Collection-scoped access checks are still used for protocols that ask the
+//! receiver to actively serve or enumerate state (for example DocSync,
+//! BranchableSync, CAR fetch). They are intentionally not the primary ingress
+//! gate for passive PushLog/Gossip delivery, matching Go.
 
 mod access;
 mod accessors;

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -287,8 +287,8 @@ mod access_tests;
 #[cfg(test)]
 mod shutdown_tests {
     use super::SyncShutdownHandle;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
     use std::time::Duration;
 
     #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -138,6 +138,10 @@ impl SyncShutdownHandle {
             std::mem::take(&mut *tasks)
         };
 
+        for handle in &handles {
+            handle.abort();
+        }
+
         let started = tokio::time::Instant::now();
 
         for handle in &mut handles {
@@ -151,7 +155,7 @@ impl SyncShutdownHandle {
                 Err(_) => {
                     tracing::debug!(
                         timeout_ms = timeout.as_millis() as u64,
-                        "Coordinator background task exceeded graceful shutdown window; aborting"
+                        "Coordinator background task exceeded shutdown drain window after abort"
                     );
                     break;
                 }

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -88,7 +88,7 @@ struct SyncShutdownState {
     background_tasks: Mutex<Vec<JoinHandle<()>>>,
 }
 
-const BACKGROUND_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const BACKGROUND_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Shared shutdown state for coordinator-owned background replication work.
 #[derive(Clone)]
@@ -138,10 +138,6 @@ impl SyncShutdownHandle {
             std::mem::take(&mut *tasks)
         };
 
-        for handle in &handles {
-            handle.abort();
-        }
-
         let started = tokio::time::Instant::now();
 
         for handle in &mut handles {
@@ -155,7 +151,7 @@ impl SyncShutdownHandle {
                 Err(_) => {
                     tracing::debug!(
                         timeout_ms = timeout.as_millis() as u64,
-                        "Coordinator background task exceeded shutdown drain window after abort"
+                        "Coordinator background task exceeded shutdown drain window; aborting remaining tasks"
                     );
                     break;
                 }

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -48,10 +48,15 @@ mod subscriptions;
 
 pub use result_types::{CreateReplicatorResult, LoadReplicatorsResult};
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use acp::DocumentACP;
 use blockstore::Blockstore;
+use cid::Cid;
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::transport::P2PTransport;
@@ -78,6 +83,90 @@ pub struct PushFailure {
     pub collection_id: String,
 }
 
+struct SyncShutdownState {
+    is_shutting_down: AtomicBool,
+    background_tasks: Mutex<Vec<JoinHandle<()>>>,
+}
+
+const BACKGROUND_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Shared shutdown state for coordinator-owned background replication work.
+#[derive(Clone)]
+pub struct SyncShutdownHandle {
+    inner: Arc<SyncShutdownState>,
+}
+
+impl SyncShutdownHandle {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(SyncShutdownState {
+                is_shutting_down: AtomicBool::new(false),
+                background_tasks: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+
+    fn begin_shutdown(&self) -> bool {
+        !self.inner.is_shutting_down.swap(true, Ordering::AcqRel)
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        self.inner.is_shutting_down.load(Ordering::Acquire)
+    }
+
+    pub async fn shutdown(&self) {
+        if !self.begin_shutdown() {
+            return;
+        }
+
+        self.drain_background_tasks(BACKGROUND_TASK_SHUTDOWN_TIMEOUT)
+            .await;
+    }
+
+    fn register_task(&self, handle: JoinHandle<()>) {
+        let mut tasks = self.inner.background_tasks.lock();
+        if self.is_shutting_down() {
+            handle.abort();
+        } else {
+            tasks.push(handle);
+        }
+    }
+
+    async fn drain_background_tasks(&self, timeout: Duration) {
+        let mut handles = {
+            let mut tasks = self.inner.background_tasks.lock();
+            std::mem::take(&mut *tasks)
+        };
+
+        let started = tokio::time::Instant::now();
+
+        for idx in 0..handles.len() {
+            let elapsed = started.elapsed();
+            let Some(remaining) = timeout.checked_sub(elapsed) else {
+                break;
+            };
+
+            let handle = &mut handles[idx];
+            match tokio::time::timeout(remaining, handle).await {
+                Ok(Ok(())) | Ok(Err(_)) => {}
+                Err(_) => {
+                    tracing::debug!(
+                        timeout_ms = timeout.as_millis() as u64,
+                        "Coordinator background task exceeded graceful shutdown window; aborting"
+                    );
+                    break;
+                }
+            }
+        }
+
+        for handle in handles {
+            if !handle.is_finished() {
+                handle.abort();
+            }
+        }
+    }
+}
+
 /// Runtime services and async limits used by coordinator handlers.
 pub(super) struct SyncRuntime<T: P2PTransport> {
     /// Transport for sending responses and managing connections.
@@ -97,6 +186,9 @@ pub(super) struct SyncRuntime<T: P2PTransport> {
 
     /// Per-peer rate limiter applied at event dispatch to throttle abusive peers.
     pub(super) rate_limiter: Arc<PeerRateLimiter>,
+
+    /// Shutdown state for coordinator-owned background tasks.
+    pub(super) shutdown: SyncShutdownHandle,
 }
 
 /// Access control and peer identity state for the coordinator.
@@ -147,6 +239,40 @@ pub struct SyncCoordinator<B: Blockstore, T: P2PTransport> {
     pub(super) document_acp: std::sync::OnceLock<Arc<dyn DocumentACP>>,
 }
 
+impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    pub(crate) fn clear_pending_dag(&self, root_cid: &Cid) -> bool {
+        self.manager.clear_pending_dag(root_cid)
+    }
+
+    pub fn shutdown_handle(&self) -> SyncShutdownHandle {
+        self.runtime.shutdown.clone()
+    }
+
+    pub async fn shutdown(&self) {
+        self.runtime.dag_fetch_semaphore.close();
+        self.runtime.push_semaphore.close();
+        self.runtime.shutdown.shutdown().await;
+    }
+
+    pub(crate) fn spawn_background_task<F>(&self, task_name: &'static str, future: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        if self.runtime.shutdown.is_shutting_down() {
+            tracing::debug!(task = task_name, "Skipping background task during shutdown");
+            return;
+        }
+
+        let handle = tokio::spawn(future);
+        self.runtime.shutdown.register_task(handle);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_dag_count(&self) -> usize {
+        self.manager.pending_dag_count()
+    }
+}
+
 /// Type alias for SyncCoordinator using the libp2p transport.
 pub type Libp2pSyncCoordinator<B> =
     SyncCoordinator<B, crate::host::libp2p_transport::Libp2pTransport>;
@@ -157,3 +283,51 @@ pub type IrohSyncCoordinator<B> = SyncCoordinator<B, crate::iroh::IrohTransport>
 
 #[cfg(test)]
 mod access_tests;
+
+#[cfg(test)]
+mod shutdown_tests {
+    use super::SyncShutdownHandle;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn shutdown_waits_for_in_flight_background_task_completion() {
+        let shutdown = SyncShutdownHandle::new();
+        let completed = Arc::new(AtomicBool::new(false));
+        let completed_for_task = Arc::clone(&completed);
+
+        shutdown.register_task(tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            completed_for_task.store(true, Ordering::SeqCst);
+        }));
+
+        shutdown.shutdown().await;
+
+        assert!(
+            completed.load(Ordering::SeqCst),
+            "shutdown should allow in-flight background tasks to finish"
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_uses_single_global_budget_for_background_tasks() {
+        let shutdown = SyncShutdownHandle::new();
+
+        for _ in 0..3 {
+            shutdown.register_task(tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }));
+        }
+
+        let started = tokio::time::Instant::now();
+        shutdown.shutdown().await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(7),
+            "shutdown should use one shared deadline, got {:?}",
+            elapsed
+        );
+    }
+}

--- a/crates/p2p/src/sync/coordinator/replicators.rs
+++ b/crates/p2p/src/sync/coordinator/replicators.rs
@@ -232,6 +232,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     }
 
     fn register_replicator_access(&self, peer_id: &PeerId, collections: &[String]) {
+        self.access.replicators.remove_peer(peer_id.as_str());
         for collection_id in collections {
             self.access
                 .replicators

--- a/crates/p2p/src/sync/coordinator/replicators.rs
+++ b/crates/p2p/src/sync/coordinator/replicators.rs
@@ -21,6 +21,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .create_replicator(peer_id, collections.clone())
             .await?;
 
+        self.register_replicator_access(peer_id, &collections);
+
         let mut result = CreateReplicatorResult {
             subscribed: Vec::new(),
             failed_subscriptions: Vec::new(),
@@ -72,6 +74,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         };
 
         self.runtime.transport.delete_replicator(peer_id).await?;
+        self.access.replicators.remove_peer(peer_id.as_str());
         tracing::info!(peer_id = %peer_id, "Deleted replicator");
 
         self.unsubscribe_orphaned_collections(&removed_collections)
@@ -93,6 +96,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             };
 
             self.runtime.transport.delete_replicator(peer_id).await?;
+            self.access.replicators.remove_peer(peer_id.as_str());
             tracing::info!(peer_id = %peer_id, "Deleted replicator (empty collections = delete all)");
 
             self.unsubscribe_orphaned_collections(&removed_collections)
@@ -106,6 +110,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .transport
             .remove_replicator_collections(peer_id, collections.clone())
             .await?;
+
+        for collection_id in &collections {
+            self.access
+                .replicators
+                .remove_replicator(collection_id, peer_id.as_str());
+        }
 
         if fully_deleted {
             tracing::info!(
@@ -219,5 +229,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         result
+    }
+
+    fn register_replicator_access(&self, peer_id: &PeerId, collections: &[String]) {
+        for collection_id in collections {
+            self.access
+                .replicators
+                .add_replicator(collection_id, peer_id.as_str());
+        }
     }
 }

--- a/crates/p2p/src/sync/coordinator/replicators.rs
+++ b/crates/p2p/src/sync/coordinator/replicators.rs
@@ -232,11 +232,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     }
 
     fn register_replicator_access(&self, peer_id: &PeerId, collections: &[String]) {
-        self.access.replicators.remove_peer(peer_id.as_str());
-        for collection_id in collections {
-            self.access
-                .replicators
-                .add_replicator(collection_id, peer_id.as_str());
-        }
+        self.access
+            .replicators
+            .set_peer_collections(peer_id.as_str(), collections);
     }
 }

--- a/crates/p2p/src/sync/manager/events.rs
+++ b/crates/p2p/src/sync/manager/events.rs
@@ -46,11 +46,11 @@ pub enum SyncEvent {
     /// Failed to process a sync request.
     SyncError { cid: Cid, error: String },
 
-    /// DAG has missing blocks that need to be fetched via Bitswap.
+    /// DAG has missing blocks that need to be fetched.
     ///
     /// The coordinator should:
-    /// 1. Call host.bitswap_sync() with the missing CIDs
-    /// 2. Register the QueryId with manager.register_query()
+    /// 1. Prefer a source-peer DAG fetch when the announcing peer is known
+    /// 2. Fall back to transport block sync when only provider hints are available
     DagNeedsFetch {
         /// Root CID of the DAG being synced
         root_cid: Cid,

--- a/crates/p2p/src/sync/manager/events.rs
+++ b/crates/p2p/src/sync/manager/events.rs
@@ -40,6 +40,7 @@ pub enum SyncEvent {
         cid: Cid,
         doc_id: String,
         collection_id: String,
+        creator: String,
         acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
     },
 

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -118,7 +118,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// Expired entries (older than `PENDING_DAG_TTL`) are removed before checking
     /// the capacity. If the map is still at `MAX_PENDING_DAGS` after eviction the
     /// new entry is silently dropped and `false` is returned so callers can log.
-    fn insert_pending_dag(&self, root_cid: Cid, dag: PendingDag) -> bool {
+    pub(super) fn insert_pending_dag(&self, root_cid: Cid, dag: PendingDag) -> bool {
         let mut pending = self.pending_dags.write();
         let now = Instant::now();
 
@@ -131,6 +131,11 @@ impl<B: Blockstore + 'static> SyncManager<B> {
 
         pending.insert(root_cid, dag);
         true
+    }
+
+    /// Remove a pending DAG entry once another fetch path has completed it.
+    pub fn clear_pending_dag(&self, root_cid: &Cid) -> bool {
+        self.pending_dags.write().remove(root_cid).is_some()
     }
 
     /// Register a pending DAG for DocSync.

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -149,6 +149,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                                 cid,
                                 doc_id: msg.doc_id.clone(),
                                 collection_id: msg.collection_id.clone(),
+                                creator: msg.creator.clone(),
                                 acp_actor_relationships: msg.acp_actor_relationships.clone(),
                             })
                             .await
@@ -210,6 +211,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                         cid: *cid,
                         doc_id: msg.doc_id.clone(),
                         collection_id: msg.collection_id.clone(),
+                        creator: msg.creator.clone(),
                         acp_actor_relationships: msg.acp_actor_relationships.clone(),
                     })
                     .await

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -11,7 +11,7 @@ use crate::error::{Error, Result};
 use crate::message::PushLogBroadcast;
 use crate::sync::manager::events::SyncEvent;
 use crate::sync::manager::links::find_all_missing_links;
-use crate::sync::manager::pending::{PendingDag, MAX_PENDING_DAGS, PENDING_DAG_TTL};
+use crate::sync::manager::pending::{PendingDag, MAX_PENDING_DAGS};
 use crate::ExplicitReplayAuthorization;
 
 use super::SyncManager;
@@ -360,34 +360,23 @@ impl<B: Blockstore + 'static> SyncManager<B> {
 
             // Track this DAG as pending (enforces TTL eviction and capacity limit).
             {
-                let inserted = {
-                    let mut pending = self.pending_dags.write();
-                    let now = Instant::now();
-                    pending.retain(|_, v| now.duration_since(v.inserted_at) < PENDING_DAG_TTL);
-                    if pending.len() < MAX_PENDING_DAGS {
-                        pending.insert(
-                            *cid,
-                            PendingDag {
-                                doc_id: msg.doc_id.clone(),
-                                collection_id: msg.collection_id.clone(),
-                                creator: msg.creator.clone(),
-                                missing: missing.iter().cloned().collect(),
-                                source_peer: sender_peer.map(str::to_owned),
-                                is_explicit_replicator,
-                                explicit_replay_authorization: explicit_replay_authorization
-                                    .clone(),
-                                acp_actor_relationships: msg.acp_actor_relationships.clone(),
-                                inserted_at: now,
-                                attempts: 0,
-                                fetch_failures: 0,
-                                last_fetch_error: None,
-                            },
-                        );
-                        true
-                    } else {
-                        false
-                    }
-                };
+                let inserted = self.insert_pending_dag(
+                    *cid,
+                    PendingDag {
+                        doc_id: msg.doc_id.clone(),
+                        collection_id: msg.collection_id.clone(),
+                        creator: msg.creator.clone(),
+                        missing: missing.iter().cloned().collect(),
+                        source_peer: sender_peer.map(str::to_owned),
+                        is_explicit_replicator,
+                        explicit_replay_authorization: explicit_replay_authorization.clone(),
+                        acp_actor_relationships: msg.acp_actor_relationships.clone(),
+                        inserted_at: Instant::now(),
+                        attempts: 0,
+                        fetch_failures: 0,
+                        last_fetch_error: None,
+                    },
+                );
                 if !inserted {
                     tracing::warn!(
                         cid = %cid,

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -26,7 +26,7 @@ pub use collection_store::{NoOpCollectionStorage, P2PCollectionStorage, P2PColle
 pub use coordinator::IrohSyncCoordinator;
 pub use coordinator::{
     CreateReplicatorResult, Libp2pSyncCoordinator, LoadReplicatorsResult, PushFailure,
-    SyncCoordinator,
+    SyncCoordinator, SyncShutdownHandle,
 };
 pub use dag_sync::{DagSync, DagSyncConfig, DagSyncState, NeedsFetchData, SyncPlan};
 pub use head_provider::{DocumentHeadProvider, NoOpHeadProvider};

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -12,9 +12,7 @@ use crate::sync::manager::SyncEvent;
 use crate::sync::merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
 use crate::transport::P2PTransport;
 
-/// Handle a DagNeedsFetch event by initiating a Bitswap sync.
-pub(super) async fn handle_dag_needs_fetch<B, T>(
-    coordinator: &SyncCoordinator<B, T>,
+pub(super) struct DagFetchRequest {
     root_cid: Cid,
     missing: Vec<Cid>,
     providers: Vec<String>,
@@ -22,11 +20,27 @@ pub(super) async fn handle_dag_needs_fetch<B, T>(
     collection_id: String,
     creator: String,
     sender_peer: Option<String>,
+}
+
+/// Handle a DagNeedsFetch event by initiating a Bitswap sync.
+pub(super) async fn handle_dag_needs_fetch<B, T>(
+    coordinator: &SyncCoordinator<B, T>,
+    request: DagFetchRequest,
 ) -> ReplicationResult
 where
     B: Blockstore + 'static,
     T: P2PTransport,
 {
+    let DagFetchRequest {
+        root_cid,
+        missing,
+        providers,
+        doc_id,
+        collection_id,
+        creator,
+        sender_peer,
+    } = request;
+
     tracing::debug!(
         cid = %root_cid,
         missing_count = missing.len(),
@@ -138,6 +152,7 @@ where
     let doc_id_for_result = metadata.doc_id.unwrap_or("").to_string();
     let collection_id_for_result = metadata.collection_id.unwrap_or("").to_string();
     let collection_id_for_broadcast = metadata.collection_id.unwrap_or("");
+    let effective_creator = metadata.effective_creator().map(str::to_string);
 
     // Delegate merge to handler
     match handler.handle_block(&cid, &block_data, metadata).await {
@@ -203,7 +218,11 @@ where
             }
 
             if let Err(error) = coordinator
-                .apply_replicated_actor_relationships(&doc_id_for_result, acp_actor_relationships)
+                .apply_replicated_actor_relationships(
+                    &doc_id_for_result,
+                    effective_creator.as_deref(),
+                    acp_actor_relationships,
+                )
                 .await
             {
                 return ReplicationResult::Failed {
@@ -229,6 +248,7 @@ where
                 if let Err(error) = coordinator
                     .apply_replicated_actor_relationships(
                         &doc_id_for_result,
+                        effective_creator.as_deref(),
                         acp_actor_relationships,
                     )
                     .await
@@ -495,10 +515,15 @@ where
             cid,
             doc_id,
             collection_id,
+            creator,
             acp_actor_relationships,
         } => {
             if let Err(error) = coordinator
-                .apply_replicated_actor_relationships(&doc_id, acp_actor_relationships.as_ref())
+                .apply_replicated_actor_relationships(
+                    &doc_id,
+                    Some(&creator),
+                    acp_actor_relationships.as_ref(),
+                )
                 .await
             {
                 ReplicationResult::Failed {
@@ -528,13 +553,15 @@ where
         } => {
             handle_dag_needs_fetch(
                 coordinator,
-                root_cid,
-                missing,
-                providers,
-                doc_id,
-                collection_id,
-                creator,
-                sender_peer,
+                DagFetchRequest {
+                    root_cid,
+                    missing,
+                    providers,
+                    doc_id,
+                    collection_id,
+                    creator,
+                    sender_peer,
+                },
             )
             .await
         }

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -18,6 +18,10 @@ pub(super) async fn handle_dag_needs_fetch<B, T>(
     root_cid: Cid,
     missing: Vec<Cid>,
     providers: Vec<String>,
+    doc_id: String,
+    collection_id: String,
+    creator: String,
+    sender_peer: Option<String>,
 ) -> ReplicationResult
 where
     B: Blockstore + 'static,
@@ -29,6 +33,35 @@ where
         provider_count = providers.len(),
         "Initiating Bitswap fetch for missing blocks"
     );
+
+    if let Some(source_peer) = sender_peer {
+        tracing::debug!(
+            cid = %root_cid,
+            source_peer = %source_peer,
+            "Using poll-based DAG fetcher for push-driven DAG recovery"
+        );
+
+        let transport = coordinator.transport().clone();
+        let blockstore = coordinator.blockstore().clone();
+        let event_tx = coordinator.manager().event_sender();
+        let source_peer = crate::transport::PeerId::new(source_peer);
+
+        coordinator.spawn_background_task("pushlog_fetch_dag", async move {
+            crate::sync::coordinator::dag_fetcher::poll_fetch_dag(
+                transport,
+                blockstore,
+                event_tx,
+                root_cid,
+                doc_id,
+                collection_id,
+                creator,
+                source_peer,
+            )
+            .await;
+        });
+
+        return ReplicationResult::DagFetchStarted { root_cid };
+    }
 
     // Convert string peer IDs to transport PeerIds.
     // If the provider list is empty, fall back to all connected transport peers.
@@ -320,6 +353,10 @@ where
             explicit_replay_authorization,
         ) = event_to_merge_metadata(event);
 
+        if matches!(event, SyncEvent::DagReady { .. }) {
+            coordinator.clear_pending_dag(&cid);
+        }
+
         match coordinator.blockstore().get(&cid).await {
             Ok(Some(data)) => {
                 merge_blocks.push(MergeBlock {
@@ -483,8 +520,24 @@ where
             root_cid,
             missing,
             providers,
+            doc_id,
+            collection_id,
+            creator,
+            sender_peer,
             ..
-        } => handle_dag_needs_fetch(coordinator, root_cid, missing, providers).await,
+        } => {
+            handle_dag_needs_fetch(
+                coordinator,
+                root_cid,
+                missing,
+                providers,
+                doc_id,
+                collection_id,
+                creator,
+                sender_peer,
+            )
+            .await
+        }
         SyncEvent::DagReady {
             root_cid,
             doc_id,
@@ -495,6 +548,7 @@ where
             explicit_replay_authorization,
             acp_actor_relationships,
         } => {
+            coordinator.clear_pending_dag(&root_cid);
             // DAG is complete after Bitswap fetch - process as block received
             tracing::info!(
                 cid = %root_cid,

--- a/crates/p2p/src/sync/replication/loop_runner.rs
+++ b/crates/p2p/src/sync/replication/loop_runner.rs
@@ -122,6 +122,12 @@ impl ReplicationLoop {
                         should_break = true;
                         break;
                     }
+                    ReplicationResult::DagFetchStarted { root_cid } => {
+                        tracing::debug!(
+                            cid = %root_cid,
+                            "Poll-based DAG fetch started for missing blocks"
+                        );
+                    }
                     ReplicationResult::BitswapFetchStarted { root_cid, query_id } => {
                         tracing::debug!(
                             cid = %root_cid,

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -31,7 +31,7 @@ pub use result::ReplicationResult;
 
 #[cfg(test)]
 mod tests {
-    use super::handlers::handle_block_received;
+    use super::handlers::{handle_block_received, process_event};
     use super::*;
     use crate::bitswap::AccessMode;
     use crate::error::Result as P2PResult;
@@ -42,7 +42,7 @@ mod tests {
     use crate::sync::manager::SyncEvent;
     use crate::sync::merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
     use crate::topics::DefraTopic;
-    use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
+    use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, TransportEvent};
     use crate::QueryId;
     use crate::ReplicatorInfo;
     use async_trait::async_trait;
@@ -110,6 +110,248 @@ mod tests {
                 peer_id: PeerId::new("local-peer".to_string()),
                 pubkey: vec![1, 2, 3],
             }
+        }
+    }
+
+    #[derive(Clone)]
+    struct PollFetchTransport {
+        peer_id: PeerId,
+        pubkey: Vec<u8>,
+        blockstore: Arc<DefraBlockstore<MemoryStore>>,
+        child_cid: Cid,
+        child_data: Vec<u8>,
+        sync_blocks_calls: Arc<AtomicUsize>,
+    }
+
+    impl PollFetchTransport {
+        fn new(
+            blockstore: Arc<DefraBlockstore<MemoryStore>>,
+            child_cid: Cid,
+            child_data: Vec<u8>,
+        ) -> Self {
+            Self {
+                peer_id: PeerId::new("local-peer".to_string()),
+                pubkey: vec![1, 2, 3],
+                blockstore,
+                child_cid,
+                child_data,
+                sync_blocks_calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn sync_blocks_calls(&self) -> usize {
+            self.sync_blocks_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl P2PTransport for PollFetchTransport {
+        type ResponseToken = ();
+
+        fn local_peer_id(&self) -> &PeerId {
+            &self.peer_id
+        }
+
+        fn local_public_key_proto(&self) -> &[u8] {
+            &self.pubkey
+        }
+
+        fn sign(&self, _data: &[u8]) -> P2PResult<Vec<u8>> {
+            Ok(vec![0])
+        }
+
+        async fn dial(&self, _peer_id: &PeerId, _addrs: Vec<PeerAddr>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn listen(&self, _addr: PeerAddr) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn connected_peers(&self) -> P2PResult<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn listen_addresses(&self) -> P2PResult<Vec<PeerAddr>> {
+            Ok(Vec::new())
+        }
+
+        async fn poll_until_connected(
+            &self,
+            _peer_id: &PeerId,
+            _timeout: Duration,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn peer_addresses(&self) -> P2PResult<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn topic_peers(&self, _topic: DefraTopic) -> P2PResult<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn subscribe(&self, _topic: DefraTopic) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn unsubscribe(&self, _topic: DefraTopic) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn publish(
+            &self,
+            _topic: DefraTopic,
+            _msg: PushLogBroadcast,
+        ) -> P2PResult<MessageId> {
+            Ok(MessageId::new("noop".to_string()))
+        }
+
+        async fn send_pushlog_response(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: PushLogReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_two_stream_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushLogRequest,
+        ) -> P2PResult<PushLogReply> {
+            Ok(PushLogReply::success("noop"))
+        }
+
+        async fn send_two_stream_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: PushLogReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: DocSyncRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: DocSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: BranchableSyncRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: BranchableSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_request(&self, _peer_id: &PeerId, _root_cid: Cid) -> P2PResult<()> {
+            self.blockstore
+                .put(&self.child_cid, &self.child_data)
+                .await
+                .map_err(|e| crate::error::Error::BlockstoreError(e.to_string()))?;
+            Ok(())
+        }
+
+        async fn send_car_response(&self, _peer_id: &PeerId, _car_data: Vec<u8>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_car_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _car_data: Vec<u8>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: DocSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: BranchableSyncReply,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn send_se_artifacts(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushSEArtifactsRequest,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn sync_blocks(
+            &self,
+            _root: Cid,
+            _providers: Vec<PeerId>,
+            _missing: Vec<Cid>,
+        ) -> P2PResult<QueryId> {
+            self.sync_blocks_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(QueryId(1))
+        }
+
+        async fn cancel_sync(&self, _query_id: QueryId) -> P2PResult<bool> {
+            Ok(true)
+        }
+
+        async fn create_replicator(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn delete_replicator(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn list_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_replicator(&self, _peer_id: &PeerId) -> P2PResult<Option<ReplicatorInfo>> {
+            Ok(None)
+        }
+
+        async fn remove_replicator_collections(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> P2PResult<bool> {
+            Ok(false)
+        }
+
+        async fn shutdown(&self) -> P2PResult<()> {
+            Ok(())
         }
     }
 
@@ -613,6 +855,117 @@ mod tests {
             blockstore.is_merged(&cid).await.unwrap(),
             "successful replay should mark the CID as merged"
         );
+    }
+
+    #[tokio::test]
+    async fn test_pushlog_dag_needs_fetch_uses_poll_fetcher_when_sender_known() {
+        use defra_core::{Block, CompositeDeltaPayload, CrdtDelta, DAGLink, LwwDeltaPayload};
+
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+        let child_block = Block::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: b"doc1".to_vec(),
+                field_name: "name".to_string(),
+                priority: 1,
+                schema_version_id: "schema1".to_string(),
+                data: b"value".to_vec(),
+            }),
+            vec![],
+            vec![],
+        );
+        let child_data = child_block.to_dag_cbor().unwrap();
+        let child_cid = child_block.generate_cid().unwrap();
+
+        let root_block = Block::new(
+            CrdtDelta::Composite(CompositeDeltaPayload {
+                doc_id: b"doc1".to_vec(),
+                schema_version_id: "schema1".to_string(),
+                priority: 1,
+                status: 1,
+            }),
+            vec![],
+            vec![DAGLink::new("name", child_cid)],
+        );
+        let root_data = root_block.to_dag_cbor().unwrap();
+        let root_cid = root_block.generate_cid().unwrap();
+
+        blockstore.put(&root_cid, &root_data).await.unwrap();
+
+        let transport = PollFetchTransport::new(blockstore.clone(), child_cid, child_data);
+        let transport_handle = transport.clone();
+        let (coordinator, mut events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                transport,
+                blockstore.clone(),
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+
+        coordinator
+            .handle_transport_event(TransportEvent::TwoStreamRequest {
+                peer_id: PeerId::new("source-peer".to_string()),
+                request: PushLogRequest::new(
+                    "doc1".to_string(),
+                    bytes::Bytes::from(root_cid.to_bytes()),
+                    "col1".to_string(),
+                    "creator-1".to_string(),
+                    bytes::Bytes::from(root_data),
+                ),
+                token: None,
+                is_explicit_replicator: false,
+                explicit_replay_authorization: None,
+            })
+            .await
+            .unwrap();
+
+        let dag_needs_fetch = tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("DagNeedsFetch should arrive")
+            .expect("event should be present");
+
+        assert_eq!(coordinator.pending_dag_count(), 1);
+
+        let result = process_event(
+            &coordinator,
+            dag_needs_fetch,
+            &TestMergeHandler::new(true, false),
+            &ReplicationConfig::default(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            ReplicationResult::DagFetchStarted { root_cid: cid } if cid == root_cid
+        ));
+
+        let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+            .await
+            .expect("DagReady should arrive")
+            .expect("event should be present");
+
+        assert!(matches!(&event, SyncEvent::DagReady { root_cid: cid, .. } if *cid == root_cid));
+        assert_eq!(transport_handle.sync_blocks_calls(), 0);
+        assert!(blockstore.has(&child_cid).await.unwrap());
+
+        let merge_result = process_event(
+            &coordinator,
+            event,
+            &TestMergeHandler::new(true, false),
+            &ReplicationConfig::default(),
+        )
+        .await;
+
+        assert!(matches!(
+            merge_result,
+            ReplicationResult::Merged { cid, .. } if cid == root_cid
+        ));
+        assert_eq!(coordinator.pending_dag_count(), 0);
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/replication/recovery.rs
+++ b/crates/p2p/src/sync/replication/recovery.rs
@@ -117,6 +117,12 @@ where
                     "Failed to recover block - manual intervention may be required"
                 );
             }
+            ReplicationResult::DagFetchStarted { root_cid } => {
+                tracing::warn!(
+                    cid = %root_cid,
+                    "Unexpected DagFetchStarted during recovery - block may have missing links"
+                );
+            }
             ReplicationResult::BitswapFetchStarted { root_cid, .. } => {
                 // Unexpected during recovery - blocks should already be in blockstore
                 tracing::warn!(

--- a/crates/p2p/src/sync/replication/result.rs
+++ b/crates/p2p/src/sync/replication/result.rs
@@ -35,6 +35,8 @@ pub enum ReplicationResult {
     MergedButNotMarked { cid: Cid, error: String },
     /// Event channel closed
     ChannelClosed,
+    /// Poll-based DAG fetch started for a known source peer
+    DagFetchStarted { root_cid: Cid },
     /// Bitswap fetch started for missing blocks
     BitswapFetchStarted { root_cid: Cid, query_id: QueryId },
 }

--- a/tools/integration-test/tests/acp/negative_p2p.rs
+++ b/tools/integration-test/tests/acp/negative_p2p.rs
@@ -178,37 +178,35 @@ async fn p2p_merge_denial_test(cluster: TestCluster) {
         "Bob must read _commits on node1 after the reader grant replicates"
     );
 
-    // Charlie was never granted access, so replication must not make the
-    // document visible to him on node1.
-    let charlie_node1 = node1
-        .query_with_identity("query { User { _docID name } }", &charlie.private_key_hex)
-        .expect("Charlie query on node1");
-    let charlie_node1_count = charlie_node1["User"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0);
-    assert_eq!(
-        charlie_node1_count, 0,
-        "replication must not grant access on node1 to identities without a relationship"
-    );
+    let node1_ref = &node1;
+    let charlie_key = charlie.private_key_hex.clone();
+    let doc_id_for_charlie = doc_id.clone();
+    poll_until(
+        || {
+            let visible_docs = node1_ref
+                .query_with_identity("query { User { _docID name } }", &charlie_key)
+                .ok()
+                .and_then(|value| value["User"].as_array().map(|rows| rows.len()))
+                .unwrap_or(usize::MAX);
+            let visible_commits = node1_ref
+                .query_with_identity(
+                    &format!(
+                        r#"query {{ _commits(docID: "{}") {{ cid height }} }}"#,
+                        doc_id_for_charlie
+                    ),
+                    &charlie_key,
+                )
+                .ok()
+                .and_then(|value| value["_commits"].as_array().map(|rows| rows.len()))
+                .unwrap_or(usize::MAX);
 
-    let charlie_commits_node1 = node1
-        .query_with_identity(
-            &format!(
-                r#"query {{ _commits(docID: "{}") {{ cid height }} }}"#,
-                doc_id
-            ),
-            &charlie.private_key_hex,
-        )
-        .expect("Charlie commits query on node1");
-    let charlie_commits_count = charlie_commits_node1["_commits"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0);
-    assert_eq!(
-        charlie_commits_count, 0,
-        "Charlie must not read _commits on node1 without a local or replicated grant"
-    );
+            visible_docs == 0 && visible_commits == 0
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(200),
+        "replication must not grant access on node1 to identities without a relationship",
+    )
+    .await;
 
     // Alice can still read the document on node1 (she's the owner, not relying on grant)
     let alice_node1 = node1


### PR DESCRIPTION
## Summary
- keep the coordinator access registry in sync with replicator lifecycle changes
- make successful `create_replicator` immediately authorize collection gossip/push handling
- add regression coverage for immediate authorization and revocation

## Repro
The current reproducer is the defra-agent three-agent desktop live soak artifact bundle:
`/Users/johnzampolin/go/src/github.com/sourcenetwork/defra-agent/target/desktop-live-soak/desktop-live-three-agent-20260418T163330Z-f97a09010c094c6899ca53482e382d5c`

That soak still failed after PR #892 with the same core signature:
- `Access denied: peer is not a replicator for this collection`
- `Dropping GossipSub message from unauthorized peer`
- downstream Bitswap fetch exhaustion

## Root Cause
`p2p-adapter` calls `SyncCoordinator::create_replicator(...)` during bootstrap, but coordinator ingress authorization checks `self.access.replicators`.

Before this patch, `create_replicator` only updated the transport-side replicator state and did not update the coordinator-side access registry. That left a gap where bootstrap had succeeded, but the next gossip/push request for the collection still failed authorization.

## Testing
- `cargo test -p p2p create_replicator_updates_access_registry_for_gossip`
- `cargo test -p p2p delete_replicator_revokes_access_for_gossip`
- `cargo test -p p2p pushlog_registered_replicator_is_marked_explicit_replicator`
- `cargo test -p p2p branchable_sync_controlled_mode_rejects_wrong_collection`