### PR TITLE
fix(db): type unique constraint errors

### DIFF
--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -179,16 +179,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         collection
             .create_with_indexes(&datastore, &doc, &index_manager, id_was_generated)
             .await
-            .map_err(|e| {
-                let msg = e.to_string();
-                if msg.contains("can not index a doc's field(s) that violates unique index") {
-                    query::error::QueryError::execution(
-                        "can not index a doc's field(s) that violates unique index.".to_string(),
-                    )
-                } else {
-                    query::error::QueryError::execution(format!("create error: {}", e))
-                }
-            })?;
+            .map_err(|e| crate::error::index_write_query_error("create", e))?;
 
         let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id();
@@ -318,17 +309,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
                 crate::error::Error::DocumentNotFound(id) => {
                     query::error::QueryError::document_not_found(id)
                 }
-                other => {
-                    let msg = other.to_string();
-                    if msg.contains("can not index a doc's field(s) that violates unique index") {
-                        query::error::QueryError::execution(
-                            "can not index a doc's field(s) that violates unique index."
-                                .to_string(),
-                        )
-                    } else {
-                        query::error::QueryError::execution(format!("update error: {}", other))
-                    }
-                }
+                other => crate::error::index_write_query_error("update", other),
             })?;
 
         let short_id = collection.resolved_root_id();

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -69,18 +69,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             collection
                 .create_with_indexes(&datastore, &doc, &index_manager, id_was_generated)
                 .await
-                .map_err(|e| {
-                    let msg = e.to_string();
-                    // If this is a unique constraint violation, return the core message without wrapping
-                    if msg.contains("can not index a doc's field(s) that violates unique index") {
-                        query::error::QueryError::execution(
-                            "can not index a doc's field(s) that violates unique index."
-                                .to_string(),
-                        )
-                    } else {
-                        query::error::QueryError::execution(format!("create error: {}", e))
-                    }
-                })
+                .map_err(|e| crate::error::index_write_query_error("create", e))
         };
 
         match result {

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -148,18 +148,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 collection
                     .create_with_indexes(&datastore, &doc, &index_manager, id_was_generated)
                     .await
-                    .map_err(|e| {
-                        let msg = e.to_string();
-                        if msg.contains("can not index a doc's field(s) that violates unique index")
-                        {
-                            query::error::QueryError::execution(
-                                "can not index a doc's field(s) that violates unique index."
-                                    .to_string(),
-                            )
-                        } else {
-                            query::error::QueryError::execution(format!("create error: {}", e))
-                        }
-                    })?;
+                    .map_err(|e| crate::error::index_write_query_error("create", e))?;
             } // datastore dropped
 
             // Insert pre-computed blocks + collection blocks

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -71,19 +71,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     crate::error::Error::DocumentNotFound(id) => {
                         query::error::QueryError::document_not_found(id)
                     }
-                    other => {
-                        let msg = other.to_string();
-                        // If this is a unique constraint violation, return the core message without wrapping
-                        if msg.contains("can not index a doc's field(s) that violates unique index")
-                        {
-                            query::error::QueryError::execution(
-                                "can not index a doc's field(s) that violates unique index."
-                                    .to_string(),
-                            )
-                        } else {
-                            query::error::QueryError::execution(format!("update error: {}", other))
-                        }
-                    }
+                    other => crate::error::index_write_query_error("update", other),
                 })
         };
 

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -117,17 +117,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         collection
             .create_with_indexes(&datastore, &doc, &index_manager, id_was_generated)
             .await
-            .map_err(|e| {
-                let msg = e.to_string();
-                // If this is a unique constraint violation, return the core message without wrapping
-                if msg.contains("can not index a doc's field(s) that violates unique index") {
-                    query::error::QueryError::execution(
-                        "can not index a doc's field(s) that violates unique index.".to_string(),
-                    )
-                } else {
-                    query::error::QueryError::execution(format!("create error: {}", e))
-                }
-            })?;
+            .map_err(|e| crate::error::index_write_query_error("create", e))?;
 
         {
             let txn_guard = self.txn.lock().await;
@@ -222,18 +212,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 crate::error::Error::DocumentNotFound(id) => {
                     query::error::QueryError::document_not_found(id)
                 }
-                other => {
-                    let msg = other.to_string();
-                    // If this is a unique constraint violation, return the core message without wrapping
-                    if msg.contains("can not index a doc's field(s) that violates unique index") {
-                        query::error::QueryError::execution(
-                            "can not index a doc's field(s) that violates unique index."
-                                .to_string(),
-                        )
-                    } else {
-                        query::error::QueryError::execution(format!("update error: {}", other))
-                    }
-                }
+                other => crate::error::index_write_query_error("update", other),
             })?;
 
         // Return count of actually modified fields

--- a/crates/db/src/error.rs
+++ b/crates/db/src/error.rs
@@ -129,6 +129,10 @@ impl From<db_index::Error> for Error {
 }
 
 impl Error {
+    pub fn is_unique_constraint_violation(&self) -> bool {
+        matches!(self, Error::Storage(source) if source.is_unique_constraint_violation())
+    }
+
     pub fn document_at_key(key: &[u8], source: document::Error) -> Self {
         Self::DocumentAtKey {
             key: String::from_utf8_lossy(key).into_owned(),
@@ -158,12 +162,20 @@ impl Error {
     }
 }
 
+pub(crate) fn index_write_query_error(operation: &str, error: Error) -> query::error::QueryError {
+    if error.is_unique_constraint_violation() {
+        query::error::QueryError::execution(storage::corekv::UNIQUE_CONSTRAINT_VIOLATION_MESSAGE)
+    } else {
+        query::error::QueryError::execution(format!("{operation} error: {error}"))
+    }
+}
+
 /// Result type for database operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
 mod tests {
-    use super::Error;
+    use super::{index_write_query_error, Error};
 
     #[test]
     fn document_at_key_preserves_display_message() {
@@ -211,5 +223,17 @@ mod tests {
 
         assert!(matches!(error, Error::TextDecode { .. }));
         assert!(error.to_string().starts_with("invalid version encoding: "));
+    }
+
+    #[test]
+    fn index_write_query_error_preserves_unique_constraint_message() {
+        let error = Error::Storage(storage::Error::UniqueConstraintViolation);
+
+        assert!(error.is_unique_constraint_violation());
+        assert!(matches!(
+            index_write_query_error("create", error),
+            query::error::QueryError::Execution(message)
+                if message == storage::corekv::UNIQUE_CONSTRAINT_VIOLATION_MESSAGE
+        ));
     }
 }

--- a/crates/db/tests/index_manager_tests.rs
+++ b/crates/db/tests/index_manager_tests.rs
@@ -1387,9 +1387,13 @@ async fn test_unique_constraint_violation_returns_error() {
         doc2.generate_and_set_doc_id().unwrap();
 
         let result = manager.on_document_create(&datastore, &doc2, &schema).await;
+        let error = result.expect_err("duplicate value should fail through IndexManager");
         assert!(
-            result.is_err(),
-            "Duplicate value in unique index should fail through IndexManager"
+            matches!(
+                error,
+                db_index::Error::Storage(storage::Error::UniqueConstraintViolation)
+            ),
+            "duplicate value should preserve typed unique constraint error: {error}"
         );
     }
 }

--- a/crates/storage/src/corekv/errors.rs
+++ b/crates/storage/src/corekv/errors.rs
@@ -7,6 +7,10 @@ use thiserror::Error;
 /// Result type alias for CoreKV operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Go-compatible unique index violation message.
+pub const UNIQUE_CONSTRAINT_VIOLATION_MESSAGE: &str =
+    "can not index a doc's field(s) that violates unique index.";
+
 /// CoreKV error types.
 ///
 /// These errors match the error types defined in the Go corekv package
@@ -52,6 +56,10 @@ pub enum Error {
     /// The transaction should typically be retried.
     #[error("transaction conflict. Please retry")]
     TxnConflict,
+
+    /// Unique index constraint violation.
+    #[error("can not index a doc's field(s) that violates unique index.")]
+    UniqueConstraintViolation,
 
     /// Attempted a write operation on a read-only transaction.
     ///
@@ -99,6 +107,11 @@ impl Error {
     /// Check if this error indicates a transaction conflict.
     pub fn is_txn_conflict(&self) -> bool {
         matches!(self, Error::TxnConflict)
+    }
+
+    /// Check if this error indicates a unique index constraint violation.
+    pub fn is_unique_constraint_violation(&self) -> bool {
+        matches!(self, Error::UniqueConstraintViolation)
     }
 
     /// Check if this error indicates a closed database.
@@ -157,6 +170,10 @@ mod tests {
         assert_eq!(
             Error::TxnConflict.to_string(),
             "transaction conflict. Please retry"
+        );
+        assert_eq!(
+            Error::UniqueConstraintViolation.to_string(),
+            UNIQUE_CONSTRAINT_VIOLATION_MESSAGE
         );
     }
 

--- a/crates/storage/src/corekv/mod.rs
+++ b/crates/storage/src/corekv/mod.rs
@@ -70,7 +70,7 @@ pub mod traits;
 pub mod types;
 
 // Re-export commonly used types and traits for convenience
-pub use errors::{Error, Result};
+pub use errors::{Error, Result, UNIQUE_CONSTRAINT_VIOLATION_MESSAGE};
 pub use iterator::{Iterator, KvPair};
 pub use traits::private;
 pub use traits::{

--- a/crates/storage/src/index/tests.rs
+++ b/crates/storage/src/index/tests.rs
@@ -192,12 +192,14 @@ async fn test_unique_index_rejects_duplicates() {
 
     // Same value, different doc ID - should fail
     let result = index.save(&mut txn, "doc2", &values).await;
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("violates unique index"),
-        "error should mention unique index violation: {}",
-        err_msg
+    let error = result.expect_err("duplicate unique value should fail");
+    assert!(matches!(
+        error,
+        crate::corekv::Error::UniqueConstraintViolation
+    ));
+    assert_eq!(
+        error.to_string(),
+        crate::corekv::UNIQUE_CONSTRAINT_VIOLATION_MESSAGE
     );
 }
 
@@ -385,12 +387,14 @@ async fn test_unique_index_update_to_existing_value_fails() {
         )
         .await;
 
-    assert!(result.is_err());
-    let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("violates unique index"),
-        "error should mention unique index violation: {}",
-        err_msg
+    let error = result.expect_err("duplicate unique value should fail");
+    assert!(matches!(
+        error,
+        crate::corekv::Error::UniqueConstraintViolation
+    ));
+    assert_eq!(
+        error.to_string(),
+        crate::corekv::UNIQUE_CONSTRAINT_VIOLATION_MESSAGE
     );
 }
 

--- a/crates/storage/src/index/unique.rs
+++ b/crates/storage/src/index/unique.rs
@@ -238,9 +238,7 @@ impl CollectionIndex for UniqueIndex {
         // would indicate duplicate values within the same document (e.g., JSON
         // array self-duplicates like [5, 8, 5]).
         if txn.has(&key).await? {
-            return Err(crate::corekv::Error::Other(
-                "can not index a doc's field(s) that violates unique index.".to_string(),
-            ));
+            return Err(crate::corekv::Error::UniqueConstraintViolation);
         }
 
         // Store doc_id as the value
@@ -266,9 +264,7 @@ impl CollectionIndex for UniqueIndex {
                 let existing_doc_id = String::from_utf8(existing)
                     .map_err(|e| crate::corekv::Error::Other(e.to_string()))?;
                 if existing_doc_id != doc_id {
-                    return Err(crate::corekv::Error::Other(
-                        "can not index a doc's field(s) that violates unique index.".to_string(),
-                    ));
+                    return Err(crate::corekv::Error::UniqueConstraintViolation);
                 }
             }
         }

--- a/crates/storage/tests/index_tests.rs
+++ b/crates/storage/tests/index_tests.rs
@@ -538,9 +538,13 @@ async fn test_composite_unique_enforced_on_non_null() {
 
     // Should fail - same non-NULL values
     let result = index.save(&mut txn, "doc2", &values).await;
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("violates unique index"));
+    let error = result.expect_err("duplicate composite unique value should fail");
+    assert!(matches!(
+        error,
+        storage::corekv::Error::UniqueConstraintViolation
+    ));
+    assert_eq!(
+        error.to_string(),
+        storage::corekv::UNIQUE_CONSTRAINT_VIOLATION_MESSAGE
+    );
 }


### PR DESCRIPTION
## Summary

Addresses #658 by replacing unique-index violation string matching with a typed storage error while preserving the existing Go-compatible public error message.

## Why

Mutation paths were detecting unique constraint violations by converting errors to strings and checking for a substring. That made the db/query boundary fragile: any wording change in the storage/index layer could silently break duplicate-unique handling.

## Changes

| Area | Change |
|---|---|
| Storage errors | Add `UniqueConstraintViolation` as a typed `storage::Error` variant |
| Unique indexes | Return the typed variant from unique index create/update collision checks |
| DB mutations | Replace duplicated string matching with one typed `index_write_query_error` mapper |
| Compatibility | Preserve the exact public message: `can not index a doc's field(s) that violates unique index.` |
| Tests | Assert typed propagation through storage and db-index paths |

## Out of scope

- No broader redesign of `defra_core::Error` or db error hierarchy.
- No change to unique index semantics.
- No change to HTTP/query response text.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p storage`
- [x] `cargo test -p db unique`
- [x] `cargo test -p db`
- [x] `cargo clippy -p storage -p db --all-targets -- -D warnings`
