### PR TITLE
fix(p2p): align host relay and DHT bootstrap parity (#831)

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -226,7 +226,7 @@ impl Node {
                     } => {
                         info!(
                             peer_id = %peer_id,
-                            message_id = %request.metadata.message_id,
+                            message_id = %request.message_id,
                             doc_id = %request.doc_id,
                             "Processing TwoStreamRequest through coordinator"
                         );

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -17,7 +17,10 @@ use libp2p::{
     identity::Keypair, noise, request_response, swarm::behaviour::toggle::Toggle, tcp, yamux,
     Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
-use tokio::sync::mpsc;
+use tokio::{
+    sync::mpsc,
+    time::{self, Instant, MissedTickBehavior},
+};
 use tracing::{debug, info, warn};
 
 use crate::behaviour::DefraBehaviour;
@@ -34,6 +37,44 @@ use super::ResponseChannel;
 
 /// Default idle connection timeout.
 const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Periodic DHT refresh interval.
+const DHT_BOOTSTRAP_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Delay used to coalesce connection-triggered DHT bootstrap requests.
+const DHT_BOOTSTRAP_DEBOUNCE: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+struct BootstrapScheduler {
+    pending: bool,
+    debounce: Duration,
+}
+
+impl BootstrapScheduler {
+    fn new(debounce: Duration) -> Self {
+        Self {
+            pending: false,
+            debounce,
+        }
+    }
+
+    fn is_pending(&self) -> bool {
+        self.pending
+    }
+
+    fn schedule(&mut self, now: Instant) -> Option<Instant> {
+        if self.pending {
+            return None;
+        }
+
+        self.pending = true;
+        Some(now + self.debounce)
+    }
+
+    fn mark_fired(&mut self) {
+        self.pending = false;
+    }
+}
 
 /// Configuration options for P2P host construction.
 #[derive(Debug, Clone)]
@@ -64,7 +105,7 @@ impl Default for P2PHostConfig {
     fn default() -> Self {
         Self {
             enable_pubsub: true,
-            enable_relay: false,
+            enable_relay: true,
             max_msg_size: 16 * 1024 * 1024,
             max_car_size: 64 * 1024 * 1024,
             stream_timeout: 30,
@@ -150,7 +191,7 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
 
     /// Create a new P2P host with the given keypair and blockstore.
     ///
-    /// Uses default config: pubsub enabled, relay disabled.
+    /// Uses default config: pubsub enabled, relay enabled.
     ///
     /// # Arguments
     ///
@@ -374,6 +415,12 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
     ///
     /// This method runs until shutdown is requested.
     pub async fn run(mut self) {
+        let mut bootstrap_scheduler = BootstrapScheduler::new(DHT_BOOTSTRAP_DEBOUNCE);
+        let mut bootstrap_deadline = Box::pin(time::sleep(DHT_BOOTSTRAP_DEBOUNCE));
+        let mut bootstrap_interval = time::interval(DHT_BOOTSTRAP_INTERVAL);
+        bootstrap_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        bootstrap_interval.tick().await;
+
         loop {
             // Biased select: process swarm events before commands.
             // This ensures ConnectionEstablished events (which update peer_addrs)
@@ -382,7 +429,15 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
                 biased;
 
                 event = self.swarm.select_next_some() => {
-                    self.handle_swarm_event(event).await;
+                    if self.handle_swarm_event(event).await {
+                        if let Some(deadline) = bootstrap_scheduler.schedule(Instant::now()) {
+                            bootstrap_deadline.as_mut().reset(deadline);
+                            debug!(
+                                delay_ms = DHT_BOOTSTRAP_DEBOUNCE.as_millis() as u64,
+                                "Scheduled debounced Kademlia bootstrap"
+                            );
+                        }
+                    }
                 }
                 // Handle two-stream protocol events (Go compatibility)
                 Some(two_stream_event) = self.two_stream_event_rx.recv() => {
@@ -401,10 +456,28 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
                         }
                     }
                 }
+                _ = &mut bootstrap_deadline, if bootstrap_scheduler.is_pending() => {
+                    bootstrap_scheduler.mark_fired();
+                    self.run_kademlia_bootstrap("debounced connection");
+                }
+                _ = bootstrap_interval.tick() => {
+                    self.run_kademlia_bootstrap("periodic");
+                }
             }
         }
 
         info!("P2P host shutdown complete");
+    }
+
+    fn run_kademlia_bootstrap(&mut self, reason: &'static str) {
+        match self.swarm.behaviour_mut().kademlia.bootstrap() {
+            Ok(query_id) => {
+                debug!(?query_id, reason, "Started Kademlia bootstrap");
+            }
+            Err(error) => {
+                debug!(?error, reason, "Skipped Kademlia bootstrap");
+            }
+        }
     }
 
     /// Dial a peer at the given addresses.
@@ -436,5 +509,32 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
                 resp.message_id
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_enables_relay() {
+        assert!(P2PHostConfig::default().enable_relay);
+    }
+
+    #[test]
+    fn bootstrap_scheduler_debounces_pending_connection_triggers() {
+        let mut scheduler = BootstrapScheduler::new(Duration::from_secs(30));
+        let now = Instant::now();
+
+        assert_eq!(scheduler.schedule(now), Some(now + Duration::from_secs(30)));
+        assert!(scheduler.is_pending());
+        assert_eq!(scheduler.schedule(now + Duration::from_secs(1)), None);
+
+        scheduler.mark_fired();
+        assert!(!scheduler.is_pending());
+        assert_eq!(
+            scheduler.schedule(now + Duration::from_secs(31)),
+            Some(now + Duration::from_secs(61))
+        );
     }
 }

--- a/crates/p2p/src/host/p2p_host/swarm.rs
+++ b/crates/p2p/src/host/p2p_host/swarm.rs
@@ -11,7 +11,9 @@ use crate::host::event::HostEvent;
 
 impl<S: Store> P2PHost<S> {
     /// Handle a swarm event.
-    pub(super) async fn handle_swarm_event(&mut self, event: SwarmEvent<DefraEvent>) {
+    ///
+    /// Returns `true` when the host should schedule a debounced DHT bootstrap.
+    pub(super) async fn handle_swarm_event(&mut self, event: SwarmEvent<DefraEvent>) -> bool {
         match event {
             SwarmEvent::NewListenAddr { address, .. } => {
                 info!(address = %address, "Created LibP2P host");
@@ -23,6 +25,7 @@ impl<S: Store> P2PHost<S> {
                 {
                     warn!(address = %address, "Failed to send Listening event - receiver dropped");
                 }
+                false
             }
 
             SwarmEvent::ConnectionEstablished {
@@ -44,7 +47,8 @@ impl<S: Store> P2PHost<S> {
                 // Add peer to Kademlia BEFORE bootstrap. Kademlia's own
                 // ConnectionEstablished handler doesn't add peers to the
                 // routing table until protocol negotiation completes (async).
-                // We add the address now so bootstrap() has a peer to query.
+                // We add the address now so scheduled bootstrap queries have
+                // at least one peer to query.
                 self.swarm
                     .behaviour_mut()
                     .kademlia
@@ -69,11 +73,6 @@ impl<S: Store> P2PHost<S> {
                 );
                 debug!(peer_id = %peer_id, "Bitswap protocol pre-announce complete");
 
-                // Trigger Kademlia bootstrap to discover peers through the DHT.
-                // When node2 connects to node0 (who already knows node1),
-                // this causes node2 to query node0, discover node1, and dial it.
-                let _ = self.swarm.behaviour_mut().kademlia.bootstrap();
-
                 if self
                     .event_tx
                     .send(HostEvent::PeerConnected(peer_id))
@@ -82,6 +81,7 @@ impl<S: Store> P2PHost<S> {
                 {
                     warn!(peer_id = %peer_id, "Failed to send PeerConnected event - receiver dropped");
                 }
+                true
             }
 
             SwarmEvent::ConnectionClosed {
@@ -101,22 +101,27 @@ impl<S: Store> P2PHost<S> {
                 {
                     warn!(peer_id = %peer_id, "Failed to send PeerDisconnected event - receiver dropped");
                 }
+                false
             }
 
             SwarmEvent::Behaviour(DefraEvent::Identify(identify_event)) => {
                 self.handle_identify_event(identify_event).await;
+                false
             }
 
             SwarmEvent::Behaviour(DefraEvent::PushLog(pushlog_event)) => {
                 self.handle_pushlog_event(pushlog_event).await;
+                false
             }
 
             SwarmEvent::Behaviour(DefraEvent::GossipSub(gossipsub_event)) => {
                 self.handle_gossipsub_event(gossipsub_event).await;
+                false
             }
 
             SwarmEvent::Behaviour(DefraEvent::Bitswap(bitswap_event)) => {
                 self.handle_bitswap_event(bitswap_event).await;
+                false
             }
 
             SwarmEvent::Behaviour(DefraEvent::Relay(relay_event)) => {
@@ -152,10 +157,12 @@ impl<S: Store> P2PHost<S> {
                         );
                     }
                 }
+                false
             }
 
             SwarmEvent::Behaviour(DefraEvent::Kademlia(kad_event)) => {
                 self.handle_kademlia_event(kad_event).await;
+                false
             }
 
             SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
@@ -164,6 +171,7 @@ impl<S: Store> P2PHost<S> {
                     error = %error,
                     "Outgoing connection failed"
                 );
+                false
             }
 
             SwarmEvent::IncomingConnectionError {
@@ -178,6 +186,7 @@ impl<S: Store> P2PHost<S> {
                     error = %error,
                     "Incoming connection failed"
                 );
+                false
             }
 
             SwarmEvent::ListenerError { listener_id, error } => {
@@ -186,6 +195,7 @@ impl<S: Store> P2PHost<S> {
                     error = %error,
                     "Listener error"
                 );
+                false
             }
 
             SwarmEvent::ListenerClosed {
@@ -198,6 +208,7 @@ impl<S: Store> P2PHost<S> {
                     reason = ?reason,
                     "Listener closed"
                 );
+                false
             }
 
             SwarmEvent::ExpiredListenAddr {
@@ -209,6 +220,7 @@ impl<S: Store> P2PHost<S> {
                     address = %address,
                     "Listen address expired"
                 );
+                false
             }
 
             SwarmEvent::Dialing {
@@ -216,15 +228,18 @@ impl<S: Store> P2PHost<S> {
                 ..
             } => {
                 debug!(peer_id = %peer_id, "Dialing peer");
+                false
             }
 
             SwarmEvent::Dialing { peer_id: None, .. } => {
                 // Dialing without a specific peer ID (rare, usually has peer_id)
+                false
             }
 
             _ => {
                 // Other swarm events (e.g., Dialing, NewExternalAddrCandidate) are
                 // handled by libp2p internally and don't require explicit handling
+                false
             }
         }
     }


### PR DESCRIPTION
## Summary

Part of #831. Aligns the Rust libp2p host with Go parity for relay defaults and DHT bootstrap behavior by enabling relay by default and replacing per-connection Kademlia bootstrap calls with debounced and periodic refreshes.

## Why

Rust still diverged from Go at the host layer in two high-impact places:

- Relay was disabled by default, while Go enables relay support by default.
- `kademlia.bootstrap()` ran on every `ConnectionEstablished`, which can amplify connection churn and create unnecessary DHT query pressure.

The host also lacked a steady bootstrap refresh path, making peer discovery depend too directly on connection events.

## Changes

| Area | Change |
|---|---|
| Relay default | Set `P2PHostConfig::default().enable_relay` to `true` and update the default-config docs. |
| DHT bootstrap | Remove immediate per-connection `kademlia.bootstrap()` from swarm event handling. |
| Bootstrap scheduler | Add a small scheduler that coalesces connection-triggered bootstrap requests with a 30s debounce. |
| Periodic refresh | Add a 5-minute periodic Kademlia bootstrap refresh in the host run loop. |
| Tests | Add unit coverage for relay default parity and bootstrap debounce behavior. |

## Stacking note

This branch is intentionally based on `iverc/cli-pushlog-message-id-882`, so the CLI PushLog message-id CI fix is present until that PR lands on `main`. Once the fix branch is merged, that diff should disappear from this PR.

## Out of scope

- Dual-DHT support.
- Active connection manager/resource-manager parity.
- QUIC, WebSocket, or WebTransport transport parity.
- Kademlia auto mode; the current libp2p version only exposes `Client` and `Server` modes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p` -- passed outside sandbox; sandboxed run hit local TCP transport restrictions in `bitswap_acp_filter_tests`.
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet` -- passed outside sandbox.
