### PR TITLE
fix(p2p): bind two-stream replies to transport peer (#833)

### DIFF
--- a/crates/p2p/src/host/command_handler/messaging.rs
+++ b/crates/p2p/src/host/command_handler/messaging.rs
@@ -92,13 +92,13 @@ impl<S: Store> P2PHost<S> {
             {
                 Ok(Ok(reply)) => Ok(reply),
                 Ok(Err(_)) => {
-                    handler.lock().await.cleanup_pending(&message_id);
+                    handler.lock().await.cleanup_pending(peer_id, &message_id);
                     Err(crate::error::Error::Transport(
                         "response channel closed".into(),
                     ))
                 }
                 Err(_) => {
-                    handler.lock().await.cleanup_pending(&message_id);
+                    handler.lock().await.cleanup_pending(peer_id, &message_id);
                     Err(crate::error::Error::Transport(
                         "timeout waiting for response".into(),
                     ))

--- a/crates/p2p/src/two_stream/handler/doc_sync.rs
+++ b/crates/p2p/src/two_stream/handler/doc_sync.rs
@@ -7,7 +7,7 @@ use crate::codec::write_message;
 use crate::error::{Error, Result};
 use crate::message::{DocSyncReply, DocSyncRequest};
 
-use super::{TwoStreamHandler, RESPONSE_TIMEOUT};
+use super::{PendingResponseKey, TwoStreamHandler, RESPONSE_TIMEOUT};
 
 impl TwoStreamHandler {
     /// Send a DocSync request to a peer and wait for response.
@@ -20,16 +20,17 @@ impl TwoStreamHandler {
         request: DocSyncRequest,
     ) -> Result<DocSyncReply> {
         let message_id = request.message_id.clone();
+        let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
 
         // Create response channel
         let (tx, rx) = tokio::sync::oneshot::channel();
 
-        // Register pending response (use the same pending map, keyed by message ID)
+        // Register pending response against the expected peer as well as the message ID.
         {
             let mut pending = self.pending.lock();
             // Store as a PushLogReply channel - we'll need a different approach for DocSyncReply
             // Actually, we need a separate map for DocSync responses
-            pending.channels.insert(message_id.clone(), tx);
+            pending.channels.insert(pending_key.clone(), tx);
         }
 
         // Open stream and send request
@@ -40,14 +41,14 @@ impl TwoStreamHandler {
             .map_err(|e| {
                 // Clean up pending on failure
                 let mut pending = self.pending.lock();
-                pending.channels.remove(&message_id);
+                pending.channels.remove(&pending_key);
                 Error::Transport(format!("failed to open stream: {}", e))
             })?;
 
         write_message(&mut stream, &request).await.map_err(|e| {
             // Clean up pending on failure
             let mut pending = self.pending.lock();
-            pending.channels.remove(&message_id);
+            pending.channels.remove(&pending_key);
             Error::CborSerialization(format!("failed to write request: {}", e))
         })?;
 
@@ -72,12 +73,12 @@ impl TwoStreamHandler {
             }
             Ok(Err(_)) => {
                 let mut pending = self.pending.lock();
-                pending.channels.remove(&message_id);
+                pending.channels.remove(&pending_key);
                 Err(Error::Transport("response channel closed".into()))
             }
             Err(_) => {
                 let mut pending = self.pending.lock();
-                pending.channels.remove(&message_id);
+                pending.channels.remove(&pending_key);
                 Err(Error::Transport("timeout waiting for response".into()))
             }
         }

--- a/crates/p2p/src/two_stream/handler/identity.rs
+++ b/crates/p2p/src/two_stream/handler/identity.rs
@@ -5,7 +5,7 @@ use crate::codec::write_message;
 use crate::error::{Error, Result};
 use crate::message::{IdentityRequest, IdentityResponse};
 
-use super::{TwoStreamHandler, RESPONSE_TIMEOUT};
+use super::{PendingResponseKey, TwoStreamHandler, RESPONSE_TIMEOUT};
 
 impl TwoStreamHandler {
     pub async fn send_identity_request(
@@ -14,11 +14,12 @@ impl TwoStreamHandler {
         request: IdentityRequest,
     ) -> Result<IdentityResponse> {
         let message_id = request.message_id.clone();
+        let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
         let (tx, rx) = oneshot::channel();
 
         {
             let mut pending = self.pending.lock();
-            pending.identity_channels.insert(message_id.clone(), tx);
+            pending.identity_channels.insert(pending_key.clone(), tx);
         }
 
         let mut stream = self
@@ -26,25 +27,25 @@ impl TwoStreamHandler {
             .open_stream(peer_id, Self::identity_request_protocol())
             .await
             .map_err(|e| {
-                self.cleanup_pending_identity(&message_id);
+                self.cleanup_pending_identity(peer_id, &message_id);
                 Error::Transport(format!("failed to open identity stream: {}", e))
             })?;
 
         write_message(&mut stream, &request).await.map_err(|e| {
-            self.cleanup_pending_identity(&message_id);
+            self.cleanup_pending_identity(peer_id, &message_id);
             Error::CborSerialization(format!("failed to write identity request: {}", e))
         })?;
 
         match tokio::time::timeout(RESPONSE_TIMEOUT, rx).await {
             Ok(Ok(reply)) => Ok(reply),
             Ok(Err(_)) => {
-                self.cleanup_pending_identity(&message_id);
+                self.cleanup_pending_identity(peer_id, &message_id);
                 Err(Error::Transport(
                     "identity response channel closed".to_string(),
                 ))
             }
             Err(_) => {
-                self.cleanup_pending_identity(&message_id);
+                self.cleanup_pending_identity(peer_id, &message_id);
                 Err(Error::ResponseTimeout)
             }
         }

--- a/crates/p2p/src/two_stream/handler/inbound.rs
+++ b/crates/p2p/src/two_stream/handler/inbound.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use libp2p::{PeerId, Stream};
 use parking_lot::Mutex;
 
-use super::PendingResponses;
+use super::{PendingResponseKey, PendingResponses};
 use crate::error::{Error, Result};
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, IdentityRequest,
@@ -160,6 +160,7 @@ impl TwoStreamHandler {
         match serde_cbor::from_slice::<BranchableSyncReply>(&buf) {
             Ok(reply) if !reply.collection_id.is_empty() => {
                 crate::verify_message(&reply)?;
+                ensure_transport_sender(&peer_id, &reply)?;
                 tracing::debug!(
                     peer_id = %peer_id,
                     message_id = %reply.message_id,
@@ -185,13 +186,15 @@ impl TwoStreamHandler {
         // shape changes the serialized bytes and fails validation.
         if let Ok(response) = serde_cbor::from_slice::<PushLogReply>(&buf) {
             let message_id = response.message_id.clone();
+            let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
             let is_pending_pushlog = {
                 let pending = pending.lock();
-                pending.channels.contains_key(&message_id)
+                pending.channels.contains_key(&pending_key)
             };
 
             if is_pending_pushlog {
                 crate::verify_message(&response)?;
+                ensure_transport_sender(&peer_id, &response)?;
 
                 tracing::debug!(
                     peer_id = %peer_id,
@@ -201,7 +204,7 @@ impl TwoStreamHandler {
 
                 let sender = {
                     let mut pending = pending.lock();
-                    pending.channels.remove(&message_id)
+                    pending.channels.remove(&pending_key)
                 };
 
                 if let Some(sender) = sender {
@@ -214,11 +217,13 @@ impl TwoStreamHandler {
 
         if let Ok(reply) = serde_cbor::from_slice::<IdentityResponse>(&buf) {
             crate::verify_message(&reply)?;
+            ensure_transport_sender(&peer_id, &reply)?;
             let message_id = reply.message_id.clone();
+            let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
 
             let sender = {
                 let mut pending = pending.lock();
-                pending.identity_channels.remove(&message_id)
+                pending.identity_channels.remove(&pending_key)
             };
 
             if let Some(sender) = sender {
@@ -238,6 +243,7 @@ impl TwoStreamHandler {
         // shape and DocSyncReply defaults Results to empty, so DocSync must come later.
         if let Ok(reply) = serde_cbor::from_slice::<DocSyncReply>(&buf) {
             crate::verify_message(&reply)?;
+            ensure_transport_sender(&peer_id, &reply)?;
             let message_id = reply.message_id.clone();
 
             // No pending channel - this is a DocSyncReply for the coordinator
@@ -253,7 +259,9 @@ impl TwoStreamHandler {
         // Fallback: try PushLogReply in case the message doesn't parse as DocSyncReply
         if let Ok(response) = serde_cbor::from_slice::<PushLogReply>(&buf) {
             crate::verify_message(&response)?;
+            ensure_transport_sender(&peer_id, &response)?;
             let message_id = response.message_id.clone();
+            let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
 
             tracing::debug!(
                 peer_id = %peer_id,
@@ -263,7 +271,7 @@ impl TwoStreamHandler {
 
             let sender = {
                 let mut pending = pending.lock();
-                pending.channels.remove(&message_id)
+                pending.channels.remove(&pending_key)
             };
 
             if let Some(sender) = sender {

--- a/crates/p2p/src/two_stream/handler/mod.rs
+++ b/crates/p2p/src/two_stream/handler/mod.rs
@@ -23,6 +23,8 @@ use libp2p_stream as stream;
 use parking_lot::Mutex;
 use tokio::sync::oneshot;
 
+use libp2p::PeerId;
+
 use crate::message::{IdentityResponse, PushLogReply, PushLogRequest};
 use crate::protocol::{
     CAR_REQUEST_PROTOCOL, CAR_RESPONSE_PROTOCOL, IDENTITY_REQUEST_PROTOCOL,
@@ -33,13 +35,29 @@ use crate::protocol::{
 /// Timeout for waiting for a response.
 pub(super) const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Pending response key bound to the expected transport peer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct PendingResponseKey {
+    pub(crate) peer_id: PeerId,
+    pub(crate) message_id: String,
+}
+
+impl PendingResponseKey {
+    pub(crate) fn new(peer_id: PeerId, message_id: impl Into<String>) -> Self {
+        Self {
+            peer_id,
+            message_id: message_id.into(),
+        }
+    }
+}
+
 /// State for tracking pending responses.
 #[derive(Default)]
 pub(crate) struct PendingResponses {
-    /// Map of MessageID to response channel.
-    pub(crate) channels: HashMap<String, oneshot::Sender<PushLogReply>>,
-    /// Map of MessageID to identity response channel.
-    pub(crate) identity_channels: HashMap<String, oneshot::Sender<IdentityResponse>>,
+    /// Map of expected peer + MessageID to response channel.
+    pub(crate) channels: HashMap<PendingResponseKey, oneshot::Sender<PushLogReply>>,
+    /// Map of expected peer + MessageID to identity response channel.
+    pub(crate) identity_channels: HashMap<PendingResponseKey, oneshot::Sender<IdentityResponse>>,
 }
 
 /// Two-stream protocol handler.
@@ -51,7 +69,7 @@ pub(crate) struct PendingResponses {
 pub struct TwoStreamHandler {
     /// Control for the stream behaviour (for opening streams).
     pub(super) control: stream::Control,
-    /// Pending response channels keyed by MessageID.
+    /// Pending response channels keyed by expected peer and MessageID.
     pub(super) pending: Arc<Mutex<PendingResponses>>,
 }
 
@@ -110,15 +128,19 @@ impl TwoStreamHandler {
     }
 
     /// Clean up a pending response channel (used on timeout or cancellation).
-    pub fn cleanup_pending(&self, message_id: &str) {
+    pub fn cleanup_pending(&self, peer_id: PeerId, message_id: &str) {
         let mut pending = self.pending.lock();
-        pending.channels.remove(message_id);
+        pending
+            .channels
+            .remove(&PendingResponseKey::new(peer_id, message_id));
     }
 
     /// Clean up a pending identity response channel (used on timeout or cancellation).
-    pub fn cleanup_pending_identity(&self, message_id: &str) {
+    pub fn cleanup_pending_identity(&self, peer_id: PeerId, message_id: &str) {
         let mut pending = self.pending.lock();
-        pending.identity_channels.remove(message_id);
+        pending
+            .identity_channels
+            .remove(&PendingResponseKey::new(peer_id, message_id));
     }
 
     /// Create a success reply for a request.

--- a/crates/p2p/src/two_stream/handler/pushlog.rs
+++ b/crates/p2p/src/two_stream/handler/pushlog.rs
@@ -7,7 +7,7 @@ use crate::codec::write_message;
 use crate::error::{Error, Result};
 use crate::message::{PushLogReply, PushLogRequest};
 
-use super::TwoStreamHandler;
+use super::{PendingResponseKey, TwoStreamHandler};
 
 impl TwoStreamHandler {
     /// Send a request to a peer and return a receiver for the response.
@@ -22,6 +22,7 @@ impl TwoStreamHandler {
         request: PushLogRequest,
     ) -> Result<(String, oneshot::Receiver<PushLogReply>)> {
         let message_id = request.message_id.clone();
+        let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
 
         // Create response channel
         let (tx, rx) = oneshot::channel();
@@ -29,7 +30,7 @@ impl TwoStreamHandler {
         // Register pending response
         {
             let mut pending = self.pending.lock();
-            pending.channels.insert(message_id.clone(), tx);
+            pending.channels.insert(pending_key.clone(), tx);
         }
 
         // Open stream and send request
@@ -40,14 +41,14 @@ impl TwoStreamHandler {
             .map_err(|e| {
                 // Clean up pending on failure
                 let mut pending = self.pending.lock();
-                pending.channels.remove(&message_id);
+                pending.channels.remove(&pending_key);
                 Error::Transport(format!("failed to open stream: {}", e))
             })?;
 
         write_message(&mut stream, &request).await.map_err(|e| {
             // Clean up pending on failure
             let mut pending = self.pending.lock();
-            pending.channels.remove(&message_id);
+            pending.channels.remove(&pending_key);
             Error::CborSerialization(format!("failed to write request: {}", e))
         })?;
 

--- a/crates/p2p/tests/host_tests.rs
+++ b/crates/p2p/tests/host_tests.rs
@@ -207,6 +207,101 @@ async fn test_identity_protocol_roundtrip_returns_defra_identity() {
 }
 
 #[tokio::test]
+async fn test_two_stream_reply_from_wrong_transport_peer_is_rejected() {
+    let store0 = MockBitswapStore::new();
+    let store1 = MockBitswapStore::new();
+    let store2 = MockBitswapStore::new();
+    let (host0, handle0, _events0, _replicators0) = P2PHost::new(store0).await.unwrap();
+    let (host1, handle1, mut events1, _replicators1) = P2PHost::new(store1).await.unwrap();
+    let (host2, handle2, _events2, _replicators2) = P2PHost::new(store2).await.unwrap();
+
+    tokio::spawn(host0.run());
+    tokio::spawn(host1.run());
+    tokio::spawn(host2.run());
+
+    handle1
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let addr1 = handle1.listen_addresses().await.unwrap().remove(0);
+    handle0
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let addr0 = handle0.listen_addresses().await.unwrap().remove(0);
+
+    let peer0 = handle0.local_peer_id_cached();
+    let peer1 = handle1.local_peer_id_cached();
+    let peer2 = handle2.local_peer_id_cached();
+
+    handle0.dial(peer1, vec![addr1]).await.unwrap();
+    handle2.dial(peer0, vec![addr0]).await.unwrap();
+    wait_until_connected(&handle0, peer1).await;
+    wait_until_connected(&handle1, peer0).await;
+    wait_until_connected(&handle0, peer2).await;
+    wait_until_connected(&handle2, peer0).await;
+
+    let request = PushLogRequest::new(
+        "doc1".to_string(),
+        Bytes::from(vec![1, 2, 3]),
+        "collection1".to_string(),
+        "creator1".to_string(),
+        Bytes::from(b"block-data".to_vec()),
+    );
+
+    let sender_handle = handle0.clone();
+    let mut send_task =
+        tokio::spawn(async move { sender_handle.send_two_stream_request(peer1, request).await });
+
+    let received_request = loop {
+        let event = timeout(Duration::from_secs(5), events1.recv())
+            .await
+            .expect("timed out waiting for two-stream request")
+            .expect("host event channel closed");
+
+        match event {
+            p2p::HostEvent::TwoStreamRequest {
+                peer_id, request, ..
+            } => {
+                assert_eq!(peer_id, peer0);
+                break request;
+            }
+            _ => continue,
+        }
+    };
+
+    let mut replayed_reply = PushLogReply::success(&received_request.message_id);
+    sign_message(handle1.keypair(), &mut replayed_reply).unwrap();
+    handle2
+        .send_two_stream_response(peer0, replayed_reply)
+        .await
+        .unwrap();
+
+    match timeout(Duration::from_millis(300), &mut send_task).await {
+        Err(_) => {}
+        Ok(result) => panic!("wrong-peer replay unexpectedly completed request: {result:?}"),
+    }
+
+    let mut legitimate_reply = PushLogReply::success(&received_request.message_id);
+    sign_message(handle1.keypair(), &mut legitimate_reply).unwrap();
+    handle1
+        .send_two_stream_response(peer0, legitimate_reply)
+        .await
+        .unwrap();
+
+    let reply = timeout(Duration::from_secs(5), send_task)
+        .await
+        .expect("timed out waiting for legitimate two-stream response")
+        .unwrap()
+        .unwrap();
+    assert_eq!(reply.message_id, received_request.message_id);
+
+    handle0.shutdown().await.unwrap();
+    handle1.shutdown().await.unwrap();
+    handle2.shutdown().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_two_stream_registered_replicator_without_capability_is_not_marked_explicit() {
     let store0 = MockBitswapStore::new();
     let store1 = MockBitswapStore::new();


### PR DESCRIPTION
## Summary

Closes #833. Binds pending two-stream replies to the expected transport peer as well as the message ID, and rejects signed replies that arrive over a different peer connection.

## Why

Two-stream requests already verify that the signed sender matches the libp2p transport peer, but the reply path only keyed pending responses by `message_id`. That allowed any peer holding a valid signed reply for an in-flight message ID to satisfy another peer's pending request.

## Changes

| Area | Change |
|---|---|
| Pending replies | Replace raw message ID pending keys with `(PeerId, message_id)` keys for PushLog, DocSync, and identity response paths. |
| Response validation | Verify response sender identity against the transport peer before delivering PushLog, DocSync, BranchableSync, and identity replies. |
| Cleanup paths | Update timeout and cancellation cleanup to remove pending entries by expected peer and message ID. |
| Tests | Add a three-peer replay regression where a third peer replays another peer's signed reply and cannot satisfy the pending request. |

## Stacking note

This branch has been merged with latest `origin/main`, including the recently merged P2P PRs. The PR diff against `main` should show only the #833 reply-binding changes.

## Out of scope

- Changing two-stream protocol IDs or wire formats.
- Adding live Go interop tests that require a running Go DefraDB node.
- Refactoring DocSync's existing simplified synchronous response channel design.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p test_two_stream_reply_from_wrong_transport_peer_is_rejected -- --nocapture` -- passed outside sandbox; sandboxed run hit local TCP transport restrictions.
- [x] `cargo test -p p2p` -- passed outside sandbox.
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet` -- passed outside sandbox.
