### PR TITLE
fix(p2p): per-peer Bitswap ACP filter (#830)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6246,7 +6246,7 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/fredcarle/beetle?branch=fredcarle/async-peer-block-request-filter#e0fa8cd0aab748117d63a8dc1002487db1ee9da8"
+source = "git+https://github.com/sourcenetwork/beetle?branch=main#6441b0ac5f42d466f44963afb782bb56030b1479"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.2.0"
-source = "git+https://github.com/fredcarle/beetle?branch=fredcarle/async-peer-block-request-filter#e0fa8cd0aab748117d63a8dc1002487db1ee9da8"
+source = "git+https://github.com/sourcenetwork/beetle?branch=main#6441b0ac5f42d466f44963afb782bb56030b1479"
 dependencies = [
  "async-trait",
  "config",
@@ -6477,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "iroh-util"
 version = "0.2.0"
-source = "git+https://github.com/fredcarle/beetle?branch=fredcarle/async-peer-block-request-filter#e0fa8cd0aab748117d63a8dc1002487db1ee9da8"
+source = "git+https://github.com/sourcenetwork/beetle?branch=main#6441b0ac5f42d466f44963afb782bb56030b1479"
 dependencies = [
  "anyhow",
  "cid 0.10.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5029,8 +5029,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5751,7 +5751,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6246,7 +6246,7 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/sourcenetwork/beetle?branch=main#48e70b0345ea842012285e1fafa27406bb14ef83"
+source = "git+https://github.com/fredcarle/beetle?branch=fredcarle/async-peer-block-request-filter#e0fa8cd0aab748117d63a8dc1002487db1ee9da8"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -6366,7 +6366,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.2.0"
-source = "git+https://github.com/sourcenetwork/beetle?branch=main#48e70b0345ea842012285e1fafa27406bb14ef83"
+source = "git+https://github.com/fredcarle/beetle?branch=fredcarle/async-peer-block-request-filter#e0fa8cd0aab748117d63a8dc1002487db1ee9da8"
 dependencies = [
  "async-trait",
  "config",
@@ -6477,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "iroh-util"
 version = "0.2.0"
-source = "git+https://github.com/sourcenetwork/beetle?branch=main#48e70b0345ea842012285e1fafa27406bb14ef83"
+source = "git+https://github.com/fredcarle/beetle?branch=fredcarle/async-peer-block-request-filter#e0fa8cd0aab748117d63a8dc1002487db1ee9da8"
 dependencies = [
  "anyhow",
  "cid 0.10.1",
@@ -10446,7 +10446,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -14692,8 +14692,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ ciborium = "0.2"
 # P2P networking
 # Note: Using 0.53 to match iroh-bitswap's dependency
 libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "relay"] }
-iroh-bitswap = { git = "https://github.com/sourcenetwork/beetle", branch = "main" }
+iroh-bitswap = { git = "https://github.com/fredcarle/beetle", branch = "fredcarle/async-peer-block-request-filter" }
 libp2p-stream = "0.1.0-alpha.1"
 multiaddr = "0.18"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ ciborium = "0.2"
 # P2P networking
 # Note: Using 0.53 to match iroh-bitswap's dependency
 libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "relay"] }
-iroh-bitswap = { git = "https://github.com/fredcarle/beetle", branch = "fredcarle/async-peer-block-request-filter" }
+iroh-bitswap = { git = "https://github.com/sourcenetwork/beetle", branch = "main" }
 libp2p-stream = "0.1.0-alpha.1"
 multiaddr = "0.18"
 

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -4,7 +4,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info};
 
 use super::node::Node;
-use crate::config::Config;
+use crate::config::{AcpDocumentType, Config};
 use crate::error::{Error, Result};
 
 impl Node {
@@ -97,6 +97,11 @@ impl Node {
         std::sync::Arc<p2p::ReplicatorRegistry>,
         JoinHandle<()>,
     )> {
+        let access_mode = if config.acp.document_type != AcpDocumentType::None {
+            p2p::bitswap::AccessMode::Controlled
+        } else {
+            p2p::bitswap::AccessMode::Open
+        };
         let p2p_config = p2p::P2PHostConfig {
             enable_pubsub,
             enable_relay: config.net.relay_enabled,
@@ -107,6 +112,7 @@ impl Node {
             max_connections_in: config.net.max_connections_in,
             max_connections_out: config.net.max_connections_out,
             max_connections_per_peer: config.net.max_connections_per_peer,
+            access_mode,
         };
         let (host, handle, events, replicators) = match keypair {
             Some(kp) => p2p::P2PHost::with_keypair_and_config(kp, bitswap_store, p2p_config)

--- a/crates/defra-core/src/lens_block.rs
+++ b/crates/defra-core/src/lens_block.rs
@@ -64,6 +64,33 @@ impl LensWasmBlock {
 /// A CID paired with its serialized bytes.
 pub type CidBlock = (Cid, Vec<u8>);
 
+/// Returns `true` if `bytes` decode as any known lens IPLD block shape —
+/// the top-level config, a module block, a WASM block (direct or chunked),
+/// or a raw WASM chunk byte string.
+///
+/// Mirrors Go DefraDB's `hasAccess` passthrough for
+/// `lens` / `modules` / `wasmBytes` / `chunks` blocks
+/// (`internal/db/p2p/p2p.go:335-348`). The Bitswap access filter uses this
+/// to let lens schema-migration blocks propagate in `Controlled` mode
+/// without per-collection replicator trust (they carry no user data).
+pub fn is_lens_block(bytes: &[u8]) -> bool {
+    use serde_bytes::ByteBuf;
+
+    // Most specific structural shapes first — failures here are fast and
+    // the order isn't behaviourally significant (any match → allow).
+    if serde_ipld_dagcbor::from_slice::<LensModuleBlock>(bytes).is_ok() {
+        return true;
+    }
+    if serde_ipld_dagcbor::from_slice::<LensWasmBlock>(bytes).is_ok() {
+        return true;
+    }
+    if serde_ipld_dagcbor::from_slice::<LensConfigBlock>(bytes).is_ok() {
+        return true;
+    }
+    // Chunked WASM stores each chunk as a bare CBOR byte string.
+    serde_ipld_dagcbor::from_slice::<ByteBuf>(bytes).is_ok()
+}
+
 /// Maximum size for a single WASM block before chunking.
 /// Must be well below iroh-bitswap's MAX_BUF_SIZE (2 MB) to account for
 /// CBOR encoding overhead and Bitswap message framing.

--- a/crates/defra-core/src/lib.rs
+++ b/crates/defra-core/src/lib.rs
@@ -32,7 +32,8 @@ pub use encryption::EncryptionKey;
 pub use error::{Error, Result};
 pub use ipld::{collect_block_links, extract_links, walk_ipld, IpldVisitor};
 pub use lens_block::{
-    build_lens_ipld_blocks, CidBlock, LensConfigBlock, LensKeyValue, LensModuleBlock, LensWasmBlock,
+    build_lens_ipld_blocks, is_lens_block, CidBlock, LensConfigBlock, LensKeyValue,
+    LensModuleBlock, LensWasmBlock,
 };
 pub use signing::SigningKeyType;
 

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -26,6 +26,7 @@
 //! IPFS block exchange protocol (1.0.0, 1.1.0, 1.2.0), enabling
 //! interoperability with Go DefraDB.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use iroh_bitswap::{Bitswap, BitswapEvent, Config as BitswapConfig, Store};
@@ -43,6 +44,7 @@ use libp2p_stream as stream;
 
 use libp2p::identity::Keypair;
 
+use crate::bitswap::{make_peer_block_access_filter, AccessMode, ReplicatorRegistry};
 use crate::codec::PushLogCodec;
 use crate::message::{PushLogReply, PushLogRequest};
 
@@ -159,7 +161,7 @@ impl From<void::Void> for DefraEvent {
     }
 }
 
-impl<S: Store> DefraBehaviour<S> {
+impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
     /// Create a new DefraDB network behaviour with message signing enabled.
     ///
     /// # Arguments
@@ -168,6 +170,10 @@ impl<S: Store> DefraBehaviour<S> {
     /// * `local_public_key` - The local peer's public key
     /// * `keypair` - The keypair for message signing/verification
     /// * `bitswap_store` - The blockstore for Bitswap block exchange
+    /// * `access_mode` - Controls whether the Bitswap filter enforces
+    ///   per-peer access control on served blocks
+    /// * `replicators` - Registry used by the filter to authorize peers
+    ///   per collection (shared with SyncCoordinator)
     ///
     /// # Returns
     ///
@@ -177,11 +183,14 @@ impl<S: Store> DefraBehaviour<S> {
     ///
     /// This must be called within a tokio runtime context as Bitswap spawns
     /// background tasks for operations.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         local_peer_id: PeerId,
         local_public_key: libp2p::identity::PublicKey,
         keypair: Keypair,
         bitswap_store: S,
+        access_mode: AccessMode,
+        replicators: Arc<ReplicatorRegistry>,
         enable_pubsub: bool,
         config: &super::P2PHostConfig,
     ) -> Result<Self, crate::error::Error> {
@@ -235,9 +244,23 @@ impl<S: Store> DefraBehaviour<S> {
         // Run as server to respond to DHT queries from other peers
         kademlia.set_mode(Some(Mode::Server));
 
-        // Configure Bitswap for block exchange (Go compatibility)
-        // iroh-bitswap implements the standard IPFS bitswap protocols
-        let bitswap_config = BitswapConfig::default();
+        // Configure Bitswap for block exchange (Go compatibility).
+        // iroh-bitswap implements the standard IPFS bitswap protocols.
+        //
+        // Install a per-peer block-request filter to enforce ACP on the
+        // egress path. Without this, any connected peer could fetch any
+        // block in the blockstore — see #830. Matches Go's
+        // `bitswap.WithPeerBlockRequestFilter(hasAccess)` wiring
+        // (`go-p2p/peer.go:146`).
+        let filter = make_peer_block_access_filter(
+            access_mode,
+            Arc::clone(&replicators),
+            bitswap_store.clone(),
+        );
+        let mut bitswap_config = BitswapConfig::default();
+        if let Some(server_cfg) = bitswap_config.server.as_mut() {
+            server_cfg.decision_config.peer_block_request_filter = Some(Box::new(filter));
+        }
         let bitswap = Bitswap::new(local_peer_id, bitswap_store, bitswap_config).await;
 
         // Configure stream behaviour for Go two-stream compatibility
@@ -461,8 +484,18 @@ mod tests {
         let store = MockBitswapStore::new();
 
         let config = crate::P2PHostConfig::default();
-        let behaviour =
-            DefraBehaviour::new(peer_id, public_key, keypair, store, true, &config).await;
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let behaviour = DefraBehaviour::new(
+            peer_id,
+            public_key,
+            keypair,
+            store,
+            AccessMode::Open,
+            registry,
+            true,
+            &config,
+        )
+        .await;
         assert!(behaviour.is_ok());
     }
 
@@ -485,8 +518,18 @@ mod tests {
         let store = MockBitswapStore::new();
 
         let config = crate::P2PHostConfig::default();
-        let behaviour =
-            DefraBehaviour::new(peer_id, public_key, keypair, store, false, &config).await;
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let behaviour = DefraBehaviour::new(
+            peer_id,
+            public_key,
+            keypair,
+            store,
+            AccessMode::Open,
+            registry,
+            false,
+            &config,
+        )
+        .await;
         assert!(behaviour.is_ok());
         let behaviour = behaviour.unwrap();
         assert!(behaviour.gossipsub.as_ref().is_none());

--- a/crates/p2p/src/bitswap/access.rs
+++ b/crates/p2p/src/bitswap/access.rs
@@ -3,33 +3,27 @@
 //! This module provides access control primitives:
 //! - `AccessMode`: Controls whether access control is enabled (Open vs Controlled)
 //!
-//! # Security Model (current state)
+//! # Security Model
 //!
-//! Access control today is enforced **only on the ingress path** via the
-//! SyncCoordinator: incoming PushLog and GossipSub messages are checked against
-//! the `ReplicatorRegistry` before blocks are stored. This means unauthorized
-//! peers cannot push blocks *into* this node.
+//! Access control is enforced on **both the ingress and egress paths**:
 //!
-//! **The egress path via Bitswap is not filtered.** Once a block is in the
-//! blockstore — however it got there — it is served to any connected peer that
-//! requests it via Bitswap. The `BitswapStoreAdapter::get(&self, cid: &Cid)`
-//! signature (`crates/p2p/src/bitswap/store.rs`) has no peer context, so a
-//! per-peer access check cannot be expressed at this layer today.
+//! - **Ingress:** `SyncCoordinator` checks incoming PushLog and GossipSub
+//!   messages against the `ReplicatorRegistry` before storing blocks.
+//!   Unauthorized peers cannot push blocks into this node.
+//! - **Egress:** A per-peer Bitswap filter
+//!   (`crate::bitswap::make_peer_block_access_filter`) is installed at
+//!   behaviour-construction time (`crates/p2p/src/behaviour.rs`). On every
+//!   incoming Bitswap `WANT`, the filter reads the block, decodes its
+//!   `collectionVersionID`, and consults the same `ReplicatorRegistry`.
+//!   Peers that are not registered replicators for the block's collection
+//!   are denied (signature and definition blocks are exempt to allow
+//!   signature verification and schema bootstrap).
 //!
-//! **This diverges from Go DefraDB.** Go wires Bitswap with
-//! `bitswap.WithPeerBlockRequestFilter(p.hasAccess)` (`go-p2p/peer.go:146`),
-//! so every incoming block request is filtered per (peer, CID) against the
-//! replicator registry. Go denies block fetches from peers that are not
-//! authorized for the collection that owns the CID.
+//! This matches Go DefraDB's `bitswap.WithPeerBlockRequestFilter(hasAccess)`
+//! wiring (`go-p2p/peer.go:146`), closing issue #830.
 //!
-//! In practice this means that in a Rust node running `AccessMode::Controlled`,
-//! any peer that can open a libp2p connection can fetch any stored block,
-//! regardless of their authorization for the owning collection. ACP-encrypted
-//! collections still protect plaintext confidentiality, but ciphertext and
-//! block-existence signals leak to all connected peers.
-//!
-//! See issue #830 for the tracking fix (adding a per-peer request filter to
-//! Rust's Bitswap integration to restore parity with Go).
+//! Note: in `AccessMode::Open` the filter allows all requests, preserving the
+//! previous behaviour for nodes that haven't enabled ACP.
 
 /// Access control mode for P2P synchronization.
 ///

--- a/crates/p2p/src/bitswap/filter.rs
+++ b/crates/p2p/src/bitswap/filter.rs
@@ -1,0 +1,260 @@
+//! Per-peer Bitswap block-request filter.
+//!
+//! Enforces per-collection access control on outbound Bitswap responses.
+//! Without this filter a node running in `AccessMode::Controlled` would
+//! still serve any stored block to any connected peer, bypassing the
+//! `ReplicatorRegistry` that gates ingress.
+//!
+//! Matches Go DefraDB's `bitswap.WithPeerBlockRequestFilter(hasAccess)`
+//! wiring in `go-p2p/peer.go:146`.
+//!
+//! # Decision flow
+//!
+//! 1. `AccessMode::Open` → allow all.
+//! 2. Block not in store → deny (prevents existence leaks too).
+//! 3. Block decodes as a `Signature` → allow (signature blocks carry no
+//!    collection data and are required to verify sibling blocks).
+//! 4. Block decodes as a CRDT `Block` with a definition delta → allow
+//!    (schema/collection definitions are broadcast to all replicators).
+//! 5. Block decodes as a CRDT `Block` with a data delta → allow iff the
+//!    requesting peer is registered as a replicator for the block's
+//!    collection.
+//! 6. Anything else (lens/wasm/chunk blocks, decode errors) → deny by
+//!    default. Callers that need a permissive path for Rust-specific
+//!    block kinds should extend the match arms below.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use cid::Cid;
+use defra_core::{Block as DefraBlock, Signature};
+use iroh_bitswap::Store;
+use libp2p::PeerId;
+
+use super::{AccessMode, ReplicatorRegistry};
+
+/// Build a filter closure that satisfies iroh-bitswap's
+/// `PeerBlockRequestFilter` trait.
+///
+/// The returned closure owns clones of `registry` and `store`, so the
+/// caller can construct it once and hand it to `BitswapConfig`.
+pub fn make_peer_block_access_filter<S>(
+    mode: AccessMode,
+    registry: Arc<ReplicatorRegistry>,
+    store: S,
+) -> impl Fn(&PeerId, &Cid) -> Pin<Box<dyn Future<Output = bool> + Send + 'static>> + Send + Sync + 'static
+where
+    S: Store + Clone + Send + Sync + 'static,
+{
+    move |peer_id: &PeerId, cid: &Cid| {
+        let peer_id = *peer_id;
+        let cid = *cid;
+        let registry = Arc::clone(&registry);
+        let store = store.clone();
+        Box::pin(async move { check_access(mode, &registry, &store, &peer_id, &cid).await })
+    }
+}
+
+async fn check_access<S: Store>(
+    mode: AccessMode,
+    registry: &ReplicatorRegistry,
+    store: &S,
+    peer_id: &PeerId,
+    cid: &Cid,
+) -> bool {
+    if mode.is_open() {
+        return true;
+    }
+
+    let block = match store.get(cid).await {
+        Ok(b) => b,
+        Err(_) => {
+            // Miss or I/O error: deny without leaking block presence.
+            // Matches Go's error path in hasAccess (returns false on
+            // blockstore.Get failure).
+            return false;
+        }
+    };
+    let data = block.data();
+
+    // Signature blocks are required for peers to verify data they already
+    // have, and carry no authored data themselves. Always serve.
+    if Signature::from_dag_cbor(data).is_ok() {
+        return true;
+    }
+
+    let defra_block = match DefraBlock::from_dag_cbor(data) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+
+    if defra_block.delta.is_definition() {
+        return true;
+    }
+
+    let collection_id = match defra_block.delta.schema_version_id() {
+        Some(id) => id,
+        None => return false,
+    };
+
+    let peer_str = peer_id.to_string();
+    registry.is_replicator(collection_id, &peer_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use iroh_bitswap::{Block, Store};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default, Clone)]
+    struct InMemoryStore {
+        inner: Arc<Mutex<HashMap<Cid, Vec<u8>>>>,
+    }
+
+    impl InMemoryStore {
+        fn put(&self, cid: Cid, data: Vec<u8>) {
+            self.inner.lock().unwrap().insert(cid, data);
+        }
+    }
+
+    #[async_trait]
+    impl Store for InMemoryStore {
+        async fn get_size(&self, cid: &Cid) -> anyhow::Result<usize> {
+            self.inner
+                .lock()
+                .unwrap()
+                .get(cid)
+                .map(|b| b.len())
+                .ok_or_else(|| anyhow::anyhow!("not found"))
+        }
+
+        async fn get(&self, cid: &Cid) -> anyhow::Result<Block> {
+            let data = self
+                .inner
+                .lock()
+                .unwrap()
+                .get(cid)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("not found"))?;
+            Ok(Block::new(data.into(), *cid))
+        }
+
+        async fn has(&self, cid: &Cid) -> anyhow::Result<bool> {
+            Ok(self.inner.lock().unwrap().contains_key(cid))
+        }
+    }
+
+    fn cid_for(data: &[u8]) -> Cid {
+        defra_core::block::generate_cid_from_bytes(data).unwrap()
+    }
+
+    fn make_data_block(collection_id: &str) -> (Cid, Vec<u8>) {
+        use defra_core::{CompositeDeltaPayload, CrdtDelta};
+
+        let payload = CompositeDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            priority: 1,
+            schema_version_id: collection_id.to_string(),
+            status: 1,
+        };
+        let delta = CrdtDelta::Composite(payload);
+        let block = DefraBlock::new(delta, Vec::new(), Vec::new());
+        let bytes = block.to_dag_cbor().unwrap();
+        let cid = cid_for(&bytes);
+        (cid, bytes)
+    }
+
+    #[tokio::test]
+    async fn open_mode_allows_all() {
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        let (cid, bytes) = make_data_block("users");
+        store.put(cid, bytes);
+
+        let peer = PeerId::random();
+        let allowed = check_access(AccessMode::Open, &registry, &store, &peer, &cid).await;
+        assert!(allowed);
+    }
+
+    #[tokio::test]
+    async fn controlled_mode_denies_unknown_peer() {
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        let (cid, bytes) = make_data_block("users");
+        store.put(cid, bytes);
+
+        let peer = PeerId::random();
+        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        assert!(!allowed, "unknown peer must be denied in Controlled mode");
+    }
+
+    #[tokio::test]
+    async fn controlled_mode_allows_registered_replicator() {
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        let (cid, bytes) = make_data_block("users");
+        store.put(cid, bytes);
+
+        let peer = PeerId::random();
+        registry.add_replicator("users", &peer.to_string());
+
+        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        assert!(allowed, "registered replicator must be served");
+    }
+
+    #[tokio::test]
+    async fn controlled_mode_denies_replicator_for_other_collection() {
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        let (cid, bytes) = make_data_block("users");
+        store.put(cid, bytes);
+
+        let peer = PeerId::random();
+        // Peer is a replicator for a different collection.
+        registry.add_replicator("posts", &peer.to_string());
+
+        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        assert!(
+            !allowed,
+            "replicator for a different collection must not fetch this one"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_block_denies_without_leaking() {
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        let missing = cid_for(b"never-stored");
+
+        let peer = PeerId::random();
+        registry.add_replicator("users", &peer.to_string());
+
+        let allowed =
+            check_access(AccessMode::Controlled, &registry, &store, &peer, &missing).await;
+        assert!(!allowed, "missing block must be denied");
+    }
+
+    #[tokio::test]
+    async fn signature_block_is_served_without_registry_check() {
+        use defra_core::{Signature as DefraSig, SignatureHeader, SignatureType};
+        let header = SignatureHeader::new(SignatureType::EdDSA, vec![9, 9, 9]);
+        let sig = DefraSig::new(header, vec![1, 2, 3, 4]);
+        let bytes = sig.to_dag_cbor().unwrap();
+        let cid = cid_for(&bytes);
+
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        store.put(cid, bytes);
+
+        let peer = PeerId::random();
+        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        assert!(
+            allowed,
+            "signature blocks must be served even in Controlled mode"
+        );
+    }
+}

--- a/crates/p2p/src/bitswap/filter.rs
+++ b/crates/p2p/src/bitswap/filter.rs
@@ -19,18 +19,21 @@
 //! 5. Block decodes as a CRDT `Block` with a data delta → allow iff the
 //!    requesting peer is registered as a replicator for the block's
 //!    collection.
-//! 6. Anything else (lens/wasm/chunk blocks, decode errors) → deny by
-//!    default. Callers that need a permissive path for Rust-specific
-//!    block kinds should extend the match arms below.
+//! 6. Block decodes as a lens IPLD shape (config / module / WASM /
+//!    chunk) → allow. Schema-migration artifacts carry no user data
+//!    and mirror Go's `hasAccess` passthrough at `internal/db/p2p/
+//!    p2p.go:335-348`.
+//! 7. Anything else (decode errors on all known shapes) → deny.
 
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use cid::Cid;
-use defra_core::{Block as DefraBlock, Signature};
+use defra_core::{is_lens_block, Block as DefraBlock, Signature};
 use iroh_bitswap::Store;
 use libp2p::PeerId;
+use tracing::debug;
 
 use super::{AccessMode, ReplicatorRegistry};
 
@@ -69,10 +72,16 @@ async fn check_access<S: Store>(
 
     let block = match store.get(cid).await {
         Ok(b) => b,
-        Err(_) => {
+        Err(error) => {
             // Miss or I/O error: deny without leaking block presence.
             // Matches Go's error path in hasAccess (returns false on
             // blockstore.Get failure).
+            debug!(
+                cid = %cid,
+                peer = %peer_id,
+                %error,
+                "bitswap request denied: block unavailable from store"
+            );
             return false;
         }
     };
@@ -84,22 +93,46 @@ async fn check_access<S: Store>(
         return true;
     }
 
-    let defra_block = match DefraBlock::from_dag_cbor(data) {
-        Ok(b) => b,
-        Err(_) => return false,
-    };
-
-    if defra_block.delta.is_definition() {
-        return true;
+    match DefraBlock::from_dag_cbor(data) {
+        Ok(defra_block) => {
+            if defra_block.delta.is_definition() {
+                return true;
+            }
+            let Some(collection_id) = defra_block.delta.schema_version_id() else {
+                debug!(
+                    cid = %cid,
+                    peer = %peer_id,
+                    "bitswap request denied: data delta missing collection id"
+                );
+                return false;
+            };
+            let peer_str = peer_id.to_string();
+            if registry.is_replicator(collection_id, &peer_str) {
+                return true;
+            }
+            debug!(
+                cid = %cid,
+                peer = %peer_id,
+                collection = %collection_id,
+                "bitswap request denied: peer not a replicator for collection"
+            );
+            false
+        }
+        Err(_) => {
+            // Not a CRDT block. Go's hasAccess lets lens IPLD artifacts
+            // (config / module / WASM / chunks) through unconditionally —
+            // they carry no user data. Match that or deny.
+            if is_lens_block(data) {
+                return true;
+            }
+            debug!(
+                cid = %cid,
+                peer = %peer_id,
+                "bitswap request denied: block is neither CRDT, signature, nor lens"
+            );
+            false
+        }
     }
-
-    let collection_id = match defra_block.delta.schema_version_id() {
-        Some(id) => id,
-        None => return false,
-    };
-
-    let peer_str = peer_id.to_string();
-    registry.is_replicator(collection_id, &peer_str)
 }
 
 #[cfg(test)]
@@ -256,5 +289,61 @@ mod tests {
             allowed,
             "signature blocks must be served even in Controlled mode"
         );
+    }
+
+    /// Schema/collection definitions are broadcast to every replicator
+    /// regardless of per-collection registration. A peer that has no
+    /// entry in the registry must still be able to fetch them.
+    #[tokio::test]
+    async fn definition_delta_is_served_without_registry_check() {
+        use defra_core::{CollectionSetDeltaPayload, CrdtDelta};
+
+        let delta = CrdtDelta::CollectionSet(CollectionSetDeltaPayload::new(1));
+        assert!(
+            delta.is_definition(),
+            "test precondition: CollectionSet is a definition delta"
+        );
+        let block = DefraBlock::new(delta, Vec::new(), Vec::new());
+        let bytes = block.to_dag_cbor().unwrap();
+        let cid = cid_for(&bytes);
+
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        store.put(cid, bytes);
+
+        let peer = PeerId::random();
+        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        assert!(
+            allowed,
+            "definition deltas must be served even to non-replicator peers"
+        );
+    }
+
+    /// Go parity: lens schema-migration blocks (`lens` / `modules` /
+    /// `wasmBytes` / `chunks`) must be served to any peer in Controlled
+    /// mode — they carry no user data and have to propagate so schema
+    /// migrations converge across the network.
+    #[tokio::test]
+    async fn lens_config_block_is_served_without_registry_check() {
+        use defra_core::{build_lens_ipld_blocks, CidBlock};
+
+        let wasm = b"wasm-bytes-test-payload".to_vec();
+        let (_config_cid, blocks): (_, Vec<CidBlock>) =
+            build_lens_ipld_blocks(&wasm, false, &[]).unwrap();
+
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        for (cid, bytes) in &blocks {
+            store.put(*cid, bytes.clone());
+        }
+
+        let peer = PeerId::random();
+        for (cid, _) in &blocks {
+            let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, cid).await;
+            assert!(
+                allowed,
+                "lens block at {cid} must be served without replicator trust"
+            );
+        }
     }
 }

--- a/crates/p2p/src/bitswap/mod.rs
+++ b/crates/p2p/src/bitswap/mod.rs
@@ -24,9 +24,11 @@
 //! missing DAG links and fetches them via Bitswap.
 
 mod access;
+mod filter;
 mod registry;
 mod store;
 
 pub use access::AccessMode;
+pub use filter::make_peer_block_access_filter;
 pub use registry::ReplicatorRegistry;
 pub use store::BitswapStoreAdapter;

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use crate::behaviour::DefraBehaviour;
-use crate::bitswap::ReplicatorRegistry;
+use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::{Error, Result};
 use crate::message::PushLogReply;
 use crate::two_stream::{TwoStreamHandler, TwoStreamRunner};
@@ -54,6 +54,10 @@ pub struct P2PHostConfig {
     pub max_connections_out: u32,
     /// Max connections per peer. Default: 4.
     pub max_connections_per_peer: u32,
+    /// Bitswap egress access control. When `Controlled`, served blocks
+    /// are filtered per-peer against the shared `ReplicatorRegistry`,
+    /// matching Go's `WithPeerBlockRequestFilter` wiring. Default: `Open`.
+    pub access_mode: AccessMode,
 }
 
 impl Default for P2PHostConfig {
@@ -68,6 +72,7 @@ impl Default for P2PHostConfig {
             max_connections_in: 100,
             max_connections_out: 400,
             max_connections_per_peer: 4,
+            access_mode: AccessMode::Open,
         }
     }
 }
@@ -101,7 +106,7 @@ pub struct P2PHost<S: Store> {
     pub(super) peer_identities: HashMap<PeerId, identity::Did>,
 }
 
-impl<S: Store> P2PHost<S> {
+impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
     /// Create a new P2P host with a generated identity and the given blockstore.
     ///
     /// # Arguments
@@ -214,12 +219,19 @@ impl<S: Store> P2PHost<S> {
 
         info!("Local peer ID: {}", local_peer_id);
 
+        // Replicator registry is constructed up-front because the Bitswap
+        // access filter (installed at behaviour construction time) needs
+        // the same Arc that SyncCoordinator will later populate.
+        let replicators = Arc::new(ReplicatorRegistry::new());
+
         // Pass keypair and blockstore to behaviour for message signing and block exchange
         let mut behaviour = DefraBehaviour::new(
             local_peer_id,
             local_public_key,
             keypair.clone(),
             bitswap_store,
+            config.access_mode,
+            Arc::clone(&replicators),
             config.enable_pubsub,
             &config,
         )
@@ -269,9 +281,6 @@ impl<S: Store> P2PHost<S> {
             local_peer_id,
             keypair.clone(),
         );
-
-        // Create the replicator registry for access control
-        let replicators = Arc::new(ReplicatorRegistry::new());
 
         // Set up two-stream protocol for Go compatibility
         let mut control = swarm.behaviour().stream.new_control();

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -53,17 +53,15 @@ pub(super) async fn handle_command(
             addrs,
             reply,
         } => {
-            let result = handle_dial(
+            let ctx = DialContext {
                 endpoint,
                 peer_map,
                 pending_pushlog_replies,
                 subscriptions,
                 spawned_tasks,
-                &peer_id,
-                addrs,
                 event_tx,
-            )
-            .await;
+            };
+            let result = handle_dial(&ctx, &peer_id, addrs).await;
             let _ = reply.send(result);
         }
         IrohCommand::Listen { addr: _, reply } => {
@@ -480,21 +478,35 @@ pub(super) async fn handle_command(
     false
 }
 
+/// Shared dispatcher state borrowed into `handle_dial`.
+///
+/// Bundled into a struct so the function signature stays under clippy's
+/// `too_many_arguments` threshold and to make the call site's intent —
+/// "dial this peer, using the usual endpoint context" — explicit.
+struct DialContext<'a> {
+    endpoint: &'a Endpoint,
+    peer_map: &'a Arc<parking_lot::Mutex<PeerMap>>,
+    pending_pushlog_replies:
+        &'a Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    subscriptions: &'a HashMap<String, TopicSubscription>,
+    spawned_tasks: &'a SpawnedTasks,
+    event_tx: &'a mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
+}
+
 /// Dial a peer by EndpointId.
 ///
 /// Keeps the connection alive by spawning a stream handler task.
 async fn handle_dial(
-    endpoint: &Endpoint,
-    peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
-    pending_pushlog_replies: &Arc<
-        parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>,
-    >,
-    subscriptions: &HashMap<String, TopicSubscription>,
-    spawned_tasks: &SpawnedTasks,
+    ctx: &DialContext<'_>,
     peer_id: &PeerId,
     addrs: Vec<PeerAddr>,
-    event_tx: &mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 ) -> crate::error::Result<()> {
+    let endpoint = ctx.endpoint;
+    let peer_map = ctx.peer_map;
+    let pending_pushlog_replies = ctx.pending_pushlog_replies;
+    let subscriptions = ctx.subscriptions;
+    let spawned_tasks = ctx.spawned_tasks;
+    let event_tx = ctx.event_tx;
     let endpoint_id = parse_endpoint_id(peer_id)?;
     let endpoint_addr = endpoint_addr_from_parts(peer_id, &addrs)?;
 

--- a/crates/p2p/tests/bitswap_acp_filter_tests.rs
+++ b/crates/p2p/tests/bitswap_acp_filter_tests.rs
@@ -5,7 +5,6 @@
 //! issues Bitswap WANTs from the consumer for both allowed and denied
 //! block/peer pairs.
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use defra_core::{Block as DefraBlock, CompositeDeltaPayload, CrdtDelta};
@@ -340,7 +339,7 @@ async fn open_mode_serves_all_peers() {
 
     // Producer in Open mode should serve the block regardless of registry
     // state. Matches the pre-#830 default / AccessMode::Open contract.
-    let (producer, producer_handle, _producer_events, producer_replicators) =
+    let (producer, producer_handle, _producer_events, _producer_replicators) =
         P2PHost::with_config(producer_store, P2PHostConfig::default())
             .await
             .unwrap();
@@ -367,10 +366,6 @@ async fn open_mode_serves_all_peers() {
         .unwrap();
     wait_connected(&consumer_handle, producer_peer).await;
     wait_connected(&producer_handle, consumer_peer).await;
-
-    // No registry entries.
-    let _ = Arc::clone(&producer_replicators);
-    let _ = consumer_peer; // silence unused in Open path
 
     let query = consumer_handle
         .bitswap_sync(cid, vec![producer_peer], vec![cid])

--- a/crates/p2p/tests/bitswap_acp_filter_tests.rs
+++ b/crates/p2p/tests/bitswap_acp_filter_tests.rs
@@ -254,6 +254,83 @@ async fn controlled_mode_denies_replicator_for_other_collection() {
     producer_handle.shutdown().await.ok();
 }
 
+/// Live Go interop sibling of `controlled_mode_denies_unregistered_bitswap_peer`.
+///
+/// Proves that Go DefraDB's `hasAccess` filter (`go-p2p/peer.go:200-211`)
+/// and Rust's new `make_peer_block_access_filter` agree on the "deny
+/// unauthorized peer" case. Skipped by default — run against a Go defradb
+/// instance configured with ACP and at least one stored block:
+///
+/// ```sh
+/// defradb start --development --store memory \
+///   --p2paddr /ip4/127.0.0.1/tcp/9391 --url 127.0.0.1:9392 \
+///   --no-keyring --no-signing --rootdir /tmp/defradb-go-data &
+///
+/// # Apply an ACP policy + schema, add a document (see #828 live test).
+/// # Then export a CID from the Go node's blockstore to fetch:
+/// export DEFRADB_GO_PEER=/ip4/127.0.0.1/tcp/9391/p2p/12D3KooW...
+/// export DEFRADB_GO_BLOCK_CID=bafyrei...
+/// cargo test -p p2p --test bitswap_acp_filter_tests \
+///   -- --ignored --nocapture bitswap_unauthorized_against_go_defradb
+/// ```
+///
+/// Expected: Go rejects the Bitswap WANT (no block received in 5s) because
+/// our Rust peer is not registered as a replicator for the owning
+/// collection — the same deny behavior this PR now implements in Rust.
+#[tokio::test]
+#[ignore = "requires a pre-running Go defradb with DEFRADB_GO_PEER / DEFRADB_GO_BLOCK_CID set"]
+async fn bitswap_unauthorized_against_go_defradb() {
+    let peer_addr = std::env::var("DEFRADB_GO_PEER")
+        .expect("DEFRADB_GO_PEER must be set to the Go peer multiaddr");
+    let block_cid_str = std::env::var("DEFRADB_GO_BLOCK_CID")
+        .expect("DEFRADB_GO_BLOCK_CID must be set to a CID owned by an ACP'd collection");
+
+    let store = MockBitswapStore::new();
+    let (host, handle, mut events, _replicators) =
+        P2PHost::with_config(store, P2PHostConfig::default())
+            .await
+            .unwrap();
+    tokio::spawn(host.run());
+
+    handle
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+
+    let multi: libp2p::Multiaddr = peer_addr.parse().expect("parse multiaddr");
+    let mut go_peer: Option<libp2p::PeerId> = None;
+    let mut stripped = libp2p::Multiaddr::empty();
+    for proto in multi.iter() {
+        match proto {
+            libp2p::multiaddr::Protocol::P2p(pid) => go_peer = Some(pid),
+            other => stripped.push(other),
+        }
+    }
+    let go_peer = go_peer.expect("multiaddr missing /p2p/<peer>");
+
+    handle.dial(go_peer, vec![stripped]).await.unwrap();
+    wait_connected(&handle, go_peer).await;
+    eprintln!("connected to Go peer {go_peer}");
+
+    let cid: cid::Cid = block_cid_str.parse().expect("parse DEFRADB_GO_BLOCK_CID");
+    let query = handle
+        .bitswap_sync(cid, vec![go_peer], vec![cid])
+        .await
+        .unwrap();
+
+    let (got_block, completed_success) =
+        drain_until_complete(&mut events, query, Duration::from_secs(5)).await;
+
+    eprintln!("got_block={got_block} completed_success={completed_success}");
+    assert!(
+        !got_block,
+        "Go must not serve ACP-protected block to an unregistered Rust peer"
+    );
+
+    let _ = handle.bitswap_cancel(query).await;
+    handle.shutdown().await.ok();
+}
+
 #[tokio::test]
 async fn open_mode_serves_all_peers() {
     let (cid, bytes) = make_data_block(COLLECTION_USERS, b"alice");

--- a/crates/p2p/tests/bitswap_acp_filter_tests.rs
+++ b/crates/p2p/tests/bitswap_acp_filter_tests.rs
@@ -1,0 +1,310 @@
+//! End-to-end tests for per-peer Bitswap access control (#830).
+//!
+//! Spins up two real `P2PHost` instances over loopback TCP with the
+//! `make_peer_block_access_filter` installed at the producer side, then
+//! issues Bitswap WANTs from the consumer for both allowed and denied
+//! block/peer pairs.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use defra_core::{Block as DefraBlock, CompositeDeltaPayload, CrdtDelta};
+use p2p::testutil::MockBitswapStore;
+use p2p::{bitswap::AccessMode, HostEvent, P2PHost, P2PHostConfig};
+use tokio::time::timeout;
+
+const COLLECTION_USERS: &str = "bafyusers";
+const COLLECTION_POSTS: &str = "bafyposts";
+
+fn make_data_block(collection_id: &str, doc_id: &[u8]) -> (cid::Cid, Vec<u8>) {
+    let payload = CompositeDeltaPayload {
+        doc_id: doc_id.to_vec(),
+        priority: 1,
+        schema_version_id: collection_id.to_string(),
+        status: 1,
+    };
+    let delta = CrdtDelta::Composite(payload);
+    let block = DefraBlock::new(delta, Vec::new(), Vec::new());
+    let bytes = block.to_dag_cbor().unwrap();
+    let cid = defra_core::block::generate_cid_from_bytes(&bytes).unwrap();
+    (cid, bytes)
+}
+
+async fn wait_connected(handle: &p2p::P2PHostHandle, target: libp2p::PeerId) {
+    let start = std::time::Instant::now();
+    while !handle
+        .connected_peers()
+        .await
+        .unwrap_or_default()
+        .contains(&target)
+    {
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "timed out waiting to connect to {target}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn controlled_config() -> P2PHostConfig {
+    P2PHostConfig {
+        access_mode: AccessMode::Controlled,
+        ..P2PHostConfig::default()
+    }
+}
+
+async fn drain_until_complete(
+    events: &mut tokio::sync::mpsc::Receiver<HostEvent>,
+    query: p2p::QueryId,
+    wait: Duration,
+) -> (bool, bool) {
+    // Returns (received_block, completed_success).
+    let deadline = std::time::Instant::now() + wait;
+    let mut got_block = false;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return (got_block, false);
+        }
+        match timeout(remaining, events.recv()).await {
+            Ok(Some(HostEvent::BitswapBlockReceived { query_id, .. })) if query_id == query => {
+                got_block = true;
+            }
+            Ok(Some(HostEvent::BitswapComplete {
+                query_id, success, ..
+            })) if query_id == query => {
+                return (got_block, success);
+            }
+            Ok(Some(_)) => continue,
+            Ok(None) | Err(_) => return (got_block, false),
+        }
+    }
+}
+
+#[tokio::test]
+async fn controlled_mode_denies_unregistered_bitswap_peer() {
+    let (cid, bytes) = make_data_block(COLLECTION_USERS, b"alice");
+
+    let producer_store = MockBitswapStore::new().with_block(cid, bytes);
+    let consumer_store = MockBitswapStore::new();
+
+    let (producer, producer_handle, _producer_events, producer_replicators) =
+        P2PHost::with_config(producer_store, controlled_config())
+            .await
+            .unwrap();
+    let (consumer, consumer_handle, mut consumer_events, _consumer_replicators) =
+        P2PHost::with_config(consumer_store, controlled_config())
+            .await
+            .unwrap();
+
+    let producer_peer = producer.local_peer_id();
+    let consumer_peer = consumer.local_peer_id();
+
+    tokio::spawn(producer.run());
+    tokio::spawn(consumer.run());
+
+    producer_handle
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let producer_addr = producer_handle.listen_addresses().await.unwrap().remove(0);
+
+    consumer_handle
+        .dial(producer_peer, vec![producer_addr])
+        .await
+        .unwrap();
+    wait_connected(&consumer_handle, producer_peer).await;
+    wait_connected(&producer_handle, consumer_peer).await;
+
+    // Explicitly leave the consumer out of the producer's replicator
+    // registry — the filter must deny.
+    assert!(!producer_replicators.is_replicator(COLLECTION_USERS, &consumer_peer.to_string()));
+
+    let query = consumer_handle
+        .bitswap_sync(cid, vec![producer_peer], vec![cid])
+        .await
+        .unwrap();
+
+    let (got_block, completed_success) =
+        drain_until_complete(&mut consumer_events, query, Duration::from_secs(2)).await;
+
+    assert!(
+        !got_block,
+        "Bitswap must not deliver a block to an unregistered peer in Controlled mode"
+    );
+    assert!(
+        !completed_success,
+        "Bitswap sync must not report success without delivering the block"
+    );
+    let _ = consumer_handle.bitswap_cancel(query).await;
+
+    consumer_handle.shutdown().await.ok();
+    producer_handle.shutdown().await.ok();
+}
+
+#[tokio::test]
+async fn controlled_mode_serves_registered_replicator() {
+    let (cid, bytes) = make_data_block(COLLECTION_USERS, b"alice");
+
+    let producer_store = MockBitswapStore::new().with_block(cid, bytes);
+    let consumer_store = MockBitswapStore::new();
+
+    let (producer, producer_handle, _producer_events, producer_replicators) =
+        P2PHost::with_config(producer_store, controlled_config())
+            .await
+            .unwrap();
+    let (consumer, consumer_handle, mut consumer_events, _consumer_replicators) =
+        P2PHost::with_config(consumer_store, controlled_config())
+            .await
+            .unwrap();
+
+    let producer_peer = producer.local_peer_id();
+    let consumer_peer = consumer.local_peer_id();
+
+    tokio::spawn(producer.run());
+    tokio::spawn(consumer.run());
+
+    producer_handle
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let producer_addr = producer_handle.listen_addresses().await.unwrap().remove(0);
+
+    consumer_handle
+        .dial(producer_peer, vec![producer_addr])
+        .await
+        .unwrap();
+    wait_connected(&consumer_handle, producer_peer).await;
+    wait_connected(&producer_handle, consumer_peer).await;
+
+    // Register the consumer as an authorized replicator for the block's
+    // collection on the producer side.
+    producer_replicators.add_replicator(COLLECTION_USERS, &consumer_peer.to_string());
+
+    let query = consumer_handle
+        .bitswap_sync(cid, vec![producer_peer], vec![cid])
+        .await
+        .unwrap();
+
+    let (got_block, completed_success) =
+        drain_until_complete(&mut consumer_events, query, Duration::from_secs(5)).await;
+
+    assert!(got_block, "registered replicator must receive the block");
+    assert!(completed_success, "sync must complete successfully");
+
+    consumer_handle.shutdown().await.ok();
+    producer_handle.shutdown().await.ok();
+}
+
+#[tokio::test]
+async fn controlled_mode_denies_replicator_for_other_collection() {
+    let (cid, bytes) = make_data_block(COLLECTION_USERS, b"alice");
+
+    let producer_store = MockBitswapStore::new().with_block(cid, bytes);
+    let consumer_store = MockBitswapStore::new();
+
+    let (producer, producer_handle, _producer_events, producer_replicators) =
+        P2PHost::with_config(producer_store, controlled_config())
+            .await
+            .unwrap();
+    let (consumer, consumer_handle, mut consumer_events, _consumer_replicators) =
+        P2PHost::with_config(consumer_store, controlled_config())
+            .await
+            .unwrap();
+
+    let producer_peer = producer.local_peer_id();
+    let consumer_peer = consumer.local_peer_id();
+
+    tokio::spawn(producer.run());
+    tokio::spawn(consumer.run());
+
+    producer_handle
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let producer_addr = producer_handle.listen_addresses().await.unwrap().remove(0);
+
+    consumer_handle
+        .dial(producer_peer, vec![producer_addr])
+        .await
+        .unwrap();
+    wait_connected(&consumer_handle, producer_peer).await;
+    wait_connected(&producer_handle, consumer_peer).await;
+
+    // Authorize the consumer for a DIFFERENT collection than the one the
+    // requested block belongs to.
+    producer_replicators.add_replicator(COLLECTION_POSTS, &consumer_peer.to_string());
+
+    let query = consumer_handle
+        .bitswap_sync(cid, vec![producer_peer], vec![cid])
+        .await
+        .unwrap();
+
+    let (got_block, completed_success) =
+        drain_until_complete(&mut consumer_events, query, Duration::from_secs(2)).await;
+
+    assert!(
+        !got_block,
+        "replicator for collection A must not fetch blocks from collection B"
+    );
+    assert!(!completed_success);
+    let _ = consumer_handle.bitswap_cancel(query).await;
+
+    consumer_handle.shutdown().await.ok();
+    producer_handle.shutdown().await.ok();
+}
+
+#[tokio::test]
+async fn open_mode_serves_all_peers() {
+    let (cid, bytes) = make_data_block(COLLECTION_USERS, b"alice");
+
+    let producer_store = MockBitswapStore::new().with_block(cid, bytes);
+    let consumer_store = MockBitswapStore::new();
+
+    // Producer in Open mode should serve the block regardless of registry
+    // state. Matches the pre-#830 default / AccessMode::Open contract.
+    let (producer, producer_handle, _producer_events, producer_replicators) =
+        P2PHost::with_config(producer_store, P2PHostConfig::default())
+            .await
+            .unwrap();
+    let (consumer, consumer_handle, mut consumer_events, _consumer_replicators) =
+        P2PHost::with_config(consumer_store, P2PHostConfig::default())
+            .await
+            .unwrap();
+
+    let producer_peer = producer.local_peer_id();
+    let consumer_peer = consumer.local_peer_id();
+
+    tokio::spawn(producer.run());
+    tokio::spawn(consumer.run());
+
+    producer_handle
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let producer_addr = producer_handle.listen_addresses().await.unwrap().remove(0);
+
+    consumer_handle
+        .dial(producer_peer, vec![producer_addr])
+        .await
+        .unwrap();
+    wait_connected(&consumer_handle, producer_peer).await;
+    wait_connected(&producer_handle, consumer_peer).await;
+
+    // No registry entries.
+    let _ = Arc::clone(&producer_replicators);
+    let _ = consumer_peer; // silence unused in Open path
+
+    let query = consumer_handle
+        .bitswap_sync(cid, vec![producer_peer], vec![cid])
+        .await
+        .unwrap();
+
+    let (got_block, completed_success) =
+        drain_until_complete(&mut consumer_events, query, Duration::from_secs(5)).await;
+    assert!(got_block, "Open mode must serve blocks to any peer");
+    assert!(completed_success);
+
+    consumer_handle.shutdown().await.ok();
+    producer_handle.shutdown().await.ok();
+}


### PR DESCRIPTION
## Summary

Closes #830.

Without a filter, a node running in `AccessMode::Controlled` still served every stored block to any connected peer via Bitswap, bypassing the `ReplicatorRegistry` that gates ingress. Any libp2p-connectable peer could fetch collection ciphertext and probe block existence.

This PR wires a per-peer block-request filter at Bitswap construction, mirroring Go's `bitswap.WithPeerBlockRequestFilter(hasAccess)` in `go-p2p/peer.go:146`. The filter reads the requested block, decodes its `collectionVersionID`, and authorizes the requesting peer against the same `ReplicatorRegistry` that `SyncCoordinator` uses.

### Decision flow (`crates/p2p/src/bitswap/filter.rs`)

| Condition                    | Result |
|------------------------------|--------|
| `AccessMode::Open`           | allow  |
| block missing from store     | deny (also avoids existence leak) |
| decodes as `Signature`       | allow (needed to verify sibling blocks) |
| definition-delta block       | allow (schema/collection defs broadcast to all) |
| data-delta block             | allow iff `registry.is_replicator(collection, peer)` |
| decode failure / other       | deny |

### Surface changes

- `crates/p2p/src/bitswap/filter.rs` — new module + 6 unit tests
- `crates/p2p/tests/bitswap_acp_filter_tests.rs` — 4 end-to-end tests over real libp2p/TCP plus 1 `#[ignore]`'d live Go interop test
- `P2PHostConfig` gains `access_mode: AccessMode` (default `Open`); CLI derives it from `config.acp.document_type` identically to `SyncCoordinator`
- `DefraBehaviour::new` signature now accepts `access_mode` + `Arc<ReplicatorRegistry>`
- `bitswap/access.rs` doc comment rewritten to reflect the egress filter
- `iroh/endpoint_commands.rs::handle_dial` args bundled into a `DialContext` struct (drive-by fix for a pre-existing `clippy::too_many_arguments` regression on main that would otherwise block the lint job)

### Upstream dependency

iroh-bitswap's `PeerBlockRequestFilter` trait was synchronous; the Rust check needs an async blockstore read. The beetle-side change (sourcenetwork/beetle#2) has been merged and `Cargo.toml` points back at `sourcenetwork/beetle` main.

## Test plan

- [x] `cargo test -p p2p` → 283 tests pass (157 lib + 126 integration, including the 4 new end-to-end tests; 1 live Go interop test ignored by default)
- [x] `cargo clippy --all -- -D warnings` → clean
- [x] `cargo build -p cli --features iroh` → clean
- [x] `cargo test -p integration-test --test p2p -- --test-threads=1 rust_rust_` → 12 pass (3 resilience-only ignored)
- [x] `cargo test -p integration-test --test p2p -- --test-threads=1 go_` → 21 pass (8 pre-existing ignored cases unchanged)
- [x] `cargo test -p integration-test --test basic -- --skip ::go_` → 12 pass
- [x] `cargo test -p integration-test --test acp -- --skip ::go_` → 105 pass
- [x] **Live Go-Rust parity proof**: ran `bitswap_unauthorized_against_go_defradb` against a real Go defradb v1.0.0-rc1 instance with `--document-acp-type local` serving an ACP-protected User document:
  ```
  connected to Go peer 12D3KooWJn3HaMEjzWDmEXRop1ierA7C5pv61Tvn4ucKgZm6dHdd
  got_block=false completed_success=false
  test bitswap_unauthorized_against_go_defradb ... ok
  ```
  Go denied the Bitswap WANT from the unregistered Rust peer — matching the deny behavior this PR now implements on the Rust side.