### PR TITLE
fix(p2p): harden bidirectional sync recovery

### DIFF
--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -191,7 +191,16 @@ async fn emit_dag_ready(
 ) {
     let mut context = context.clone();
     context.fill_missing_from_block(root_data);
-    let _ = event_tx.send(context.into_dag_ready(root_cid)).await;
+    if event_tx
+        .send(context.into_dag_ready(root_cid))
+        .await
+        .is_err()
+    {
+        warn!(
+            root_cid = %root_cid,
+            "Failed to emit DagReady after DAG fetch"
+        );
+    }
 }
 
 /// Try to fetch an entire DAG via a single CAR request.

--- a/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
@@ -38,18 +38,29 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                             providers.push(source_transport_id);
                         }
                     }
-                    if let Err(e) = self
+                    match self
                         .runtime
                         .transport
                         .sync_blocks(root_cid, providers, missing)
                         .await
                     {
-                        tracing::warn!(
-                            query_id = query_id.0,
-                            root_cid = %root_cid,
-                            error = %e,
-                            "Failed to start Bitswap fetch for remaining child blocks"
-                        );
+                        Ok(retry_query_id) => {
+                            self.manager.register_query(retry_query_id, root_cid);
+                            tracing::debug!(
+                                query_id = query_id.0,
+                                retry_query_id = retry_query_id.0,
+                                root_cid = %root_cid,
+                                "Started Bitswap fetch for remaining child blocks"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                query_id = query_id.0,
+                                root_cid = %root_cid,
+                                error = %e,
+                                "Failed to start Bitswap fetch for remaining child blocks"
+                            );
+                        }
                     }
                 }
             }
@@ -617,12 +628,28 @@ mod tests {
         assert_eq!(coordinator.manager().pending_dag_attempts(&root2_cid), 0);
 
         coordinator
+            .handle_bitswap_complete(
+                QueryId(999),
+                false,
+                Some("remaining child fetch failed".to_string()),
+            )
+            .await
+            .expect("registered retry bitswap complete");
+        assert_eq!(
+            transport_handle.sync_calls().len(),
+            2,
+            "retry query completion should trigger another retry"
+        );
+        assert_eq!(coordinator.manager().pending_dag_attempts(&root1_cid), 2);
+        assert_eq!(coordinator.manager().pending_dag_attempts(&root2_cid), 0);
+
+        coordinator
             .handle_bitswap_complete(QueryId(9999), false, Some("ignored".to_string()))
             .await
             .expect("unknown query is ignored");
         assert_eq!(
             transport_handle.sync_calls().len(),
-            1,
+            2,
             "unknown query should not trigger another retry"
         );
     }

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -306,7 +306,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                                 doc_id = %doc_id,
                                 "DAG complete locally, emitting BlockReceived for re-merge"
                             );
-                            let _ = event_tx
+                            if event_tx
                                 .send(crate::sync::manager::SyncEvent::BlockReceived {
                                     cid,
                                     doc_id: context.doc_id,
@@ -317,7 +317,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                                     explicit_replay_authorization: None,
                                     acp_actor_relationships: None,
                                 })
-                                .await;
+                                .await
+                                .is_err()
+                            {
+                                tracing::error!(
+                                    cid = %cid,
+                                    doc_id = %doc_id,
+                                    "Failed to emit BlockReceived for locally complete DocSync DAG"
+                                );
+                                return Err(Error::ChannelSend);
+                            }
                         } else {
                             tracing::info!(
                                 cid = %cid,

--- a/crates/p2p/src/sync/manager/process/pending_dag.rs
+++ b/crates/p2p/src/sync/manager/process/pending_dag.rs
@@ -400,7 +400,6 @@ impl<B: Blockstore + 'static> SyncManager<B> {
             );
             return Ok(false);
         };
-        self.diagnostics.record_pending_dag_resolved();
         tracing::info!(
             root_cid = %root_cid,
             doc_id = %info.doc_id,
@@ -411,7 +410,7 @@ impl<B: Blockstore + 'static> SyncManager<B> {
         );
 
         // Emit event that DAG is ready for merge
-        let _ = self
+        if self
             .event_tx
             .send(SyncEvent::DagReady {
                 root_cid: *root_cid,
@@ -423,8 +422,19 @@ impl<B: Blockstore + 'static> SyncManager<B> {
                 explicit_replay_authorization: info.explicit_replay_authorization.clone(),
                 acp_actor_relationships: info.acp_actor_relationships.clone(),
             })
-            .await;
+            .await
+            .is_err()
+        {
+            let reinserted = self.insert_pending_dag(*root_cid, info);
+            tracing::error!(
+                root_cid = %root_cid,
+                reinserted,
+                "Failed to emit DagReady for completed DAG"
+            );
+            return Err(Error::ChannelSend);
+        }
 
+        self.diagnostics.record_pending_dag_resolved();
         Ok(true)
     }
 }

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -541,7 +541,7 @@ pub(super) async fn process_merge_batch<B, T, H>(
     coordinator: &SyncCoordinator<B, T>,
     events: Vec<SyncEvent>,
     handler: &H,
-    _config: &ReplicationConfig,
+    config: &ReplicationConfig,
 ) -> Vec<ReplicationResult>
 where
     B: Blockstore + 'static,
@@ -677,6 +677,59 @@ where
                     *result = ReplicationResult::MergedButNotMarked {
                         cid,
                         error: e.to_string(),
+                    };
+                }
+            }
+        }
+    }
+
+    if config.rebroadcast_on_merge {
+        for (index, block) in merge_blocks.iter().enumerate() {
+            let result_index = batch_result_start + index;
+            if block.collection_id.is_empty()
+                || !matches!(results[result_index], ReplicationResult::Merged { .. })
+            {
+                continue;
+            }
+
+            match coordinator
+                .broadcast_local_update(
+                    &block.cid,
+                    block.block_data.as_ref(),
+                    &block.doc_id,
+                    &block.collection_id,
+                )
+                .await
+            {
+                Ok(crate::sync::BroadcastResult::Success) => {}
+                Ok(crate::sync::BroadcastResult::PartialDocumentOnly { collection_error }) => {
+                    results[result_index] = ReplicationResult::MergedButBroadcastFailed {
+                        cid: block.cid,
+                        doc_id: block.doc_id.clone(),
+                        collection_id: block.collection_id.clone(),
+                        broadcast_error: format!(
+                            "Partial: document topic succeeded but collection topic failed: {}",
+                            collection_error
+                        ),
+                    };
+                }
+                Ok(crate::sync::BroadcastResult::PartialCollectionOnly { document_error }) => {
+                    results[result_index] = ReplicationResult::MergedButBroadcastFailed {
+                        cid: block.cid,
+                        doc_id: block.doc_id.clone(),
+                        collection_id: block.collection_id.clone(),
+                        broadcast_error: format!(
+                            "Partial: collection topic succeeded but document topic failed: {}",
+                            document_error
+                        ),
+                    };
+                }
+                Err(error) => {
+                    results[result_index] = ReplicationResult::MergedButBroadcastFailed {
+                        cid: block.cid,
+                        doc_id: block.doc_id.clone(),
+                        collection_id: block.collection_id.clone(),
+                        broadcast_error: error.to_string(),
                     };
                 }
             }

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -146,6 +146,7 @@ mod tests {
     struct NoopTransport {
         peer_id: PeerId,
         pubkey: Vec<u8>,
+        publish_calls: Arc<AtomicUsize>,
     }
 
     impl NoopTransport {
@@ -153,7 +154,12 @@ mod tests {
             Self {
                 peer_id: PeerId::new("local-peer".to_string()),
                 pubkey: vec![1, 2, 3],
+                publish_calls: Arc::new(AtomicUsize::new(0)),
             }
+        }
+
+        fn publish_calls(&self) -> usize {
+            self.publish_calls.load(Ordering::SeqCst)
         }
     }
 
@@ -460,6 +466,7 @@ mod tests {
             _topic: DefraTopic,
             _msg: PushLogBroadcast,
         ) -> P2PResult<MessageId> {
+            self.publish_calls.fetch_add(1, Ordering::SeqCst);
             Ok(MessageId::new("noop".to_string()))
         }
 
@@ -1498,6 +1505,58 @@ mod tests {
         assert_eq!(handler.batch_calls(), 1);
         assert_eq!(handler.batch_block_count(), 3);
         assert_eq!(rx.len(), 7, "remaining backlog must stay queued");
+    }
+
+    #[tokio::test]
+    async fn test_process_merge_batch_rebroadcasts_when_config_enabled() {
+        let store = Arc::new(MemoryStore::new());
+        let blockstore = Arc::new(DefraBlockstore::new(store, true));
+        let cid = make_cid(b"rebroadcast-batch");
+        blockstore.put(&cid, b"rebroadcast-batch").await.unwrap();
+
+        let transport = NoopTransport::new();
+        let transport_handle = transport.clone();
+        let (coordinator, _events) =
+            crate::sync::coordinator::SyncCoordinator::with_access_control(
+                transport,
+                blockstore.clone(),
+                crate::sync::SyncConfig::default(),
+                AccessMode::Open,
+                Arc::new(crate::ReplicatorRegistry::new()),
+                Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+            )
+            .await
+            .unwrap();
+
+        let events = vec![SyncEvent::BlockReceived {
+            cid,
+            doc_id: "doc1".to_string(),
+            collection_id: "col1".to_string(),
+            creator: "peer1".to_string(),
+            sender_peer: None,
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+            acp_actor_relationships: None,
+        }];
+        let config = ReplicationConfig {
+            continue_on_error: true,
+            rebroadcast_on_merge: true,
+            batch_size: 50,
+            max_workers: 1,
+        };
+        let handler = BatchTestHandler::new();
+
+        let results = process_merge_batch(&coordinator, events, &handler, &config).await;
+
+        assert!(matches!(
+            results.as_slice(),
+            [ReplicationResult::Merged { cid: merged_cid, .. }] if *merged_cid == cid
+        ));
+        assert_eq!(
+            transport_handle.publish_calls(),
+            2,
+            "document and collection topics should be rebroadcast"
+        );
     }
 
     #[tokio::test]

--- a/crates/p2p/src/two_stream/handler/branchable_se.rs
+++ b/crates/p2p/src/two_stream/handler/branchable_se.rs
@@ -6,7 +6,7 @@ use crate::codec::write_message;
 use crate::error::{Error, Result};
 use crate::message::{BranchableSyncReply, BranchableSyncRequest, PushSEArtifactsRequest};
 
-use super::TwoStreamHandler;
+use super::{PendingResponseKey, TwoStreamHandler};
 
 impl TwoStreamHandler {
     /// Send a BranchableSync request to a peer without waiting for response.
@@ -18,16 +18,26 @@ impl TwoStreamHandler {
         request: BranchableSyncRequest,
     ) -> Result<()> {
         let message_id = request.message_id.clone();
+        let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
+
+        {
+            let mut pending = self.pending.lock();
+            pending.register_branchable_sync_request(pending_key);
+        }
 
         let mut stream = self
             .control
             .open_stream(peer_id, Self::request_protocol())
             .await
-            .map_err(|e| Error::Transport(format!("failed to open stream: {}", e)))?;
+            .map_err(|e| {
+                self.cleanup_pending_branchable_sync(peer_id, &message_id);
+                Error::Transport(format!("failed to open stream: {}", e))
+            })?;
 
-        write_message(&mut stream, &request)
-            .await
-            .map_err(|e| Error::CborSerialization(format!("failed to write request: {}", e)))?;
+        write_message(&mut stream, &request).await.map_err(|e| {
+            self.cleanup_pending_branchable_sync(peer_id, &message_id);
+            Error::CborSerialization(format!("failed to write request: {}", e))
+        })?;
 
         tracing::info!(
             peer_id = %peer_id,

--- a/crates/p2p/src/two_stream/handler/doc_sync.rs
+++ b/crates/p2p/src/two_stream/handler/doc_sync.rs
@@ -28,9 +28,7 @@ impl TwoStreamHandler {
         // Register pending response against the expected peer as well as the message ID.
         {
             let mut pending = self.pending.lock();
-            // Store as a PushLogReply channel - we'll need a different approach for DocSyncReply
-            // Actually, we need a separate map for DocSync responses
-            pending.channels.insert(pending_key.clone(), tx);
+            pending.doc_sync_channels.insert(pending_key.clone(), tx);
         }
 
         // Open stream and send request
@@ -41,14 +39,14 @@ impl TwoStreamHandler {
             .map_err(|e| {
                 // Clean up pending on failure
                 let mut pending = self.pending.lock();
-                pending.channels.remove(&pending_key);
+                pending.doc_sync_channels.remove(&pending_key);
                 Error::Transport(format!("failed to open stream: {}", e))
             })?;
 
         write_message(&mut stream, &request).await.map_err(|e| {
             // Clean up pending on failure
             let mut pending = self.pending.lock();
-            pending.channels.remove(&pending_key);
+            pending.doc_sync_channels.remove(&pending_key);
             Error::CborSerialization(format!("failed to write request: {}", e))
         })?;
 
@@ -59,26 +57,17 @@ impl TwoStreamHandler {
             "Sent DocSync request on two-stream protocol"
         );
 
-        // Wait for response with timeout - we'll receive a PushLogReply and need to
-        // handle DocSyncReply differently. For now, this is a simplified approach.
-        // The actual DocSyncReply handling needs to be done in handle_response_stream.
+        // Wait for the response routed by handle_response_stream.
         match timeout(RESPONSE_TIMEOUT, rx).await {
-            Ok(Ok(_response)) => {
-                // The response channel receives PushLogReply, but we need DocSyncReply
-                // This is a limitation of the current design - we need separate channels
-                // For now, return an error indicating the simplified implementation
-                Err(Error::Transport(
-                    "DocSync response handling requires dedicated channel".into(),
-                ))
-            }
+            Ok(Ok(response)) => Ok(response),
             Ok(Err(_)) => {
                 let mut pending = self.pending.lock();
-                pending.channels.remove(&pending_key);
+                pending.doc_sync_channels.remove(&pending_key);
                 Err(Error::Transport("response channel closed".into()))
             }
             Err(_) => {
                 let mut pending = self.pending.lock();
-                pending.channels.remove(&pending_key);
+                pending.doc_sync_channels.remove(&pending_key);
                 Err(Error::Transport("timeout waiting for response".into()))
             }
         }
@@ -95,17 +84,27 @@ impl TwoStreamHandler {
         request: DocSyncRequest,
     ) -> Result<()> {
         let message_id = request.message_id.clone();
+        let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
+
+        {
+            let mut pending = self.pending.lock();
+            pending.register_doc_sync_request(pending_key.clone());
+        }
 
         // Open stream and send request
         let mut stream = self
             .control
             .open_stream(peer_id, Self::request_protocol())
             .await
-            .map_err(|e| Error::Transport(format!("failed to open stream: {}", e)))?;
+            .map_err(|e| {
+                self.cleanup_pending_doc_sync(peer_id, &message_id);
+                Error::Transport(format!("failed to open stream: {}", e))
+            })?;
 
-        write_message(&mut stream, &request)
-            .await
-            .map_err(|e| Error::CborSerialization(format!("failed to write request: {}", e)))?;
+        write_message(&mut stream, &request).await.map_err(|e| {
+            self.cleanup_pending_doc_sync(peer_id, &message_id);
+            Error::CborSerialization(format!("failed to write request: {}", e))
+        })?;
 
         tracing::info!(
             peer_id = %peer_id,

--- a/crates/p2p/src/two_stream/handler/inbound.rs
+++ b/crates/p2p/src/two_stream/handler/inbound.rs
@@ -149,9 +149,26 @@ impl TwoStreamHandler {
             Ok(reply) if !reply.collection_id.is_empty() => {
                 crate::verify_message(&reply)?;
                 ensure_transport_sender(&peer_id, &reply)?;
+                let message_id = reply.message_id.clone();
+                let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
+                let is_pending_branchable_sync = {
+                    let mut pending = pending.lock();
+                    pending.consume_branchable_sync_request(&pending_key)
+                };
+
+                if !is_pending_branchable_sync {
+                    tracing::debug!(
+                        peer_id = %peer_id,
+                        message_id = %message_id,
+                        collection_id = %reply.collection_id,
+                        "Ignoring BranchableSync response for unknown request"
+                    );
+                    return Ok(None);
+                }
+
                 tracing::debug!(
                     peer_id = %peer_id,
-                    message_id = %reply.message_id,
+                    message_id = %message_id,
                     collection_id = %reply.collection_id,
                     heads_count = reply.heads.len(),
                     "Received BranchableSync response on two-stream protocol"
@@ -233,8 +250,36 @@ impl TwoStreamHandler {
             crate::verify_message(&reply)?;
             ensure_transport_sender(&peer_id, &reply)?;
             let message_id = reply.message_id.clone();
+            let pending_key = PendingResponseKey::new(peer_id, message_id.clone());
 
-            // No pending channel - this is a DocSyncReply for the coordinator
+            let doc_sync_sender = {
+                let mut pending = pending.lock();
+                pending.doc_sync_channels.remove(&pending_key)
+            };
+            if let Some(sender) = doc_sync_sender {
+                let _ = sender.send(reply);
+                tracing::debug!(
+                    peer_id = %peer_id,
+                    message_id = %message_id,
+                    "Received awaited DocSync response on two-stream protocol"
+                );
+                return Ok(None);
+            }
+
+            let is_pending_doc_sync = {
+                let mut pending = pending.lock();
+                pending.consume_doc_sync_request(&pending_key)
+            };
+
+            if !is_pending_doc_sync {
+                tracing::debug!(
+                    peer_id = %peer_id,
+                    message_id = %message_id,
+                    "Ignoring DocSync response for unknown request"
+                );
+                return Ok(None);
+            }
+
             tracing::debug!(
                 peer_id = %peer_id,
                 message_id = %message_id,

--- a/crates/p2p/src/two_stream/handler/mod.rs
+++ b/crates/p2p/src/two_stream/handler/mod.rs
@@ -17,7 +17,7 @@ mod se_query;
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use libp2p::StreamProtocol;
 use libp2p_stream as stream;
@@ -26,7 +26,7 @@ use tokio::sync::oneshot;
 
 use libp2p::PeerId;
 
-use crate::message::{IdentityResponse, PushLogReply, PushLogRequest};
+use crate::message::{DocSyncReply, IdentityResponse, PushLogReply, PushLogRequest};
 use crate::protocol::{
     CAR_REQUEST_PROTOCOL, CAR_RESPONSE_PROTOCOL, IDENTITY_REQUEST_PROTOCOL,
     IDENTITY_RESPONSE_PROTOCOL, REP_REQUEST_PROTOCOL, REP_RESPONSE_PROTOCOL,
@@ -73,6 +73,42 @@ pub(crate) struct PendingResponses {
     pub(crate) channels: HashMap<PendingResponseKey, oneshot::Sender<PushLogReply>>,
     /// Map of expected peer + MessageID to identity response channel.
     pub(crate) identity_channels: HashMap<PendingResponseKey, oneshot::Sender<IdentityResponse>>,
+    /// Map of expected peer + MessageID to DocSync response channel.
+    pub(crate) doc_sync_channels: HashMap<PendingResponseKey, oneshot::Sender<DocSyncReply>>,
+    /// Fire-and-forget DocSync requests awaiting an async response event.
+    pub(crate) doc_sync_requests: HashMap<PendingResponseKey, Instant>,
+    /// Fire-and-forget BranchableSync requests awaiting an async response event.
+    pub(crate) branchable_sync_requests: HashMap<PendingResponseKey, Instant>,
+}
+
+impl PendingResponses {
+    fn prune_expired(&mut self) {
+        let now = Instant::now();
+        self.doc_sync_requests
+            .retain(|_, inserted_at| now.duration_since(*inserted_at) <= RESPONSE_TIMEOUT);
+        self.branchable_sync_requests
+            .retain(|_, inserted_at| now.duration_since(*inserted_at) <= RESPONSE_TIMEOUT);
+    }
+
+    pub(crate) fn register_doc_sync_request(&mut self, key: PendingResponseKey) {
+        self.prune_expired();
+        self.doc_sync_requests.insert(key, Instant::now());
+    }
+
+    pub(crate) fn consume_doc_sync_request(&mut self, key: &PendingResponseKey) -> bool {
+        self.prune_expired();
+        self.doc_sync_requests.remove(key).is_some()
+    }
+
+    pub(crate) fn register_branchable_sync_request(&mut self, key: PendingResponseKey) {
+        self.prune_expired();
+        self.branchable_sync_requests.insert(key, Instant::now());
+    }
+
+    pub(crate) fn consume_branchable_sync_request(&mut self, key: &PendingResponseKey) -> bool {
+        self.prune_expired();
+        self.branchable_sync_requests.remove(key).is_some()
+    }
 }
 
 /// Two-stream protocol handler.
@@ -168,6 +204,22 @@ impl TwoStreamHandler {
             .remove(&PendingResponseKey::new(peer_id, message_id));
     }
 
+    /// Clean up a pending DocSync request.
+    pub fn cleanup_pending_doc_sync(&self, peer_id: PeerId, message_id: &str) {
+        let mut pending = self.pending.lock();
+        let key = PendingResponseKey::new(peer_id, message_id);
+        pending.doc_sync_channels.remove(&key);
+        pending.doc_sync_requests.remove(&key);
+    }
+
+    /// Clean up a pending BranchableSync request.
+    pub fn cleanup_pending_branchable_sync(&self, peer_id: PeerId, message_id: &str) {
+        let mut pending = self.pending.lock();
+        pending
+            .branchable_sync_requests
+            .remove(&PendingResponseKey::new(peer_id, message_id));
+    }
+
     /// Create a success reply for a request.
     pub fn success_reply(request: &PushLogRequest) -> PushLogReply {
         PushLogReply::success(&request.message_id)
@@ -176,5 +228,40 @@ impl TwoStreamHandler {
     /// Create an error reply for a request.
     pub fn error_reply(request: &PushLogRequest, error: &str) -> PushLogReply {
         PushLogReply::error(&request.message_id, error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doc_sync_pending_requests_are_peer_bound_and_single_use() {
+        let peer = PeerId::random();
+        let other_peer = PeerId::random();
+        let key = PendingResponseKey::new(peer, "doc-sync-1");
+        let wrong_peer_key = PendingResponseKey::new(other_peer, "doc-sync-1");
+        let mut pending = PendingResponses::default();
+
+        pending.register_doc_sync_request(key.clone());
+
+        assert!(!pending.consume_doc_sync_request(&wrong_peer_key));
+        assert!(pending.consume_doc_sync_request(&key));
+        assert!(!pending.consume_doc_sync_request(&key));
+    }
+
+    #[test]
+    fn branchable_sync_pending_requests_are_peer_bound_and_single_use() {
+        let peer = PeerId::random();
+        let other_peer = PeerId::random();
+        let key = PendingResponseKey::new(peer, "branchable-sync-1");
+        let wrong_peer_key = PendingResponseKey::new(other_peer, "branchable-sync-1");
+        let mut pending = PendingResponses::default();
+
+        pending.register_branchable_sync_request(key.clone());
+
+        assert!(!pending.consume_branchable_sync_request(&wrong_peer_key));
+        assert!(pending.consume_branchable_sync_request(&key));
+        assert!(!pending.consume_branchable_sync_request(&key));
     }
 }

--- a/tools/integration-test/tests/p2p/sync.rs
+++ b/tools/integration-test/tests/p2p/sync.rs
@@ -78,14 +78,9 @@ async fn document_sync_test(cluster: TestCluster) {
         .expect("could not extract _docID");
 
     // Explicitly sync the document.
-    // Note: Rust's sync_documents handler can block for up to 90s with retries,
-    // causing HTTP timeouts when Rust is involved. Go-Go topology works fine.
-    // Automatic replication (tested in replication.rs) works for all topologies.
-    let sync_result = node0.p2p_document_sync("Task", &[doc_id]);
-    if sync_result.is_err() {
-        // Sync endpoint timed out — skip the poll check
-        return;
-    }
+    node0
+        .p2p_document_sync("Task", &[doc_id])
+        .expect("p2p document sync should succeed");
 
     // Poll node1 until the doc appears
     let deadline = Instant::now() + Duration::from_secs(15);


### PR DESCRIPTION
## Summary
- register Bitswap retry query IDs so retry completions keep driving pending DAG recovery
- bind DocSync and BranchableSync two-stream replies to pending peer/message IDs
- honor `rebroadcast_on_merge` in batch merges and surface ready-event send failures
- make explicit DocSync integration failures fail the test instead of returning early

## Tests
- cargo test -p p2p --lib
- cargo test -p integration-test --test p2p --no-run