### PR TITLE
fix(p2p): register SE query two-stream channel (#829)

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -226,7 +226,7 @@ impl Node {
                     } => {
                         info!(
                             peer_id = %peer_id,
-                            message_id = %request.metadata.message_id,
+                            message_id = %request.message_id,
                             doc_id = %request.doc_id,
                             "Processing TwoStreamRequest through coordinator"
                         );

--- a/crates/p2p/src/host/command.rs
+++ b/crates/p2p/src/host/command.rs
@@ -220,6 +220,20 @@ pub enum HostCommand {
         response: oneshot::Sender<Result<()>>,
     },
 
+    /// Send an SE query request to a peer via SE query two-stream protocol.
+    SendSEQueryRequest {
+        peer_id: PeerId,
+        request: crate::message::QuerySEArtifactsRequest,
+        response: oneshot::Sender<Result<()>>,
+    },
+
+    /// Send an SE query response to a peer via SE query two-stream protocol.
+    SendSEQueryResponse {
+        peer_id: PeerId,
+        reply: crate::message::QuerySEArtifactsReply,
+        response: oneshot::Sender<Result<()>>,
+    },
+
     /// Send a CAR request to a peer (request DAG as CARv1).
     SendCarRequest {
         peer_id: PeerId,

--- a/crates/p2p/src/host/command_handler/messaging.rs
+++ b/crates/p2p/src/host/command_handler/messaging.rs
@@ -9,7 +9,8 @@ use crate::error::{Error, Result};
 use crate::host::ResponseChannel;
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, IdentityRequest,
-    PushLogReply, PushLogRequest, PushSEArtifactsRequest,
+    PushLogReply, PushLogRequest, PushSEArtifactsRequest, QuerySEArtifactsReply,
+    QuerySEArtifactsRequest,
 };
 
 use super::super::p2p_host::P2PHost;
@@ -189,6 +190,40 @@ impl<S: Store> P2PHost<S> {
             let result = h.send_se_artifacts_fire_and_forget(peer_id, request).await;
             if response.send(result).is_err() {
                 debug!(peer_id = %peer_id, "SendSEArtifacts command response dropped - caller cancelled");
+            }
+        });
+    }
+
+    pub(super) fn handle_send_se_query_request(
+        &mut self,
+        peer_id: PeerId,
+        request: QuerySEArtifactsRequest,
+        response: tokio::sync::oneshot::Sender<Result<()>>,
+    ) {
+        let handler = self.two_stream_handler.clone();
+        self.spawned_tasks.spawn(async move {
+            let mut h = handler.lock().await;
+            let result = h
+                .send_se_query_request_fire_and_forget(peer_id, request)
+                .await;
+            if response.send(result).is_err() {
+                debug!(peer_id = %peer_id, "SendSEQueryRequest command response dropped - caller cancelled");
+            }
+        });
+    }
+
+    pub(super) fn handle_send_se_query_response(
+        &mut self,
+        peer_id: PeerId,
+        reply: QuerySEArtifactsReply,
+        response: tokio::sync::oneshot::Sender<Result<()>>,
+    ) {
+        let handler = self.two_stream_handler.clone();
+        self.spawned_tasks.spawn(async move {
+            let mut h = handler.lock().await;
+            let result = h.send_se_query_response(peer_id, reply).await;
+            if response.send(result).is_err() {
+                debug!(peer_id = %peer_id, "SendSEQueryResponse command response dropped - caller cancelled");
             }
         });
     }

--- a/crates/p2p/src/host/command_handler/mod.rs
+++ b/crates/p2p/src/host/command_handler/mod.rs
@@ -142,6 +142,20 @@ impl<S: Store> P2PHost<S> {
             } => {
                 self.handle_send_se_artifacts(peer_id, request, response);
             }
+            HostCommand::SendSEQueryRequest {
+                peer_id,
+                request,
+                response,
+            } => {
+                self.handle_send_se_query_request(peer_id, request, response);
+            }
+            HostCommand::SendSEQueryResponse {
+                peer_id,
+                reply,
+                response,
+            } => {
+                self.handle_send_se_query_response(peer_id, reply, response);
+            }
             HostCommand::CreateReplicator {
                 peer_id,
                 collections,

--- a/crates/p2p/src/host/event.rs
+++ b/crates/p2p/src/host/event.rs
@@ -135,4 +135,16 @@ pub enum HostEvent {
         /// Raw CBOR bytes of the PushSEArtifactsRequest for the db layer to process.
         data: Vec<u8>,
     },
+
+    /// Received an SE query request from a peer.
+    SEQueryRequest {
+        peer_id: PeerId,
+        request: crate::message::QuerySEArtifactsRequest,
+    },
+
+    /// Received an SE query reply from a peer.
+    SEQueryReply {
+        peer_id: PeerId,
+        reply: crate::message::QuerySEArtifactsReply,
+    },
 }

--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -675,6 +675,44 @@ impl P2PHostHandle {
         response_rx.await.map_err(|_| Error::ChannelReceive)?
     }
 
+    /// Send an SE query request to a peer via the SE query two-stream protocol.
+    ///
+    /// The response arrives asynchronously as [`HostEvent::SEQueryReply`].
+    pub async fn send_se_query_request(
+        &self,
+        peer_id: PeerId,
+        request: crate::message::QuerySEArtifactsRequest,
+    ) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(HostCommand::SendSEQueryRequest {
+                peer_id,
+                request,
+                response: response_tx,
+            })
+            .await
+            .map_err(|_| Error::ChannelSend)?;
+        response_rx.await.map_err(|_| Error::ChannelReceive)?
+    }
+
+    /// Send an SE query response to a peer via the SE query two-stream protocol.
+    pub async fn send_se_query_response(
+        &self,
+        peer_id: PeerId,
+        reply: crate::message::QuerySEArtifactsReply,
+    ) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(HostCommand::SendSEQueryResponse {
+                peer_id,
+                reply,
+                response: response_tx,
+            })
+            .await
+            .map_err(|_| Error::ChannelSend)?;
+        response_rx.await.map_err(|_| Error::ChannelReceive)?
+    }
+
     /// Send a CAR request to a peer (request DAG as CARv1).
     pub async fn send_car_request(&self, peer_id: PeerId, root_cid: Cid) -> Result<()> {
         let (response_tx, response_rx) = oneshot::channel();

--- a/crates/p2p/src/host/libp2p_transport.rs
+++ b/crates/p2p/src/host/libp2p_transport.rs
@@ -12,7 +12,8 @@ use crate::error::{Error, Result};
 use crate::host::{P2PHostHandle, ResponseChannel};
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
-    PushLogReply, PushLogRequest, PushSEArtifactsRequest,
+    PushLogReply, PushLogRequest, PushSEArtifactsRequest, QuerySEArtifactsReply,
+    QuerySEArtifactsRequest,
 };
 use crate::replicator::ReplicatorInfo;
 use crate::topics::DefraTopic;
@@ -243,6 +244,24 @@ impl P2PTransport for Libp2pTransport {
         self.handle.send_se_artifacts(pid, req).await
     }
 
+    async fn send_se_query_request(
+        &self,
+        peer_id: &PeerId,
+        req: QuerySEArtifactsRequest,
+    ) -> Result<()> {
+        let pid = parse_libp2p_peer_id(peer_id)?;
+        self.handle.send_se_query_request(pid, req).await
+    }
+
+    async fn send_se_query_response(
+        &self,
+        peer_id: &PeerId,
+        reply: QuerySEArtifactsReply,
+    ) -> Result<()> {
+        let pid = parse_libp2p_peer_id(peer_id)?;
+        self.handle.send_se_query_response(pid, reply).await
+    }
+
     async fn sync_blocks(
         &self,
         root: Cid,
@@ -418,6 +437,14 @@ pub fn convert_host_event(event: crate::host::HostEvent) -> TransportEvent<Respo
         HostEvent::SEArtifactsReceived { peer_id, data } => TransportEvent::SEArtifactsReceived {
             peer_id: PeerId::from(peer_id),
             data,
+        },
+        HostEvent::SEQueryRequest { peer_id, request } => TransportEvent::SEQueryRequest {
+            peer_id: PeerId::from(peer_id),
+            request,
+        },
+        HostEvent::SEQueryReply { peer_id, reply } => TransportEvent::SEQueryReply {
+            peer_id: PeerId::from(peer_id),
+            reply,
         },
     }
 }

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -301,6 +301,14 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
         let se_response_streams = control
             .accept(TwoStreamHandler::se_response_protocol())
             .map_err(|_| Error::Behaviour("Failed to register SE response protocol".into()))?;
+        let se_query_request_streams = control
+            .accept(TwoStreamHandler::se_query_request_protocol())
+            .map_err(|_| Error::Behaviour("Failed to register SE query request protocol".into()))?;
+        let se_query_response_streams = control
+            .accept(TwoStreamHandler::se_query_response_protocol())
+            .map_err(|_| {
+                Error::Behaviour("Failed to register SE query response protocol".into())
+            })?;
         let car_request_streams = control
             .accept(TwoStreamHandler::car_request_protocol())
             .map_err(|_| Error::Behaviour("Failed to register CAR request protocol".into()))?;
@@ -328,6 +336,8 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             response_streams,
             se_request_streams,
             se_response_streams,
+            se_query_request_streams,
+            se_query_response_streams,
             car_request_streams,
             car_response_streams,
             identity_request_streams,

--- a/crates/p2p/src/host/p2p_host/two_stream.rs
+++ b/crates/p2p/src/host/p2p_host/two_stream.rs
@@ -276,6 +276,39 @@ impl<S: Store> P2PHost<S> {
                     }
                 }
             }
+            TwoStreamEvent::SEQueryRequest { peer_id, request } => {
+                info!(
+                    peer_id = %peer_id,
+                    message_id = %request.message_id,
+                    collection_id = %request.collection_id,
+                    query_count = request.queries.len(),
+                    "Host received SE query request via two-stream protocol"
+                );
+                if self
+                    .event_tx
+                    .send(HostEvent::SEQueryRequest { peer_id, request })
+                    .await
+                    .is_err()
+                {
+                    error!(peer_id = %peer_id, "Failed to send SEQueryRequest event");
+                }
+            }
+            TwoStreamEvent::SEQueryReply { peer_id, reply } => {
+                debug!(
+                    peer_id = %peer_id,
+                    message_id = %reply.message_id,
+                    doc_count = reply.doc_ids.len(),
+                    "Host received SE query reply via two-stream protocol"
+                );
+                if self
+                    .event_tx
+                    .send(HostEvent::SEQueryReply { peer_id, reply })
+                    .await
+                    .is_err()
+                {
+                    error!(peer_id = %peer_id, "Failed to send SEQueryReply event");
+                }
+            }
             TwoStreamEvent::DecodeError { peer_id, error } => {
                 warn!(
                     peer_id = %peer_id,

--- a/crates/p2p/src/protocol.rs
+++ b/crates/p2p/src/protocol.rs
@@ -49,6 +49,14 @@ pub const SE_REQUEST_PROTOCOL: &str = "/defradb/rep_se_req/0.0.1";
 /// Go uses "rep_se" as the channel name: `/defradb/rep_se_resp/0.0.1`
 pub const SE_RESPONSE_PROTOCOL: &str = "/defradb/rep_se_resp/0.0.1";
 
+/// SE query request protocol ID.
+/// Go uses "se_query" as the channel name: `/defradb/se_query_req/0.0.1`
+pub const SE_QUERY_REQUEST_PROTOCOL: &str = "/defradb/se_query_req/0.0.1";
+
+/// SE query response protocol ID.
+/// Go uses "se_query" as the channel name: `/defradb/se_query_resp/0.0.1`
+pub const SE_QUERY_RESPONSE_PROTOCOL: &str = "/defradb/se_query_resp/0.0.1";
+
 /// CAR (Content ARchive) request protocol ID.
 pub const CAR_REQUEST_PROTOCOL: &str = "/defradb/car_req/0.0.1";
 
@@ -69,6 +77,16 @@ pub fn se_request_protocol() -> StreamProtocol {
 /// StreamProtocol for the SE response protocol.
 pub fn se_response_protocol() -> StreamProtocol {
     StreamProtocol::new(SE_RESPONSE_PROTOCOL)
+}
+
+/// StreamProtocol for the SE query request protocol.
+pub fn se_query_request_protocol() -> StreamProtocol {
+    StreamProtocol::new(SE_QUERY_REQUEST_PROTOCOL)
+}
+
+/// StreamProtocol for the SE query response protocol.
+pub fn se_query_response_protocol() -> StreamProtocol {
+    StreamProtocol::new(SE_QUERY_RESPONSE_PROTOCOL)
 }
 
 /// StreamProtocol for the CAR request protocol.
@@ -136,6 +154,18 @@ mod tests {
     fn test_rep_protocols() {
         assert_eq!(rep_request_protocol().as_ref(), "/defradb/rep_req/0.0.1");
         assert_eq!(rep_response_protocol().as_ref(), "/defradb/rep_resp/0.0.1");
+    }
+
+    #[test]
+    fn test_se_query_protocols() {
+        assert_eq!(
+            se_query_request_protocol().as_ref(),
+            "/defradb/se_query_req/0.0.1"
+        );
+        assert_eq!(
+            se_query_response_protocol().as_ref(),
+            "/defradb/se_query_resp/0.0.1"
+        );
     }
 
     #[test]

--- a/crates/p2p/src/transport.rs
+++ b/crates/p2p/src/transport.rs
@@ -13,7 +13,8 @@ use cid::Cid;
 use crate::error::Result;
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, CarFetchRequest, DocSyncReply, DocSyncRequest,
-    PushLogBroadcast, PushLogReply, PushLogRequest, PushSEArtifactsRequest,
+    PushLogBroadcast, PushLogReply, PushLogRequest, PushSEArtifactsRequest, QuerySEArtifactsReply,
+    QuerySEArtifactsRequest,
 };
 use crate::replicator::ReplicatorInfo;
 use crate::topics::DefraTopic;
@@ -203,6 +204,14 @@ pub enum TransportEvent<ResponseToken> {
         peer_id: PeerId,
         data: Vec<u8>,
     },
+    SEQueryRequest {
+        peer_id: PeerId,
+        request: QuerySEArtifactsRequest,
+    },
+    SEQueryReply {
+        peer_id: PeerId,
+        reply: QuerySEArtifactsReply,
+    },
     Listening(PeerAddr),
 }
 
@@ -353,6 +362,26 @@ pub trait P2PTransport: Clone + Send + Sync + 'static {
     ) -> Result<()>;
 
     async fn send_se_artifacts(&self, peer_id: &PeerId, req: PushSEArtifactsRequest) -> Result<()>;
+
+    async fn send_se_query_request(
+        &self,
+        _peer_id: &PeerId,
+        _req: QuerySEArtifactsRequest,
+    ) -> Result<()> {
+        Err(crate::error::Error::Transport(
+            "send_se_query_request is not supported on this transport".to_string(),
+        ))
+    }
+
+    async fn send_se_query_response(
+        &self,
+        _peer_id: &PeerId,
+        _reply: QuerySEArtifactsReply,
+    ) -> Result<()> {
+        Err(crate::error::Error::Transport(
+            "send_se_query_response is not supported on this transport".to_string(),
+        ))
+    }
 
     // ---- Block sync ----
 

--- a/crates/p2p/src/two_stream/event.rs
+++ b/crates/p2p/src/two_stream/event.rs
@@ -5,7 +5,8 @@ use libp2p::PeerId;
 
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, IdentityRequest,
-    IdentityResponse, PushLogRequest, PushSEArtifactsRequest,
+    IdentityResponse, PushLogRequest, PushSEArtifactsRequest, QuerySEArtifactsReply,
+    QuerySEArtifactsRequest,
 };
 
 /// Event emitted by the two-stream handler.
@@ -59,6 +60,16 @@ pub enum TwoStreamEvent {
     SEArtifactsReceived {
         peer_id: PeerId,
         request: PushSEArtifactsRequest,
+    },
+    /// Received an SE query request from a peer.
+    SEQueryRequest {
+        peer_id: PeerId,
+        request: QuerySEArtifactsRequest,
+    },
+    /// Received an SE query reply from a peer.
+    SEQueryReply {
+        peer_id: PeerId,
+        reply: QuerySEArtifactsReply,
     },
     /// Failed to decode an incoming message.
     DecodeError { peer_id: PeerId, error: String },

--- a/crates/p2p/src/two_stream/handler/inbound.rs
+++ b/crates/p2p/src/two_stream/handler/inbound.rs
@@ -5,27 +5,15 @@ use std::sync::Arc;
 use libp2p::{PeerId, Stream};
 use parking_lot::Mutex;
 
-use super::PendingResponses;
+use super::{ensure_transport_sender, PendingResponses};
 use crate::error::{Error, Result};
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, IdentityRequest,
-    IdentityResponse, Message, PushLogReply, PushLogRequest,
+    IdentityResponse, PushLogReply, PushLogRequest,
 };
 use crate::two_stream::event::TwoStreamEvent;
 
 use super::TwoStreamHandler;
-
-fn ensure_transport_sender<M: Message>(peer_id: &PeerId, msg: &M) -> Result<()> {
-    if msg.sender_id() == peer_id.to_string() {
-        Ok(())
-    } else {
-        Err(Error::Transport(format!(
-            "transport peer {} did not match signed sender {}",
-            peer_id,
-            msg.sender_id()
-        )))
-    }
-}
 
 impl TwoStreamHandler {
     /// Handle an incoming stream on the request protocol.

--- a/crates/p2p/src/two_stream/handler/mod.rs
+++ b/crates/p2p/src/two_stream/handler/mod.rs
@@ -13,6 +13,7 @@ mod doc_sync;
 mod identity;
 mod inbound;
 mod pushlog;
+mod se_query;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -26,12 +27,26 @@ use tokio::sync::oneshot;
 use crate::message::{IdentityResponse, PushLogReply, PushLogRequest};
 use crate::protocol::{
     CAR_REQUEST_PROTOCOL, CAR_RESPONSE_PROTOCOL, IDENTITY_REQUEST_PROTOCOL,
-    IDENTITY_RESPONSE_PROTOCOL, REP_REQUEST_PROTOCOL, REP_RESPONSE_PROTOCOL, SE_REQUEST_PROTOCOL,
+    IDENTITY_RESPONSE_PROTOCOL, REP_REQUEST_PROTOCOL, REP_RESPONSE_PROTOCOL,
+    SE_QUERY_REQUEST_PROTOCOL, SE_QUERY_RESPONSE_PROTOCOL, SE_REQUEST_PROTOCOL,
     SE_RESPONSE_PROTOCOL,
 };
+use crate::{error::Error, message::Message, Result};
 
 /// Timeout for waiting for a response.
 pub(super) const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(super) fn ensure_transport_sender<M: Message>(peer_id: &libp2p::PeerId, msg: &M) -> Result<()> {
+    if msg.sender_id() == peer_id.to_string() {
+        Ok(())
+    } else {
+        Err(Error::Transport(format!(
+            "transport peer {} did not match signed sender {}",
+            peer_id,
+            msg.sender_id()
+        )))
+    }
+}
 
 /// State for tracking pending responses.
 #[derive(Default)]
@@ -87,6 +102,16 @@ impl TwoStreamHandler {
     /// Get the SE response protocol.
     pub fn se_response_protocol() -> StreamProtocol {
         StreamProtocol::new(SE_RESPONSE_PROTOCOL)
+    }
+
+    /// Get the SE query request protocol.
+    pub fn se_query_request_protocol() -> StreamProtocol {
+        StreamProtocol::new(SE_QUERY_REQUEST_PROTOCOL)
+    }
+
+    /// Get the SE query response protocol.
+    pub fn se_query_response_protocol() -> StreamProtocol {
+        StreamProtocol::new(SE_QUERY_RESPONSE_PROTOCOL)
     }
 
     /// Get the CAR request protocol.

--- a/crates/p2p/src/two_stream/handler/se_query.rs
+++ b/crates/p2p/src/two_stream/handler/se_query.rs
@@ -1,0 +1,161 @@
+//! Searchable Encryption query request and response methods.
+
+use futures::AsyncReadExt;
+use libp2p::{PeerId, Stream};
+
+use crate::codec::write_message;
+use crate::error::{Error, Result};
+use crate::message::{QuerySEArtifactsReply, QuerySEArtifactsRequest};
+use crate::two_stream::event::TwoStreamEvent;
+
+use super::{ensure_transport_sender, TwoStreamHandler};
+
+impl TwoStreamHandler {
+    /// Send an SE query request to a peer without waiting for response.
+    ///
+    /// The response arrives asynchronously via [`TwoStreamEvent::SEQueryReply`].
+    pub async fn send_se_query_request_fire_and_forget(
+        &mut self,
+        peer_id: PeerId,
+        request: QuerySEArtifactsRequest,
+    ) -> Result<()> {
+        let message_id = request.message_id.clone();
+        let query_count = request.queries.len();
+
+        let mut stream = self
+            .control
+            .open_stream(peer_id, Self::se_query_request_protocol())
+            .await
+            .map_err(|e| Error::Transport(format!("failed to open SE query stream: {e}")))?;
+
+        write_message(&mut stream, &request).await.map_err(|e| {
+            Error::CborSerialization(format!("failed to write SE query request: {e}"))
+        })?;
+
+        tracing::info!(
+            peer_id = %peer_id,
+            message_id = %message_id,
+            collection_id = %request.collection_id,
+            query_count = query_count,
+            "Sent QuerySEArtifacts request on SE query protocol"
+        );
+
+        Ok(())
+    }
+
+    /// Send an SE query response to a peer.
+    pub async fn send_se_query_response(
+        &mut self,
+        peer_id: PeerId,
+        reply: QuerySEArtifactsReply,
+    ) -> Result<()> {
+        let message_id = reply.message_id.clone();
+        let doc_count = reply.doc_ids.len();
+
+        let mut stream = self
+            .control
+            .open_stream(peer_id, Self::se_query_response_protocol())
+            .await
+            .map_err(|e| {
+                Error::Transport(format!("failed to open SE query response stream: {e}"))
+            })?;
+
+        write_message(&mut stream, &reply).await.map_err(|e| {
+            Error::CborSerialization(format!("failed to write SE query response: {e}"))
+        })?;
+
+        tracing::info!(
+            peer_id = %peer_id,
+            message_id = %message_id,
+            doc_count = doc_count,
+            "Sent QuerySEArtifacts response on SE query protocol"
+        );
+
+        Ok(())
+    }
+
+    /// Handle an incoming SE query request stream.
+    pub async fn handle_se_query_request_stream(
+        peer_id: PeerId,
+        stream: Stream,
+        max_msg_size: u64,
+        stream_read_timeout: std::time::Duration,
+    ) -> Result<TwoStreamEvent> {
+        let request = read_cbor_message::<QuerySEArtifactsRequest>(
+            peer_id,
+            stream,
+            max_msg_size,
+            stream_read_timeout,
+            "SE query request",
+        )
+        .await?;
+
+        crate::verify_message(&request)?;
+        ensure_transport_sender(&peer_id, &request)?;
+
+        tracing::info!(
+            peer_id = %peer_id,
+            message_id = %request.message_id,
+            collection_id = %request.collection_id,
+            query_count = request.queries.len(),
+            "Received QuerySEArtifacts request on SE query protocol"
+        );
+
+        Ok(TwoStreamEvent::SEQueryRequest { peer_id, request })
+    }
+
+    /// Handle an incoming SE query response stream.
+    pub async fn handle_se_query_response_stream(
+        peer_id: PeerId,
+        stream: Stream,
+        max_msg_size: u64,
+        stream_read_timeout: std::time::Duration,
+    ) -> Result<TwoStreamEvent> {
+        let reply = read_cbor_message::<QuerySEArtifactsReply>(
+            peer_id,
+            stream,
+            max_msg_size,
+            stream_read_timeout,
+            "SE query response",
+        )
+        .await?;
+
+        crate::verify_message(&reply)?;
+        ensure_transport_sender(&peer_id, &reply)?;
+
+        tracing::debug!(
+            peer_id = %peer_id,
+            message_id = %reply.message_id,
+            doc_count = reply.doc_ids.len(),
+            "Received QuerySEArtifacts response on SE query protocol"
+        );
+
+        Ok(TwoStreamEvent::SEQueryReply { peer_id, reply })
+    }
+}
+
+async fn read_cbor_message<T>(
+    peer_id: PeerId,
+    mut stream: Stream,
+    max_msg_size: u64,
+    stream_read_timeout: std::time::Duration,
+    label: &'static str,
+) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let mut buf = Vec::new();
+    tokio::time::timeout(
+        stream_read_timeout,
+        (&mut stream).take(max_msg_size).read_to_end(&mut buf),
+    )
+    .await
+    .map_err(|_| {
+        tracing::warn!(peer_id = %peer_id, "SE query stream read timed out");
+        Error::CborDeserialization(format!("{label} stream read timed out"))
+    })?
+    .map_err(|e| Error::CborDeserialization(format!("failed to read {label}: {e}")))?;
+
+    serde_cbor::from_slice(&buf)
+        .map_err(|e| Error::CborDeserialization(format!("failed to decode {label}: {e}")))
+}

--- a/crates/p2p/src/two_stream/mod.rs
+++ b/crates/p2p/src/two_stream/mod.rs
@@ -30,6 +30,14 @@ mod tests {
             TwoStreamHandler::response_protocol().as_ref(),
             "/defradb/rep_resp/0.0.1"
         );
+        assert_eq!(
+            TwoStreamHandler::se_query_request_protocol().as_ref(),
+            "/defradb/se_query_req/0.0.1"
+        );
+        assert_eq!(
+            TwoStreamHandler::se_query_response_protocol().as_ref(),
+            "/defradb/se_query_resp/0.0.1"
+        );
     }
 
     #[test]

--- a/crates/p2p/src/two_stream/runner.rs
+++ b/crates/p2p/src/two_stream/runner.rs
@@ -30,6 +30,10 @@ pub struct TwoStreamRunner {
     se_request_streams: stream::IncomingStreams,
     /// Incoming SE response streams.
     se_response_streams: stream::IncomingStreams,
+    /// Incoming SE query request streams.
+    se_query_request_streams: stream::IncomingStreams,
+    /// Incoming SE query response streams.
+    se_query_response_streams: stream::IncomingStreams,
     /// Incoming CAR request streams.
     car_request_streams: stream::IncomingStreams,
     /// Incoming CAR response streams.
@@ -59,6 +63,8 @@ impl TwoStreamRunner {
         response_streams: stream::IncomingStreams,
         se_request_streams: stream::IncomingStreams,
         se_response_streams: stream::IncomingStreams,
+        se_query_request_streams: stream::IncomingStreams,
+        se_query_response_streams: stream::IncomingStreams,
         car_request_streams: stream::IncomingStreams,
         car_response_streams: stream::IncomingStreams,
         identity_request_streams: stream::IncomingStreams,
@@ -75,6 +81,8 @@ impl TwoStreamRunner {
             response_streams,
             se_request_streams,
             se_response_streams,
+            se_query_request_streams,
+            se_query_response_streams,
             car_request_streams,
             car_response_streams,
             identity_request_streams,
@@ -246,6 +254,62 @@ impl TwoStreamRunner {
                                     buf_len = buf.len(),
                                     "Received SE response (acknowledgement)"
                                 );
+                            }
+                        }
+                    });
+                }
+                // Handle incoming SE query request streams
+                Some((peer_id, stream)) = self.se_query_request_streams.next() => {
+                    let event_tx = self.event_tx.clone();
+                    let sem = self.semaphore.clone();
+                    let max_msg_size = self.max_msg_size;
+                    let stream_read_timeout = self.stream_read_timeout;
+                    tokio::spawn(async move {
+                        let Ok(_permit) = sem.acquire().await else { return };
+                        match TwoStreamHandler::handle_se_query_request_stream(peer_id, stream, max_msg_size, stream_read_timeout).await {
+                            Ok(event) => {
+                                if event_tx.send(event).await.is_err() {
+                                    tracing::warn!(peer_id = %peer_id, "Failed to send SE query request event");
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    peer_id = %peer_id,
+                                    error = %e,
+                                    "Failed to handle SE query request stream"
+                                );
+                                let _ = event_tx.send(TwoStreamEvent::DecodeError {
+                                    peer_id,
+                                    error: e.to_string(),
+                                }).await;
+                            }
+                        }
+                    });
+                }
+                // Handle incoming SE query response streams
+                Some((peer_id, stream)) = self.se_query_response_streams.next() => {
+                    let event_tx = self.event_tx.clone();
+                    let sem = self.semaphore.clone();
+                    let max_msg_size = self.max_msg_size;
+                    let stream_read_timeout = self.stream_read_timeout;
+                    tokio::spawn(async move {
+                        let Ok(_permit) = sem.acquire().await else { return };
+                        match TwoStreamHandler::handle_se_query_response_stream(peer_id, stream, max_msg_size, stream_read_timeout).await {
+                            Ok(event) => {
+                                if event_tx.send(event).await.is_err() {
+                                    tracing::warn!(peer_id = %peer_id, "Failed to send SE query response event");
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    peer_id = %peer_id,
+                                    error = %e,
+                                    "Failed to handle SE query response stream"
+                                );
+                                let _ = event_tx.send(TwoStreamEvent::DecodeError {
+                                    peer_id,
+                                    error: e.to_string(),
+                                }).await;
                             }
                         }
                     });

--- a/crates/p2p/tests/host_tests.rs
+++ b/crates/p2p/tests/host_tests.rs
@@ -6,7 +6,11 @@ use identity::{Identity, RawIdentity};
 use std::time::Duration;
 
 use p2p::testutil::MockBitswapStore;
-use p2p::{message::PushLogReply, signing::sign_message, P2PHost, PeerId, PushLogRequest};
+use p2p::{
+    message::{PushLogReply, QuerySEArtifactsReply, QuerySEArtifactsRequest, SEFieldQuery},
+    signing::sign_message,
+    P2PHost, PeerId, PushLogRequest,
+};
 use tokio::time::timeout;
 
 fn authorizer_identity() -> RawIdentity {
@@ -201,6 +205,90 @@ async fn test_identity_protocol_roundtrip_returns_defra_identity() {
         peer_identity.to_string(),
         node_identity1.did().unwrap().to_string()
     );
+
+    handle0.shutdown().await.unwrap();
+    handle1.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_se_query_protocol_roundtrip() {
+    let store0 = MockBitswapStore::new();
+    let store1 = MockBitswapStore::new();
+    let (host0, handle0, mut events0, _replicators0) = P2PHost::new(store0).await.unwrap();
+    let (host1, handle1, mut events1, _replicators1) = P2PHost::new(store1).await.unwrap();
+
+    tokio::spawn(host0.run());
+    tokio::spawn(host1.run());
+
+    handle1
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let addr1 = handle1.listen_addresses().await.unwrap().remove(0);
+    let peer1 = handle1.local_peer_id_cached();
+    let peer0 = handle0.local_peer_id_cached();
+
+    handle0.dial(peer1, vec![addr1]).await.unwrap();
+    wait_until_connected(&handle0, peer1).await;
+    wait_until_connected(&handle1, peer0).await;
+
+    let mut request = QuerySEArtifactsRequest::new(
+        "collection1",
+        vec![SEFieldQuery::new("name", "name", vec![1, 2, 3])],
+    );
+    sign_message(handle0.keypair(), &mut request).unwrap();
+    let request_message_id = request.message_id.clone();
+
+    handle0
+        .send_se_query_request(peer1, request.clone())
+        .await
+        .unwrap();
+
+    let received_request = loop {
+        let event = timeout(Duration::from_secs(5), events1.recv())
+            .await
+            .expect("timed out waiting for SE query request")
+            .expect("host event channel closed");
+
+        match event {
+            p2p::HostEvent::SEQueryRequest { peer_id, request } => {
+                assert_eq!(peer_id, peer0);
+                break request;
+            }
+            _ => continue,
+        }
+    };
+    assert_eq!(received_request.message_id, request_message_id);
+    assert_eq!(received_request.sender_id, peer0.to_string());
+    assert_eq!(received_request.collection_id, "collection1");
+    assert_eq!(received_request.queries.len(), 1);
+    assert_eq!(received_request.queries[0].search_tag, vec![1, 2, 3]);
+
+    let mut reply =
+        QuerySEArtifactsReply::success(&request_message_id, vec!["doc1".into(), "doc2".into()]);
+    sign_message(handle1.keypair(), &mut reply).unwrap();
+    handle1
+        .send_se_query_response(peer0, reply.clone())
+        .await
+        .unwrap();
+
+    loop {
+        let event = timeout(Duration::from_secs(5), events0.recv())
+            .await
+            .expect("timed out waiting for SE query reply")
+            .expect("host event channel closed");
+
+        match event {
+            p2p::HostEvent::SEQueryReply { peer_id, reply } => {
+                assert_eq!(peer_id, peer1);
+                assert_eq!(reply.message_id, request_message_id);
+                assert_eq!(reply.sender_id, peer1.to_string());
+                assert_eq!(reply.doc_ids, vec!["doc1".to_string(), "doc2".to_string()]);
+                break;
+            }
+            _ => continue,
+        }
+    }
 
     handle0.shutdown().await.unwrap();
     handle1.shutdown().await.unwrap();


### PR DESCRIPTION
## Summary

Closes #829. Registers Rust's missing Go-compatible Searchable Encryption `se_query` two-stream channel and wires signed query request/reply handling through the host and transport layers.

## Why

Go registers two SE CommChannels: `rep_se` for artifact storage and `se_query` for encrypted-index query traffic. Rust only registered the `rep_se` pair, so Go peers attempting to query SE artifacts against a Rust node would fail protocol negotiation.

The query message types already existed in Rust, but there was no registered stream pair or host-level path for them.

## Changes

| Area | Change |
|---|---|
| Protocol IDs | Add `/defradb/se_query_req/0.0.1` and `/defradb/se_query_resp/0.0.1` constants and constructors. |
| Two-stream handler | Add dedicated SE query request/response send and decode handlers using `QuerySEArtifactsRequest` and `QuerySEArtifactsReply`. |
| Host registration | Register both SE query streams alongside the existing SE artifact streams. |
| Host/transport events | Add SE query request/reply events and conversion through the libp2p transport boundary. |
| Public handle APIs | Add `send_se_query_request` and `send_se_query_response`. |
| Tests | Add protocol ID coverage and a signed Rust-to-Rust SE query round-trip test. |

## Stacking note

This branch is intentionally based on `iverc/cli-pushlog-message-id-882`, so the CLI PushLog message-id CI fix is present until that PR lands on `main`. Once the fix branch is merged, that diff should disappear from this PR.

## Out of scope

- Implementing full SE query evaluation in the database planner.
- Adding Go live interop tests that require a running Go DefraDB node.
- Changing the existing `rep_se` artifact storage channel semantics.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p test_se_query_protocol_roundtrip -- --nocapture` -- passed outside sandbox; sandboxed run hit local TCP transport restrictions.
- [x] `cargo test -p p2p` -- passed outside sandbox.
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet` -- passed outside sandbox.
