### PR TITLE
feat(query): configure query limits

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -184,6 +184,18 @@ pub struct StartArgs {
     #[arg(long)]
     pub query_timeout: Option<u64>,
 
+    /// Max GraphQL selection nesting depth (0 = unlimited, default: 20)
+    #[arg(long)]
+    pub query_max_depth: Option<usize>,
+
+    /// Max fields at any GraphQL selection level (0 = unlimited, default: 100)
+    #[arg(long)]
+    pub query_max_width: Option<usize>,
+
+    /// Max recursive filter nesting depth (0 = unlimited, default: 50)
+    #[arg(long)]
+    pub query_max_filter_depth: Option<usize>,
+
     /// Per-peer rate limit burst capacity (max tokens). Default: 500.
     #[arg(long)]
     pub p2p_rate_limit_burst: Option<u32>,
@@ -474,6 +486,15 @@ impl StartArgs {
         }
         if let Some(timeout) = self.query_timeout {
             config.api.query_timeout = timeout;
+        }
+        if let Some(depth) = self.query_max_depth {
+            config.api.query_max_depth = depth;
+        }
+        if let Some(width) = self.query_max_width {
+            config.api.query_max_width = width;
+        }
+        if let Some(depth) = self.query_max_filter_depth {
+            config.api.query_max_filter_depth = depth;
         }
         if let Some(ref addr) = self.pg_address {
             config.api.pg_address = addr.clone();

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -44,7 +44,12 @@ impl Node {
         .with_mutator(mutator)
         .with_acp(document_acp)
         .with_lens_store(database.lens_store().clone())
-        .with_query_timeout(config.api.query_timeout);
+        .with_query_timeout(config.api.query_timeout)
+        .with_query_limits(query::QueryLimits {
+            max_query_depth: config.api.query_max_depth,
+            max_query_width: config.api.query_max_width,
+            max_filter_depth: config.api.query_max_filter_depth,
+        });
 
         if !config.datastore.no_encryption {
             info!("CRDT delta encryption enabled");

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 
 use serde::{Deserialize, Serialize};
 
+use query::{DEFAULT_MAX_FILTER_DEPTH, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_QUERY_WIDTH};
 use storage::backends::DurabilityMode;
 
 use super::types::{
@@ -66,6 +67,15 @@ pub struct ApiConfig {
     /// Query execution timeout in seconds (0 = no timeout). Default: 30.
     #[serde(default = "default_query_timeout")]
     pub query_timeout: u64,
+    /// Max GraphQL selection nesting depth (0 = unlimited). Default: 20.
+    #[serde(default = "default_query_max_depth")]
+    pub query_max_depth: usize,
+    /// Max fields at any GraphQL selection level (0 = unlimited). Default: 100.
+    #[serde(default = "default_query_max_width")]
+    pub query_max_width: usize,
+    /// Max recursive filter nesting depth (0 = unlimited). Default: 50.
+    #[serde(default = "default_query_max_filter_depth")]
+    pub query_max_filter_depth: usize,
     /// Postgres wire protocol address (empty = disabled). Default: "" (disabled).
     #[serde(default)]
     pub pg_address: String,
@@ -83,6 +93,18 @@ fn default_query_timeout() -> u64 {
     30
 }
 
+fn default_query_max_depth() -> usize {
+    DEFAULT_MAX_QUERY_DEPTH
+}
+
+fn default_query_max_width() -> usize {
+    DEFAULT_MAX_QUERY_WIDTH
+}
+
+fn default_query_max_filter_depth() -> usize {
+    DEFAULT_MAX_FILTER_DEPTH
+}
+
 impl Default for ApiConfig {
     fn default() -> Self {
         Self {
@@ -96,6 +118,9 @@ impl Default for ApiConfig {
             request_timeout: default_request_timeout(),
             max_concurrent_requests: default_max_concurrent(),
             query_timeout: default_query_timeout(),
+            query_max_depth: default_query_max_depth(),
+            query_max_width: default_query_max_width(),
+            query_max_filter_depth: default_query_max_filter_depth(),
             pg_address: String::new(),
         }
     }

--- a/crates/cli/tests/config_sections_tests.rs
+++ b/crates/cli/tests/config_sections_tests.rs
@@ -25,6 +25,12 @@ fn test_api_config_defaults() {
     assert!(config.allowed_origins.is_empty());
     assert!(config.pubkey_path.is_empty());
     assert!(config.privkey_path.is_empty());
+    assert_eq!(config.query_max_depth, query::DEFAULT_MAX_QUERY_DEPTH);
+    assert_eq!(config.query_max_width, query::DEFAULT_MAX_QUERY_WIDTH);
+    assert_eq!(
+        config.query_max_filter_depth,
+        query::DEFAULT_MAX_FILTER_DEPTH
+    );
 }
 
 #[test]

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -179,6 +179,18 @@ fn test_config_serialization_roundtrip() {
     assert_eq!(original.log.level, deserialized.log.level);
     assert_eq!(original.datastore.store, deserialized.datastore.store);
     assert_eq!(original.api.address, deserialized.api.address);
+    assert_eq!(
+        original.api.query_max_depth,
+        deserialized.api.query_max_depth
+    );
+    assert_eq!(
+        original.api.query_max_width,
+        deserialized.api.query_max_width
+    );
+    assert_eq!(
+        original.api.query_max_filter_depth,
+        deserialized.api.query_max_filter_depth
+    );
     assert_eq!(original.embedding.url, deserialized.embedding.url);
     assert_eq!(original.embedding.model, deserialized.embedding.model);
     assert_eq!(

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -45,6 +45,9 @@ fn default_start_args() -> StartArgs {
         p2p_rate_limit_rate: None,
         max_merge_depth: None,
         query_timeout: None,
+        query_max_depth: None,
+        query_max_width: None,
+        query_max_filter_depth: None,
         p2p_transport: None,
         pg_address: None,
         acp_cache_ttl: None,
@@ -134,6 +137,9 @@ fn test_apply_to_config_all_flags() {
         p2p_rate_limit_rate: Some(4.5),
         max_merge_depth: Some(2048),
         query_timeout: Some(45),
+        query_max_depth: Some(12),
+        query_max_width: Some(64),
+        query_max_filter_depth: Some(24),
         p2p_transport: None,
         pg_address: None,
         acp_cache_ttl: None,
@@ -181,6 +187,9 @@ fn test_apply_to_config_all_flags() {
     assert!(config.datastore.no_searchable_encryption);
     assert_eq!(config.replicator_retry_intervals, vec![10, 20, 30]);
     assert_eq!(config.api.query_timeout, 45);
+    assert_eq!(config.api.query_max_depth, 12);
+    assert_eq!(config.api.query_max_width, 64);
+    assert_eq!(config.api.query_max_filter_depth, 24);
     assert_eq!(config.embedding.url, "http://localhost:11434/v1");
     assert_eq!(config.embedding.model, "nomic-embed-text");
     assert_eq!(config.embedding.api_key_env, "CUSTOM_EMBEDDING_KEY");

--- a/crates/query-parse/src/lib.rs
+++ b/crates/query-parse/src/lib.rs
@@ -8,6 +8,9 @@ pub mod schema_gen;
 pub mod sdl_parse;
 pub mod select_convert;
 
-pub use query_parse::{parse_mutations, parse_query, parse_request, ExplainType, ParsedOperation};
+pub use query_parse::{
+    parse_mutations, parse_mutations_with_limits, parse_query, parse_query_with_limits,
+    parse_request, parse_request_with_limits, ExplainType, ParsedOperation,
+};
 pub use sdl_parse::{parse_sdl, parse_sdl_with_known_types};
 pub use select_convert::select_to_go_json;

--- a/crates/query-parse/src/query_parse/limits.rs
+++ b/crates/query-parse/src/query_parse/limits.rs
@@ -1,45 +1,67 @@
 //! Query structure limits to prevent denial-of-service via deeply nested or wide queries.
 
 use query_types::error::{QueryError, Result};
+use query_types::limits::{QueryLimits, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_QUERY_WIDTH};
 use query_types::mapper::{Requestable, Select};
 
 /// Maximum nesting depth for GraphQL selections.
 ///
 /// A query like `{ A { B { C { ... } } } }` has depth equal to the number of
 /// nested select levels. Queries deeper than this limit are rejected.
-pub const MAX_QUERY_DEPTH: usize = 20;
+pub const MAX_QUERY_DEPTH: usize = DEFAULT_MAX_QUERY_DEPTH;
 
 /// Maximum number of fields at any single selection level.
 ///
 /// This caps the fan-out per level to prevent wide queries that would generate
 /// an unbounded number of fetches.
-pub const MAX_QUERY_WIDTH: usize = 100;
+pub const MAX_QUERY_WIDTH: usize = DEFAULT_MAX_QUERY_WIDTH;
 
 /// Validate a parsed Select tree against depth and width limits.
 ///
 /// Called after parsing to reject queries that would cause excessive work.
 pub fn validate_select_limits(select: &Select) -> Result<()> {
-    validate_select_at_depth(select, 1)
+    validate_select_limits_with(select, QueryLimits::default())
 }
 
-fn validate_select_at_depth(select: &Select, depth: usize) -> Result<()> {
-    if depth > MAX_QUERY_DEPTH {
+/// Validate a parsed Select tree against custom depth and width limits.
+pub fn validate_select_limits_with(select: &Select, limits: QueryLimits) -> Result<()> {
+    validate_select_at_depth(select, 1, limits)
+}
+
+/// Validate a parsed requestable field list against custom depth and width limits.
+pub fn validate_requestable_limits_with(
+    requestables: &[Requestable],
+    limits: QueryLimits,
+) -> Result<()> {
+    validate_requestables_at_depth(requestables, 1, limits)
+}
+
+fn validate_select_at_depth(select: &Select, depth: usize, limits: QueryLimits) -> Result<()> {
+    if limits.max_query_depth > 0 && depth > limits.max_query_depth {
         return Err(QueryError::parse(format!(
             "query exceeds maximum nesting depth of {}",
-            MAX_QUERY_DEPTH
+            limits.max_query_depth
         )));
     }
 
-    if select.fields.len() > MAX_QUERY_WIDTH {
+    validate_requestables_at_depth(&select.fields, depth, limits)
+}
+
+fn validate_requestables_at_depth(
+    requestables: &[Requestable],
+    depth: usize,
+    limits: QueryLimits,
+) -> Result<()> {
+    if limits.max_query_width > 0 && requestables.len() > limits.max_query_width {
         return Err(QueryError::parse(format!(
             "query exceeds maximum field width of {} at depth {}",
-            MAX_QUERY_WIDTH, depth
+            limits.max_query_width, depth
         )));
     }
 
-    for field in &select.fields {
+    for field in requestables {
         if let Requestable::Select(nested) = field {
-            validate_select_at_depth(nested, depth + 1)?;
+            validate_select_at_depth(nested, depth + 1, limits)?;
         }
     }
 

--- a/crates/query-parse/src/query_parse/limits_tests.rs
+++ b/crates/query-parse/src/query_parse/limits_tests.rs
@@ -1,0 +1,69 @@
+use query_types::limits::QueryLimits;
+
+use super::{parse_request_with_limits, ParsedOperation};
+
+fn limits(max_query_depth: usize, max_query_width: usize, max_filter_depth: usize) -> QueryLimits {
+    QueryLimits {
+        max_query_depth,
+        max_query_width,
+        max_filter_depth,
+    }
+}
+
+#[test]
+fn custom_query_depth_limit_rejects_deep_selects() {
+    let result = parse_request_with_limits(
+        "{ Users { name posts { title } } }",
+        None,
+        None,
+        limits(1, 100, 50),
+    );
+
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("query exceeds maximum nesting depth of 1"));
+}
+
+#[test]
+fn custom_query_width_limit_rejects_wide_selects() {
+    let result = parse_request_with_limits(
+        "{ Users { name age active } }",
+        None,
+        None,
+        limits(20, 2, 50),
+    );
+
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("query exceeds maximum field width of 2 at depth 1"));
+}
+
+#[test]
+fn custom_filter_depth_limit_rejects_nested_filters() {
+    let result = parse_request_with_limits(
+        r#"{ Users(filter: {_and: [{_and: [{name: {_eq: "Alice"}}]}]}) { name } }"#,
+        None,
+        None,
+        limits(20, 100, 1),
+    );
+
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("filter exceeds maximum nesting depth of 1"));
+}
+
+#[test]
+fn zero_query_limits_disable_shape_checks() {
+    let parsed = parse_request_with_limits(
+        "{ Users { name age posts { title body } } }",
+        None,
+        None,
+        limits(0, 0, 50),
+    )
+    .unwrap();
+
+    assert!(matches!(parsed, ParsedOperation::Query { .. }));
+}

--- a/crates/query-parse/src/query_parse/mod.rs
+++ b/crates/query-parse/src/query_parse/mod.rs
@@ -23,7 +23,8 @@ mod variables;
 // Re-export everything from parser for backwards compatibility
 pub use limits::{MAX_QUERY_DEPTH, MAX_QUERY_WIDTH};
 pub use parser::{
-    parse_mutations, parse_mutations_with_variables, parse_query, parse_query_with_variables,
-    parse_request, parse_request_with_variables, ExplainType, ParsedOperation,
+    parse_mutations, parse_mutations_with_limits, parse_mutations_with_variables, parse_query,
+    parse_query_with_limits, parse_query_with_variables, parse_request, parse_request_with_limits,
+    parse_request_with_variables, ExplainType, ParsedOperation,
 };
 pub use validation::validate_parsed_operation;

--- a/crates/query-parse/src/query_parse/parser.rs
+++ b/crates/query-parse/src/query_parse/parser.rs
@@ -12,6 +12,7 @@ use tracing::instrument;
 
 use query_types::document::DocumentMapping;
 use query_types::error::{QueryError, Result};
+use query_types::limits::QueryLimits;
 use query_types::mapper::{
     AggregateType, Field as SelectField, Limit, Mutation, Requestable, Select,
 };
@@ -21,7 +22,7 @@ use super::explain::{
     check_field_explain_directive, parse_exhaustive_directive, parse_explain_directive,
 };
 use super::filters::parse_filter_value;
-use super::limits::validate_select_limits;
+use super::limits::{validate_requestable_limits_with, validate_select_limits_with};
 use super::mutations::{parse_bm25_field, parse_field_to_mutation, parse_similarity_field};
 use super::ordering::parse_order_value;
 use super::values::{
@@ -192,7 +193,16 @@ pub fn parse_query_with_variables(
     query: &str,
     variables: Option<&HashMap<String, JsonValue>>,
 ) -> Result<Vec<Select>> {
-    match parse_request_with_variables(query, variables, None)? {
+    parse_query_with_limits(query, variables, QueryLimits::default())
+}
+
+/// Parse a GraphQL query string with variable substitution and custom limits.
+pub fn parse_query_with_limits(
+    query: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
+    limits: QueryLimits,
+) -> Result<Vec<Select>> {
+    match parse_request_with_limits(query, variables, None, limits)? {
         ParsedOperation::Query { selects, .. } => Ok(selects),
         ParsedOperation::Mutation { .. } => Err(QueryError::parse(
             "Expected query but got mutation. Use parse_mutations_with_variables() for mutations.",
@@ -220,7 +230,16 @@ pub fn parse_mutations_with_variables(
     query: &str,
     variables: Option<&HashMap<String, JsonValue>>,
 ) -> Result<Vec<Mutation>> {
-    match parse_request_with_variables(query, variables, None)? {
+    parse_mutations_with_limits(query, variables, QueryLimits::default())
+}
+
+/// Parse a GraphQL mutation string with variable substitution and custom limits.
+pub fn parse_mutations_with_limits(
+    query: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
+    limits: QueryLimits,
+) -> Result<Vec<Mutation>> {
+    match parse_request_with_limits(query, variables, None, limits)? {
         ParsedOperation::Mutation { mutations, .. } => Ok(mutations),
         ParsedOperation::Query { .. } => Err(QueryError::parse("Expected mutation but got query")),
         ParsedOperation::Subscription { .. } => {
@@ -279,11 +298,21 @@ fn is_introspection_query(doc: &Document<'_, String>) -> bool {
     false
 }
 
-#[instrument(name = "query.parse", skip(query, variables), fields(query_len = query.len()))]
 pub fn parse_request_with_variables(
     query: &str,
     variables: Option<&HashMap<String, JsonValue>>,
     operation_name: Option<&str>,
+) -> Result<ParsedOperation> {
+    parse_request_with_limits(query, variables, operation_name, QueryLimits::default())
+}
+
+/// Parse a GraphQL request with variable substitution and custom limits.
+#[instrument(name = "query.parse", skip(query, variables, limits), fields(query_len = query.len()))]
+pub fn parse_request_with_limits(
+    query: &str,
+    variables: Option<&HashMap<String, JsonValue>>,
+    operation_name: Option<&str>,
+    limits: QueryLimits,
 ) -> Result<ParsedOperation> {
     let doc: Document<'_, String> = graphql_parser::parse_query(query).map_err(|e| {
         let msg = e.to_string();
@@ -476,16 +505,22 @@ pub fn parse_request_with_variables(
 
     if has_subscription {
         // subscription_selects is guaranteed to have exactly one element due to earlier validation
-        let select = subscription_selects.into_iter().next().unwrap();
-        validate_select_limits(&select)?;
+        let mut select = subscription_selects.into_iter().next().unwrap();
+        apply_limits_to_select(&mut select, limits)?;
+        validate_select_limits_with(&select, limits)?;
         Ok(ParsedOperation::Subscription {
             select: Box::new(select),
         })
     } else if has_mutation {
+        for mutation in &mut mutations {
+            apply_limits_to_mutation(mutation, limits)?;
+            validate_requestable_limits_with(&mutation.fields, limits)?;
+        }
         Ok(ParsedOperation::Mutation { mutations, explain })
     } else {
-        for select in &selects {
-            validate_select_limits(select)?;
+        for select in &mut selects {
+            apply_limits_to_select(select, limits)?;
+            validate_select_limits_with(select, limits)?;
         }
         Ok(ParsedOperation::Query {
             selects,
@@ -493,6 +528,57 @@ pub fn parse_request_with_variables(
             exhaustive,
         })
     }
+}
+
+fn apply_limits_to_mutation(mutation: &mut Mutation, limits: QueryLimits) -> Result<()> {
+    if let Some(filter) = mutation.filter.as_mut() {
+        apply_limit_to_filter(filter, limits)?;
+    }
+
+    for field in &mut mutation.fields {
+        apply_limits_to_requestable(field, limits)?;
+    }
+
+    Ok(())
+}
+
+fn apply_limits_to_select(select: &mut Select, limits: QueryLimits) -> Result<()> {
+    if let Some(filter) = select.filter.as_mut() {
+        apply_limit_to_filter(filter, limits)?;
+    }
+
+    for field in &mut select.fields {
+        apply_limits_to_requestable(field, limits)?;
+    }
+
+    Ok(())
+}
+
+fn apply_limits_to_requestable(requestable: &mut Requestable, limits: QueryLimits) -> Result<()> {
+    match requestable {
+        Requestable::Select(select) => apply_limits_to_select(select, limits)?,
+        Requestable::Aggregate(aggregate) => {
+            if let Some(filter) = aggregate.filter.as_mut() {
+                apply_limit_to_filter(filter, limits)?;
+            }
+            for target in &mut aggregate.targets {
+                if let Some(filter) = target.filter.as_mut() {
+                    apply_limit_to_filter(filter, limits)?;
+                }
+            }
+        }
+        Requestable::Field(_) | Requestable::Similarity(_) | Requestable::FullTextSearch(_) => {}
+    }
+
+    Ok(())
+}
+
+fn apply_limit_to_filter(
+    filter: &mut query_types::mapper::Filter,
+    limits: QueryLimits,
+) -> Result<()> {
+    filter.set_max_depth(limits.max_filter_depth);
+    filter.validate_depth()
 }
 
 /// Parse a single GraphQL field into a Select operation.
@@ -892,3 +978,7 @@ mod variable_tests;
 #[cfg(test)]
 #[path = "subscription_tests.rs"]
 mod subscription_tests;
+
+#[cfg(test)]
+#[path = "limits_tests.rs"]
+mod limits_tests;

--- a/crates/query-plan/src/planner/builder/filter_prep.rs
+++ b/crates/query-plan/src/planner/builder/filter_prep.rs
@@ -58,7 +58,10 @@ impl super::Planner {
                     for (k, v) in doc_ids_filter.conditions() {
                         merged.insert(k.clone(), v.clone());
                     }
-                    Some(Filter::from_conditions(merged))
+                    Some(Filter::from_conditions_with_max_depth(
+                        merged,
+                        existing.max_depth(),
+                    ))
                 }
                 None => Some(doc_ids_filter),
             }
@@ -140,7 +143,15 @@ impl super::Planner {
             if combined_conditions.is_empty() {
                 None
             } else {
-                Some(Filter::from_conditions(combined_conditions))
+                let max_depth = scalar_filter_raw
+                    .as_ref()
+                    .or(relation_filter.as_ref())
+                    .map(Filter::max_depth)
+                    .unwrap_or(query_types::DEFAULT_MAX_FILTER_DEPTH);
+                Some(Filter::from_conditions_with_max_depth(
+                    combined_conditions,
+                    max_depth,
+                ))
             }
         };
 

--- a/crates/query-plan/src/planner/builder/groupby.rs
+++ b/crates/query-plan/src/planner/builder/groupby.rs
@@ -270,7 +270,14 @@ impl super::Planner {
                                 .or_insert(serde_json::json!({
                                     "_neq": serde_json::Value::Null
                                 }));
-                            cs.filter = Some(Filter::from_conditions(conditions));
+                            let max_depth = cs
+                                .filter
+                                .as_ref()
+                                .map(Filter::max_depth)
+                                .unwrap_or(query_types::DEFAULT_MAX_FILTER_DEPTH);
+                            cs.filter = Some(Filter::from_conditions_with_max_depth(
+                                conditions, max_depth,
+                            ));
                         }
                     }
                 }

--- a/crates/query-plan/src/planner/joins/aggregate_joins.rs
+++ b/crates/query-plan/src/planner/joins/aggregate_joins.rs
@@ -351,7 +351,10 @@ impl Planner {
                                         .or_insert(
                                             serde_json::json!({"_neq": serde_json::Value::Null}),
                                         );
-                                    Filter::from_conditions(merged)
+                                    Filter::from_conditions_with_max_depth(
+                                        merged,
+                                        existing.max_depth(),
+                                    )
                                 }
                                 None => neq_null_filter,
                             });

--- a/crates/query-plan/src/planner/joins/mod.rs
+++ b/crates/query-plan/src/planner/joins/mod.rs
@@ -659,17 +659,26 @@ impl Planner {
 
             // Build a combined filter from doc_ids and explicit filter
             let doc_ids_filter = if let Some(ref doc_ids) = nested_select.doc_ids {
+                let max_depth = nested_select
+                    .filter
+                    .as_ref()
+                    .map(Filter::max_depth)
+                    .unwrap_or(query_types::DEFAULT_MAX_FILTER_DEPTH);
                 // Create a filter: _docID IN [...]
                 if doc_ids.len() == 1 {
                     // Single ID: _docID == "..."
                     let mut conditions = serde_json::Map::new();
                     conditions.insert("_docID".to_string(), serde_json::json!({"_eq": doc_ids[0]}));
-                    Some(Filter::from_conditions(conditions))
+                    Some(Filter::from_conditions_with_max_depth(
+                        conditions, max_depth,
+                    ))
                 } else {
                     // Multiple IDs: _docID IN [...]
                     let mut conditions = serde_json::Map::new();
                     conditions.insert("_docID".to_string(), serde_json::json!({"_in": doc_ids}));
-                    Some(Filter::from_conditions(conditions))
+                    Some(Filter::from_conditions_with_max_depth(
+                        conditions, max_depth,
+                    ))
                 }
             } else {
                 None

--- a/crates/query-types/src/lib.rs
+++ b/crates/query-types/src/lib.rs
@@ -8,6 +8,7 @@ pub mod doc;
 pub mod document;
 pub mod error;
 pub mod json_convert;
+pub mod limits;
 pub mod mapper;
 
 // Re-export primary types
@@ -15,4 +16,7 @@ pub use collection_provider::{CollectionProvider, StaticCollectionProvider};
 pub use doc::{Doc, DocFields, DocStatus};
 pub use document::{DocumentMapping, RenderKey};
 pub use error::{QueryError, Result, TransactionError};
+pub use limits::{
+    QueryLimits, DEFAULT_MAX_FILTER_DEPTH, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_QUERY_WIDTH,
+};
 pub use mapper::{Filter, Mutation, MutationType, Select};

--- a/crates/query-types/src/limits.rs
+++ b/crates/query-types/src/limits.rs
@@ -1,0 +1,30 @@
+//! Query guardrail defaults and configuration.
+
+/// Default maximum nesting depth for GraphQL selection sets.
+pub const DEFAULT_MAX_QUERY_DEPTH: usize = 20;
+
+/// Default maximum number of fields at any single selection level.
+pub const DEFAULT_MAX_QUERY_WIDTH: usize = 100;
+
+/// Default maximum recursive depth for filter evaluation.
+pub const DEFAULT_MAX_FILTER_DEPTH: usize = 50;
+
+/// Configurable limits applied while parsing and executing queries.
+///
+/// A value of `0` disables that individual limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryLimits {
+    pub max_query_depth: usize,
+    pub max_query_width: usize,
+    pub max_filter_depth: usize,
+}
+
+impl Default for QueryLimits {
+    fn default() -> Self {
+        Self {
+            max_query_depth: DEFAULT_MAX_QUERY_DEPTH,
+            max_query_width: DEFAULT_MAX_QUERY_WIDTH,
+            max_filter_depth: DEFAULT_MAX_FILTER_DEPTH,
+        }
+    }
+}

--- a/crates/query-types/src/mapper/filter/eval_alias.rs
+++ b/crates/query-types/src/mapper/filter/eval_alias.rs
@@ -13,12 +13,15 @@ impl Filter {
     /// Evaluate alias-based filter conditions.
     /// Alias filters allow filtering by render key names instead of field names.
     /// Supports logical operators (_and, _or, _not) within the alias block.
-    pub(crate) fn eval_alias_conditions(
+    pub(crate) fn eval_alias_conditions_at_depth(
         &self,
         conditions: &Map<String, JsonValue>,
         fields: &[Option<JsonValue>],
         mapping: &DocumentMapping,
+        depth: usize,
     ) -> Result<bool> {
+        self.check_depth(depth)?;
+
         for (key, value) in conditions {
             // Check for logical operators within alias block
             if let Some(op) = FilterOp::parse(key) {
@@ -31,7 +34,12 @@ impl Filter {
                             let sub_conditions = item.as_object().ok_or_else(|| {
                                 QueryError::invalid_filter("_and items must be objects in _alias")
                             })?;
-                            if !self.eval_alias_conditions(sub_conditions, fields, mapping)? {
+                            if !self.eval_alias_conditions_at_depth(
+                                sub_conditions,
+                                fields,
+                                mapping,
+                                depth + 1,
+                            )? {
                                 return Ok(false);
                             }
                         }
@@ -46,7 +54,12 @@ impl Filter {
                             let sub_conditions = item.as_object().ok_or_else(|| {
                                 QueryError::invalid_filter("_or items must be objects in _alias")
                             })?;
-                            if self.eval_alias_conditions(sub_conditions, fields, mapping)? {
+                            if self.eval_alias_conditions_at_depth(
+                                sub_conditions,
+                                fields,
+                                mapping,
+                                depth + 1,
+                            )? {
                                 any_match = true;
                                 break;
                             }
@@ -60,7 +73,12 @@ impl Filter {
                         let sub_conditions = value.as_object().ok_or_else(|| {
                             QueryError::invalid_filter("_not requires object in _alias")
                         })?;
-                        if self.eval_alias_conditions(sub_conditions, fields, mapping)? {
+                        if self.eval_alias_conditions_at_depth(
+                            sub_conditions,
+                            fields,
+                            mapping,
+                            depth + 1,
+                        )? {
                             return Ok(false);
                         }
                         continue;

--- a/crates/query-types/src/mapper/filter/eval_relation.rs
+++ b/crates/query-types/src/mapper/filter/eval_relation.rs
@@ -18,6 +18,17 @@ impl Filter {
         conditions: &serde_json::Map<String, JsonValue>,
         obj: &serde_json::Map<String, JsonValue>,
     ) -> Result<bool> {
+        self.eval_relation_conditions_at_depth(conditions, obj, 0)
+    }
+
+    fn eval_relation_conditions_at_depth(
+        &self,
+        conditions: &serde_json::Map<String, JsonValue>,
+        obj: &serde_json::Map<String, JsonValue>,
+        depth: usize,
+    ) -> Result<bool> {
+        self.check_depth(depth)?;
+
         for (key, value) in conditions {
             // Check for logical operators
             if let Some(op) = FilterOp::parse(key) {
@@ -30,7 +41,7 @@ impl Filter {
                             let sub_conds = item.as_object().ok_or_else(|| {
                                 QueryError::invalid_filter("_and items must be objects")
                             })?;
-                            if !self.eval_relation_conditions(sub_conds, obj)? {
+                            if !self.eval_relation_conditions_at_depth(sub_conds, obj, depth + 1)? {
                                 return Ok(false);
                             }
                         }
@@ -45,7 +56,7 @@ impl Filter {
                             let sub_conds = item.as_object().ok_or_else(|| {
                                 QueryError::invalid_filter("_or items must be objects")
                             })?;
-                            if self.eval_relation_conditions(sub_conds, obj)? {
+                            if self.eval_relation_conditions_at_depth(sub_conds, obj, depth + 1)? {
                                 any_match = true;
                                 break;
                             }
@@ -59,7 +70,7 @@ impl Filter {
                         let sub_conds = value
                             .as_object()
                             .ok_or_else(|| QueryError::invalid_filter("_not requires object"))?;
-                        if self.eval_relation_conditions(sub_conds, obj)? {
+                        if self.eval_relation_conditions_at_depth(sub_conds, obj, depth + 1)? {
                             return Ok(false);
                         }
                         continue;
@@ -93,7 +104,7 @@ impl Filter {
                     let mut any_match = false;
                     for elem in arr {
                         if let Some(obj) = elem.as_object() {
-                            if self.eval_relation_conditions(ops, obj)? {
+                            if self.eval_relation_conditions_at_depth(ops, obj, depth + 1)? {
                                 any_match = true;
                                 break;
                             }
@@ -103,7 +114,7 @@ impl Filter {
                         return Ok(false);
                     }
                 } else if let Some(nested_obj) = field_value.as_object() {
-                    if !self.eval_relation_conditions(ops, nested_obj)? {
+                    if !self.eval_relation_conditions_at_depth(ops, nested_obj, depth + 1)? {
                         return Ok(false);
                     }
                 } else {

--- a/crates/query-types/src/mapper/filter/filter_impl.rs
+++ b/crates/query-types/src/mapper/filter/filter_impl.rs
@@ -7,21 +7,27 @@ use super::eval::{eval_op, values_equal};
 use super::op::FilterOp;
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
-
-/// Maximum recursive depth for filter evaluation.
-///
-/// Filters with `_and`/`_or`/`_not` can nest arbitrarily. This limit prevents
-/// stack exhaustion from pathologically deep filter trees.
-const MAX_FILTER_DEPTH: usize = 50;
+use crate::limits::DEFAULT_MAX_FILTER_DEPTH;
 
 /// Filter condition containing parsed conditions.
 ///
 /// Conditions map field names to their filter values.
 /// Supports nested conditions for related objects.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Filter {
     /// Parsed filter conditions
     conditions: Map<String, JsonValue>,
+    /// Maximum recursive depth for this filter. `0` disables the limit.
+    max_depth: usize,
+}
+
+impl Default for Filter {
+    fn default() -> Self {
+        Self {
+            conditions: Map::new(),
+            max_depth: DEFAULT_MAX_FILTER_DEPTH,
+        }
+    }
 }
 
 impl Filter {
@@ -32,7 +38,37 @@ impl Filter {
 
     /// Create a filter from conditions map
     pub fn from_conditions(conditions: Map<String, JsonValue>) -> Self {
-        Self { conditions }
+        Self {
+            conditions,
+            max_depth: DEFAULT_MAX_FILTER_DEPTH,
+        }
+    }
+
+    /// Create a filter from conditions map with a custom recursive depth limit.
+    pub fn from_conditions_with_max_depth(
+        conditions: Map<String, JsonValue>,
+        max_depth: usize,
+    ) -> Self {
+        Self {
+            conditions,
+            max_depth,
+        }
+    }
+
+    /// Set the maximum recursive depth for this filter. `0` disables the limit.
+    pub fn set_max_depth(&mut self, max_depth: usize) {
+        self.max_depth = max_depth;
+    }
+
+    /// Return a copy of this filter with a custom recursive depth limit.
+    pub fn with_max_depth(mut self, max_depth: usize) -> Self {
+        self.set_max_depth(max_depth);
+        self
+    }
+
+    /// Get the maximum recursive depth configured for this filter.
+    pub fn max_depth(&self) -> usize {
+        self.max_depth
     }
 
     /// Check if the filter is empty
@@ -44,12 +80,16 @@ impl Filter {
     ///
     /// Returns a new filter where both conditions must be satisfied.
     pub fn and(&self, other: Filter) -> Filter {
+        let max_depth = match (self.max_depth, other.max_depth) {
+            (0, _) | (_, 0) => 0,
+            (left, right) => left.min(right),
+        };
         let mut combined_conditions = Map::new();
         combined_conditions.insert(
             "_and".to_string(),
-            serde_json::json!([self.conditions, other.conditions]),
+            serde_json::json!([self.conditions.clone(), other.conditions]),
         );
-        Filter::from_conditions(combined_conditions)
+        Filter::from_conditions_with_max_depth(combined_conditions, max_depth)
     }
 
     /// Get a reference to the conditions map
@@ -84,6 +124,66 @@ impl Filter {
         self.eval_conditions(&self.conditions, fields, mapping, 0)
     }
 
+    /// Validate this filter's recursive structure against its configured depth limit.
+    pub fn validate_depth(&self) -> Result<()> {
+        self.validate_conditions_depth(&self.conditions, 0)
+    }
+
+    pub(crate) fn check_depth(&self, depth: usize) -> Result<()> {
+        if self.max_depth > 0 && depth > self.max_depth {
+            return Err(QueryError::invalid_filter(format!(
+                "filter exceeds maximum nesting depth of {}",
+                self.max_depth
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_conditions_depth(
+        &self,
+        conditions: &Map<String, JsonValue>,
+        depth: usize,
+    ) -> Result<()> {
+        self.check_depth(depth)?;
+
+        for (key, value) in conditions {
+            match FilterOp::parse(key) {
+                Some(FilterOp::And | FilterOp::Or) => {
+                    let items = value.as_array().ok_or_else(|| {
+                        QueryError::invalid_filter(format!("{} requires array", key))
+                    })?;
+                    for item in items {
+                        let sub_conditions = item.as_object().ok_or_else(|| {
+                            QueryError::invalid_filter(format!("{} items must be objects", key))
+                        })?;
+                        self.validate_conditions_depth(sub_conditions, depth + 1)?;
+                    }
+                }
+                Some(FilterOp::Not) => {
+                    let sub_conditions = value
+                        .as_object()
+                        .ok_or_else(|| QueryError::invalid_filter("_not requires object"))?;
+                    self.validate_conditions_depth(sub_conditions, depth + 1)?;
+                }
+                _ if key == "_alias" => {
+                    let alias_conditions = value
+                        .as_object()
+                        .ok_or_else(|| QueryError::invalid_filter("_alias requires object"))?;
+                    self.validate_conditions_depth(alias_conditions, depth + 1)?;
+                }
+                _ => {
+                    if let Some(obj) = value.as_object() {
+                        if obj.keys().any(|k| FilterOp::parse(k).is_none()) {
+                            self.validate_conditions_depth(obj, depth + 1)?;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn eval_conditions(
         &self,
         conditions: &Map<String, JsonValue>,
@@ -91,12 +191,7 @@ impl Filter {
         mapping: &DocumentMapping,
         depth: usize,
     ) -> Result<bool> {
-        if depth > MAX_FILTER_DEPTH {
-            return Err(QueryError::invalid_filter(format!(
-                "filter exceeds maximum nesting depth of {}",
-                MAX_FILTER_DEPTH
-            )));
-        }
+        self.check_depth(depth)?;
 
         for (key, value) in conditions {
             // Check for logical operators
@@ -176,7 +271,12 @@ impl Filter {
                     }
                 };
 
-                if !self.eval_alias_conditions(alias_conditions, fields, mapping)? {
+                if !self.eval_alias_conditions_at_depth(
+                    alias_conditions,
+                    fields,
+                    mapping,
+                    depth + 1,
+                )? {
                     return Ok(false);
                 }
                 continue;

--- a/crates/query-types/src/mapper/filter/filter_tests.rs
+++ b/crates/query-types/src/mapper/filter/filter_tests.rs
@@ -137,6 +137,22 @@ fn test_not_filter() {
 }
 
 #[test]
+fn test_custom_filter_depth_limit() {
+    let filter = Filter::from_conditions(map([(
+        "_and".to_string(),
+        json!([{ "_and": [{ "name": { "_eq": "Alice" } }] }]),
+    )]))
+    .with_max_depth(1);
+    let mapping = make_mapping();
+    let fields = make_fields();
+
+    let err = filter.matches(&fields, &mapping).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("filter exceeds maximum nesting depth of 1"));
+}
+
+#[test]
 fn test_like_filter() {
     let filter = Filter::from_conditions(map([("name".to_string(), json!({"_like": "Ali%"}))]));
     let mapping = make_mapping();

--- a/crates/query-types/src/mapper/filter/json_match.rs
+++ b/crates/query-types/src/mapper/filter/json_match.rs
@@ -15,6 +15,12 @@ impl Filter {
     ///
     /// Null values don't match comparison filters (they are excluded from aggregation).
     pub fn matches_scalar_value(&self, value: &JsonValue) -> Result<bool> {
+        self.matches_scalar_value_at_depth(value, 0)
+    }
+
+    fn matches_scalar_value_at_depth(&self, value: &JsonValue, depth: usize) -> Result<bool> {
+        self.check_depth(depth)?;
+
         if self.conditions().is_empty() {
             return Ok(true);
         }
@@ -33,8 +39,11 @@ impl Filter {
                             let sub = item.as_object().ok_or_else(|| {
                                 QueryError::invalid_filter("_and items must be objects")
                             })?;
-                            let f = Filter::from_conditions(sub.clone());
-                            if !f.matches_scalar_value(value)? {
+                            let f = Filter::from_conditions_with_max_depth(
+                                sub.clone(),
+                                self.max_depth(),
+                            );
+                            if !f.matches_scalar_value_at_depth(value, depth + 1)? {
                                 return Ok(false);
                             }
                         }
@@ -48,8 +57,11 @@ impl Filter {
                             let sub = item.as_object().ok_or_else(|| {
                                 QueryError::invalid_filter("_or items must be objects")
                             })?;
-                            let f = Filter::from_conditions(sub.clone());
-                            if f.matches_scalar_value(value)? {
+                            let f = Filter::from_conditions_with_max_depth(
+                                sub.clone(),
+                                self.max_depth(),
+                            );
+                            if f.matches_scalar_value_at_depth(value, depth + 1)? {
                                 any_match = true;
                                 break;
                             }
@@ -62,8 +74,9 @@ impl Filter {
                         let sub = expected
                             .as_object()
                             .ok_or_else(|| QueryError::invalid_filter("_not requires object"))?;
-                        let f = Filter::from_conditions(sub.clone());
-                        if f.matches_scalar_value(value)? {
+                        let f =
+                            Filter::from_conditions_with_max_depth(sub.clone(), self.max_depth());
+                        if f.matches_scalar_value_at_depth(value, depth + 1)? {
                             return Ok(false);
                         }
                     }
@@ -94,6 +107,12 @@ impl Filter {
     /// - Operator-only conditions: `{_gt: 4.8}` (falls back to matches_scalar_value)
     /// - Compound conditions: `{_and: [...]}`, `{_or: [...]}`, `{_not: {...}}`
     pub fn matches_json_object(&self, obj: &JsonValue) -> Result<bool> {
+        self.matches_json_object_at_depth(obj, 0)
+    }
+
+    fn matches_json_object_at_depth(&self, obj: &JsonValue, depth: usize) -> Result<bool> {
+        self.check_depth(depth)?;
+
         if self.conditions().is_empty() {
             return Ok(true);
         }
@@ -110,8 +129,11 @@ impl Filter {
                             let sub = item.as_object().ok_or_else(|| {
                                 QueryError::invalid_filter("_and items must be objects")
                             })?;
-                            let f = Filter::from_conditions(sub.clone());
-                            if !f.matches_json_object(obj)? {
+                            let f = Filter::from_conditions_with_max_depth(
+                                sub.clone(),
+                                self.max_depth(),
+                            );
+                            if !f.matches_json_object_at_depth(obj, depth + 1)? {
                                 return Ok(false);
                             }
                         }
@@ -125,8 +147,11 @@ impl Filter {
                             let sub = item.as_object().ok_or_else(|| {
                                 QueryError::invalid_filter("_or items must be objects")
                             })?;
-                            let f = Filter::from_conditions(sub.clone());
-                            if f.matches_json_object(obj)? {
+                            let f = Filter::from_conditions_with_max_depth(
+                                sub.clone(),
+                                self.max_depth(),
+                            );
+                            if f.matches_json_object_at_depth(obj, depth + 1)? {
                                 any_match = true;
                                 break;
                             }
@@ -139,8 +164,9 @@ impl Filter {
                         let sub = expected
                             .as_object()
                             .ok_or_else(|| QueryError::invalid_filter("_not requires object"))?;
-                        let f = Filter::from_conditions(sub.clone());
-                        if f.matches_json_object(obj)? {
+                        let f =
+                            Filter::from_conditions_with_max_depth(sub.clone(), self.max_depth());
+                        if f.matches_json_object_at_depth(obj, depth + 1)? {
                             return Ok(false);
                         }
                     }
@@ -165,15 +191,18 @@ impl Filter {
                     // If they're field-based, recursively use matches_json_object
                     let has_field_conditions =
                         conditions_obj.keys().any(|k| FilterOp::parse(k).is_none());
-                    let f = Filter::from_conditions(conditions_obj.clone());
+                    let f = Filter::from_conditions_with_max_depth(
+                        conditions_obj.clone(),
+                        self.max_depth(),
+                    );
                     if has_field_conditions {
                         // Nested field access - recursively match
-                        if !f.matches_json_object(field_value)? {
+                        if !f.matches_json_object_at_depth(field_value, depth + 1)? {
                             return Ok(false);
                         }
                     } else {
                         // Operator conditions on the field value
-                        if !f.matches_scalar_value(field_value)? {
+                        if !f.matches_scalar_value_at_depth(field_value, depth + 1)? {
                             return Ok(false);
                         }
                     }

--- a/crates/query-types/src/mapper/filter/relation.rs
+++ b/crates/query-types/src/mapper/filter/relation.rs
@@ -88,7 +88,10 @@ impl Filter {
                 // Check if this is a nested filter (has non-operator keys)
                 let is_nested = obj.keys().any(|k| FilterOp::parse(k).is_none());
                 if is_nested {
-                    return Some(Filter::from_conditions(obj.clone()));
+                    return Some(Filter::from_conditions_with_max_depth(
+                        obj.clone(),
+                        self.max_depth(),
+                    ));
                 }
             }
         }
@@ -104,7 +107,10 @@ impl Filter {
                                     let is_nested =
                                         rel_obj.keys().any(|k| FilterOp::parse(k).is_none());
                                     if is_nested {
-                                        return Some(Filter::from_conditions(rel_obj.clone()));
+                                        return Some(Filter::from_conditions_with_max_depth(
+                                            rel_obj.clone(),
+                                            self.max_depth(),
+                                        ));
                                     }
                                 }
                             }
@@ -219,15 +225,19 @@ impl Filter {
             return Some(self.clone());
         }
 
-        Self::extract_at_path_recursive(self.conditions(), path)
+        Self::extract_at_path_recursive(self.conditions(), path, self.max_depth())
     }
 
     fn extract_at_path_recursive(
         conditions: &Map<String, JsonValue>,
         path: &[String],
+        max_depth: usize,
     ) -> Option<Filter> {
         if path.is_empty() {
-            return Some(Filter::from_conditions(conditions.clone()));
+            return Some(Filter::from_conditions_with_max_depth(
+                conditions.clone(),
+                max_depth,
+            ));
         }
 
         let current_key = &path[0];
@@ -238,10 +248,13 @@ impl Filter {
             if let Some(obj) = value.as_object() {
                 if remaining_path.is_empty() {
                     // We've reached the end of the path - return this level's conditions
-                    return Some(Filter::from_conditions(obj.clone()));
+                    return Some(Filter::from_conditions_with_max_depth(
+                        obj.clone(),
+                        max_depth,
+                    ));
                 } else {
                     // Continue down the path
-                    return Self::extract_at_path_recursive(obj, remaining_path);
+                    return Self::extract_at_path_recursive(obj, remaining_path, max_depth);
                 }
             }
         }
@@ -252,7 +265,9 @@ impl Filter {
                 if let Some(arr) = value.as_array() {
                     for item in arr {
                         if let Some(obj) = item.as_object() {
-                            if let Some(filter) = Self::extract_at_path_recursive(obj, path) {
+                            if let Some(filter) =
+                                Self::extract_at_path_recursive(obj, path, max_depth)
+                            {
                                 return Some(filter);
                             }
                         }

--- a/crates/query-types/src/mapper/filter/split.rs
+++ b/crates/query-types/src/mapper/filter/split.rs
@@ -62,13 +62,19 @@ impl Filter {
         let scalar = if scalar_conditions.is_empty() {
             None
         } else {
-            Some(Filter::from_conditions(scalar_conditions))
+            Some(Filter::from_conditions_with_max_depth(
+                scalar_conditions,
+                self.max_depth(),
+            ))
         };
 
         let relation = if relation_conditions.is_empty() {
             None
         } else {
-            Some(Filter::from_conditions(relation_conditions))
+            Some(Filter::from_conditions_with_max_depth(
+                relation_conditions,
+                self.max_depth(),
+            ))
         };
 
         (scalar, relation)
@@ -98,13 +104,19 @@ impl Filter {
         let non_alias_filter = if non_alias.is_empty() {
             None
         } else {
-            Some(Filter::from_conditions(non_alias))
+            Some(Filter::from_conditions_with_max_depth(
+                non_alias,
+                self.max_depth(),
+            ))
         };
 
         let alias_filter = if alias_only.is_empty() {
             None
         } else {
-            Some(Filter::from_conditions(alias_only))
+            Some(Filter::from_conditions_with_max_depth(
+                alias_only,
+                self.max_depth(),
+            ))
         };
 
         (non_alias_filter, alias_filter)
@@ -140,6 +152,9 @@ impl Filter {
             new_conditions.insert(key.clone(), value.clone());
         }
 
-        (Filter::from_conditions(new_conditions), has_aggregate_alias)
+        (
+            Filter::from_conditions_with_max_depth(new_conditions, self.max_depth()),
+            has_aggregate_alias,
+        )
     }
 }

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -22,6 +22,7 @@
 pub use query_types::document;
 pub use query_types::error;
 pub use query_types::json_convert;
+pub use query_types::limits;
 pub use query_types::mapper;
 
 // Parsing extracted to query-parse crate.
@@ -54,6 +55,9 @@ pub use document::{DocumentMapping, RenderKey};
 pub use error::{QueryError, Result, TransactionError};
 pub use executor::{QueryExecutor, QueryRequest, QueryResponse, QueryResponseError};
 pub use fetcher::{CollectionProvider, StaticCollectionProvider};
+pub use limits::{
+    QueryLimits, DEFAULT_MAX_FILTER_DEPTH, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_QUERY_WIDTH,
+};
 pub use mapper::{Filter, Mutation, MutationType, Select};
 pub use mutator::{
     BroadcastStatus, CreateResult, DeleteResult, DocMutator, MutationBatch,
@@ -64,7 +68,10 @@ pub use plan::{
     TypeJoinMany, TypeJoinOne, UpdateInput, UpdateNode, UpsertAction, UpsertInput, UpsertNode,
 };
 pub use planner::{Doc, DocStatus, ExecInfo, PlanNode, Planner};
-pub use query_parse::{parse_mutations, parse_query, parse_request, ExplainType, ParsedOperation};
+pub use query_parse::{
+    parse_mutations, parse_mutations_with_limits, parse_query, parse_query_with_limits,
+    parse_request, parse_request_with_limits, ExplainType, ParsedOperation,
+};
 pub use rest::{RestError, RestOperations, RestOperationsImpl, RestResult};
 pub use runner::{DocFetcher, FetchByIdsResult, NacChecker, QueryRunner};
 pub use sdl_parse::{parse_sdl, parse_sdl_with_known_types};

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -11,9 +11,7 @@ use identity::Did;
 
 use crate::error::{Result, TransactionError};
 use crate::executor::{QueryExecutor, QueryRequest, QueryResponse, QueryResponseError};
-use crate::query_parse::{
-    parse_request_with_variables, validate_parsed_operation, ParsedOperation,
-};
+use crate::query_parse::{parse_request_with_limits, validate_parsed_operation, ParsedOperation};
 use crate::txn::{GetTransactionResult, TransactionHandle, TransactionRegistry};
 
 use super::{DocFetcher, QueryRunner};
@@ -112,10 +110,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         let variables = convert_variables(&request.variables);
 
         // First, parse the request to determine if it's a query or mutation
-        let parsed = match parse_request_with_variables(
+        let parsed = match parse_request_with_limits(
             &request.query,
             variables.as_ref(),
             request.operation_name.as_deref(),
+            self.query_limits,
         ) {
             Ok(p) => p,
             Err(e) => {
@@ -305,10 +304,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
         let variables = convert_variables(&request.variables);
 
         // Parse the request to determine if it's a query or mutation
-        let parsed = match parse_request_with_variables(
+        let parsed = match parse_request_with_limits(
             &request.query,
             variables.as_ref(),
             request.operation_name.as_deref(),
+            self.query_limits,
         ) {
             Ok(p) => p,
             Err(e) => {

--- a/crates/query/src/runner/explain/execute.rs
+++ b/crates/query/src/runner/explain/execute.rs
@@ -13,7 +13,7 @@ use crate::planner::index_selection::{
     can_be_ordered_by_index, can_or_filter_use_index, select_best_index,
 };
 use crate::planner::Planner;
-use crate::query_parse::{parse_query_with_variables, ExplainType};
+use crate::query_parse::{parse_query_with_limits, ExplainType};
 use crate::txn::TransactionRegistry;
 
 use super::super::fetcher::FetcherWrapper;
@@ -29,7 +29,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         caller_identity: Option<Did>,
         variables: Option<&std::collections::HashMap<String, JsonValue>>,
     ) -> Result<JsonValue> {
-        let mut selects = parse_query_with_variables(query, variables)?;
+        let mut selects = parse_query_with_limits(query, variables, self.query_limits)?;
         if query.contains("@exhaustive") {
             for s in &mut selects {
                 s.exhaustive = true;

--- a/crates/query/src/runner/explain/mod.rs
+++ b/crates/query/src/runner/explain/mod.rs
@@ -7,7 +7,7 @@ use identity::Did;
 use serde_json::Value as JsonValue;
 
 use crate::error::Result;
-use crate::query_parse::{parse_query_with_variables, ExplainType};
+use crate::query_parse::{parse_query_with_limits, ExplainType};
 use crate::txn::TransactionRegistry;
 
 use super::{DocFetcher, QueryRunner};
@@ -56,7 +56,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         match explain_type {
             ExplainType::Simple | ExplainType::Debug => {
                 // Simple and Debug modes: explain without execution
-                let mut selects = parse_query_with_variables(query, variables)?;
+                let mut selects = parse_query_with_limits(query, variables, self.query_limits)?;
                 if query.contains("@exhaustive") {
                     for s in &mut selects {
                         s.exhaustive = true;
@@ -113,12 +113,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         caller_identity: Option<Did>,
         explain_type: ExplainType,
     ) -> Result<JsonValue> {
-        use crate::query_parse::parse_mutations;
+        use crate::query_parse::parse_mutations_with_limits;
 
         match explain_type {
             ExplainType::Simple | ExplainType::Debug => {
                 // Simple and Debug modes: explain without execution
-                let mutations = parse_mutations(mutation_str)?;
+                let mutations = parse_mutations_with_limits(mutation_str, None, self.query_limits)?;
                 let mut operation_children: Vec<JsonValue> = Vec::new();
 
                 for mutation in mutations {

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
 use crate::fetcher::{CollectionProvider, StaticCollectionProvider};
+use crate::limits::QueryLimits;
 use crate::mutator::DocMutator;
 use crate::planner::Doc;
 use crate::txn::{NoOpTransactionRegistry, TransactionRegistry};
@@ -191,6 +192,8 @@ pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRe
     pub(crate) nac: Arc<dyn NacChecker>,
     /// Query execution timeout in seconds (0 = no timeout). Default: 30.
     pub(crate) query_timeout: u64,
+    /// Query parsing and filter evaluation guardrails.
+    pub(crate) query_limits: QueryLimits,
 }
 
 impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
@@ -209,6 +212,7 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
+            query_limits: QueryLimits::default(),
         }
     }
 
@@ -227,6 +231,7 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
+            query_limits: QueryLimits::default(),
         }
     }
 }
@@ -247,6 +252,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
+            query_limits: QueryLimits::default(),
         }
     }
 
@@ -270,6 +276,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
+            query_limits: QueryLimits::default(),
         }
     }
 
@@ -292,6 +299,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
+            query_limits: QueryLimits::default(),
         }
     }
 
@@ -343,6 +351,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     /// Set query execution timeout in seconds (0 = no timeout).
     pub fn with_query_timeout(mut self, timeout_secs: u64) -> Self {
         self.query_timeout = timeout_secs;
+        self
+    }
+
+    /// Set query parsing and filter evaluation limits.
+    pub fn with_query_limits(mut self, limits: QueryLimits) -> Self {
+        self.query_limits = limits;
         self
     }
 

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -11,7 +11,7 @@ use crate::mapper::{Mutation, MutationType, Requestable};
 use crate::mutator::DocMutator;
 use crate::plan::{CreateNode, DeleteNode, UpdateNode, UpsertNode};
 use crate::planner::PlanNode;
-use crate::query_parse::parse_mutations_with_variables;
+use crate::query_parse::parse_mutations_with_limits;
 use crate::txn::TransactionRegistry;
 
 use super::{DocFetcher, QueryRunner};
@@ -122,7 +122,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         variables: Option<&std::collections::HashMap<String, JsonValue>>,
         fetcher_override: Option<Arc<dyn crate::fetcher::DocFetcher>>,
     ) -> Result<JsonValue> {
-        let mutations = parse_mutations_with_variables(mutation_str, variables)?;
+        let mutations = parse_mutations_with_limits(mutation_str, variables, self.query_limits)?;
         self.execute_parsed_mutations(mutations, mutator, caller_identity, fetcher_override)
             .await
     }

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -231,7 +231,7 @@ pub(crate) fn build_plan(
                                     }
                                 })
                                 .or_insert(serde_json::json!({"_neq": serde_json::Value::Null}));
-                            Filter::from_conditions(merged)
+                            Filter::from_conditions_with_max_depth(merged, existing.max_depth())
                         }
                         None => {
                             let mut conditions = serde_json::Map::new();
@@ -378,7 +378,14 @@ pub(crate) fn build_plan(
                             .or_insert(serde_json::json!({
                                 "_neq": serde_json::Value::Null
                             }));
-                        cs.filter = Some(Filter::from_conditions(conditions));
+                        let max_depth = cs
+                            .filter
+                            .as_ref()
+                            .map(Filter::max_depth)
+                            .unwrap_or(query_types::DEFAULT_MAX_FILTER_DEPTH);
+                        cs.filter = Some(Filter::from_conditions_with_max_depth(
+                            conditions, max_depth,
+                        ));
                     }
                 }
             }

--- a/crates/query/src/runner/query/mod.rs
+++ b/crates/query/src/runner/query/mod.rs
@@ -14,7 +14,7 @@ use tracing::instrument;
 
 use crate::error::Result;
 use crate::mapper::Select;
-use crate::query_parse::parse_query_with_variables;
+use crate::query_parse::parse_query_with_limits;
 use crate::txn::TransactionRegistry;
 
 use super::{DocFetcher, QueryRunner};
@@ -74,7 +74,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         caller_identity: Option<Did>,
         variables: Option<&std::collections::HashMap<String, JsonValue>>,
     ) -> Result<JsonValue> {
-        let selects = parse_query_with_variables(query, variables)?;
+        let selects = parse_query_with_limits(query, variables, self.query_limits)?;
 
         let mut results = Map::new();
 


### PR DESCRIPTION
## Summary

Addresses #508 by making GraphQL query depth, query width, and filter nesting limits configurable while preserving the existing defaults.

## Why

The Rust query engine had hardcoded guardrails for selection depth, selection width, and recursive filter nesting. That made deployments unable to tune DoS protection for their workload without code changes.

## Changes

| Area | Change |
|---|---|
| Query types | Add shared `QueryLimits` defaults and configuration type |
| Query parser | Support custom limits for request, query, mutation, and subscription parsing |
| Filter evaluation | Store and enforce configurable filter nesting limits on parsed filters |
| Query runner | Thread configured limits through execute, transaction, explain, query, and mutation paths |
| CLI config | Add API config fields for query depth, width, and filter-depth limits |
| Start flags | Add `--query-max-depth`, `--query-max-width`, and `--query-max-filter-depth` |
| Planner | Preserve filter depth limits when deriving or combining planner filters |
| Tests | Add parser, filter, CLI config, and serialization coverage |

## Out of scope

- No per-request GraphQL limit overrides.
- No runtime hot-reload of query limits after node startup.
- No change to default limit values.

## Test plan

- [x] `cargo test -p query-types mapper::filter`
- [x] `cargo test -p query-parse`
- [x] `cargo test -p query --lib`
- [x] `cargo test -p query-plan`
- [x] `cargo test -p cli --test start_tests --test config_sections_tests`
- [x] `cargo test -p cli --test config_tests`
- [x] `cargo clippy -p query-types -p query-parse -p query-plan -p query -p cli --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`