### PR TITLE
fix(p2p): match Go time.Time{} reset on replicator recovery (#914)

### DIFF
--- a/crates/p2p/src/replicator.rs
+++ b/crates/p2p/src/replicator.rs
@@ -237,9 +237,21 @@ impl ReplicatorInfo {
         true
     }
 
-    /// Update status using the current UTC timestamp when the state changes.
+    /// Update status using Go's recovery-aware timestamp rule.
+    ///
+    /// Mirrors Go's `updateReplicatorStatus`
+    /// (`defradb/internal/db/p2p/replicator.go:495`):
+    /// - `Active → Inactive` stamps `Utc::now()`.
+    /// - `Inactive → Active` resets to `time.Time{}` so a recovered record
+    ///   serializes identically to a freshly-constructed one.
+    ///
+    /// Same-status calls leave the timestamp untouched.
     pub fn set_status_if_changed_now(&mut self, status: ReplicatorStatus) -> bool {
-        self.set_status_if_changed(status, Utc::now())
+        let changed_at = match status {
+            ReplicatorStatus::Inactive => Utc::now(),
+            ReplicatorStatus::Active => go_time_zero(),
+        };
+        self.set_status_if_changed(status, changed_at)
     }
 
     /// Format `LastStatusChange` exactly like Go's `time.Time.MarshalJSON`.

--- a/crates/p2p/tests/replicator_tests.rs
+++ b/crates/p2p/tests/replicator_tests.rs
@@ -131,6 +131,34 @@ fn status_update_records_first_transition_only() {
 }
 
 #[test]
+fn set_status_if_changed_now_matches_go_recovery_rule() {
+    // Go's `updateReplicatorStatus` (`defradb/internal/db/p2p/replicator.go:495`)
+    // resets `LastStatusChange` to `time.Time{}` on `Inactive → Active`,
+    // and stamps `time.Now()` on `Active → Inactive`. Mirroring that here
+    // keeps the JSON wire format identical to a Go-produced peerstore record.
+    let peer_id = PeerId::random();
+    let mut info = ReplicatorInfo::new(peer_id, vec!["users".to_string()]).unwrap();
+    let go_zero = Utc.with_ymd_and_hms(1, 1, 1, 0, 0, 0).unwrap();
+
+    let before = Utc::now();
+    assert!(info.set_status_if_changed_now(ReplicatorStatus::Inactive));
+    let after = Utc::now();
+    assert_eq!(info.status, ReplicatorStatus::Inactive);
+    assert!(
+        info.last_status_change >= before && info.last_status_change <= after,
+        "Active → Inactive must stamp now(), got {}",
+        info.last_status_change
+    );
+
+    assert!(info.set_status_if_changed_now(ReplicatorStatus::Active));
+    assert_eq!(info.status, ReplicatorStatus::Active);
+    assert_eq!(
+        info.last_status_change, go_zero,
+        "Inactive → Active must reset to Go's time.Time{{}} zero value"
+    );
+}
+
+#[test]
 fn timestamp_encodes_like_go_rfc3339nano_with_trailing_zeros() {
     // Go's `time.Time.MarshalJSON` uses RFC3339Nano, which strips trailing
     // zeros from the fractional seconds (`.100` → `.1`, `.001` stays `.001`).


### PR DESCRIPTION
## Summary

Closes #914.

`ReplicatorInfo::set_status_if_changed_now` was stamping `last_status_change` with `Utc::now()` for every transition. Go's `updateReplicatorStatus` (`defradb/internal/db/p2p/replicator.go:495`) special-cases the `Inactive → Active` recovery transition and resets `LastStatusChange` to `time.Time{}` (`0001-01-01T00:00:00Z`) so a recovered record serializes identically to a freshly-constructed one. Without this, recovery transitions write JSON that diverges byte-for-byte from a Go-produced peerstore record — regressing the wire-format contract established in #902.

The fix is local to one method: pick `Utc::now()` for `Active → Inactive` and the existing `go_time_zero()` helper for `Inactive → Active`. Both call sites (`crates/p2p-adapter/src/replicator_status.rs` and the inline copy in `crates/cli/src/commands/start/server_p2p.rs`) inherit the corrected behavior automatically.

The previous test (`status_update_records_first_transition_only`) only exercises `set_status_if_changed` (the explicit-timestamp variant) and continues to pass — added a new test that pins the Go-parity rule for the `_now` variant.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all -- -D warnings` — clean (rustc 1.95)
- [x] `cargo test -p p2p -p defra-p2p-adapter` — all green (~382 tests)
- [x] New test `set_status_if_changed_now_matches_go_recovery_rule` confirmed red before fix, green after