### PR TITLE
fix(p2p): add QUIC and WebSocket transports (#831)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6963,6 +6963,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
+ "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
  "pin-project",
@@ -7396,6 +7397,27 @@ dependencies = [
  "tokio",
  "tracing",
  "void",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b953b6803a1f3161a989538974d72511c4e48a4af355337b6fb90723c56c05"
+dependencies = [
+ "either",
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot 0.12.5",
+ "pin-project-lite",
+ "rw-stream-sink",
+ "soketto",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -11782,6 +11804,21 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ ciborium = "0.2"
 
 # P2P networking
 # Note: Using 0.53 to match iroh-bitswap's dependency
-libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "relay", "secp256k1"] }
+libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "kad", "identify", "relay", "dns", "quic", "websocket", "secp256k1"] }
 iroh-bitswap = { git = "https://github.com/sourcenetwork/beetle", branch = "main" }
 libp2p-stream = "0.1.0-alpha.1"
 multiaddr = "0.18"

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -19,7 +19,7 @@ identity = { path = "../identity" }
 acp = { path = "../acp" }
 
 # P2P
-libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad", "relay"] }
+libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad", "relay", "dns", "quic", "websocket"] }
 iroh-bitswap = { workspace = true }
 libp2p-stream = { workspace = true }
 multiaddr = { workspace = true }

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -298,6 +298,12 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
                 .with_tokio()
                 .with_tcp(tcp_config, noise::Config::new, yamux::Config::default)
                 .map_err(|e| Error::Transport(e.to_string()))?
+                .with_quic()
+                .with_dns()
+                .map_err(|e| Error::Transport(e.to_string()))?
+                .with_websocket(noise::Config::new, yamux::Config::default)
+                .await
+                .map_err(|e| Error::Transport(e.to_string()))?
                 .with_relay_client(noise::Config::new, yamux::Config::default)
                 .map_err(|e| Error::Transport(e.to_string()))?
                 .with_behaviour(|_key, relay_client| {
@@ -311,6 +317,12 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             SwarmBuilder::with_existing_identity(keypair.clone())
                 .with_tokio()
                 .with_tcp(tcp_config, noise::Config::new, yamux::Config::default)
+                .map_err(|e| Error::Transport(e.to_string()))?
+                .with_quic()
+                .with_dns()
+                .map_err(|e| Error::Transport(e.to_string()))?
+                .with_websocket(noise::Config::new, yamux::Config::default)
+                .await
                 .map_err(|e| Error::Transport(e.to_string()))?
                 .with_behaviour(|_key| behaviour)
                 .expect("behaviour already constructed")

--- a/crates/p2p/tests/host_tests.rs
+++ b/crates/p2p/tests/host_tests.rs
@@ -36,6 +36,28 @@ async fn wait_until_connected(handle: &p2p::P2PHostHandle, peer_id: PeerId) {
     }
 }
 
+async fn assert_hosts_connect_over(listen_addr: &str) {
+    let store0 = MockBitswapStore::new();
+    let store1 = MockBitswapStore::new();
+    let (host0, handle0, _events0, _replicators0) = P2PHost::new(store0).await.unwrap();
+    let (host1, handle1, _events1, _replicators1) = P2PHost::new(store1).await.unwrap();
+
+    tokio::spawn(host0.run());
+    tokio::spawn(host1.run());
+
+    handle1.listen(listen_addr.parse().unwrap()).await.unwrap();
+    let addr1 = handle1.listen_addresses().await.unwrap().remove(0);
+    let peer1 = handle1.local_peer_id_cached();
+    let peer0 = handle0.local_peer_id_cached();
+
+    handle0.dial(peer1, vec![addr1]).await.unwrap();
+    wait_until_connected(&handle0, peer1).await;
+    wait_until_connected(&handle1, peer0).await;
+
+    handle0.shutdown().await.unwrap();
+    handle1.shutdown().await.unwrap();
+}
+
 async fn send_two_stream_request_and_capture_flag(
     sender: &p2p::P2PHostHandle,
     receiver: &p2p::P2PHostHandle,
@@ -113,6 +135,16 @@ async fn test_host_creation() {
 
     // Shutdown
     handle.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_host_connects_over_quic() {
+    assert_hosts_connect_over("/ip4/127.0.0.1/udp/0/quic-v1").await;
+}
+
+#[tokio::test]
+async fn test_host_connects_over_websocket() {
+    assert_hosts_connect_over("/ip4/127.0.0.1/tcp/0/ws").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Addresses part of #831. Adds QUIC, DNS, and WebSocket support to the Rust libp2p host so it can listen on and dial more of the multiaddrs advertised by Go/libp2p peers.

## Why

Rust host setup was TCP-only while Go uses libp2p default transports. That meant peers advertising `/udp/.../quic-v1` or `/tcp/.../ws` addresses were unreachable from Rust, reducing interop and reachability in mixed networks.

## Changes

| Area | Change |
|---|---|
| libp2p features | Enable `dns`, `quic`, and `websocket` in the workspace and p2p crate dependency features. |
| Host builder | Add QUIC, DNS, and WebSocket transports to both relay-enabled and relay-disabled SwarmBuilder paths. |
| Lockfile | Add the `libp2p-websocket` dependency chain required by the new transport feature. |
| Tests | Add host connectivity coverage for `/ip4/127.0.0.1/udp/0/quic-v1` and `/ip4/127.0.0.1/tcp/0/ws`. |

## Out of scope

- WebTransport support.
- Full Go↔Rust QUIC integration fixtures.
- Dual-DHT, resource-manager, and active connection-manager parity work from the broader #831 epic.
- Changing Kademlia mode or connection-pruning semantics.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p test_host_connects_over`
- [x] `cargo test -p p2p`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet`
