### PR TITLE
fix(p2p): preserve one-way Iroh gossip direction

### DIFF
--- a/crates/p2p/src/sync/coordinator/access.rs
+++ b/crates/p2p/src/sync/coordinator/access.rs
@@ -1,11 +1,11 @@
 //! Access control for the sync coordinator.
 //!
-//! The actual decision lives in [`super::authorizer::RuntimeAuthorizer`]
-//! so the pubsub_rpc handlers (which don't have easy access to the
-//! generic `SyncCoordinator`) can make the same decision. These helpers
-//! adapt the shared boolean authorizer into the `Result<()>` shape the
-//! two-stream event handlers expect, including the log/`AccessDenied`
-//! error details.
+//! Most decisions live in [`super::authorizer::RuntimeAuthorizer`] so the
+//! pubsub_rpc handlers (which don't have easy access to the generic
+//! `SyncCoordinator`) can make the same decision. These helpers adapt the
+//! shared boolean authorizer into the `Result<()>` shape the event handlers
+//! expect, and layer in local collection-subscription ingress where the sync
+//! API explicitly opts this node into receiving collection updates.
 
 use blockstore::Blockstore;
 
@@ -16,6 +16,46 @@ use crate::error::{Error, Result};
 use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    /// Returns true when this node has joined the collection's sync topic.
+    pub(super) async fn is_locally_subscribed_collection(&self, collection_id: &str) -> bool {
+        self.subscriptions
+            .subscribed_collections
+            .read()
+            .await
+            .contains(collection_id)
+    }
+
+    /// Check if a peer (by string ID) has direct PushLog access to sync a collection.
+    ///
+    /// Direct PushLog is the delivery path used by one-way replicators. A local
+    /// collection subscription means this node has explicitly opted into
+    /// receiving updates for that collection; merge-time ACP still decides
+    /// whether the document content is acceptable.
+    pub(super) async fn check_pushlog_access_str(
+        &self,
+        peer_id_str: &str,
+        collection_id: &str,
+    ) -> Result<()> {
+        if self
+            .authorizer
+            .peer_authorized_for_collection(peer_id_str, collection_id)
+            .await
+            || self.is_locally_subscribed_collection(collection_id).await
+        {
+            return Ok(());
+        }
+
+        tracing::warn!(
+            peer_id = %peer_id_str,
+            collection_id = %collection_id,
+            "Access denied: peer is not authorized for direct PushLog on this collection"
+        );
+        Err(Error::AccessDenied {
+            peer_id: peer_id_str.to_string(),
+            collection_id: collection_id.to_string(),
+        })
+    }
+
     /// Check if a peer (by string ID) has access to sync a collection.
     ///
     /// Returns `Ok(())` if access is granted, or `Err(Error::AccessDenied)` if denied.

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -1062,6 +1062,42 @@ async fn pushlog_controlled_mode_rejects_non_replicator_connected_peer() {
 }
 
 #[tokio::test]
+async fn pushlog_controlled_mode_allows_locally_subscribed_collection() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let peer = random_peer_id();
+    let (coordinator, mut events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+
+    coordinator
+        .subscriptions
+        .subscribed_collections
+        .write()
+        .await
+        .insert("collection1".to_string());
+
+    coordinator
+        .handle_transport_event(pushlog_event(peer.clone(), "collection1"))
+        .await
+        .unwrap();
+
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived {
+            sender_peer,
+            is_explicit_replicator,
+            ..
+        } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+            assert!(
+                !is_explicit_replicator,
+                "collection subscription should not mark the source as an explicit replicator"
+            );
+        }
+        other => panic!("expected BlockReceived, got {:?}", other),
+    }
+}
+
+#[tokio::test]
 async fn pushlog_registered_replicator_is_marked_explicit_replicator() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
@@ -1113,6 +1149,42 @@ async fn two_stream_controlled_mode_rejects_non_replicator_connected_peer() {
         "Connected-but-not-registered peer must be denied on two-stream ingress, got {:?}",
         result
     );
+}
+
+#[tokio::test]
+async fn two_stream_controlled_mode_allows_locally_subscribed_collection() {
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let peer = random_peer_id();
+    let (coordinator, mut events) =
+        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+
+    coordinator
+        .subscriptions
+        .subscribed_collections
+        .write()
+        .await
+        .insert("collection1".to_string());
+
+    coordinator
+        .handle_transport_event(two_stream_event(peer.clone(), "collection1", false))
+        .await
+        .unwrap();
+
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived {
+            sender_peer,
+            is_explicit_replicator,
+            ..
+        } => {
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+            assert!(
+                !is_explicit_replicator,
+                "collection subscription should not mark two-stream senders as explicit replicators"
+            );
+        }
+        other => panic!("expected BlockReceived, got {:?}", other),
+    }
 }
 
 // --- GossipSub access check tests ---
@@ -1190,7 +1262,7 @@ async fn gossip_controlled_mode_rejects_mismatched_topic_and_payload_collection(
 }
 
 #[tokio::test]
-async fn create_replicator_updates_access_registry_for_gossip() {
+async fn gossip_controlled_mode_rejects_outbound_replicator_target() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
     let peer = random_peer_id();
@@ -1203,50 +1275,46 @@ async fn create_replicator_updates_access_registry_for_gossip() {
         .await
         .unwrap();
 
+    coordinator
+        .subscriptions
+        .subscribed_collections
+        .write()
+        .await
+        .insert("collection1".to_string());
+
     let result = coordinator
         .handle_transport_event(gossip_event(peer, "collection1"))
         .await;
 
     assert!(
-        !matches!(&result, Err(Error::AccessDenied { .. })),
-        "registered replicator should authorize gossip immediately, got {:?}",
+        matches!(&result, Err(Error::AccessDenied { .. })),
+        "outbound replicator targets must not be accepted as gossip sources, got {:?}",
         result
     );
 }
 
 #[tokio::test]
-async fn gossip_registered_replicator_is_marked_explicit_replicator() {
+async fn gossip_open_mode_rejects_outbound_replicator_target() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
     let peer = random_peer_id();
     replicators.add_replicator("collection1", peer.as_str());
 
-    let (coordinator, mut events) =
-        create_test_coordinator(AccessMode::Controlled, replicators, peer_state);
+    let (coordinator, _events) = create_test_coordinator(AccessMode::Open, replicators, peer_state);
 
-    coordinator
+    let result = coordinator
         .handle_transport_event(gossip_event(peer.clone(), "collection1"))
-        .await
-        .unwrap();
+        .await;
 
-    match recv_block_received(&mut events).await {
-        SyncEvent::BlockReceived {
-            sender_peer,
-            is_explicit_replicator,
-            ..
-        } => {
-            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
-            assert!(
-                is_explicit_replicator,
-                "registered gossip source should preserve explicit replicator trust"
-            );
-        }
-        other => panic!("expected BlockReceived, got {:?}", other),
-    }
+    assert!(
+        matches!(&result, Err(Error::AccessDenied { .. })),
+        "open access mode must still preserve one-way replicator gossip direction, got {:?}",
+        result
+    );
 }
 
 #[tokio::test]
-async fn gossip_access_falls_back_to_transport_replicator_state() {
+async fn gossip_ignores_transport_replicator_state_for_directionality() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
     let transport = NoopTransport::new();
@@ -1282,9 +1350,13 @@ async fn gossip_access_falls_back_to_transport_replicator_state() {
         .await;
 
     assert!(
-        !matches!(&result, Err(Error::AccessDenied { .. })),
-        "transport replicator state should authorize gossip on registry miss, got {:?}",
+        matches!(&result, Err(Error::AccessDenied { .. })),
+        "transport outbound replicator state must not authorize inbound gossip, got {:?}",
         result
+    );
+    assert!(
+        !replicators.is_replicator("collection1", peer.as_str()),
+        "gossip access checks must not backfill outbound replicator state as inbound gossip trust"
     );
 }
 
@@ -1330,7 +1402,7 @@ async fn delete_replicator_removes_gossip_access_without_subscription() {
 }
 
 #[tokio::test]
-async fn create_replicator_update_removes_old_collection_gossip_access() {
+async fn create_replicator_update_keeps_outbound_targets_from_gossip_sources() {
     let replicators = Arc::new(ReplicatorRegistry::new());
     let peer_state = Arc::new(PeerStateTracker::new());
     let transport = NoopTransport::new();
@@ -1375,8 +1447,8 @@ async fn create_replicator_update_removes_old_collection_gossip_access() {
         old_collection_result
     );
     assert!(
-        !matches!(&new_collection_result, Err(Error::AccessDenied { .. })),
-        "updating a replicator must authorize the new collection immediately, got {:?}",
+        matches!(&new_collection_result, Err(Error::AccessDenied { .. })),
+        "updating a replicator must not turn the outbound target into a gossip source, got {:?}",
         new_collection_result
     );
 }

--- a/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/gossip.rs
@@ -3,7 +3,6 @@
 use blockstore::Blockstore;
 use cid::Cid;
 
-use super::super::authorizer::AccessAuthorizer;
 use super::super::SyncCoordinator;
 use crate::error::Result;
 use crate::message::PushLogBroadcast;
@@ -24,35 +23,31 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             "Received GossipSub message"
         );
 
-        if !self.access.access_mode.is_open() {
-            let topic_matches_collection = topic == message.collection_id;
-            let is_authorized_replicator = self
-                .authorizer
-                .peer_authorized_for_collection(propagation_source.as_str(), &message.collection_id)
-                .await;
-            let is_subscribed = self
-                .subscriptions
-                .subscribed_collections
-                .read()
-                .await
-                .contains(&message.collection_id);
+        let topic_matches_collection = topic == message.collection_id;
+        let is_subscribed = self
+            .is_locally_subscribed_collection(&message.collection_id)
+            .await;
+        let is_outbound_replicator_target =
+            self.is_registered_replicator(propagation_source.as_str(), &message.collection_id);
 
-            if !topic_matches_collection || (!is_authorized_replicator && !is_subscribed) {
-                tracing::warn!(
-                    peer_id = %propagation_source,
-                    topic = %topic,
-                    collection_id = %message.collection_id,
-                    doc_id = %message.doc_id,
-                    topic_matches_collection,
-                    is_authorized_replicator,
-                    is_subscribed,
-                    "Dropping GossipSub message from unauthorized peer"
-                );
-                return Err(crate::error::Error::AccessDenied {
-                    peer_id: propagation_source.to_string(),
-                    collection_id: message.collection_id.clone(),
-                });
-            }
+        if !topic_matches_collection
+            || is_outbound_replicator_target
+            || (!self.access.access_mode.is_open() && !is_subscribed)
+        {
+            tracing::warn!(
+                peer_id = %propagation_source,
+                topic = %topic,
+                collection_id = %message.collection_id,
+                doc_id = %message.doc_id,
+                topic_matches_collection,
+                is_subscribed,
+                is_outbound_replicator_target,
+                "Dropping GossipSub message outside accepted replication direction"
+            );
+            return Err(crate::error::Error::AccessDenied {
+                peer_id: propagation_source.to_string(),
+                collection_id: message.collection_id.clone(),
+            });
         }
 
         // Parse CID

--- a/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pushlog.rs
@@ -25,7 +25,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         );
 
         if let Err(e) = self
-            .check_access_str(peer_id.as_str(), &request.collection_id)
+            .check_pushlog_access_str(peer_id.as_str(), &request.collection_id)
             .await
         {
             tracing::warn!(
@@ -169,7 +169,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let access_err = if is_explicit_replicator {
             None
         } else {
-            self.check_access_str(peer_id.as_str(), &request.collection_id)
+            self.check_pushlog_access_str(peer_id.as_str(), &request.collection_id)
                 .await
                 .err()
         };

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -26,10 +26,10 @@
 //!   replay trust. It controls what we push and which peers are treated as
 //!   explicit replicators.
 //! - **Inbound PushLog acceptance** requires collection replicator membership,
-//!   except for requests carrying explicit replay authorization.
-//! - **Inbound Gossip acceptance** also allows locally subscribed collection
-//!   topics so subscription-based sync can receive updates without registering
-//!   the publisher as an explicit replicator.
+//!   a local collection subscription, or explicit replay authorization.
+//! - **Inbound Gossip acceptance** is topic-scoped to local collection
+//!   subscriptions and rejects outbound replicator targets so one-way
+//!   replicators do not receive reverse-direction gossip from their targets.
 //! - **Document-level ACP** remains the authoritative policy boundary for whether
 //!   replicated document content is actually mergeable/readable locally.
 //!

--- a/tools/integration-test/tests/p2p_iroh/peer/create.rs
+++ b/tools/integration-test/tests/p2p_iroh/peer/create.rs
@@ -72,11 +72,10 @@ async fn create_does_not_sync() {
 
 /// Port: TestP2PCreateWithP2PCollection
 /// When collection subscription + replicator are set, docs sync one-way.
-/// KNOWN GAP: Bidirectional gossip subscriptions override one-way replicator semantics.
-/// Both nodes subscribe to the same gossip topic, so broadcasts from node1 reach node0.
+/// Both nodes subscribe to the same gossip topic, but node0 must still reject
+/// reverse-direction gossip from its outbound replicator target.
 #[tokio::test]
 #[serial]
-#[ignore = "gossip subscriptions override replicator directionality"]
 async fn create_with_p2p_collection() {
     let cluster = TestCluster::builder()
         .rust_nodes(2)


### PR DESCRIPTION
## Summary

Addresses #511 by preventing outbound one-way replicator targets from being accepted as inbound Iroh gossip sources.

## Why

Iroh gossip delivers messages bidirectionally when both peers subscribe to the same collection topic. That meant a one-way replicator such as node0 -> node1 could still sync documents back from node1 -> node0 through gossip, breaking Go parity and one-way replication semantics.

## Changes

| Area | Change |
|---|---|
| Gossip ingress | Reject messages from outbound replicator targets, even in open access mode |
| PushLog ingress | Allow direct PushLog/two-stream sync for locally subscribed collections without marking the sender as an explicit replicator |
| Access model docs | Clarify the difference between direct PushLog ingress, gossip ingress, and explicit replicator trust |
| Tests | Add coordinator regressions for one-way gossip directionality and subscription-based PushLog ingress |
| Integration test | Re-enable the Iroh one-way collection replication regression test |

## Out of scope

- No change to document-level ACP merge policy.
- No change to gossip topic naming.
- No change to explicit replay authorization semantics.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p p2p sync::coordinator::access_tests`
- [x] `cargo test -p p2p`
- [x] `cargo clippy -p p2p -- -D warnings`