### PR TITLE
fix(p2p): persist replicator retry status (#837)

### DIFF
--- a/crates/cli/src/commands/client/http_client/p2p.rs
+++ b/crates/cli/src/commands/client/http_client/p2p.rs
@@ -38,12 +38,25 @@ pub struct P2pReplicatorInfo {
     pub id: Option<String>,
 
     /// Collections being replicated
-    #[serde(rename = "collections", alias = "Collections", default)]
+    #[serde(
+        rename = "collections",
+        alias = "Collections",
+        alias = "CollectionIDs",
+        default
+    )]
     pub collections: Vec<String>,
 
     /// Peer address
     #[serde(rename = "address", alias = "Address", default)]
     pub address: Option<String>,
+
+    /// Active=0, Inactive=1.
+    #[serde(rename = "status", alias = "Status", default)]
+    pub status: Option<u8>,
+
+    /// Last time the replicator status changed.
+    #[serde(rename = "lastStatusChange", alias = "LastStatusChange", default)]
+    pub last_status_change: Option<String>,
 }
 
 /// P2P replicator request (Go-compatible format).
@@ -182,5 +195,24 @@ impl HttpClient {
             "collectionID": collection_id,
         }))?;
         self.request_void("POST", &url, Some(&body)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replicator_info_accepts_go_status_fields() {
+        let json = r#"{"ID":"peer-1","Addresses":["/ip4/127.0.0.1/tcp/9000"],"CollectionIDs":["Users"],"Status":1,"LastStatusChange":"2026-04-26T10:00:00Z"}"#;
+        let info: P2pReplicatorInfo = serde_json::from_str(json).unwrap();
+
+        assert_eq!(info.id.as_deref(), Some("peer-1"));
+        assert_eq!(info.collections, vec!["Users"]);
+        assert_eq!(info.status, Some(1));
+        assert_eq!(
+            info.last_status_change.as_deref(),
+            Some("2026-04-26T10:00:00Z")
+        );
     }
 }

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -13,6 +13,35 @@ use p2p::P2PTransport;
 
 type WireDocumentAcp = Option<Box<dyn FnOnce(Arc<dyn acp::DocumentACP>)>>;
 
+async fn set_persisted_replicator_status<S: storage::corekv::Store>(
+    peerstore: &storage::stores::Peerstore<S>,
+    peer_id: &str,
+    status: p2p::ReplicatorStatus,
+) -> Result<bool> {
+    let Some(bytes) = peerstore
+        .get_replicator(peer_id)
+        .await
+        .map_err(|e| Error::Server(format!("failed to load replicator: {e}")))?
+    else {
+        return Ok(false);
+    };
+
+    let mut info = p2p::ReplicatorInfo::from_bytes(&bytes)
+        .map_err(|e| Error::Server(format!("failed to decode replicator: {e}")))?;
+    if !info.set_status_if_changed_now(status) {
+        return Ok(false);
+    }
+
+    let bytes = info
+        .to_bytes()
+        .map_err(|e| Error::Server(format!("failed to encode replicator: {e}")))?;
+    peerstore
+        .create_replicator(peer_id, &bytes)
+        .await
+        .map_err(|e| Error::Server(format!("failed to persist replicator: {e}")))?;
+    Ok(true)
+}
+
 pub(super) struct P2PSetup {
     pub(super) host_handle: Option<p2p::P2PHostHandle>,
     pub(super) p2p_tasks: Option<P2PTasks>,
@@ -290,6 +319,16 @@ impl Node {
                     .await
                 {
                     warn!(error = %e, "Failed to record push failure");
+                    continue;
+                }
+                if let Err(e) = set_persisted_replicator_status(
+                    &peerstore,
+                    &failure.peer_id.to_string(),
+                    p2p::ReplicatorStatus::Inactive,
+                )
+                .await
+                {
+                    warn!(error = %e, "Failed to mark replicator inactive");
                 }
             }
         });
@@ -327,6 +366,12 @@ impl Node {
                     };
                     if docs.is_empty() {
                         let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                        let _ = set_persisted_replicator_status(
+                            &peerstore,
+                            &peer_id_str,
+                            p2p::ReplicatorStatus::Active,
+                        )
+                        .await;
                         continue;
                     }
                     let mut all_succeeded = true;
@@ -345,7 +390,19 @@ impl Node {
                     }
                     if all_succeeded {
                         let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                        let _ = set_persisted_replicator_status(
+                            &peerstore,
+                            &peer_id_str,
+                            p2p::ReplicatorStatus::Active,
+                        )
+                        .await;
                     } else {
+                        let _ = set_persisted_replicator_status(
+                            &peerstore,
+                            &peer_id_str,
+                            p2p::ReplicatorStatus::Inactive,
+                        )
+                        .await;
                         retry_info.bump();
                         if let Ok(bytes) = retry_info.to_bytes() {
                             let _ = peerstore.update_retry_info(&peer_id_str, &bytes).await;
@@ -618,6 +675,16 @@ impl Node {
                     .await
                 {
                     warn!(error = %e, "Failed to record push failure");
+                    continue;
+                }
+                if let Err(e) = set_persisted_replicator_status(
+                    &peerstore,
+                    &failure.peer_id,
+                    p2p::ReplicatorStatus::Inactive,
+                )
+                .await
+                {
+                    warn!(error = %e, "Failed to mark replicator inactive");
                 }
             }
         });
@@ -649,6 +716,12 @@ impl Node {
                     };
                     if docs.is_empty() {
                         let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                        let _ = set_persisted_replicator_status(
+                            &peerstore,
+                            &peer_id_str,
+                            p2p::ReplicatorStatus::Active,
+                        )
+                        .await;
                         continue;
                     }
                     let mut all_succeeded = true;
@@ -667,7 +740,19 @@ impl Node {
                     }
                     if all_succeeded {
                         let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                        let _ = set_persisted_replicator_status(
+                            &peerstore,
+                            &peer_id_str,
+                            p2p::ReplicatorStatus::Active,
+                        )
+                        .await;
                     } else {
+                        let _ = set_persisted_replicator_status(
+                            &peerstore,
+                            &peer_id_str,
+                            p2p::ReplicatorStatus::Inactive,
+                        )
+                        .await;
                         retry_info.bump();
                         if let Ok(bytes) = retry_info.to_bytes() {
                             let _ = peerstore.update_retry_info(&peer_id_str, &bytes).await;

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -226,7 +226,7 @@ impl Node {
                     } => {
                         info!(
                             peer_id = %peer_id,
-                            message_id = %request.metadata.message_id,
+                            message_id = %request.message_id,
                             doc_id = %request.doc_id,
                             "Processing TwoStreamRequest through coordinator"
                         );

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -32,6 +32,19 @@ pub struct IrohP2PAdapter<B: Blockstore + 'static> {
 }
 
 impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
+    fn to_http_replicator_info(info: p2p::ReplicatorInfo) -> ReplicatorInfo {
+        let address = info.addresses_str().first().map(|s| s.to_string());
+        let status = Some(info.status.into());
+        let last_status_change = Some(info.last_status_change_go_string());
+        ReplicatorInfo {
+            id: Some(info.peer_id_str().to_string()),
+            collections: info.collections,
+            address,
+            status,
+            last_status_change,
+        }
+    }
+
     pub fn with_full_context(
         transport: IrohTransport,
         coordinator: Arc<IrohSyncCoordinator<B>>,
@@ -129,22 +142,26 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
     }
 
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
-        let p2p_infos = self
-            .transport
-            .list_replicators()
-            .await
-            .map_err(|e| P2PError::Transport(e.to_string()))?;
+        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
+            match pusher.load_persisted_replicators().await {
+                Ok(Some(infos)) => infos,
+                Ok(None) => self
+                    .transport
+                    .list_replicators()
+                    .await
+                    .map_err(|e| P2PError::Transport(e.to_string()))?,
+                Err(e) => return Err(P2PError::Internal(e)),
+            }
+        } else {
+            self.transport
+                .list_replicators()
+                .await
+                .map_err(|e| P2PError::Transport(e.to_string()))?
+        };
 
         let http_infos: Vec<ReplicatorInfo> = p2p_infos
             .into_iter()
-            .map(|info| {
-                let address = info.addresses_str().first().map(|s| s.to_string());
-                ReplicatorInfo {
-                    id: Some(info.peer_id_str().to_string()),
-                    collections: info.collections,
-                    address,
-                }
-            })
+            .map(Self::to_http_replicator_info)
             .collect();
 
         Ok(http_infos)

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -51,6 +51,10 @@ pub trait DocPusher: Send + Sync {
 
     async fn delete_persisted_replicator(&self, peer_id: &str) -> Result<(), String>;
 
+    async fn load_persisted_replicators(&self) -> Result<Option<Vec<p2p::ReplicatorInfo>>, String> {
+        Ok(None)
+    }
+
     async fn persist_p2p_documents(&self, doc_ids: &[String]) -> Result<(), String>;
 
     async fn load_p2p_documents(&self) -> Result<Vec<String>, String>;
@@ -115,6 +119,19 @@ pub struct P2PAdapter<
 }
 
 impl<B: Blockstore + 'static> P2PAdapter<B> {
+    fn to_http_replicator_info(info: p2p::ReplicatorInfo) -> ReplicatorInfo {
+        let address = info.addresses_str().first().map(|s| s.to_string());
+        let status = Some(info.status.into());
+        let last_status_change = Some(info.last_status_change_go_string());
+        ReplicatorInfo {
+            id: Some(info.peer_id_str().to_string()),
+            collections: info.collections,
+            address,
+            status,
+            last_status_change,
+        }
+    }
+
     /// Create a new adapter wrapping the given P2P handle.
     pub fn new(handle: P2PHostHandle) -> Self {
         Self {
@@ -299,22 +316,26 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
     }
 
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
-        let p2p_infos = self
-            .handle
-            .list_replicators()
-            .await
-            .map_err(|e| P2PError::Transport(e.to_string()))?;
+        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
+            match pusher.load_persisted_replicators().await {
+                Ok(Some(infos)) => infos,
+                Ok(None) => self
+                    .handle
+                    .list_replicators()
+                    .await
+                    .map_err(|e| P2PError::Transport(e.to_string()))?,
+                Err(e) => return Err(P2PError::Internal(e)),
+            }
+        } else {
+            self.handle
+                .list_replicators()
+                .await
+                .map_err(|e| P2PError::Transport(e.to_string()))?
+        };
 
         let http_infos: Vec<ReplicatorInfo> = p2p_infos
             .into_iter()
-            .map(|info| {
-                let address = info.addresses_str().first().map(|s| s.to_string());
-                ReplicatorInfo {
-                    id: Some(info.peer_id_str().to_string()),
-                    collections: info.collections,
-                    address,
-                }
-            })
+            .map(Self::to_http_replicator_info)
             .collect();
 
         Ok(http_infos)

--- a/crates/cli/src/p2p_doc_pusher.rs
+++ b/crates/cli/src/p2p_doc_pusher.rs
@@ -90,12 +90,32 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         let pid: libp2p::PeerId = peer_id
             .parse()
             .map_err(|e| format!("invalid peer ID: {}", e))?;
-        let info = p2p::ReplicatorInfo::new(pid, collections.to_vec())
-            .map_err(|e| format!("invalid replicator info: {}", e))?;
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let mut info = match peerstore
+            .get_replicator(peer_id)
+            .await
+            .map_err(|e| format!("failed to load persisted replicator: {}", e))?
+        {
+            Some(bytes) => match p2p::ReplicatorInfo::from_bytes(&bytes) {
+                Ok(info) => info,
+                Err(e) => {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Replacing invalid persisted replicator"
+                    );
+                    p2p::ReplicatorInfo::new(pid, collections.to_vec())
+                        .map_err(|e| format!("invalid replicator info: {}", e))?
+                }
+            },
+            None => p2p::ReplicatorInfo::new(pid, collections.to_vec())
+                .map_err(|e| format!("invalid replicator info: {}", e))?,
+        };
+        info.id = peer_id.to_string();
+        info.collections = collections.to_vec();
         let bytes = info
             .to_bytes()
             .map_err(|e| format!("failed to serialize replicator info: {}", e))?;
-        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         peerstore
             .create_replicator(peer_id, &bytes)
             .await
@@ -108,6 +128,29 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             .delete_replicator(peer_id)
             .await
             .map_err(|e| format!("failed to delete persisted replicator: {}", e))
+    }
+
+    async fn load_persisted_replicators(&self) -> Result<Option<Vec<p2p::ReplicatorInfo>>, String> {
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let entries = peerstore
+            .list_replicators()
+            .await
+            .map_err(|e| format!("failed to list persisted replicators: {}", e))?;
+
+        let mut replicators = Vec::with_capacity(entries.len());
+        for (peer_id, bytes) in entries {
+            match p2p::ReplicatorInfo::from_bytes(&bytes) {
+                Ok(info) => replicators.push(info),
+                Err(e) => {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Skipping invalid persisted replicator"
+                    );
+                }
+            }
+        }
+        Ok(Some(replicators))
     }
 
     async fn persist_p2p_documents(&self, doc_ids: &[String]) -> Result<(), String> {

--- a/crates/cli/src/transport_doc_pusher.rs
+++ b/crates/cli/src/transport_doc_pusher.rs
@@ -52,6 +52,10 @@ pub trait TransportDocPusher: Send + Sync {
 
     async fn delete_persisted_replicator(&self, peer_id: &str) -> Result<(), String>;
 
+    async fn load_persisted_replicators(&self) -> Result<Option<Vec<p2p::ReplicatorInfo>>, String> {
+        Ok(None)
+    }
+
     async fn persist_p2p_documents(&self, doc_ids: &[String]) -> Result<(), String>;
 
     async fn load_p2p_documents(&self) -> Result<Vec<String>, String>;
@@ -248,12 +252,24 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         peer_id: &str,
         collections: &[String],
     ) -> Result<(), String> {
-        let info =
-            p2p::ReplicatorInfo::from_raw(peer_id.to_string(), collections.to_vec(), Vec::new());
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let mut info = match peerstore
+            .get_replicator(peer_id)
+            .await
+            .map_err(|e| format!("failed to load persisted replicator: {}", e))?
+        {
+            Some(bytes) => p2p::ReplicatorInfo::from_bytes(&bytes).unwrap_or_else(|_| {
+                p2p::ReplicatorInfo::from_raw(peer_id.to_string(), collections.to_vec(), Vec::new())
+            }),
+            None => {
+                p2p::ReplicatorInfo::from_raw(peer_id.to_string(), collections.to_vec(), Vec::new())
+            }
+        };
+        info.id = peer_id.to_string();
+        info.collections = collections.to_vec();
         let bytes = info
             .to_bytes()
             .map_err(|e| format!("failed to serialize replicator info: {}", e))?;
-        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         peerstore
             .create_replicator(peer_id, &bytes)
             .await
@@ -266,6 +282,29 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             .delete_replicator(peer_id)
             .await
             .map_err(|e| format!("failed to delete persisted replicator: {}", e))
+    }
+
+    async fn load_persisted_replicators(&self) -> Result<Option<Vec<p2p::ReplicatorInfo>>, String> {
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let entries = peerstore
+            .list_replicators()
+            .await
+            .map_err(|e| format!("failed to list persisted replicators: {}", e))?;
+
+        let mut replicators = Vec::with_capacity(entries.len());
+        for (peer_id, bytes) in entries {
+            match p2p::ReplicatorInfo::from_bytes(&bytes) {
+                Ok(info) => replicators.push(info),
+                Err(e) => {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        error = %e,
+                        "Skipping invalid persisted replicator"
+                    );
+                }
+            }
+        }
+        Ok(Some(replicators))
     }
 
     async fn persist_p2p_documents(&self, doc_ids: &[String]) -> Result<(), String> {

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -938,6 +938,16 @@ fn spawn_failure_recorder<S: storage::corekv::Store + 'static>(
                 .await
             {
                 tracing::warn!(error = %error, "failed to record push failure");
+                continue;
+            }
+            if let Err(error) = defra_p2p_adapter::set_persisted_replicator_status(
+                &peerstore,
+                &failure.peer_id.to_string(),
+                p2p::ReplicatorStatus::Inactive,
+            )
+            .await
+            {
+                tracing::warn!(error = %error, "failed to mark replicator inactive");
             }
         }
     })
@@ -987,6 +997,12 @@ fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
                 };
                 if docs.is_empty() {
                     let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Active,
+                    )
+                    .await;
                     continue;
                 }
 
@@ -1019,7 +1035,19 @@ fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
 
                 if all_succeeded {
                     let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Active,
+                    )
+                    .await;
                 } else {
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Inactive,
+                    )
+                    .await;
                     retry_info.bump();
                     if let Ok(bytes) = retry_info.to_bytes() {
                         let _ = peerstore.update_retry_info(&peer_id_str, &bytes).await;

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -237,6 +237,16 @@ pub(crate) fn spawn_failure_recorder<S: storage::corekv::Store + 'static>(
                 .await
             {
                 tracing::warn!(error = %error, "failed to record push failure");
+                continue;
+            }
+            if let Err(error) = defra_p2p_adapter::set_persisted_replicator_status(
+                &peerstore,
+                &failure.peer_id.to_string(),
+                p2p::ReplicatorStatus::Inactive,
+            )
+            .await
+            {
+                tracing::warn!(error = %error, "failed to mark replicator inactive");
             }
         }
     })
@@ -287,6 +297,12 @@ pub(crate) fn spawn_libp2p_retry_loop<S: storage::corekv::Store + 'static>(
                 };
                 if docs.is_empty() {
                     let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Active,
+                    )
+                    .await;
                     continue;
                 }
 
@@ -308,7 +324,19 @@ pub(crate) fn spawn_libp2p_retry_loop<S: storage::corekv::Store + 'static>(
 
                 if all_succeeded {
                     let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Active,
+                    )
+                    .await;
                 } else {
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Inactive,
+                    )
+                    .await;
                     retry_info.bump();
                     if let Ok(bytes) = retry_info.to_bytes() {
                         let _ = peerstore.update_retry_info(&peer_id_str, &bytes).await;
@@ -357,6 +385,12 @@ pub(crate) fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
                 };
                 if docs.is_empty() {
                     let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Active,
+                    )
+                    .await;
                     continue;
                 }
 
@@ -375,7 +409,19 @@ pub(crate) fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
 
                 if all_succeeded {
                     let _ = peerstore.clear_retry_peer(&peer_id_str).await;
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Active,
+                    )
+                    .await;
                 } else {
+                    let _ = defra_p2p_adapter::set_persisted_replicator_status(
+                        &peerstore,
+                        &peer_id_str,
+                        p2p::ReplicatorStatus::Inactive,
+                    )
+                    .await;
                     retry_info.bump();
                     if let Ok(bytes) = retry_info.to_bytes() {
                         let _ = peerstore.update_retry_info(&peer_id_str, &bytes).await;

--- a/crates/http/src/handlers/p2p/replicators.rs
+++ b/crates/http/src/handlers/p2p/replicators.rs
@@ -23,6 +23,12 @@ pub struct ReplicatorInfoResponse {
     /// Collection IDs being replicated (Go uses CollectionIDs).
     #[serde(rename = "CollectionIDs")]
     pub collection_ids: Vec<String>,
+    /// Active=0, Inactive=1, matching Go's client.ReplicatorStatus.
+    #[serde(rename = "Status")]
+    pub status: u8,
+    /// Last time the status changed, formatted like Go's time.Time JSON.
+    #[serde(rename = "LastStatusChange")]
+    pub last_status_change: String,
 }
 
 /// Request to add a replicator (Go-compatible format).
@@ -55,7 +61,7 @@ pub struct ReplicatorDeleteRequest {
 /// GET /api/v0/p2p/replicators
 ///
 /// Returns array of replicators with Go-compatible PascalCase field names:
-/// `[{"ID": "...", "Addresses": [...], "CollectionIDs": [...]}]`
+/// `[{"ID": "...", "Addresses": [...], "CollectionIDs": [...], "Status": 0, "LastStatusChange": "..."}]`
 ///
 /// Requires `P2pReplicatorList` permission when NAC is enabled.
 pub async fn list_replicators(
@@ -76,6 +82,10 @@ pub async fn list_replicators(
             addresses: r.address.into_iter().collect(),
             // Use collections as collection IDs
             collection_ids: r.collections,
+            status: r.status.unwrap_or(0),
+            last_status_change: r
+                .last_status_change
+                .unwrap_or_else(|| "0001-01-01T00:00:00Z".to_string()),
         })
         .collect();
 
@@ -207,11 +217,15 @@ mod tests {
             id: Some("replicator-123".to_string()),
             addresses: vec!["/ip4/127.0.0.1/tcp/9000".to_string()],
             collection_ids: vec!["Users".to_string(), "Posts".to_string()],
+            status: 0,
+            last_status_change: "0001-01-01T00:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&response).unwrap();
         // Verify PascalCase field names
         assert!(json.contains("\"ID\""));
         assert!(json.contains("\"Addresses\""));
         assert!(json.contains("\"CollectionIDs\""));
+        assert!(json.contains("\"Status\""));
+        assert!(json.contains("\"LastStatusChange\""));
     }
 }

--- a/crates/http/src/mock/p2p.rs
+++ b/crates/http/src/mock/p2p.rs
@@ -59,6 +59,8 @@ impl MockP2POperations {
             id: Some("12D3KooWReplicator".to_string()),
             collections,
             address,
+            status: Some(0),
+            last_status_change: Some("0001-01-01T00:00:00Z".to_string()),
         });
         self
     }
@@ -118,6 +120,8 @@ impl P2POperations for MockP2POperations {
             id: Some("12D3KooWNewReplicator".to_string()),
             collections,
             address: addr.map(|s| s.to_string()),
+            status: Some(0),
+            last_status_change: Some("0001-01-01T00:00:00Z".to_string()),
         });
         Ok(())
     }

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -138,6 +138,8 @@ pub struct ReplicatorInfo {
     pub id: Option<String>,
     pub collections: Vec<String>,
     pub address: Option<String>,
+    pub status: Option<u8>,
+    pub last_status_change: Option<String>,
 }
 
 /// P2P document information for HTTP responses.

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -31,6 +31,19 @@ pub struct IrohP2PAdapter<B: Blockstore + 'static> {
 }
 
 impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
+    fn to_http_replicator_info(info: p2p::ReplicatorInfo) -> ReplicatorInfo {
+        let address = info.addresses_str().first().map(|addr| addr.to_string());
+        let status = Some(info.status.into());
+        let last_status_change = Some(info.last_status_change_go_string());
+        ReplicatorInfo {
+            id: Some(info.peer_id_str().to_string()),
+            collections: info.collections,
+            address,
+            status,
+            last_status_change,
+        }
+    }
+
     async fn resubscribe_tracked_document_topics(&self) {
         let doc_ids: Vec<String> = match self.tracked_documents.read() {
             Ok(docs) => docs.iter().cloned().collect(),
@@ -176,22 +189,25 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
     }
 
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
-        let p2p_infos = self
-            .transport
-            .list_replicators()
-            .await
-            .map_err(|error| P2PError::transport(error.to_string()))?;
+        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
+            match pusher.load_persisted_replicators().await? {
+                Some(infos) => infos,
+                None => self
+                    .transport
+                    .list_replicators()
+                    .await
+                    .map_err(|error| P2PError::transport(error.to_string()))?,
+            }
+        } else {
+            self.transport
+                .list_replicators()
+                .await
+                .map_err(|error| P2PError::transport(error.to_string()))?
+        };
 
         Ok(p2p_infos
             .into_iter()
-            .map(|info| {
-                let address = info.addresses_str().first().map(|addr| addr.to_string());
-                ReplicatorInfo {
-                    id: Some(info.peer_id_str().to_string()),
-                    collections: info.collections,
-                    address,
-                }
-            })
+            .map(Self::to_http_replicator_info)
             .collect())
     }
 

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -6,6 +6,7 @@ mod iroh;
 mod libp2p;
 #[cfg(feature = "libp2p")]
 mod libp2p_doc_pusher;
+mod replicator_status;
 #[cfg(feature = "iroh")]
 mod transport_doc_pusher;
 #[cfg(feature = "iroh")]
@@ -19,6 +20,7 @@ pub use iroh::IrohP2PAdapter;
 pub use libp2p::{CollectionLookup, P2PAdapter, VersionSyncer};
 #[cfg(feature = "libp2p")]
 pub use libp2p_doc_pusher::{DbDocPusher, DocPusher};
+pub use replicator_status::{load_persisted_replicators, set_persisted_replicator_status};
 #[cfg(feature = "iroh")]
 pub use transport_doc_pusher::{DbTransportDocPusher, TransportDocPusher};
 #[cfg(feature = "iroh")]

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -43,6 +43,19 @@ pub struct P2PAdapter<B: Blockstore + 'static> {
 }
 
 impl<B: Blockstore + 'static> P2PAdapter<B> {
+    fn to_http_replicator_info(info: p2p::ReplicatorInfo) -> ReplicatorInfo {
+        let address = info.addresses_str().first().map(|addr| addr.to_string());
+        let status = Some(info.status.into());
+        let last_status_change = Some(info.last_status_change_go_string());
+        ReplicatorInfo {
+            id: Some(info.peer_id_str().to_string()),
+            collections: info.collections,
+            address,
+            status,
+            last_status_change,
+        }
+    }
+
     async fn resubscribe_tracked_document_topics(&self) {
         let doc_ids: Vec<String> = match self.tracked_documents.read() {
             Ok(docs) => docs.iter().cloned().collect(),
@@ -176,22 +189,25 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
     }
 
     async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
-        let p2p_infos = self
-            .handle
-            .list_replicators()
-            .await
-            .map_err(|error| P2PError::transport(error.to_string()))?;
+        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
+            match pusher.load_persisted_replicators().await? {
+                Some(infos) => infos,
+                None => self
+                    .handle
+                    .list_replicators()
+                    .await
+                    .map_err(|error| P2PError::transport(error.to_string()))?,
+            }
+        } else {
+            self.handle
+                .list_replicators()
+                .await
+                .map_err(|error| P2PError::transport(error.to_string()))?
+        };
 
         Ok(p2p_infos
             .into_iter()
-            .map(|info| {
-                let address = info.addresses_str().first().map(|addr| addr.to_string());
-                ReplicatorInfo {
-                    id: Some(info.peer_id_str().to_string()),
-                    collections: info.collections,
-                    address,
-                }
-            })
+            .map(Self::to_http_replicator_info)
             .collect())
     }
 

--- a/crates/p2p-adapter/src/libp2p_doc_pusher.rs
+++ b/crates/p2p-adapter/src/libp2p_doc_pusher.rs
@@ -27,6 +27,10 @@ pub trait DocPusher: Send + Sync {
 
     async fn delete_persisted_replicator(&self, peer_id: &str) -> P2PResult<()>;
 
+    async fn load_persisted_replicators(&self) -> P2PResult<Option<Vec<p2p::ReplicatorInfo>>> {
+        Ok(None)
+    }
+
     async fn persist_p2p_documents(&self, doc_ids: &[String]) -> P2PResult<()>;
 
     async fn load_p2p_documents(&self) -> P2PResult<Vec<String>>;
@@ -134,14 +138,35 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         let parsed_peer_id: libp2p::PeerId = peer_id
             .parse()
             .map_err(|error| P2PError::invalid_input(format!("invalid peer ID: {error}")))?;
-        let info =
-            p2p::ReplicatorInfo::new(parsed_peer_id, collections.to_vec()).map_err(|error| {
-                P2PError::invalid_input(format!("invalid replicator info: {error}"))
-            })?;
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let mut info =
+            match peerstore.get_replicator(peer_id).await.map_err(|error| {
+                P2PError::persistence(format!("failed to load persisted replicator: {error}"))
+            })? {
+                Some(bytes) => match p2p::ReplicatorInfo::from_bytes(&bytes) {
+                    Ok(info) => info,
+                    Err(error) => {
+                        tracing::warn!(
+                            peer_id = %peer_id,
+                            error = %error,
+                            "replacing invalid persisted replicator"
+                        );
+                        p2p::ReplicatorInfo::new(parsed_peer_id, collections.to_vec()).map_err(
+                            |error| {
+                                P2PError::invalid_input(format!("invalid replicator info: {error}"))
+                            },
+                        )?
+                    }
+                },
+                None => p2p::ReplicatorInfo::new(parsed_peer_id, collections.to_vec()).map_err(
+                    |error| P2PError::invalid_input(format!("invalid replicator info: {error}")),
+                )?,
+            };
+        info.id = peer_id.to_string();
+        info.collections = collections.to_vec();
         let bytes = info.to_bytes().map_err(|error| {
             P2PError::internal(format!("failed to serialize replicator info: {error}"))
         })?;
-        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         peerstore
             .create_replicator(peer_id, &bytes)
             .await
@@ -155,6 +180,13 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         peerstore.delete_replicator(peer_id).await.map_err(|error| {
             P2PError::persistence(format!("failed to delete persisted replicator: {error}"))
         })
+    }
+
+    async fn load_persisted_replicators(&self) -> P2PResult<Option<Vec<p2p::ReplicatorInfo>>> {
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        crate::load_persisted_replicators(&peerstore)
+            .await
+            .map(Some)
     }
 
     async fn persist_p2p_documents(&self, doc_ids: &[String]) -> P2PResult<()> {

--- a/crates/p2p-adapter/src/replicator_status.rs
+++ b/crates/p2p-adapter/src/replicator_status.rs
@@ -1,0 +1,118 @@
+use crate::{P2PError, P2PErrorExt as _, P2PResult};
+
+pub async fn set_persisted_replicator_status<S: storage::corekv::Store>(
+    peerstore: &storage::stores::Peerstore<S>,
+    peer_id: &str,
+    status: p2p::ReplicatorStatus,
+) -> P2PResult<bool> {
+    let Some(bytes) = peerstore
+        .get_replicator(peer_id)
+        .await
+        .map_err(|error| P2PError::persistence(format!("failed to load replicator: {error}")))?
+    else {
+        return Ok(false);
+    };
+
+    let mut info = p2p::ReplicatorInfo::from_bytes(&bytes)
+        .map_err(|error| P2PError::internal(format!("failed to decode replicator: {error}")))?;
+    if !info.set_status_if_changed_now(status) {
+        return Ok(false);
+    }
+
+    let bytes = info.to_bytes().map_err(|error| {
+        P2PError::internal(format!("failed to encode replicator status: {error}"))
+    })?;
+    peerstore
+        .create_replicator(peer_id, &bytes)
+        .await
+        .map_err(|error| P2PError::persistence(format!("failed to persist replicator: {error}")))?;
+
+    Ok(true)
+}
+
+pub async fn load_persisted_replicators<S: storage::corekv::Store>(
+    peerstore: &storage::stores::Peerstore<S>,
+) -> P2PResult<Vec<p2p::ReplicatorInfo>> {
+    let entries = peerstore
+        .list_replicators()
+        .await
+        .map_err(|error| P2PError::persistence(format!("failed to list replicators: {error}")))?;
+
+    let mut replicators = Vec::with_capacity(entries.len());
+    for (peer_id, bytes) in entries {
+        match p2p::ReplicatorInfo::from_bytes(&bytes) {
+            Ok(info) => replicators.push(info),
+            Err(error) => {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    error = %error,
+                    "skipping invalid persisted replicator"
+                );
+            }
+        }
+    }
+    Ok(replicators)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use storage::backends::MemoryStore;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn status_update_persists_first_transition_only() {
+        let store = Arc::new(MemoryStore::new());
+        let peerstore = storage::stores::Peerstore::new(store);
+        let peer_id = p2p::PeerId::random();
+        let info = p2p::ReplicatorInfo::new(peer_id, vec!["users".to_string()]).unwrap();
+        peerstore
+            .create_replicator(info.peer_id_str(), &info.to_bytes().unwrap())
+            .await
+            .unwrap();
+
+        assert!(set_persisted_replicator_status(
+            &peerstore,
+            info.peer_id_str(),
+            p2p::ReplicatorStatus::Inactive,
+        )
+        .await
+        .unwrap());
+        let inactive = p2p::ReplicatorInfo::from_bytes(
+            &peerstore
+                .get_replicator(info.peer_id_str())
+                .await
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(inactive.status, p2p::ReplicatorStatus::Inactive);
+
+        assert!(!set_persisted_replicator_status(
+            &peerstore,
+            info.peer_id_str(),
+            p2p::ReplicatorStatus::Inactive,
+        )
+        .await
+        .unwrap());
+        let repeated = p2p::ReplicatorInfo::from_bytes(
+            &peerstore
+                .get_replicator(info.peer_id_str())
+                .await
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(repeated.last_status_change, inactive.last_status_change);
+
+        assert!(set_persisted_replicator_status(
+            &peerstore,
+            info.peer_id_str(),
+            p2p::ReplicatorStatus::Active,
+        )
+        .await
+        .unwrap());
+    }
+}

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -42,6 +42,10 @@ pub trait TransportDocPusher: Send + Sync {
 
     async fn delete_persisted_replicator(&self, peer_id: &str) -> P2PResult<()>;
 
+    async fn load_persisted_replicators(&self) -> P2PResult<Option<Vec<p2p::ReplicatorInfo>>> {
+        Ok(None)
+    }
+
     async fn persist_p2p_documents(&self, doc_ids: &[String]) -> P2PResult<()>;
 
     async fn load_p2p_documents(&self) -> P2PResult<Vec<String>>;
@@ -215,12 +219,22 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
     }
 
     async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()> {
-        let info =
-            p2p::ReplicatorInfo::from_raw(peer_id.to_string(), collections.to_vec(), Vec::new());
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let mut info = match peerstore.get_replicator(peer_id).await.map_err(|error| {
+            P2PError::persistence(format!("failed to load persisted replicator: {error}"))
+        })? {
+            Some(bytes) => p2p::ReplicatorInfo::from_bytes(&bytes).unwrap_or_else(|_| {
+                p2p::ReplicatorInfo::from_raw(peer_id.to_string(), collections.to_vec(), Vec::new())
+            }),
+            None => {
+                p2p::ReplicatorInfo::from_raw(peer_id.to_string(), collections.to_vec(), Vec::new())
+            }
+        };
+        info.id = peer_id.to_string();
+        info.collections = collections.to_vec();
         let bytes = info.to_bytes().map_err(|error| {
             P2PError::internal(format!("failed to serialize replicator info: {error}"))
         })?;
-        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         peerstore
             .create_replicator(peer_id, &bytes)
             .await
@@ -234,6 +248,13 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         peerstore.delete_replicator(peer_id).await.map_err(|error| {
             P2PError::persistence(format!("failed to delete persisted replicator: {error}"))
         })
+    }
+
+    async fn load_persisted_replicators(&self) -> P2PResult<Option<Vec<p2p::ReplicatorInfo>>> {
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        crate::load_persisted_replicators(&peerstore)
+            .await
+            .map(Some)
     }
 
     async fn persist_p2p_documents(&self, doc_ids: &[String]) -> P2PResult<()> {

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -129,7 +129,7 @@ pub use iroh_bitswap::Store as BitswapStore;
 pub struct QueryId(pub u64);
 
 // Re-export replicator types
-pub use replicator::ReplicatorInfo;
+pub use replicator::{ReplicatorInfo, ReplicatorStatus};
 
 // Re-export two-stream protocol types
 pub use two_stream::{TwoStreamEvent, TwoStreamHandler, TwoStreamRunner};

--- a/crates/p2p/src/replicator.rs
+++ b/crates/p2p/src/replicator.rs
@@ -98,29 +98,30 @@ mod go_time_serde {
     use super::*;
 
     pub fn serialize<S: Serializer>(t: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error> {
-        // `SecondsFormat::AutoSi` picks 0/3/6/9 digits; trim trailing zeros
-        // off the fractional tail to match Go's RFC3339Nano rule.
-        let formatted = t.to_rfc3339_opts(SecondsFormat::AutoSi, true);
-        let normalized = match formatted.find('.') {
-            None => formatted,
-            Some(dot_idx) => {
-                // Suffix after the digits is always "Z" for UTC here.
-                let z_idx = formatted.len() - 1;
-                let digits = &formatted[dot_idx + 1..z_idx];
-                let trimmed = digits.trim_end_matches('0');
-                if trimmed.is_empty() {
-                    // All zeros → drop the fractional component entirely.
-                    format!("{}Z", &formatted[..dot_idx])
-                } else {
-                    format!("{}.{}Z", &formatted[..dot_idx], trimmed)
-                }
-            }
-        };
-        s.serialize_str(&normalized)
+        s.serialize_str(&format_go_time(t))
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<DateTime<Utc>, D::Error> {
         DateTime::<Utc>::deserialize(d)
+    }
+}
+
+fn format_go_time(t: &DateTime<Utc>) -> String {
+    // `SecondsFormat::AutoSi` picks 0/3/6/9 digits; trim trailing zeros off
+    // the fractional tail to match Go's RFC3339Nano rule.
+    let formatted = t.to_rfc3339_opts(SecondsFormat::AutoSi, true);
+    match formatted.find('.') {
+        None => formatted,
+        Some(dot_idx) => {
+            let z_idx = formatted.len() - 1;
+            let digits = &formatted[dot_idx + 1..z_idx];
+            let trimmed = digits.trim_end_matches('0');
+            if trimmed.is_empty() {
+                format!("{}Z", &formatted[..dot_idx])
+            } else {
+                format!("{}.{}Z", &formatted[..dot_idx], trimmed)
+            }
+        }
     }
 }
 
@@ -220,6 +221,30 @@ impl ReplicatorInfo {
     /// Raw address strings as persisted.
     pub fn addresses_str(&self) -> &[String] {
         &self.addresses
+    }
+
+    /// Update status and timestamp only when the state actually changes.
+    pub fn set_status_if_changed(
+        &mut self,
+        status: ReplicatorStatus,
+        changed_at: DateTime<Utc>,
+    ) -> bool {
+        if self.status == status {
+            return false;
+        }
+        self.status = status;
+        self.last_status_change = changed_at;
+        true
+    }
+
+    /// Update status using the current UTC timestamp when the state changes.
+    pub fn set_status_if_changed_now(&mut self, status: ReplicatorStatus) -> bool {
+        self.set_status_if_changed(status, Utc::now())
+    }
+
+    /// Format `LastStatusChange` exactly like Go's `time.Time.MarshalJSON`.
+    pub fn last_status_change_go_string(&self) -> String {
+        format_go_time(&self.last_status_change)
     }
 
     /// Serialize to JSON bytes for peerstore persistence.

--- a/crates/p2p/tests/replicator_tests.rs
+++ b/crates/p2p/tests/replicator_tests.rs
@@ -111,6 +111,26 @@ fn json_round_trip_preserves_all_fields() {
 }
 
 #[test]
+fn status_update_records_first_transition_only() {
+    let peer_id = PeerId::random();
+    let mut info = ReplicatorInfo::new(peer_id, vec!["users".to_string()]).unwrap();
+    let inactive_at = Utc.with_ymd_and_hms(2026, 4, 26, 10, 0, 0).unwrap();
+    let repeated_at = Utc.with_ymd_and_hms(2026, 4, 26, 10, 5, 0).unwrap();
+    let active_at = Utc.with_ymd_and_hms(2026, 4, 26, 10, 10, 0).unwrap();
+
+    assert!(info.set_status_if_changed(ReplicatorStatus::Inactive, inactive_at));
+    assert_eq!(info.status, ReplicatorStatus::Inactive);
+    assert_eq!(info.last_status_change, inactive_at);
+
+    assert!(!info.set_status_if_changed(ReplicatorStatus::Inactive, repeated_at));
+    assert_eq!(info.last_status_change, inactive_at);
+
+    assert!(info.set_status_if_changed(ReplicatorStatus::Active, active_at));
+    assert_eq!(info.status, ReplicatorStatus::Active);
+    assert_eq!(info.last_status_change, active_at);
+}
+
+#[test]
 fn timestamp_encodes_like_go_rfc3339nano_with_trailing_zeros() {
     // Go's `time.Time.MarshalJSON` uses RFC3339Nano, which strips trailing
     // zeros from the fractional seconds (`.100` → `.1`, `.001` stays `.001`).

--- a/crates/storage/src/stores/retry_info.rs
+++ b/crates/storage/src/stores/retry_info.rs
@@ -4,8 +4,10 @@
 /// backoff intervals matching Go DefraDB's replicator retry behavior.
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Exponential backoff intervals in seconds: 30s, 1m, 2m, 4m, 8m, 16m, 32m.
-pub const RETRY_INTERVALS_SECS: &[u64] = &[30, 60, 120, 240, 480, 960, 1920];
+/// Exponential backoff intervals in seconds, matching Go's seconds-to-hours retry ladder.
+pub const RETRY_INTERVALS_SECS: &[u64] = &[
+    30, 60, 120, 240, 480, 960, 1920, 3600, 7200, 14400, 28800, 43200,
+];
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RetryInfo {
@@ -71,6 +73,14 @@ mod tests {
         info.bump();
         assert_eq!(info.num_retries, 1);
         assert!(!info.is_due());
+    }
+
+    #[test]
+    fn test_retry_intervals_reach_hours_scale_cap() {
+        assert_eq!(
+            RETRY_INTERVALS_SECS,
+            &[30, 60, 120, 240, 480, 960, 1920, 3600, 7200, 14400, 28800, 43200]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #837. Completes the missing persisted retry/status pieces around the existing P2P retry loops: failed pushes now mark replicators `Inactive`, successful retry drain marks them `Active`, and the status/timestamp are exposed through the HTTP/CLI replicator list paths.

Also extends the persisted retry backoff ladder from the short 32-minute cap to a Go-style seconds-to-hours sequence ending at 12 hours.

## Why

Rust already had the beginnings of the retry machine: retry queue entries in the peerstore and 2-second libp2p/Iroh retry loops. The missing part was the state machine that Go uses to make those retries observable and durable.

Without status updates, operators cannot distinguish a healthy replicator from one that has been failing for minutes or hours, and retry state can be silently reset by later replicator updates.

## Changes

| Area | Change |
|---|---|
| `p2p::ReplicatorInfo` | Add status transition helpers and reusable Go-compatible `LastStatusChange` formatting. Re-export `ReplicatorStatus`. |
| Retry backoff | Extend `RetryInfo` intervals to `30s → 12h` over 12 steps. |
| Embedded / CLI / defra-node retry loops | Mark persisted replicators `Inactive` after first failed push, `Active` after queued retries drain, and preserve `LastStatusChange` when status does not change. |
| `defra-p2p-adapter` | Add shared persisted-replicator status/load helpers; list persisted replicators when DB context is available so status is visible. |
| HTTP / CLI surface | Include Go-compatible `Status` and `LastStatusChange` fields in replicator list responses; CLI accepts `CollectionIDs`, `Status`, and `LastStatusChange`. |
| Persistence updates | Preserve existing status/timestamp when updating a persisted replicator's collection set. |

## Stacking note

This branch is intentionally based on `iverc/cli-pushlog-message-id-882`, so the CLI PushLog message-id CI fix is present until that PR lands on `main`. Once the fix branch is merged, that diff should disappear from this PR.

## Out of scope

- A full kill-peer / restart-peer integration test. This PR adds unit coverage around status transitions, backoff, response serialization, and CLI parsing; the full transient-peer scenario remains better suited to the integration harness once the related fixture PR lands.
- Persisting individual failed head CIDs. The current retry queue remains document-scoped and replays the current composite heads for the failed document.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p --test replicator_tests`
- [x] `cargo test -p storage retry_info`
- [x] `cargo test -p defra-p2p-adapter replicator_status`
- [x] `cargo test -p defra-http replicator`
- [x] `cargo test -p cli replicator_info_accepts_go_status_fields`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet` — passed outside sandbox; the sandboxed run hit the known `PermissionDenied` in defra-node benchmark tests.
