### PR TITLE
Expose registered node identity in defra-node

### DIFF
--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -24,6 +24,8 @@ use std::sync::Arc;
 #[cfg(feature = "p2p")]
 use std::sync::Mutex;
 
+use defra_core::signing::SigningConfig;
+use identity::{Identity as _, IdentityKeyType, RawIdentity};
 #[cfg(feature = "p2p")]
 use p2p::P2PTransport;
 
@@ -72,6 +74,7 @@ pub struct EmbeddedNode {
     event_bus: Arc<dyn events::Bus>,
     schema_ops: Arc<dyn SchemaOps>,
     embedding_config: db::EmbeddingClientConfig,
+    node_identity_did: Option<String>,
     #[cfg(feature = "p2p")]
     p2p_ops: Option<Arc<dyn defra_http::P2POperations>>,
     #[cfg(feature = "p2p")]
@@ -229,7 +232,26 @@ impl EmbeddedNode {
 
     /// Execute a GraphQL query or mutation.
     pub async fn execute(&self, query_str: &str) -> QueryResponse {
-        self.runner.execute(QueryRequest::new(query_str)).await
+        let request = QueryRequest::new(query_str);
+        let Some(node_identity_did) = self.node_identity_did.as_deref() else {
+            return self.runner.execute(request).await;
+        };
+
+        let signing_config = defra_core::signing::resolve_signing_config_with_flag(
+            None,
+            Some(node_identity_did),
+            true,
+        );
+        let Some(signing_config) = signing_config else {
+            return self.runner.execute(request).await;
+        };
+
+        execute_with_signing_context(self.runner.clone(), request, signing_config).await
+    }
+
+    /// DID used as the embedded node identity for signing, when configured.
+    pub fn node_identity_did(&self) -> Option<&str> {
+        self.node_identity_did.as_deref()
     }
 
     /// Add a schema from a GraphQL SDL type definition.
@@ -359,6 +381,76 @@ impl EmbeddedNode {
     }
 }
 
+async fn execute_with_signing_context(
+    executor: Arc<dyn QueryExecutor>,
+    request: QueryRequest,
+    signing_config: SigningConfig,
+) -> QueryResponse {
+    let handle = tokio::runtime::Handle::current();
+    let batch_session_key = Some(signing_config.public_key_hex.clone());
+
+    match tokio::task::spawn_blocking(move || {
+        defra_core::signing::set_signing_config(Some(signing_config));
+        defra_core::batch_signing::set_batch_session_key(batch_session_key);
+        handle.block_on(async { executor.execute(request).await })
+    })
+    .await
+    {
+        Ok(response) => response,
+        Err(join_error) => {
+            QueryResponse::error(format!("query execution task failed: {join_error}"))
+        }
+    }
+}
+
+fn resolve_registered_node_identity(did: &str) -> anyhow::Result<SigningConfig> {
+    let config = defra_core::signing::get_identity(did).ok_or_else(|| {
+        anyhow::anyhow!("node identity DID {did} is not registered in the DefraDB signing registry")
+    })?;
+    if !config.has_local_private_key() && !config.has_remote_signer() {
+        anyhow::bail!(
+            "node identity DID {did} is registered without local key bytes or a remote signer"
+        );
+    }
+    Ok(config)
+}
+
+fn local_raw_identity_from_registered_config(
+    did: &str,
+    config: &SigningConfig,
+) -> anyhow::Result<Option<RawIdentity>> {
+    if !config.has_local_private_key() {
+        return Ok(None);
+    }
+
+    let key_type = identity_key_type_from_signing_key_type(config.key_type)?;
+    let identity = RawIdentity::from_identity_key_type(key_type, &config.private_key_bytes)
+        .map_err(|error| {
+            anyhow::anyhow!("failed to load registered node identity {did}: {error}")
+        })?;
+    let derived_did = identity
+        .did()
+        .map_err(|error| anyhow::anyhow!("failed to derive registered node identity DID: {error}"))?
+        .to_string();
+    if derived_did != did {
+        anyhow::bail!(
+            "registered node identity DID mismatch: expected {did}, derived {derived_did}"
+        );
+    }
+    Ok(Some(identity))
+}
+
+fn identity_key_type_from_signing_key_type(
+    key_type: defra_core::signing::SigningKeyType,
+) -> anyhow::Result<IdentityKeyType> {
+    match key_type {
+        defra_core::signing::SigningKeyType::Ed25519 => Ok(IdentityKeyType::Ed25519),
+        defra_core::signing::SigningKeyType::Secp256k1 => Ok(IdentityKeyType::Secp256k1),
+        defra_core::signing::SigningKeyType::Secp256r1 => Ok(IdentityKeyType::Secp256r1),
+        unsupported => anyhow::bail!("unsupported registered node identity key type {unsupported}"),
+    }
+}
+
 /// Selects which persistent storage backend to use when `data_path` is set.
 ///
 /// Defaults to `Redb` for backwards compatibility.
@@ -383,6 +475,7 @@ pub struct NodeBuilder {
     embedding_model: Option<String>,
     embedding_api_key: Option<String>,
     document_acp: DocumentAcpConfig,
+    node_identity_did: Option<String>,
     #[cfg(feature = "http")]
     http_config: Option<HttpConfig>,
     #[cfg(feature = "p2p")]
@@ -430,6 +523,16 @@ impl NodeBuilder {
         self
     }
 
+    /// Use an identity already registered in DefraDB's process-local signing registry.
+    ///
+    /// The caller must register the signer before calling [`NodeBuilder::build`].
+    /// Registered identities may be backed by exportable private key bytes or by a
+    /// remote signer such as a host Secure Enclave adapter.
+    pub fn with_node_identity_did(mut self, did: impl Into<String>) -> Self {
+        self.node_identity_did = Some(did.into());
+        self
+    }
+
     /// Enable the HTTP GraphQL server.
     #[cfg(feature = "http")]
     pub fn with_http(mut self, config: HttpConfig) -> Self {
@@ -446,6 +549,12 @@ impl NodeBuilder {
 
     /// Build and start the embedded DefraDB node.
     pub async fn build(self) -> anyhow::Result<EmbeddedNode> {
+        let node_identity_did = self.node_identity_did.clone();
+        let node_identity_config = node_identity_did
+            .as_deref()
+            .map(resolve_registered_node_identity)
+            .transpose()?;
+
         // 1. Event bus
         let event_bus: Arc<dyn events::Bus> = Arc::new(events::ChannelBus::default());
 
@@ -459,6 +568,13 @@ impl NodeBuilder {
             }
             if let Some(api_key) = self.embedding_api_key.as_ref() {
                 options = options.with_embedding_api_key(api_key.clone());
+            }
+            if let (Some(did), Some(config)) =
+                (node_identity_did.as_deref(), node_identity_config.as_ref())
+            {
+                if let Some(identity) = local_raw_identity_from_registered_config(did, config)? {
+                    options = options.with_node_identity(identity);
+                }
             }
             options
         };
@@ -496,6 +612,7 @@ impl NodeBuilder {
                         self.document_acp.clone(),
                         db_options.clone(),
                         event_bus,
+                        node_identity_did.clone(),
                         #[cfg(feature = "p2p")]
                         p2p_config,
                     )
@@ -522,6 +639,7 @@ impl NodeBuilder {
                         self.document_acp.clone(),
                         db_options.clone(),
                         event_bus,
+                        node_identity_did.clone(),
                         #[cfg(feature = "p2p")]
                         p2p_config,
                     )
@@ -549,6 +667,7 @@ impl NodeBuilder {
                 self.document_acp,
                 db_options,
                 event_bus,
+                node_identity_did.clone(),
                 #[cfg(feature = "p2p")]
                 p2p_config,
             )
@@ -565,6 +684,12 @@ impl NodeBuilder {
             let server =
                 defra_http::Server::from_arc_with_config(node.runner.clone(), server_config)
                     .with_event_bus_arc(node.event_bus.clone());
+
+            let server = if let Some(did) = node_identity_did.as_ref() {
+                server.with_node_identity_did(did.clone())
+            } else {
+                server
+            };
 
             #[cfg(feature = "p2p")]
             let server = if let Some(p2p) = node.p2p_ops.as_ref() {
@@ -620,6 +745,7 @@ impl NodeBuilder {
         document_acp_config: DocumentAcpConfig,
         db_options: db::DbOptions,
         event_bus: Arc<dyn events::Bus>,
+        node_identity_did: Option<String>,
         #[cfg(feature = "p2p")] p2p_config: Option<P2PConfig>,
     ) -> anyhow::Result<EmbeddedNode> {
         let embedding_config = db_options.embedding_config();
@@ -692,6 +818,7 @@ impl NodeBuilder {
             event_bus,
             schema_ops,
             embedding_config,
+            node_identity_did,
             #[cfg(feature = "p2p")]
             p2p_ops,
             #[cfg(feature = "p2p")]
@@ -1048,12 +1175,21 @@ struct P2PSetupResult {
     wire_document_acp: Option<WireDocumentAcpCallback>,
 }
 
-#[cfg(all(test, feature = "http"))]
+#[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use defra_core::signing::{RemoteSigner, SigningConfig, SigningKeyType};
+
+    use super::EmbeddedNode;
+
+    #[cfg(feature = "http")]
     use axum::{routing::get, Router};
 
+    #[cfg(feature = "http")]
     use super::HttpConfig;
 
+    #[cfg(feature = "http")]
     #[test]
     fn http_config_accepts_extra_routes() {
         let config = HttpConfig::new(9182)
@@ -1061,6 +1197,67 @@ mod tests {
 
         assert_eq!(config.address.port(), 9182);
         assert!(config.extra_routes.is_some());
+    }
+
+    #[tokio::test]
+    async fn node_identity_did_requires_registered_signer() {
+        defra_core::signing::clear_identity_store();
+
+        let error = match EmbeddedNode::builder()
+            .with_node_identity_did("did:key:zMissing")
+            .build()
+            .await
+        {
+            Ok(_) => panic!("unregistered node identity must fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("is not registered in the DefraDB signing registry"),
+            "{error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn node_identity_did_accepts_registered_remote_signer() {
+        defra_core::signing::clear_identity_store();
+
+        let did = "did:key:zRegisteredRemote";
+        defra_core::signing::store_identity(
+            did,
+            SigningConfig {
+                key_type: SigningKeyType::Secp256r1,
+                private_key_bytes: Vec::new(),
+                public_key_bytes: vec![2, 3, 4],
+                public_key_hex: "020304".to_string(),
+                remote_signer: Some(Arc::new(TestRemoteSigner)),
+                signing_authorization: None,
+            },
+        );
+
+        let node = EmbeddedNode::builder()
+            .with_node_identity_did(did)
+            .build()
+            .await
+            .expect("registered remote signer should build");
+
+        assert_eq!(node.node_identity_did(), Some(did));
+        node.shutdown().await;
+        defra_core::signing::clear_identity_store();
+    }
+
+    struct TestRemoteSigner;
+
+    impl RemoteSigner for TestRemoteSigner {
+        fn sign_sync(
+            &self,
+            _data: &[u8],
+            _authorization: Option<&defra_core::signing::SigningAuthorization>,
+        ) -> Result<Vec<u8>, String> {
+            Ok(vec![1, 2, 3])
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a defra-node builder hook for process-registered node identity DIDs
- apply the registered node identity to direct EmbeddedNode::execute calls and embedded HTTP startup
- validate that configured node identities exist in the DefraDB signing registry before build

## Tests
- cargo test -p defra-node node_identity_did
- cargo test -p defra-node --features http node_identity_did