### PR TITLE
fix(p2p): add rate-limit backoff and push timeouts (#843)

### DIFF
--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -22,7 +22,7 @@ use crate::message::{
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
 use crate::sync::head_provider::{DocumentHeadProvider, NoOpHeadProvider};
-use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager};
+use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager, DEFAULT_PUSH_SEND_TIMEOUT};
 use crate::sync::peer_state::PeerStateTracker;
 use crate::sync::rate_limiter::PeerRateLimiter;
 use crate::sync::SyncShutdownHandle;
@@ -146,6 +146,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
                 DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
             )),
             rate_limiter,
+            push_send_timeout: DEFAULT_PUSH_SEND_TIMEOUT,
             shutdown: SyncShutdownHandle::new(),
         },
         manager,

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -223,12 +223,18 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             let doc_id_owned = doc_id.to_string();
             let collection_id_owned = collection_id.to_string();
             let semaphore = self.runtime.push_semaphore.clone();
+            let send_timeout = self.runtime.push_send_timeout;
             self.spawn_background_task("push_dag_to_replicators", async move {
                 let Ok(_permit) = semaphore.acquire().await else {
                     return;
                 };
-                let any_failed =
-                    Self::send_ordered_pushlogs_via_transport(&transport, &peer_id, requests).await;
+                let any_failed = Self::send_ordered_pushlogs_via_transport(
+                    &transport,
+                    &peer_id,
+                    requests,
+                    send_timeout,
+                )
+                .await;
                 if any_failed {
                     Self::report_push_failure(
                         &failure_tx,
@@ -299,6 +305,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             let collection_id_owned = collection_id.to_string();
             let semaphore = self.runtime.push_semaphore.clone();
             let peer_id_clone = peer_id.clone();
+            let send_timeout = self.runtime.push_send_timeout;
             self.spawn_background_task("push_to_replicators", async move {
                 let Ok(_permit) = semaphore.acquire().await else {
                     return;
@@ -307,6 +314,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     &transport,
                     &peer_id_clone,
                     vec![(cid_clone, request)],
+                    send_timeout,
                 )
                 .await;
                 if any_failed {
@@ -374,16 +382,50 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         transport: &T,
         peer_id: &PeerId,
         requests: Vec<(Cid, PushLogRequest)>,
+        send_timeout: Duration,
     ) -> bool {
         let mut any_failed = false;
         'requests: for (cid, request) in requests {
             let mut rate_limited_attempts = 0;
             loop {
-                match transport
-                    .send_two_stream_request(peer_id, request.clone())
-                    .await
+                match tokio::time::timeout(
+                    send_timeout,
+                    transport.send_two_stream_request(peer_id, request.clone()),
+                )
+                .await
                 {
-                    Ok(reply) => {
+                    Err(_) => {
+                        tracing::warn!(
+                            peer_id = %peer_id,
+                            cid = %cid,
+                            timeout_ms = send_timeout.as_millis(),
+                            "PushLog to replicator timed out"
+                        );
+                        any_failed = true;
+                        break 'requests;
+                    }
+                    Ok(Err(e)) => {
+                        if e.is_connection_like() {
+                            tracing::debug!(
+                                peer_id = %peer_id,
+                                cid = %cid,
+                                error = %e,
+                                "PushLog to replicator failed because the connection became unavailable; stopping replay for this peer"
+                            );
+                            any_failed = true;
+                            break 'requests;
+                        }
+
+                        tracing::debug!(
+                            peer_id = %peer_id,
+                            cid = %cid,
+                            error = %e,
+                            "PushLog to replicator failed"
+                        );
+                        any_failed = true;
+                        break;
+                    }
+                    Ok(Ok(reply)) => {
                         let Some(error_message) = reply.err_message.as_deref() else {
                             break;
                         };
@@ -422,27 +464,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         any_failed = true;
                         break;
                     }
-                    Err(e) => {
-                        if e.is_connection_like() {
-                            tracing::debug!(
-                                peer_id = %peer_id,
-                                cid = %cid,
-                                error = %e,
-                                "PushLog to replicator failed because the connection became unavailable; stopping replay for this peer"
-                            );
-                            any_failed = true;
-                            break 'requests;
-                        }
-
-                        tracing::debug!(
-                            peer_id = %peer_id,
-                            cid = %cid,
-                            error = %e,
-                            "PushLog to replicator failed"
-                        );
-                        any_failed = true;
-                        break;
-                    }
                 }
             }
         }
@@ -476,6 +497,7 @@ mod tests {
         pubkey: Vec<u8>,
         replies: Arc<Mutex<VecDeque<PushLogReply>>>,
         sent_cids: Arc<Mutex<Vec<Vec<u8>>>>,
+        send_delay: Duration,
     }
 
     impl TestTransport {
@@ -485,7 +507,13 @@ mod tests {
                 pubkey: vec![1, 2, 3],
                 replies: Arc::new(Mutex::new(VecDeque::from(replies))),
                 sent_cids: Arc::new(Mutex::new(Vec::new())),
+                send_delay: Duration::ZERO,
             }
+        }
+
+        fn with_send_delay(mut self, send_delay: Duration) -> Self {
+            self.send_delay = send_delay;
+            self
         }
 
         fn sent_cids(&self) -> Vec<Vec<u8>> {
@@ -571,6 +599,9 @@ mod tests {
             req: PushLogRequest,
         ) -> P2PResult<PushLogReply> {
             self.sent_cids.lock().unwrap().push(req.cid.to_vec());
+            if !self.send_delay.is_zero() {
+                tokio::time::sleep(self.send_delay).await;
+            }
             Ok(self
                 .replies
                 .lock()
@@ -738,12 +769,16 @@ mod tests {
             ),
         ];
 
-        let any_failed =
-            SyncCoordinator::<
-                blockstore::DefraBlockstore<storage::backends::MemoryStore>,
-                TestTransport,
-            >::send_ordered_pushlogs_via_transport(&transport, &peer_id, requests)
-            .await;
+        let any_failed = SyncCoordinator::<
+            blockstore::DefraBlockstore<storage::backends::MemoryStore>,
+            TestTransport,
+        >::send_ordered_pushlogs_via_transport(
+            &transport,
+            &peer_id,
+            requests,
+            Duration::from_secs(1),
+        )
+        .await;
 
         assert!(!any_failed);
         assert_eq!(
@@ -785,17 +820,66 @@ mod tests {
             ),
         ];
 
-        let any_failed =
-            SyncCoordinator::<
-                blockstore::DefraBlockstore<storage::backends::MemoryStore>,
-                TestTransport,
-            >::send_ordered_pushlogs_via_transport(&transport, &peer_id, requests)
-            .await;
+        let any_failed = SyncCoordinator::<
+            blockstore::DefraBlockstore<storage::backends::MemoryStore>,
+            TestTransport,
+        >::send_ordered_pushlogs_via_transport(
+            &transport,
+            &peer_id,
+            requests,
+            Duration::from_secs(1),
+        )
+        .await;
 
         assert!(any_failed);
         assert_eq!(
             transport.sent_cids(),
             vec![cid1.to_bytes(); MAX_RATE_LIMITED_PUSH_ATTEMPTS + 1]
         );
+    }
+
+    #[tokio::test]
+    async fn ordered_pushlogs_timeout_stops_peer_push() {
+        let transport = TestTransport::new(vec![PushLogReply::success("first")])
+            .with_send_delay(Duration::from_millis(25));
+        let peer_id = PeerId::new("remote-peer".to_string());
+        let cid1 = Cid::new_v1(0x55, Code::Sha2_256.digest(b"cid-1"));
+        let cid2 = Cid::new_v1(0x55, Code::Sha2_256.digest(b"cid-2"));
+        let requests = vec![
+            (
+                cid1,
+                PushLogRequest::new(
+                    "doc-1".to_string(),
+                    Bytes::from(cid1.to_bytes()),
+                    "collection".to_string(),
+                    "creator".to_string(),
+                    Bytes::from_static(b"block-1"),
+                ),
+            ),
+            (
+                cid2,
+                PushLogRequest::new(
+                    "doc-1".to_string(),
+                    Bytes::from(cid2.to_bytes()),
+                    "collection".to_string(),
+                    "creator".to_string(),
+                    Bytes::from_static(b"block-2"),
+                ),
+            ),
+        ];
+
+        let any_failed = SyncCoordinator::<
+            blockstore::DefraBlockstore<storage::backends::MemoryStore>,
+            TestTransport,
+        >::send_ordered_pushlogs_via_transport(
+            &transport,
+            &peer_id,
+            requests,
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert!(any_failed);
+        assert_eq!(transport.sent_cids(), vec![cid1.to_bytes()]);
     }
 }

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -1,6 +1,7 @@
 //! Constructor methods for the sync coordinator.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use blockstore::Blockstore;
 use tokio::sync::mpsc;
@@ -12,7 +13,7 @@ use crate::error::Result;
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::{NoOpCollectionStorage, P2PCollectionStorage};
 use crate::sync::head_provider::{DocumentHeadProvider, NoOpHeadProvider};
-use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager};
+use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager, DEFAULT_PUSH_SEND_TIMEOUT};
 use crate::sync::peer_state::PeerStateTracker;
 use crate::sync::rate_limiter::PeerRateLimiter;
 use crate::transport::P2PTransport;
@@ -100,6 +101,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let max_push_tasks = config.max_concurrent_push_tasks.max(1);
         let rate_limit_burst = config.rate_limit_burst;
         let rate_limit_rate = config.rate_limit_rate;
+        let rate_limit_backoff = config.rate_limit_backoff.clone();
+        let push_send_timeout = if config.push_send_timeout.is_zero() {
+            DEFAULT_PUSH_SEND_TIMEOUT
+        } else {
+            config.push_send_timeout.max(Duration::from_millis(1))
+        };
         let subscribed_collections =
             Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new()));
         let (manager, events) = SyncManager::new(blockstore, peer_state.clone(), config);
@@ -124,7 +131,12 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     failure_tx: None,
                     dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(max_dag_fetches)),
                     push_semaphore: Arc::new(tokio::sync::Semaphore::new(max_push_tasks)),
-                    rate_limiter: Arc::new(PeerRateLimiter::new(rate_limit_burst, rate_limit_rate)),
+                    rate_limiter: Arc::new(PeerRateLimiter::with_backoff_steps(
+                        rate_limit_burst,
+                        rate_limit_rate,
+                        rate_limit_backoff,
+                    )),
+                    push_send_timeout,
                     shutdown: super::SyncShutdownHandle::new(),
                 },
                 manager,

--- a/crates/p2p/src/sync/coordinator/event_handler/mod.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/mod.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use super::SyncCoordinator;
 use crate::error::{Error, Result};
+use crate::sync::rate_limiter::RateLimitDecision;
 use crate::transport::{P2PTransport, PeerId, TransportEvent};
 
 const MAX_RETRIABLE_EVENT_ATTEMPTS: usize = 4;
@@ -76,6 +77,28 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .peer_unsubscribed(peer_id.as_str(), &topic);
     }
 
+    fn enforce_gossip_rate_limit(&self, peer_id: &PeerId, event_kind: &'static str) -> Result<()> {
+        match self.runtime.rate_limiter.check(peer_id) {
+            RateLimitDecision::Allowed => Ok(()),
+            RateLimitDecision::Limited {
+                retry_after,
+                consecutive_failures,
+            } => {
+                tracing::debug!(
+                    peer_id = %peer_id,
+                    event_kind,
+                    retry_after_ms = retry_after.as_millis(),
+                    consecutive_failures,
+                    "Rate limit exceeded for gossip event, dropping"
+                );
+                Err(Error::AccessDenied {
+                    peer_id: peer_id.to_string(),
+                    collection_id: "rate-limited".into(),
+                })
+            }
+        }
+    }
+
     /// Handle an event from the transport layer.
     ///
     /// This should be called from the event loop that processes TransportEvents.
@@ -107,16 +130,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 topic,
                 ..
             } => {
-                if !self.runtime.rate_limiter.check(&propagation_source) {
-                    tracing::debug!(
-                        peer_id = %propagation_source,
-                        "Rate limit exceeded for GossipMessage, dropping"
-                    );
-                    return Err(Error::AccessDenied {
-                        peer_id: propagation_source.to_string(),
-                        collection_id: "rate-limited".into(),
-                    });
-                }
+                self.enforce_gossip_rate_limit(&propagation_source, "GossipMessage")?;
                 self.handle_gossip_message(propagation_source, message, topic)
                     .await?;
             }
@@ -126,16 +140,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 data,
                 ..
             } => {
-                if !self.runtime.rate_limiter.check(&propagation_source) {
-                    tracing::debug!(
-                        peer_id = %propagation_source,
-                        "Rate limit exceeded for GossipRawMessage, dropping"
-                    );
-                    return Err(Error::AccessDenied {
-                        peer_id: propagation_source.to_string(),
-                        collection_id: "rate-limited".into(),
-                    });
-                }
+                self.enforce_gossip_rate_limit(&propagation_source, "GossipRawMessage")?;
                 self.handle_gossip_raw_message(propagation_source, topic, data)
                     .await?;
             }

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -192,6 +192,9 @@ pub(super) struct SyncRuntime<T: P2PTransport> {
     /// Per-peer rate limiter applied at event dispatch to throttle abusive peers.
     pub(super) rate_limiter: Arc<PeerRateLimiter>,
 
+    /// Timeout for one outbound PushLog send to a replicator peer.
+    pub(super) push_send_timeout: Duration,
+
     /// Shutdown state for coordinator-owned background tasks.
     pub(super) shutdown: SyncShutdownHandle,
 }

--- a/crates/p2p/src/sync/manager/config.rs
+++ b/crates/p2p/src/sync/manager/config.rs
@@ -1,5 +1,7 @@
 //! Sync manager configuration.
 
+use std::time::Duration;
+
 /// Default maximum number of concurrent DAG fetch tasks.
 ///
 /// Lowered from 16 to 4 for mobile client compatibility — 16 concurrent
@@ -14,6 +16,25 @@ pub const DEFAULT_RATE_LIMIT_BURST: u32 = 500;
 
 /// Default per-peer rate limit refill rate (tokens per second).
 pub const DEFAULT_RATE_LIMIT_RATE: f64 = 50.0;
+
+/// Default per-peer rate-limit backoff ladder, in seconds.
+///
+/// Mirrors the persisted replicator retry ladder: seconds-to-hours, capped at
+/// 12 hours, so abusive peers are retried less aggressively over time.
+pub const DEFAULT_RATE_LIMIT_BACKOFF_SECS: &[u64] = &[
+    30, 60, 120, 240, 480, 960, 1920, 3600, 7200, 14400, 28800, 43200,
+];
+
+/// Default timeout for one outbound PushLog send to a replicator peer.
+pub const DEFAULT_PUSH_SEND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default rate-limit backoff ladder as durations.
+pub fn default_rate_limit_backoff() -> Vec<Duration> {
+    DEFAULT_RATE_LIMIT_BACKOFF_SECS
+        .iter()
+        .map(|seconds| Duration::from_secs(*seconds))
+        .collect()
+}
 
 /// Configuration for the SyncManager.
 #[derive(Debug, Clone)]
@@ -38,6 +59,12 @@ pub struct SyncConfig {
 
     /// Per-peer rate limit refill rate (tokens per second).
     pub rate_limit_rate: f64,
+
+    /// Per-peer backoff ladder after rate-limit refusals.
+    pub rate_limit_backoff: Vec<Duration>,
+
+    /// Timeout for one outbound PushLog send to a replicator peer.
+    pub push_send_timeout: Duration,
 }
 
 impl Default for SyncConfig {
@@ -48,6 +75,8 @@ impl Default for SyncConfig {
             max_concurrent_push_tasks: DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
             rate_limit_burst: DEFAULT_RATE_LIMIT_BURST,
             rate_limit_rate: DEFAULT_RATE_LIMIT_RATE,
+            rate_limit_backoff: default_rate_limit_backoff(),
+            push_send_timeout: DEFAULT_PUSH_SEND_TIMEOUT,
         }
     }
 }

--- a/crates/p2p/src/sync/manager/mod.rs
+++ b/crates/p2p/src/sync/manager/mod.rs
@@ -20,7 +20,8 @@ mod pending;
 mod process;
 
 pub use config::{
-    SyncConfig, DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+    default_rate_limit_backoff, SyncConfig, DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
+    DEFAULT_MAX_CONCURRENT_PUSH_TASKS, DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS,
     DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
 };
 pub(crate) use diagnostics::record_gossip_decode_failure_sample;

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -32,9 +32,11 @@ pub use dag_sync::{DagSync, DagSyncConfig, DagSyncState, NeedsFetchData, SyncPla
 pub use head_provider::{DocumentHeadProvider, NoOpHeadProvider};
 pub(crate) use manager::record_gossip_decode_failure_sample;
 pub use manager::{
-    GossipDecodeFailureSample, GossipTransport, SyncConfig, SyncDiagnostics,
-    SyncDiagnosticsSnapshot, SyncEvent, SyncManager, DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
-    DEFAULT_MAX_CONCURRENT_PUSH_TASKS, DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
+    default_rate_limit_backoff, GossipDecodeFailureSample, GossipTransport, SyncConfig,
+    SyncDiagnostics, SyncDiagnosticsSnapshot, SyncEvent, SyncManager,
+    DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+    DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS, DEFAULT_RATE_LIMIT_BURST,
+    DEFAULT_RATE_LIMIT_RATE,
 };
 pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata};
 pub use peer_state::{PeerStateTracker, PeerStats};

--- a/crates/p2p/src/sync/rate_limiter.rs
+++ b/crates/p2p/src/sync/rate_limiter.rs
@@ -6,24 +6,15 @@
 //! Tokens refill at a constant rate up to the bucket capacity.
 
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 
 use crate::transport::PeerId;
 
-/// Default bucket capacity (burst allowance).
-///
-/// P2P sync is naturally bursty — a peer reconnecting after a restart will
-/// send many TwoStreamRequests in rapid succession to catch up.  The burst
-/// must be large enough to absorb that initial flood.
-const DEFAULT_CAPACITY: u32 = 500;
-
-/// Default refill rate: tokens per second.
-///
-/// Sustained request rate allowed per peer.  50/s is generous enough for
-/// normal sync traffic while still capping a misbehaving peer.
-const DEFAULT_REFILL_RATE: f64 = 50.0;
+use super::manager::{
+    default_rate_limit_backoff, DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
+};
 
 /// Maximum number of peer buckets to retain.
 ///
@@ -38,6 +29,10 @@ struct Bucket {
     tokens: f64,
     /// When tokens were last refilled.
     last_refill: Instant,
+    /// Consecutive rate-limit refusals since the last allowed event.
+    consecutive_failures: u32,
+    /// Earliest time this peer should be retried after a refusal.
+    next_retry_after: Option<Instant>,
 }
 
 impl Bucket {
@@ -45,24 +40,66 @@ impl Bucket {
         Self {
             tokens: capacity as f64,
             last_refill: Instant::now(),
+            consecutive_failures: 0,
+            next_retry_after: None,
         }
     }
 
     /// Refill tokens based on elapsed time and return whether one token is
     /// available to consume.
-    fn try_consume(&mut self, capacity: u32, refill_rate: f64) -> bool {
-        let now = Instant::now();
+    fn try_consume(
+        &mut self,
+        now: Instant,
+        capacity: u32,
+        refill_rate: f64,
+        backoff_steps: &[Duration],
+    ) -> RateLimitDecision {
+        if let Some(next_retry_after) = self.next_retry_after {
+            if next_retry_after > now {
+                return RateLimitDecision::Limited {
+                    retry_after: next_retry_after.duration_since(now),
+                    consecutive_failures: self.consecutive_failures,
+                };
+            }
+            self.next_retry_after = None;
+        }
+
         let elapsed = now.duration_since(self.last_refill).as_secs_f64();
         self.tokens = (self.tokens + elapsed * refill_rate).min(capacity as f64);
         self.last_refill = now;
 
         if self.tokens >= 1.0 {
             self.tokens -= 1.0;
-            true
+            self.consecutive_failures = 0;
+            RateLimitDecision::Allowed
         } else {
-            false
+            self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+            let retry_after = backoff_for_failure(backoff_steps, self.consecutive_failures);
+            self.next_retry_after = Some(now + retry_after);
+            RateLimitDecision::Limited {
+                retry_after,
+                consecutive_failures: self.consecutive_failures,
+            }
         }
     }
+}
+
+fn backoff_for_failure(backoff_steps: &[Duration], consecutive_failures: u32) -> Duration {
+    let index = consecutive_failures.saturating_sub(1) as usize;
+    backoff_steps
+        .get(index)
+        .or_else(|| backoff_steps.last())
+        .copied()
+        .unwrap_or_else(|| Duration::from_secs(1))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RateLimitDecision {
+    Allowed,
+    Limited {
+        retry_after: Duration,
+        consecutive_failures: u32,
+    },
 }
 
 /// Per-peer rate limiter backed by token buckets.
@@ -75,11 +112,12 @@ pub struct PeerRateLimiter {
     buckets: Mutex<HashMap<String, Bucket>>,
     capacity: u32,
     refill_rate: f64,
+    backoff_steps: Vec<Duration>,
 }
 
 impl Default for PeerRateLimiter {
     fn default() -> Self {
-        Self::new(DEFAULT_CAPACITY, DEFAULT_REFILL_RATE)
+        Self::new(DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE)
     }
 }
 
@@ -89,17 +127,27 @@ impl PeerRateLimiter {
     /// * `capacity`    – Maximum tokens per peer (burst size).
     /// * `refill_rate` – Tokens added per second per peer.
     pub fn new(capacity: u32, refill_rate: f64) -> Self {
+        Self::with_backoff_steps(capacity, refill_rate, default_rate_limit_backoff())
+    }
+
+    /// Create a new limiter with explicit rate-limit backoff steps.
+    pub fn with_backoff_steps(
+        capacity: u32,
+        refill_rate: f64,
+        backoff_steps: Vec<Duration>,
+    ) -> Self {
         Self {
             buckets: Mutex::new(HashMap::new()),
             capacity,
             refill_rate,
+            backoff_steps,
         }
     }
 
     /// Attempt to consume one token for `peer`.
     ///
-    /// Returns `true` if the event is allowed, `false` if the peer is rate-limited.
-    pub fn check(&self, peer: &PeerId) -> bool {
+    /// Returns backoff metadata when the peer is rate-limited.
+    pub(crate) fn check(&self, peer: &PeerId) -> RateLimitDecision {
         let key = peer.as_str().to_string();
         let mut buckets = self.buckets.lock();
 
@@ -117,14 +165,74 @@ impl PeerRateLimiter {
 
         let capacity = self.capacity;
         let refill_rate = self.refill_rate;
+        let now = Instant::now();
         buckets
             .entry(key)
             .or_insert_with(|| Bucket::new(capacity))
-            .try_consume(capacity, refill_rate)
+            .try_consume(now, capacity, refill_rate, &self.backoff_steps)
     }
 
     /// Discard the bucket for `peer` (called on disconnect to free memory).
     pub fn remove_peer(&self, peer: &PeerId) {
         self.buckets.lock().remove(peer.as_str());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn limited(decision: RateLimitDecision) -> (Duration, u32) {
+        match decision {
+            RateLimitDecision::Allowed => panic!("expected rate-limited decision"),
+            RateLimitDecision::Limited {
+                retry_after,
+                consecutive_failures,
+            } => (retry_after, consecutive_failures),
+        }
+    }
+
+    #[test]
+    fn peer_backoff_grows_after_repeated_rate_limit_windows() {
+        let limiter = PeerRateLimiter::with_backoff_steps(
+            0,
+            0.0,
+            vec![
+                Duration::from_millis(1),
+                Duration::from_millis(2),
+                Duration::from_millis(4),
+            ],
+        );
+        let peer = PeerId::new("peer-1".to_string());
+
+        let (_, failures) = limited(limiter.check(&peer));
+        assert_eq!(failures, 1);
+
+        std::thread::sleep(Duration::from_millis(2));
+        let (_, failures) = limited(limiter.check(&peer));
+        assert_eq!(failures, 2);
+
+        std::thread::sleep(Duration::from_millis(3));
+        let (_, failures) = limited(limiter.check(&peer));
+        assert_eq!(failures, 3);
+    }
+
+    #[test]
+    fn peer_backoff_resets_after_allowed_request() {
+        let limiter = PeerRateLimiter::with_backoff_steps(
+            1,
+            1_000.0,
+            vec![Duration::from_millis(1), Duration::from_millis(2)],
+        );
+        let peer = PeerId::new("peer-1".to_string());
+
+        assert_eq!(limiter.check(&peer), RateLimitDecision::Allowed);
+        let (_, failures) = limited(limiter.check(&peer));
+        assert_eq!(failures, 1);
+
+        std::thread::sleep(Duration::from_millis(2));
+        assert_eq!(limiter.check(&peer), RateLimitDecision::Allowed);
+        let (_, failures) = limited(limiter.check(&peer));
+        assert_eq!(failures, 1);
     }
 }


### PR DESCRIPTION
## Summary

Addresses #843. Adds explicit P2P gossip rate-limit backoff handling and outbound push send timeouts so sync pressure is surfaced and failed cleanly instead of silently dropping or hanging.

## Why

The existing peer rate limiter only returned an allow/drop boolean, which made repeated limits silent and gave callers no retry/backoff context. Ordered push sends also had no timeout, so a stalled transport could block progress instead of flowing into the existing push-failure handling.

## Changes

| Area | Change |
|---|---|
| Sync config | Add configurable rate-limit backoff windows and push send timeout defaults. |
| Peer rate limiter | Return `RateLimitDecision` with retry delay and consecutive failure count instead of a boolean. |
| Backoff behavior | Apply increasing retry windows for repeated rate-limit failures and reset the counter after an allowed request. |
| Gossip handling | Log rate-limit rejections with event kind, retry delay, and failure count before returning `AccessDenied`. |
| Push broadcasts | Wrap ordered push transport sends in a timeout and route timeout failures through the existing failure path. |
| Tests | Add regression coverage for backoff growth/reset and ordered push timeout behavior. |

## Out of scope

- Protocol-level retry-after responses to remote peers.
- Changing the existing `AccessDenied` error shape used for local rate-limit rejection.
- Reworking push scheduling or transport retry policy beyond adding bounded send timeouts.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p rate_limiter -- --nocapture`
- [x] `cargo test -p p2p ordered_pushlogs -- --nocapture`
- [x] `cargo test -p p2p gossip_remains_rate_limited_when_bucket_is_empty -- --nocapture`
- [x] `cargo test -p p2p`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet`
