### PR TITLE
fix(db-merge): harden push-doc replay safety (#853)

### DIFF
--- a/crates/db-merge/src/lib.rs
+++ b/crates/db-merge/src/lib.rs
@@ -10,6 +10,8 @@ pub mod merge_handler;
 pub mod peer_identity;
 pub mod push_docs;
 pub mod push_docs_common;
+mod push_docs_creator;
+mod push_docs_replay;
 pub mod push_docs_transport;
 pub mod replication;
 pub mod se;
@@ -22,8 +24,14 @@ pub use merge_handler::{DbMergeHandler, MergeError};
 pub use peer_identity::{
     create_peer_to_did_mapper, peer_id_to_did, public_key_to_did, PeerIdentityError,
 };
-pub use push_docs::{push_existing_docs, retry_doc};
-pub use push_docs_transport::{push_existing_docs_via_transport, retry_doc_via_transport};
+pub use push_docs::{
+    push_existing_docs, push_existing_docs_with_config, retry_doc, PushExistingDocsSeOptions,
+};
+pub use push_docs_replay::ReplayPushConfig;
+pub use push_docs_transport::{
+    push_existing_docs_via_transport, push_existing_docs_via_transport_with_config,
+    retry_doc_via_transport,
+};
 pub use replication::{
     attach_failure_channel, create_acp_merge_handler, create_broadcast_mutator,
     create_head_provider, create_merge_handler, create_replication_stack,

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -5,11 +5,16 @@ use bytes::Bytes;
 use p2p::message::PushLogRequest;
 use storage::corekv::{IterOptions, Reader, Store};
 
-use crate::push_docs_common::{
-    load_latest_composite_head_cids, load_push_dag_blocks, resolve_push_creator,
-    MAX_CONCURRENT_REPLAY_TASKS,
-};
+use crate::push_docs_common::{load_latest_composite_head_cids, load_push_dag_blocks};
+use crate::push_docs_creator::resolve_push_creator;
+use crate::push_docs_replay::{ReplayPushConfig, ReplayPushGate};
 use db::database::DB;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PushExistingDocsSeOptions<'a> {
+    pub encryption_key: Option<&'a [u8]>,
+    pub identity_pubkey: Option<&'a [u8]>,
+}
 
 /// Push existing documents to a replicator peer.
 ///
@@ -26,6 +31,31 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
     collections: &[String],
     se_encryption_key: Option<&[u8]>,
     se_identity_pubkey: Option<&[u8]>,
+) -> Result<(), String> {
+    push_existing_docs_with_config(
+        handle,
+        db,
+        document_acp,
+        peer_id,
+        collections,
+        PushExistingDocsSeOptions {
+            encryption_key: se_encryption_key,
+            identity_pubkey: se_identity_pubkey,
+        },
+        ReplayPushConfig::default(),
+    )
+    .await
+}
+
+/// Push existing documents to a replicator peer with explicit replay limits.
+pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>(
+    handle: &p2p::P2PHostHandle,
+    db: &DB<S>,
+    document_acp: Option<&dyn DocumentACP>,
+    peer_id: libp2p::PeerId,
+    collections: &[String],
+    se_options: PushExistingDocsSeOptions<'_>,
+    replay_config: ReplayPushConfig,
 ) -> Result<(), String> {
     // Wait for the connection to be fully established (dial is non-blocking).
     // After a node restart, re-establishing connectivity can take longer than
@@ -69,7 +99,9 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
 
     // Collect JoinHandles so we can await all pushes before signaling completion.
     let mut push_handles = Vec::new();
-    let replay_semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_REPLAY_TASKS));
+    let replay_gate = Arc::new(ReplayPushGate::new(replay_config));
+    let peer_key = p2p::transport::PeerId::from(peer_id);
+    let mut skipped_creator_docs = 0usize;
 
     for col_name in collections {
         let collection = match db
@@ -115,8 +147,27 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
         // processes the composite block, otherwise it tries Bitswap which
         // doesn't work reliably cross-platform.
         for doc_id in &doc_ids {
-            let creator =
-                resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id_str).await;
+            let creator = match resolve_push_creator(
+                document_acp,
+                &collection,
+                doc_id,
+                &local_peer_id_str,
+            )
+            .await
+            {
+                Ok(creator) => creator,
+                Err(error) => {
+                    skipped_creator_docs += 1;
+                    tracing::warn!(
+                        collection = %collection.name(),
+                        collection_id = %collection.collection_id(),
+                        doc_id = %doc_id,
+                        error = %error,
+                        "Skipping existing document replay because ACP creator could not be resolved"
+                    );
+                    continue;
+                }
+            };
             // Collect phase: pre-load all DAG blocks before spawning tasks.
             let mut doc_blocks = Vec::new();
             for head_cid in
@@ -154,18 +205,22 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
 
             if !requests.is_empty() {
                 let push_h = handle.clone();
+                let gate = replay_gate.clone();
+                let peer_key = peer_key.clone();
                 let total_blocks = requests.len();
-                let permit = replay_semaphore
-                    .clone()
-                    .acquire_owned()
+                let permit = replay_gate
+                    .acquire_document_task()
                     .await
-                    .map_err(|_| "replay semaphore closed before scheduling push".to_string())?;
+                    .map_err(|e| format!("replay gate closed before scheduling push: {e}"))?;
                 push_handles.push(tokio::spawn(async move {
                     let _permit = permit;
                     let mut completed_blocks = 0usize;
                     for req in requests {
                         let cid = req.cid.clone();
-                        match push_h.send_two_stream_request(peer_id, req).await {
+                        match gate
+                            .send_pushlog(&peer_key, push_h.send_two_stream_request(peer_id, req))
+                            .await
+                        {
                             Ok(reply) if reply.err_message.is_some() => {
                                 tracing::warn!(
                                     peer_id = %peer_id,
@@ -218,9 +273,15 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
     }
     tracing::debug!("all push tasks completed");
 
+    if skipped_creator_docs > 0 {
+        return Err(format!(
+            "skipped {skipped_creator_docs} existing document replay(s) because ACP creator could not be resolved"
+        ));
+    }
+
     // Generate and push SE artifacts for collections with encrypted indexes.
-    if let Some(se_key) = se_encryption_key {
-        let coordinator = match se_identity_pubkey {
+    if let Some(se_key) = se_options.encryption_key {
+        let coordinator = match se_options.identity_pubkey {
             Some(pubkey) => {
                 crate::se::SECoordinator::with_key_and_identity(se_key.to_vec(), pubkey.to_vec())
             }
@@ -359,7 +420,9 @@ pub async fn retry_doc<S: Store + 'static>(
         .find_collection_by_id(collection_id)
         .map_err(|e| format!("failed to get collection: {}", e))?
         .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
-    let creator = resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id_str).await;
+    let creator = resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id_str)
+        .await
+        .map_err(|e| e.to_string())?;
 
     let headstore = storage::stores::Headstore::new(db.store().clone());
     let head_txn = headstore

--- a/crates/db-merge/src/push_docs_common.rs
+++ b/crates/db-merge/src/push_docs_common.rs
@@ -1,80 +1,9 @@
 use std::collections::HashSet;
 use std::str::FromStr;
 
-use acp::DocumentACP;
 use cid::Cid;
 use storage::corekv::{IterOptions, Reader};
 use storage::keys::headstore::{HeadstoreDocKey, HeadstorePriorityKey};
-
-use db::Collection;
-
-/// Maximum concurrent per-document push tasks during initial replay.
-///
-/// Lower than the coordinator's live push limit (32) because initial replay
-/// is background work that shouldn't starve real-time sync traffic.
-pub(crate) const MAX_CONCURRENT_REPLAY_TASKS: usize = 8;
-
-pub(crate) async fn resolve_push_creator(
-    document_acp: Option<&dyn DocumentACP>,
-    collection: &Collection,
-    doc_id: &str,
-    fallback_creator: &str,
-) -> String {
-    let Some(policy) = &collection.schema().policy else {
-        return fallback_creator.to_string();
-    };
-
-    let mut resource_names = vec![policy.resource_name.clone()];
-    for candidate in [
-        collection.name().to_string(),
-        collection.name().to_lowercase(),
-        format!("{}s", collection.name().to_lowercase()),
-    ] {
-        if !resource_names.iter().any(|existing| existing == &candidate) {
-            resource_names.push(candidate);
-        }
-    }
-
-    if let Some(acp) = document_acp {
-        for resource_name in &resource_names {
-            match acp.get_doc_owner(&policy.id, resource_name, doc_id).await {
-                Ok(Some(owner)) => {
-                    if resource_name != &policy.resource_name {
-                        tracing::info!(
-                            collection = %collection.name(),
-                            collection_id = %collection.collection_id(),
-                            resource_name = %resource_name,
-                            doc_id = %doc_id,
-                            "Resolved ACP owner for replicator push using fallback resource name"
-                        );
-                    }
-                    return owner.to_string();
-                }
-                Ok(None) => {}
-                Err(error) => {
-                    tracing::warn!(
-                        collection = %collection.name(),
-                        collection_id = %collection.collection_id(),
-                        resource_name = %resource_name,
-                        doc_id = %doc_id,
-                        error = %error,
-                        "Failed to resolve ACP owner for replicator push"
-                    );
-                }
-            }
-        }
-    }
-
-    tracing::warn!(
-        collection = %collection.name(),
-        collection_id = %collection.collection_id(),
-        resource_names = ?resource_names,
-        doc_id = %doc_id,
-        fallback_creator = %fallback_creator,
-        "Falling back to peer identity for replicator replay creator"
-    );
-    fallback_creator.to_string()
-}
 
 pub(crate) async fn load_push_dag_blocks<R: Reader + ?Sized, E: Reader + ?Sized>(
     block_reader: &R,

--- a/crates/db-merge/src/push_docs_creator.rs
+++ b/crates/db-merge/src/push_docs_creator.rs
@@ -1,0 +1,290 @@
+use std::fmt;
+
+use acp::DocumentACP;
+use db::Collection;
+
+#[derive(Debug)]
+pub(crate) enum PushCreatorError {
+    AcpUnavailable {
+        collection: String,
+        collection_id: String,
+        doc_id: String,
+    },
+    LookupFailed {
+        collection: String,
+        collection_id: String,
+        doc_id: String,
+        errors: Vec<String>,
+    },
+    OwnerMissing {
+        collection: String,
+        collection_id: String,
+        doc_id: String,
+    },
+}
+
+impl fmt::Display for PushCreatorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AcpUnavailable {
+                collection,
+                collection_id,
+                doc_id,
+            } => write!(
+                f,
+                "ACP is unavailable for protected replay document {collection}/{collection_id}/{doc_id}"
+            ),
+            Self::LookupFailed {
+                collection,
+                collection_id,
+                doc_id,
+                errors,
+            } => write!(
+                f,
+                "failed to resolve ACP owner for replay document {collection}/{collection_id}/{doc_id}: {}",
+                errors.join("; ")
+            ),
+            Self::OwnerMissing {
+                collection,
+                collection_id,
+                doc_id,
+            } => write!(
+                f,
+                "ACP owner is missing for protected replay document {collection}/{collection_id}/{doc_id}"
+            ),
+        }
+    }
+}
+
+pub(crate) async fn resolve_push_creator(
+    document_acp: Option<&dyn DocumentACP>,
+    collection: &Collection,
+    doc_id: &str,
+    fallback_creator: &str,
+) -> Result<String, PushCreatorError> {
+    let Some(policy) = &collection.schema().policy else {
+        return Ok(fallback_creator.to_string());
+    };
+
+    let mut resource_names = vec![policy.resource_name.clone()];
+    for candidate in [
+        collection.name().to_string(),
+        collection.name().to_lowercase(),
+        format!("{}s", collection.name().to_lowercase()),
+    ] {
+        if !resource_names.iter().any(|existing| existing == &candidate) {
+            resource_names.push(candidate);
+        }
+    }
+
+    let Some(acp) = document_acp else {
+        return Err(PushCreatorError::AcpUnavailable {
+            collection: collection.name().to_string(),
+            collection_id: collection.collection_id().to_string(),
+            doc_id: doc_id.to_string(),
+        });
+    };
+
+    let mut lookup_errors = Vec::new();
+    for resource_name in &resource_names {
+        match acp.get_doc_owner(&policy.id, resource_name, doc_id).await {
+            Ok(Some(owner)) => {
+                if resource_name != &policy.resource_name {
+                    tracing::info!(
+                        collection = %collection.name(),
+                        collection_id = %collection.collection_id(),
+                        resource_name = %resource_name,
+                        doc_id = %doc_id,
+                        "Resolved ACP owner for replicator push using fallback resource name"
+                    );
+                }
+                return Ok(owner.to_string());
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    collection = %collection.name(),
+                    collection_id = %collection.collection_id(),
+                    resource_name = %resource_name,
+                    doc_id = %doc_id,
+                    error = %error,
+                    "Failed to resolve ACP owner for replicator push"
+                );
+                lookup_errors.push(format!("{resource_name}: {error}"));
+            }
+        }
+    }
+
+    if lookup_errors.is_empty() {
+        Err(PushCreatorError::OwnerMissing {
+            collection: collection.name().to_string(),
+            collection_id: collection.collection_id().to_string(),
+            doc_id: doc_id.to_string(),
+        })
+    } else {
+        Err(PushCreatorError::LookupFailed {
+            collection: collection.name().to_string(),
+            collection_id: collection.collection_id().to_string(),
+            doc_id: doc_id.to_string(),
+            errors: lookup_errors,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use acp::{
+        DocumentPermission, Identity, LocalDocumentACP, MemoryAcpStore, ReplicatedActorRelationship,
+    };
+    use identity::Did;
+    use schema::{CollectionVersion, PolicyDescription};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn resolve_push_creator_uses_owner_for_protected_document() {
+        let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+        let owner = Did::new("did:key:z6Mkowner").unwrap();
+        acp.register_doc_object(&owner, "policy-1", "Users", "doc1")
+            .await
+            .unwrap();
+
+        let creator =
+            resolve_push_creator(Some(&acp), &protected_collection(), "doc1", "local-peer")
+                .await
+                .unwrap();
+
+        assert_eq!(creator, owner.to_string());
+    }
+
+    #[tokio::test]
+    async fn resolve_push_creator_falls_back_only_without_collection_policy() {
+        let collection = Collection::new(CollectionVersion::new("Users", "v1", "col1", vec![]));
+
+        let creator = resolve_push_creator(None, &collection, "doc1", "local-peer")
+            .await
+            .unwrap();
+
+        assert_eq!(creator, "local-peer");
+    }
+
+    #[tokio::test]
+    async fn resolve_push_creator_errors_when_owner_is_missing() {
+        let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+
+        let error = resolve_push_creator(Some(&acp), &protected_collection(), "doc1", "local-peer")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, PushCreatorError::OwnerMissing { .. }));
+    }
+
+    #[tokio::test]
+    async fn resolve_push_creator_errors_when_acp_lookup_fails() {
+        let error = resolve_push_creator(
+            Some(&FailingAcp),
+            &protected_collection(),
+            "doc1",
+            "local-peer",
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, PushCreatorError::LookupFailed { .. }));
+    }
+
+    fn protected_collection() -> Collection {
+        Collection::new(
+            CollectionVersion::new("Users", "v1", "col1", vec![])
+                .with_policy(PolicyDescription::new("policy-1", "Users")),
+        )
+    }
+
+    struct FailingAcp;
+
+    #[async_trait::async_trait]
+    impl DocumentACP for FailingAcp {
+        async fn register_doc_object(
+            &self,
+            _identity: &Did,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<()> {
+            Err(acp::Error::Storage("boom".to_string()))
+        }
+
+        async fn is_doc_registered(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("boom".to_string()))
+        }
+
+        async fn get_doc_owner(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<Option<Did>> {
+            Err(acp::Error::Storage("boom".to_string()))
+        }
+
+        async fn check_doc_access(
+            &self,
+            _identity: &Identity,
+            _permission: DocumentPermission,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("boom".to_string()))
+        }
+
+        async fn add_actor_relationship(
+            &self,
+            _requestor: &Did,
+            _target: &Did,
+            _policy_id: &str,
+            _collection_id: &str,
+            _doc_id: &str,
+            _relation: &str,
+            _managing_relations: &[String],
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("boom".to_string()))
+        }
+
+        async fn delete_actor_relationship(
+            &self,
+            _requestor: &Did,
+            _target: &Did,
+            _policy_id: &str,
+            _collection_id: &str,
+            _doc_id: &str,
+            _relation: &str,
+            _managing_relations: &[String],
+        ) -> acp::Result<bool> {
+            Err(acp::Error::Storage("boom".to_string()))
+        }
+
+        async fn export_actor_relationships(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<Vec<ReplicatedActorRelationship>> {
+            Err(acp::Error::Storage("boom".to_string()))
+        }
+
+        async fn unregister_doc_object(
+            &self,
+            _policy_id: &str,
+            _resource_name: &str,
+            _doc_id: &str,
+        ) -> acp::Result<()> {
+            Err(acp::Error::Storage("boom".to_string()))
+        }
+    }
+}

--- a/crates/db-merge/src/push_docs_replay.rs
+++ b/crates/db-merge/src/push_docs_replay.rs
@@ -1,0 +1,282 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use p2p::message::PushLogReply;
+use p2p::transport::PeerId;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Maximum concurrent per-document push tasks during initial replay.
+///
+/// Lower than the coordinator's live push limit (32) because initial replay
+/// is background work that shouldn't starve real-time sync traffic.
+pub(crate) const MAX_CONCURRENT_REPLAY_TASKS: usize = 8;
+
+/// Maximum concurrent outbound PushLog requests across replay tasks.
+pub const DEFAULT_MAX_CONCURRENT_REPLAY_SENDS: usize = 8;
+
+/// Default per-peer replay burst. Mirrors the sync manager's live rate limiter.
+pub const DEFAULT_REPLAY_RATE_LIMIT_BURST: u32 = p2p::sync::DEFAULT_RATE_LIMIT_BURST;
+
+/// Default per-peer replay refill rate. Mirrors the sync manager's live rate limiter.
+pub const DEFAULT_REPLAY_RATE_LIMIT_RATE: f64 = p2p::sync::DEFAULT_RATE_LIMIT_RATE;
+
+/// Default timeout for a single replay PushLog request.
+pub const DEFAULT_REPLAY_SEND_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone)]
+pub struct ReplayPushConfig {
+    /// Maximum number of documents whose DAG blocks may be replayed concurrently.
+    pub max_concurrent_document_tasks: usize,
+
+    /// Maximum number of outbound PushLog requests in flight across all replay tasks.
+    pub max_concurrent_outbound_pushes: usize,
+
+    /// Number of per-peer replay tokens available for short bursts.
+    pub per_peer_rate_limit_burst: u32,
+
+    /// Number of per-peer replay tokens refilled per second.
+    pub per_peer_rate_limit_rate: f64,
+
+    /// Timeout for one outbound replay PushLog request.
+    pub send_timeout: Duration,
+}
+
+impl Default for ReplayPushConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_document_tasks: MAX_CONCURRENT_REPLAY_TASKS,
+            max_concurrent_outbound_pushes: DEFAULT_MAX_CONCURRENT_REPLAY_SENDS,
+            per_peer_rate_limit_burst: DEFAULT_REPLAY_RATE_LIMIT_BURST,
+            per_peer_rate_limit_rate: DEFAULT_REPLAY_RATE_LIMIT_RATE,
+            send_timeout: DEFAULT_REPLAY_SEND_TIMEOUT,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ReplayPushSendError {
+    SemaphoreClosed,
+    Timeout { timeout: Duration },
+    Transport(p2p::Error),
+}
+
+impl ReplayPushSendError {
+    pub(crate) fn is_connection_like(&self) -> bool {
+        matches!(self, Self::Transport(error) if error.is_connection_like())
+    }
+}
+
+impl fmt::Display for ReplayPushSendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SemaphoreClosed => f.write_str("replay send semaphore closed"),
+            Self::Timeout { timeout } => {
+                write!(f, "replay PushLog timed out after {}s", timeout.as_secs())
+            }
+            Self::Transport(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ReplayPushGate {
+    document_task_semaphore: Arc<Semaphore>,
+    outbound_push_semaphore: Arc<Semaphore>,
+    peer_pacer: ReplayPeerPacer,
+    rate_retry_delay: Duration,
+    send_timeout: Duration,
+}
+
+impl ReplayPushGate {
+    pub(crate) fn new(config: ReplayPushConfig) -> Self {
+        let rate = if config.per_peer_rate_limit_rate.is_finite()
+            && config.per_peer_rate_limit_rate > 0.0
+        {
+            config.per_peer_rate_limit_rate
+        } else {
+            DEFAULT_REPLAY_RATE_LIMIT_RATE
+        };
+
+        Self {
+            document_task_semaphore: Arc::new(Semaphore::new(
+                config.max_concurrent_document_tasks.max(1),
+            )),
+            outbound_push_semaphore: Arc::new(Semaphore::new(
+                config.max_concurrent_outbound_pushes.max(1),
+            )),
+            peer_pacer: ReplayPeerPacer::new(config.per_peer_rate_limit_burst.max(1), rate),
+            rate_retry_delay: Duration::from_secs_f64((1.0 / rate).clamp(0.001, 1.0)),
+            send_timeout: config.send_timeout.max(Duration::from_millis(1)),
+        }
+    }
+
+    pub(crate) async fn acquire_document_task(
+        &self,
+    ) -> Result<OwnedSemaphorePermit, ReplayPushSendError> {
+        self.document_task_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| ReplayPushSendError::SemaphoreClosed)
+    }
+
+    pub(crate) async fn send_pushlog<F>(
+        &self,
+        peer_id: &PeerId,
+        send: F,
+    ) -> Result<PushLogReply, ReplayPushSendError>
+    where
+        F: Future<Output = p2p::Result<PushLogReply>>,
+    {
+        while !self.peer_pacer.try_consume(peer_id.as_str()) {
+            tokio::time::sleep(self.rate_retry_delay).await;
+        }
+
+        let _permit = self
+            .outbound_push_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| ReplayPushSendError::SemaphoreClosed)?;
+
+        tokio::time::timeout(self.send_timeout, send)
+            .await
+            .map_err(|_| ReplayPushSendError::Timeout {
+                timeout: self.send_timeout,
+            })?
+            .map_err(ReplayPushSendError::Transport)
+    }
+}
+
+#[derive(Debug)]
+struct ReplayPeerPacer {
+    buckets: parking_lot::Mutex<HashMap<String, ReplayPeerBucket>>,
+    capacity: u32,
+    refill_rate: f64,
+}
+
+impl ReplayPeerPacer {
+    fn new(capacity: u32, refill_rate: f64) -> Self {
+        Self {
+            buckets: parking_lot::Mutex::new(HashMap::new()),
+            capacity,
+            refill_rate,
+        }
+    }
+
+    fn try_consume(&self, peer_id: &str) -> bool {
+        let mut buckets = self.buckets.lock();
+        buckets
+            .entry(peer_id.to_string())
+            .or_insert_with(|| ReplayPeerBucket::new(self.capacity))
+            .try_consume(self.capacity, self.refill_rate)
+    }
+}
+
+#[derive(Debug)]
+struct ReplayPeerBucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl ReplayPeerBucket {
+    fn new(capacity: u32) -> Self {
+        Self {
+            tokens: capacity as f64,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn try_consume(&mut self, capacity: u32, refill_rate: f64) -> bool {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * refill_rate).min(capacity as f64);
+        self.last_refill = now;
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn replay_push_gate_caps_concurrent_sends() {
+        let gate = Arc::new(ReplayPushGate::new(ReplayPushConfig {
+            max_concurrent_document_tasks: 8,
+            max_concurrent_outbound_pushes: 2,
+            per_peer_rate_limit_burst: 100,
+            per_peer_rate_limit_rate: 100.0,
+            send_timeout: Duration::from_secs(1),
+        }));
+        let current = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let peer = PeerId::new("peer-1".to_string());
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let gate = gate.clone();
+            let current = current.clone();
+            let max_seen = max_seen.clone();
+            let peer = peer.clone();
+            handles.push(tokio::spawn(async move {
+                gate.send_pushlog(&peer, async move {
+                    let active = current.fetch_add(1, Ordering::SeqCst) + 1;
+                    record_max(&max_seen, active);
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    current.fetch_sub(1, Ordering::SeqCst);
+                    Ok(PushLogReply::success("message"))
+                })
+                .await
+                .unwrap();
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        assert_eq!(max_seen.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn replay_push_gate_paces_after_peer_burst() {
+        let gate = ReplayPushGate::new(ReplayPushConfig {
+            max_concurrent_document_tasks: 1,
+            max_concurrent_outbound_pushes: 1,
+            per_peer_rate_limit_burst: 1,
+            per_peer_rate_limit_rate: 10.0,
+            send_timeout: Duration::from_secs(1),
+        });
+        let peer = PeerId::new("peer-1".to_string());
+
+        let start = Instant::now();
+        for _ in 0..3 {
+            gate.send_pushlog(&peer, async { Ok(PushLogReply::success("message")) })
+                .await
+                .unwrap();
+        }
+
+        assert!(start.elapsed() >= Duration::from_millis(150));
+    }
+
+    fn record_max(max_seen: &AtomicUsize, value: usize) {
+        let mut observed = max_seen.load(Ordering::SeqCst);
+        while value > observed {
+            match max_seen.compare_exchange(observed, value, Ordering::SeqCst, Ordering::SeqCst) {
+                Ok(_) => return,
+                Err(current) => observed = current,
+            }
+        }
+    }
+}

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -7,10 +7,9 @@ use p2p::transport::PeerId;
 use p2p::P2PTransport;
 use storage::corekv::{IterOptions, Reader, Store};
 
-use crate::push_docs_common::{
-    load_latest_composite_head_cids, load_push_dag_blocks, resolve_push_creator,
-    MAX_CONCURRENT_REPLAY_TASKS,
-};
+use crate::push_docs_common::{load_latest_composite_head_cids, load_push_dag_blocks};
+use crate::push_docs_creator::resolve_push_creator;
+use crate::push_docs_replay::{ReplayPushConfig, ReplayPushGate};
 use db::database::DB;
 
 /// Push existing documents to a replicator peer via a generic transport.
@@ -24,6 +23,28 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
     peer_id: &PeerId,
     collections: &[String],
     se_encryption_key: Option<&[u8]>,
+) -> Result<(), String> {
+    push_existing_docs_via_transport_with_config(
+        transport,
+        db,
+        document_acp,
+        peer_id,
+        collections,
+        se_encryption_key,
+        ReplayPushConfig::default(),
+    )
+    .await
+}
+
+/// Push existing documents to a replicator peer via a generic transport with explicit replay limits.
+pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T: P2PTransport>(
+    transport: &T,
+    db: &DB<S>,
+    document_acp: Option<&dyn DocumentACP>,
+    peer_id: &PeerId,
+    collections: &[String],
+    se_encryption_key: Option<&[u8]>,
+    replay_config: ReplayPushConfig,
 ) -> Result<(), String> {
     let conn_timeout = std::time::Duration::from_secs(15);
     let conn_start = std::time::Instant::now();
@@ -73,7 +94,8 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
         .map_err(|e| format!("failed to get datastore: {}", e))?;
 
     let mut push_handles = Vec::new();
-    let replay_semaphore = Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_REPLAY_TASKS));
+    let replay_gate = Arc::new(ReplayPushGate::new(replay_config));
+    let mut skipped_creator_docs = 0usize;
 
     for col_name in collections {
         let collection = match db
@@ -111,8 +133,27 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
             .map_err(|e| format!("datastore close error: {}", e))?;
 
         for doc_id in &doc_ids {
-            let creator =
-                resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id).await;
+            let creator = match resolve_push_creator(
+                document_acp,
+                &collection,
+                doc_id,
+                &local_peer_id,
+            )
+            .await
+            {
+                Ok(creator) => creator,
+                Err(error) => {
+                    skipped_creator_docs += 1;
+                    tracing::warn!(
+                        collection = %collection.name(),
+                        collection_id = %collection.collection_id(),
+                        doc_id = %doc_id,
+                        error = %error,
+                        "Skipping existing document replay because ACP creator could not be resolved"
+                    );
+                    continue;
+                }
+            };
             let mut doc_blocks = Vec::new();
             for head_cid in
                 load_latest_composite_head_cids(&headstore, &blockstore_view, doc_id).await
@@ -148,18 +189,22 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
             if !requests.is_empty() {
                 let t = transport.clone();
                 let pid = peer_id.clone();
+                let gate = replay_gate.clone();
+                let peer_key = pid.clone();
                 let total_blocks = requests.len();
-                let permit = replay_semaphore
-                    .clone()
-                    .acquire_owned()
+                let permit = replay_gate
+                    .acquire_document_task()
                     .await
-                    .map_err(|_| "replay semaphore closed before scheduling push".to_string())?;
+                    .map_err(|e| format!("replay gate closed before scheduling push: {e}"))?;
                 push_handles.push(tokio::spawn(async move {
                     let _permit = permit;
                     let mut completed_blocks = 0usize;
                     for req in requests {
                         let cid = req.cid.clone();
-                        match t.send_two_stream_request(&pid, req).await {
+                        match gate
+                            .send_pushlog(&peer_key, t.send_two_stream_request(&pid, req))
+                            .await
+                        {
                             Ok(reply) if reply.err_message.is_some() => {
                                 tracing::warn!(
                                     peer_id = %pid,
@@ -210,6 +255,12 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
         }
     }
     tracing::debug!("all push tasks completed");
+
+    if skipped_creator_docs > 0 {
+        return Err(format!(
+            "skipped {skipped_creator_docs} existing document replay(s) because ACP creator could not be resolved"
+        ));
+    }
 
     if let Some(se_key) = se_encryption_key {
         let coordinator = crate::se::SECoordinator::with_key(se_key.to_vec());
@@ -337,7 +388,9 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
         .find_collection_by_id(collection_id)
         .map_err(|e| format!("failed to get collection: {}", e))?
         .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
-    let creator = resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id).await;
+    let creator = resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id)
+        .await
+        .map_err(|e| e.to_string())?;
 
     let headstore = storage::stores::Headstore::new(db.store().clone());
     let head_txn = headstore


### PR DESCRIPTION
## Summary

Addresses #853. Hardens initial push-doc replay by bounding replay fan-out and removing the silent ACP creator fallback for policy-protected collections.

## Why

Initial replay had two related safety gaps:

- Replay traffic was only capped at the per-document task level, so large collections could still generate bursts of outbound PushLog requests.
- ACP creator lookup failures fell back to the local peer ID, producing incorrect creator metadata and making replication failures difficult to diagnose.

## Changes

| Area | Change |
|---|---|
| Replay throttling | Add `ReplayPushConfig` and `ReplayPushGate` with bounded document tasks, bounded outbound PushLog sends, per-peer token-bucket pacing, and per-send timeouts. |
| Host push path | Route `push_existing_docs` through the replay gate and expose `push_existing_docs_with_config` for explicit replay limits. |
| Transport push path | Apply the same replay gate to `push_existing_docs_via_transport` and expose `push_existing_docs_via_transport_with_config`. |
| ACP creator resolution | Move creator lookup into a dedicated helper that returns explicit errors for ACP lookup failure, missing ACP, or missing owner. |
| Failure visibility | Skip protected-document replays when creator metadata cannot be resolved and return a clear caller-facing error instead of silently using the wrong creator. |
| Tests | Add regression coverage for replay concurrency/rate gating and ACP creator lookup failure modes. |

## Out of scope

- A full 1000-document network integration fixture for replay rate bounds.
- A multi-peer slow-peer starvation integration test.
- Wiring replay limits through a broader node-level `SyncConfig`; this PR introduces a db-merge-level config surface while preserving existing defaults.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p db-merge`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet` -- passed outside sandbox; sandboxed run hit the known `PermissionDenied` in `defra-node` benchmark support tests.