### PR TITLE
feat(http): paginate collection doc IDs

### DIFF
--- a/crates/db/src/auto_commit_fetcher.rs
+++ b/crates/db/src/auto_commit_fetcher.rs
@@ -75,6 +75,79 @@ impl<S: Store + 'static> DocFetcher for AutoCommitFetcher<S> {
         result
     }
 
+    async fn get_all_page(
+        &self,
+        collection_name: &str,
+        limit: Option<u64>,
+        offset: u64,
+    ) -> query::error::Result<Vec<Document>> {
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        let datastore = txn.datastore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get datastore for collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+
+        let result = collection
+            .get_all_page_with_datastore(&datastore, limit, offset)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)));
+
+        if let Err(e) = txn.discard() {
+            warn!(
+                collection = %collection_name,
+                error = %e,
+                "Failed to discard read-only transaction after get_all_page"
+            );
+        }
+
+        result
+    }
+
+    async fn count_all(&self, collection_name: &str) -> query::error::Result<u64> {
+        let collection = self
+            .db
+            .get_collection(collection_name)
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
+
+        let txn = self.db.new_txn(true).await.map_err(|e| {
+            query::error::QueryError::execution(format!("failed to create txn: {}", e))
+        })?;
+
+        let datastore = txn.datastore().map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to get datastore for collection '{}': {}",
+                collection_name, e
+            ))
+        })?;
+
+        let result = collection
+            .count_all_with_datastore(&datastore)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)));
+
+        if let Err(e) = txn.discard() {
+            warn!(
+                collection = %collection_name,
+                error = %e,
+                "Failed to discard read-only transaction after count_all"
+            );
+        }
+
+        result
+    }
+
     async fn get_all_with_deleted(
         &self,
         collection_name: &str,

--- a/crates/db/src/collection/crud_datastore.rs
+++ b/crates/db/src/collection/crud_datastore.rs
@@ -73,6 +73,93 @@ impl Collection {
         Ok(result.into_iter().map(|(doc, _)| doc).collect())
     }
 
+    /// Get one page of non-deleted documents using a NamespaceView directly.
+    pub async fn get_all_page_with_datastore(
+        &self,
+        datastore: &NamespaceView,
+        limit: Option<u64>,
+        offset: u64,
+    ) -> Result<Vec<Document>> {
+        let prefix = self.collection_key_prefix();
+        let opts = IterOptions::new().with_prefix(prefix);
+
+        let mut iter = datastore.iterator(opts).await.map_err(Error::Storage)?;
+        let mut docs = Vec::new();
+        let mut skipped = 0u64;
+
+        while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
+            if pair.key.ends_with(b"/v") {
+                continue;
+            }
+
+            let Some(pos) = pair.key.iter().rposition(|&b| b == b'/') else {
+                continue;
+            };
+            let doc_id_str = String::from_utf8_lossy(&pair.key[pos + 1..]);
+            let Ok(doc_id) = doc_id_str.parse::<DocID>() else {
+                continue;
+            };
+
+            if self.is_deleted(datastore, &doc_id).await? {
+                continue;
+            }
+
+            if skipped < offset {
+                skipped += 1;
+                continue;
+            }
+
+            if let Some(limit) = limit {
+                if docs.len() as u64 >= limit {
+                    break;
+                }
+            }
+
+            let mut doc = Document::from_cbor(&pair.value)
+                .map_err(|e| Error::document_at_key(&pair.key, e))?;
+            doc.set_id(doc_id.clone());
+
+            if let Some(version) = self.load_version(datastore, &doc_id).await? {
+                doc.set_schema_version_id(version);
+            }
+
+            docs.push(doc);
+        }
+
+        iter.close().await.map_err(Error::Storage)?;
+        Ok(docs)
+    }
+
+    /// Count non-deleted documents using a NamespaceView directly.
+    pub async fn count_all_with_datastore(&self, datastore: &NamespaceView) -> Result<u64> {
+        let prefix = self.collection_key_prefix();
+        let opts = IterOptions::new().with_prefix(prefix);
+
+        let mut iter = datastore.iterator(opts).await.map_err(Error::Storage)?;
+        let mut count = 0u64;
+
+        while let Some(pair) = iter.next().await.map_err(Error::Storage)? {
+            if pair.key.ends_with(b"/v") {
+                continue;
+            }
+
+            let Some(pos) = pair.key.iter().rposition(|&b| b == b'/') else {
+                continue;
+            };
+            let doc_id_str = String::from_utf8_lossy(&pair.key[pos + 1..]);
+            let Ok(doc_id) = doc_id_str.parse::<DocID>() else {
+                continue;
+            };
+
+            if !self.is_deleted(datastore, &doc_id).await? {
+                count += 1;
+            }
+        }
+
+        iter.close().await.map_err(Error::Storage)?;
+        Ok(count)
+    }
+
     /// Get all documents in the collection with deletion status.
     ///
     /// If `show_deleted` is true, returns all documents including deleted ones.

--- a/crates/db/src/doc_fetcher.rs
+++ b/crates/db/src/doc_fetcher.rs
@@ -90,6 +90,31 @@ impl<S: Store + 'static> DocFetcher for DbDocFetcher<S> {
             .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))
     }
 
+    async fn get_all_page(
+        &self,
+        collection_name: &str,
+        limit: Option<u64>,
+        offset: u64,
+    ) -> query::error::Result<Vec<Document>> {
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
+
+        collection
+            .get_all_page_with_datastore(&datastore, limit, offset)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))
+    }
+
+    async fn count_all(&self, collection_name: &str) -> query::error::Result<u64> {
+        let (collection, datastore) =
+            get_collection_with_lazy_load(&self.txn, collection_name).await?;
+
+        collection
+            .count_all_with_datastore(&datastore)
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("storage error: {}", e)))
+    }
+
     async fn get_all_with_deleted(
         &self,
         collection_name: &str,

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -6,16 +6,20 @@
 //! All endpoints enforce NAC permissions when NAC is enabled.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     Json,
 };
-use serde::Serialize;
+use query::rest::{CollectionDocIdsPage, CollectionDocIdsPagination};
+use serde::{Deserialize, Serialize};
 
 use crate::error::HttpError;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
 use crate::router::{AppState, NodePermission};
+
+const DEFAULT_DOC_IDS_LIMIT: usize = 100;
+const MAX_DOC_IDS_LIMIT: usize = 1000;
 
 /// Response for listing collections.
 #[derive(Debug, Clone, Serialize)]
@@ -27,6 +31,56 @@ pub struct CollectionsResponse {
 #[derive(Debug, Clone, Serialize)]
 pub struct DocIdsResponse {
     pub doc_ids: Vec<String>,
+    pub total: usize,
+    pub offset: usize,
+    pub limit: usize,
+    pub has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_offset: Option<usize>,
+}
+
+impl From<CollectionDocIdsPage> for DocIdsResponse {
+    fn from(page: CollectionDocIdsPage) -> Self {
+        let next_offset = page
+            .has_more
+            .then(|| page.offset.saturating_add(page.doc_ids.len()));
+
+        Self {
+            doc_ids: page.doc_ids,
+            total: page.total,
+            offset: page.offset,
+            limit: page.limit,
+            has_more: page.has_more,
+            next_offset,
+        }
+    }
+}
+
+/// Query parameters for document ID pagination.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub struct DocIdsQuery {
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+impl DocIdsQuery {
+    fn into_pagination(self) -> Result<CollectionDocIdsPagination, HttpError> {
+        let limit = self.limit.unwrap_or(DEFAULT_DOC_IDS_LIMIT);
+        if limit == 0 {
+            return Err(HttpError::BadRequest("limit must be greater than 0".into()));
+        }
+        if limit > MAX_DOC_IDS_LIMIT {
+            return Err(HttpError::BadRequest(format!(
+                "limit must be less than or equal to {}",
+                MAX_DOC_IDS_LIMIT
+            )));
+        }
+
+        Ok(CollectionDocIdsPagination {
+            limit,
+            offset: self.offset.unwrap_or(0),
+        })
+    }
 }
 
 /// List all collection names.
@@ -54,9 +108,9 @@ pub async fn list_collections(
     }
 }
 
-/// Get all document IDs in a collection.
+/// Get document IDs in a collection.
 ///
-/// GET /api/v0/collections/{name}
+/// GET /api/v0/collections/{name}?limit=100&offset=0
 ///
 /// Identity is extracted from the Authorization header and used to filter
 /// documents based on read permissions (protected documents will only be
@@ -67,16 +121,21 @@ pub async fn get_collection_doc_ids(
     State(state): State<AppState>,
     identity: ExtractIdentity,
     Path(name): Path<String>,
+    Query(query): Query<DocIdsQuery>,
 ) -> Result<Json<DocIdsResponse>, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionGet).await?;
+    let pagination = query.into_pagination()?;
 
     let rest = state
         .rest
         .as_ref()
         .ok_or_else(|| HttpError::Internal("REST operations not configured".into()))?;
 
-    match rest.get_collection_doc_ids(&name, identity.did()).await {
-        Ok(doc_ids) => Ok(Json(DocIdsResponse { doc_ids })),
+    match rest
+        .get_collection_doc_ids(&name, pagination, identity.did())
+        .await
+    {
+        Ok(page) => Ok(Json(page.into())),
         Err(e) => {
             tracing::warn!(collection = %name, error = %e, "Failed to get collection doc IDs");
             Err(e.into())
@@ -402,9 +461,12 @@ mod tests {
     use crate::identity_extractor::ExtractIdentity;
     use crate::mock::{FailingMockRestOperations, MockQueryExecutor, MockRestOperations};
     use crate::router::AppStateBuilder;
+    use axum::body::Body;
+    use axum::http::Request;
     use query::executor::QueryExecutor;
     use query::rest::RestOperations;
     use std::sync::Arc;
+    use tower::ServiceExt;
 
     fn create_state() -> AppState {
         AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
@@ -453,21 +515,93 @@ mod tests {
     async fn test_get_collection_doc_ids() {
         let state = create_state();
         let identity = ExtractIdentity::anonymous();
-        let result =
-            get_collection_doc_ids(State(state), identity, Path("Users".to_string())).await;
+        let result = get_collection_doc_ids(
+            State(state),
+            identity,
+            Path("Users".to_string()),
+            Query(DocIdsQuery::default()),
+        )
+        .await;
         assert!(result.is_ok());
         let response = result.unwrap();
         assert_eq!(response.doc_ids.len(), 2);
+        assert_eq!(response.total, 2);
+        assert_eq!(response.offset, 0);
+        assert_eq!(response.limit, DEFAULT_DOC_IDS_LIMIT);
+        assert!(!response.has_more);
+        assert_eq!(response.next_offset, None);
         assert!(response.doc_ids.contains(&"bae-123".to_string()));
         assert!(response.doc_ids.contains(&"bae-456".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_get_collection_doc_ids_paginated() {
+        let state = create_state();
+        let identity = ExtractIdentity::anonymous();
+        let result = get_collection_doc_ids(
+            State(state),
+            identity,
+            Path("Users".to_string()),
+            Query(DocIdsQuery {
+                limit: Some(1),
+                offset: Some(0),
+            }),
+        )
+        .await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.doc_ids, vec!["bae-123".to_string()]);
+        assert_eq!(response.total, 2);
+        assert_eq!(response.offset, 0);
+        assert_eq!(response.limit, 1);
+        assert!(response.has_more);
+        assert_eq!(response.next_offset, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_get_collection_doc_ids_rejects_invalid_limit() {
+        let state = create_state();
+        let identity = ExtractIdentity::anonymous();
+        let result = get_collection_doc_ids(
+            State(state),
+            identity,
+            Path("Users".to_string()),
+            Query(DocIdsQuery {
+                limit: Some(MAX_DOC_IDS_LIMIT + 1),
+                offset: None,
+            }),
+        )
+        .await;
+        assert!(matches!(result, Err(HttpError::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn test_get_collection_doc_ids_route_is_registered() {
+        let app = crate::router::create_router_with_state(create_state());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v0/collections/Users?limit=1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn test_get_collection_doc_ids_not_found() {
         let state = create_state();
         let identity = ExtractIdentity::anonymous();
-        let result =
-            get_collection_doc_ids(State(state), identity, Path("NonExistent".to_string())).await;
+        let result = get_collection_doc_ids(
+            State(state),
+            identity,
+            Path("NonExistent".to_string()),
+            Query(DocIdsQuery::default()),
+        )
+        .await;
         assert!(result.is_err());
         match result.unwrap_err() {
             HttpError::NotFound(msg) => assert!(msg.contains("NonExistent")),
@@ -479,8 +613,13 @@ mod tests {
     async fn test_get_collection_doc_ids_no_rest() {
         let state = create_state_without_rest();
         let identity = ExtractIdentity::anonymous();
-        let result =
-            get_collection_doc_ids(State(state), identity, Path("Users".to_string())).await;
+        let result = get_collection_doc_ids(
+            State(state),
+            identity,
+            Path("Users".to_string()),
+            Query(DocIdsQuery::default()),
+        )
+        .await;
         assert!(result.is_err());
     }
 
@@ -488,10 +627,17 @@ mod tests {
     async fn test_get_empty_collection() {
         let state = create_state();
         let identity = ExtractIdentity::anonymous();
-        let result =
-            get_collection_doc_ids(State(state), identity, Path("Books".to_string())).await;
+        let result = get_collection_doc_ids(
+            State(state),
+            identity,
+            Path("Books".to_string()),
+            Query(DocIdsQuery::default()),
+        )
+        .await;
         assert!(result.is_ok());
         let response = result.unwrap();
         assert!(response.doc_ids.is_empty());
+        assert_eq!(response.total, 0);
+        assert!(!response.has_more);
     }
 }

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -37,7 +37,8 @@ pub use graphql::{
 // Re-export REST handlers
 pub use collections::{
     collection_exists, delete_collection, delete_collection_versions, describe_collection,
-    find_collection_by_id, get_all_collections, get_collection_by_version_id, list_collections,
-    patch_collection, set_active, truncate_collection, CollectionsResponse,
+    find_collection_by_id, get_all_collections, get_collection_by_version_id,
+    get_collection_doc_ids, list_collections, patch_collection, set_active, truncate_collection,
+    CollectionsResponse,
 };
 pub use documents::{create_document, delete_document, get_document, update_document};

--- a/crates/http/src/mock/rest.rs
+++ b/crates/http/src/mock/rest.rs
@@ -6,7 +6,9 @@ use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use query::rest::{RestError, RestOperations, RestResult};
+use query::rest::{
+    CollectionDocIdsPage, CollectionDocIdsPagination, RestError, RestOperations, RestResult,
+};
 
 /// Internal document storage for mock REST operations.
 #[derive(Debug, Clone, Default)]
@@ -105,11 +107,25 @@ impl RestOperations for MockRestOperations {
     async fn get_collection_doc_ids(
         &self,
         collection: &str,
+        pagination: CollectionDocIdsPagination,
         _identity: Option<&Did>,
-    ) -> RestResult<Vec<String>> {
+    ) -> RestResult<CollectionDocIdsPage> {
         let collections = self.collections.read().unwrap();
         match collections.get(collection) {
-            Some(docs) => Ok(docs.iter().map(|d| d.doc_id.clone()).collect()),
+            Some(docs) => {
+                let total = docs.len();
+                let start = pagination.offset.min(total);
+                let end = start.saturating_add(pagination.limit).min(total);
+                let doc_ids = docs[start..end].iter().map(|d| d.doc_id.clone()).collect();
+
+                Ok(CollectionDocIdsPage {
+                    doc_ids,
+                    total,
+                    offset: pagination.offset,
+                    limit: pagination.limit,
+                    has_more: end < total,
+                })
+            }
             None => Err(RestError::collection_not_found(collection)),
         }
     }
@@ -284,8 +300,9 @@ impl RestOperations for FailingMockRestOperations {
     async fn get_collection_doc_ids(
         &self,
         _collection: &str,
+        _pagination: CollectionDocIdsPagination,
         _identity: Option<&Did>,
-    ) -> RestResult<Vec<String>> {
+    ) -> RestResult<CollectionDocIdsPage> {
         Err(self.error.clone())
     }
 

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -80,7 +80,9 @@ pub fn create_router_with_state(state: AppState) -> Router {
         .route("/indexes", get(handlers::index::go_list_all_indexes))
         .route(
             "/{name}",
-            post(handlers::create_document).delete(handlers::delete_collection),
+            get(handlers::get_collection_doc_ids)
+                .post(handlers::create_document)
+                .delete(handlers::delete_collection),
         )
         .route("/{name}/describe", get(handlers::describe_collection))
         .route("/{name}/exists", get(handlers::collection_exists))

--- a/crates/query-plan/src/fetcher.rs
+++ b/crates/query-plan/src/fetcher.rs
@@ -121,6 +121,37 @@ pub trait DocFetcher: MaybeSendSync {
     /// Get all documents from a collection (excludes deleted documents).
     async fn get_all(&self, collection_name: &str) -> Result<Vec<Document>>;
 
+    /// Get a page of documents from a collection (excludes deleted documents).
+    ///
+    /// Implementations can override this to stop storage iteration once the
+    /// requested page has been collected. The default keeps existing fetcher
+    /// behavior by loading all documents and slicing in memory.
+    async fn get_all_page(
+        &self,
+        collection_name: &str,
+        limit: Option<u64>,
+        offset: u64,
+    ) -> Result<Vec<Document>> {
+        let docs = self.get_all(collection_name).await?;
+        let offset = usize::try_from(offset).unwrap_or(usize::MAX);
+        let iter = docs.into_iter().skip(offset);
+
+        Ok(match limit {
+            Some(limit) => iter
+                .take(usize::try_from(limit).unwrap_or(usize::MAX))
+                .collect(),
+            None => iter.collect(),
+        })
+    }
+
+    /// Count all non-deleted documents in a collection.
+    ///
+    /// Implementations can override this to count while iterating keys instead
+    /// of materializing every document. The default preserves existing behavior.
+    async fn count_all(&self, collection_name: &str) -> Result<u64> {
+        Ok(self.get_all(collection_name).await?.len() as u64)
+    }
+
     /// Get all documents from a collection with their deletion status.
     ///
     /// If `show_deleted` is true, returns all documents including deleted ones.

--- a/crates/query/src/rest/mod.rs
+++ b/crates/query/src/rest/mod.rs
@@ -9,7 +9,7 @@ mod trait_def;
 
 pub use error::{RestError, RestResult};
 pub use operations::RestOperationsImpl;
-pub use trait_def::RestOperations;
+pub use trait_def::{CollectionDocIdsPage, CollectionDocIdsPagination, RestOperations};
 
 #[cfg(test)]
 mod tests;

--- a/crates/query/src/rest/operations.rs
+++ b/crates/query/src/rest/operations.rs
@@ -11,7 +11,7 @@ use crate::runner::QueryRunner;
 use crate::txn::TransactionRegistry;
 
 use super::error::{RestError, RestResult};
-use super::trait_def::RestOperations;
+use super::trait_def::{CollectionDocIdsPage, CollectionDocIdsPagination, RestOperations};
 
 /// Production implementation of REST operations using QueryRunner.
 ///
@@ -55,9 +55,18 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperationsImpl<F, R> {
         }
     }
 
-    fn build_list_ids_query(&self, collection: &str) -> String {
+    fn build_list_ids_query(&self, collection: &str, limit: usize, offset: usize) -> String {
         format!(
-            r#"{{ {collection} {{ _docID }} }}"#,
+            r#"{{ {collection}(limit: {limit}, offset: {offset}) {{ _docID }} }}"#,
+            collection = collection,
+            limit = limit,
+            offset = offset
+        )
+    }
+
+    fn build_count_query(&self, collection: &str) -> String {
+        format!(
+            r#"{{ total: COUNT({collection}: {{}}) }}"#,
             collection = collection
         )
     }
@@ -135,6 +144,40 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperationsImpl<F, R> {
             .collect())
     }
 
+    fn extract_total(&self, result: &JsonValue, collection: &str) -> RestResult<usize> {
+        let total = result
+            .get("total")
+            .and_then(|value| value.as_u64())
+            .ok_or_else(|| {
+                tracing::warn!(
+                    collection = %collection,
+                    result = ?result,
+                    "Count result missing numeric total"
+                );
+                RestError::internal(format!("count result missing total for '{}'", collection))
+            })?;
+
+        usize::try_from(total).map_err(|_| {
+            RestError::internal(format!(
+                "count result for '{}' does not fit into usize",
+                collection
+            ))
+        })
+    }
+
+    async fn count_collection_doc_ids(
+        &self,
+        collection: &str,
+        identity: Option<&Did>,
+    ) -> RestResult<usize> {
+        let query = self.build_count_query(collection);
+        let result = self
+            .runner
+            .execute_query_with_identity(&query, identity.cloned())
+            .await?;
+        self.extract_total(&result, collection)
+    }
+
     async fn fetch_full_document(
         &self,
         collection: &str,
@@ -192,8 +235,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
     async fn get_collection_doc_ids(
         &self,
         collection: &str,
+        pagination: CollectionDocIdsPagination,
         identity: Option<&Did>,
-    ) -> RestResult<Vec<String>> {
+    ) -> RestResult<CollectionDocIdsPage> {
         if !self
             .runner
             .has_collection(collection)
@@ -203,12 +247,24 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Err(RestError::collection_not_found(collection));
         }
 
-        let query = self.build_list_ids_query(collection);
+        let fetch_limit = pagination.limit.saturating_add(1);
+        let query = self.build_list_ids_query(collection, fetch_limit, pagination.offset);
         let result = self
             .runner
             .execute_query_with_identity(&query, identity.cloned())
             .await?;
-        self.extract_doc_ids(&result, collection)
+        let mut doc_ids = self.extract_doc_ids(&result, collection)?;
+        let has_more = doc_ids.len() > pagination.limit;
+        doc_ids.truncate(pagination.limit);
+        let total = self.count_collection_doc_ids(collection, identity).await?;
+
+        Ok(CollectionDocIdsPage {
+            doc_ids,
+            total,
+            offset: pagination.offset,
+            limit: pagination.limit,
+            has_more,
+        })
     }
 
     async fn get_document(

--- a/crates/query/src/rest/tests.rs
+++ b/crates/query/src/rest/tests.rs
@@ -1,7 +1,12 @@
 use super::*;
 use crate::error::QueryError;
+use crate::runner::QueryRunner;
+use crate::test_utils::MockFetcher;
+use document::Document;
+use schema::{CollectionVersion, FieldDescription, FieldKind};
 use serde_json::json;
 use serde_json::Value as JsonValue;
+use std::sync::Arc;
 
 fn json_to_graphql(value: &JsonValue) -> String {
     match value {
@@ -229,4 +234,54 @@ fn test_rest_error_from_query_error() {
     let rest_err: RestError = err.into();
     assert!(matches!(rest_err, RestError::PermissionDenied(_)));
     assert!(rest_err.to_string().contains("ACP registration failed"));
+}
+
+#[tokio::test]
+async fn test_get_collection_doc_ids_paginates_and_counts() {
+    let fetcher = MockFetcher::new();
+    fetcher.add_doc(
+        "Users",
+        Document::from_json_str(r#"{"_docID":"bae-11111111-1111-1111-1111-111111111111"}"#)
+            .unwrap(),
+    );
+    fetcher.add_doc(
+        "Users",
+        Document::from_json_str(r#"{"_docID":"bae-22222222-2222-2222-2222-222222222222"}"#)
+            .unwrap(),
+    );
+    fetcher.add_doc(
+        "Users",
+        Document::from_json_str(r#"{"_docID":"bae-33333333-3333-3333-3333-333333333333"}"#)
+            .unwrap(),
+    );
+
+    let collection = CollectionVersion::new(
+        "Users",
+        "v1",
+        "coll-users",
+        vec![FieldDescription::new("1", "_docID", FieldKind::doc_id())],
+    );
+    let runner = Arc::new(QueryRunner::new(fetcher, vec![collection]));
+    let rest = RestOperationsImpl::new(runner);
+
+    let page = rest
+        .get_collection_doc_ids(
+            "Users",
+            CollectionDocIdsPagination {
+                limit: 1,
+                offset: 1,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        page.doc_ids,
+        vec!["bae-22222222-2222-2222-2222-222222222222".to_string()]
+    );
+    assert_eq!(page.total, 3);
+    assert_eq!(page.offset, 1);
+    assert_eq!(page.limit, 1);
+    assert!(page.has_more);
 }

--- a/crates/query/src/rest/trait_def.rs
+++ b/crates/query/src/rest/trait_def.rs
@@ -7,6 +7,23 @@ use storage::corekv::MaybeSendSync;
 
 use super::error::RestResult;
 
+/// Pagination request for collection document ID listing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CollectionDocIdsPagination {
+    pub limit: usize,
+    pub offset: usize,
+}
+
+/// Paginated document IDs in a collection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CollectionDocIdsPage {
+    pub doc_ids: Vec<String>,
+    pub total: usize,
+    pub offset: usize,
+    pub limit: usize,
+    pub has_more: bool,
+}
+
 /// REST operations trait for collection and document CRUD.
 ///
 /// This trait provides REST-specific operations separate from GraphQL execution.
@@ -25,12 +42,13 @@ pub trait RestOperations: MaybeSendSync {
     /// List all collection names.
     async fn list_collections(&self) -> RestResult<Vec<String>>;
 
-    /// Get all document IDs in a collection.
+    /// Get document IDs in a collection.
     async fn get_collection_doc_ids(
         &self,
         collection: &str,
+        pagination: CollectionDocIdsPagination,
         identity: Option<&Did>,
-    ) -> RestResult<Vec<String>>;
+    ) -> RestResult<CollectionDocIdsPage>;
 
     /// Get a single document by ID.
     async fn get_document(

--- a/crates/query/src/runner/fetcher.rs
+++ b/crates/query/src/runner/fetcher.rs
@@ -97,6 +97,35 @@ impl DocFetcher for FetcherWrapper {
             })
     }
 
+    async fn get_all_page(
+        &self,
+        collection_name: &str,
+        limit: Option<u64>,
+        offset: u64,
+    ) -> Result<Vec<Document>> {
+        self.get_fetcher()
+            .get_all_page(collection_name, limit, offset)
+            .await
+            .map_err(|e| {
+                QueryError::execution(format!(
+                    "fetcher error during planner execution for collection '{}' (page limit {:?}, offset {}): {}",
+                    collection_name, limit, offset, e
+                ))
+            })
+    }
+
+    async fn count_all(&self, collection_name: &str) -> Result<u64> {
+        self.get_fetcher()
+            .count_all(collection_name)
+            .await
+            .map_err(|e| {
+                QueryError::execution(format!(
+                    "fetcher error during planner execution for collection '{}' (count): {}",
+                    collection_name, e
+                ))
+            })
+    }
+
     async fn get_all_with_deleted(
         &self,
         collection_name: &str,

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -29,6 +29,19 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         collection: &Arc<CollectionVersion>,
         identity: Option<Did>,
     ) -> Result<JsonValue> {
+        if collection.policy.is_none() && select.fields.len() == 1 {
+            if let Some(Requestable::Aggregate(agg)) = select.fields.first() {
+                let can_count_at_fetch = agg.aggregate_type == crate::mapper::AggregateType::Count
+                    && agg.targets.len() == 1
+                    && agg.targets[0].filter.is_none()
+                    && agg.targets[0].field_name.is_none();
+                if can_count_at_fetch {
+                    let count = fetcher.count_all(&select.collection_name).await?;
+                    return Ok(JsonValue::Number(count.into()));
+                }
+            }
+        }
+
         // Fetch all documents from the collection
         let docs = fetcher.get_all(&select.collection_name).await?;
 

--- a/crates/query/src/runner/query/simple.rs
+++ b/crates/query/src/runner/query/simple.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn};
 
 use crate::document::{documents_to_plan_docs, documents_with_status_to_plan_docs};
 use crate::error::Result;
-use crate::mapper::Select;
+use crate::mapper::{Requestable, Select};
 use crate::planner::index_selection::{filter_to_index_scan, select_best_index};
 use crate::txn::TransactionRegistry;
 
@@ -28,8 +28,31 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         collection: &Arc<CollectionVersion>,
         identity: Option<Did>,
     ) -> Result<JsonValue> {
+        let can_page_at_fetch = select.limit.is_some()
+            && !select.show_deleted
+            && select.filter.is_none()
+            && select.doc_ids.is_none()
+            && select.order_by.is_none()
+            && select.group_by.is_none()
+            && collection.policy.is_none()
+            && select
+                .fields
+                .iter()
+                .all(|field| !matches!(field, Requestable::Aggregate(_)));
+        let select_without_limit;
+        let select_for_plan = if can_page_at_fetch {
+            select_without_limit = {
+                let mut select = select.clone();
+                select.limit = None;
+                select
+            };
+            &select_without_limit
+        } else {
+            select
+        };
+
         // Build document mapping first (needed for both paths)
-        let mapping = plan::build_mapping(select, collection)?;
+        let mapping = plan::build_mapping(select_for_plan, collection)?;
 
         // When show_deleted is true, we need to use get_all_with_deleted to include
         // logically deleted documents. The doc_ids filter will be applied by the plan.
@@ -104,7 +127,18 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     fetcher.get_all(&select.collection_name).await?
                 }
             } else {
-                fetcher.get_all(&select.collection_name).await?
+                if can_page_at_fetch {
+                    let limit = select.limit.as_ref().and_then(|limit| match limit.limit {
+                        Some(0) => None,
+                        other => other,
+                    });
+                    let offset = select.limit.as_ref().map(|limit| limit.offset).unwrap_or(0);
+                    fetcher
+                        .get_all_page(&select.collection_name, limit, offset)
+                        .await?
+                } else {
+                    fetcher.get_all(&select.collection_name).await?
+                }
             };
             documents_to_plan_docs(&docs, &mapping)?
         };
@@ -118,8 +152,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         });
 
         // Build and execute the plan (ACP filter is inserted inside, after Select but before aggregates)
-        let mut plan =
-            plan::build_plan(select, plan_docs, mapping.clone(), collection, acp_filter)?;
+        let mut plan = plan::build_plan(
+            select_for_plan,
+            plan_docs,
+            mapping.clone(),
+            collection,
+            acp_filter,
+        )?;
 
         // Execute the plan and collect results
         plan.init().await?;


### PR DESCRIPTION
## Summary

Addresses #105 by adding bounded pagination metadata to `GET /api/v0/collections/{name}` and wiring the missing GET route for collection document ID listing.

## Why

The collection document ID endpoint could return every ID in one response. That makes large collections expensive for clients and servers, and the Rust router was not exposing the existing handler through the expected GET route.

## Changes

| Area | Change |
|---|---|
| HTTP API | Add `limit` and `offset` query params with default `100` and max `1000` |
| Response | Return `doc_ids`, `total`, `offset`, `limit`, `has_more`, and `next_offset` |
| Router | Register `GET /api/v0/collections/{name}` for document ID listing |
| REST layer | Pass pagination through `RestOperations` and fetch `limit + 1` to detect more pages |
| Query/storage | Add paged fetch and count hooks so simple unfiltered reads avoid materializing full collections when safe |
| Tests | Cover handler pagination, invalid limits, route registration, and REST operation pagination/counting |

## Out of scope

- No cursor pagination.
- No pagination for filtered or ordered arbitrary GraphQL queries beyond the existing query support.
- No change to document CRUD routes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p query`
- [x] `cargo test -p defra-http`
- [x] `cargo test -p db`
- [x] `cargo test -p query-plan`
- [x] `cargo clippy -p query-plan -p query -p db -p defra-http --all-targets -- -D warnings`