### PR TITLE
fix(cli): use inlined PushLog message id (#882)

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -226,7 +226,7 @@ impl Node {
                     } => {
                         info!(
                             peer_id = %peer_id,
-                            message_id = %request.metadata.message_id,
+                            message_id = %request.message_id,
                             doc_id = %request.doc_id,
                             "Processing TwoStreamRequest through coordinator"
                         );


### PR DESCRIPTION
## Summary

Fix the CLI P2P event logger after #882 inlined `PushLogRequest` metadata fields for CBOR compatibility.

## Why

`PushLogRequest` no longer has a nested `metadata` field. Most call sites were updated to use the inlined `message_id`, but `crates/cli/src/commands/start/server_p2p.rs` still referenced `request.metadata.message_id`, breaking workspace build/test and clippy on current `main`.

## Changes

| File | Change |
|---|---|
| `crates/cli/src/commands/start/server_p2p.rs` | Replace `request.metadata.message_id` with `request.message_id` in the TwoStream request log line. |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p cli`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test`
- [x] `cargo clippy --all -- -D warnings`
