### PR TITLE
fix(query): demote no-signing-config notice to debug (#872)

### DIFF
--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -499,7 +499,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     None
                 }
                 None => {
-                    tracing::warn!(
+                    // No signing config is the normal case for nodes that don't
+                    // run with `--signer-type=...`. There is nothing to authorize
+                    // and nothing actionable for an operator to do, so this stays
+                    // at debug. The two `warn!` arms above remain warnings because
+                    // they signal a *partially* configured remote-signer setup.
+                    tracing::debug!(
                         collection = %mutation.collection_name,
                         "create mutation has no signing config; remote signer authorization skipped"
                     );


### PR DESCRIPTION
Tracks #872 (first bullet on the noise list).

## Summary

The "create mutation has no signing config; remote signer authorization skipped" message fires for every Create on nodes that don't run with a remote signer (i.e. the default for desktop/dev/CI). It is informational — nothing is misconfigured, there is no remote signer to call, and the write proceeds normally — yet at warn level it pollutes successful runs with one line per Create.

Demoted to debug. The two existing `warn!` arms higher in the match — "received no access decision" and "missing prerequisites" — are kept at warn because both indicate a *partially* configured remote-signer setup that operators would want to investigate.

## Test plan

- [x] `cargo test -p query --lib` — 63 passed
- [x] `cargo clippy -p query --no-deps -- -D warnings` clean
- [x] `cargo fmt --all` applied