### PR TITLE
fix(p2p): serialize duplicate CID merges (#839)

### DIFF
--- a/crates/p2p/src/sync/manager/process/mod.rs
+++ b/crates/p2p/src/sync/manager/process/mod.rs
@@ -140,6 +140,11 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             .map_err(|e| crate::error::Error::BlockstoreError(e.to_string()))
     }
 
+    /// Get the process queue used to serialize work for the same CID.
+    pub(crate) fn process_queue(&self) -> ProcessQueue {
+        self.process_queue.clone()
+    }
+
     /// Get all unmerged block CIDs.
     pub async fn get_unmerged(&self) -> crate::error::Result<Vec<Cid>> {
         self.blockstore

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -290,6 +290,104 @@ pub(super) fn is_mergeable_event(event: &SyncEvent) -> bool {
     }
 }
 
+fn event_merge_cid(event: &SyncEvent) -> Option<Cid> {
+    match event {
+        SyncEvent::BlockReceived { cid, .. } => Some(*cid),
+        SyncEvent::DagReady { root_cid, .. } => Some(*root_cid),
+        _ => None,
+    }
+}
+
+async fn skipped_if_already_merged<B, T>(
+    coordinator: &SyncCoordinator<B, T>,
+    event: &SyncEvent,
+    cid: Cid,
+) -> Option<ReplicationResult>
+where
+    B: Blockstore + 'static,
+    T: P2PTransport,
+{
+    match coordinator.manager().is_merged(&cid).await {
+        Ok(false) => None,
+        Ok(true) => match event {
+            SyncEvent::BlockReceived {
+                doc_id,
+                collection_id,
+                creator,
+                acp_actor_relationships,
+                ..
+            } => Some(
+                already_merged_result(
+                    coordinator,
+                    cid,
+                    doc_id,
+                    collection_id,
+                    creator,
+                    acp_actor_relationships.as_ref(),
+                )
+                .await,
+            ),
+            SyncEvent::DagReady {
+                root_cid,
+                doc_id,
+                collection_id,
+                creator,
+                acp_actor_relationships,
+                ..
+            } => {
+                coordinator.clear_pending_dag(root_cid);
+                Some(
+                    already_merged_result(
+                        coordinator,
+                        cid,
+                        doc_id,
+                        collection_id,
+                        creator,
+                        acp_actor_relationships.as_ref(),
+                    )
+                    .await,
+                )
+            }
+            _ => None,
+        },
+        Err(error) => Some(ReplicationResult::Failed {
+            cid,
+            error: error.to_string(),
+        }),
+    }
+}
+
+async fn already_merged_result<B, T>(
+    coordinator: &SyncCoordinator<B, T>,
+    cid: Cid,
+    doc_id: &str,
+    collection_id: &str,
+    creator: &str,
+    acp_actor_relationships: Option<&ReplicatedDocActorRelationships>,
+) -> ReplicationResult
+where
+    B: Blockstore + 'static,
+    T: P2PTransport,
+{
+    if let Err(error) = coordinator
+        .apply_replicated_actor_relationships(doc_id, Some(creator), acp_actor_relationships)
+        .await
+    {
+        return ReplicationResult::Failed {
+            cid,
+            error: error.to_string(),
+        };
+    }
+
+    ReplicationResult::Skipped {
+        cid,
+        doc_id: doc_id.to_string(),
+        collection_id: collection_id.to_string(),
+        reason: "already merged".to_string(),
+        terminal: true,
+    }
+}
+
 /// Extract merge block metadata from a SyncEvent.
 fn event_to_merge_metadata(
     event: &SyncEvent,
@@ -600,4 +698,69 @@ where
             .await
         }
     }
+}
+
+/// Process a sync event after acquiring the CID-level merge guard.
+pub(super) async fn process_event_serialized<B, T, H>(
+    coordinator: &SyncCoordinator<B, T>,
+    event: SyncEvent,
+    handler: &H,
+    config: &ReplicationConfig,
+) -> ReplicationResult
+where
+    B: Blockstore + 'static,
+    T: P2PTransport,
+    H: MergeHandler + ?Sized + 'static,
+{
+    let Some(cid) = event_merge_cid(&event) else {
+        return process_event(coordinator, event, handler, config).await;
+    };
+
+    loop {
+        match coordinator
+            .manager()
+            .process_queue()
+            .try_acquire(&cid)
+            .await
+        {
+            Ok(_guard) => return process_event(coordinator, event, handler, config).await,
+            Err(wait_for_current_merge) => {
+                if wait_for_current_merge.await.is_err() {
+                    tracing::debug!(
+                        cid = %cid,
+                        "CID merge guard owner was cancelled; checking merge status"
+                    );
+                }
+                if let Some(result) = skipped_if_already_merged(coordinator, &event, cid).await {
+                    return result;
+                }
+            }
+        }
+    }
+}
+
+pub(super) async fn process_events_individually<B, T, H>(
+    coordinator: &SyncCoordinator<B, T>,
+    events: Vec<SyncEvent>,
+    handler: &H,
+    config: &ReplicationConfig,
+) -> Vec<ReplicationResult>
+where
+    B: Blockstore + 'static,
+    T: P2PTransport,
+    H: MergeHandler + ?Sized + 'static,
+{
+    let mut results = Vec::with_capacity(events.len());
+    for event in events {
+        results.push(process_event_serialized(coordinator, event, handler, config).await);
+    }
+    results
+}
+
+pub(super) fn has_duplicate_merge_cids(events: &[SyncEvent]) -> bool {
+    let mut seen = std::collections::HashSet::with_capacity(events.len());
+    events
+        .iter()
+        .filter_map(event_merge_cid)
+        .any(|cid| !seen.insert(cid))
 }

--- a/crates/p2p/src/sync/replication/loop_runner.rs
+++ b/crates/p2p/src/sync/replication/loop_runner.rs
@@ -24,7 +24,10 @@ use blockstore::Blockstore;
 use tokio::sync::{mpsc, Semaphore};
 
 use super::config::ReplicationConfig;
-use super::handlers::{is_mergeable_event, process_event, process_merge_batch};
+use super::handlers::{
+    has_duplicate_merge_cids, is_mergeable_event, process_event_serialized,
+    process_events_individually, process_merge_batch,
+};
 use super::result::ReplicationResult;
 use crate::sync::coordinator::SyncCoordinator;
 use crate::sync::manager::SyncEvent;
@@ -218,7 +221,7 @@ impl ReplicationLoop {
             let cb = on_result.clone();
 
             tokio::spawn(async move {
-                let result = process_event(&coord, event, h.as_ref(), &c).await;
+                let result = process_event_serialized(&coord, event, h.as_ref(), &c).await;
                 cb(result);
                 drop(permit);
             });
@@ -248,7 +251,7 @@ impl ReplicationLoop {
             None => return ReplicationResult::ChannelClosed,
         };
 
-        process_event(coordinator, event, handler, config).await
+        process_event_serialized(coordinator, event, handler, config).await
     }
 
     /// Process the next batch of sync events.
@@ -298,14 +301,21 @@ impl ReplicationLoop {
 
         // Process immediate events normally
         for event in immediate {
-            results.push(process_event(coordinator, event, handler, config).await);
+            results.push(process_event_serialized(coordinator, event, handler, config).await);
         }
 
         // Batch-process merge events
         if !merge_events.is_empty() {
-            tracing::debug!(batch_size = merge_events.len(), "Processing merge batch");
-            let batch_results =
-                process_merge_batch(coordinator, merge_events, handler, config).await;
+            let batch_results = if has_duplicate_merge_cids(&merge_events) {
+                tracing::debug!(
+                    batch_size = merge_events.len(),
+                    "Processing duplicate-CID merge batch individually"
+                );
+                process_events_individually(coordinator, merge_events, handler, config).await
+            } else {
+                tracing::debug!(batch_size = merge_events.len(), "Processing merge batch");
+                process_merge_batch(coordinator, merge_events, handler, config).await
+            };
             results.extend(batch_results);
         }
 
@@ -332,7 +342,8 @@ impl ReplicationLoop {
             match events.try_recv() {
                 Ok(event) => {
                     let result =
-                        process_event(&coordinator, event, handler.as_ref(), &config).await;
+                        process_event_serialized(&coordinator, event, handler.as_ref(), &config)
+                            .await;
                     results.push(result);
                 }
                 Err(mpsc::error::TryRecvError::Empty) => break,

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -87,6 +87,45 @@ mod tests {
         }
     }
 
+    struct SlowMergeHandler {
+        call_count: AtomicUsize,
+        in_flight: AtomicUsize,
+        max_in_flight: AtomicUsize,
+    }
+
+    impl SlowMergeHandler {
+        fn new() -> Self {
+            Self {
+                call_count: AtomicUsize::new(0),
+                in_flight: AtomicUsize::new(0),
+                max_in_flight: AtomicUsize::new(0),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.call_count.load(Ordering::SeqCst)
+        }
+
+        fn max_in_flight(&self) -> usize {
+            self.max_in_flight.load(Ordering::SeqCst)
+        }
+
+        fn record_in_flight(&self, current: usize) {
+            let mut observed = self.max_in_flight.load(Ordering::SeqCst);
+            while current > observed {
+                match self.max_in_flight.compare_exchange(
+                    observed,
+                    current,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => break,
+                    Err(next) => observed = next,
+                }
+            }
+        }
+    }
+
     #[derive(Debug)]
     struct TestError(String);
 
@@ -616,6 +655,25 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl MergeHandler for SlowMergeHandler {
+        type Error = TestError;
+
+        async fn handle_block(
+            &self,
+            _cid: &Cid,
+            _block_data: &[u8],
+            _metadata: BlockMetadata<'_>,
+        ) -> Result<MergeOutcome, Self::Error> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.record_in_flight(current);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(MergeOutcome::Merged)
+        }
+    }
+
     /// Batch-aware merge handler that tracks per-block and batch calls separately.
     struct BatchTestHandler {
         per_block_calls: AtomicUsize,
@@ -1074,6 +1132,92 @@ mod tests {
             0,
             "closed semaphore should stop the loop before any worker starts"
         );
+    }
+
+    #[tokio::test]
+    async fn test_run_parallel_serializes_duplicate_cids() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let cid = test_cid();
+        blockstore.put(&cid, b"test data").await.unwrap();
+
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore,
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+
+        let (tx, rx) = mpsc::channel(2);
+        for _ in 0..2 {
+            tx.send(SyncEvent::BlockReceived {
+                cid,
+                doc_id: "doc1".to_string(),
+                collection_id: "col1".to_string(),
+                creator: "peer1".to_string(),
+                sender_peer: Some("sender1".to_string()),
+                is_explicit_replicator: true,
+                explicit_replay_authorization: None,
+                acp_actor_relationships: None,
+            })
+            .await
+            .unwrap();
+        }
+        drop(tx);
+
+        let handler = Arc::new(SlowMergeHandler::new());
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+
+        ReplicationLoop::run_parallel_with_semaphore(
+            Arc::new(coordinator),
+            rx,
+            handler.clone(),
+            ReplicationConfig {
+                max_workers: 2,
+                ..Default::default()
+            },
+            move |result| {
+                let _ = result_tx.send(result);
+            },
+            Arc::new(Semaphore::new(2)),
+        )
+        .await;
+
+        let mut results = Vec::new();
+        for _ in 0..2 {
+            results.push(
+                tokio::time::timeout(Duration::from_secs(1), result_rx.recv())
+                    .await
+                    .expect("result should arrive")
+                    .expect("result channel should remain open"),
+            );
+        }
+
+        assert_eq!(handler.calls(), 1, "duplicate CID should merge once");
+        assert_eq!(
+            handler.max_in_flight(),
+            1,
+            "duplicate CID merges must not overlap"
+        );
+        assert!(results
+            .iter()
+            .any(|result| matches!(result, ReplicationResult::Merged { cid: c, .. } if *c == cid)));
+        assert!(results.iter().any(|result| {
+            matches!(
+                result,
+                ReplicationResult::Skipped {
+                    cid: c,
+                    terminal: true,
+                    reason,
+                    ..
+                } if *c == cid && reason == "already merged"
+            )
+        }));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Closes #839. Routes replication merge processing through the existing per-CID `ProcessQueue` so concurrent events for the same CID do not merge the same block in parallel.

## Why

`ReplicationLoop::run_parallel` could spawn multiple workers for the same block CID before the first merge completed. Go serializes this path through `processQueue`, and Rust already had the matching `ProcessQueue` primitive, but the replication loop was not using it.

Without this guard, duplicate in-flight `BlockReceived` / `DagReady` events can race in the merge layer, causing avoidable transaction conflicts and duplicate side effects around ACP relationship application.

## Changes

| File | Change |
|---|---|
| `crates/p2p/src/sync/manager/process/mod.rs` | Expose the existing `ProcessQueue` to replication handlers. |
| `crates/p2p/src/sync/replication/handlers.rs` | Add CID extraction, serialized event processing, duplicate-CID batch detection, and already-merged skip handling after waiting on an existing merge. |
| `crates/p2p/src/sync/replication/loop_runner.rs` | Route parallel, single, immediate, and drain paths through the serialized processor. Duplicate-CID batches fall back to individual serialized processing. |
| `crates/p2p/src/sync/replication/mod.rs` | Add a slow merge handler regression test proving duplicate CIDs are serialized. |

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test -p p2p --lib`
- [x] `cargo test -p p2p --test bitswap_acp_filter_tests`
- [x] `cargo clippy -p crypto -p p2p -p defra-p2p-adapter --all-targets -- -D warnings`
