### PR TITLE
fix(p2p): cap and revoke explicit replay capabilities (#835)

### DIFF
--- a/crates/p2p/src/explicit_replay.rs
+++ b/crates/p2p/src/explicit_replay.rs
@@ -1,15 +1,35 @@
+//! Explicit replay capability signing, validation, and local revocation.
+//!
+//! Capabilities are authorizer-signed tokens that allow one transport peer to
+//! replay encrypted data to one target peer for one collection. Verifiers always
+//! enforce sender/target/collection binding, expiry, and a maximum remaining TTL
+//! so compromised authorizer keys cannot mint effectively-eternal capabilities.
+//!
+//! Revocation is verifier-local: each process keeps an in-memory deny-list keyed
+//! by a stable digest of the signed claims and signature. Deployments that need
+//! early invalidation must distribute revoked capabilities to each verifier and
+//! call [`revoke_capability`], or use [`ExplicitReplayRevocationRegistry`] with
+//! [`verify_capability_with_revocations`] for a custom synced deny-list.
+
+use std::collections::HashSet;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use crypto::{did::parse_did_key, public_key_from_bytes};
+use crypto::{did::parse_did_key, public_key_from_bytes, sha256, Sha256Hash};
 use identity::FullIdentity;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 
 use crate::error::{Error, Result};
 
 const CAPABILITY_VERSION: u8 = 1;
 const CAPABILITY_PURPOSE: &str = "explicit-replay";
 pub const DEFAULT_CAPABILITY_TTL: Duration = Duration::from_secs(365 * 24 * 60 * 60);
+pub const MAX_CAPABILITY_TTL: Duration = DEFAULT_CAPABILITY_TTL;
+
+static PROCESS_REVOCATIONS: LazyLock<ExplicitReplayRevocationRegistry> =
+    LazyLock::new(ExplicitReplayRevocationRegistry::default);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExplicitReplayCapabilityClaims {
@@ -38,6 +58,33 @@ pub struct ExplicitReplayAuthorization {
     pub expires_at: u64,
 }
 
+#[derive(Debug, Default)]
+pub struct ExplicitReplayRevocationRegistry {
+    revoked_capabilities: RwLock<HashSet<Sha256Hash>>,
+}
+
+impl ExplicitReplayRevocationRegistry {
+    pub fn revoke_capability(&self, capability: &str) -> Result<bool> {
+        let envelope = decode_envelope(capability)?;
+        Ok(self
+            .revoked_capabilities
+            .write()
+            .insert(capability_revocation_key(&envelope)?))
+    }
+
+    pub fn is_capability_revoked(&self, capability: &str) -> Result<bool> {
+        let envelope = decode_envelope(capability)?;
+        self.is_envelope_revoked(&envelope)
+    }
+
+    fn is_envelope_revoked(&self, envelope: &ExplicitReplayCapabilityEnvelope) -> Result<bool> {
+        Ok(self
+            .revoked_capabilities
+            .read()
+            .contains(&capability_revocation_key(envelope)?))
+    }
+}
+
 fn now_unix() -> Result<u64> {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -49,6 +96,24 @@ fn encode_claims(claims: &ExplicitReplayCapabilityClaims) -> Result<Vec<u8>> {
     serde_cbor::to_vec(claims).map_err(|error| {
         Error::ExplicitReplayCapability(format!("failed to encode claims: {error}"))
     })
+}
+
+fn capability_revocation_key(envelope: &ExplicitReplayCapabilityEnvelope) -> Result<Sha256Hash> {
+    let mut bytes = encode_claims(&envelope.claims)?;
+    bytes.extend_from_slice(&envelope.signature);
+    Ok(sha256(&bytes))
+}
+
+fn validate_expiration_cap(expires_at: u64) -> Result<()> {
+    let now = now_unix()?;
+    if expires_at.saturating_sub(now) > MAX_CAPABILITY_TTL.as_secs() {
+        return Err(Error::ExplicitReplayCapability(format!(
+            "expires_at {expires_at} exceeds max ttl of {} seconds",
+            MAX_CAPABILITY_TTL.as_secs()
+        )));
+    }
+
+    Ok(())
 }
 
 fn decode_envelope(capability: &str) -> Result<ExplicitReplayCapabilityEnvelope> {
@@ -107,10 +172,19 @@ fn validate_claims(
         ));
     }
 
-    if claims.expires_at < now_unix()? {
+    let now = now_unix()?;
+    if claims.expires_at < now {
         return Err(Error::ExplicitReplayCapability(format!(
             "expired at {}",
             claims.expires_at
+        )));
+    }
+
+    if claims.expires_at - now > MAX_CAPABILITY_TTL.as_secs() {
+        return Err(Error::ExplicitReplayCapability(format!(
+            "expires_at {} exceeds max ttl of {} seconds",
+            claims.expires_at,
+            MAX_CAPABILITY_TTL.as_secs()
         )));
     }
 
@@ -124,6 +198,13 @@ pub fn generate_capability<I: FullIdentity>(
     collection_id: &str,
     lifetime: Duration,
 ) -> Result<String> {
+    if lifetime > MAX_CAPABILITY_TTL {
+        return Err(Error::ExplicitReplayCapability(format!(
+            "lifetime exceeds max ttl of {} seconds",
+            MAX_CAPABILITY_TTL.as_secs()
+        )));
+    }
+
     let issued_at = now_unix()?;
     let expires_at = issued_at.saturating_add(lifetime.as_secs());
     let authorizer_did = authorizer.did().map_err(|error| {
@@ -145,6 +226,8 @@ pub fn generate_capability_from_claims<I: FullIdentity>(
     authorizer: &I,
     claims: ExplicitReplayCapabilityClaims,
 ) -> Result<String> {
+    validate_expiration_cap(claims.expires_at)?;
+
     let claims_bytes = encode_claims(&claims)?;
     let signature = authorizer
         .sign(&claims_bytes)
@@ -173,6 +256,22 @@ pub fn verify_capability(
     target_peer_id: &str,
     collection_id: &str,
 ) -> Result<ExplicitReplayAuthorization> {
+    verify_capability_with_revocations(
+        capability,
+        transport_sender_peer_id,
+        target_peer_id,
+        collection_id,
+        &PROCESS_REVOCATIONS,
+    )
+}
+
+pub fn verify_capability_with_revocations(
+    capability: &str,
+    transport_sender_peer_id: &str,
+    target_peer_id: &str,
+    collection_id: &str,
+    revocations: &ExplicitReplayRevocationRegistry,
+) -> Result<ExplicitReplayAuthorization> {
     let envelope = decode_envelope(capability)?;
     validate_claims(
         &envelope.claims,
@@ -194,6 +293,12 @@ pub fn verify_capability(
         ));
     }
 
+    if revocations.is_envelope_revoked(&envelope)? {
+        return Err(Error::ExplicitReplayCapability(
+            "capability has been revoked".to_string(),
+        ));
+    }
+
     Ok(ExplicitReplayAuthorization {
         source_peer_id: envelope.claims.source_peer_id,
         target_peer_id: envelope.claims.target_peer_id,
@@ -201,6 +306,14 @@ pub fn verify_capability(
         authorizer_did: envelope.claims.authorizer_did,
         expires_at: envelope.claims.expires_at,
     })
+}
+
+pub fn revoke_capability(capability: &str) -> Result<bool> {
+    PROCESS_REVOCATIONS.revoke_capability(capability)
+}
+
+pub fn is_capability_revoked(capability: &str) -> Result<bool> {
+    PROCESS_REVOCATIONS.is_capability_revoked(capability)
 }
 
 #[cfg(test)]
@@ -211,6 +324,16 @@ mod tests {
 
     fn authorizer() -> RawIdentity {
         RawIdentity::from_private_key(generate_ed25519().unwrap()).unwrap()
+    }
+
+    fn generate_capability_from_claims_unchecked<I: FullIdentity>(
+        authorizer: &I,
+        claims: ExplicitReplayCapabilityClaims,
+    ) -> String {
+        let claims_bytes = encode_claims(&claims).unwrap();
+        let signature = authorizer.sign(&claims_bytes).unwrap();
+        let envelope = ExplicitReplayCapabilityEnvelope { claims, signature };
+        URL_SAFE_NO_PAD.encode(serde_cbor::to_vec(&envelope).unwrap())
     }
 
     #[test]
@@ -284,6 +407,146 @@ mod tests {
 
         let msg = error.to_string();
         assert!(msg.contains("expired"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn generate_capability_from_claims_rejects_effectively_eternal_expiry() {
+        let authorizer = authorizer();
+        let source_peer_id = "peer-source".to_string();
+        let error = generate_capability_from_claims(
+            &authorizer,
+            ExplicitReplayCapabilityClaims {
+                version: CAPABILITY_VERSION,
+                purpose: CAPABILITY_PURPOSE.to_string(),
+                source_peer_id,
+                target_peer_id: "peer-target".to_string(),
+                collection_id: "collection-a".to_string(),
+                authorizer_did: authorizer.did().unwrap().to_string(),
+                expires_at: u64::MAX,
+            },
+        )
+        .unwrap_err();
+
+        let msg = error.to_string();
+        assert!(msg.contains("max ttl"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn verify_capability_rejects_effectively_eternal_expiry() {
+        let authorizer = authorizer();
+        let source_peer_id = "peer-source".to_string();
+        let capability = generate_capability_from_claims_unchecked(
+            &authorizer,
+            ExplicitReplayCapabilityClaims {
+                version: CAPABILITY_VERSION,
+                purpose: CAPABILITY_PURPOSE.to_string(),
+                source_peer_id: source_peer_id.clone(),
+                target_peer_id: "peer-target".to_string(),
+                collection_id: "collection-a".to_string(),
+                authorizer_did: authorizer.did().unwrap().to_string(),
+                expires_at: u64::MAX,
+            },
+        );
+
+        let error = verify_capability(&capability, &source_peer_id, "peer-target", "collection-a")
+            .unwrap_err();
+
+        let msg = error.to_string();
+        assert!(msg.contains("max ttl"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn generate_capability_rejects_lifetime_past_max_ttl() {
+        let authorizer = authorizer();
+        let source_peer_id = "peer-source".to_string();
+        let error = generate_capability(
+            &authorizer,
+            &source_peer_id,
+            "peer-target",
+            "collection-a",
+            MAX_CAPABILITY_TTL + Duration::from_secs(1),
+        )
+        .unwrap_err();
+
+        let msg = error.to_string();
+        assert!(msg.contains("max ttl"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn verify_capability_rejects_expiry_past_max_ttl() {
+        let authorizer = authorizer();
+        let source_peer_id = "peer-source".to_string();
+        let capability = generate_capability_from_claims_unchecked(
+            &authorizer,
+            ExplicitReplayCapabilityClaims {
+                version: CAPABILITY_VERSION,
+                purpose: CAPABILITY_PURPOSE.to_string(),
+                source_peer_id: source_peer_id.clone(),
+                target_peer_id: "peer-target".to_string(),
+                collection_id: "collection-a".to_string(),
+                authorizer_did: authorizer.did().unwrap().to_string(),
+                expires_at: now_unix()
+                    .unwrap()
+                    .saturating_add(MAX_CAPABILITY_TTL.as_secs())
+                    .saturating_add(60),
+            },
+        );
+
+        let error = verify_capability(&capability, &source_peer_id, "peer-target", "collection-a")
+            .unwrap_err();
+
+        let msg = error.to_string();
+        assert!(msg.contains("max ttl"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn verify_capability_accepts_expiry_within_max_ttl() {
+        let authorizer = authorizer();
+        let source_peer_id = "peer-source".to_string();
+        let capability = generate_capability(
+            &authorizer,
+            &source_peer_id,
+            "peer-target",
+            "collection-a",
+            MAX_CAPABILITY_TTL,
+        )
+        .unwrap();
+
+        let authorization =
+            verify_capability(&capability, &source_peer_id, "peer-target", "collection-a").unwrap();
+
+        assert_eq!(authorization.collection_id, "collection-a");
+    }
+
+    #[test]
+    fn verify_capability_rejects_revoked_capability() {
+        let authorizer = authorizer();
+        let source_peer_id = "peer-source".to_string();
+        let capability = generate_capability(
+            &authorizer,
+            &source_peer_id,
+            "peer-target",
+            "collection-a",
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        let revocations = ExplicitReplayRevocationRegistry::default();
+
+        assert!(!revocations.is_capability_revoked(&capability).unwrap());
+        assert!(revocations.revoke_capability(&capability).unwrap());
+        assert!(revocations.is_capability_revoked(&capability).unwrap());
+
+        let error = verify_capability_with_revocations(
+            &capability,
+            &source_peer_id,
+            "peer-target",
+            "collection-a",
+            &revocations,
+        )
+        .unwrap_err();
+
+        let msg = error.to_string();
+        assert!(msg.contains("revoked"), "unexpected error: {msg}");
     }
 
     #[test]

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -83,9 +83,13 @@ pub use error::{Error, Result};
 pub use explicit_replay::{
     generate_capability as generate_explicit_replay_capability,
     generate_capability_from_claims as generate_explicit_replay_capability_from_claims,
-    verify_capability as verify_explicit_replay_capability, ExplicitReplayAuthorization,
-    ExplicitReplayCapabilityClaims,
+    is_capability_revoked as is_explicit_replay_capability_revoked,
+    revoke_capability as revoke_explicit_replay_capability,
+    verify_capability as verify_explicit_replay_capability,
+    verify_capability_with_revocations as verify_explicit_replay_capability_with_revocations,
+    ExplicitReplayAuthorization, ExplicitReplayCapabilityClaims, ExplicitReplayRevocationRegistry,
     DEFAULT_CAPABILITY_TTL as DEFAULT_EXPLICIT_REPLAY_CAPABILITY_TTL,
+    MAX_CAPABILITY_TTL as MAX_EXPLICIT_REPLAY_CAPABILITY_TTL,
 };
 pub use host::{
     convert_host_event, HostCommand, HostEvent, Libp2pTransport, P2PHost, P2PHostConfig,


### PR DESCRIPTION
## Summary

Addresses #835. Adds maximum TTL enforcement and verifier-side revocation support for explicit replay capabilities so compromised or stale authorizer keys cannot mint effectively-eternal replay tokens.

## Why

`ExplicitReplayCapability` already binds the token to the source peer, target peer, and collection, but callers could still sign claims with arbitrarily distant `expires_at` values. There was also no revocation surface for invalidating a capability before its expiry.

## Changes

| Area | Change |
|---|---|
| TTL cap | Define `MAX_CAPABILITY_TTL` and reject capability lifetimes/expiries beyond the cap. |
| Claim validation | Enforce the max remaining TTL during verification, including for externally produced or legacy tokens. |
| Revocation | Add `ExplicitReplayRevocationRegistry`, keyed by a stable digest of signed claims plus signature. |
| Default verifier | Route `verify_capability` through a process-local revocation registry. |
| Public API | Export revocation helpers and custom-registry verification for integrations that sync their own deny-list. |
| Docs | Document the local revocation model and its deployment expectations in the module docs. |
| Tests | Add coverage for `u64::MAX`, `MAX_CAPABILITY_TTL + 1`, valid max TTL, and revoked capabilities. |

## Out of scope

- A distributed CRL or network-synced revocation protocol.
- Wire-format changes such as `issued_at`, `not_before`, or nonce claims.
- Changing existing source/target/collection binding semantics.
- Persistent revocation storage across process restarts.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p explicit_replay -- --nocapture`
- [x] `cargo test -p p2p test_two_stream_capability -- --nocapture`
- [x] `cargo test -p p2p`
- [x] `cargo test --workspace --exclude integration-test --exclude ffi-test --quiet`
