### PR TITLE
fix(p2p): actively prune established connections

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -164,11 +164,11 @@ pub struct StartArgs {
     #[arg(long)]
     pub max_p2p_tasks: Option<usize>,
 
-    /// Max established inbound P2P connections (default: 100)
+    /// P2P connection manager low watermark (default: 100)
     #[arg(long)]
     pub max_connections_in: Option<u32>,
 
-    /// Max established outbound P2P connections (default: 400)
+    /// P2P connection manager high watermark (default: 400)
     #[arg(long)]
     pub max_connections_out: Option<u32>,
 

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -212,10 +212,10 @@ pub struct NetConfig {
     /// Max concurrent P2P stream handler tasks. Default: 64.
     #[serde(default = "default_max_p2p_tasks")]
     pub max_p2p_tasks: usize,
-    /// Max established inbound P2P connections. Default: 100.
+    /// P2P connection manager low watermark. Default: 100.
     #[serde(default = "default_max_connections_in")]
     pub max_connections_in: u32,
-    /// Max established outbound P2P connections. Default: 400.
+    /// P2P connection manager high watermark. Default: 400.
     #[serde(default = "default_max_connections_out")]
     pub max_connections_out: u32,
     /// Max established connections per peer. Default: 4.

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -80,9 +80,10 @@ pub struct DefraBehaviour<S: Store> {
     /// Go's DefraDB uses separate streams for request and response.
     pub stream: stream::Behaviour,
 
-    /// Connection limits to prevent resource exhaustion from too many peers.
-    /// Watermarks match Go DefraDB's defaults: 100 pending/established inbound,
-    /// 400 established outbound, 4 streams per peer.
+    /// Hard connection limits for pending handshakes and per-peer fan-out.
+    /// Total established connection pruning is handled by `P2PHost` so new
+    /// peers are not rejected before the Go-compatible low/high-water pruner
+    /// can trim older connections.
     pub connection_limits: connection_limits::Behaviour,
 }
 
@@ -269,8 +270,6 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
         let limits = ConnectionLimits::default()
             .with_max_pending_incoming(Some(config.max_connections_in))
             .with_max_pending_outgoing(Some(config.max_connections_out))
-            .with_max_established_incoming(Some(config.max_connections_in))
-            .with_max_established_outgoing(Some(config.max_connections_out))
             .with_max_established_per_peer(Some(config.max_connections_per_peer));
         let connection_limits = connection_limits::Behaviour::new(limits);
 
@@ -351,12 +350,11 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
         // Configure stream behaviour for Go two-stream compatibility
         let stream = stream::Behaviour::new();
 
-        // Configure connection limits — matches Go DefraDB watermarks
+        // Configure hard pending/per-peer limits; total connection pruning
+        // happens at the host layer to match Go's active conn manager.
         let limits = ConnectionLimits::default()
             .with_max_pending_incoming(Some(100))
             .with_max_pending_outgoing(Some(100))
-            .with_max_established_incoming(Some(100))
-            .with_max_established_outgoing(Some(400))
             .with_max_established_per_peer(Some(4));
         let connection_limits = connection_limits::Behaviour::new(limits);
 

--- a/crates/p2p/src/host/p2p_host/connection_manager.rs
+++ b/crates/p2p/src/host/p2p_host/connection_manager.rs
@@ -1,0 +1,192 @@
+//! Active connection pruning for libp2p hosts.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use libp2p::{swarm::ConnectionId, PeerId};
+use tokio::time::Instant;
+
+#[derive(Debug)]
+pub(super) struct ActiveConnectionManager {
+    low_water: usize,
+    high_water: usize,
+    grace_period: Duration,
+    connections: HashMap<ConnectionId, ManagedConnection>,
+}
+
+#[derive(Debug)]
+pub(super) struct PruneCandidate {
+    pub connection_id: ConnectionId,
+    pub peer_id: PeerId,
+    pub age: Duration,
+}
+
+#[derive(Debug)]
+struct ManagedConnection {
+    peer_id: PeerId,
+    established_at: Instant,
+    closing: bool,
+}
+
+impl ActiveConnectionManager {
+    pub(super) fn new(low_water: u32, high_water: u32, grace_period: Duration) -> Self {
+        let low_water = low_water as usize;
+        let high_water = high_water.max(low_water as u32) as usize;
+
+        Self {
+            low_water,
+            high_water,
+            grace_period,
+            connections: HashMap::new(),
+        }
+    }
+
+    pub(super) fn on_established(
+        &mut self,
+        connection_id: ConnectionId,
+        peer_id: PeerId,
+        now: Instant,
+    ) {
+        self.connections.insert(
+            connection_id,
+            ManagedConnection {
+                peer_id,
+                established_at: now,
+                closing: false,
+            },
+        );
+    }
+
+    pub(super) fn on_closed(&mut self, connection_id: ConnectionId) {
+        self.connections.remove(&connection_id);
+    }
+
+    pub(super) fn prune_candidates(&mut self, now: Instant) -> Vec<PruneCandidate> {
+        let active_count = self
+            .connections
+            .values()
+            .filter(|connection| !connection.closing)
+            .count();
+
+        if active_count <= self.high_water {
+            return Vec::new();
+        }
+
+        let target_count = self.low_water.min(self.high_water);
+        let needed = active_count.saturating_sub(target_count);
+        if needed == 0 {
+            return Vec::new();
+        }
+
+        let mut eligible = self
+            .connections
+            .iter()
+            .filter_map(|(connection_id, connection)| {
+                let age = now.duration_since(connection.established_at);
+                (!connection.closing && age >= self.grace_period).then_some((
+                    *connection_id,
+                    connection.peer_id,
+                    connection.established_at,
+                    age,
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        eligible.sort_by_key(|(_, _, established_at, _)| *established_at);
+
+        eligible
+            .into_iter()
+            .take(needed)
+            .filter_map(|(connection_id, peer_id, _, age)| {
+                let connection = self.connections.get_mut(&connection_id)?;
+                connection.closing = true;
+                Some(PruneCandidate {
+                    connection_id,
+                    peer_id,
+                    age,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn connection_id(id: usize) -> ConnectionId {
+        ConnectionId::new_unchecked(id)
+    }
+
+    #[test]
+    fn below_high_water_does_not_prune() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let now = Instant::now();
+
+        for id in 0..4 {
+            manager.on_established(connection_id(id), PeerId::random(), now);
+        }
+
+        assert!(manager
+            .prune_candidates(now + Duration::from_secs(30))
+            .is_empty());
+    }
+
+    #[test]
+    fn grace_period_protects_new_connections() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let now = Instant::now();
+
+        for id in 0..5 {
+            manager.on_established(connection_id(id), PeerId::random(), now);
+        }
+
+        assert!(manager
+            .prune_candidates(now + Duration::from_secs(10))
+            .is_empty());
+    }
+
+    #[test]
+    fn prunes_oldest_connections_toward_low_water() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let now = Instant::now();
+
+        for id in 0..5 {
+            manager.on_established(
+                connection_id(id),
+                PeerId::random(),
+                now + Duration::from_secs(id as u64),
+            );
+        }
+
+        let candidates = manager.prune_candidates(now + Duration::from_secs(30));
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.connection_id)
+                .collect::<Vec<_>>(),
+            vec![connection_id(0), connection_id(1), connection_id(2)]
+        );
+    }
+
+    #[test]
+    fn closing_candidates_are_not_repeated() {
+        let mut manager = ActiveConnectionManager::new(2, 4, Duration::from_secs(20));
+        let now = Instant::now();
+
+        for id in 0..5 {
+            manager.on_established(connection_id(id), PeerId::random(), now);
+        }
+
+        assert_eq!(
+            manager
+                .prune_candidates(now + Duration::from_secs(30))
+                .len(),
+            3
+        );
+        assert!(manager
+            .prune_candidates(now + Duration::from_secs(31))
+            .is_empty());
+    }
+}

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides the main P2P host that manages the libp2p swarm,
 //! handles peer connections, and coordinates CRDT synchronization.
 
+mod connection_manager;
 mod protocols;
 mod swarm;
 mod two_stream;
@@ -30,6 +31,8 @@ use crate::message::PushLogReply;
 use crate::two_stream::{TwoStreamHandler, TwoStreamRunner};
 use crate::QueryId;
 
+use connection_manager::ActiveConnectionManager;
+
 use super::command::HostCommand;
 use super::event::HostEvent;
 use super::handle::P2PHostHandle;
@@ -43,6 +46,12 @@ const DHT_BOOTSTRAP_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 /// Delay used to coalesce connection-triggered DHT bootstrap requests.
 const DHT_BOOTSTRAP_DEBOUNCE: Duration = Duration::from_secs(30);
+
+/// Go libp2p connection manager grace period before pruning new connections.
+const CONNECTION_MANAGER_GRACE_PERIOD: Duration = Duration::from_secs(20);
+
+/// Frequency for checking whether the active connection set should be pruned.
+const CONNECTION_PRUNE_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
 struct BootstrapScheduler {
@@ -89,9 +98,9 @@ pub struct P2PHostConfig {
     pub stream_timeout: u64,
     /// Max concurrent stream handler tasks. Default: 64.
     pub max_p2p_tasks: usize,
-    /// Max established inbound connections. Default: 100.
+    /// Connection manager low watermark. Default: 100.
     pub max_connections_in: u32,
-    /// Max established outbound connections. Default: 400.
+    /// Connection manager high watermark. Default: 400.
     pub max_connections_out: u32,
     /// Max connections per peer. Default: 4.
     pub max_connections_per_peer: u32,
@@ -145,6 +154,9 @@ pub struct P2PHost<S: Store> {
     pub(super) node_identity: Option<Arc<identity::RawIdentity>>,
     /// Verified peer DEFRA DIDs keyed by peer ID.
     pub(super) peer_identities: HashMap<PeerId, identity::Did>,
+    /// Tracks established connections and actively prunes them after the
+    /// Go-compatible low/high watermarks are exceeded.
+    connection_manager: ActiveConnectionManager,
     /// Topics whose incoming gossipsub messages bypass the PushLog decoder
     /// and flow through `HostEvent::GossipRawMessage` instead. Populated
     /// by `HostCommand::RegisterPubsubRpcTopic` when the coordinator wires
@@ -417,6 +429,11 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             peer_addrs: HashMap::new(),
             node_identity,
             peer_identities: HashMap::new(),
+            connection_manager: ActiveConnectionManager::new(
+                config.max_connections_in,
+                config.max_connections_out,
+                CONNECTION_MANAGER_GRACE_PERIOD,
+            ),
             pubsub_rpc_topics: HashSet::new(),
         };
 
@@ -442,6 +459,9 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
         let mut bootstrap_interval = time::interval(DHT_BOOTSTRAP_INTERVAL);
         bootstrap_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         bootstrap_interval.tick().await;
+        let mut connection_prune_interval = time::interval(CONNECTION_PRUNE_INTERVAL);
+        connection_prune_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        connection_prune_interval.tick().await;
 
         loop {
             // Biased select: process swarm events before commands.
@@ -460,6 +480,7 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
                             );
                         }
                     }
+                    self.prune_connections("swarm event");
                 }
                 // Handle two-stream protocol events (Go compatibility)
                 Some(two_stream_event) = self.two_stream_event_rx.recv() => {
@@ -485,6 +506,9 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
                 _ = bootstrap_interval.tick() => {
                     self.run_kademlia_bootstrap("periodic");
                 }
+                _ = connection_prune_interval.tick() => {
+                    self.prune_connections("periodic");
+                }
             }
         }
 
@@ -498,6 +522,22 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             }
             Err(error) => {
                 debug!(?error, reason, "Skipped Kademlia bootstrap");
+            }
+        }
+    }
+
+    fn prune_connections(&mut self, reason: &'static str) {
+        for candidate in self.connection_manager.prune_candidates(Instant::now()) {
+            if self.swarm.close_connection(candidate.connection_id) {
+                debug!(
+                    peer_id = %candidate.peer_id,
+                    connection_id = %candidate.connection_id,
+                    age_secs = candidate.age.as_secs(),
+                    reason,
+                    "Pruning established P2P connection above high watermark"
+                );
+            } else {
+                self.connection_manager.on_closed(candidate.connection_id);
             }
         }
     }

--- a/crates/p2p/src/host/p2p_host/swarm.rs
+++ b/crates/p2p/src/host/p2p_host/swarm.rs
@@ -29,9 +29,18 @@ impl<S: Store> P2PHost<S> {
             }
 
             SwarmEvent::ConnectionEstablished {
-                peer_id, endpoint, ..
+                peer_id,
+                connection_id,
+                endpoint,
+                ..
             } => {
                 info!(peer_id = %peer_id, "Peer connected");
+                self.connection_manager.on_established(
+                    connection_id,
+                    peer_id,
+                    tokio::time::Instant::now(),
+                );
+
                 // Store the remote peer's address from the connection endpoint.
                 // For dialer: the address we dialed (peer's listen addr).
                 // For listener: the send_back_addr. With TCP port reuse enabled,
@@ -86,10 +95,12 @@ impl<S: Store> P2PHost<S> {
 
             SwarmEvent::ConnectionClosed {
                 peer_id,
+                connection_id,
                 num_established,
                 ..
             } => {
                 info!(peer_id = %peer_id, "Peer disconnected");
+                self.connection_manager.on_closed(connection_id);
                 if num_established == 0 {
                     self.peer_addrs.remove(&peer_id);
                 }


### PR DESCRIPTION
## Summary

Tracks #831 by replacing Rust established-connection hard cap behavior with Go-style active pruning.

## Why

Go DefraDB uses a connection manager with low/high watermarks and a grace period: new connections can establish, then older connections are pruned back toward the low watermark. Rust was using libp2p `connection_limits` as a hard established-connection cap, which could reject new peers instead of accepting them and trimming older connections.

## Changes

| Area | Change |
|---|---|
| P2P host | Add an active established-connection manager with low/high watermarks |
| Pruning policy | Close oldest grace-expired connections after the high watermark is exceeded |
| Connection limits | Keep hard limits for pending handshakes and per-peer fan-out only |
| Swarm events | Track established and closed `ConnectionId`s for pruning |
| CLI/config docs | Clarify existing `max_connections_in/out` values as low/high watermarks |
| Tests | Add deterministic policy coverage for high-water pruning, grace period, oldest-first selection, and duplicate close suppression |

## Out of scope

- No full libp2p ResourceManager implementation.
- No memory or file-descriptor budget enforcement.
- No dual LAN/WAN DHT work.
- No change to existing config field names.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p p2p connection_manager`
- [x] `cargo test -p p2p`
- [x] `cargo clippy -p p2p -- -D warnings`
- [x] `cargo clippy -p p2p --all-targets -- -D warnings`