### PR TITLE
fix(p2p): harden sync pending DAG state (#844)

### DIFF
--- a/crates/p2p/src/sync/dag_sync/config.rs
+++ b/crates/p2p/src/sync/dag_sync/config.rs
@@ -1,6 +1,5 @@
 //! DAG sync configuration.
 
-use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use crate::error::Result;
@@ -10,12 +9,6 @@ use crate::error::Result;
 pub struct DagSyncConfig {
     /// Timeout for fetching a single block via Bitswap.
     block_fetch_timeout: Duration,
-
-    /// Maximum depth to recursively sync (None = unlimited).
-    max_depth: Option<NonZeroUsize>,
-
-    /// Maximum concurrent block fetches (guaranteed non-zero).
-    max_concurrent_fetches: NonZeroUsize,
 }
 
 impl DagSyncConfig {
@@ -24,17 +17,11 @@ impl DagSyncConfig {
     /// # Arguments
     ///
     /// * `block_fetch_timeout` - Timeout for fetching blocks (must be > 0)
-    /// * `max_depth` - Maximum sync depth (None = unlimited)
-    /// * `max_concurrent_fetches` - Max concurrent fetches (guaranteed non-zero)
     ///
     /// # Errors
     ///
     /// Returns `Error::InvalidConfig` if `block_fetch_timeout` is zero.
-    pub fn new(
-        block_fetch_timeout: Duration,
-        max_depth: Option<NonZeroUsize>,
-        max_concurrent_fetches: NonZeroUsize,
-    ) -> Result<Self> {
+    pub fn new(block_fetch_timeout: Duration) -> Result<Self> {
         if block_fetch_timeout.is_zero() {
             return Err(crate::error::Error::InvalidConfig(
                 "block_fetch_timeout must be greater than zero".to_string(),
@@ -42,24 +29,12 @@ impl DagSyncConfig {
         }
         Ok(Self {
             block_fetch_timeout,
-            max_depth,
-            max_concurrent_fetches,
         })
     }
 
     /// Get the block fetch timeout.
     pub fn block_fetch_timeout(&self) -> Duration {
         self.block_fetch_timeout
-    }
-
-    /// Get the maximum sync depth (None = unlimited).
-    pub fn max_depth(&self) -> Option<NonZeroUsize> {
-        self.max_depth
-    }
-
-    /// Get the maximum concurrent fetches.
-    pub fn max_concurrent_fetches(&self) -> NonZeroUsize {
-        self.max_concurrent_fetches
     }
 
     /// Builder method to set block fetch timeout.
@@ -76,26 +51,12 @@ impl DagSyncConfig {
         self.block_fetch_timeout = timeout;
         Ok(self)
     }
-
-    /// Builder method to set max depth.
-    pub fn with_max_depth(mut self, depth: Option<NonZeroUsize>) -> Self {
-        self.max_depth = depth;
-        self
-    }
-
-    /// Builder method to set max concurrent fetches.
-    pub fn with_max_concurrent_fetches(mut self, count: NonZeroUsize) -> Self {
-        self.max_concurrent_fetches = count;
-        self
-    }
 }
 
 impl Default for DagSyncConfig {
     fn default() -> Self {
         Self {
             block_fetch_timeout: Duration::from_secs(30),
-            max_depth: None,
-            max_concurrent_fetches: NonZeroUsize::new(16).unwrap(),
         }
     }
 }

--- a/crates/p2p/src/sync/dag_sync/state.rs
+++ b/crates/p2p/src/sync/dag_sync/state.rs
@@ -84,7 +84,11 @@ impl DagSyncState {
         self.state.read().await.syncing.contains(cid)
     }
 
-    /// Check if a CID has already been synced.
+    /// Check if a CID has recently been synced.
+    ///
+    /// This is a bounded in-memory hint used to avoid duplicate work during a
+    /// session, not a persistent claim. A `false` result may mean the CID was
+    /// never synced or that it was evicted from the recent synced cache.
     pub async fn is_synced(&self, cid: &Cid) -> bool {
         self.state.read().await.synced.contains(cid)
     }

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -1,5 +1,6 @@
 //! Pending DAG registration and retry logic.
 
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use cid::Cid;
@@ -20,6 +21,23 @@ pub struct PendingDagFetchFailure {
     pub source_peer: Option<String>,
     pub missing_count: usize,
     pub fetch_failures: u32,
+}
+
+fn evict_expired_pending_dags(
+    pending: &mut HashMap<Cid, PendingDag>,
+    now: Instant,
+) -> Vec<(Cid, PendingDag)> {
+    let expired: Vec<_> = pending
+        .iter()
+        .filter(|(_, dag)| now.duration_since(dag.inserted_at) >= PENDING_DAG_TTL)
+        .map(|(cid, dag)| (*cid, dag.clone()))
+        .collect();
+
+    for (cid, _) in &expired {
+        pending.remove(cid);
+    }
+
+    expired
 }
 
 impl<B: Blockstore + 'static> SyncManager<B> {
@@ -120,17 +138,43 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// new entry is silently dropped and `false` is returned so callers can log.
     pub(super) fn insert_pending_dag(&self, root_cid: Cid, dag: PendingDag) -> bool {
         let mut pending = self.pending_dags.write();
-        let now = Instant::now();
+        evict_expired_pending_dags(&mut pending, Instant::now());
 
-        // Evict expired entries.
-        pending.retain(|_, v| now.duration_since(v.inserted_at) < PENDING_DAG_TTL);
-
-        if pending.len() >= MAX_PENDING_DAGS {
+        if pending.len() >= MAX_PENDING_DAGS && !pending.contains_key(&root_cid) {
             return false;
         }
 
         pending.insert(root_cid, dag);
         true
+    }
+
+    fn update_pending_dag_missing_if_current(
+        &self,
+        root_cid: &Cid,
+        inserted_at: Instant,
+        missing: HashSet<Cid>,
+    ) -> bool {
+        let mut pending = self.pending_dags.write();
+        let Some(dag) = pending.get_mut(root_cid) else {
+            return false;
+        };
+        if dag.inserted_at != inserted_at {
+            return false;
+        }
+        dag.missing = missing;
+        true
+    }
+
+    fn take_pending_dag_if_current(
+        &self,
+        root_cid: &Cid,
+        inserted_at: Instant,
+    ) -> Option<PendingDag> {
+        let mut pending = self.pending_dags.write();
+        match pending.get(root_cid) {
+            Some(dag) if dag.inserted_at == inserted_at => pending.remove(root_cid),
+            _ => None,
+        }
     }
 
     /// Remove a pending DAG entry once another fetch path has completed it.
@@ -236,14 +280,24 @@ impl<B: Blockstore + 'static> SyncManager<B> {
     /// blocks have arrived. We re-check the DAG for any remaining missing links
     /// (recursively, at all depths) and process it if complete.
     pub async fn retry_pending_dag(&self, root_cid: &Cid) -> Result<bool> {
+        enum PendingDagRetryEntry {
+            Current(PendingDag),
+            Expired(PendingDag),
+        }
+
         // Record the attempt (and capture the incremented value) while holding
         // the lock so concurrent retries observe monotonic attempt counts.
         let pending_info = {
             let mut pending = self.pending_dags.write();
-            pending.get_mut(root_cid).map(|dag| {
-                dag.attempts = dag.attempts.saturating_add(1);
-                dag.clone()
-            })
+            let expired = evict_expired_pending_dags(&mut pending, Instant::now());
+            if let Some((_, dag)) = expired.into_iter().find(|(cid, _)| cid == root_cid) {
+                Some(PendingDagRetryEntry::Expired(dag))
+            } else {
+                pending.get_mut(root_cid).map(|dag| {
+                    dag.attempts = dag.attempts.saturating_add(1);
+                    PendingDagRetryEntry::Current(dag.clone())
+                })
+            }
         };
 
         let Some(info) = pending_info else {
@@ -254,26 +308,27 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             return Ok(false);
         };
 
-        self.diagnostics.record_missing_link_retry();
+        let info = match info {
+            PendingDagRetryEntry::Current(info) => info,
+            PendingDagRetryEntry::Expired(info) => {
+                self.diagnostics.record_pending_dag_expired();
+                tracing::warn!(
+                    root_cid = %root_cid,
+                    doc_id = %info.doc_id,
+                    collection_id = %info.collection_id,
+                    source_peer = ?info.source_peer,
+                    missing_count = info.missing.len(),
+                    attempts = info.attempts,
+                    fetch_failures = info.fetch_failures,
+                    last_fetch_error = ?info.last_fetch_error,
+                    age_secs = info.inserted_at.elapsed().as_secs(),
+                    "Pending DAG expired (TTL exceeded), dropping"
+                );
+                return Ok(false);
+            }
+        };
 
-        // Check TTL before retrying.
-        if info.inserted_at.elapsed() >= PENDING_DAG_TTL {
-            self.pending_dags.write().remove(root_cid);
-            self.diagnostics.record_pending_dag_expired();
-            tracing::warn!(
-                root_cid = %root_cid,
-                doc_id = %info.doc_id,
-                collection_id = %info.collection_id,
-                source_peer = ?info.source_peer,
-                missing_count = info.missing.len(),
-                attempts = info.attempts,
-                fetch_failures = info.fetch_failures,
-                last_fetch_error = ?info.last_fetch_error,
-                age_secs = info.inserted_at.elapsed().as_secs(),
-                "Pending DAG expired (TTL exceeded), dropping"
-            );
-            return Ok(false);
-        }
+        self.diagnostics.record_missing_link_retry();
 
         // Load the root block from blockstore
         let block_data = match self.blockstore.get(root_cid).await {
@@ -324,18 +379,27 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 "Still missing blocks for DAG"
             );
             // Update the pending info with new missing CIDs (preserve original inserted_at).
-            self.pending_dags.write().insert(
-                *root_cid,
-                PendingDag {
-                    missing: missing.into_iter().collect(),
-                    ..info
-                },
-            );
+            if !self.update_pending_dag_missing_if_current(
+                root_cid,
+                info.inserted_at,
+                missing.into_iter().collect(),
+            ) {
+                tracing::debug!(
+                    root_cid = %root_cid,
+                    "Pending DAG changed before retry update; skipping stale retry result"
+                );
+            }
             return Ok(false);
         }
 
         // DAG is complete at all depths - remove from pending and process
-        self.pending_dags.write().remove(root_cid);
+        let Some(info) = self.take_pending_dag_if_current(root_cid, info.inserted_at) else {
+            tracing::debug!(
+                root_cid = %root_cid,
+                "Pending DAG changed before ready event; skipping stale retry result"
+            );
+            return Ok(false);
+        };
         self.diagnostics.record_pending_dag_resolved();
         tracing::info!(
             root_cid = %root_cid,
@@ -362,5 +426,116 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             .await;
 
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use blockstore::DefraBlockstore;
+    use cid::multihash::{Code, MultihashDigest};
+    use storage::backends::MemoryStore;
+
+    use crate::sync::{PeerStateTracker, SyncConfig};
+
+    fn test_cid(label: usize) -> Cid {
+        Cid::new_v1(
+            0x55,
+            Code::Sha2_256.digest(format!("cid-{label}").as_bytes()),
+        )
+    }
+
+    fn test_manager() -> SyncManager<DefraBlockstore<MemoryStore>> {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, _events) = SyncManager::new(blockstore, peer_state, SyncConfig::default());
+        manager
+    }
+
+    fn pending_dag(doc_id: &str, inserted_at: Instant) -> PendingDag {
+        PendingDag {
+            doc_id: doc_id.to_string(),
+            collection_id: "collection".to_string(),
+            creator: "creator".to_string(),
+            missing: HashSet::new(),
+            source_peer: Some("peer".to_string()),
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+            acp_actor_relationships: None,
+            inserted_at,
+            attempts: 0,
+            fetch_failures: 0,
+            last_fetch_error: None,
+        }
+    }
+
+    #[test]
+    fn insert_pending_dag_replaces_existing_entry_at_capacity() {
+        let manager = test_manager();
+        let root = test_cid(0);
+
+        assert!(manager.insert_pending_dag(root, pending_dag("original", Instant::now())));
+        for idx in 1..MAX_PENDING_DAGS {
+            assert!(manager.insert_pending_dag(
+                test_cid(idx),
+                pending_dag(&format!("doc-{idx}"), Instant::now()),
+            ));
+        }
+        assert_eq!(manager.pending_dag_count(), MAX_PENDING_DAGS);
+
+        assert!(manager.insert_pending_dag(root, pending_dag("replacement", Instant::now())));
+        assert_eq!(manager.pending_dag_count(), MAX_PENDING_DAGS);
+        assert_eq!(
+            manager
+                .pending_dags
+                .read()
+                .get(&root)
+                .map(|dag| dag.doc_id.as_str()),
+            Some("replacement")
+        );
+    }
+
+    #[test]
+    fn stale_pending_dag_update_does_not_resurrect_old_generation() {
+        let manager = test_manager();
+        let root = test_cid(0);
+        let current_inserted_at = Instant::now();
+        let stale_inserted_at = current_inserted_at + std::time::Duration::from_secs(1);
+
+        assert!(manager.insert_pending_dag(root, pending_dag("current", current_inserted_at)));
+        assert!(!manager.update_pending_dag_missing_if_current(
+            &root,
+            stale_inserted_at,
+            [test_cid(1)].into_iter().collect(),
+        ));
+        assert!(manager.pending_dag_missing(&root).is_empty());
+    }
+
+    #[test]
+    fn concurrent_pending_dag_insert_burst_stays_bounded() {
+        let manager = Arc::new(test_manager());
+        let mut handles = Vec::new();
+
+        for worker in 0..8 {
+            let manager = Arc::clone(&manager);
+            handles.push(std::thread::spawn(move || {
+                for idx in 0..200 {
+                    let label = worker * 1_000 + idx;
+                    manager.insert_pending_dag(
+                        test_cid(label),
+                        pending_dag(&format!("doc-{label}"), Instant::now()),
+                    );
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("insert worker should not panic");
+        }
+
+        assert!(manager.pending_dag_count() <= MAX_PENDING_DAGS);
     }
 }

--- a/crates/p2p/src/sync/manager/process/pushlog.rs
+++ b/crates/p2p/src/sync/manager/process/pushlog.rs
@@ -582,4 +582,36 @@ mod tests {
             vec![field_cid]
         );
     }
+
+    #[tokio::test]
+    async fn process_pushlog_clears_pending_dag_when_fetch_event_receiver_is_dropped() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let peer_state = Arc::new(PeerStateTracker::new());
+        let (manager, events) =
+            SyncManager::new(blockstore.clone(), peer_state, SyncConfig::default());
+        drop(events);
+
+        let (field_cid, _field_block) = create_lww_block("name");
+        let (composite_cid, composite_block) = create_composite_block("doc123", "name", field_cid);
+        blockstore
+            .put(&composite_cid, &composite_block)
+            .await
+            .expect("store composite block");
+
+        let (collection_cid, collection_block) =
+            create_collection_block("schema1", "doc123", composite_cid);
+
+        let result = manager
+            .process_pushlog(
+                &make_broadcast("doc123", collection_cid, collection_block, "collection1"),
+                Some("peer-1"),
+                false,
+                None,
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::ChannelSend)));
+        assert_eq!(manager.pending_dag_count(), 0);
+    }
 }

--- a/crates/p2p/src/sync/peer_state/tracker/memory.rs
+++ b/crates/p2p/src/sync/peer_state/tracker/memory.rs
@@ -62,6 +62,7 @@ impl PeerStateTracker {
                     break;
                 }
                 if let Some(info) = peers.get_mut(&peer_id) {
+                    info.debug_assert_cid_tracking_consistent();
                     // Evict oldest CIDs from this peer
                     while evicted < excess && !info.cid_order.is_empty() {
                         if let Some(cid) = info.cid_order.pop_front() {
@@ -69,6 +70,7 @@ impl PeerStateTracker {
                             evicted += 1;
                         }
                     }
+                    info.debug_assert_cid_tracking_consistent();
                 }
             }
 

--- a/crates/p2p/src/sync/peer_state/tracker/mod.rs
+++ b/crates/p2p/src/sync/peer_state/tracker/mod.rs
@@ -54,10 +54,31 @@ impl PeerInfo {
         }
     }
 
+    #[cfg(debug_assertions)]
+    pub(super) fn debug_assert_cid_tracking_consistent(&self) {
+        debug_assert_eq!(
+            self.known_cids.len(),
+            self.cid_order.len(),
+            "known_cids and cid_order must remain in lockstep"
+        );
+        debug_assert!(
+            self.cid_order
+                .iter()
+                .all(|cid| self.known_cids.contains(cid)),
+            "cid_order must not contain CIDs missing from known_cids"
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub(super) fn debug_assert_cid_tracking_consistent(&self) {}
+
     /// Add a CID with LRU eviction if at capacity.
     pub(super) fn add_cid(&mut self, cid: Cid, max_cids: usize) {
+        self.debug_assert_cid_tracking_consistent();
+
         // If already present, don't add again (maintains LRU order)
         if self.known_cids.contains(&cid) {
+            self.debug_assert_cid_tracking_consistent();
             return;
         }
 
@@ -73,6 +94,7 @@ impl PeerInfo {
         // Add the new CID
         self.known_cids.insert(cid);
         self.cid_order.push_back(cid);
+        self.debug_assert_cid_tracking_consistent();
     }
 }
 

--- a/crates/p2p/src/sync/peer_state/tracker/operations.rs
+++ b/crates/p2p/src/sync/peer_state/tracker/operations.rs
@@ -61,6 +61,7 @@ impl PeerStateTracker {
             .entry(peer_id.to_string())
             .or_insert_with(PeerInfo::new);
         info.add_cid(cid, max_cids);
+        info.debug_assert_cid_tracking_consistent();
         info.last_seen = Instant::now();
         self.enforce_global_limits(&mut peers);
     }
@@ -81,6 +82,7 @@ impl PeerStateTracker {
         for cid in cids {
             info.add_cid(cid, max_cids);
         }
+        info.debug_assert_cid_tracking_consistent();
         info.last_seen = Instant::now();
         self.enforce_global_limits(&mut peers);
     }

--- a/crates/p2p/tests/dag_sync_tests.rs
+++ b/crates/p2p/tests/dag_sync_tests.rs
@@ -1,6 +1,5 @@
 //! Tests for DAG synchronization.
 
-use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -323,7 +322,7 @@ async fn test_dag_sync_state_concurrent_complete() {
 #[test]
 fn test_dag_sync_config_zero_timeout_returns_error() {
     // DagSyncConfig::new should return error if block_fetch_timeout is zero
-    let result = DagSyncConfig::new(Duration::ZERO, None, NonZeroUsize::new(16).unwrap());
+    let result = DagSyncConfig::new(Duration::ZERO);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(err.to_string().contains("block_fetch_timeout"));
@@ -341,11 +340,7 @@ fn test_dag_sync_config_with_timeout_zero_returns_error() {
 #[test]
 fn test_dag_sync_config_valid_timeout_succeeds() {
     // Valid timeout should succeed
-    let result = DagSyncConfig::new(
-        Duration::from_secs(10),
-        None,
-        NonZeroUsize::new(16).unwrap(),
-    );
+    let result = DagSyncConfig::new(Duration::from_secs(10));
     assert!(result.is_ok());
     let config = result.unwrap();
     assert_eq!(config.block_fetch_timeout(), Duration::from_secs(10));
@@ -357,21 +352,15 @@ fn test_dag_sync_config_default_values() {
 
     // Verify default values
     assert_eq!(config.block_fetch_timeout(), Duration::from_secs(30));
-    assert!(config.max_depth().is_none()); // Unlimited
-    assert_eq!(config.max_concurrent_fetches().get(), 16);
 }
 
 #[test]
 fn test_dag_sync_config_builder() {
     let config = DagSyncConfig::default()
         .with_timeout(Duration::from_secs(60))
-        .expect("valid timeout")
-        .with_max_depth(Some(NonZeroUsize::new(10).unwrap()))
-        .with_max_concurrent_fetches(NonZeroUsize::new(32).unwrap());
+        .expect("valid timeout");
 
     assert_eq!(config.block_fetch_timeout(), Duration::from_secs(60));
-    assert_eq!(config.max_depth(), Some(NonZeroUsize::new(10).unwrap()));
-    assert_eq!(config.max_concurrent_fetches().get(), 32);
 }
 
 #[tokio::test]
@@ -413,6 +402,23 @@ async fn test_sync_state_eviction() {
 
     // Evicted CIDs can be synced again
     assert!(state.start_sync(cids[0]).await);
+}
+
+#[tokio::test]
+async fn test_sync_state_is_synced_is_recent_memory_hint() {
+    let state = DagSyncState::with_max_synced(1);
+    let first = test_cid();
+    let second = test_cid2();
+
+    state.start_sync(first).await;
+    state.complete_sync(first).await;
+    assert!(state.is_synced(&first).await);
+
+    state.start_sync(second).await;
+    state.complete_sync(second).await;
+
+    assert!(!state.is_synced(&first).await);
+    assert!(state.start_sync(first).await);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Addresses #844. Finishes the remaining P2P sync hardening around pending-DAG state, stale retry updates, unused DAG sync config, and peer CID tracking invariants.

## Why

Recent merges already moved rate-limit defaults into `SyncConfig` and propagated dropped `DagNeedsFetch` channel errors. This PR tightens the remaining edges so pending DAG state cannot drift or be resurrected by stale retry work, and so bounded in-memory sync state is documented and tested explicitly.

## Changes

| Area | Change |
|---|---|
| Pending DAG insertion | Share TTL eviction through one helper and keep eviction/capacity/insert under the write lock. |
| Pending DAG retries | Guard missing-link updates and ready-event removal with the pending entry generation so stale retry work cannot overwrite or resurrect newer state. |
| Channel failure cleanup | Add regression coverage that dropped `DagNeedsFetch` receivers clear the pending DAG and return `ChannelSend`. |
| DAG sync config | Remove unused `max_depth` and `max_concurrent_fetches` fields/builders from `DagSyncConfig`. |
| Synced cache semantics | Document and test `is_synced` as a bounded recent-memory hint rather than a persistent synced claim. |
| Peer CID tracking | Add debug invariants around `known_cids` / `cid_order` mutation boundaries. |
| Tests | Add bounded concurrent pending-DAG insert coverage and stale-generation regression coverage. |

## Out of scope

- Full network integration fixtures for pending-DAG concurrency; this PR uses focused unit/concurrency tests around the protected state.
- Broader rate-limiter backoff work tracked separately in #843.
- Reworking pending DAG storage into a different data structure.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p` -- passed outside sandbox; sandboxed run hit local libp2p transport restrictions.
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet` -- passed outside sandbox.