### PR TITLE
fix(p2p): harden batch merge contracts (#841)

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -226,7 +226,7 @@ impl Node {
                     } => {
                         info!(
                             peer_id = %peer_id,
-                            message_id = %request.metadata.message_id,
+                            message_id = %request.message_id,
                             doc_id = %request.doc_id,
                             "Processing TwoStreamRequest through coordinator"
                         );

--- a/crates/db-merge/src/acp_merge_handler.rs
+++ b/crates/db-merge/src/acp_merge_handler.rs
@@ -5,7 +5,7 @@ use acp::{DocumentACP, DocumentPermission, Identity};
 use async_trait::async_trait;
 use cid::Cid;
 use identity::Identity as _;
-use p2p::sync::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
+use p2p::sync::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata};
 use schema::CollectionVersion;
 use storage::corekv::Store;
 
@@ -230,6 +230,24 @@ where
     B: blockstore::Blockstore + Send + Sync + 'static,
 {
     type Error = AcpMergeError;
+
+    async fn validate_authorization(
+        &self,
+        authorization: Option<&p2p::ExplicitReplayAuthorization>,
+        block: &MergeBlock,
+    ) -> Result<(), Self::Error> {
+        self.inner
+            .validate_authorization(authorization, block)
+            .await
+    }
+
+    async fn recover_block_metadata(
+        &self,
+        cid: &Cid,
+        block_data: &[u8],
+    ) -> Result<Option<RecoveredBlockMetadata>, Self::Error> {
+        self.inner.recover_block_metadata(cid, block_data).await
+    }
 
     async fn handle_block(
         &self,

--- a/crates/db-merge/src/merge_handler/batch.rs
+++ b/crates/db-merge/src/merge_handler/batch.rs
@@ -30,6 +30,17 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMe
 
         let mut results = Vec::with_capacity(blocks.len());
         for block in blocks {
+            if let Err(error) = self
+                .validate_explicit_replay_authorization(
+                    block.explicit_replay_authorization.as_ref(),
+                    block,
+                )
+                .await
+            {
+                results.push(Err(error));
+                continue;
+            }
+
             // Serialize merges for the same document
             let _guard = self.merge_queue.acquire(&block.doc_id).await;
 
@@ -148,6 +159,12 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMe
             let headstore = txn.headstore()?;
 
             for block in blocks {
+                self.validate_explicit_replay_authorization(
+                    block.explicit_replay_authorization.as_ref(),
+                    block,
+                )
+                .await?;
+
                 let metadata = BlockMetadata::normal(
                     &block.doc_id,
                     &block.collection_id,

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -36,7 +36,7 @@ use defra_core::block::{
 use defra_core::types::DocId;
 use document::{DocID, Document, NormalValue};
 use events::{MergeCompleteData, Message, Update};
-use p2p::sync::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
+use p2p::sync::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata};
 use schema::{
     self, CType, CollectionSource, CollectionVersion, FieldDescription, FieldKind, QuerySource,
     ScalarKind,
@@ -134,6 +134,81 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
     /// Get reference to blockstore.
     pub fn blockstore(&self) -> &Arc<B> {
         &self.blockstore
+    }
+
+    pub(crate) async fn validate_explicit_replay_authorization(
+        &self,
+        authorization: Option<&p2p::ExplicitReplayAuthorization>,
+        block: &MergeBlock,
+    ) -> Result<(), MergeError> {
+        let Some(authorization) = authorization else {
+            return Ok(());
+        };
+
+        if authorization.collection_id != block.collection_id {
+            return Err(MergeError::MergeFailed(format!(
+                "explicit replay authorization collection '{}' does not match block collection '{}'",
+                authorization.collection_id, block.collection_id
+            )));
+        }
+
+        let decoded_block = Block::from_dag_cbor(&block.block_data)
+            .map_err(|error| MergeError::BlockDecode(error.to_string()))?;
+        let verified_creator = self
+            .verify_block_signature(&block.cid, &decoded_block, &block.block_data)
+            .await?;
+        let effective_creator = verified_creator
+            .as_deref()
+            .unwrap_or(block.creator.as_str());
+
+        if effective_creator != authorization.authorizer_did {
+            return Err(MergeError::MergeFailed(format!(
+                "explicit replay authorization authorizer '{}' does not match block creator '{}'",
+                authorization.authorizer_did, effective_creator
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn recover_metadata_from_block(
+        &self,
+        cid: &Cid,
+        block_data: &[u8],
+    ) -> Result<Option<RecoveredBlockMetadata>, MergeError> {
+        let block =
+            Block::from_dag_cbor(block_data).map_err(|e| MergeError::BlockDecode(e.to_string()))?;
+
+        let Some((doc_id, collection_id)) = Self::doc_metadata_from_block(&block) else {
+            return Ok(None);
+        };
+
+        let Some(creator) = self.verify_block_signature(cid, &block, block_data).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            RecoveredBlockMetadata::new(doc_id, collection_id, creator.clone())
+                .with_verified_creator(Some(creator)),
+        ))
+    }
+
+    fn doc_metadata_from_block(block: &Block) -> Option<(String, String)> {
+        match &block.delta {
+            CrdtDelta::Lww(payload) => Some((
+                String::from_utf8_lossy(&payload.doc_id).to_string(),
+                payload.schema_version_id.clone(),
+            )),
+            CrdtDelta::Counter(payload) => Some((
+                String::from_utf8_lossy(&payload.doc_id).to_string(),
+                payload.schema_version_id.clone(),
+            )),
+            CrdtDelta::Composite(payload) => Some((
+                String::from_utf8_lossy(&payload.doc_id).to_string(),
+                payload.schema_version_id.clone(),
+            )),
+            _ => None,
+        }
     }
 
     /// Decrypt block delta data using the encryption metadata block.
@@ -339,6 +414,23 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> Merg
     for DbMergeHandler<S, B>
 {
     type Error = MergeError;
+
+    async fn validate_authorization(
+        &self,
+        authorization: Option<&p2p::ExplicitReplayAuthorization>,
+        block: &MergeBlock,
+    ) -> Result<(), Self::Error> {
+        self.validate_explicit_replay_authorization(authorization, block)
+            .await
+    }
+
+    async fn recover_block_metadata(
+        &self,
+        cid: &Cid,
+        block_data: &[u8],
+    ) -> Result<Option<RecoveredBlockMetadata>, Self::Error> {
+        self.recover_metadata_from_block(cid, block_data).await
+    }
 
     async fn handle_block(
         &self,
@@ -726,6 +818,98 @@ mod tests {
             verified_identity.unwrap().starts_with("did:key:"),
             "verified identity should be a DID"
         );
+    }
+
+    #[tokio::test]
+    async fn recover_block_metadata_extracts_signed_lww_metadata() {
+        let (handler, blockstore) = make_handler();
+
+        let mut block = make_lww_block(None);
+        let (_priv_key, _pub_hex, did) = sign_block_ed25519(&mut block, &blockstore).await;
+        let cid = block.generate_cid().unwrap();
+        let block_data = block.to_dag_cbor().unwrap();
+
+        let metadata = handler
+            .recover_block_metadata(&cid, &block_data)
+            .await
+            .unwrap()
+            .expect("signed document block should recover metadata");
+
+        assert_eq!(metadata.doc_id, "doc1");
+        assert_eq!(metadata.collection_id, "v1");
+        assert_eq!(metadata.creator, did);
+        assert_eq!(metadata.verified_creator.as_deref(), Some(did.as_str()));
+    }
+
+    #[tokio::test]
+    async fn recover_block_metadata_refuses_unsigned_blocks() {
+        let (handler, _blockstore) = make_handler();
+
+        let block = make_lww_block(None);
+        let cid = block.generate_cid().unwrap();
+        let block_data = block.to_dag_cbor().unwrap();
+
+        let metadata = handler
+            .recover_block_metadata(&cid, &block_data)
+            .await
+            .unwrap();
+
+        assert!(
+            metadata.is_none(),
+            "recovery metadata must include a verifiable creator"
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_explicit_replay_authorization_checks_collection_and_creator() {
+        let (handler, blockstore) = make_handler();
+
+        let mut block = make_lww_block(None);
+        let (_priv_key, _pub_hex, did) = sign_block_ed25519(&mut block, &blockstore).await;
+        let cid = block.generate_cid().unwrap();
+        let block_data = block.to_dag_cbor().unwrap();
+        let mut merge_block = MergeBlock {
+            cid,
+            block_data: bytes::Bytes::from(block_data),
+            doc_id: "doc1".to_string(),
+            collection_id: "v1".to_string(),
+            creator: did.clone(),
+            sender_peer: Some("source-peer".to_string()),
+            is_explicit_replicator: true,
+            explicit_replay_authorization: None,
+            verified_creator: None,
+        };
+        let valid_authorization = p2p::ExplicitReplayAuthorization {
+            source_peer_id: "source-peer".to_string(),
+            target_peer_id: "target-peer".to_string(),
+            collection_id: "v1".to_string(),
+            authorizer_did: did.clone(),
+            expires_at: u64::MAX,
+        };
+
+        handler
+            .validate_authorization(Some(&valid_authorization), &merge_block)
+            .await
+            .expect("matching explicit replay authorization should validate");
+
+        let wrong_creator = p2p::ExplicitReplayAuthorization {
+            authorizer_did: "did:key:z6MkWrongCreator".to_string(),
+            ..valid_authorization.clone()
+        };
+        let error = handler
+            .validate_authorization(Some(&wrong_creator), &merge_block)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("does not match block creator"));
+
+        merge_block.collection_id = "other-collection".to_string();
+        let error = handler
+            .validate_authorization(Some(&valid_authorization), &merge_block)
+            .await
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("does not match block collection"));
     }
 
     #[tokio::test]

--- a/crates/p2p/src/sync/merge.rs
+++ b/crates/p2p/src/sync/merge.rs
@@ -31,6 +31,43 @@ pub struct MergeBlock {
     pub verified_creator: Option<String>,
 }
 
+/// Metadata recovered from block contents during startup crash recovery.
+///
+/// Normal replication carries this metadata in the push message. Recovery only
+/// has a CID and raw block bytes, so handlers must reconstruct these fields
+/// from durable block contents before the block is merged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveredBlockMetadata {
+    pub doc_id: String,
+    pub collection_id: String,
+    pub creator: String,
+    pub verified_creator: Option<String>,
+}
+
+impl RecoveredBlockMetadata {
+    pub fn new(
+        doc_id: impl Into<String>,
+        collection_id: impl Into<String>,
+        creator: impl Into<String>,
+    ) -> Self {
+        Self {
+            doc_id: doc_id.into(),
+            collection_id: collection_id.into(),
+            creator: creator.into(),
+            verified_creator: None,
+        }
+    }
+
+    pub fn with_verified_creator(mut self, verified_creator: Option<String>) -> Self {
+        self.verified_creator = verified_creator;
+        self
+    }
+
+    pub fn is_complete(&self) -> bool {
+        !self.doc_id.is_empty() && !self.collection_id.is_empty() && !self.creator.is_empty()
+    }
+}
+
 /// Outcome of a merge operation.
 ///
 /// Used by `MergeHandler::handle_block` to communicate the result.
@@ -176,6 +213,29 @@ impl<'a> BlockMetadata<'a> {
         }
     }
 
+    /// Create crash-recovery metadata after a handler has extracted it.
+    ///
+    /// The `is_recovery` flag remains true so merge implementations can keep
+    /// recovery-specific behavior while still receiving complete identifiers.
+    pub fn recovered(
+        doc_id: &'a str,
+        collection_id: &'a str,
+        creator: &'a str,
+        verified_creator: Option<String>,
+    ) -> Self {
+        Self {
+            doc_id: Some(doc_id),
+            collection_id: Some(collection_id),
+            creator: Some(creator),
+            sender_peer: None,
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+            verified_creator,
+            is_recovery: true,
+            is_schema_block: false,
+        }
+    }
+
     pub fn with_explicit_replay_authorization(
         mut self,
         authorization: Option<ExplicitReplayAuthorization>,
@@ -264,6 +324,32 @@ pub trait MergeHandler: Send + Sync {
         metadata: BlockMetadata<'_>,
     ) -> Result<MergeOutcome, Self::Error>;
 
+    /// Validate explicit replay authorization before merge work starts.
+    ///
+    /// Implementations that honor `ExplicitReplayAuthorization` should reject
+    /// authorizations that do not apply to this block's collection or creator.
+    /// The replication loop invokes this for both single-block and batch paths
+    /// before dispatching the block to merge code.
+    async fn validate_authorization(
+        &self,
+        _authorization: Option<&ExplicitReplayAuthorization>,
+        _block: &MergeBlock,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Recover complete metadata for a crash-recovery block.
+    ///
+    /// Returning `None` means the handler could not recover all required
+    /// fields, and the replication recovery path will refuse to merge the block.
+    async fn recover_block_metadata(
+        &self,
+        _cid: &Cid,
+        _block_data: &[u8],
+    ) -> Result<Option<RecoveredBlockMetadata>, Self::Error> {
+        Ok(None)
+    }
+
     /// Process a batch of blocks. Default impl calls handle_block() per block.
     ///
     /// Implementations can override this to process all blocks within a single
@@ -274,6 +360,14 @@ pub trait MergeHandler: Send + Sync {
     ) -> Vec<Result<MergeOutcome, Self::Error>> {
         let mut results = Vec::with_capacity(blocks.len());
         for block in blocks {
+            if let Err(error) = self
+                .validate_authorization(block.explicit_replay_authorization.as_ref(), block)
+                .await
+            {
+                results.push(Err(error));
+                continue;
+            }
+
             let metadata = BlockMetadata::normal(
                 &block.doc_id,
                 &block.collection_id,
@@ -335,6 +429,14 @@ mod tests {
         let mut meta = BlockMetadata::recovery();
         meta.verified_creator = Some("did:key:VERIFIED".to_string());
         assert_eq!(meta.effective_creator(), Some("did:key:VERIFIED"));
+    }
+
+    #[test]
+    fn recovered_metadata_is_complete_only_when_all_required_fields_exist() {
+        assert!(RecoveredBlockMetadata::new("doc1", "col1", "did:key:creator").is_complete());
+        assert!(!RecoveredBlockMetadata::new("", "col1", "did:key:creator").is_complete());
+        assert!(!RecoveredBlockMetadata::new("doc1", "", "did:key:creator").is_complete());
+        assert!(!RecoveredBlockMetadata::new("doc1", "col1", "").is_complete());
     }
 
     #[test]

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -36,7 +36,7 @@ pub use manager::{
     SyncDiagnosticsSnapshot, SyncEvent, SyncManager, DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
     DEFAULT_MAX_CONCURRENT_PUSH_TASKS, DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
 };
-pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
+pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata};
 pub use peer_state::{PeerStateTracker, PeerStats};
 pub use queue::ProcessQueue;
 pub use replication::{recover_unmerged, ReplicationConfig, ReplicationLoop, ReplicationResult};

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -9,7 +9,9 @@ use super::config::ReplicationConfig;
 use super::result::ReplicationResult;
 use crate::sync::coordinator::SyncCoordinator;
 use crate::sync::manager::SyncEvent;
-use crate::sync::merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
+use crate::sync::merge::{
+    BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata,
+};
 use crate::transport::P2PTransport;
 
 pub(super) struct DagFetchRequest {
@@ -20,6 +22,67 @@ pub(super) struct DagFetchRequest {
     collection_id: String,
     creator: String,
     sender_peer: Option<String>,
+}
+
+struct MergeEventMetadata {
+    cid: Cid,
+    doc_id: String,
+    collection_id: String,
+    creator: String,
+    sender_peer: Option<String>,
+    is_explicit_replicator: bool,
+    explicit_replay_authorization: Option<crate::ExplicitReplayAuthorization>,
+    acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
+}
+
+fn merge_block_from_metadata(
+    cid: Cid,
+    block_data: bytes::Bytes,
+    metadata: &BlockMetadata<'_>,
+) -> Option<MergeBlock> {
+    Some(MergeBlock {
+        cid,
+        block_data,
+        doc_id: metadata.doc_id?.to_string(),
+        collection_id: metadata.collection_id?.to_string(),
+        creator: metadata.creator?.to_string(),
+        sender_peer: metadata.sender_peer.map(str::to_string),
+        is_explicit_replicator: metadata.is_explicit_replicator,
+        explicit_replay_authorization: metadata.explicit_replay_authorization.clone(),
+        verified_creator: metadata.verified_creator.clone(),
+    })
+}
+
+fn recovered_metadata_error(cid: Cid, details: impl Into<String>) -> ReplicationResult {
+    ReplicationResult::Failed {
+        cid,
+        error: format!("Recovery metadata incomplete: {}", details.into()),
+    }
+}
+
+async fn recover_metadata_for_block<H>(
+    handler: &H,
+    cid: Cid,
+    block_data: &[u8],
+) -> Result<RecoveredBlockMetadata, ReplicationResult>
+where
+    H: MergeHandler + ?Sized + 'static,
+{
+    match handler.recover_block_metadata(&cid, block_data).await {
+        Ok(Some(metadata)) if metadata.is_complete() => Ok(metadata),
+        Ok(Some(metadata)) => Err(recovered_metadata_error(
+            cid,
+            format!(
+                "handler returned doc_id='{}', collection_id='{}', creator='{}'",
+                metadata.doc_id, metadata.collection_id, metadata.creator
+            ),
+        )),
+        Ok(None) => Err(recovered_metadata_error(
+            cid,
+            "handler did not return recovered metadata",
+        )),
+        Err(error) => Err(recovered_metadata_error(cid, error.to_string())),
+    }
 }
 
 /// Handle a DagNeedsFetch event by initiating a Bitswap sync.
@@ -148,7 +211,45 @@ where
         }
     };
 
-    // Extract doc_id and collection_id for use in result (use empty string if recovery mode)
+    let recovered_metadata: Option<RecoveredBlockMetadata>;
+    let metadata = if metadata.is_recovery && metadata.is_incomplete() {
+        let recovered = match recover_metadata_for_block(handler, cid, &block_data).await {
+            Ok(recovered) => recovered,
+            Err(result) => return result,
+        };
+        recovered_metadata = Some(recovered);
+        let recovered = recovered_metadata
+            .as_ref()
+            .expect("recovered metadata was just stored");
+        BlockMetadata::recovered(
+            &recovered.doc_id,
+            &recovered.collection_id,
+            &recovered.creator,
+            recovered.verified_creator.clone(),
+        )
+    } else {
+        metadata
+    };
+
+    if metadata.explicit_replay_authorization.is_some() {
+        let Some(block) = merge_block_from_metadata(cid, block_data.clone(), &metadata) else {
+            return ReplicationResult::Failed {
+                cid,
+                error: "Explicit replay authorization requires complete block metadata".to_string(),
+            };
+        };
+        if let Err(error) = handler
+            .validate_authorization(block.explicit_replay_authorization.as_ref(), &block)
+            .await
+        {
+            return ReplicationResult::Failed {
+                cid,
+                error: error.to_string(),
+            };
+        }
+    }
+
+    // Extract doc_id and collection_id for use in result.
     let doc_id_for_result = metadata.doc_id.unwrap_or("").to_string();
     let collection_id_for_result = metadata.collection_id.unwrap_or("").to_string();
     let collection_id_for_broadcast = metadata.collection_id.unwrap_or("");
@@ -277,31 +378,14 @@ where
 
 /// Returns true if this event type can be batch-merged.
 pub(super) fn is_mergeable_event(event: &SyncEvent) -> bool {
-    match event {
-        SyncEvent::BlockReceived {
-            acp_actor_relationships,
-            ..
-        }
-        | SyncEvent::DagReady {
-            acp_actor_relationships,
-            ..
-        } => acp_actor_relationships.is_none(),
-        _ => false,
-    }
+    matches!(
+        event,
+        SyncEvent::BlockReceived { .. } | SyncEvent::DagReady { .. }
+    )
 }
 
 /// Extract merge block metadata from a SyncEvent.
-fn event_to_merge_metadata(
-    event: &SyncEvent,
-) -> (
-    Cid,
-    String,
-    String,
-    String,
-    Option<String>,
-    bool,
-    Option<crate::ExplicitReplayAuthorization>,
-) {
+fn event_to_merge_metadata(event: &SyncEvent) -> MergeEventMetadata {
     match event {
         SyncEvent::BlockReceived {
             cid,
@@ -311,16 +395,18 @@ fn event_to_merge_metadata(
             sender_peer,
             is_explicit_replicator,
             explicit_replay_authorization,
+            acp_actor_relationships,
             ..
-        } => (
-            *cid,
-            doc_id.clone(),
-            collection_id.clone(),
-            creator.clone(),
-            sender_peer.clone(),
-            *is_explicit_replicator,
-            explicit_replay_authorization.clone(),
-        ),
+        } => MergeEventMetadata {
+            cid: *cid,
+            doc_id: doc_id.clone(),
+            collection_id: collection_id.clone(),
+            creator: creator.clone(),
+            sender_peer: sender_peer.clone(),
+            is_explicit_replicator: *is_explicit_replicator,
+            explicit_replay_authorization: explicit_replay_authorization.clone(),
+            acp_actor_relationships: acp_actor_relationships.clone(),
+        },
         SyncEvent::DagReady {
             root_cid,
             doc_id,
@@ -329,16 +415,18 @@ fn event_to_merge_metadata(
             sender_peer,
             is_explicit_replicator,
             explicit_replay_authorization,
+            acp_actor_relationships,
             ..
-        } => (
-            *root_cid,
-            doc_id.clone(),
-            collection_id.clone(),
-            creator.clone(),
-            sender_peer.clone(),
-            *is_explicit_replicator,
-            explicit_replay_authorization.clone(),
-        ),
+        } => MergeEventMetadata {
+            cid: *root_cid,
+            doc_id: doc_id.clone(),
+            collection_id: collection_id.clone(),
+            creator: creator.clone(),
+            sender_peer: sender_peer.clone(),
+            is_explicit_replicator: *is_explicit_replicator,
+            explicit_replay_authorization: explicit_replay_authorization.clone(),
+            acp_actor_relationships: acp_actor_relationships.clone(),
+        },
         _ => unreachable!("is_mergeable_event should have filtered this"),
     }
 }
@@ -359,11 +447,12 @@ where
     H: MergeHandler + ?Sized + 'static,
 {
     let mut merge_blocks = Vec::with_capacity(events.len());
+    let mut acp_actor_relationships = Vec::with_capacity(events.len());
     let mut results = Vec::new();
 
     // Load block data for each event from blockstore
     for event in &events {
-        let (
+        let MergeEventMetadata {
             cid,
             doc_id,
             collection_id,
@@ -371,7 +460,8 @@ where
             sender_peer,
             is_explicit_replicator,
             explicit_replay_authorization,
-        ) = event_to_merge_metadata(event);
+            acp_actor_relationships: relationships,
+        } = event_to_merge_metadata(event);
 
         if matches!(event, SyncEvent::DagReady { .. }) {
             coordinator.clear_pending_dag(&cid);
@@ -379,7 +469,7 @@ where
 
         match coordinator.blockstore().get(&cid).await {
             Ok(Some(data)) => {
-                merge_blocks.push(MergeBlock {
+                let block = MergeBlock {
                     cid,
                     block_data: data,
                     doc_id,
@@ -389,7 +479,21 @@ where
                     is_explicit_replicator,
                     explicit_replay_authorization,
                     verified_creator: None,
-                });
+                };
+
+                if let Err(error) = handler
+                    .validate_authorization(block.explicit_replay_authorization.as_ref(), &block)
+                    .await
+                {
+                    results.push(ReplicationResult::Failed {
+                        cid,
+                        error: error.to_string(),
+                    });
+                    continue;
+                }
+
+                merge_blocks.push(block);
+                acp_actor_relationships.push(relationships);
             }
             Ok(None) => {
                 results.push(ReplicationResult::Failed {
@@ -411,6 +515,7 @@ where
     }
 
     // Call handler.handle_block_batch()
+    let batch_result_start = results.len();
     let batch_results = handler.handle_block_batch(&merge_blocks).await;
 
     // Collect CIDs to mark as merged
@@ -454,17 +559,61 @@ where
                 count = merged_cids.len(),
                 "Failed to batch mark_as_merged"
             );
-            // Downgrade affected Merged results to MergedButNotMarked
+            // Downgrade affected terminal results to MergedButNotMarked.
             for result in &mut results {
-                if let ReplicationResult::Merged { cid, .. } = result {
-                    if merged_cids.contains(cid) {
-                        *result = ReplicationResult::MergedButNotMarked {
-                            cid: *cid,
-                            error: e.to_string(),
-                        };
-                    }
+                let cid = match result {
+                    ReplicationResult::Merged { cid, .. } => *cid,
+                    ReplicationResult::Skipped {
+                        cid,
+                        terminal: true,
+                        ..
+                    } => *cid,
+                    _ => continue,
+                };
+
+                if merged_cids.contains(&cid) {
+                    *result = ReplicationResult::MergedButNotMarked {
+                        cid,
+                        error: e.to_string(),
+                    };
                 }
             }
+        }
+    }
+
+    for ((block, relationships), result) in merge_blocks
+        .iter()
+        .zip(acp_actor_relationships.iter())
+        .zip(results[batch_result_start..].iter_mut())
+    {
+        let should_apply = match result {
+            ReplicationResult::Merged { .. } => true,
+            ReplicationResult::Skipped { terminal, .. } => *terminal,
+            _ => false,
+        };
+
+        if !should_apply {
+            continue;
+        }
+
+        let effective_creator = Some(
+            block
+                .verified_creator
+                .as_deref()
+                .unwrap_or(block.creator.as_str()),
+        );
+        if let Err(error) = coordinator
+            .apply_replicated_actor_relationships(
+                &block.doc_id,
+                effective_creator,
+                relationships.as_ref(),
+            )
+            .await
+        {
+            *result = ReplicationResult::Failed {
+                cid: block.cid,
+                error: error.to_string(),
+            };
         }
     }
 

--- a/crates/p2p/src/sync/replication/loop_runner.rs
+++ b/crates/p2p/src/sync/replication/loop_runner.rs
@@ -275,13 +275,15 @@ impl ReplicationLoop {
         };
 
         // Drain more events non-blocking
+        let max_batch_size = config.batch_size.max(1);
         let mut batch = vec![first];
-        while batch.len() < config.batch_size {
+        while batch.len() < max_batch_size {
             match events.try_recv() {
                 Ok(e) => batch.push(e),
                 Err(_) => break,
             }
         }
+        debug_assert!(batch.len() <= max_batch_size);
 
         // Separate merge-worthy events from immediate-action events
         let mut immediate = Vec::new();

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -31,7 +31,9 @@ pub use result::ReplicationResult;
 
 #[cfg(test)]
 mod tests {
-    use super::handlers::{handle_block_received, process_event};
+    use super::handlers::{
+        handle_block_received, is_mergeable_event, process_event, process_merge_batch,
+    };
     use super::*;
     use crate::bitswap::AccessMode;
     use crate::error::Result as P2PResult;
@@ -40,9 +42,12 @@ mod tests {
         PushLogReply, PushLogRequest, PushSEArtifactsRequest,
     };
     use crate::sync::manager::SyncEvent;
-    use crate::sync::merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome};
+    use crate::sync::merge::{
+        BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata,
+    };
     use crate::topics::DefraTopic;
     use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId, TransportEvent};
+    use crate::ExplicitReplayAuthorization;
     use crate::QueryId;
     use crate::ReplicatorInfo;
     use async_trait::async_trait;
@@ -656,6 +661,50 @@ mod tests {
         }
     }
 
+    struct RejectingAuthorizationHandler {
+        validation_calls: AtomicUsize,
+        batch_calls: AtomicUsize,
+    }
+
+    impl RejectingAuthorizationHandler {
+        fn new() -> Self {
+            Self {
+                validation_calls: AtomicUsize::new(0),
+                batch_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn validation_calls(&self) -> usize {
+            self.validation_calls.load(Ordering::SeqCst)
+        }
+
+        fn batch_calls(&self) -> usize {
+            self.batch_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    struct RecoveryMetadataHandler {
+        recover_calls: AtomicUsize,
+        handle_calls: AtomicUsize,
+    }
+
+    impl RecoveryMetadataHandler {
+        fn new() -> Self {
+            Self {
+                recover_calls: AtomicUsize::new(0),
+                handle_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn recover_calls(&self) -> usize {
+            self.recover_calls.load(Ordering::SeqCst)
+        }
+
+        fn handle_calls(&self) -> usize {
+            self.handle_calls.load(Ordering::SeqCst)
+        }
+    }
+
     #[async_trait]
     impl MergeHandler for BatchTestHandler {
         type Error = TestError;
@@ -689,6 +738,82 @@ mod tests {
                     }
                 })
                 .collect()
+        }
+    }
+
+    #[async_trait]
+    impl MergeHandler for RejectingAuthorizationHandler {
+        type Error = TestError;
+
+        async fn validate_authorization(
+            &self,
+            authorization: Option<&ExplicitReplayAuthorization>,
+            _block: &MergeBlock,
+        ) -> Result<(), Self::Error> {
+            self.validation_calls.fetch_add(1, Ordering::SeqCst);
+            if authorization.is_some() {
+                Err(TestError("authorization rejected".to_string()))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn handle_block(
+            &self,
+            _cid: &Cid,
+            _block_data: &[u8],
+            _metadata: BlockMetadata<'_>,
+        ) -> Result<MergeOutcome, Self::Error> {
+            Ok(MergeOutcome::Merged)
+        }
+
+        async fn handle_block_batch(
+            &self,
+            blocks: &[MergeBlock],
+        ) -> Vec<Result<MergeOutcome, Self::Error>> {
+            self.batch_calls.fetch_add(1, Ordering::SeqCst);
+            blocks.iter().map(|_| Ok(MergeOutcome::Merged)).collect()
+        }
+    }
+
+    #[async_trait]
+    impl MergeHandler for RecoveryMetadataHandler {
+        type Error = TestError;
+
+        async fn recover_block_metadata(
+            &self,
+            _cid: &Cid,
+            _block_data: &[u8],
+        ) -> Result<Option<RecoveredBlockMetadata>, Self::Error> {
+            self.recover_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(RecoveredBlockMetadata::new(
+                "doc-recovered",
+                "col-recovered",
+                "did:key:creator",
+            )))
+        }
+
+        async fn handle_block(
+            &self,
+            _cid: &Cid,
+            _block_data: &[u8],
+            metadata: BlockMetadata<'_>,
+        ) -> Result<MergeOutcome, Self::Error> {
+            self.handle_calls.fetch_add(1, Ordering::SeqCst);
+            if !metadata.is_recovery {
+                return Err(TestError(
+                    "metadata should remain in recovery mode".to_string(),
+                ));
+            }
+            if metadata.doc_id != Some("doc-recovered")
+                || metadata.collection_id != Some("col-recovered")
+                || metadata.creator != Some("did:key:creator")
+            {
+                return Err(TestError(
+                    "recovered metadata was not forwarded".to_string(),
+                ));
+            }
+            Ok(MergeOutcome::Merged)
         }
     }
 
@@ -855,6 +980,84 @@ mod tests {
             blockstore.is_merged(&cid).await.unwrap(),
             "successful replay should mark the CID as merged"
         );
+    }
+
+    #[tokio::test]
+    async fn test_recovery_refuses_blocks_without_recovered_metadata() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let cid = test_cid();
+        blockstore.put(&cid, b"test data").await.unwrap();
+
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore,
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+
+        let handler = TestMergeHandler::new(true, false);
+        let result = handle_block_received(
+            &coordinator,
+            &handler,
+            &ReplicationConfig::default(),
+            cid,
+            BlockMetadata::recovery(),
+            None,
+        )
+        .await;
+
+        match result {
+            ReplicationResult::Failed { error, .. } => {
+                assert!(error.contains("Recovery metadata incomplete"));
+            }
+            other => panic!("expected recovery metadata failure, got {:?}", other),
+        }
+        assert_eq!(
+            handler.calls(),
+            0,
+            "recovery must fail before merge when metadata cannot be recovered"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recovery_forwards_handler_recovered_metadata() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let cid = test_cid();
+        blockstore.put(&cid, b"test data").await.unwrap();
+
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore,
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+
+        let handler = RecoveryMetadataHandler::new();
+        let result = handle_block_received(
+            &coordinator,
+            &handler,
+            &ReplicationConfig::default(),
+            cid,
+            BlockMetadata::recovery(),
+            None,
+        )
+        .await;
+
+        assert!(matches!(result, ReplicationResult::Merged { .. }));
+        assert_eq!(handler.recover_calls(), 1);
+        assert_eq!(handler.handle_calls(), 1);
     }
 
     #[tokio::test]
@@ -1079,6 +1282,210 @@ mod tests {
     // =========================================================================
     // Batch merge tests
     // =========================================================================
+
+    #[tokio::test]
+    async fn test_process_next_batch_caps_drain_at_config_batch_size() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore.clone(),
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        for i in 0..10 {
+            let data = format!("block{}", i);
+            let cid = make_cid(data.as_bytes());
+            blockstore.put(&cid, data.as_bytes()).await.unwrap();
+            tx.send(SyncEvent::BlockReceived {
+                cid,
+                doc_id: format!("doc{}", i),
+                collection_id: "col1".to_string(),
+                creator: "peer1".to_string(),
+                sender_peer: None,
+                is_explicit_replicator: false,
+                explicit_replay_authorization: None,
+                acp_actor_relationships: None,
+            })
+            .await
+            .unwrap();
+        }
+
+        let config = ReplicationConfig {
+            continue_on_error: true,
+            rebroadcast_on_merge: false,
+            batch_size: 3,
+            max_workers: 1,
+        };
+        let handler = BatchTestHandler::new();
+
+        let results =
+            ReplicationLoop::process_next_batch(&coordinator, &mut rx, &handler, &config).await;
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(handler.batch_calls(), 1);
+        assert_eq!(handler.batch_block_count(), 3);
+        assert_eq!(rx.len(), 7, "remaining backlog must stay queued");
+    }
+
+    #[tokio::test]
+    async fn test_acp_events_are_batch_mergeable() {
+        use acp::{ReplicatedActorRelationship, ReplicatedDocActorRelationships, READER_RELATION};
+
+        let event = SyncEvent::BlockReceived {
+            cid: test_cid(),
+            doc_id: "doc1".to_string(),
+            collection_id: "col1".to_string(),
+            creator: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".to_string(),
+            sender_peer: None,
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+            acp_actor_relationships: Some(ReplicatedDocActorRelationships {
+                policy_id: "policy1".to_string(),
+                resource_name: "users".to_string(),
+                relationships: vec![ReplicatedActorRelationship {
+                    relation: READER_RELATION.to_string(),
+                    actor: "did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR".to_string(),
+                }],
+            }),
+        };
+
+        assert!(
+            is_mergeable_event(&event),
+            "ACP-bearing events must stay eligible for batch merge"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_terminal_skip_applies_acp_relationships() {
+        use acp::{
+            DocumentACP, LocalDocumentACP, MemoryAcpStore, ReplicatedActorRelationship,
+            ReplicatedDocActorRelationships, READER_RELATION,
+        };
+
+        let owner = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+        let reader = "did:key:z6MkfXG2FkNy3u7Eg3jm8e2YQpGz7Z1JqWgHDAP1hLk9r2bR";
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let cid = make_cid(b"acp-terminal-skip");
+        blockstore.put(&cid, b"acp-terminal-skip").await.unwrap();
+
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore,
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+        let acp = Arc::new(LocalDocumentACP::new(Arc::new(MemoryAcpStore::new())));
+        coordinator.set_document_acp(acp.clone());
+
+        let relationships = vec![ReplicatedActorRelationship {
+            relation: READER_RELATION.to_string(),
+            actor: reader.to_string(),
+        }];
+        let events = vec![SyncEvent::BlockReceived {
+            cid,
+            doc_id: "doc1".to_string(),
+            collection_id: "col1".to_string(),
+            creator: owner.to_string(),
+            sender_peer: None,
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+            acp_actor_relationships: Some(ReplicatedDocActorRelationships {
+                policy_id: "policy1".to_string(),
+                resource_name: "users".to_string(),
+                relationships: relationships.clone(),
+            }),
+        }];
+
+        let handler = TestMergeHandler::new(true, true);
+        let results = process_merge_batch(
+            &coordinator,
+            events,
+            &handler,
+            &ReplicationConfig::default(),
+        )
+        .await;
+
+        assert!(matches!(
+            results.as_slice(),
+            [ReplicationResult::Skipped { terminal: true, .. }]
+        ));
+        assert!(acp
+            .is_doc_registered("policy1", "users", "doc1")
+            .await
+            .unwrap());
+        assert_eq!(
+            acp.export_actor_relationships("policy1", "users", "doc1")
+                .await
+                .unwrap(),
+            relationships
+        );
+    }
+
+    #[tokio::test]
+    async fn test_batch_validates_explicit_replay_before_merge() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let cid = make_cid(b"auth-rejected");
+        blockstore.put(&cid, b"auth-rejected").await.unwrap();
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                NoopTransport::new(),
+                blockstore,
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+
+        let handler = RejectingAuthorizationHandler::new();
+        let events = vec![SyncEvent::BlockReceived {
+            cid,
+            doc_id: "doc1".to_string(),
+            collection_id: "col1".to_string(),
+            creator: "did:key:authorizer".to_string(),
+            sender_peer: Some("source-peer".to_string()),
+            is_explicit_replicator: true,
+            explicit_replay_authorization: Some(ExplicitReplayAuthorization {
+                source_peer_id: "source-peer".to_string(),
+                target_peer_id: "target-peer".to_string(),
+                collection_id: "col1".to_string(),
+                authorizer_did: "did:key:authorizer".to_string(),
+                expires_at: u64::MAX,
+            }),
+            acp_actor_relationships: None,
+        }];
+
+        let results = process_merge_batch(
+            &coordinator,
+            events,
+            &handler,
+            &ReplicationConfig::default(),
+        )
+        .await;
+
+        assert!(matches!(
+            results.as_slice(),
+            [ReplicationResult::Failed { error, .. }] if error.contains("authorization rejected")
+        ));
+        assert_eq!(handler.validation_calls(), 1);
+        assert_eq!(handler.batch_calls(), 0);
+    }
 
     #[tokio::test]
     async fn test_default_handle_block_batch_calls_per_block() {


### PR DESCRIPTION
## Summary

Closes #841. Hardens the P2P batch merge path so it preserves the single-event path's ACP behavior, enforces explicit replay validation before merge work, caps batch draining, and refuses crash-recovery merges when required metadata cannot be recovered.

## Why

The batch merge path had several contract gaps around ACP side effects, explicit replay authorization, and recovery metadata. Most were latent because ACP-bearing events were filtered out of batching, but that made the batch path fragile and inconsistent with single-event processing.

Recovery also relied on doc comments requiring handlers to extract `doc_id`, `collection_id`, and `creator`, but there was no runtime guard preventing a handler from merging with incomplete metadata.

## Changes

| Area | Change |
|---|---|
| Batch drain | Cap draining at `config.batch_size.max(1)` and assert the bound after the drain. |
| Batch ACP replay | Keep ACP-bearing `BlockReceived` and `DagReady` events batchable, carry relationship snapshots through the batch, and apply them for merged and terminal-skip outcomes. |
| Explicit replay | Add `MergeHandler::validate_authorization()` and invoke it before single and batch merge dispatch. |
| DB merge handler | Validate explicit replay collection and verified/self-reported creator before accepting authorized replay. |
| Recovery | Add recovered metadata plumbing through `MergeHandler::recover_block_metadata()` and refuse recovery merges when metadata remains incomplete. |
| Tests | Add regression coverage for oversized backlog batching, ACP-bearing batch events, terminal-skip ACP replay, explicit replay prevalidation, and recovery metadata enforcement. |

## Stacking note

This branch is intentionally based on `iverc/cli-pushlog-message-id-882`, so the CLI PushLog message-id CI fix is present until that PR lands on `main`. Once the fix branch is merged, that diff should disappear from this PR.

## Out of scope

- Changing P2P wire formats.
- Broad recovery of schema-only blocks without document metadata; recovery now refuses document-block merges unless required metadata is recovered explicitly.
- Reworking the existing DB merge batching strategy beyond the authorization/recovery contracts.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p` -- passed outside sandbox; sandboxed run hit local TCP transport restrictions in `bitswap_acp_filter_tests`.
- [x] `cargo test -p db-merge`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet` -- passed outside sandbox; sandboxed run hit the known `PermissionDenied` in `defra-node` benchmark support tests.
