### PR TITLE
chore(p2p): rename connection-manager fields to match watermark semantics

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -164,13 +164,17 @@ pub struct StartArgs {
     #[arg(long)]
     pub max_p2p_tasks: Option<usize>,
 
-    /// P2P connection manager low watermark (default: 100)
+    /// P2P established connection low watermark (default: 100)
     #[arg(long)]
-    pub max_connections_in: Option<u32>,
+    pub connection_manager_low_water: Option<u32>,
 
-    /// P2P connection manager high watermark (default: 400)
+    /// P2P established connection high watermark (default: 400)
     #[arg(long)]
-    pub max_connections_out: Option<u32>,
+    pub connection_manager_high_water: Option<u32>,
+
+    /// P2P connection manager grace period in milliseconds (default: 20000)
+    #[arg(long)]
+    pub connection_manager_grace_period_ms: Option<u64>,
 
     /// Max established P2P connections per peer (default: 4)
     #[arg(long)]
@@ -472,11 +476,14 @@ impl StartArgs {
         if let Some(max) = self.max_p2p_tasks {
             config.net.max_p2p_tasks = max;
         }
-        if let Some(max) = self.max_connections_in {
-            config.net.max_connections_in = max;
+        if let Some(low_water) = self.connection_manager_low_water {
+            config.net.connection_manager_low_water = low_water;
         }
-        if let Some(max) = self.max_connections_out {
-            config.net.max_connections_out = max;
+        if let Some(high_water) = self.connection_manager_high_water {
+            config.net.connection_manager_high_water = high_water;
+        }
+        if let Some(grace_period_ms) = self.connection_manager_grace_period_ms {
+            config.net.connection_manager_grace_period_ms = grace_period_ms;
         }
         if let Some(max) = self.max_connections_per_peer {
             config.net.max_connections_per_peer = max;

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -1,5 +1,7 @@
 //! P2P initialization methods for Node
 
+use std::time::Duration;
+
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 
@@ -109,8 +111,11 @@ impl Node {
             max_car_size: config.net.max_car_size,
             stream_timeout: config.net.stream_timeout,
             max_p2p_tasks: config.net.max_p2p_tasks,
-            max_connections_in: config.net.max_connections_in,
-            max_connections_out: config.net.max_connections_out,
+            connection_manager_low_water: config.net.connection_manager_low_water,
+            connection_manager_high_water: config.net.connection_manager_high_water,
+            connection_manager_grace_period: Duration::from_millis(
+                config.net.connection_manager_grace_period_ms,
+            ),
             max_connections_per_peer: config.net.max_connections_per_peer,
             access_mode,
         };

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -237,12 +237,15 @@ pub struct NetConfig {
     /// Max concurrent P2P stream handler tasks. Default: 64.
     #[serde(default = "default_max_p2p_tasks")]
     pub max_p2p_tasks: usize,
-    /// P2P connection manager low watermark. Default: 100.
-    #[serde(default = "default_max_connections_in")]
-    pub max_connections_in: u32,
-    /// P2P connection manager high watermark. Default: 400.
-    #[serde(default = "default_max_connections_out")]
-    pub max_connections_out: u32,
+    /// P2P established connection low watermark. Default: 100.
+    #[serde(default = "default_connection_manager_low_water")]
+    pub connection_manager_low_water: u32,
+    /// P2P established connection high watermark. Default: 400.
+    #[serde(default = "default_connection_manager_high_water")]
+    pub connection_manager_high_water: u32,
+    /// P2P connection manager grace period in milliseconds. Default: 20000.
+    #[serde(default = "default_connection_manager_grace_period_ms")]
+    pub connection_manager_grace_period_ms: u64,
     /// Max established connections per peer. Default: 4.
     #[serde(default = "default_max_connections_per_peer")]
     pub max_connections_per_peer: u32,
@@ -293,11 +296,14 @@ fn default_stream_timeout() -> u64 {
 fn default_max_p2p_tasks() -> usize {
     64
 }
-fn default_max_connections_in() -> u32 {
+fn default_connection_manager_low_water() -> u32 {
     100
 }
-fn default_max_connections_out() -> u32 {
+fn default_connection_manager_high_water() -> u32 {
     400
+}
+fn default_connection_manager_grace_period_ms() -> u64 {
+    20_000
 }
 fn default_max_connections_per_peer() -> u32 {
     4
@@ -324,8 +330,9 @@ impl Default for NetConfig {
             max_car_size: default_max_car_size(),
             stream_timeout: default_stream_timeout(),
             max_p2p_tasks: default_max_p2p_tasks(),
-            max_connections_in: default_max_connections_in(),
-            max_connections_out: default_max_connections_out(),
+            connection_manager_low_water: default_connection_manager_low_water(),
+            connection_manager_high_water: default_connection_manager_high_water(),
+            connection_manager_grace_period_ms: default_connection_manager_grace_period_ms(),
             max_connections_per_peer: default_max_connections_per_peer(),
             transport: TransportType::default(),
             iroh_relay_url: None,

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -38,8 +38,9 @@ fn default_start_args() -> StartArgs {
         max_car_size: None,
         stream_timeout: None,
         max_p2p_tasks: None,
-        max_connections_in: None,
-        max_connections_out: None,
+        connection_manager_low_water: None,
+        connection_manager_high_water: None,
+        connection_manager_grace_period_ms: None,
         max_connections_per_peer: None,
         p2p_rate_limit_burst: None,
         p2p_rate_limit_rate: None,
@@ -130,8 +131,9 @@ fn test_apply_to_config_all_flags() {
         max_car_size: Some(128 * 1024 * 1024),
         stream_timeout: Some(60),
         max_p2p_tasks: Some(128),
-        max_connections_in: Some(200),
-        max_connections_out: Some(800),
+        connection_manager_low_water: Some(200),
+        connection_manager_high_water: Some(800),
+        connection_manager_grace_period_ms: Some(10_000),
         max_connections_per_peer: Some(8),
         p2p_rate_limit_burst: Some(32),
         p2p_rate_limit_rate: Some(4.5),
@@ -159,8 +161,9 @@ fn test_apply_to_config_all_flags() {
     assert_eq!(config.net.max_car_size, 128 * 1024 * 1024);
     assert_eq!(config.net.stream_timeout, 60);
     assert_eq!(config.net.max_p2p_tasks, 128);
-    assert_eq!(config.net.max_connections_in, 200);
-    assert_eq!(config.net.max_connections_out, 800);
+    assert_eq!(config.net.connection_manager_low_water, 200);
+    assert_eq!(config.net.connection_manager_high_water, 800);
+    assert_eq!(config.net.connection_manager_grace_period_ms, 10_000);
     assert_eq!(config.net.max_connections_per_peer, 8);
     assert_eq!(config.net.p2p_rate_limit_burst, 32);
     assert_eq!(config.net.p2p_rate_limit_rate, 4.5);

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -59,6 +59,11 @@ const KAD_PARALLELISM: NonZeroUsize = match NonZeroUsize::new(10) {
     None => unreachable!(),
 };
 
+/// Pending dial/listen limits are intentionally separate from the exposed
+/// established-connection watermarks and follow the Go default shape.
+const MAX_PENDING_INCOMING_CONNECTIONS: u32 = 100;
+const MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 400;
+
 /// Composite network behaviour for DefraDB nodes.
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "DefraEvent")]
@@ -286,8 +291,8 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
         let stream = stream::Behaviour::new();
 
         let limits = ConnectionLimits::default()
-            .with_max_pending_incoming(Some(config.max_connections_in))
-            .with_max_pending_outgoing(Some(config.max_connections_out))
+            .with_max_pending_incoming(Some(MAX_PENDING_INCOMING_CONNECTIONS))
+            .with_max_pending_outgoing(Some(MAX_PENDING_OUTGOING_CONNECTIONS))
             .with_max_established_per_peer(Some(config.max_connections_per_peer));
         let connection_limits = connection_limits::Behaviour::new(limits);
 

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -48,7 +48,7 @@ const DHT_BOOTSTRAP_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const DHT_BOOTSTRAP_DEBOUNCE: Duration = Duration::from_secs(30);
 
 /// Go libp2p connection manager grace period before pruning new connections.
-const CONNECTION_MANAGER_GRACE_PERIOD: Duration = Duration::from_secs(20);
+const DEFAULT_CONNECTION_MANAGER_GRACE_PERIOD: Duration = Duration::from_secs(20);
 
 /// Frequency for checking whether the active connection set should be pruned.
 const CONNECTION_PRUNE_INTERVAL: Duration = Duration::from_secs(5);
@@ -98,10 +98,12 @@ pub struct P2PHostConfig {
     pub stream_timeout: u64,
     /// Max concurrent stream handler tasks. Default: 64.
     pub max_p2p_tasks: usize,
-    /// Connection manager low watermark. Default: 100.
-    pub max_connections_in: u32,
-    /// Connection manager high watermark. Default: 400.
-    pub max_connections_out: u32,
+    /// Established connection low watermark. Default: 100.
+    pub connection_manager_low_water: u32,
+    /// Established connection high watermark. Default: 400.
+    pub connection_manager_high_water: u32,
+    /// Grace period before new established connections are eligible for pruning. Default: 20s.
+    pub connection_manager_grace_period: Duration,
     /// Max connections per peer. Default: 4.
     pub max_connections_per_peer: u32,
     /// Bitswap egress access control. When `Controlled`, served blocks
@@ -119,8 +121,9 @@ impl Default for P2PHostConfig {
             max_car_size: 64 * 1024 * 1024,
             stream_timeout: 30,
             max_p2p_tasks: 64,
-            max_connections_in: 100,
-            max_connections_out: 400,
+            connection_manager_low_water: 100,
+            connection_manager_high_water: 400,
+            connection_manager_grace_period: DEFAULT_CONNECTION_MANAGER_GRACE_PERIOD,
             max_connections_per_peer: 4,
             access_mode: AccessMode::Open,
         }
@@ -430,9 +433,9 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             node_identity,
             peer_identities: HashMap::new(),
             connection_manager: ActiveConnectionManager::new(
-                config.max_connections_in,
-                config.max_connections_out,
-                CONNECTION_MANAGER_GRACE_PERIOD,
+                config.connection_manager_low_water,
+                config.connection_manager_high_water,
+                config.connection_manager_grace_period,
             ),
             pubsub_rpc_topics: HashSet::new(),
         };

--- a/tools/integration-test/tests/p2p.rs
+++ b/tools/integration-test/tests/p2p.rs
@@ -1,3 +1,5 @@
+#[path = "p2p/connection_manager.rs"]
+mod connection_manager;
 #[path = "p2p/document.rs"]
 mod document;
 #[path = "p2p/idempotent_replay.rs"]

--- a/tools/integration-test/tests/p2p/connection_manager.rs
+++ b/tools/integration-test/tests/p2p/connection_manager.rs
@@ -1,0 +1,216 @@
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use integration_test::node::{
+    start_node, DefraNode, KeyringBackend, NodeConfig, RunningNode, RustNode,
+};
+use integration_test::ports::allocate_node_ports;
+use integration_test::{poll_until, DefraClient, NodeKind};
+
+const NODE_COUNT: usize = 5;
+const LOW_WATER: u32 = 2;
+const HIGH_WATER: u32 = 3;
+const GRACE_PERIOD_MS: u64 = 200;
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+const P2P_TIMEOUT: Duration = Duration::from_secs(15);
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+static RUST_BUILD_DONE: OnceLock<()> = OnceLock::new();
+
+struct RustNodeWithStartArgs {
+    binary_path: PathBuf,
+    extra_start_args: Vec<String>,
+}
+
+impl RustNodeWithStartArgs {
+    fn new(binary_path: PathBuf, extra_start_args: Vec<String>) -> Self {
+        Self {
+            binary_path,
+            extra_start_args,
+        }
+    }
+}
+
+impl DefraNode for RustNodeWithStartArgs {
+    fn kind(&self) -> NodeKind {
+        NodeKind::Rust
+    }
+
+    fn command_parts(&self, config: &NodeConfig) -> (PathBuf, Vec<String>, Vec<(String, String)>) {
+        let node = RustNode::from_binary(self.binary_path.clone());
+        let (program, mut args, envs) = node.command_parts(config);
+        args.extend(self.extra_start_args.clone());
+        (program, args, envs)
+    }
+
+    fn binary_path(&self) -> &Path {
+        &self.binary_path
+    }
+}
+
+fn build_rust_binary() -> PathBuf {
+    RUST_BUILD_DONE.get_or_init(|| {
+        RustNode::build().expect("failed to build Rust defra binary");
+    });
+    RustNode::workspace_binary_path()
+}
+
+fn client(node: &RunningNode) -> DefraClient {
+    DefraClient::new(
+        node.binary_path.clone(),
+        node.http_addr.clone(),
+        NodeKind::Rust,
+    )
+}
+
+fn first_p2p_addr(client: &DefraClient) -> String {
+    client
+        .p2p_info()
+        .expect("p2p_info")
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|value| value.as_str())
+        .expect("node has no P2P address")
+        .to_string()
+}
+
+fn peer_id_from_addr(addr: &str) -> String {
+    addr.rsplit_once("/p2p/")
+        .map_or(addr, |(_, peer_id)| peer_id)
+        .to_string()
+}
+
+fn active_peer_ids(client: &DefraClient) -> Vec<String> {
+    client
+        .p2p_active_peers()
+        .expect("p2p_active_peers")
+        .as_array()
+        .expect("active_peers not array")
+        .iter()
+        .map(|value| peer_id_from_addr(value.as_str().expect("active peer must be a string")))
+        .collect()
+}
+
+async fn wait_for_active_peer(client: &DefraClient, peer_id: &str) {
+    poll_until(
+        || active_peer_ids(client).iter().any(|id| id == peer_id),
+        P2P_TIMEOUT,
+        POLL_INTERVAL,
+        "peer did not appear in active_peers",
+    )
+    .await;
+}
+
+async fn start_pruning_cluster() -> (tempfile::TempDir, Vec<RunningNode>) {
+    let binary_path = build_rust_binary();
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let mut ports = allocate_node_ports(NODE_COUNT).expect("allocate node ports");
+    let mut nodes = Vec::with_capacity(NODE_COUNT);
+
+    // Node 0 is the constrained target; nodes 1..=4 are peer dialers.
+    for (index, port) in ports.iter_mut().enumerate() {
+        let name = format!("rust-connmgr-{index}");
+        let rootdir = temp_dir.path().join(format!("node-{index}/data"));
+        let log_dir = temp_dir.path().join(format!("node-{index}/logs"));
+        let mut config = NodeConfig::new(
+            name.clone(),
+            rootdir,
+            log_dir,
+            format!("127.0.0.1:{}", port.http),
+        );
+        config.p2p_enabled = true;
+        config.p2p_addr = Some(format!("/ip4/127.0.0.1/tcp/{}", port.p2p));
+        config.keyring = KeyringBackend::None;
+
+        let extra_start_args = if index == 0 {
+            vec![
+                "--connection-manager-low-water".to_string(),
+                LOW_WATER.to_string(),
+                "--connection-manager-high-water".to_string(),
+                HIGH_WATER.to_string(),
+                "--connection-manager-grace-period-ms".to_string(),
+                GRACE_PERIOD_MS.to_string(),
+            ]
+        } else {
+            Vec::new()
+        };
+
+        let node = RustNodeWithStartArgs::new(binary_path.clone(), extra_start_args);
+        port.release();
+        let running = start_node(&node, config, READY_TIMEOUT)
+            .await
+            .unwrap_or_else(|error| panic!("failed to start {name}: {error}"));
+        nodes.push(running);
+    }
+
+    for node in &nodes {
+        node.log_tracker
+            .wait_for_pattern("p2p_listening", P2P_TIMEOUT)
+            .await
+            .unwrap_or_else(|error| panic!("{} P2P listener did not start: {error}", node.name));
+    }
+
+    (temp_dir, nodes)
+}
+
+#[tokio::test]
+async fn rust_connection_manager_prunes_to_low_water_oldest_first() {
+    let (_temp_dir, nodes) = start_pruning_cluster().await;
+    let clients = nodes.iter().map(client).collect::<Vec<_>>();
+    let target = &clients[0];
+    let target_addr = first_p2p_addr(target);
+    let peer_addrs = clients[1..].iter().map(first_p2p_addr).collect::<Vec<_>>();
+    let peer_ids = peer_addrs
+        .iter()
+        .map(|addr| peer_id_from_addr(addr))
+        .collect::<Vec<_>>();
+
+    for (index, (peer_client, peer_id)) in clients[1..4].iter().zip(peer_ids.iter()).enumerate() {
+        peer_client
+            .p2p_connect(&[&target_addr])
+            .unwrap_or_else(|error| panic!("peer {} failed to connect: {error}", index + 1));
+        wait_for_active_peer(target, peer_id).await;
+        tokio::time::sleep(Duration::from_millis(GRACE_PERIOD_MS + 75)).await;
+    }
+
+    let active_before_prune = active_peer_ids(target);
+    assert_eq!(
+        active_before_prune.len(),
+        HIGH_WATER as usize,
+        "expected target to have exactly the high-water number of peers before pruning"
+    );
+    assert!(
+        peer_ids
+            .iter()
+            .take(3)
+            .all(|peer_id| active_before_prune.contains(peer_id)),
+        "expected first three peers to be active before pruning: {active_before_prune:?}"
+    );
+
+    clients[4]
+        .p2p_connect(&[&target_addr])
+        .expect("fourth peer failed to connect");
+    wait_for_active_peer(target, &peer_ids[3]).await;
+
+    let mut expected_survivors = vec![peer_ids[2].clone(), peer_ids[3].clone()];
+    expected_survivors.sort();
+    poll_until(
+        || {
+            let mut active = active_peer_ids(target);
+            active.sort();
+            active == expected_survivors
+        },
+        Duration::from_secs(10),
+        POLL_INTERVAL,
+        "connection manager did not prune to low water oldest first",
+    )
+    .await;
+
+    let mut active_after_prune = active_peer_ids(target);
+    active_after_prune.sort();
+    assert_eq!(
+        active_after_prune, expected_survivors,
+        "expected peers 3 and 4 to survive oldest-first pruning to low water"
+    );
+}


### PR DESCRIPTION
## Summary
- Rename P2P connection-manager config/CLI fields from max_connections_in/out to connection_manager_low_water/high_water to match established-connection watermark semantics.
- Keep pending dial/listen limits separate from the watermark settings while preserving the existing default values.
- Add a swarm-level Rust libp2p integration test that opens four peer connections against low=2/high=3/grace=200ms and verifies pruning to low water oldest-first.

Refs #939.
Refs #831.

## Compatibility
- This intentionally breaks the pre-release config/CLI names (`max_connections_in`, `max_connections_out`, `--max-connections-in`, `--max-connections-out`) instead of accepting aliases, because 1.0 RC has not been released and those names no longer describe the semantics.
- Pending dial/listen limits remain fixed at the previous default shape (100/400) and are intentionally separate from the exposed established-connection watermarks.

## Validation
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo test -p p2p
- cargo test -p integration-test --test p2p

Note: the full p2p integration suite needs the Go defradb binary on PATH; I used the v1.0.0-rc1 binary from the defra-harness cache.