### PR TITLE
fix(query): scope subscriptions by event CID

### DIFF
--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -2,6 +2,26 @@
 //!
 //! This crate provides a pub/sub event system for database changes,
 //! enabling GraphQL subscriptions to receive real-time updates.
+//!
+//! # Go compatibility
+//!
+//! | Surface | Go DefraDB | Rust DefraDB |
+//! | --- | --- | --- |
+//! | Raw event bus | Live-only `Publish`/`Subscribe`/`Unsubscribe` | Live-only `publish`/`subscribe`/`unsubscribe` |
+//! | HTTP GraphQL SSE | Re-runs a scoped query per live update | Re-runs a scoped query per live update |
+//! | FFI GraphQL subscriptions | Polls buffered scoped query results | Polls buffered scoped query results |
+//! | `_commits` subscriptions | Scopes by event CID and preserves docID filters | Scopes by event CID and preserves docID filters |
+//! | Cursor/replay | Not exposed | Not exposed |
+//! | Backpressure | Publisher blocks when channels fill | Messages may be dropped and counted |
+//!
+//! The raw event bus has no cursor, replay API, global sequence, or durable
+//! change log. HTTP and FFI GraphQL subscriptions build on this stream by
+//! re-running a scoped query for each live update.
+//!
+//! Unlike Go's blocking channel bus, the Rust channel bus uses bounded channels
+//! and records dropped messages per subscription. Consumers that observe a
+//! non-zero dropped count must resync from the database before trusting further
+//! incremental observations.
 
 mod bus;
 #[cfg(feature = "channel")]

--- a/crates/ffi/src/query/exec.rs
+++ b/crates/ffi/src/query/exec.rs
@@ -8,9 +8,8 @@ use crate::types::{c_str_to_string, FfiResult};
 use crate::{ffi_async, try_ffi, ERR_INVALID_NODE_HANDLE};
 
 use super::{
-    check_and_set_dac_bypass, extract_doc_id_from_query, is_commits_subscription,
-    nac_permission_for_query, subscription_to_commits_query_with_cid,
-    subscription_to_query_with_doc_id,
+    check_and_set_dac_bypass, nac_permission_for_query, subscription_accepts_doc_id,
+    subscription_doc_ids, subscription_to_scoped_query,
 };
 
 /// Execute a GraphQL query or mutation.
@@ -53,7 +52,7 @@ pub unsafe extern "C" fn exec_request(
         try_ffi!(check_nac_for_node(rt, node_ptr, identity_did, permission));
 
         let identity_str = c_str_to_string(identity_did);
-        let op_name = c_str_to_string(operation_name);
+        let op_name = c_str_to_string(operation_name).filter(|name| !name.is_empty());
         let vars_str = c_str_to_string(variables);
         let batch_session = c_str_to_string(batch_session_id);
 
@@ -103,16 +102,25 @@ pub unsafe extern "C" fn exec_request(
                 None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
             };
 
-            // Extract any pre-existing docID filter from the subscription query
-            let subscription_doc_id = extract_doc_id_from_query(&query_str);
+            let subscription_variables = match vars_str.as_ref() {
+                Some(vars) => match serde_json::from_str::<serde_json::Value>(vars) {
+                    Ok(value) => Some(value),
+                    Err(e) => return FfiResult::error(format!("failed to parse variables: {}", e)),
+                },
+                None => None,
+            };
+            let subscription_doc_ids_filter = subscription_doc_ids(
+                &query_str,
+                subscription_variables.as_ref(),
+                op_name.as_deref(),
+            );
             let sub_query = query_str.clone();
             let sub_identity = did.clone();
+            let sub_operation_name = op_name.clone();
+            let sub_variables = subscription_variables.clone();
 
             // Create result channel for buffering processed subscription results
             let (result_tx, result_rx) = tokio::sync::mpsc::channel::<String>(256);
-
-            // Detect if this is a _commits subscription (uses CID-based queries)
-            let is_commits = is_commits_subscription(&query_str);
 
             // Capture signing config and DAC bypass before spawning.
             // The thread-locals were set on this thread (lines 63-116) but the
@@ -127,26 +135,36 @@ pub unsafe extern "C" fn exec_request(
                     if let Some(update) = message.as_update() {
                         let event_doc_id = update.doc_id.clone();
 
-                        // Check subscription docID filter
-                        if let Some(ref sub_doc) = subscription_doc_id {
-                            if event_doc_id != *sub_doc {
-                                continue;
-                            }
+                        if !subscription_accepts_doc_id(
+                            subscription_doc_ids_filter.as_deref(),
+                            &event_doc_id,
+                        ) {
+                            continue;
                         }
 
-                        // Convert subscription to a query scoped to the changed document.
-                        // For _commits subscriptions, use the event's CID to get just the
-                        // composite commit. For regular subscriptions, use docID.
-                        let query_text = if is_commits {
-                            let cid_str = update.cid.to_string();
-                            subscription_to_commits_query_with_cid(&sub_query, &cid_str)
-                        } else {
-                            subscription_to_query_with_doc_id(&sub_query, &event_doc_id)
+                        let cid_str = update.cid.to_string();
+                        let query_text = match subscription_to_scoped_query(
+                            &sub_query,
+                            &event_doc_id,
+                            &cid_str,
+                            sub_operation_name.as_deref(),
+                        ) {
+                            Ok(query) => query,
+                            Err(error) => {
+                                tracing::warn!(error = %error, "failed to scope subscription query");
+                                continue;
+                            }
                         };
 
                         let mut request = query::QueryRequest::new(query_text);
                         if sub_identity.is_some() {
                             request = request.with_identity(sub_identity.clone());
+                        }
+                        if let Some(ref op_name) = sub_operation_name {
+                            request = request.with_operation_name(op_name.clone());
+                        }
+                        if let Some(ref vars) = sub_variables {
+                            request = request.with_variables(vars.clone());
                         }
 
                         // Execute inside spawn_blocking to pin thread-locals, matching

--- a/crates/ffi/src/query/mod.rs
+++ b/crates/ffi/src/query/mod.rs
@@ -19,8 +19,7 @@ use crate::types::c_str_to_string;
 // Re-export all public items so external imports remain unchanged.
 pub use exec::exec_request;
 pub(crate) use subscription::{
-    extract_doc_id_from_query, is_commits_subscription, subscription_to_commits_query_with_cid,
-    subscription_to_query_with_doc_id,
+    subscription_accepts_doc_id, subscription_doc_ids, subscription_to_scoped_query,
 };
 
 /// Determine NAC permission based on query content.

--- a/crates/ffi/src/query/subscription.rs
+++ b/crates/ffi/src/query/subscription.rs
@@ -1,4 +1,3 @@
 pub(crate) use query::subscription::{
-    extract_doc_id_from_query, is_commits_subscription, subscription_to_commits_query_with_cid,
-    subscription_to_query_with_doc_id,
+    subscription_accepts_doc_id, subscription_doc_ids, subscription_to_scoped_query,
 };

--- a/crates/http/src/handlers/graphql/query.rs
+++ b/crates/http/src/handlers/graphql/query.rs
@@ -24,8 +24,8 @@ where
     Ok(opt.filter(|s| !s.is_empty()))
 }
 use query::subscription::{
-    extract_doc_id_from_query, is_commits_subscription, response_has_data,
-    subscription_to_commits_query_with_cid, subscription_to_query_with_doc_id,
+    is_subscription_operation, response_has_data, subscription_accepts_doc_id,
+    subscription_doc_ids, subscription_to_scoped_query,
 };
 use query::{parse_request, ParsedOperation};
 
@@ -263,9 +263,10 @@ pub async fn graphql_transactional(
     // Fast path: skip the full GraphQL parse for mutations/queries (the common case).
     // Only do the full parse when the query might be a subscription.
     if might_be_subscription(&request.query)
-        && matches!(
-            parse_request(&request.query),
-            Ok(ParsedOperation::Subscription { .. })
+        && is_subscription_operation(
+            &request.query,
+            request.variables.as_ref(),
+            request.operation_name.as_deref(),
         )
     {
         if !wants_sse(&headers) {
@@ -335,14 +336,16 @@ async fn graphql_sse(
 
     let mut subscription = event_bus.subscribe(&[events::EventName::Update]);
     let query_str = request.query;
+    let operation_name = request.operation_name;
+    let variables = request.variables;
     let did = identity.did().cloned();
 
     // Resolve signing config and DAC bypass once at subscription setup time
     let signing_config = crate::query_context::resolve_signing_config(&state, &identity);
     let dac_bypass = crate::query_context::resolve_dac_bypass(&state, &identity).await;
 
-    let subscription_doc_id = extract_doc_id_from_query(&query_str);
-    let is_commits = is_commits_subscription(&query_str);
+    let subscription_doc_ids_filter =
+        subscription_doc_ids(&query_str, variables.as_ref(), operation_name.as_deref());
 
     let executor = state.executor.clone();
 
@@ -351,24 +354,36 @@ async fn graphql_sse(
             if let Some(update) = message.as_update() {
                 let event_doc_id = update.doc_id.clone();
 
-                // Check subscription docID filter
-                if let Some(ref sub_doc) = subscription_doc_id {
-                    if event_doc_id != *sub_doc {
-                        continue;
-                    }
+                if !subscription_accepts_doc_id(
+                    subscription_doc_ids_filter.as_deref(),
+                    &event_doc_id,
+                ) {
+                    continue;
                 }
 
-                // Convert subscription to a scoped query
-                let query_text = if is_commits {
-                    let cid_str = update.cid.to_string();
-                    subscription_to_commits_query_with_cid(&query_str, &cid_str)
-                } else {
-                    subscription_to_query_with_doc_id(&query_str, &event_doc_id)
+                let cid_str = update.cid.to_string();
+                let query_text = match subscription_to_scoped_query(
+                    &query_str,
+                    &event_doc_id,
+                    &cid_str,
+                    operation_name.as_deref(),
+                ) {
+                    Ok(query) => query,
+                    Err(error) => {
+                        tracing::warn!(error = %error, "failed to scope subscription query");
+                        continue;
+                    }
                 };
 
                 let mut req = QueryRequest::new(query_text);
                 if did.is_some() {
                     req = req.with_identity(did.clone());
+                }
+                if let Some(ref op_name) = operation_name {
+                    req = req.with_operation_name(op_name.clone());
+                }
+                if let Some(ref vars) = variables {
+                    req = req.with_variables(vars.clone());
                 }
                 let response = execute_with_resolved_context(
                     executor.clone(),

--- a/crates/query/src/subscription.rs
+++ b/crates/query/src/subscription.rs
@@ -1,174 +1,178 @@
-//! Shared subscription helpers for converting subscription queries to scoped queries.
+//! Shared subscription helpers for converting live subscription events into scoped queries.
 //!
 //! Used by both FFI and HTTP code paths to process subscription events.
 
+use std::collections::HashMap;
+
+use graphql_parser::query::{
+    Definition, Field, OperationDefinition, Query as GqlQuery, Selection, SelectionSet,
+    Subscription, Value,
+};
+use serde_json::Value as JsonValue;
+
+use crate::error::{QueryError, Result};
+use crate::query_parse::{parse_request_with_variables, ParsedOperation};
 use crate::QueryResponse;
 
-/// Extract a docID value from a GraphQL query string.
-///
-/// Looks for patterns like `docID: "bae-xxx"` or `docID:"bae-xxx"` in the query.
-/// Returns None if no docID is found.
-pub fn extract_doc_id_from_query(query: &str) -> Option<String> {
-    let doc_id_marker = "docID:";
-    let pos = query.find(doc_id_marker)?;
-    let after = &query[pos + doc_id_marker.len()..];
-    let after = after.trim_start();
+/// Check whether the provided request resolves to a subscription operation.
+pub fn is_subscription_operation(
+    query: &str,
+    variables: Option<&JsonValue>,
+    operation_name: Option<&str>,
+) -> bool {
+    let variable_map = variables_to_map(variables);
+    matches!(
+        parse_request_with_variables(query, variable_map.as_ref(), operation_name),
+        Ok(ParsedOperation::Subscription { .. })
+    )
+}
 
-    if after.starts_with('"') {
-        let value_start = 1;
-        let value_end = after[value_start..].find('"')?;
-        Some(after[value_start..value_start + value_end].to_string())
-    } else {
-        None
+/// Extract the parsed docID/docIDs filter from a subscription root field.
+pub fn subscription_doc_ids(
+    query: &str,
+    variables: Option<&JsonValue>,
+    operation_name: Option<&str>,
+) -> Option<Vec<String>> {
+    let variable_map = variables_to_map(variables);
+    match parse_request_with_variables(query, variable_map.as_ref(), operation_name).ok()? {
+        ParsedOperation::Subscription { select } => select.doc_ids.clone(),
+        _ => None,
     }
 }
 
-/// Convert a subscription query to a regular query scoped to a specific docID.
-///
-/// Transforms: `subscription { User(filter: ...) { fields } }`
-/// Into: `{ User(docID: "bae-xxx", filter: ...) { fields } }`
-pub fn subscription_to_query_with_doc_id(subscription_query: &str, doc_id: &str) -> String {
-    // Step 1: Remove "subscription" keyword
-    let trimmed = subscription_query.trim_start();
-    let query = if let Some(after) = trimmed.strip_prefix("subscription") {
-        let after = after.trim_start();
-        if after.starts_with('{') {
-            after.to_string()
-        } else if let Some(brace_pos) = after.find('{') {
-            after[brace_pos..].to_string()
-        } else {
-            after.to_string()
-        }
-    } else {
-        trimmed.to_string()
-    };
-
-    // Step 2: Find the root field name and inject docID
-    let brace_pos = match query.find('{') {
-        Some(p) => p,
-        None => return query,
-    };
-
-    let after_brace = &query[brace_pos + 1..];
-    let ws_len = after_brace.len() - after_brace.trim_start().len();
-    let field_start_in_q = brace_pos + 1 + ws_len;
-
-    let rest = &query[field_start_in_q..];
-    let field_end = rest
-        .find(|c: char| !c.is_alphanumeric() && c != '_')
-        .unwrap_or(rest.len());
-    let after_field = field_start_in_q + field_end;
-
-    let post_field = query[after_field..].trim_start();
-    if post_field.starts_with('(') {
-        let paren_idx = match query[after_field..].find('(') {
-            Some(offset) => after_field + offset,
-            None => return query,
-        };
-
-        if extract_doc_id_from_query(&query).is_some() {
-            query
-        } else {
-            format!(
-                "{}docID: \"{}\", {}",
-                &query[..paren_idx + 1],
-                doc_id,
-                &query[paren_idx + 1..]
-            )
-        }
-    } else {
-        format!(
-            "{}(docID: \"{}\"){}",
-            &query[..after_field],
-            doc_id,
-            &query[after_field..]
-        )
-    }
+/// Return whether a live update belongs to the subscription's explicit docID filter.
+pub fn subscription_accepts_doc_id(doc_ids: Option<&[String]>, event_doc_id: &str) -> bool {
+    doc_ids
+        .map(|ids| ids.iter().any(|id| id == event_doc_id))
+        .unwrap_or(true)
 }
 
-/// Check if a subscription query targets the `_commits` root field.
-pub fn is_commits_subscription(query: &str) -> bool {
-    let trimmed = query.trim_start();
-    let after_sub = trimmed.strip_prefix("subscription").unwrap_or(trimmed);
-    let brace_pos = match after_sub.find('{') {
-        Some(p) => p,
-        None => return false,
-    };
-    let after_brace = after_sub[brace_pos + 1..].trim_start();
-    after_brace.starts_with("_commits")
-}
-
-/// Convert a _commits subscription to a query scoped to a specific CID.
+/// Convert a subscription operation into a query scoped to the live update's docID and CID.
 ///
-/// Transforms: `subscription { _commits(docID: "...") { fields } }`
-/// Into: `{ _commits(cid: ["bafyrei-xxx"]) { fields } }`
-pub fn subscription_to_commits_query_with_cid(subscription_query: &str, cid: &str) -> String {
-    // Step 1: Remove "subscription" keyword
-    let trimmed = subscription_query.trim_start();
-    let query = if let Some(after) = trimmed.strip_prefix("subscription") {
-        let after = after.trim_start();
-        if after.starts_with('{') {
-            after.to_string()
-        } else if let Some(brace_pos) = after.find('{') {
-            after[brace_pos..].to_string()
-        } else {
-            after.to_string()
-        }
-    } else {
-        trimmed.to_string()
-    };
+/// Normal collection subscriptions are narrowed by both `docID` and `cid`, matching Go's
+/// `Select.ToSubscriptionSelect(docID, cid)` semantics. `_commits` subscriptions preserve
+/// the original arguments and replace only `cid`, matching Go's commit subscription path.
+pub fn subscription_to_scoped_query(
+    subscription_query: &str,
+    event_doc_id: &str,
+    event_cid: &str,
+    operation_name: Option<&str>,
+) -> Result<String> {
+    let document = graphql_parser::parse_query::<String>(subscription_query)
+        .map_err(|err| QueryError::parse(err.to_string()))?
+        .into_static();
 
-    // Step 2: Find the root field name (_commits)
-    let brace_pos = match query.find('{') {
-        Some(p) => p,
-        None => return query,
-    };
+    let mut fragments = Vec::new();
+    let mut scoped_operation = None;
 
-    let after_brace = &query[brace_pos + 1..];
-    let ws_len = after_brace.len() - after_brace.trim_start().len();
-    let field_start_in_q = brace_pos + 1 + ws_len;
-
-    let rest = &query[field_start_in_q..];
-    let field_end = rest
-        .find(|c: char| !c.is_alphanumeric() && c != '_')
-        .unwrap_or(rest.len());
-    let after_field = field_start_in_q + field_end;
-
-    // Step 3: Replace or inject cid argument
-    let post_field = query[after_field..].trim_start();
-    if post_field.starts_with('(') {
-        let paren_start_abs = match query[after_field..].find('(') {
-            Some(offset) => after_field + offset,
-            None => return query,
-        };
-        let mut depth = 0;
-        let mut close_paren_abs = paren_start_abs;
-        for (i, c) in query[paren_start_abs..].char_indices() {
-            if c == '(' {
-                depth += 1;
-            }
-            if c == ')' {
-                depth -= 1;
-                if depth == 0 {
-                    close_paren_abs = paren_start_abs + i;
-                    break;
+    for definition in document.definitions {
+        match definition {
+            Definition::Operation(OperationDefinition::Subscription(subscription))
+                if operation_matches(&subscription.name, operation_name) =>
+            {
+                if scoped_operation.is_some() {
+                    return Err(QueryError::parse(
+                        "operation name is required when multiple subscriptions are present",
+                    ));
                 }
+                scoped_operation = Some(Definition::Operation(OperationDefinition::Query(
+                    scoped_subscription_query(subscription, event_doc_id, event_cid)?,
+                )));
             }
+            Definition::Fragment(fragment) => fragments.push(Definition::Fragment(fragment)),
+            _ => {}
         }
-        format!(
-            "{}(cid: [\"{}\"]){}",
-            &query[..paren_start_abs],
-            cid,
-            &query[close_paren_abs + 1..]
-        )
-    } else {
-        format!(
-            "{}(cid: [\"{}\"]){}",
-            &query[..after_field],
-            cid,
-            &query[after_field..]
-        )
     }
+
+    let Some(operation) = scoped_operation else {
+        return Err(QueryError::parse("subscription operation not found"));
+    };
+
+    let mut definitions = Vec::with_capacity(1 + fragments.len());
+    definitions.push(operation);
+    definitions.extend(fragments);
+
+    Ok(graphql_parser::query::Document { definitions }.to_string())
+}
+
+fn variables_to_map(variables: Option<&JsonValue>) -> Option<HashMap<String, JsonValue>> {
+    variables.and_then(|value| {
+        value.as_object().map(|map| {
+            map.iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect()
+        })
+    })
+}
+
+fn operation_matches(name: &Option<String>, operation_name: Option<&str>) -> bool {
+    operation_name
+        .map(|target| name.as_deref() == Some(target))
+        .unwrap_or(true)
+}
+
+fn scoped_subscription_query(
+    subscription: Subscription<'static, String>,
+    event_doc_id: &str,
+    event_cid: &str,
+) -> Result<GqlQuery<'static, String>> {
+    let mut selection_set = subscription.selection_set;
+    scope_root_selection(&mut selection_set, event_doc_id, event_cid)?;
+
+    Ok(GqlQuery {
+        position: subscription.position,
+        name: subscription.name,
+        variable_definitions: subscription.variable_definitions,
+        directives: subscription.directives,
+        selection_set,
+    })
+}
+
+fn scope_root_selection(
+    selection_set: &mut SelectionSet<'static, String>,
+    event_doc_id: &str,
+    event_cid: &str,
+) -> Result<()> {
+    if selection_set.items.len() != 1 {
+        return Err(QueryError::parse(
+            "subscription must have exactly one root field",
+        ));
+    }
+
+    let Selection::Field(field) = &mut selection_set.items[0] else {
+        return Err(QueryError::parse(
+            "subscription root selection must be a field",
+        ));
+    };
+
+    scope_root_field(field, event_doc_id, event_cid);
+    Ok(())
+}
+
+fn scope_root_field(field: &mut Field<'static, String>, event_doc_id: &str, event_cid: &str) {
+    if field.name == "_commits" {
+        replace_argument(field, "cid", cid_argument(event_cid));
+    } else {
+        remove_argument(field, "docID");
+        remove_argument(field, "docIDs");
+        replace_argument(field, "cid", cid_argument(event_cid));
+        field
+            .arguments
+            .push(("docID".to_string(), Value::String(event_doc_id.to_string())));
+    }
+}
+
+fn replace_argument(field: &mut Field<'static, String>, name: &str, value: Value<'static, String>) {
+    remove_argument(field, name);
+    field.arguments.push((name.to_string(), value));
+}
+
+fn remove_argument(field: &mut Field<'static, String>, name: &str) {
+    field.arguments.retain(|(arg_name, _)| arg_name != name);
+}
+
+fn cid_argument(cid: &str) -> Value<'static, String> {
+    Value::List(vec![Value::String(cid.to_string())])
 }
 
 /// Check if a query response has any non-empty data.
@@ -186,4 +190,96 @@ pub fn response_has_data(response: &QueryResponse) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn parse_scoped_select(
+        query: &str,
+        variables: Option<&JsonValue>,
+        operation_name: Option<&str>,
+    ) -> crate::Select {
+        match parse_request_with_variables(
+            query,
+            variables_to_map(variables).as_ref(),
+            operation_name,
+        )
+        .expect("scoped query should parse")
+        {
+            ParsedOperation::Query { mut selects, .. } => {
+                assert_eq!(selects.len(), 1);
+                selects.remove(0)
+            }
+            other => panic!("expected scoped query, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scopes_collection_subscription_by_event_doc_id_and_cid() {
+        let scoped = subscription_to_scoped_query(
+            r#"subscription { User(docID: "old-doc", filter: {active: {_eq: true}}) { _docID name } }"#,
+            "event-doc",
+            "event-cid",
+            None,
+        )
+        .expect("subscription should scope");
+
+        let select = parse_scoped_select(&scoped, None, None);
+        assert_eq!(select.collection_name, "User");
+        assert_eq!(select.doc_ids, Some(vec!["event-doc".to_string()]));
+        assert_eq!(select.cid, Some(vec!["event-cid".to_string()]));
+        assert!(select.filter.is_some());
+    }
+
+    #[test]
+    fn scopes_commits_subscription_by_cid_without_dropping_doc_id() {
+        let scoped = subscription_to_scoped_query(
+            r#"subscription { _commits(docID: ["target-doc"], cid: ["old-cid"], depth: 3) { cid docID } }"#,
+            "ignored-doc",
+            "event-cid",
+            None,
+        )
+        .expect("commit subscription should scope");
+
+        let select = parse_scoped_select(&scoped, None, None);
+        assert_eq!(select.collection_name, "_commits");
+        assert_eq!(select.doc_ids, Some(vec!["target-doc".to_string()]));
+        assert_eq!(select.cid, Some(vec!["event-cid".to_string()]));
+        assert_eq!(select.depth, Some(3));
+    }
+
+    #[test]
+    fn resolves_subscription_doc_ids_from_variables() {
+        let query = r#"
+            subscription WatchUser($id: ID!, $active: Boolean!) {
+                User(docID: $id, filter: {active: {_eq: $active}}) {
+                    _docID
+                }
+            }
+        "#;
+        let variables = json!({"id": "target-doc", "active": true});
+
+        assert!(is_subscription_operation(
+            query,
+            Some(&variables),
+            Some("WatchUser"),
+        ));
+        assert_eq!(
+            subscription_doc_ids(query, Some(&variables), Some("WatchUser")),
+            Some(vec!["target-doc".to_string()])
+        );
+
+        let scoped =
+            subscription_to_scoped_query(query, "event-doc", "event-cid", Some("WatchUser"))
+                .expect("subscription should scope");
+        let select = parse_scoped_select(&scoped, Some(&variables), Some("WatchUser"));
+
+        assert_eq!(select.doc_ids, Some(vec!["event-doc".to_string()]));
+        assert_eq!(select.cid, Some(vec!["event-cid".to_string()]));
+        assert!(select.filter.is_some());
+    }
 }

--- a/tools/integration-test/tests/query/subscription_docid.rs
+++ b/tools/integration-test/tests/query/subscription_docid.rs
@@ -292,3 +292,58 @@ async fn subscription_no_filter_test(cluster: TestCluster) {
 }
 
 for_each_runtime!(subscription_no_filter, subscription_no_filter_test);
+
+// ---------------------------------------------------------------------------
+// Test: delete subscriptions are scoped by event CID
+// ---------------------------------------------------------------------------
+
+async fn subscription_delete_event_scoped_by_cid_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+    let api_url = cluster.api_url(0);
+
+    client
+        .schema_add("type User { name: String  age: Int }")
+        .expect("schema deploy");
+
+    let created = client
+        .query(r#"mutation { add_User(input: {name: "DeleteMe", age: 30}) { _docID } }"#)
+        .expect("create user");
+    let doc_id = created["add_User"][0]["_docID"]
+        .as_str()
+        .expect("user _docID")
+        .to_string();
+
+    let (handle, events) =
+        open_subscription(api_url, "subscription { User { _docID _deleted name } }");
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    client
+        .query(&format!(
+            r#"mutation {{ delete_User(docID: "{doc_id}") {{ _docID }} }}"#
+        ))
+        .expect("delete user");
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    handle.abort();
+
+    let collected = events.lock().unwrap();
+    assert!(
+        collected.iter().any(|event| {
+            extract_doc_id(event, "User").as_deref() == Some(doc_id.as_str())
+                && event
+                    .pointer("/data/User/0/_deleted")
+                    .or_else(|| event.pointer("/User/0/_deleted"))
+                    .and_then(Value::as_bool)
+                    == Some(true)
+        }),
+        "expected delete subscription event with _deleted=true for {doc_id}, got: {:?}",
+        &*collected
+    );
+}
+
+#[tokio::test]
+async fn rust_subscription_delete_event_scoped_by_cid() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    subscription_delete_event_scoped_by_cid_test(cluster).await;
+}


### PR DESCRIPTION
## Summary

Addresses #931 by making Rust GraphQL subscription scoping match Go’s live update semantics for normal collections and `_commits`.

## Why

Rust subscriptions were rebuilding follow-up queries with ad hoc string rewrites and normal collection subscriptions were scoped by event `docID` only. Go scopes normal subscriptions by both event `docID` and event `cid`, which matters for update/delete observations where clients need the event-specific document state.

## Changes

| Area | Change |
|---|---|
| Query subscriptions | Replace string-based subscription rewrites with parser/AST-backed scoped query generation |
| Collection subscriptions | Scope live events by both event `docID` and event `cid` |
| `_commits` subscriptions | Preserve explicit `docID` filters while replacing/injecting the event `cid` |
| HTTP SSE | Preserve operation names and variables when executing scoped subscription queries |
| FFI subscriptions | Preserve operation names and variables when polling scoped subscription results |
| Events docs | Document Go/Rust parity, live-only behavior, no cursor/replay support, and Rust drop-accounting behavior |
| Tests | Add scoped-query unit coverage and a Rust integration assertion for delete-event CID scoping |

## Out of scope

- No `subscribe_after(cursor)` or durable replay API.
- No change to Rust’s bounded-channel drop accounting behavior.
- No WebSocket subscription implementation.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p query subscription`
- [x] `cargo test -p events`
- [x] `cargo test -p ffi subscription`
- [x] `cargo clippy -p query -p defra-http -p ffi -p events --all-targets -- -D warnings`
- [x] `cargo clippy -p integration-test --test query -- -D warnings`
- [ ] `cargo test -p integration-test --test query rust_subscription_delete_event_scoped_by_cid` attempted normally and escalated, but the harness failed before exercising the test body: `rust-0` did not become ready and timed out waiting for node readiness.
