### PR TITLE
fix(sourcehub): hold sequence lock through tx inclusion

### DIFF
--- a/crates/sourcehub/src/cosmos/tx.rs
+++ b/crates/sourcehub/src/cosmos/tx.rs
@@ -26,7 +26,7 @@ pub(crate) struct TxSigner {
 }
 
 impl TxSigner {
-    const MAX_SEQUENCE_RETRIES: usize = 3;
+    const TX_INCLUSION_TIMEOUT_MS: u64 = 30_000;
 
     /// Create a signer from raw secp256k1 private key bytes.
     pub(crate) fn from_secp256k1_bytes(
@@ -65,12 +65,8 @@ impl TxSigner {
         policy_yaml: &str,
     ) -> Result<String, TxSignerError> {
         let msg = build_msg_create_policy(&self.address(), policy_yaml);
-        let tx_hash = self.sign_and_broadcast(client, vec![msg]).await?;
-        tracing::debug!(tx_hash = %tx_hash, "create_policy: broadcast complete");
-        let tx_result = client
-            .await_tx(&tx_hash, 30_000)
-            .await
-            .map_err(|e| TxSignerError::Broadcast(e.to_string()))?;
+        let (tx_hash, tx_result) = self.sign_and_broadcast(client, vec![msg]).await?;
+        tracing::debug!(tx_hash = %tx_hash, "create_policy: tx included");
 
         // Extract policy ID from tx_result.data (protobuf-encoded TxMsgData)
         if let Some(policy_id) = extract_policy_id_from_tx_data(&tx_result) {
@@ -99,11 +95,7 @@ impl TxSigner {
         cmd_json: serde_json::Value,
     ) -> Result<serde_json::Value, TxSignerError> {
         let msg = build_msg_bearer_policy_cmd(&self.address(), bearer_token, policy_id, cmd_json);
-        let tx_hash = self.sign_and_broadcast(client, vec![msg]).await?;
-        let tx_result = client
-            .await_tx(&tx_hash, 30_000)
-            .await
-            .map_err(|e| TxSignerError::Broadcast(e.to_string()))?;
+        let (tx_hash, tx_result) = self.sign_and_broadcast(client, vec![msg]).await?;
 
         let mut result = serde_json::json!({"tx_hash": tx_hash});
 
@@ -127,7 +119,7 @@ impl TxSigner {
         &self,
         client: &SourceHubClient,
         messages: Vec<Any>,
-    ) -> Result<String, TxSignerError> {
+    ) -> Result<(String, serde_json::Value), TxSignerError> {
         let sequence_state = sequence_state(client, &self.address());
         let mut state = sequence_state.lock().await;
 
@@ -141,112 +133,67 @@ impl TxSigner {
             400_000u64,
         );
 
-        let mut last_error = None;
+        let (account_number, sequence) = if let (Some(account_number), Some(sequence)) =
+            (state.account_number, state.next_sequence)
+        {
+            (account_number, sequence)
+        } else {
+            let (account_number, sequence) = client
+                .query_account(&self.address())
+                .await
+                .map_err(|e| TxSignerError::Broadcast(format!("account query: {}", e)))?;
+            state.account_number = Some(account_number);
+            state.next_sequence = Some(sequence);
+            (account_number, sequence)
+        };
 
-        for attempt in 0..Self::MAX_SEQUENCE_RETRIES {
-            let (account_number, sequence) = if let (Some(account_number), Some(sequence)) =
-                (state.account_number, state.next_sequence)
-            {
-                (account_number, sequence)
-            } else {
-                let (account_number, sequence) = client
-                    .query_account(&self.address())
-                    .await
-                    .map_err(|e| TxSignerError::Broadcast(format!("account query: {}", e)))?;
-                state.account_number = Some(account_number);
-                state.next_sequence = Some(sequence);
-                (account_number, sequence)
-            };
+        tracing::debug!(
+            msg_count = body.messages.len(),
+            account_number,
+            sequence,
+            "sign_and_broadcast"
+        );
 
-            tracing::debug!(
-                msg_count = body.messages.len(),
-                account_number,
-                sequence,
-                attempt,
-                "sign_and_broadcast"
-            );
+        let auth_info = SignerInfo::single_direct(Some(self.signing_key.public_key()), sequence)
+            .auth_info(fee.clone());
 
-            let auth_info =
-                SignerInfo::single_direct(Some(self.signing_key.public_key()), sequence)
-                    .auth_info(fee.clone());
+        let sign_doc = SignDoc::new(&body, &auth_info, &self.chain_id, account_number)
+            .map_err(|e| TxSignerError::Sign(format!("SignDoc creation: {}", e)))?;
 
-            let sign_doc = SignDoc::new(&body, &auth_info, &self.chain_id, account_number)
-                .map_err(|e| TxSignerError::Sign(format!("SignDoc creation: {}", e)))?;
+        let tx_raw = sign_doc
+            .sign(&self.signing_key)
+            .map_err(|e| TxSignerError::Sign(format!("signing: {}", e)))?;
 
-            let tx_raw = sign_doc
-                .sign(&self.signing_key)
-                .map_err(|e| TxSignerError::Sign(format!("signing: {}", e)))?;
+        let tx_bytes = tx_raw
+            .to_bytes()
+            .map_err(|e| TxSignerError::Sign(format!("tx serialization: {}", e)))?;
 
-            let tx_bytes = tx_raw
-                .to_bytes()
-                .map_err(|e| TxSignerError::Sign(format!("tx serialization: {}", e)))?;
+        tracing::debug!(tx_bytes_len = tx_bytes.len(), "transaction serialized");
 
-            tracing::debug!(
-                tx_bytes_len = tx_bytes.len(),
-                attempt,
-                "transaction serialized"
-            );
-
-            match client.broadcast_tx_sync(&tx_bytes).await {
-                Ok(hash) => {
-                    state.account_number = Some(account_number);
-                    state.next_sequence = Some(sequence + 1);
-                    return Ok(hash);
-                }
-                Err(e) if is_sequence_mismatch(&e) && attempt + 1 < Self::MAX_SEQUENCE_RETRIES => {
-                    tracing::warn!(
-                        attempt,
-                        error = %e,
-                        "retrying SourceHub tx after account sequence mismatch"
-                    );
-                    let (account_number, queried_sequence) = client
-                        .query_account(&self.address())
-                        .await
-                        .map_err(|query_error| {
-                            TxSignerError::Broadcast(format!("account query: {}", query_error))
-                        })?;
-                    let next_sequence = expected_sequence_from_error(&e)
-                        .unwrap_or_else(|| std::cmp::max(sequence + 1, queried_sequence));
-                    state.account_number = Some(account_number);
-                    state.next_sequence = Some(next_sequence);
-                    last_error = Some(e);
-                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-                }
-                Err(e) => return Err(TxSignerError::Broadcast(e.to_string())),
+        let tx_hash = match client.broadcast_tx_sync(&tx_bytes).await {
+            Ok(hash) => hash,
+            Err(e) => {
+                state.next_sequence = None;
+                return Err(TxSignerError::Broadcast(e.to_string()));
             }
-        }
+        };
 
-        Err(TxSignerError::Broadcast(
-            last_error
-                .map(|e| e.to_string())
-                .unwrap_or_else(|| "transaction broadcast failed".to_string()),
-        ))
-    }
-}
+        tracing::debug!(tx_hash = %tx_hash, "transaction accepted by mempool; waiting for inclusion");
 
-fn is_sequence_mismatch(error: &super::client::ClientError) -> bool {
-    match error {
-        super::client::ClientError::TxFailed(message) => {
-            message.contains("incorrect account sequence")
-                || message.contains("account sequence mismatch")
-                || message.contains("code=32")
-        }
-        _ => false,
-    }
-}
+        let tx_result = match client
+            .await_tx(&tx_hash, Self::TX_INCLUSION_TIMEOUT_MS)
+            .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                state.next_sequence = None;
+                return Err(TxSignerError::Broadcast(e.to_string()));
+            }
+        };
 
-fn expected_sequence_from_error(error: &super::client::ClientError) -> Option<u64> {
-    let super::client::ClientError::TxFailed(message) = error else {
-        return None;
-    };
-
-    let expected_idx = message.find("expected ")?;
-    let rest = &message[expected_idx + "expected ".len()..];
-    let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-    if digits.is_empty() {
-        None
-    } else {
-        digits.parse().ok()
+        state.account_number = Some(account_number);
+        state.next_sequence = Some(sequence + 1);
+        Ok((tx_hash, tx_result))
     }
 }
 
@@ -626,3 +573,6 @@ pub(crate) enum TxSignerError {
     #[error("broadcast error: {0}")]
     Broadcast(String),
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/sourcehub/src/cosmos/tx/tests.rs
+++ b/crates/sourcehub/src/cosmos/tx/tests.rs
@@ -1,0 +1,296 @@
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use cosmrs::Any;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Notify;
+
+use super::*;
+
+#[derive(Clone, Copy)]
+enum ServerMode {
+    DelayFirstTx,
+    FailFirstTx,
+}
+
+struct RpcState {
+    mode: ServerMode,
+    account_queries: AtomicUsize,
+    broadcasts: AtomicUsize,
+    tx_queries: AtomicUsize,
+    first_tx_poll_started: Notify,
+    first_tx_done: AtomicBool,
+    second_broadcast_before_first_tx_done: AtomicBool,
+}
+
+impl RpcState {
+    fn new(mode: ServerMode) -> Self {
+        Self {
+            mode,
+            account_queries: AtomicUsize::new(0),
+            broadcasts: AtomicUsize::new(0),
+            tx_queries: AtomicUsize::new(0),
+            first_tx_poll_started: Notify::new(),
+            first_tx_done: AtomicBool::new(false),
+            second_broadcast_before_first_tx_done: AtomicBool::new(false),
+        }
+    }
+}
+
+#[tokio::test]
+async fn sign_and_broadcast_holds_sequence_lock_until_inclusion() {
+    let state = Arc::new(RpcState::new(ServerMode::DelayFirstTx));
+    let base_url = spawn_sourcehub_rpc(state.clone()).await;
+    let client = Arc::new(test_client(&base_url));
+    let signer = Arc::new(test_signer());
+
+    let first = {
+        let client = client.clone();
+        let signer = signer.clone();
+        tokio::spawn(async move {
+            signer
+                .sign_and_broadcast(client.as_ref(), vec![test_msg("first")])
+                .await
+        })
+    };
+
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        state.first_tx_poll_started.notified(),
+    )
+    .await
+    .expect("first tx should start waiting for inclusion");
+
+    let second = {
+        let client = client.clone();
+        let signer = signer.clone();
+        tokio::spawn(async move {
+            signer
+                .sign_and_broadcast(client.as_ref(), vec![test_msg("second")])
+                .await
+        })
+    };
+
+    first.await.unwrap().expect("first tx should be included");
+    second.await.unwrap().expect("second tx should be included");
+
+    assert_eq!(state.account_queries.load(Ordering::SeqCst), 1);
+    assert_eq!(state.broadcasts.load(Ordering::SeqCst), 2);
+    assert!(!state
+        .second_broadcast_before_first_tx_done
+        .load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn sign_and_broadcast_resets_sequence_after_inclusion_failure() {
+    let state = Arc::new(RpcState::new(ServerMode::FailFirstTx));
+    let base_url = spawn_sourcehub_rpc(state.clone()).await;
+    let client = test_client(&base_url);
+    let signer = test_signer();
+
+    let first = signer
+        .sign_and_broadcast(&client, vec![test_msg("first")])
+        .await;
+
+    assert!(matches!(
+        first,
+        Err(TxSignerError::Broadcast(message))
+            if message.contains("tx execution failed")
+    ));
+
+    signer
+        .sign_and_broadcast(&client, vec![test_msg("second")])
+        .await
+        .expect("second tx should re-query sequence and succeed");
+
+    assert_eq!(state.account_queries.load(Ordering::SeqCst), 2);
+    assert_eq!(state.broadcasts.load(Ordering::SeqCst), 2);
+}
+
+async fn spawn_sourcehub_rpc(state: Arc<RpcState>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test rpc should bind");
+    let address = listener.local_addr().expect("test rpc should have address");
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let state = state.clone();
+            tokio::spawn(async move {
+                handle_rpc_connection(stream, state).await;
+            });
+        }
+    });
+
+    format!("http://{address}")
+}
+
+async fn handle_rpc_connection(mut stream: TcpStream, state: Arc<RpcState>) {
+    let request = read_http_request(&mut stream).await;
+    let (method, target) = request_line(&request);
+    let (status, body) = rpc_response(&state, method, target).await;
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+}
+
+async fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut buf = Vec::new();
+    let mut chunk = [0_u8; 1024];
+
+    loop {
+        let read = stream.read(&mut chunk).await.expect("request read");
+        if read == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..read]);
+
+        let Some(header_end) = find_header_end(&buf) else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&buf[..header_end]);
+        let content_len = content_length(&headers);
+        if buf.len() >= header_end + 4 + content_len {
+            break;
+        }
+    }
+
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn content_length(headers: &str) -> usize {
+    headers
+        .lines()
+        .find_map(|line| {
+            line.to_ascii_lowercase()
+                .strip_prefix("content-length:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .unwrap_or(0)
+}
+
+fn request_line(request: &str) -> (&str, &str) {
+    let mut parts = request
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    (method, target)
+}
+
+async fn rpc_response(state: &RpcState, method: &str, target: &str) -> (&'static str, String) {
+    if method == "GET" && target.starts_with("/cosmos/auth/v1beta1/accounts/") {
+        let query = state.account_queries.fetch_add(1, Ordering::SeqCst);
+        return (
+            "200 OK",
+            serde_json::json!({
+                "account": {
+                    "account_number": "7",
+                    "sequence": (41 + query).to_string(),
+                }
+            })
+            .to_string(),
+        );
+    }
+
+    if method == "POST" && target == "/" {
+        let broadcast = state.broadcasts.fetch_add(1, Ordering::SeqCst) + 1;
+        if broadcast == 2 && !state.first_tx_done.load(Ordering::SeqCst) {
+            state
+                .second_broadcast_before_first_tx_done
+                .store(true, Ordering::SeqCst);
+        }
+        return (
+            "200 OK",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "code": 0,
+                    "hash": format!("HASH{broadcast}"),
+                }
+            })
+            .to_string(),
+        );
+    }
+
+    if method == "GET" && target.starts_with("/tx?hash=0x") {
+        let query = state.tx_queries.fetch_add(1, Ordering::SeqCst) + 1;
+        return tx_query_response(state, query).await;
+    }
+
+    ("404 Not Found", "{}".to_string())
+}
+
+async fn tx_query_response(state: &RpcState, query: usize) -> (&'static str, String) {
+    match (state.mode, query) {
+        (ServerMode::DelayFirstTx, 1) => {
+            state.first_tx_poll_started.notify_waiters();
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            state.first_tx_done.store(true, Ordering::SeqCst);
+            ("200 OK", successful_tx_response())
+        }
+        (ServerMode::FailFirstTx, 1) => (
+            "200 OK",
+            serde_json::json!({
+                "result": {
+                    "tx_result": {
+                        "code": 5,
+                        "log": "forced failure",
+                    }
+                }
+            })
+            .to_string(),
+        ),
+        _ => {
+            state.first_tx_done.store(true, Ordering::SeqCst);
+            ("200 OK", successful_tx_response())
+        }
+    }
+}
+
+fn successful_tx_response() -> String {
+    serde_json::json!({
+        "result": {
+            "tx_result": {
+                "code": 0,
+                "data": "",
+                "events": [],
+            }
+        }
+    })
+    .to_string()
+}
+
+fn test_client(base_url: &str) -> SourceHubClient {
+    SourceHubClient::new(
+        base_url.to_string(),
+        base_url.to_string(),
+        Duration::from_secs(5),
+    )
+    .expect("client should build")
+}
+
+fn test_signer() -> TxSigner {
+    TxSigner::from_secp256k1_bytes(&[1_u8; 32], "sourcehub-test").expect("signer should build")
+}
+
+fn test_msg(name: &str) -> Any {
+    Any {
+        type_url: format!("/test.{name}"),
+        value: Vec::new(),
+    }
+}


### PR DESCRIPTION
## Summary

Addresses #879 by keeping SourceHub transaction sequence ownership locked until the transaction is included in a block.

## Why

`broadcast_tx_sync` only confirms mempool CheckTx acceptance. The old flow released the sequence mutex before `await_tx`, leaving a race where another transaction could consume the same account sequence before inclusion and evict the pending transaction.

## Changes

| Area | Change |
|---|---|
| SourceHub tx signing | Move `await_tx` inside `sign_and_broadcast` so the per-address sequence mutex covers broadcast through block inclusion |
| Sequence cache | Reset `next_sequence` on broadcast or inclusion failure so the next transaction re-queries chain state |
| Retry behavior | Remove the old CheckTx sequence retry loop and sequence-mismatch parsing helpers |
| Callers | Update `create_policy` and `bearer_policy_cmd` to consume the included tx result returned by `sign_and_broadcast` |
| Tests | Add focused signer tests for lock-held-through-inclusion behavior and sequence reset after inclusion failure |

## Out of scope

- No change to SourceHub fee/gas configuration.
- No switch from `broadcast_tx_sync` to `broadcast_tx_commit`.
- No changes to the SourceHub integration harness or `sourcehubd` discovery.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test -p sourcehub sign_and_broadcast`
- [x] `cargo test -p sourcehub`
- [x] `cargo clippy -p sourcehub --all-targets -- -D warnings`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p integration-test -- sourcehub` attempted; blocked locally because `sourcehubd` is not available via `SOURCEHUB_BINARY`, `SOURCEHUB_WORKSPACE`, or `PATH`
- [x] `cargo test -p integration-test --test sourcehub` attempted; blocked locally for the same missing `sourcehubd` dependency