### PR TITLE
fix(p2p): gate pubsub RPC on readiness (#899, #900, #901)

### DIFF
--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -669,7 +669,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         // so merges flow to the event bus the same way as the two-stream
         // path. Falls back to two-stream per-peer requests when no
         // coordinator is wired (e.g. light tests).
-        let use_pubsub = self.sync_coordinator.is_some();
+        let use_pubsub = self
+            .sync_coordinator
+            .as_ref()
+            .is_some_and(|coord| coord.pubsub_services_ready());
 
         for _attempt in 0..3 {
             if total_received >= total_expected || start.elapsed() >= overall_timeout {
@@ -677,7 +680,11 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             }
 
             let publish_result = if use_pubsub {
-                let coord = self.sync_coordinator.as_ref().unwrap().clone();
+                let coord = self
+                    .sync_coordinator
+                    .as_ref()
+                    .expect("pubsub readiness requires a coordinator")
+                    .clone();
                 let doc_ids = doc_ids.clone();
                 // Remaining budget for this attempt.
                 let remaining = overall_timeout.saturating_sub(start.elapsed());

--- a/crates/p2p/src/pubsub_rpc/correlator.rs
+++ b/crates/p2p/src/pubsub_rpc/correlator.rs
@@ -152,6 +152,14 @@ impl Correlator {
         self.ongoing.lock().remove(id);
     }
 
+    /// Drop every in-flight response sender and wake waiting publishers.
+    ///
+    /// Used during coordinator shutdown so callers don't sit on the normal
+    /// response timeout after the transport has already started closing.
+    pub fn cancel_all(&self) -> usize {
+        self.ongoing.lock().drain().count()
+    }
+
     /// Deliver a decoded response envelope. Routes to the matching ongoing
     /// entry if one exists; single-response entries are auto-removed after
     /// one successful delivery.
@@ -295,6 +303,20 @@ mod tests {
         assert_eq!(c.in_flight(), 1);
         drop(prep);
         assert_eq!(c.in_flight(), 0, "Drop must auto-cancel");
+    }
+
+    #[tokio::test]
+    async fn cancel_all_wakes_waiting_publishers() {
+        let c = Correlator::new();
+        let mut first = c.publish(b"first".to_vec(), PublishOptions::default());
+        let mut second = c.publish(b"second".to_vec(), PublishOptions::default());
+        assert_eq!(c.in_flight(), 2);
+
+        assert_eq!(c.cancel_all(), 2);
+        assert_eq!(c.in_flight(), 0);
+
+        assert!(first.responses.recv().await.is_none());
+        assert!(second.responses.recv().await.is_none());
     }
 
     #[test]

--- a/crates/p2p/src/pubsub_rpc/topic_handler.rs
+++ b/crates/p2p/src/pubsub_rpc/topic_handler.rs
@@ -148,6 +148,11 @@ impl TopicHandler {
         self.inner.correlator.cancel(id);
     }
 
+    /// Cancel all in-flight publishes for this topic.
+    pub fn cancel_all(&self) -> usize {
+        self.inner.correlator.cancel_all()
+    }
+
     /// Number of in-flight requests awaiting responses. Test/metric helper.
     pub fn in_flight(&self) -> usize {
         self.inner.correlator.in_flight()

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -262,6 +262,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     }
 
     pub async fn shutdown(&self) {
+        if let Some(services) = self.pubsub_services.as_ref() {
+            services.set_ready(false);
+            let cancelled = services.cancel_in_flight();
+            if cancelled > 0 {
+                tracing::debug!(
+                    cancelled,
+                    "Cancelled in-flight pubsub_rpc requests during coordinator shutdown"
+                );
+            }
+        }
         self.runtime.dag_fetch_semaphore.close();
         self.runtime.push_semaphore.close();
         self.runtime.shutdown.shutdown().await;

--- a/crates/p2p/src/sync/coordinator/pubsub_client.rs
+++ b/crates/p2p/src/sync/coordinator/pubsub_client.rs
@@ -40,15 +40,15 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// the transport so inbound messages arrive as
     /// [`crate::transport::TransportEvent::GossipRawMessage`].
     ///
-    /// Idempotent: safe to call at startup and again on reconnect.
-    /// Silently skips on transports without pubsub_rpc support
-    /// (`subscribe_raw` / `register_pubsub_rpc_topic` return `Err`/`Ok`
-    /// per the trait defaults; iroh inherits the defaults).
+    /// Idempotent: safe to call at startup and again on reconnect. Returns
+    /// an error if any subscription or registration fails so callers never
+    /// observe a partially wired pubsub_rpc service as ready.
     pub async fn start_pubsub_services(&self) -> Result<()> {
         let Some(services) = self.pubsub_services.as_ref() else {
             debug!("pubsub_rpc services disabled (local peer is not a libp2p PeerId)");
             return Ok(());
         };
+        services.set_ready(false);
 
         let doc_self = services.doc_sync.self_response_topic().to_string();
         let branch_self = services.branchable_sync.self_response_topic().to_string();
@@ -59,26 +59,26 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             doc_self.clone(),
             branch_self.clone(),
         ] {
-            // subscribe_raw returns Err on transports without gossipsub.
-            // Treat that as soft-failure so the coordinator can be started
-            // uniformly on libp2p + iroh; the raw-message dispatcher only
-            // fires when messages actually arrive.
-            if let Err(e) = self.runtime.transport.subscribe_raw(topic.clone()).await {
-                debug!(topic = %topic, error = %e, "subscribe_raw skipped");
-                return Ok(());
-            }
+            self.runtime.transport.subscribe_raw(topic.clone()).await?;
             self.runtime
                 .transport
                 .register_pubsub_rpc_topic(topic)
                 .await?;
         }
 
+        services.set_ready(true);
         debug!(
             doc_sync_topic = DOC_SYNC_TOPIC,
             branchable_topic = BRANCHABLE_SYNC_TOPIC,
             "pubsub_rpc services started"
         );
         Ok(())
+    }
+
+    pub fn pubsub_services_ready(&self) -> bool {
+        self.pubsub_services
+            .as_ref()
+            .is_some_and(|services| services.is_ready())
     }
 
     /// Publish a DocSync request over `doc-sync` and wait up to
@@ -94,6 +94,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 "pubsub_rpc DocSync is not available on this transport".into(),
             ));
         };
+        if !services.is_ready() {
+            return Err(Error::Transport(
+                "pubsub_rpc DocSync is not ready on this transport".into(),
+            ));
+        }
 
         let mut req_bytes = Vec::new();
         ciborium::into_writer(&wire::DocSyncRequest::new(doc_ids), &mut req_bytes)
@@ -168,6 +173,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 "pubsub_rpc BranchableSync is not available on this transport".into(),
             ));
         };
+        if !services.is_ready() {
+            return Err(Error::Transport(
+                "pubsub_rpc BranchableSync is not ready on this transport".into(),
+            ));
+        }
 
         let mut req_bytes = Vec::new();
         ciborium::into_writer(
@@ -247,5 +257,292 @@ fn parse_branchable_sync_response(resp: &PubsubResponse) -> Option<wire::Brancha
             warn!(from = %resp.from, error = %e, "sync-branchable: failed to decode reply");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use blockstore::DefraBlockstore;
+    use parking_lot::Mutex;
+    use storage::backends::MemoryStore;
+
+    use super::*;
+    use crate::message::{
+        BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
+        PushLogReply, PushLogRequest, PushSEArtifactsRequest,
+    };
+    use crate::sync::SyncConfig;
+    use crate::topics::DefraTopic;
+    use crate::transport::{MessageId, PeerAddr, PeerId};
+    use crate::{QueryId, ReplicatorInfo};
+
+    #[derive(Clone)]
+    struct RawSubscribeFailTransport {
+        local_peer_id: PeerId,
+        subscribe_calls: Arc<AtomicUsize>,
+        fail_on_call: usize,
+        registered_topics: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl RawSubscribeFailTransport {
+        fn new(fail_on_call: usize) -> Self {
+            let peer = libp2p::PeerId::from_public_key(
+                &libp2p::identity::Keypair::generate_ed25519().public(),
+            );
+            Self {
+                local_peer_id: PeerId::new(peer.to_string()),
+                subscribe_calls: Arc::new(AtomicUsize::new(0)),
+                fail_on_call,
+                registered_topics: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl P2PTransport for RawSubscribeFailTransport {
+        type ResponseToken = ();
+
+        fn local_peer_id(&self) -> &PeerId {
+            &self.local_peer_id
+        }
+
+        fn local_public_key_proto(&self) -> &[u8] {
+            &[]
+        }
+
+        fn sign(&self, _data: &[u8]) -> Result<Vec<u8>> {
+            Ok(Vec::new())
+        }
+
+        async fn dial(&self, _peer_id: &PeerId, _addrs: Vec<PeerAddr>) -> Result<()> {
+            Ok(())
+        }
+
+        async fn listen(&self, _addr: PeerAddr) -> Result<()> {
+            Ok(())
+        }
+
+        async fn connected_peers(&self) -> Result<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn listen_addresses(&self) -> Result<Vec<PeerAddr>> {
+            Ok(Vec::new())
+        }
+
+        async fn poll_until_connected(&self, _peer_id: &PeerId, _timeout: Duration) -> Result<()> {
+            Ok(())
+        }
+
+        async fn peer_addresses(&self) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn topic_peers(&self, _topic: DefraTopic) -> Result<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn subscribe(&self, _topic: DefraTopic) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn unsubscribe(&self, _topic: DefraTopic) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn publish(&self, _topic: DefraTopic, _msg: PushLogBroadcast) -> Result<MessageId> {
+            Ok(MessageId::new("noop".to_string()))
+        }
+
+        async fn publish_raw(&self, _topic: String, _data: Vec<u8>) -> Result<MessageId> {
+            Ok(MessageId::new("noop".to_string()))
+        }
+
+        async fn subscribe_raw(&self, _topic: String) -> Result<bool> {
+            let call = self.subscribe_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if call == self.fail_on_call {
+                Err(Error::Transport("subscribe failed".to_string()))
+            } else {
+                Ok(true)
+            }
+        }
+
+        async fn register_pubsub_rpc_topic(&self, topic: String) -> Result<()> {
+            self.registered_topics.lock().push(topic);
+            Ok(())
+        }
+
+        async fn send_pushlog_response(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: PushLogReply,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_two_stream_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushLogRequest,
+        ) -> Result<PushLogReply> {
+            Err(Error::Transport("not implemented".to_string()))
+        }
+
+        async fn send_two_stream_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: PushLogReply,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: DocSyncRequest,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: DocSyncReply,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: BranchableSyncRequest,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: BranchableSyncReply,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_car_request(&self, _peer_id: &PeerId, _root_cid: cid::Cid) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_car_response(&self, _peer_id: &PeerId, _car_data: Vec<u8>) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_car_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _car_data: Vec<u8>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: DocSyncReply,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: BranchableSyncReply,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send_se_artifacts(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushSEArtifactsRequest,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn sync_blocks(
+            &self,
+            _root: cid::Cid,
+            _providers: Vec<PeerId>,
+            _missing: Vec<cid::Cid>,
+        ) -> Result<QueryId> {
+            Ok(QueryId(0))
+        }
+
+        async fn cancel_sync(&self, _query_id: QueryId) -> Result<bool> {
+            Ok(true)
+        }
+
+        async fn create_replicator(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn delete_replicator(&self, _peer_id: &PeerId) -> Result<()> {
+            Ok(())
+        }
+
+        async fn list_replicators(&self) -> Result<Vec<ReplicatorInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_replicator(&self, _peer_id: &PeerId) -> Result<Option<ReplicatorInfo>> {
+            Ok(None)
+        }
+
+        async fn remove_replicator_collections(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn shutdown(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn start_pubsub_services_returns_error_and_stays_unready_on_partial_subscribe() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let transport = RawSubscribeFailTransport::new(2);
+        let registered_topics = transport.registered_topics.clone();
+        let subscribe_calls = transport.subscribe_calls.clone();
+        let (coordinator, _events) =
+            SyncCoordinator::new(transport, blockstore, SyncConfig::default())
+                .await
+                .expect("coordinator should construct");
+
+        let error = coordinator
+            .start_pubsub_services()
+            .await
+            .expect_err("partial subscribe failure must be visible to caller");
+
+        assert!(error.to_string().contains("subscribe failed"));
+        assert!(!coordinator.pubsub_services_ready());
+        assert_eq!(subscribe_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            registered_topics.lock().len(),
+            1,
+            "first topic registered before failure, but services must remain unready"
+        );
     }
 }

--- a/crates/p2p/src/sync/coordinator/pubsub_services.rs
+++ b/crates/p2p/src/sync/coordinator/pubsub_services.rs
@@ -11,10 +11,11 @@
 //! coordinator skips starting these services on iroh and falls back to
 //! the two-stream DocSync/Branchable paths.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use super::authorizer::AccessAuthorizer;
 use crate::message::pubsub as wire;
@@ -32,6 +33,7 @@ pub(super) const BRANCHABLE_SYNC_TOPIC: &str = "sync-branchable";
 pub(crate) struct PubsubServices {
     pub(super) doc_sync: Arc<TopicHandler>,
     pub(super) branchable_sync: Arc<TopicHandler>,
+    ready: AtomicBool,
 }
 
 impl PubsubServices {
@@ -69,7 +71,36 @@ impl PubsubServices {
         Some(Self {
             doc_sync,
             branchable_sync,
+            ready: AtomicBool::new(false),
         })
+    }
+
+    pub(super) fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+
+    pub(super) fn set_ready(&self, ready: bool) {
+        self.ready.store(ready, Ordering::Release);
+    }
+
+    pub(super) fn cancel_in_flight(&self) -> usize {
+        let doc_sync = self.doc_sync.cancel_all();
+        let branchable_sync = self.branchable_sync.cancel_all();
+        if doc_sync > 0 {
+            debug!(
+                topic = DOC_SYNC_TOPIC,
+                cancelled = doc_sync,
+                "Cancelled in-flight pubsub_rpc requests"
+            );
+        }
+        if branchable_sync > 0 {
+            debug!(
+                topic = BRANCHABLE_SYNC_TOPIC,
+                cancelled = branchable_sync,
+                "Cancelled in-flight pubsub_rpc requests"
+            );
+        }
+        doc_sync + branchable_sync
     }
 
     /// Return the TopicHandler for `topic` if this services bundle owns it.
@@ -314,6 +345,23 @@ mod tests {
             Arc::new(AllowAllAuthorizer),
         );
         assert!(services.is_none());
+    }
+
+    #[tokio::test]
+    async fn services_start_not_ready_until_all_topics_subscribe() {
+        let peer = a_libp2p_peer();
+        let services = PubsubServices::try_new(
+            &peer.to_string(),
+            Arc::new(NoOpHeadProvider),
+            Arc::new(AllowAllAuthorizer),
+        )
+        .expect("local peer parses");
+
+        assert!(!services.is_ready());
+        services.set_ready(true);
+        assert!(services.is_ready());
+        services.set_ready(false);
+        assert!(!services.is_ready());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #899. Closes #900. Closes #901. Makes pubsub RPC readiness explicit: startup now fails and stays unready on partial subscribe failure, callers check the ready flag before taking the pubsub path, and shutdown cancels in-flight pubsub waiters immediately.

## Why

`start_pubsub_services` could leave the coordinator in a half-wired state where some topic subscriptions existed but callers still treated pubsub RPC as available. `P2PAdapter::sync_documents` also used `sync_coordinator.is_some()` as a proxy for readiness, which made that partial state observable as a later publish failure.

Separately, shutdown dropped pubsub services implicitly. Any in-flight `PreparedPublish` waiters had to sit until their timeout instead of being woken by shutdown.

## Changes

| File | Change |
|---|---|
| `crates/p2p/src/sync/coordinator/pubsub_services.rs` | Add an explicit ready flag plus helpers to set readiness, query readiness, and cancel in-flight topic requests. |
| `crates/p2p/src/sync/coordinator/pubsub_client.rs` | Mark services unready before startup, return errors on subscribe/register failure, flip ready only after all topics are registered, and reject pubsub RPC calls while unready. |
| `crates/p2p/src/sync/coordinator/mod.rs` | On shutdown, mark pubsub services unready and cancel in-flight requests. |
| `crates/p2p/src/pubsub_rpc/correlator.rs` | Add `cancel_all()` so pending publishers wake immediately on shutdown. |
| `crates/p2p/src/pubsub_rpc/topic_handler.rs` | Expose `cancel_all()` through each topic handler. |
| `crates/p2p-adapter/src/libp2p.rs` | Select the pubsub RPC path only when `pubsub_services_ready()` is true instead of checking coordinator presence. |

## Tests

- Add a transport fake that fails raw subscribe startup and verifies `start_pubsub_services` returns an error while leaving services unready.
- Add coverage that pubsub services are not ready until all topic handlers subscribe/register successfully.
- Add a correlator test proving `cancel_all()` wakes pending publishers.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p p2p --lib`
- [x] `cargo test -p defra-p2p-adapter`
- [x] `cargo clippy -p p2p -p defra-p2p-adapter --all-targets -- -D warnings`
- [ ] `cargo check -p cli` currently fails on `main` due to `request.metadata.message_id` after #882; fixed separately in #906.
