### PR TITLE
fix(signing): zeroize normalized key buffers

### DIFF
--- a/crates/crypto/src/batch.rs
+++ b/crates/crypto/src/batch.rs
@@ -151,7 +151,7 @@ mod tests {
         let public_key = private_key.public_key();
         SigningConfig {
             key_type: defra_core::signing::SigningKeyType::Ed25519,
-            private_key_bytes: private_key.raw_owned(),
+            private_key_bytes: SigningConfig::private_key_bytes_from_vec(private_key.raw_owned()),
             public_key_bytes: public_key.raw_owned(),
             public_key_hex: public_key.to_hex_string(),
             remote_signer: None,
@@ -164,7 +164,7 @@ mod tests {
         let public_key = private_key.public_key();
         SigningConfig {
             key_type: defra_core::signing::SigningKeyType::Secp256k1,
-            private_key_bytes: private_key.raw_owned(),
+            private_key_bytes: SigningConfig::private_key_bytes_from_vec(private_key.raw_owned()),
             public_key_bytes: public_key.raw_owned(),
             public_key_hex: public_key.to_hex_string(),
             remote_signer: None,

--- a/crates/db-blocks/src/tests.rs
+++ b/crates/db-blocks/src/tests.rs
@@ -171,7 +171,9 @@ fn test_compute_signature_rejects_local_secp256r1_block_signing() {
 
     let signer = defra_core::signing::SigningConfig {
         key_type: defra_core::signing::SigningKeyType::Secp256r1,
-        private_key_bytes: private_key.raw().to_vec(),
+        private_key_bytes: defra_core::signing::SigningConfig::private_key_bytes_from_slice(
+            private_key.raw(),
+        ),
         public_key_bytes: public_key.raw_owned(),
         public_key_hex: hex::encode(public_key.raw()),
         remote_signer: None,

--- a/crates/defra-core/src/signing.rs
+++ b/crates/defra-core/src/signing.rs
@@ -171,11 +171,16 @@ impl SigningConfig {
     }
 
     /// Normalize owned private key bytes to an exactly sized allocation.
-    pub fn private_key_bytes_from_vec(bytes: Vec<u8>) -> Vec<u8> {
+    pub fn private_key_bytes_from_vec(mut bytes: Vec<u8>) -> Vec<u8> {
         if bytes.len() == bytes.capacity() {
             bytes
         } else {
-            Self::private_key_bytes_from_slice(&bytes)
+            let exact = Self::private_key_bytes_from_slice(&bytes);
+            // Wipe spare capacity too: oversized buffers may have held key
+            // material while being built incrementally.
+            bytes.resize(bytes.capacity(), 0);
+            bytes.zeroize();
+            exact
         }
     }
 
@@ -408,6 +413,25 @@ mod tests {
         let mut bytes = Vec::with_capacity(64);
         bytes.extend_from_slice(&[1_u8, 2, 3, 4]);
         assert_eq!(bytes.capacity(), 64);
+
+        let exact = SigningConfig::private_key_bytes_from_vec(bytes);
+
+        assert_eq!(exact, vec![1, 2, 3, 4]);
+        assert_eq!(exact.len(), exact.capacity());
+    }
+
+    #[test]
+    fn private_key_bytes_from_slice_uses_exact_capacity() {
+        let bytes = SigningConfig::private_key_bytes_from_slice(&[1_u8, 2, 3, 4]);
+
+        assert_eq!(bytes, vec![1, 2, 3, 4]);
+        assert_eq!(bytes.len(), bytes.capacity());
+    }
+
+    #[test]
+    fn private_key_bytes_from_vec_reuses_exact_capacity() {
+        let bytes = vec![1_u8, 2, 3, 4];
+        assert_eq!(bytes.len(), bytes.capacity());
 
         let exact = SigningConfig::private_key_bytes_from_vec(bytes);
 


### PR DESCRIPTION
## Summary

Addresses #808 by tightening `SigningConfig` private-key byte normalization so discarded oversized buffers are wiped before drop.

## Why

`SigningConfig` already zeroizes its current `private_key_bytes` buffer on drop, but `private_key_bytes_from_vec` could replace an over-capacity buffer with an exact-capacity copy and then drop the original allocation without explicitly wiping it. That leaves a small but important gap for key material held in spare capacity or construction-time buffers.

## Changes

| Area | Change |
|---|---|
| SigningConfig | Zeroize oversized input buffers after copying key bytes into exact-capacity storage |
| Spare capacity | Resize to full capacity before zeroizing so the discarded allocation is wiped completely |
| Construction sites | Route remaining non-empty test `SigningConfig` key-byte construction through the exact-capacity helpers |
| Tests | Add focused coverage for exact-capacity slice/vector helper behavior |

## Out of scope

- No change to the public `SigningConfig` field shape.
- No replacement of long-lived identity storage with keyring-backed lazy loading.
- No changes to signing semantics or supported key types.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test -p defra-core`
- [x] `cargo test -p crypto batch`
- [x] `cargo test -p db-blocks compute_signature`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p integration-test -- identity` attempted; blocked locally because Go `defradb` is not on `PATH` and Rust node harness tests time out waiting for node readiness
- [x] `cargo test -p integration-test --test identity` attempted; blocked for the same local harness issues