### PR TITLE
docs(p2p): document correlator overwrite on duplicate request CIDs (#898)

### DIFF
--- a/crates/p2p/src/pubsub_rpc/correlator.rs
+++ b/crates/p2p/src/pubsub_rpc/correlator.rs
@@ -115,6 +115,19 @@ impl Correlator {
     ///
     /// Derives the request ID, registers a correlation entry, and returns a
     /// handle whose `Drop` removes the entry automatically.
+    ///
+    /// # Concurrent identical requests
+    ///
+    /// The request ID is the CID of `data`, so two callers publishing
+    /// **identical** bytes derive the same ID. The second `publish` overwrites
+    /// the first's entry in the in-flight map — the first caller's response
+    /// channel is silently dropped and that caller times out instead of
+    /// receiving the reply. Go has the same behavior: `Topic.Publish` in
+    /// `sourcenetwork/go-libp2p-pubsub-rpc/rpc.go:222-230` performs an
+    /// unguarded `t.ongoing[msgID] = ongoingMessage{...}`, so this is a Go
+    /// parity match by design. Callers that need to multiplex truly identical
+    /// requests must serialize them externally or vary the payload (e.g.
+    /// add a nonce) so the derived CIDs differ.
     pub fn publish(&self, data: Vec<u8>, opts: PublishOptions) -> PreparedPublish {
         let id = derive_request_id(&data);
         let buffer = if opts.multi_response {


### PR DESCRIPTION
Resolves #898

## Summary

Adds a `# Concurrent identical requests` section to `Correlator::publish` documenting the in-flight-map overwrite behavior. Issue #898 raised the question whether two callers publishing identical payloads (same derived CID) — where the second's `insert` silently evicts the first — should be addressed by:

1. Documenting the behavior (zero-risk, parity-preserving), or
2. Re-keying the map on `(caller_peer, request_id)` (Rust-native improvement, structural divergence from Go).

Cross-checked Go's `Topic.Publish` at `sourcenetwork/go-libp2p-pubsub-rpc/rpc.go:222-230` — it performs the same unguarded `t.ongoing[msgID] = ongoingMessage{...}` assignment, so the overwrite is a Go parity match by design. Picked option 1: document the contract so callers know they need to serialize concurrent identical requests externally or vary the payload (e.g. add a nonce).

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all -- -D warnings` — clean (rustc 1.95)
- [x] `cargo test -p p2p --lib pubsub_rpc` — green (no behavior change, doc-only)
- [x] `cargo doc -p p2p --no-deps` — rustdoc renders without errors on the new section