### PR TITLE
fix(crypto): harden parity hygiene (#850)

### DIFF
--- a/crates/crypto/src/encryption/aes.rs
+++ b/crates/crypto/src/encryption/aes.rs
@@ -142,7 +142,7 @@ pub fn decrypt_aes(
     // Decrypt
     let plaintext = cipher
         .decrypt(nonce, payload)
-        .map_err(|e| crate::error::crypto_error(format!("decryption failed: {:?}", e)))?;
+        .map_err(|_| crate::error::crypto_error("decryption failed"))?;
 
     Ok(plaintext)
 }

--- a/crates/crypto/src/encryption/ecies.rs
+++ b/crates/crypto/src/encryption/ecies.rs
@@ -19,6 +19,8 @@ use crate::error::{
 };
 use crate::types::{AES_KEY_SIZE, HMAC_KEY_SIZE, HMAC_SIZE, X25519_PUBLIC_KEY_SIZE};
 
+const MIN_CIPHER_TEXT_SIZE: usize = 16;
+
 /// Options for ECIES encryption/decryption
 #[derive(Default)]
 pub struct EciesOptions {
@@ -222,6 +224,13 @@ pub fn decrypt_ecies(
         )));
     }
     let (encrypted_data, received_mac) = remaining.split_at(remaining.len() - HMAC_SIZE);
+    if encrypted_data.len() < MIN_CIPHER_TEXT_SIZE {
+        return Err(crypto_error(format!(
+            "ciphertext too short: encrypted payload is {} bytes, expected at least {} bytes",
+            encrypted_data.len(),
+            MIN_CIPHER_TEXT_SIZE
+        )));
+    }
 
     // 3. ECDH: compute shared secret
     let shared_secret = private_key.diffie_hellman(&ephemeral_public);

--- a/crates/crypto/src/keys/generation.rs
+++ b/crates/crypto/src/keys/generation.rs
@@ -188,18 +188,7 @@ pub fn private_key_from_bytes(key_type: KeyType, bytes: &[u8]) -> Result<Box<dyn
 /// # Returns
 /// A boxed private key implementing the PrivateKey trait
 pub fn private_key_from_string(key_type: KeyType, hex_str: &str) -> Result<Box<dyn PrivateKey>> {
-    let bytes = hex::decode(hex_str).map_err(|e| {
-        let preview = if hex_str.len() > 64 {
-            format!(
-                "{}...(truncated, length: {})",
-                &hex_str[..64],
-                hex_str.len()
-            )
-        } else {
-            hex_str.to_string()
-        };
-        crypto_error(format!("invalid hex string: {}, input: {}", e, preview))
-    })?;
+    let bytes = hex::decode(hex_str).map_err(|_| crypto_error("invalid private key hex format"))?;
     private_key_from_bytes(key_type, &bytes)
 }
 

--- a/crates/crypto/src/keys/secp256r1.rs
+++ b/crates/crypto/src/keys/secp256r1.rs
@@ -130,7 +130,7 @@ pub struct Secp256r1PublicKey {
 
 impl PartialEq for Secp256r1PublicKey {
     fn eq(&self, other: &Self) -> bool {
-        self.key == other.key
+        self.raw_bytes.ct_eq(&other.raw_bytes).into()
     }
 }
 

--- a/crates/crypto/tests/aes_tests.rs
+++ b/crates/crypto/tests/aes_tests.rs
@@ -50,7 +50,8 @@ fn test_decrypt_with_wrong_key_fails() {
 
     let (ciphertext, nonce) = encrypt_aes(plaintext, &key1, &[], false).unwrap();
     let result = decrypt_aes(Some(&nonce), &ciphertext, &key2, &[]);
-    assert!(result.is_err());
+    let error = result.expect_err("wrong key should fail");
+    assert_eq!(error.to_string(), "crypto error: decryption failed");
 }
 
 #[test]

--- a/crates/crypto/tests/ecies_tests.rs
+++ b/crates/crypto/tests/ecies_tests.rs
@@ -222,6 +222,23 @@ fn test_ecies_ciphertext_only_public_key_no_data() {
 }
 
 #[test]
+fn test_ecies_rejects_payload_below_go_min_ciphertext_size() {
+    let private_key = generate_x25519().unwrap();
+    let mut malformed_ct = vec![0u8; X25519_PUBLIC_KEY_SIZE];
+    malformed_ct.push(1);
+    malformed_ct.extend_from_slice(&[0u8; HMAC_SIZE]);
+
+    let options = EciesOptions::builder().prepend_public_key(true).build();
+    let error = decrypt_ecies(&malformed_ct, &private_key, options)
+        .expect_err("payload smaller than Go minCipherTextSize must fail");
+
+    assert!(
+        error.to_string().contains("encrypted payload is 1 bytes"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn test_ecies_ciphertext_no_hmac() {
     let private_key = generate_x25519().unwrap();
 

--- a/crates/crypto/tests/go_compat_p256.rs
+++ b/crates/crypto/tests/go_compat_p256.rs
@@ -124,6 +124,18 @@ fn test_rust_verifier_accepts_go_high_s_signature() {
 }
 
 #[test]
+fn test_public_key_equality_uses_raw_key_bytes() {
+    let private_key = Secp256r1PrivateKey::from_bytes(&PRIVATE_KEY).expect("valid private key");
+    let public_key = private_key.to_public_key();
+    let same_key =
+        Secp256r1PublicKey::from_bytes(&PUBLIC_KEY_COMPRESSED).expect("valid public key");
+    let other_private = Secp256r1PrivateKey::from_bytes(&[0x02; 32]).expect("valid private key");
+
+    assert_eq!(public_key, same_key);
+    assert_ne!(public_key, other_private.to_public_key());
+}
+
+#[test]
 fn test_go_sig_has_high_s_value() {
     // Document that the Go test vector actually has high-S (S > N/2).
     let s = extract_s_from_der(GO_SIG_HIGH_S);

--- a/crates/crypto/tests/keys_tests.rs
+++ b/crates/crypto/tests/keys_tests.rs
@@ -146,6 +146,20 @@ fn test_private_key_from_string_invalid_hex() {
 }
 
 #[test]
+fn test_private_key_from_string_invalid_hex_does_not_echo_input() {
+    let secret_like_input = "abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdzz";
+    let error = match private_key_from_string(KeyType::Secp256k1, secret_like_input) {
+        Ok(_) => panic!("invalid hex should fail"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+
+    assert!(!message.contains(secret_like_input));
+    assert!(!message.contains("abcdabcd"));
+    assert_eq!(message, "crypto error: invalid private key hex format");
+}
+
+#[test]
 fn test_public_key_from_string_invalid_hex() {
     // Invalid hex characters
     let result = public_key_from_string(KeyType::Ed25519, "gggggggg");


### PR DESCRIPTION
## Summary

Closes #850. Bundles four small crypto hardening fixes from the parity review: enforce ECIES minimum ciphertext size, return a constant AES-GCM decrypt error, make Secp256r1 public-key equality constant-time, and stop echoing private-key hex input on parse failure.

## Why

These are individually small hygiene issues, but together they tighten crypto error surfaces and bring Rust behavior closer to the intended parity/security posture. The fixes avoid leaking unnecessary error/input detail, align Secp256r1 with the other key types, and reject undersized ECIES payloads before decrypt.

## Changes

| File | Change |
|---|---|
| `crates/crypto/src/encryption/ecies.rs` | Add `MIN_CIPHER_TEXT_SIZE = 16` and reject encrypted payloads below that size before AES-GCM decrypt. |
| `crates/crypto/src/encryption/aes.rs` | Replace formatted AES-GCM inner decrypt errors with a constant `decryption failed` message. |
| `crates/crypto/src/keys/secp256r1.rs` | Make `Secp256r1PublicKey::PartialEq` compare raw bytes with `ct_eq`. |
| `crates/crypto/src/keys/generation.rs` | Replace private-key hex decode errors that echoed input with a generic parse error. |
| `crates/crypto/tests/*` | Add regression coverage for ECIES minimum size, AES error shape, Secp256r1 equality, and private-key hex error redaction. |

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p crypto`
- [x] `cargo clippy -p crypto -p p2p -p defra-p2p-adapter --all-targets -- -D warnings`
