### PR TITLE
fix(query): thread configured query limits through all parse entry points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6735,6 +6735,7 @@ dependencies = [
  "josekit",
  "keyring 3.6.3",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ cargo clippy --all -- -D warnings      # Lint
 cargo fmt --all                        # Format
 ```
 
+## Configuration
+
+The CLI exposes GraphQL query guardrails on `defradb start`:
+
+| Flag | Default | Description |
+| --- | ---: | --- |
+| `--query-max-depth` | `20` | Max GraphQL selection nesting depth (`0` = unlimited). |
+| `--query-max-width` | `100` | Max fields at any GraphQL selection level (`0` = unlimited). |
+| `--query-max-filter-depth` | `50` | Max recursive filter nesting depth (`0` = unlimited). |
+
 ## Testing
 
 ### Integration Tests

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -52,6 +52,12 @@ impl Node {
                     Error::InvalidApiAddress(config.api.address.clone(), e.to_string())
                 })?;
 
+        let query_limits = query::QueryLimits {
+            max_query_depth: config.api.query_max_depth,
+            max_query_width: config.api.query_max_width,
+            max_filter_depth: config.api.query_max_filter_depth,
+        };
+
         let server_config = defra_http::ServerConfig {
             address: api_address,
             allowed_origins: config.api.allowed_origins.clone(),
@@ -60,6 +66,7 @@ impl Node {
             max_backup_size: config.api.max_backup_size,
             request_timeout: config.api.request_timeout,
             max_concurrent_requests: config.api.max_concurrent_requests,
+            query_limits,
         };
 
         let mut server =
@@ -140,7 +147,8 @@ impl Node {
         server = server.with_schema_arc(schema_adapter);
         info!("Schema HTTP endpoint enabled");
 
-        let view_adapter = crate::view_adapter::ViewAdapter::new_arc(database.clone());
+        let view_adapter =
+            crate::view_adapter::ViewAdapter::new_arc(database.clone(), query_limits);
         server = server.with_view_arc(view_adapter);
         info!("View HTTP endpoints enabled");
 

--- a/crates/cli/src/view_adapter.rs
+++ b/crates/cli/src/view_adapter.rs
@@ -11,17 +11,24 @@ use storage::corekv::Store;
 /// Adapter that implements ViewOperations using the database.
 pub struct ViewAdapter<S: Store> {
     database: Arc<db::DB<S>>,
+    query_limits: query::QueryLimits,
 }
 
 impl<S: Store + 'static> ViewAdapter<S> {
-    /// Create a new adapter wrapping the given database.
-    pub fn new(database: Arc<db::DB<S>>) -> Self {
-        Self { database }
+    /// Create a new adapter wrapping the given database and query limits.
+    pub fn new(database: Arc<db::DB<S>>, query_limits: query::QueryLimits) -> Self {
+        Self {
+            database,
+            query_limits,
+        }
     }
 
     /// Create an Arc-wrapped adapter.
-    pub fn new_arc(database: Arc<db::DB<S>>) -> Arc<dyn ViewOperations> {
-        Arc::new(Self::new(database))
+    pub fn new_arc(
+        database: Arc<db::DB<S>>,
+        query_limits: query::QueryLimits,
+    ) -> Arc<dyn ViewOperations> {
+        Arc::new(Self::new(database, query_limits))
     }
 }
 
@@ -44,7 +51,7 @@ impl<S: Store + 'static> ViewOperations for ViewAdapter<S> {
             .map_err(|e| format!("failed to parse view SDL: {}", e))?;
 
         let wrapped_query = format!("query {{ {} }}", gql_query);
-        let selects = query::parse_query(&wrapped_query)
+        let selects = query::parse_query_with_limits(&wrapped_query, None, self.query_limits)
             .map_err(|e| format!("failed to parse view query: {}", e))?;
         if selects.is_empty() {
             return Err("invalid view query: no selections found".to_string());

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -7,8 +7,22 @@ use schema::CollectionVersion;
 
 use crate::SchemaOps;
 
+pub(crate) struct DbSchemaOps<S: storage::corekv::Store + 'static> {
+    database: Arc<db::DB<S>>,
+    query_limits: query::QueryLimits,
+}
+
+impl<S: storage::corekv::Store + 'static> DbSchemaOps<S> {
+    pub(crate) fn new(database: Arc<db::DB<S>>, query_limits: query::QueryLimits) -> Self {
+        Self {
+            database,
+            query_limits,
+        }
+    }
+}
+
 #[async_trait::async_trait]
-impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
+impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
     async fn add_schema(&self, sdl: &str) -> anyhow::Result<()> {
         let collections =
             query::parse_sdl(sdl).map_err(|e| anyhow::anyhow!("SDL parse error: {}", e))?;
@@ -17,7 +31,7 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
             .map_err(|e| anyhow::anyhow!("schema validation error: {}", e))?;
 
         for collection in collections {
-            db::DB::create_collection(self, collection)
+            db::DB::create_collection(&self.database, collection)
                 .await
                 .map_err(|e| anyhow::anyhow!("create collection error: {}", e))?;
         }
@@ -25,16 +39,17 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
     }
 
     async fn add_view(&self, source_query: &str, target_sdl: &str) -> anyhow::Result<()> {
-        let known_types: std::collections::HashSet<String> = db::DB::list_collections(self)
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
+        let known_types: std::collections::HashSet<String> =
+            db::DB::list_collections(&self.database)
+                .unwrap_or_default()
+                .into_iter()
+                .collect();
 
         let mut collections = query::parse_sdl_with_known_types(target_sdl, known_types)
             .map_err(|e| anyhow::anyhow!("view SDL parse error: {}", e))?;
 
         let wrapped_query = format!("query {{ {} }}", source_query.trim());
-        let selects = query::parse_query(&wrapped_query)
+        let selects = query::parse_query_with_limits(&wrapped_query, None, self.query_limits)
             .map_err(|e| anyhow::anyhow!("view query parse error: {}", e))?;
         let select = selects
             .into_iter()
@@ -48,7 +63,8 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
         for collection in &mut collections {
             if collection.downsample_interval.is_some() {
                 collection.downsample_source = Some(query_source.clone());
-                self.validate_downsample_collection(collection)
+                self.database
+                    .validate_downsample_collection(collection)
                     .map_err(|e| anyhow::anyhow!("invalid downsample definition: {}", e))?;
             } else {
                 collection.query = Some(query_source.clone());
@@ -66,20 +82,23 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
             }
         }
 
-        self.create_collections_atomic(collections)
+        self.database
+            .create_collections_atomic(collections)
             .await
             .map_err(|e| anyhow::anyhow!("create view collection error: {}", e))?;
 
         if !materialized_names.is_empty() {
-            self.refresh_views(Some(db::RefreshViewsOptions::with_names(
-                materialized_names,
-            )))
-            .await
-            .map_err(|e| anyhow::anyhow!("refresh materialized views error: {}", e))?;
+            self.database
+                .refresh_views(Some(db::RefreshViewsOptions::with_names(
+                    materialized_names,
+                )))
+                .await
+                .map_err(|e| anyhow::anyhow!("refresh materialized views error: {}", e))?;
         }
 
         if !downsample_names.is_empty() {
-            self.bootstrap_downsamples(Some(&downsample_names))
+            self.database
+                .bootstrap_downsamples(Some(&downsample_names))
                 .await
                 .map_err(|e| anyhow::anyhow!("bootstrap downsample collections error: {}", e))?;
         }
@@ -92,29 +111,29 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
         collection_name: &str,
         patch: &str,
     ) -> anyhow::Result<CollectionVersion> {
-        db::DB::patch_collection(self, collection_name, patch)
+        db::DB::patch_collection(&self.database, collection_name, patch)
             .await
             .map_err(anyhow::Error::new)
     }
 
     async fn set_active_collection_version(&self, version_id: &str) -> anyhow::Result<()> {
-        db::DB::set_active_collection_version(self, version_id)
+        db::DB::set_active_collection_version(&self.database, version_id)
             .await
             .map_err(anyhow::Error::new)
     }
 
     async fn set_migration(&self, config: LensConfig) -> anyhow::Result<TransformId> {
-        db::DB::set_migration(self, config)
+        db::DB::set_migration(&self.database, config)
             .await
             .map_err(anyhow::Error::new)
     }
 
     fn list_collections(&self) -> anyhow::Result<Vec<String>> {
-        db::DB::list_collections(self).map_err(anyhow::Error::new)
+        db::DB::list_collections(&self.database).map_err(anyhow::Error::new)
     }
 
     fn get_collection(&self, name: &str) -> anyhow::Result<Option<CollectionVersion>> {
-        Ok(db::DB::get_collection(self, name)
+        Ok(db::DB::get_collection(&self.database, name)
             .map_err(anyhow::Error::new)?
             .map(|collection| collection.schema().clone()))
     }
@@ -123,14 +142,16 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for Arc<db::DB<S>> {
         &self,
         version_id: &str,
     ) -> anyhow::Result<Option<CollectionVersion>> {
-        Ok(db::DB::get_collection_by_version_id_full(self, version_id)
-            .await
-            .map_err(anyhow::Error::new)?
-            .map(|collection| collection.schema().clone()))
+        Ok(
+            db::DB::get_collection_by_version_id_full(&self.database, version_id)
+                .await
+                .map_err(anyhow::Error::new)?
+                .map(|collection| collection.schema().clone()),
+        )
     }
 
     async fn get_all_collection_versions(&self) -> anyhow::Result<Vec<CollectionVersion>> {
-        db::DB::get_all_collection_versions(self)
+        db::DB::get_all_collection_versions(&self.database)
             .await
             .map_err(anyhow::Error::new)
     }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -44,6 +44,7 @@ pub use config::{DocumentAcpConfig, SourceHubConfig};
 pub use dense_search::{DenseHybridSearchHit, DenseHybridSearchRequest, DenseHybridSearchResponse};
 pub use events::EventName;
 pub use lens::{LensConfig, LensModule, TransformId};
+pub use query::QueryLimits;
 pub use query::{QueryExecutor, QueryRequest, QueryResponse};
 pub use schema::CollectionVersion;
 
@@ -476,8 +477,20 @@ pub struct NodeBuilder {
     embedding_api_key: Option<String>,
     document_acp: DocumentAcpConfig,
     node_identity_did: Option<String>,
+    query_limits: QueryLimits,
     #[cfg(feature = "http")]
     http_config: Option<HttpConfig>,
+    #[cfg(feature = "p2p")]
+    p2p_config: Option<P2PConfig>,
+}
+
+struct StoreBuildArgs {
+    acp_store: Arc<dyn acp::AcpStore>,
+    document_acp_config: DocumentAcpConfig,
+    db_options: db::DbOptions,
+    event_bus: Arc<dyn events::Bus>,
+    node_identity_did: Option<String>,
+    query_limits: QueryLimits,
     #[cfg(feature = "p2p")]
     p2p_config: Option<P2PConfig>,
 }
@@ -533,6 +546,12 @@ impl NodeBuilder {
         self
     }
 
+    /// Set GraphQL parsing and filter evaluation limits.
+    pub fn with_query_limits(mut self, limits: QueryLimits) -> Self {
+        self.query_limits = limits;
+        self
+    }
+
     /// Enable the HTTP GraphQL server.
     #[cfg(feature = "http")]
     pub fn with_http(mut self, config: HttpConfig) -> Self {
@@ -584,6 +603,7 @@ impl NodeBuilder {
         let http_config = self.http_config;
         #[cfg(feature = "p2p")]
         let p2p_config = self.p2p_config;
+        let query_limits = self.query_limits;
 
         // 3. Storage backend + database
         let node = if let Some(path) = self.data_path {
@@ -608,13 +628,16 @@ impl NodeBuilder {
 
                     Self::build_with_store(
                         store,
-                        acp_store,
-                        self.document_acp.clone(),
-                        db_options.clone(),
-                        event_bus,
-                        node_identity_did.clone(),
-                        #[cfg(feature = "p2p")]
-                        p2p_config,
+                        StoreBuildArgs {
+                            acp_store,
+                            document_acp_config: self.document_acp.clone(),
+                            db_options: db_options.clone(),
+                            event_bus,
+                            node_identity_did: node_identity_did.clone(),
+                            query_limits,
+                            #[cfg(feature = "p2p")]
+                            p2p_config,
+                        },
                     )
                     .await?
                 }
@@ -635,13 +658,16 @@ impl NodeBuilder {
 
                     Self::build_with_store(
                         store,
-                        acp_store,
-                        self.document_acp.clone(),
-                        db_options.clone(),
-                        event_bus,
-                        node_identity_did.clone(),
-                        #[cfg(feature = "p2p")]
-                        p2p_config,
+                        StoreBuildArgs {
+                            acp_store,
+                            document_acp_config: self.document_acp.clone(),
+                            db_options: db_options.clone(),
+                            event_bus,
+                            node_identity_did: node_identity_did.clone(),
+                            query_limits,
+                            #[cfg(feature = "p2p")]
+                            p2p_config,
+                        },
                     )
                     .await?
                 }
@@ -663,13 +689,16 @@ impl NodeBuilder {
 
             Self::build_with_store(
                 store,
-                acp_store,
-                self.document_acp,
-                db_options,
-                event_bus,
-                node_identity_did.clone(),
-                #[cfg(feature = "p2p")]
-                p2p_config,
+                StoreBuildArgs {
+                    acp_store,
+                    document_acp_config: self.document_acp,
+                    db_options,
+                    event_bus,
+                    node_identity_did: node_identity_did.clone(),
+                    query_limits,
+                    #[cfg(feature = "p2p")]
+                    p2p_config,
+                },
             )
             .await?
         };
@@ -679,6 +708,7 @@ impl NodeBuilder {
         if let Some(http_cfg) = http_config {
             let server_config = defra_http::ServerConfig {
                 address: http_cfg.address,
+                query_limits,
                 ..Default::default()
             };
             let server =
@@ -741,13 +771,19 @@ impl NodeBuilder {
 
     async fn build_with_store<S: storage::corekv::Store + 'static>(
         store: Arc<S>,
-        acp_store: Arc<dyn acp::AcpStore>,
-        document_acp_config: DocumentAcpConfig,
-        db_options: db::DbOptions,
-        event_bus: Arc<dyn events::Bus>,
-        node_identity_did: Option<String>,
-        #[cfg(feature = "p2p")] p2p_config: Option<P2PConfig>,
+        args: StoreBuildArgs,
     ) -> anyhow::Result<EmbeddedNode> {
+        let StoreBuildArgs {
+            acp_store,
+            document_acp_config,
+            db_options,
+            event_bus,
+            node_identity_did,
+            query_limits,
+            #[cfg(feature = "p2p")]
+            p2p_config,
+        } = args;
+
         let embedding_config = db_options.embedding_config();
 
         // Open database
@@ -802,10 +838,12 @@ impl NodeBuilder {
             query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry)
                 .with_mutator(mutator)
                 .with_acp(document_acp)
-                .with_lens_store(database.lens_store().clone());
+                .with_lens_store(database.lens_store().clone())
+                .with_query_limits(query_limits);
 
         let runner: Arc<dyn QueryExecutor> = Arc::new(query_runner);
-        let schema_ops: Arc<dyn SchemaOps> = Arc::new(database.clone());
+        let schema_ops: Arc<dyn SchemaOps> =
+            Arc::new(db_impls::DbSchemaOps::new(database.clone(), query_limits));
 
         #[cfg(feature = "p2p")]
         let (p2p_ops, p2p_lifecycle) = match p2p_result {

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -97,6 +97,7 @@ pub struct EmbeddedNodeConfig {
     pub transport: TransportConfig,
     pub signing: SigningConfig,
     pub document_acp: DocumentAcpConfig,
+    pub query_limits: query::QueryLimits,
     pub max_concurrent_dag_fetches: Option<usize>,
     pub max_concurrent_push_tasks: Option<usize>,
     pub rate_limit_burst: Option<u32>,

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -34,6 +34,7 @@ pub struct EmbeddedNode<S: storage::corekv::Store> {
     pub event_bus: Arc<dyn events::Bus>,
     pub node_identity_did: Option<String>,
     pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+    pub query_limits: query::QueryLimits,
     pub p2p: Option<Arc<ManagedP2PSystem>>,
     /// Idempotency guard for [`EmbeddedNode::shutdown`]. Set to `true`
     /// by the first caller of `shutdown()`.
@@ -207,6 +208,11 @@ impl NodeBuilder {
 
     pub fn with_sourcehub(mut self, config: SourceHubConfig) -> Self {
         self.config.document_acp = DocumentAcpConfig::SourceHub(config);
+        self
+    }
+
+    pub fn with_query_limits(mut self, limits: query::QueryLimits) -> Self {
+        self.config.query_limits = limits;
         self
     }
 
@@ -430,7 +436,8 @@ where
             .unwrap_or_else(|| Arc::new(db::AutoCommitMutator::new(database.clone()))),
     )
     .with_acp(document_acp.clone())
-    .with_lens_store(database.lens_store().clone());
+    .with_lens_store(database.lens_store().clone())
+    .with_query_limits(config.query_limits);
 
     let query_runner: Arc<dyn query::QueryExecutor> = Arc::new(query_runner);
 
@@ -445,6 +452,7 @@ where
         event_bus,
         node_identity_did,
         sourcehub_acp,
+        query_limits: config.query_limits,
         p2p: p2p_setup.map(|setup| setup.system),
         shutdown_started: AtomicBool::new(false),
         shutdown_finished: AtomicBool::new(false),

--- a/crates/ffi/src/collection/view.rs
+++ b/crates/ffi/src/collection/view.rs
@@ -4,6 +4,7 @@ use acp::nac::NodePermission;
 
 use crate::helpers::{get_node_database, get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
+use crate::state::NODES;
 use crate::types::{c_str_to_string, FfiResult};
 use crate::{ffi_async, ffi_entry, try_ffi};
 use query::select_to_go_json;
@@ -62,7 +63,12 @@ pub unsafe extern "C" fn add_view(
         let query_str = try_ffi!(require_c_str(gql_query, "gql_query"));
         let sdl_str = try_ffi!(require_c_str(sdl, "sdl"));
         let transform_opt = c_str_to_string(transform);
-        let database = try_ffi!(get_node_database(node_ptr));
+        let (database, query_limits) = match NODES.get(node_ptr, |state| {
+            (state.database.clone(), state.query_limits)
+        }) {
+            Some(state) => state,
+            None => return FfiResult::error(crate::ERR_INVALID_NODE_HANDLE),
+        };
 
         ffi_async!(rt, {
             // Get existing collection names so the SDL parser can resolve external type references
@@ -79,7 +85,7 @@ pub unsafe extern "C" fn add_view(
             // Parse the GQL query into a Select, matching Go's `addView` behavior:
             // Go wraps query as `query { <input> }` then parses to request.Select
             let wrapped_query = format!("query {{ {} }}", &query_str);
-            let selects = query::parse_query(&wrapped_query)
+            let selects = query::parse_query_with_limits(&wrapped_query, None, query_limits)
                 .map_err(|e| format!("failed to parse view query: {}", e))?;
             if selects.is_empty() {
                 return Err("invalid view query: no selections found".to_string());

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -60,6 +60,7 @@ pub(crate) async fn build_node_state(
         node_identity_did: node.node_identity_did.clone(),
         signing_enabled: node.node_identity_did.is_some(),
         sourcehub_acp: node.sourcehub_acp.clone(),
+        query_limits: node.query_limits,
         se_encryption_key: None,
     })
 }
@@ -219,6 +220,7 @@ fn resolve_embedded_config(
         transport: embedded::TransportConfig::None,
         signing,
         document_acp,
+        query_limits: query::QueryLimits::default(),
         max_concurrent_dag_fetches: if options.max_concurrent_dag_fetches > 0 {
             Some(options.max_concurrent_dag_fetches)
         } else {

--- a/crates/ffi/src/state/mod.rs
+++ b/crates/ffi/src/state/mod.rs
@@ -116,6 +116,8 @@ pub struct NodeState {
     /// SourceHub ACP (optional - only set when using SourceHub for document ACP).
     /// Used by add_dac_policy to route policy creation through SourceHub transactions.
     pub sourcehub_acp: Option<Arc<sourcehub::SourceHubDocumentACP>>,
+    /// Query parsing and filter evaluation limits configured for this node.
+    pub query_limits: query::QueryLimits,
     /// Searchable encryption key (32-byte AES-256 key). Zeroized on drop.
     /// Set via `set_se_encryption_key` FFI when SE is enabled in test config.
     pub se_encryption_key: Option<Zeroizing<Vec<u8>>>,

--- a/crates/http/src/handlers/graphql/query.rs
+++ b/crates/http/src/handlers/graphql/query.rs
@@ -24,10 +24,10 @@ where
     Ok(opt.filter(|s| !s.is_empty()))
 }
 use query::subscription::{
-    is_subscription_operation, response_has_data, subscription_accepts_doc_id,
-    subscription_doc_ids, subscription_to_scoped_query,
+    is_subscription_operation_with_limits, response_has_data, subscription_accepts_doc_id,
+    subscription_doc_ids_with_limits, subscription_to_scoped_query,
 };
-use query::{parse_request, ParsedOperation};
+use query::{parse_request_with_limits, ParsedOperation, QueryLimits};
 
 use crate::error::HttpError;
 use crate::identity_extractor::ExtractIdentity;
@@ -51,7 +51,7 @@ fn check_encrypted_fields(state: &AppState, query: &str) -> Result<(), HttpError
     if state.p2p.is_some() {
         return Ok(());
     }
-    let parsed = match parse_request(query) {
+    let parsed = match parse_request_with_limits(query, None, None, state.query_limits) {
         Ok(p) => p,
         Err(_) => return Ok(()),
     };
@@ -102,8 +102,8 @@ fn wants_sse(headers: &HeaderMap) -> bool {
 /// - Other mutations → `DocumentUpdate`
 /// - Subscriptions → `DocumentRead`
 /// - Introspection → `DocumentRead`
-fn graphql_required_permission(query: &str) -> NodePermission {
-    match parse_request(query) {
+fn graphql_required_permission(query: &str, limits: QueryLimits) -> NodePermission {
+    match parse_request_with_limits(query, None, None, limits) {
         Ok(ParsedOperation::Mutation { mutations, .. }) => {
             if mutations
                 .iter()
@@ -141,7 +141,7 @@ pub async fn graphql(
     check_encrypted_fields(&state, &request.query)?;
 
     // Enforce NAC permission before executing the query
-    let permission = graphql_required_permission(&request.query);
+    let permission = graphql_required_permission(&request.query, state.query_limits);
     require_permission(&state, &identity, permission).await?;
 
     // Wire identity from Authorization header into the request
@@ -256,17 +256,18 @@ pub async fn graphql_transactional(
     check_encrypted_fields(&state, &request.query)?;
 
     // Enforce NAC permission before executing the query
-    let permission = graphql_required_permission(&request.query);
+    let permission = graphql_required_permission(&request.query, state.query_limits);
     require_permission(&state, &identity, permission).await?;
 
     // Check if this is a subscription query.
     // Fast path: skip the full GraphQL parse for mutations/queries (the common case).
     // Only do the full parse when the query might be a subscription.
     if might_be_subscription(&request.query)
-        && is_subscription_operation(
+        && is_subscription_operation_with_limits(
             &request.query,
             request.variables.as_ref(),
             request.operation_name.as_deref(),
+            state.query_limits,
         )
     {
         if !wants_sse(&headers) {
@@ -344,8 +345,12 @@ async fn graphql_sse(
     let signing_config = crate::query_context::resolve_signing_config(&state, &identity);
     let dac_bypass = crate::query_context::resolve_dac_bypass(&state, &identity).await;
 
-    let subscription_doc_ids_filter =
-        subscription_doc_ids(&query_str, variables.as_ref(), operation_name.as_deref());
+    let subscription_doc_ids_filter = subscription_doc_ids_with_limits(
+        &query_str,
+        variables.as_ref(),
+        operation_name.as_deref(),
+        state.query_limits,
+    );
 
     let executor = state.executor.clone();
 
@@ -419,4 +424,55 @@ pub async fn graphql_ws_handler() -> impl IntoResponse {
         StatusCode::NOT_IMPLEMENTED,
         "GraphQL subscriptions over WebSocket are not yet implemented",
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use query::executor::QueryExecutor;
+
+    use super::*;
+    use crate::{router::AppStateBuilder, MockQueryExecutor};
+
+    fn state_with_limits(query_limits: QueryLimits) -> AppState {
+        AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+            .with_query_limits(query_limits)
+            .build()
+    }
+
+    fn deep_encrypted_query(depth: usize) -> String {
+        let mut query = "query { encrypted_User ".to_string();
+        for level in 0..depth {
+            query.push_str(&format!("{{ f{level} "));
+        }
+        query.push_str("{ leaf }");
+        for _ in 0..depth {
+            query.push('}');
+        }
+        query.push_str(" }");
+        query
+    }
+
+    #[test]
+    fn encrypted_field_preparse_uses_configured_query_depth_limit() {
+        let query = deep_encrypted_query(30);
+        assert!(query::parse_request(&query).is_err());
+
+        let default_state = state_with_limits(QueryLimits::default());
+        assert!(check_encrypted_fields(&default_state, &query).is_ok());
+
+        let raised_state = state_with_limits(QueryLimits {
+            max_query_depth: 100,
+            ..QueryLimits::default()
+        });
+        let err = check_encrypted_fields(&raised_state, &query).unwrap_err();
+
+        match err {
+            HttpError::BadRequest(message) => {
+                assert!(message.contains("Cannot query field \"encrypted_User\""));
+            }
+            other => panic!("expected encrypted field validation error, got {other:?}"),
+        }
+    }
 }

--- a/crates/http/src/router/state.rs
+++ b/crates/http/src/router/state.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use query::executor::QueryExecutor;
 use query::rest::RestOperations;
+use query::QueryLimits;
 
 use super::{
     AcpOperations, BackupOperations, BlockOperations, CollectionManagementOperations,
@@ -35,6 +36,7 @@ pub struct AppState {
     pub node_identity_did: Option<String>,
     pub signing_enabled: bool,
     pub dev_mode: bool,
+    pub query_limits: QueryLimits,
 }
 
 impl std::fmt::Debug for AppState {
@@ -83,6 +85,7 @@ impl std::fmt::Debug for AppState {
             .field("event_bus", &self.event_bus.as_ref().map(|_| "<EventBus>"))
             .field("node_identity_did", &self.node_identity_did)
             .field("dev_mode", &self.dev_mode)
+            .field("query_limits", &self.query_limits)
             .finish()
     }
 }
@@ -239,6 +242,7 @@ pub struct AppStateBuilder {
     node_identity_did: Option<String>,
     signing_enabled: bool,
     dev_mode: bool,
+    query_limits: QueryLimits,
 }
 
 impl AppStateBuilder {
@@ -265,6 +269,7 @@ impl AppStateBuilder {
             node_identity_did: None,
             signing_enabled: false,
             dev_mode: false,
+            query_limits: QueryLimits::default(),
         }
     }
 
@@ -388,6 +393,12 @@ impl AppStateBuilder {
         self
     }
 
+    /// Set GraphQL parsing and filter evaluation limits.
+    pub fn with_query_limits(mut self, limits: QueryLimits) -> Self {
+        self.query_limits = limits;
+        self
+    }
+
     /// Build the AppState.
     pub fn build(self) -> AppState {
         AppState {
@@ -411,6 +422,7 @@ impl AppStateBuilder {
             node_identity_did: self.node_identity_did,
             signing_enabled: self.signing_enabled,
             dev_mode: self.dev_mode,
+            query_limits: self.query_limits,
         }
     }
 }

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -17,6 +17,7 @@ use tower_http::trace::TraceLayer;
 
 use query::executor::QueryExecutor;
 use query::rest::RestOperations;
+use query::QueryLimits;
 
 use crate::error::Result;
 use crate::router::{
@@ -44,6 +45,8 @@ pub struct ServerConfig {
     pub request_timeout: u64,
     /// Max concurrent requests (0 = unlimited).
     pub max_concurrent_requests: usize,
+    /// GraphQL parsing and filter evaluation limits.
+    pub query_limits: QueryLimits,
 }
 
 impl Default for ServerConfig {
@@ -56,6 +59,7 @@ impl Default for ServerConfig {
             max_backup_size: 0,
             request_timeout: 300,
             max_concurrent_requests: 1000,
+            query_limits: QueryLimits::default(),
         }
     }
 }
@@ -353,6 +357,12 @@ impl Server {
         self
     }
 
+    /// Set GraphQL parsing and filter evaluation limits.
+    pub fn with_query_limits(mut self, limits: QueryLimits) -> Self {
+        self.config.query_limits = limits;
+        self
+    }
+
     /// Build the router with all routes and middleware.
     ///
     /// CORS configuration matches Go DefraDB behavior:
@@ -419,6 +429,7 @@ impl Server {
             builder = builder.with_signing_enabled(true);
         }
         builder = builder.with_dev_mode(self.dev_mode);
+        builder = builder.with_query_limits(self.config.query_limits);
         let state = builder.build();
         let state_for_middleware = state.clone();
         let mut router = create_router_with_state(state);

--- a/crates/keyring/Cargo.toml
+++ b/crates/keyring/Cargo.toml
@@ -35,6 +35,7 @@ keyring_crate = { package = "keyring", version = "3" }
 [dev-dependencies]
 tempfile = "3"
 serde_json.workspace = true
+serial_test = "3.0"
 
 [lints]
 workspace = true

--- a/crates/keyring/src/lib.rs
+++ b/crates/keyring/src/lib.rs
@@ -64,9 +64,14 @@ pub fn open_file_keyring(dir: impl AsRef<std::path::Path>) -> Result<FileKeyring
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::env;
 
+    // These tests mutate the process-global KEYRING_SECRET_ENV; #[serial] keeps
+    // them from racing each other (and any other test that touches the same var).
+
     #[test]
+    #[serial]
     fn test_load_secret_from_env() {
         let test_secret = "my-test-secret";
 
@@ -78,6 +83,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_load_secret_from_env_not_set() {
         env::remove_var(KEYRING_SECRET_ENV);
         let result = load_secret_from_env();
@@ -85,6 +91,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_open_file_keyring_with_env() {
         let temp_dir = tempfile::tempdir().unwrap();
         let test_secret = "test-keyring-secret";

--- a/crates/query-plan/src/planner/builder/filter_prep.rs
+++ b/crates/query-plan/src/planner/builder/filter_prep.rs
@@ -147,7 +147,7 @@ impl super::Planner {
                     .as_ref()
                     .or(relation_filter.as_ref())
                     .map(Filter::max_depth)
-                    .unwrap_or(query_types::DEFAULT_MAX_FILTER_DEPTH);
+                    .unwrap_or(self.query_limits.max_filter_depth);
                 Some(Filter::from_conditions_with_max_depth(
                     combined_conditions,
                     max_depth,

--- a/crates/query-plan/src/planner/builder/groupby.rs
+++ b/crates/query-plan/src/planner/builder/groupby.rs
@@ -274,7 +274,7 @@ impl super::Planner {
                                 .filter
                                 .as_ref()
                                 .map(Filter::max_depth)
-                                .unwrap_or(query_types::DEFAULT_MAX_FILTER_DEPTH);
+                                .unwrap_or(self.query_limits.max_filter_depth);
                             cs.filter = Some(Filter::from_conditions_with_max_depth(
                                 conditions, max_depth,
                             ));

--- a/crates/query-plan/src/planner/builder/mod.rs
+++ b/crates/query-plan/src/planner/builder/mod.rs
@@ -24,6 +24,7 @@ use crate::plan::{IndexScanNode, PermissionFilterNode, SEFilterNode, ScanNode, S
 use crate::planner::index_selection::IndexScanParams;
 use crate::planner::PlanNode;
 use query_types::error::{QueryError, Result};
+use query_types::limits::QueryLimits;
 use query_types::mapper::{Requestable, Select};
 
 /// Maximum allowed nesting depth for nested queries (0-indexed).
@@ -76,6 +77,8 @@ pub struct Planner {
     identity_did: Option<Did>,
     /// Pre-computed FTS scores: output_name → (doc_id → score)
     pub(crate) fts_scores: HashMap<String, HashMap<String, f64>>,
+    /// Query parsing and filter evaluation guardrails.
+    pub(crate) query_limits: QueryLimits,
 }
 
 impl Planner {
@@ -113,6 +116,7 @@ impl Planner {
             acp: None,
             identity_did: None,
             fts_scores: HashMap::new(),
+            query_limits: QueryLimits::default(),
         }
     }
 
@@ -134,6 +138,12 @@ impl Planner {
     /// Set pre-computed FTS scores for BM25 nodes.
     pub fn with_fts_scores(mut self, scores: HashMap<String, HashMap<String, f64>>) -> Self {
         self.fts_scores = scores;
+        self
+    }
+
+    /// Set query parsing and filter evaluation limits.
+    pub fn with_query_limits(mut self, limits: QueryLimits) -> Self {
+        self.query_limits = limits;
         self
     }
 

--- a/crates/query-plan/src/planner/joins/mod.rs
+++ b/crates/query-plan/src/planner/joins/mod.rs
@@ -663,7 +663,7 @@ impl Planner {
                     .filter
                     .as_ref()
                     .map(Filter::max_depth)
-                    .unwrap_or(query_types::DEFAULT_MAX_FILTER_DEPTH);
+                    .unwrap_or(self.query_limits.max_filter_depth);
                 // Create a filter: _docID IN [...]
                 if doc_ids.len() == 1 {
                     // Single ID: _docID == "..."

--- a/crates/query/src/runner/explain/execute.rs
+++ b/crates/query/src/runner/explain/execute.rs
@@ -259,6 +259,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 collections_map.values().map(|c| (**c).clone()).collect();
 
             let mut planner = Planner::new(collections)
+                .with_query_limits(self.query_limits)
                 .with_fetcher(Arc::new(fetcher_arc))
                 .with_acp(self.acp.clone(), caller_identity.clone());
             if let Some(ref lens_store) = self.lens_store {
@@ -344,6 +345,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 mapping.clone(),
                 &collection,
                 acp_filter,
+                self.query_limits,
             )?;
 
             // Execute the plan and count iterations

--- a/crates/query/src/runner/explain/mutation.rs
+++ b/crates/query/src/runner/explain/mutation.rs
@@ -16,9 +16,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         mutation_str: &str,
         caller_identity: Option<Did>,
     ) -> Result<JsonValue> {
-        use crate::query_parse::parse_mutations;
+        use crate::query_parse::parse_mutations_with_limits;
 
-        let mutations = parse_mutations(mutation_str)?;
+        let mutations = parse_mutations_with_limits(mutation_str, None, self.query_limits)?;
         let mut operation_children: Vec<JsonValue> = Vec::new();
         let mut execution_success = true;
         let mut execution_errors: Vec<String> = Vec::new();

--- a/crates/query/src/runner/explain/select.rs
+++ b/crates/query/src/runner/explain/select.rs
@@ -156,7 +156,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             }
         }
 
-        let mut planner = Planner::new(collections);
+        let mut planner = Planner::new(collections).with_query_limits(self.query_limits);
         if let Some(ref lens_store) = self.lens_store {
             planner = planner.with_lens_store(lens_store.clone());
         }
@@ -188,7 +188,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let mapping = plan::build_mapping(select, collection)?;
 
         // Create an empty plan with no documents for explanation purposes
-        let plan = plan::build_plan(select, vec![], mapping, collection, None)?;
+        let plan = plan::build_plan(select, vec![], mapping, collection, None, self.query_limits)?;
 
         // Get the plan explanation based on type
         let explain = match explain_type {

--- a/crates/query/src/runner/plan.rs
+++ b/crates/query/src/runner/plan.rs
@@ -8,6 +8,7 @@ use serde_json::{Map, Value as JsonValue};
 
 use crate::document::DocumentMapping;
 use crate::error::{QueryError, Result};
+use crate::limits::QueryLimits;
 use crate::mapper::{AggregateType, Filter, Requestable, Select};
 use crate::plan::{
     AllDocsNode, ChildSelectMeta, GroupAlias, GroupByNode, LimitNode, OrderByNode,
@@ -193,6 +194,7 @@ pub(crate) fn build_plan(
     mapping: DocumentMapping,
     collection: &CollectionVersion,
     acp_filter: Option<AcpFilter>,
+    query_limits: QueryLimits,
 ) -> Result<Box<dyn PlanNode>> {
     // Create ScanNode with preloaded documents, filter, and docIDs
     let mut scan = ScanNode::new(collection.clone(), mapping.clone())
@@ -239,7 +241,10 @@ pub(crate) fn build_plan(
                                 field_name.clone(),
                                 serde_json::json!({"_neq": serde_json::Value::Null}),
                             );
-                            Filter::from_conditions(conditions)
+                            Filter::from_conditions_with_max_depth(
+                                conditions,
+                                query_limits.max_filter_depth,
+                            )
                         }
                     });
                 }
@@ -382,7 +387,7 @@ pub(crate) fn build_plan(
                             .filter
                             .as_ref()
                             .map(Filter::max_depth)
-                            .unwrap_or(query_types::DEFAULT_MAX_FILTER_DEPTH);
+                            .unwrap_or(query_limits.max_filter_depth);
                         cs.filter = Some(Filter::from_conditions_with_max_depth(
                             conditions, max_depth,
                         ));

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -267,6 +267,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             collections_map.values().map(|c| (**c).clone()).collect();
 
         let mut planner = Planner::new(collections)
+            .with_query_limits(self.query_limits)
             .with_fetcher(Arc::new(fetcher_arc))
             .with_acp(self.acp.clone(), identity);
         if let Some(ref lens_store) = self.lens_store {

--- a/crates/query/src/runner/query/nested.rs
+++ b/crates/query/src/runner/query/nested.rs
@@ -63,6 +63,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         let plan_build_start = Instant::now();
         let mut planner = Planner::new(collections)
+            .with_query_limits(self.query_limits)
             .with_fetcher(Arc::new(fetcher_arc))
             .with_acp(self.acp.clone(), identity);
         if !fts_scores.is_empty() {

--- a/crates/query/src/runner/query/simple.rs
+++ b/crates/query/src/runner/query/simple.rs
@@ -118,8 +118,14 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         });
 
         // Build and execute the plan (ACP filter is inserted inside, after Select but before aggregates)
-        let mut plan =
-            plan::build_plan(select, plan_docs, mapping.clone(), collection, acp_filter)?;
+        let mut plan = plan::build_plan(
+            select,
+            plan_docs,
+            mapping.clone(),
+            collection,
+            acp_filter,
+            self.query_limits,
+        )?;
 
         // Execute the plan and collect results
         plan.init().await?;

--- a/crates/query/src/subscription.rs
+++ b/crates/query/src/subscription.rs
@@ -11,8 +11,8 @@ use graphql_parser::query::{
 use serde_json::Value as JsonValue;
 
 use crate::error::{QueryError, Result};
-use crate::query_parse::{parse_request_with_variables, ParsedOperation};
-use crate::QueryResponse;
+use crate::query_parse::{parse_request_with_limits, ParsedOperation};
+use crate::{QueryLimits, QueryResponse};
 
 /// Check whether the provided request resolves to a subscription operation.
 pub fn is_subscription_operation(
@@ -20,9 +20,19 @@ pub fn is_subscription_operation(
     variables: Option<&JsonValue>,
     operation_name: Option<&str>,
 ) -> bool {
+    is_subscription_operation_with_limits(query, variables, operation_name, QueryLimits::default())
+}
+
+/// Check whether the provided request resolves to a subscription operation with custom limits.
+pub fn is_subscription_operation_with_limits(
+    query: &str,
+    variables: Option<&JsonValue>,
+    operation_name: Option<&str>,
+    limits: QueryLimits,
+) -> bool {
     let variable_map = variables_to_map(variables);
     matches!(
-        parse_request_with_variables(query, variable_map.as_ref(), operation_name),
+        parse_request_with_limits(query, variable_map.as_ref(), operation_name, limits),
         Ok(ParsedOperation::Subscription { .. })
     )
 }
@@ -33,8 +43,18 @@ pub fn subscription_doc_ids(
     variables: Option<&JsonValue>,
     operation_name: Option<&str>,
 ) -> Option<Vec<String>> {
+    subscription_doc_ids_with_limits(query, variables, operation_name, QueryLimits::default())
+}
+
+/// Extract the parsed docID/docIDs filter from a subscription root field with custom limits.
+pub fn subscription_doc_ids_with_limits(
+    query: &str,
+    variables: Option<&JsonValue>,
+    operation_name: Option<&str>,
+    limits: QueryLimits,
+) -> Option<Vec<String>> {
     let variable_map = variables_to_map(variables);
-    match parse_request_with_variables(query, variable_map.as_ref(), operation_name).ok()? {
+    match parse_request_with_limits(query, variable_map.as_ref(), operation_name, limits).ok()? {
         ParsedOperation::Subscription { select } => select.doc_ids.clone(),
         _ => None,
     }
@@ -203,7 +223,7 @@ mod tests {
         variables: Option<&JsonValue>,
         operation_name: Option<&str>,
     ) -> crate::Select {
-        match parse_request_with_variables(
+        match crate::query_parse::parse_request_with_variables(
             query,
             variables_to_map(variables).as_ref(),
             operation_name,


### PR DESCRIPTION
Fixes query-limit coverage gaps found after #935.

## Summary
- thread QueryLimits through HTTP pre-parse checks, subscription pre-parse helpers, CLI/FFI/embedded view parsing
- carry QueryLimits through Planner and runner plan synthesis for derived filters
- wire mutation @explain execution parsing through configured QueryLimits
- document query limit CLI flags and defaults
- add HTTP pre-parse unit test proving raised depth loosens the parser cap

## Validation
- cargo fmt --all
- cargo clippy --all -- -D warnings
- cargo clippy -p defra-node --features "http p2p" -- -D warnings
- cargo test -p query
- cargo test -p query -p defra-http encrypted_field_preparse_uses_configured_query_depth_limit
- cargo test -p query -p query-parse -p query-plan -p defra-http -p cli
- cargo test -p integration-test --test query rust_
- cargo check -p defra-node --features http
- cargo check -p defra-node --features "http p2p"

Note: `cargo test -p integration-test --test query` was also run; Rust cases passed, but Go-compat cases failed because the Go `defradb` binary is not available on PATH in this environment. Also, the requested `-p http` package selector is ambiguous in this workspace, so the workspace package was validated as `-p defra-http`.
