### PR TITLE
fix(p2p): match Go gossipsub MessageId binary format for cross-impl parity

### DIFF
--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -72,6 +72,9 @@ const MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 400;
 /// go-libp2p-pubsub@v0.15.0 pubsub.go:1356 uses raw `from || seqno` bytes.
 /// rust-libp2p's default uses base58/decimal strings, which breaks cross-impl
 /// IHAVE/IWANT parity.
+///
+/// This requires message authenticity modes that populate source and sequence
+/// number; anonymous messages would all collapse to the empty ID.
 pub fn go_compatible_gossipsub_message_id(message: &gossipsub::Message) -> MessageId {
     let mut id = Vec::with_capacity(GO_MESSAGE_ID_CAPACITY);
     if let Some(peer_id) = message.source {
@@ -250,8 +253,7 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(1))
                 .validation_mode(ValidationMode::Strict)
-                // Match go-libp2p-pubsub@v0.15.0 pubsub.go:1356 for
-                // cross-impl IHAVE/IWANT parity.
+                // See `go_compatible_gossipsub_message_id`.
                 .message_id_fn(go_compatible_gossipsub_message_id)
                 // Enable peer exchange (PX) in PRUNE messages — matches Go's
                 // pubsub.WithPeerExchange(true). Allows peers sharing a topic
@@ -361,8 +363,7 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(1))
                 .validation_mode(ValidationMode::Permissive)
-                // Match go-libp2p-pubsub@v0.15.0 pubsub.go:1356 for
-                // cross-impl IHAVE/IWANT parity.
+                // See `go_compatible_gossipsub_message_id`.
                 .message_id_fn(go_compatible_gossipsub_message_id)
                 .build()
                 .map_err(|e| crate::error::Error::GossipSubConfig(e.to_string()))?;

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 use iroh_bitswap::{Bitswap, BitswapEvent, Config as BitswapConfig, Store};
 use libp2p::{
     connection_limits::{self, ConnectionLimits},
-    gossipsub::{self, MessageAuthenticity, ValidationMode},
+    gossipsub::{self, MessageAuthenticity, MessageId, ValidationMode},
     identify,
     kad::{self, store::MemoryStore},
     relay,
@@ -52,6 +52,9 @@ use crate::message::{PushLogReply, PushLogRequest};
 /// Timeout for PushLog requests.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Enough for the common identity multihash plus an 8-byte sequence number.
+const GO_MESSAGE_ID_CAPACITY: usize = 48;
+
 /// Kademlia query parallelism. Matches Go's `dht.Concurrency(10)`
 /// (`go-p2p/host.go:44`). rust-libp2p defaults to `ALPHA_VALUE` = 3.
 const KAD_PARALLELISM: NonZeroUsize = match NonZeroUsize::new(10) {
@@ -63,6 +66,22 @@ const KAD_PARALLELISM: NonZeroUsize = match NonZeroUsize::new(10) {
 /// established-connection watermarks and follow the Go default shape.
 const MAX_PENDING_INCOMING_CONNECTIONS: u32 = 100;
 const MAX_PENDING_OUTGOING_CONNECTIONS: u32 = 400;
+
+/// Go-compatible gossipsub message ID derivation.
+///
+/// go-libp2p-pubsub@v0.15.0 pubsub.go:1356 uses raw `from || seqno` bytes.
+/// rust-libp2p's default uses base58/decimal strings, which breaks cross-impl
+/// IHAVE/IWANT parity.
+pub fn go_compatible_gossipsub_message_id(message: &gossipsub::Message) -> MessageId {
+    let mut id = Vec::with_capacity(GO_MESSAGE_ID_CAPACITY);
+    if let Some(peer_id) = message.source {
+        id.extend_from_slice(&peer_id.to_bytes());
+    }
+    if let Some(seqno) = message.sequence_number {
+        id.extend_from_slice(&seqno.to_be_bytes());
+    }
+    MessageId::from(id)
+}
 
 /// Composite network behaviour for DefraDB nodes.
 #[derive(NetworkBehaviour)]
@@ -227,18 +246,13 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
         );
 
         // Configure GossipSub (matches Go's `if options.EnablePubSub` conditional)
-        //
-        // We deliberately do NOT override `message_id_fn`. Go DefraDB (via
-        // go-libp2p-pubsub at `go-p2p/peer.go:133-139`) uses the default
-        // message-id derivation (`source + seqno`). Using the same default
-        // here keeps Rust and Go mesh-propagation semantics aligned: two
-        // peers publishing identical payloads produce distinct message IDs,
-        // so neither implementation silently dedups legitimate duplicate
-        // content from different senders. See issue #834.
         let gossipsub = if enable_pubsub {
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(1))
                 .validation_mode(ValidationMode::Strict)
+                // Match go-libp2p-pubsub@v0.15.0 pubsub.go:1356 for
+                // cross-impl IHAVE/IWANT parity.
+                .message_id_fn(go_compatible_gossipsub_message_id)
                 // Enable peer exchange (PX) in PRUNE messages — matches Go's
                 // pubsub.WithPeerExchange(true). Allows peers sharing a topic
                 // to discover each other through mesh management.
@@ -343,18 +357,13 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
         );
 
         // Configure GossipSub (optional, matches Go's `if options.EnablePubSub`).
-        //
-        // We deliberately do NOT override `message_id_fn`. Go DefraDB (via
-        // go-libp2p-pubsub at `go-p2p/peer.go:133-139`) uses the default
-        // message-id derivation (`source + seqno`). Using the same default
-        // here keeps Rust and Go mesh-propagation semantics aligned: two
-        // peers publishing identical payloads produce distinct message IDs,
-        // so neither implementation silently dedups legitimate duplicate
-        // content from different senders. See issue #834.
         let gossipsub = if enable_pubsub {
             let gossipsub_config = gossipsub::ConfigBuilder::default()
                 .heartbeat_interval(Duration::from_secs(1))
                 .validation_mode(ValidationMode::Permissive)
+                // Match go-libp2p-pubsub@v0.15.0 pubsub.go:1356 for
+                // cross-impl IHAVE/IWANT parity.
+                .message_id_fn(go_compatible_gossipsub_message_id)
                 .build()
                 .map_err(|e| crate::error::Error::GossipSubConfig(e.to_string()))?;
 

--- a/crates/p2p/tests/gossipsub_message_id_go_parity.rs
+++ b/crates/p2p/tests/gossipsub_message_id_go_parity.rs
@@ -1,0 +1,77 @@
+use std::str::FromStr;
+
+use libp2p::{
+    gossipsub::{ConfigBuilder, IdentTopic, Message},
+    PeerId,
+};
+use p2p::behaviour::go_compatible_gossipsub_message_id;
+
+struct GoMessageIdFixture {
+    source_peer_id: &'static str,
+    seqno: u64,
+    expected_message_id_hex: &'static str,
+}
+
+// Fixtures generated with github.com/libp2p/go-libp2p-pubsub v0.15.0,
+// the version pulled in by github.com/sourcenetwork/go-p2p v0.1.9.
+// Go's DefaultMsgIdFn returns raw `from` bytes followed by raw `seqno` bytes.
+const GO_MESSAGE_ID_FIXTURES: &[GoMessageIdFixture] = &[
+    GoMessageIdFixture {
+        source_peer_id: "12D3KooWRthjSZqhYSw9stPs7gyDZNCQj56DPrexwu81x4pBPWrf",
+        seqno: 0,
+        expected_message_id_hex:
+            "002408011220eed76f5297f40aa13424a7d137b0ece2767af93cb1e7ab1d6a1822246c3e9d040000000000000000",
+    },
+    GoMessageIdFixture {
+        source_peer_id: "12D3KooWRVrtCQVw1cS9yL6be2LubujAwLfWBj8ezdAmaVsfG3Mk",
+        seqno: 1,
+        expected_message_id_hex:
+            "002408011220e8fd6c5b8d0f7af079c17f7283e71980b9e7489adb8f25a6a37dc47d3df138730000000000000001",
+    },
+    GoMessageIdFixture {
+        source_peer_id: "12D3KooWJE6tgHjS38qKvYxJyxj6v4wiL3qm5zpGfZXRue94AXjt",
+        seqno: 42,
+        expected_message_id_hex:
+            "0024080112207cf2293b8c0ab992f698ad6b9dc4e3d623c707ff5e7c9c96517facc1ff88a0c7000000000000002a",
+    },
+    GoMessageIdFixture {
+        source_peer_id: "12D3KooWQcTgQo6AqZZi93a6RmjSSyiaM6Pox3UwQcGQZLxoc93t",
+        seqno: 72_623_859_790_382_856,
+        expected_message_id_hex:
+            "002408011220dbd290e8c6bb7efe5adcf2405dbc014e19c3ce73dc15dbf82e95436cee47433f0102030405060708",
+    },
+    GoMessageIdFixture {
+        source_peer_id: "12D3KooWGvPsoXFvBELWCpmJfNLj2iP6CSQCtNhYfbm6h7gbeLD4",
+        seqno: u64::MAX,
+        expected_message_id_hex:
+            "002408011220698d39770c1d14d255b15d8b59183aab280159446a7345c0a0ceed86ffc45a2fffffffffffffffff",
+    },
+];
+
+#[test]
+fn go_compatible_gossipsub_message_id_matches_go_pubsub_fixtures() {
+    let config = ConfigBuilder::default()
+        .message_id_fn(go_compatible_gossipsub_message_id)
+        .build()
+        .unwrap();
+    let topic = IdentTopic::new("defra/go-message-id-parity").hash();
+
+    for fixture in GO_MESSAGE_ID_FIXTURES {
+        let source = PeerId::from_str(fixture.source_peer_id).unwrap();
+        let message = Message {
+            source: Some(source),
+            data: b"message-id is independent of payload".to_vec(),
+            sequence_number: Some(fixture.seqno),
+            topic: topic.clone(),
+        };
+
+        let actual_message_id_hex = hex::encode(config.message_id(&message).0);
+
+        assert_eq!(
+            actual_message_id_hex, fixture.expected_message_id_hex,
+            "Rust gossipsub MessageId drifted from go-libp2p-pubsub \
+             DefaultMsgIdFn for source {} seqno {}",
+            fixture.source_peer_id, fixture.seqno
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR #857 removed the old Rust-only content-hash `message_id_fn` to restore source+seqno semantics and keep #834 fixed, but it missed that the two library defaults are not byte-compatible. rust-libp2p's default renders `base58(peer_id) ++ decimal(seqno)`; go-libp2p-pubsub@v0.15.0 `DefaultMsgIdFn` at `pubsub.go:1356` returns raw `from` bytes followed by the raw 8-byte big-endian `seqno`.

This sets the Rust gossipsub config in both constructors to Go's binary `source || seqno` MessageId format so mixed Rust/Go peers advertise and request identical IHAVE/IWANT IDs. #834's identical-payload collapse remains fixed because the ID still includes publisher source and sequence number, matching Go's semantics.

Adds Go-generated fixtures from the go-p2p v0.1.9 dependency set to pin the byte format.

Links: #857, #834

## Validation

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test -p p2p --test gossipsub_message_id_go_parity`
- `cargo test -p p2p --test host_tests regression_834_gossipsub_message_id_distinguishes_senders`
- `cargo test -p p2p`
- `PATH="/tmp/defradb-go-bin:$PATH" cargo test -p integration-test --test p2p`
