### PR TITLE
fix(p2p): match Go Kademlia parallelism and auto mode (#831)

### DIFF
--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -26,6 +26,7 @@
 //! IPFS block exchange protocol (1.0.0, 1.1.0, 1.2.0), enabling
 //! interoperability with Go DefraDB.
 
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -34,7 +35,7 @@ use libp2p::{
     connection_limits::{self, ConnectionLimits},
     gossipsub::{self, MessageAuthenticity, MessageId, ValidationMode},
     identify,
-    kad::{self, store::MemoryStore, Mode},
+    kad::{self, store::MemoryStore},
     relay,
     request_response::{self, ProtocolSupport},
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
@@ -50,6 +51,13 @@ use crate::message::{PushLogReply, PushLogRequest};
 
 /// Timeout for PushLog requests.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Kademlia query parallelism. Matches Go's `dht.Concurrency(10)`
+/// (`go-p2p/host.go:44`). rust-libp2p defaults to `ALPHA_VALUE` = 3.
+const KAD_PARALLELISM: NonZeroUsize = match NonZeroUsize::new(10) {
+    Some(n) => n,
+    None => unreachable!(),
+};
 
 /// Composite network behaviour for DefraDB nodes.
 #[derive(NetworkBehaviour)]
@@ -240,9 +248,15 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
         // Configure Kademlia DHT for peer discovery
         // Required for Bitswap to find peers who have specific blocks
         let kad_store = MemoryStore::new(local_peer_id);
-        let mut kademlia = kad::Behaviour::new(local_peer_id, kad_store);
-        // Run as server to respond to DHT queries from other peers
-        kademlia.set_mode(Some(Mode::Server));
+        let mut kad_config = kad::Config::default();
+        // Match Go DefraDB's `dht.Concurrency(10)` (`go-p2p/host.go:44`).
+        // rust-libp2p defaults to ALPHA_VALUE = 3.
+        kad_config.set_parallelism(KAD_PARALLELISM);
+        let mut kademlia = kad::Behaviour::with_config(local_peer_id, kad_store, kad_config);
+        // Auto mode mirrors Go's `dht.ModeAuto` (`go-p2p/host.go:45`):
+        // start as Client, swap to Server once an external address is
+        // confirmed. set_mode(None) is rust-libp2p's auto-mode opt-in.
+        kademlia.set_mode(None);
 
         // Configure Bitswap for block exchange (Go compatibility).
         // iroh-bitswap implements the standard IPFS bitswap protocols.
@@ -339,10 +353,13 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             Toggle::from(None)
         };
 
-        // Configure Kademlia DHT for peer discovery
+        // Configure Kademlia DHT for peer discovery — same Go-parity knobs
+        // as the production constructor (concurrency=10, auto mode).
         let kad_store = MemoryStore::new(local_peer_id);
-        let mut kademlia = kad::Behaviour::new(local_peer_id, kad_store);
-        kademlia.set_mode(Some(Mode::Server));
+        let mut kad_config = kad::Config::default();
+        kad_config.set_parallelism(KAD_PARALLELISM);
+        let mut kademlia = kad::Behaviour::with_config(local_peer_id, kad_store, kad_config);
+        kademlia.set_mode(None);
 
         // Configure Bitswap for block exchange
         let bitswap_config = BitswapConfig::default();


### PR DESCRIPTION
Tracks #831 (sub-task 1: DHT mode + concurrency).

## Summary

Two host-level Kademlia parity tweaks landed in one commit because they share the same `kad::Config` plumbing:

- **Concurrency 10**: rust-libp2p defaults to `ALPHA_VALUE = 3`. Go DefraDB configures `dht.Concurrency(10)` (\`go-p2p/host.go:44\`). Apply the same 10-way parallelism via \`kad::Config::set_parallelism\` so iterative lookups fan out to the same number of peers as Go.
- **Auto mode** (\`set_mode(None)\`): previously forced \`Mode::Server\`. Auto mode starts as Client and swaps to Server once libp2p sees a confirmed external address, mirroring Go's \`dht.Mode(dht.ModeAuto)\` (\`go-p2p/host.go:45\`).

Same knobs applied in both \`DefraBehaviour::new\` (production) and \`new_unsigned\` (test-only) constructors.

## Status note for #831

Of the 7 sub-tasks listed in #831, the bootstrap scheduler items (#6, #7) and transports/relay items (#4, #5) already landed in main:

- ✅ #4 QUIC + WebSocket — landed (\`2276e6a2\`)
- ✅ #5 Relay default true — landed (\`b0c0501f\`)
- ✅ #6 Periodic DHT bootstrap refresh — landed (\`b0c0501f\`)
- ✅ #7 Per-connection bootstrap removed — landed (\`b0c0501f\`)
- 🟡 #1 Dual DHT — this PR addresses the Mode::Auto + Concurrency parts; LAN/WAN split + PublicKey validator still pending (rust-libp2p has no \`NamespacedValidator\` equivalent today)
- ⏳ #2 Active connection manager (low/high watermarks + grace) — not yet
- ⏳ #3 ResourceManager — not yet

## Test plan

- [x] \`cargo test -p p2p --lib\` — 258 passed
- [x] \`cargo test -p integration-test --test p2p\` — 36 passed
- [x] \`cargo test -p integration-test --test acp\` — 196 passed
- [x] \`cargo clippy -p p2p --no-deps -- -D warnings\` clean
- [x] \`cargo fmt --all\` applied