### PR TITLE
fix(merge): tighten composite and SE polish

### DIFF
--- a/crates/db-merge/src/broadcast_mutator/broadcast.rs
+++ b/crates/db-merge/src/broadcast_mutator/broadcast.rs
@@ -8,6 +8,7 @@ use query::mutator::BroadcastStatus;
 use db_blocks::BlockResult;
 
 pub(crate) const BROADCAST_MAX_RETRIES: u32 = 10;
+const BROADCAST_MAX_RETRY_DELAY_MS: u64 = 10_000;
 
 fn is_expected_fire_and_forget_failure(err: &str) -> bool {
     let lower = err.to_ascii_lowercase();
@@ -28,7 +29,17 @@ pub(crate) fn broadcast_retry_delay_ms(
     if connected_peers == 0 || attempt > BROADCAST_MAX_RETRIES {
         return None;
     }
-    Some(100 * (1u64 << attempt.min(5)))
+    let base_delay_ms = 100 * (1u64 << attempt.min(5));
+    let peer_multiplier = match connected_peers {
+        1 => 4,
+        2 => 2,
+        _ => 1,
+    };
+    Some(
+        base_delay_ms
+            .saturating_mul(peer_multiplier)
+            .min(BROADCAST_MAX_RETRY_DELAY_MS),
+    )
 }
 
 async fn connected_peer_count<B: Blockstore + 'static, T: P2PTransport>(
@@ -201,9 +212,26 @@ mod tests {
     }
 
     #[test]
-    fn insufficient_peers_with_connections_retries_with_backoff() {
+    fn insufficient_peers_with_two_connections_uses_peer_aware_backoff() {
         let delay = broadcast_retry_delay_ms("gossipsub publish error: InsufficientPeers", 2, 3);
-        assert_eq!(delay, Some(800));
+        assert_eq!(delay, Some(1600));
+    }
+
+    #[test]
+    fn insufficient_peers_with_one_connection_waits_longer_than_many_peers() {
+        let sparse_delay =
+            broadcast_retry_delay_ms("gossipsub publish error: InsufficientPeers", 1, 3).unwrap();
+        let many_peer_delay =
+            broadcast_retry_delay_ms("gossipsub publish error: InsufficientPeers", 8, 3).unwrap();
+
+        assert!(sparse_delay > many_peer_delay);
+        assert_eq!(many_peer_delay, 800);
+    }
+
+    #[test]
+    fn insufficient_peers_retry_delay_is_capped() {
+        let delay = broadcast_retry_delay_ms("gossipsub publish error: InsufficientPeers", 1, 10);
+        assert_eq!(delay, Some(10_000));
     }
 
     #[test]

--- a/crates/db-merge/src/se/artifact_gen.rs
+++ b/crates/db-merge/src/se/artifact_gen.rs
@@ -2,6 +2,9 @@
 //!
 //! Generates search tags for encrypted-indexed fields using HMAC-SHA256.
 //! Matches Go's internal/se/se.go generateDocArtifacts and generateFieldArtifact.
+//! Passing `None` for `identity_pubkey` preserves Go-compatible tags. Passing
+//! `Some` enables Rust-only per-identity tag isolation and should be limited to
+//! Rust-only deployments until Go supports the same isolation input.
 
 use crypto::se::{generate_equality_tag, Artifact};
 use document::NormalValue;

--- a/crates/db-merge/src/se/coordinator.rs
+++ b/crates/db-merge/src/se/coordinator.rs
@@ -59,8 +59,6 @@ pub struct SECoordinatorConfig {
     pub enc_key: Zeroizing<Vec<u8>>,
     /// Identity's public key for tag isolation.
     pub identity_pubkey: Option<Vec<u8>>,
-    /// Maximum number of retry attempts.
-    pub max_retries: usize,
 }
 
 impl Default for SECoordinatorConfig {
@@ -68,7 +66,6 @@ impl Default for SECoordinatorConfig {
         Self {
             enc_key: Zeroizing::new(vec![0u8; 32]),
             identity_pubkey: None,
-            max_retries: 5,
         }
     }
 }
@@ -102,7 +99,6 @@ impl SECoordinator {
         Self::new(SECoordinatorConfig {
             enc_key: Zeroizing::new(enc_key),
             identity_pubkey: Some(identity_pubkey),
-            max_retries: 5,
         })
     }
 
@@ -200,7 +196,6 @@ mod tests {
         let config = SECoordinatorConfig {
             enc_key: Zeroizing::new(vec![1u8; 32]),
             identity_pubkey: Some(b"user_pubkey".to_vec()),
-            max_retries: 3,
         };
         let coordinator = SECoordinator::new(config);
 

--- a/crates/defra-core/src/block_delta.rs
+++ b/crates/defra-core/src/block_delta.rs
@@ -5,6 +5,8 @@
 use cid::Cid;
 use serde::{Deserialize, Serialize};
 
+use crate::block_signature::DocumentStatus;
+
 /// LWW Register delta payload for block embedding
 ///
 /// Matches Go's `crdt.LWWDelta` structure.
@@ -75,8 +77,24 @@ pub struct CompositeDeltaPayload {
     pub priority: u64,
 
     /// Document status (1 = active, 2 = deleted)
-    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_document_status")]
     pub status: u8,
+}
+
+impl CompositeDeltaPayload {
+    pub(crate) fn validate_status(status: u8) -> Result<u8, String> {
+        DocumentStatus::from_u8(status)
+            .map(|_| status)
+            .ok_or_else(|| format!("invalid document status: {status}"))
+    }
+}
+
+fn deserialize_document_status<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let status = u8::deserialize(deserializer)?;
+    CompositeDeltaPayload::validate_status(status).map_err(serde::de::Error::custom)
 }
 
 /// Collection delta payload for block embedding

--- a/crates/defra-core/src/ipld/from_ipld.rs
+++ b/crates/defra-core/src/ipld/from_ipld.rs
@@ -231,11 +231,14 @@ impl TryFrom<&Ipld> for CompositeDeltaPayload {
             }
         };
 
+        let status = CompositeDeltaPayload::validate_status(parse_u8(map, "status")?)
+            .map_err(Error::IpldError)?;
+
         Ok(CompositeDeltaPayload {
             doc_id: parse_bytes(map, "docID")?,
             schema_version_id: parse_string(map, "schemaVersionID")?,
             priority: parse_u64(map, "priority")?,
-            status: parse_u8(map, "status")?,
+            status,
         })
     }
 }

--- a/crates/defra-core/src/ipld/tests.rs
+++ b/crates/defra-core/src/ipld/tests.rs
@@ -366,6 +366,47 @@ fn test_parse_u8_out_of_range_fails() {
 }
 
 #[test]
+fn test_composite_status_zero_fails() {
+    let mut map = BTreeMap::new();
+    map.insert("docID".to_string(), Ipld::Bytes(b"doc".to_vec()));
+    map.insert(
+        "schemaVersionID".to_string(),
+        Ipld::String("v1".to_string()),
+    );
+    map.insert("priority".to_string(), Ipld::Integer(1));
+    map.insert("status".to_string(), Ipld::Integer(0));
+    let ipld = Ipld::Map(map);
+
+    let result = CompositeDeltaPayload::try_from(&ipld);
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("invalid document status: 0"));
+}
+
+#[test]
+fn test_composite_status_missing_fails() {
+    let mut map = BTreeMap::new();
+    map.insert("docID".to_string(), Ipld::Bytes(b"doc".to_vec()));
+    map.insert(
+        "schemaVersionID".to_string(),
+        Ipld::String("v1".to_string()),
+    );
+    map.insert("priority".to_string(), Ipld::Integer(1));
+    let ipld = Ipld::Map(map);
+
+    let result = CompositeDeltaPayload::try_from(&ipld);
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Missing field 'status'"));
+}
+
+#[test]
 fn test_field_definition_optional_field_wrong_type_fails() {
     let mut map = BTreeMap::new();
     map.insert("priority".to_string(), Ipld::Integer(1));

--- a/crates/defra-core/tests/block_tests.rs
+++ b/crates/defra-core/tests/block_tests.rs
@@ -792,6 +792,53 @@ fn test_block_with_corrupted_cid_in_heads() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_composite_status_zero_cbor_rejected() {
+    let block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc-1".to_vec(),
+            schema_version_id: "schema-v1".to_string(),
+            priority: 1,
+            status: 0,
+        }),
+        vec![],
+        vec![],
+    );
+    let bytes = block.to_dag_cbor().expect("invalid status can serialize");
+
+    let result = Block::from_dag_cbor(&bytes);
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("invalid document status: 0"));
+}
+
+#[test]
+fn test_composite_missing_status_cbor_rejected() {
+    let mut composite = std::collections::BTreeMap::new();
+    composite.insert("docID".to_string(), libipld::Ipld::Bytes(b"doc-1".to_vec()));
+    composite.insert(
+        "schemaVersionID".to_string(),
+        libipld::Ipld::String("schema-v1".to_string()),
+    );
+    composite.insert("priority".to_string(), libipld::Ipld::Integer(1));
+
+    let mut delta = std::collections::BTreeMap::new();
+    delta.insert("composite".to_string(), libipld::Ipld::Map(composite));
+
+    let mut block = std::collections::BTreeMap::new();
+    block.insert("delta".to_string(), libipld::Ipld::Map(delta));
+
+    let bytes =
+        serde_ipld_dagcbor::to_vec(&libipld::Ipld::Map(block)).expect("manual block should encode");
+    let result = Block::from_dag_cbor(&bytes);
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("missing field"));
+}
+
 // ============================================================================
 // Go Wire Compatibility: Encryption Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

Addresses #854 by landing the concrete merge/SE polish items that are safe to handle together without overlapping the open P2P replay PRs.

## Why

A few small correctness gaps were clustered together: composite status accepted malformed `0` values, broadcast retry timing ignored sparse-peer topology, and SE exposed an unused retry knob plus unclear Rust-only identity tag isolation behavior.

## Changes

| Area | Change |
|---|---|
| Composite deltas | Require `status` and validate it against Go-compatible values `1` active and `2` deleted |
| IPLD / DAG-CBOR | Reject missing or invalid composite status in both manual IPLD conversion and serde/DAG-CBOR decode paths |
| Broadcast retry | Scale `InsufficientPeers` retry delay for sparse peer sets and cap the delay at `10s` |
| Searchable encryption | Remove unused `SECoordinatorConfig::max_retries` |
| Searchable encryption | Document that `identity_pubkey = None` preserves Go-compatible tags, while `Some` is Rust-only identity isolation |
| Tests | Add focused coverage for invalid/missing composite status and peer-aware retry timing |

## Out of scope

- No change to SE tag generation semantics.
- No enforcement of identity-isolated SE tags.
- No changes to `push_docs.rs` to avoid overlap with the open push-doc replay hardening PR.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test -p defra-core`
- [x] `cargo test -p db-merge`
- [x] `cargo test -p db-merge insufficient_peers`
- [x] `cargo test -p db-merge se::`
- [x] `cargo clippy --all -- -D warnings`