### PR TITLE
fix(p2p): preserve DAG fetch context (#842)

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -226,7 +226,7 @@ impl Node {
                     } => {
                         info!(
                             peer_id = %peer_id,
-                            message_id = %request.metadata.message_id,
+                            message_id = %request.message_id,
                             doc_id = %request.doc_id,
                             "Processing TwoStreamRequest through coordinator"
                         );

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -15,10 +15,13 @@ use tokio::time::timeout;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Error;
-use crate::message::{BranchableSyncRequest, DocSyncRequest, PushLogBroadcast, PushLogRequest};
+use crate::message::{
+    BranchableSyncRequest, CarFetchRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
+    PushLogRequest,
+};
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
-use crate::sync::head_provider::NoOpHeadProvider;
+use crate::sync::head_provider::{DocumentHeadProvider, NoOpHeadProvider};
 use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager};
 use crate::sync::peer_state::PeerStateTracker;
 use crate::sync::rate_limiter::PeerRateLimiter;
@@ -101,6 +104,16 @@ fn create_test_coordinator_with_blockstore<B: Blockstore + 'static>(
     SyncCoordinator<B, NoopTransport>,
     tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
 ) {
+    create_test_coordinator_with_blockstore_and_head_provider(params, Arc::new(NoOpHeadProvider))
+}
+
+fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'static>(
+    params: TestCoordinatorParams<B>,
+    head_provider: Arc<dyn DocumentHeadProvider>,
+) -> (
+    SyncCoordinator<B, NoopTransport>,
+    tokio::sync::mpsc::Receiver<crate::sync::manager::SyncEvent>,
+) {
     let TestCoordinatorParams {
         access_mode,
         replicators,
@@ -147,7 +160,7 @@ fn create_test_coordinator_with_blockstore<B: Blockstore + 'static>(
                 std::collections::HashSet::new(),
             )),
             collection_store: Arc::new(NoOpCollectionStorage),
-            head_provider: Arc::new(NoOpHeadProvider),
+            head_provider,
         },
         authorizer,
         document_acp: std::sync::OnceLock::new(),
@@ -252,6 +265,7 @@ struct NoopTransport {
     pubkey: Vec<u8>,
     replicators: Arc<RwLock<std::collections::HashMap<String, Vec<String>>>>,
     connected_peers: Arc<RwLock<Vec<PeerId>>>,
+    doc_sync_replies: Arc<RwLock<Vec<DocSyncReply>>>,
 }
 
 impl NoopTransport {
@@ -261,11 +275,16 @@ impl NoopTransport {
             pubkey: vec![1, 2, 3],
             replicators: Arc::new(RwLock::new(std::collections::HashMap::new())),
             connected_peers: Arc::new(RwLock::new(Vec::new())),
+            doc_sync_replies: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
     fn set_connected_peers(&self, peers: Vec<PeerId>) {
         *self.connected_peers.write() = peers;
+    }
+
+    fn doc_sync_replies(&self) -> Vec<DocSyncReply> {
+        self.doc_sync_replies.read().clone()
     }
 }
 
@@ -368,8 +387,9 @@ impl P2PTransport for NoopTransport {
     async fn send_doc_sync_response(
         &self,
         _peer_id: &PeerId,
-        _reply: crate::message::DocSyncReply,
+        reply: crate::message::DocSyncReply,
     ) -> crate::Result<()> {
+        self.doc_sync_replies.write().push(reply);
         Ok(())
     }
 
@@ -408,8 +428,9 @@ impl P2PTransport for NoopTransport {
     async fn send_doc_sync_response_token(
         &self,
         _token: Self::ResponseToken,
-        _reply: crate::message::DocSyncReply,
+        reply: crate::message::DocSyncReply,
     ) -> crate::Result<()> {
+        self.doc_sync_replies.write().push(reply);
         Ok(())
     }
 
@@ -558,6 +579,29 @@ fn gossip_event_on_topic(peer_id: PeerId, topic: &str, collection_id: &str) -> T
         message_id: MessageId::new("gossip".to_string()),
         topic: topic.to_string(),
         message: PushLogBroadcast::from_request(&pushlog_request(collection_id)),
+    }
+}
+
+fn car_fetch_event(peer_id: PeerId, root_cid: Cid) -> TransportEvent<()> {
+    TransportEvent::CarFetchRequest {
+        peer_id,
+        request: CarFetchRequest::full_dag(root_cid),
+        token: None,
+    }
+}
+
+struct StaticHeadProvider {
+    heads: Vec<Cid>,
+}
+
+#[async_trait]
+impl DocumentHeadProvider for StaticHeadProvider {
+    async fn get_document_heads(&self, _doc_id: &str) -> crate::Result<Vec<Cid>> {
+        Ok(self.heads.clone())
+    }
+
+    async fn get_collection_heads(&self, _collection_id: &str) -> crate::Result<Vec<Cid>> {
+        Ok(Vec::new())
     }
 }
 
@@ -719,6 +763,116 @@ async fn doc_sync_controlled_mode_allows_any_replicator() {
     assert!(
         !matches!(&result, Err(Error::AccessDenied { .. })),
         "Registered replicator (any collection) should be allowed, got {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn doc_sync_filters_heads_outside_replicator_collection() {
+    use defra_core::{Block, CompositeDeltaPayload, CrdtDelta};
+
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+
+    let peer = random_peer_id();
+    replicators.add_replicator("collection_a", peer.as_str());
+
+    let transport = NoopTransport::new();
+    let transport_handle = transport.clone();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+    let block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            schema_version_id: "collection_b".to_string(),
+            priority: 1,
+            status: 1,
+        }),
+        vec![],
+        vec![],
+    );
+    let block_data = block.to_dag_cbor().unwrap();
+    let cid = block.generate_cid().unwrap();
+    blockstore.put(&cid, &block_data).await.unwrap();
+
+    let (coordinator, _events) = create_test_coordinator_with_blockstore_and_head_provider(
+        TestCoordinatorParams {
+            access_mode: AccessMode::Controlled,
+            replicators,
+            peer_state,
+            transport,
+            local_peer_id,
+            broadcaster,
+            blockstore,
+            rate_limiter: Arc::new(PeerRateLimiter::default()),
+        },
+        Arc::new(StaticHeadProvider { heads: vec![cid] }),
+    );
+
+    coordinator
+        .handle_transport_event(doc_sync_event(peer))
+        .await
+        .unwrap();
+
+    let replies = transport_handle.doc_sync_replies();
+    assert_eq!(replies.len(), 1);
+    assert!(
+        replies[0].results.is_empty(),
+        "DocSync must not return heads from collections the peer cannot replicate"
+    );
+}
+
+#[tokio::test]
+async fn car_fetch_controlled_mode_rejects_wrong_collection_root() {
+    use defra_core::{Block, CompositeDeltaPayload, CrdtDelta};
+
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+
+    let peer = random_peer_id();
+    replicators.add_replicator("collection_a", peer.as_str());
+
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+    let block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            schema_version_id: "collection_b".to_string(),
+            priority: 1,
+            status: 1,
+        }),
+        vec![],
+        vec![],
+    );
+    let block_data = block.to_dag_cbor().unwrap();
+    let cid = block.generate_cid().unwrap();
+    blockstore.put(&cid, &block_data).await.unwrap();
+
+    let (coordinator, _events) = create_test_coordinator_with_blockstore(TestCoordinatorParams {
+        access_mode: AccessMode::Controlled,
+        replicators,
+        peer_state,
+        transport,
+        local_peer_id,
+        broadcaster,
+        blockstore,
+        rate_limiter: Arc::new(PeerRateLimiter::default()),
+    });
+
+    let result = coordinator
+        .handle_transport_event(car_fetch_event(peer, cid))
+        .await;
+
+    assert!(
+        matches!(result, Err(Error::AccessDenied { .. })),
+        "CAR root access must be collection-scoped in Controlled mode, got {:?}",
         result
     );
 }
@@ -1057,6 +1211,37 @@ async fn create_replicator_updates_access_registry_for_gossip() {
         "registered replicator should authorize gossip immediately, got {:?}",
         result
     );
+}
+
+#[tokio::test]
+async fn gossip_registered_replicator_is_marked_explicit_replicator() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let peer = random_peer_id();
+    replicators.add_replicator("collection1", peer.as_str());
+
+    let (coordinator, mut events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+
+    coordinator
+        .handle_transport_event(gossip_event(peer.clone(), "collection1"))
+        .await
+        .unwrap();
+
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived {
+            sender_peer,
+            is_explicit_replicator,
+            ..
+        } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+            assert!(
+                is_explicit_replicator,
+                "registered gossip source should preserve explicit replicator trust"
+            );
+        }
+        other => panic!("expected BlockReceived, got {:?}", other),
+    }
 }
 
 #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/dag_context.rs
+++ b/crates/p2p/src/sync/coordinator/dag_context.rs
@@ -1,0 +1,126 @@
+//! Context carried while fetching a DAG before merge.
+
+use acp::ReplicatedDocActorRelationships;
+use cid::Cid;
+use defra_core::Block as DefraBlock;
+
+use crate::sync::manager::SyncEvent;
+use crate::transport::PeerId;
+use crate::ExplicitReplayAuthorization;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct BlockContext {
+    pub(crate) doc_id: Option<String>,
+    pub(crate) collection_id: Option<String>,
+}
+
+pub(crate) fn block_context_from_data(block_data: &[u8]) -> BlockContext {
+    let Ok(block) = DefraBlock::from_dag_cbor(block_data) else {
+        return BlockContext::default();
+    };
+
+    BlockContext {
+        doc_id: block
+            .delta
+            .doc_id()
+            .map(|doc_id| String::from_utf8_lossy(doc_id).to_string()),
+        collection_id: block.delta.schema_version_id().map(ToString::to_string),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DagFetchContext {
+    pub(crate) doc_id: String,
+    pub(crate) collection_id: String,
+    pub(crate) creator: String,
+    pub(crate) source_peer: PeerId,
+    pub(crate) is_explicit_replicator: bool,
+    explicit_replicator_collections: Option<Vec<String>>,
+    pub(crate) explicit_replay_authorization: Option<ExplicitReplayAuthorization>,
+    pub(crate) acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
+}
+
+impl DagFetchContext {
+    pub(crate) fn new(
+        doc_id: String,
+        collection_id: String,
+        creator: String,
+        source_peer: PeerId,
+    ) -> Self {
+        Self {
+            doc_id,
+            collection_id,
+            creator,
+            source_peer,
+            is_explicit_replicator: false,
+            explicit_replicator_collections: None,
+            explicit_replay_authorization: None,
+            acp_actor_relationships: None,
+        }
+    }
+
+    pub(crate) fn with_explicit_replicator(mut self, is_explicit_replicator: bool) -> Self {
+        self.is_explicit_replicator = is_explicit_replicator;
+        self
+    }
+
+    pub(crate) fn with_explicit_replicator_collections(mut self, collections: Vec<String>) -> Self {
+        self.explicit_replicator_collections = Some(collections);
+        self.refresh_explicit_replicator_from_collection();
+        self
+    }
+
+    pub(crate) fn with_explicit_replay_authorization(
+        mut self,
+        authorization: Option<ExplicitReplayAuthorization>,
+    ) -> Self {
+        self.explicit_replay_authorization = authorization;
+        self
+    }
+
+    pub(crate) fn with_acp_actor_relationships(
+        mut self,
+        relationships: Option<ReplicatedDocActorRelationships>,
+    ) -> Self {
+        self.acp_actor_relationships = relationships;
+        self
+    }
+
+    pub(crate) fn fill_missing_from_block(&mut self, block_data: &[u8]) {
+        let block_context = block_context_from_data(block_data);
+        if self.doc_id.is_empty() {
+            if let Some(doc_id) = block_context.doc_id {
+                self.doc_id = doc_id;
+            }
+        }
+        if self.collection_id.is_empty() {
+            if let Some(collection_id) = block_context.collection_id {
+                self.collection_id = collection_id;
+            }
+        }
+        self.refresh_explicit_replicator_from_collection();
+    }
+
+    fn refresh_explicit_replicator_from_collection(&mut self) {
+        let Some(collections) = &self.explicit_replicator_collections else {
+            return;
+        };
+        self.is_explicit_replicator = !self.collection_id.is_empty()
+            && collections
+                .iter()
+                .any(|collection_id| collection_id == &self.collection_id);
+    }
+
+    pub(crate) fn into_dag_ready(self, root_cid: Cid) -> SyncEvent {
+        SyncEvent::DagReady {
+            root_cid,
+            doc_id: self.doc_id,
+            collection_id: self.collection_id,
+            creator: self.creator,
+            sender_peer: Some(self.source_peer.to_string()),
+            is_explicit_replicator: self.is_explicit_replicator,
+            explicit_replay_authorization: self.explicit_replay_authorization,
+            acp_actor_relationships: self.acp_actor_relationships,
+        }
+    }
+}

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -11,6 +11,7 @@ use cid::Cid;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
+use super::dag_context::DagFetchContext;
 use crate::sync::manager::links::find_all_missing_links;
 use crate::sync::manager::SyncEvent;
 use crate::transport::{P2PTransport, PeerId};
@@ -28,21 +29,19 @@ enum FetchBatchOutcome {
 ///
 /// Strategy: try CAR fetch first (one round-trip), then selective block fetch
 /// for any missing blocks.
-#[allow(clippy::too_many_arguments)]
 pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
     transport: T,
     blockstore: Arc<B>,
     event_tx: mpsc::Sender<SyncEvent>,
     root_cid: Cid,
-    doc_id: String,
-    collection_id: String,
-    schema_version_id: String,
-    source_peer: PeerId,
+    context: DagFetchContext,
 ) {
     debug!(
         root_cid = %root_cid,
-        doc_id = %doc_id,
-        source_peer = %source_peer,
+        doc_id = %context.doc_id,
+        collection_id = %context.collection_id,
+        source_peer = %context.source_peer,
+        is_explicit_replicator = context.is_explicit_replicator,
         "Starting DAG fetch (CAR-first, selective block fallback)"
     );
 
@@ -59,7 +58,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
         &transport,
         &blockstore,
         &root_cid,
-        &source_peer,
+        &context.source_peer,
         car_missing_watch.as_deref(),
     )
     .await
@@ -69,19 +68,8 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
                 .await
                 .unwrap_or_default();
             if missing.is_empty() {
-                info!(root_cid = %root_cid, doc_id = %doc_id, "DAG fetch complete via CAR");
-                let _ = event_tx
-                    .send(SyncEvent::DagReady {
-                        root_cid,
-                        doc_id,
-                        collection_id,
-                        creator: schema_version_id,
-                        sender_peer: Some(source_peer.to_string()),
-                        is_explicit_replicator: false,
-                        explicit_replay_authorization: None,
-                        acp_actor_relationships: None,
-                    })
-                    .await;
+                info!(root_cid = %root_cid, doc_id = %context.doc_id, "DAG fetch complete via CAR");
+                emit_dag_ready(&event_tx, root_cid, &context, &root_data).await;
                 return;
             }
             debug!(
@@ -99,7 +87,7 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
             std::slice::from_ref(&root_cid),
             &transport,
             &blockstore,
-            &source_peer,
+            &context.source_peer,
         )
         .await,
         FetchBatchOutcome::Complete
@@ -139,7 +127,15 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
 
         let mut made_progress = false;
         for batch in missing.chunks(SELECTIVE_FETCH_BATCH_SIZE) {
-            match poll_fetch_blocks(&root_cid, batch, &transport, &blockstore, &source_peer).await {
+            match poll_fetch_blocks(
+                &root_cid,
+                batch,
+                &transport,
+                &blockstore,
+                &context.source_peer,
+            )
+            .await
+            {
                 FetchBatchOutcome::Complete => {
                     made_progress = true;
                 }
@@ -175,27 +171,27 @@ pub async fn poll_fetch_dag<B: Blockstore + 'static, T: P2PTransport>(
         .unwrap_or_default();
 
     if remaining.is_empty() {
-        info!(root_cid = %root_cid, doc_id = %doc_id, "DAG fetch complete");
-        let _ = event_tx
-            .send(SyncEvent::DagReady {
-                root_cid,
-                doc_id,
-                collection_id,
-                creator: schema_version_id,
-                sender_peer: Some(source_peer.to_string()),
-                is_explicit_replicator: false,
-                explicit_replay_authorization: None,
-                acp_actor_relationships: None,
-            })
-            .await;
+        info!(root_cid = %root_cid, doc_id = %context.doc_id, "DAG fetch complete");
+        emit_dag_ready(&event_tx, root_cid, &context, &root_data).await;
     } else {
         warn!(
             root_cid = %root_cid,
-            doc_id = %doc_id,
+            doc_id = %context.doc_id,
             remaining_count = remaining.len(),
             "DAG fetch incomplete"
         );
     }
+}
+
+async fn emit_dag_ready(
+    event_tx: &mpsc::Sender<SyncEvent>,
+    root_cid: Cid,
+    context: &DagFetchContext,
+    root_data: &[u8],
+) {
+    let mut context = context.clone();
+    context.fill_missing_from_block(root_data);
+    let _ = event_tx.send(context.into_dag_ready(root_cid)).await;
 }
 
 /// Try to fetch an entire DAG via a single CAR request.
@@ -622,17 +618,35 @@ mod tests {
             blockstore.clone(),
             event_tx,
             root_cid,
-            "doc-id".to_string(),
-            "collection-id".to_string(),
-            "schema-version-id".to_string(),
-            source_peer,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                source_peer.clone(),
+            )
+            .with_explicit_replicator(true),
         )
         .await;
 
-        assert!(matches!(
-            event_rx.recv().await,
-            Some(SyncEvent::DagReady { root_cid: ready_cid, .. }) if ready_cid == root_cid
-        ));
+        match event_rx.recv().await {
+            Some(SyncEvent::DagReady {
+                root_cid: ready_cid,
+                doc_id,
+                collection_id,
+                creator,
+                sender_peer,
+                is_explicit_replicator,
+                ..
+            }) => {
+                assert_eq!(ready_cid, root_cid);
+                assert_eq!(doc_id, "doc-id");
+                assert_eq!(collection_id, "collection-id");
+                assert_eq!(creator, "creator-id");
+                assert_eq!(sender_peer.as_deref(), Some(source_peer.as_str()));
+                assert!(is_explicit_replicator);
+            }
+            other => panic!("expected DagReady, got {:?}", other),
+        }
         assert!(matches!(blockstore.has(&child_one_cid).await, Ok(true)));
         assert!(matches!(blockstore.has(&child_two_cid).await, Ok(true)));
         assert_eq!(transport.car_request_count(), 1);
@@ -673,10 +687,12 @@ mod tests {
             blockstore.clone(),
             event_tx,
             root_cid,
-            "doc-id".to_string(),
-            "collection-id".to_string(),
-            "schema-version-id".to_string(),
-            source_peer,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                source_peer,
+            ),
         )
         .await;
 
@@ -729,10 +745,12 @@ mod tests {
             blockstore.clone(),
             event_tx,
             root_cid,
-            "doc-id".to_string(),
-            "collection-id".to_string(),
-            "schema-version-id".to_string(),
-            source_peer,
+            DagFetchContext::new(
+                "doc-id".to_string(),
+                "collection-id".to_string(),
+                "creator-id".to_string(),
+                source_peer,
+            ),
         )
         .await;
 

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -4,6 +4,7 @@ use cid::Cid;
 
 use blockstore::Blockstore;
 
+use super::super::dag_context::DagFetchContext;
 use super::super::SyncCoordinator;
 use crate::error::Result;
 use crate::message::BranchableSyncReply;
@@ -191,6 +192,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 let collection_id = reply.collection_id.clone();
                 let semaphore = semaphore.clone();
                 let source_peer = peer_id.clone();
+                let is_explicit_replicator =
+                    self.is_registered_replicator(peer_id.as_str(), &collection_id);
 
                 self.spawn_background_task("branchable_sync_reply_fetch_dag", async move {
                     let Ok(_permit) = semaphore.acquire_owned().await else {
@@ -201,10 +204,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         blockstore,
                         event_tx,
                         root_cid,
-                        String::new(),
-                        collection_id,
-                        String::new(),
-                        source_peer,
+                        DagFetchContext::new(
+                            String::new(),
+                            collection_id,
+                            String::new(),
+                            source_peer,
+                        )
+                        .with_explicit_replicator(is_explicit_replicator),
                     )
                     .await;
                 });

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -3,9 +3,11 @@
 use blockstore::{verify_block_cid, Blockstore};
 use cid::Cid;
 
-use crate::error::Result;
+use super::super::authorizer::AccessAuthorizer;
+use crate::error::{Error, Result};
 use crate::message::CarFetchRequest;
 use crate::sync::car::{collect_dag_blocks, collect_exact_blocks, decode_car, encode_car};
+use crate::sync::coordinator::dag_context::block_context_from_data;
 use crate::sync::coordinator::SyncCoordinator;
 use crate::transport::{P2PTransport, PeerId};
 
@@ -14,6 +16,67 @@ fn sample_cids(cids: &[Cid]) -> Vec<String> {
 }
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    async fn check_car_fetch_access(
+        &self,
+        peer_id: &PeerId,
+        request: &CarFetchRequest,
+    ) -> Result<()> {
+        if self.access.access_mode.is_open() {
+            return Ok(());
+        }
+
+        let mut checked_collection = false;
+        for cid in request.response_roots() {
+            let block_data = match self.manager.blockstore().get(&cid).await {
+                Ok(Some(data)) => data,
+                Ok(None) => continue,
+                Err(error) => {
+                    tracing::debug!(
+                        cid = %cid,
+                        peer_id = %peer_id,
+                        error = %error,
+                        "CAR handler: failed to read requested block for collection access check"
+                    );
+                    continue;
+                }
+            };
+
+            let Some(collection_id) = block_context_from_data(&block_data).collection_id else {
+                continue;
+            };
+
+            checked_collection = true;
+            let is_collection_replicator = self
+                .authorizer
+                .peer_authorized_for_collection(peer_id.as_str(), &collection_id)
+                .await;
+            let is_collection_subscriber = self
+                .access
+                .peer_state
+                .peer_subscribed_to_collection(peer_id.as_str(), &collection_id);
+
+            if !is_collection_replicator && !is_collection_subscriber {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    collection_id = %collection_id,
+                    is_collection_replicator,
+                    is_collection_subscriber,
+                    "Access denied: peer cannot fetch CAR blocks for this collection"
+                );
+                return Err(Error::AccessDenied {
+                    peer_id: peer_id.to_string(),
+                    collection_id,
+                });
+            }
+        }
+
+        if checked_collection {
+            Ok(())
+        } else {
+            self.check_peer_is_replicator(peer_id).await
+        }
+    }
+
     /// Handle an inbound CAR fetch request: collect the DAG and send CARv1 response.
     pub(crate) async fn handle_car_fetch_request(
         &self,
@@ -34,7 +97,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             }
         };
 
-        if let Err(error) = self.check_peer_is_replicator(&peer_id).await {
+        if let Err(error) = self.check_car_fetch_access(&peer_id, &request).await {
             tracing::warn!(
                 root_cid = %request.root_cid,
                 peer_id = %peer_id,

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -4,6 +4,8 @@ use cid::Cid;
 
 use blockstore::Blockstore;
 
+use super::super::authorizer::AccessAuthorizer;
+use super::super::dag_context::{block_context_from_data, DagFetchContext};
 use super::super::SyncCoordinator;
 use crate::error::{Error, Result};
 use crate::message::{DocSyncItem, DocSyncReply, MAX_DOC_IDS};
@@ -42,6 +44,78 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         Ok(())
+    }
+
+    async fn filter_authorized_doc_heads(
+        &self,
+        peer_id: &PeerId,
+        doc_id: &str,
+        heads: Vec<Cid>,
+    ) -> Vec<Cid> {
+        if self.access.access_mode.is_open() {
+            return heads;
+        }
+
+        let mut authorized = Vec::with_capacity(heads.len());
+        for cid in heads {
+            let block_data = match self.manager.blockstore().get(&cid).await {
+                Ok(Some(data)) => data,
+                Ok(None) => {
+                    tracing::debug!(
+                        peer_id = %peer_id,
+                        doc_id = %doc_id,
+                        cid = %cid,
+                        "Skipping DocSync head with missing local block during access check"
+                    );
+                    continue;
+                }
+                Err(error) => {
+                    tracing::debug!(
+                        peer_id = %peer_id,
+                        doc_id = %doc_id,
+                        cid = %cid,
+                        error = %error,
+                        "Skipping DocSync head after blockstore access-check failure"
+                    );
+                    continue;
+                }
+            };
+
+            let Some(collection_id) = block_context_from_data(&block_data).collection_id else {
+                tracing::debug!(
+                    peer_id = %peer_id,
+                    doc_id = %doc_id,
+                    cid = %cid,
+                    "Skipping DocSync head without collection context in Controlled mode"
+                );
+                continue;
+            };
+
+            let is_collection_replicator = self
+                .authorizer
+                .peer_authorized_for_collection(peer_id.as_str(), &collection_id)
+                .await;
+            let is_collection_subscriber = self
+                .access
+                .peer_state
+                .peer_subscribed_to_collection(peer_id.as_str(), &collection_id);
+
+            if is_collection_replicator || is_collection_subscriber {
+                authorized.push(cid);
+            } else {
+                tracing::debug!(
+                    peer_id = %peer_id,
+                    doc_id = %doc_id,
+                    cid = %cid,
+                    collection_id = %collection_id,
+                    is_collection_replicator,
+                    is_collection_subscriber,
+                    "Skipping DocSync head for unauthorized collection"
+                );
+            }
+        }
+
+        authorized
     }
 
     pub(super) async fn handle_doc_sync_request(
@@ -83,6 +157,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 .await
             {
                 Ok(heads) => {
+                    let heads = self
+                        .filter_authorized_doc_heads(&peer_id, doc_id, heads)
+                        .await;
                     tracing::debug!(
                         doc_id = %doc_id,
                         head_count = heads.len(),
@@ -214,6 +291,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         .unwrap_or_default();
 
                         if missing.is_empty() {
+                            let mut context = DagFetchContext::new(
+                                doc_id.clone(),
+                                String::new(),
+                                String::new(),
+                                peer_id.clone(),
+                            )
+                            .with_explicit_replicator_collections(
+                                self.access.replicators.get_collections(peer_id.as_str()),
+                            );
+                            context.fill_missing_from_block(&data);
                             tracing::info!(
                                 cid = %cid,
                                 doc_id = %doc_id,
@@ -222,11 +309,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                             let _ = event_tx
                                 .send(crate::sync::manager::SyncEvent::BlockReceived {
                                     cid,
-                                    doc_id: doc_id.clone(),
-                                    collection_id: String::new(),
-                                    creator: String::new(),
-                                    sender_peer: Some(peer_id.to_string()),
-                                    is_explicit_replicator: false,
+                                    doc_id: context.doc_id,
+                                    collection_id: context.collection_id,
+                                    creator: context.creator,
+                                    sender_peer: Some(context.source_peer.to_string()),
+                                    is_explicit_replicator: context.is_explicit_replicator,
                                     explicit_replay_authorization: None,
                                     acp_actor_relationships: None,
                                 })
@@ -271,6 +358,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 let event_tx = event_tx.clone();
                 let semaphore = semaphore.clone();
                 let source_peer = peer_id.clone();
+                let explicit_replicator_collections =
+                    self.access.replicators.get_collections(peer_id.as_str());
 
                 self.spawn_background_task("doc_sync_reply_fetch_dag", async move {
                     let Ok(_permit) = semaphore.acquire_owned().await else {
@@ -281,10 +370,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         blockstore,
                         event_tx,
                         root_cid,
-                        doc_id,
-                        String::new(),
-                        String::new(),
-                        source_peer,
+                        DagFetchContext::new(doc_id, String::new(), String::new(), source_peer)
+                            .with_explicit_replicator_collections(explicit_replicator_collections),
                     )
                     .await;
                 });

--- a/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
@@ -76,8 +76,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             }
         }
 
+        let is_explicit_replicator =
+            self.is_registered_replicator(propagation_source.as_str(), &message.collection_id);
+
         self.manager
-            .process_pushlog(&message, Some(propagation_source.as_str()), false, None)
+            .process_pushlog(
+                &message,
+                Some(propagation_source.as_str()),
+                is_explicit_replicator,
+                None,
+            )
             .await
     }
 }

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -43,6 +43,7 @@ mod accessors;
 mod authorizer;
 mod broadcast;
 mod constructor;
+pub(crate) mod dag_context;
 pub(crate) mod dag_fetcher;
 mod event_handler;
 mod pubsub_client;

--- a/crates/p2p/src/sync/peer_state/tracker/operations.rs
+++ b/crates/p2p/src/sync/peer_state/tracker/operations.rs
@@ -156,6 +156,15 @@ impl PeerStateTracker {
             .unwrap_or(false)
     }
 
+    /// Check if a peer has advertised interest in a specific data collection.
+    pub fn peer_subscribed_to_collection(&self, peer_id: &str, collection_id: &str) -> bool {
+        let peers = self.peers.read();
+        peers
+            .get(peer_id)
+            .map(|info| info.subscribed_collections.contains(collection_id))
+            .unwrap_or(false)
+    }
+
     /// Get all connected peers.
     pub fn connected_peers(&self) -> Vec<String> {
         let peers = self.peers.read();

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -7,6 +7,7 @@ use acp::ReplicatedDocActorRelationships;
 
 use super::config::ReplicationConfig;
 use super::result::ReplicationResult;
+use crate::sync::coordinator::dag_context::DagFetchContext;
 use crate::sync::coordinator::SyncCoordinator;
 use crate::sync::manager::SyncEvent;
 use crate::sync::merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
@@ -20,6 +21,9 @@ pub(super) struct DagFetchRequest {
     collection_id: String,
     creator: String,
     sender_peer: Option<String>,
+    is_explicit_replicator: bool,
+    explicit_replay_authorization: Option<crate::ExplicitReplayAuthorization>,
+    acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
 }
 
 /// Handle a DagNeedsFetch event by initiating a Bitswap sync.
@@ -39,6 +43,9 @@ where
         collection_id,
         creator,
         sender_peer,
+        is_explicit_replicator,
+        explicit_replay_authorization,
+        acp_actor_relationships,
     } = request;
 
     tracing::debug!(
@@ -59,17 +66,14 @@ where
         let blockstore = coordinator.blockstore().clone();
         let event_tx = coordinator.manager().event_sender();
         let source_peer = crate::transport::PeerId::new(source_peer);
+        let context = DagFetchContext::new(doc_id, collection_id, creator, source_peer)
+            .with_explicit_replicator(is_explicit_replicator)
+            .with_explicit_replay_authorization(explicit_replay_authorization)
+            .with_acp_actor_relationships(acp_actor_relationships);
 
         coordinator.spawn_background_task("pushlog_fetch_dag", async move {
             crate::sync::coordinator::dag_fetcher::poll_fetch_dag(
-                transport,
-                blockstore,
-                event_tx,
-                root_cid,
-                doc_id,
-                collection_id,
-                creator,
-                source_peer,
+                transport, blockstore, event_tx, root_cid, context,
             )
             .await;
         });
@@ -549,7 +553,9 @@ where
             collection_id,
             creator,
             sender_peer,
-            ..
+            is_explicit_replicator,
+            explicit_replay_authorization,
+            acp_actor_relationships,
         } => {
             handle_dag_needs_fetch(
                 coordinator,
@@ -561,6 +567,9 @@ where
                     collection_id,
                     creator,
                     sender_peer,
+                    is_explicit_replicator,
+                    explicit_replay_authorization,
+                    acp_actor_relationships,
                 },
             )
             .await

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -918,7 +918,7 @@ mod tests {
                     bytes::Bytes::from(root_data),
                 ),
                 token: None,
-                is_explicit_replicator: false,
+                is_explicit_replicator: true,
                 explicit_replay_authorization: None,
             })
             .await
@@ -949,7 +949,28 @@ mod tests {
             .expect("DagReady should arrive")
             .expect("event should be present");
 
-        assert!(matches!(&event, SyncEvent::DagReady { root_cid: cid, .. } if *cid == root_cid));
+        match &event {
+            SyncEvent::DagReady {
+                root_cid: cid,
+                doc_id,
+                collection_id,
+                creator,
+                sender_peer,
+                is_explicit_replicator,
+                ..
+            } => {
+                assert_eq!(*cid, root_cid);
+                assert_eq!(doc_id, "doc1");
+                assert_eq!(collection_id, "col1");
+                assert_eq!(creator, "creator-1");
+                assert_eq!(sender_peer.as_deref(), Some("source-peer"));
+                assert!(
+                    *is_explicit_replicator,
+                    "poll fetcher should preserve push-driven explicit replicator trust"
+                );
+            }
+            other => panic!("expected DagReady, got {:?}", other),
+        }
         assert_eq!(transport_handle.sync_blocks_calls(), 0);
         assert!(blockstore.has(&child_cid).await.unwrap());
 


### PR DESCRIPTION
## Summary

Closes #842. Preserves DAG fetch context across DocSync, BranchableSync, push-driven DAG recovery, and gossip paths so the merge layer receives the correct collection, sender, creator, and explicit-replicator trust metadata.

This also tightens collection-scoped access checks for DocSync and CAR fetches in Controlled mode, preventing peers authorized for one collection from receiving heads or CAR data for another collection.

## Why

Several fetch paths were losing context before emitting `DagReady` or `BlockReceived`: the poll-based DAG fetcher hardcoded `is_explicit_replicator = false`, DocSync emitted locally-present blocks with empty collection/creator fields, and push-driven `DagNeedsFetch` dropped trust metadata before spawning the fetcher.

That made downstream ACP and merge routing decisions less reliable, especially when a block arrived from a registered replicator but was later merged as untrusted or collection-less.

## Changes

| Area | Change |
|---|---|
| DAG fetcher | Add `DagFetchContext` and use it to preserve doc ID, collection ID, creator, source peer, explicit-replicator trust, explicit replay auth, and ACP relationship snapshots. |
| Push-driven recovery | Thread `DagNeedsFetch` metadata through `handle_dag_needs_fetch()` into the poll fetcher instead of dropping it at the handler boundary. |
| DocSync | Filter returned heads by decoded collection access in Controlled mode and fill missing merge context from the fetched root block. |
| BranchableSync | Preserve collection context and registered-replicator trust when spawning DAG fetches from collection-head replies. |
| CAR fetch | Apply collection-scoped access checks when requested roots can be decoded locally. |
| Gossip | Mark gossip from registered collection replicators as explicit-replicator traffic. |
| Peer state | Add a collection-specific subscription helper for controlled DocSync/CAR access decisions. |

## Stacking note

This branch is intentionally based on `iverc/cli-pushlog-message-id-882`, so the CLI PushLog message-id CI fix is present until that PR lands on `main`. Once the fix branch is merged, that diff should disappear from this PR.

## Out of scope

- Full cross-node integration coverage for every transport path. This PR adds focused regression coverage in the P2P unit/coordinator tests.
- Changing DocSync or CAR wire formats. The fix preserves existing wire compatibility and derives missing collection context from locally available block data where possible.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p dag_fetcher`
- [x] `cargo test -p p2p access_tests`
- [x] `cargo test -p p2p test_pushlog_dag_needs_fetch_uses_poll_fetcher_when_sender_known`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet` — passed outside sandbox; the sandboxed run hit the known `PermissionDenied` in `defra-node` benchmark support tests.
