### PR TITLE
feat(p2p): dual-DHT routing + pk-namespaced validator (#831 P-20)

### DIFF
--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -26,7 +26,6 @@
 //! IPFS block exchange protocol (1.0.0, 1.1.0, 1.2.0), enabling
 //! interoperability with Go DefraDB.
 
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -34,9 +33,7 @@ use iroh_bitswap::{Bitswap, BitswapEvent, Config as BitswapConfig, Store};
 use libp2p::{
     connection_limits::{self, ConnectionLimits},
     gossipsub::{self, MessageAuthenticity, MessageId, ValidationMode},
-    identify,
-    kad::{self, store::MemoryStore},
-    relay,
+    identify, relay,
     request_response::{self, ProtocolSupport},
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
     PeerId, StreamProtocol,
@@ -49,18 +46,18 @@ use crate::bitswap::{make_peer_block_access_filter, AccessMode, ReplicatorRegist
 use crate::codec::PushLogCodec;
 use crate::message::{PushLogReply, PushLogRequest};
 
+mod dual_kademlia;
+
+pub use dual_kademlia::{
+    validate_pk_namespaced_record, DefraKademliaEvent, DualKademlia, KademliaNetwork,
+    PublicKeyRecordValidationError, LAN_KAD_PROTOCOL, WAN_KAD_PROTOCOL,
+};
+
 /// Timeout for PushLog requests.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Enough for the common identity multihash plus an 8-byte sequence number.
 const GO_MESSAGE_ID_CAPACITY: usize = 48;
-
-/// Kademlia query parallelism. Matches Go's `dht.Concurrency(10)`
-/// (`go-p2p/host.go:44`). rust-libp2p defaults to `ALPHA_VALUE` = 3.
-const KAD_PARALLELISM: NonZeroUsize = match NonZeroUsize::new(10) {
-    Some(n) => n,
-    None => unreachable!(),
-};
 
 /// Pending dial/listen limits are intentionally separate from the exposed
 /// established-connection watermarks and follow the Go default shape.
@@ -93,9 +90,8 @@ pub struct DefraBehaviour<S: Store> {
     /// Peer identification protocol.
     pub identify: identify::Behaviour,
 
-    /// Kademlia DHT for peer discovery and content routing.
-    /// Required for Bitswap to find peers who have specific blocks.
-    pub kademlia: kad::Behaviour<MemoryStore>,
+    /// LAN and WAN Kademlia DHTs for peer discovery and content routing.
+    pub kademlia: DualKademlia,
 
     /// Bitswap block exchange protocol (Go compatibility).
     /// Uses iroh-bitswap for IPFS block exchange.
@@ -130,7 +126,7 @@ pub enum DefraEvent {
     Identify(identify::Event),
 
     /// Kademlia DHT event.
-    Kademlia(kad::Event),
+    Kademlia(DefraKademliaEvent),
 
     /// Bitswap block exchange event.
     Bitswap(BitswapEvent),
@@ -151,8 +147,8 @@ impl From<identify::Event> for DefraEvent {
     }
 }
 
-impl From<kad::Event> for DefraEvent {
-    fn from(event: kad::Event) -> Self {
+impl From<DefraKademliaEvent> for DefraEvent {
+    fn from(event: DefraKademliaEvent) -> Self {
         DefraEvent::Kademlia(event)
     }
 }
@@ -271,18 +267,7 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             Toggle::from(None)
         };
 
-        // Configure Kademlia DHT for peer discovery
-        // Required for Bitswap to find peers who have specific blocks
-        let kad_store = MemoryStore::new(local_peer_id);
-        let mut kad_config = kad::Config::default();
-        // Match Go DefraDB's `dht.Concurrency(10)` (`go-p2p/host.go:44`).
-        // rust-libp2p defaults to ALPHA_VALUE = 3.
-        kad_config.set_parallelism(KAD_PARALLELISM);
-        let mut kademlia = kad::Behaviour::with_config(local_peer_id, kad_store, kad_config);
-        // Auto mode mirrors Go's `dht.ModeAuto` (`go-p2p/host.go:45`):
-        // start as Client, swap to Server once an external address is
-        // confirmed. set_mode(None) is rust-libp2p's auto-mode opt-in.
-        kademlia.set_mode(None);
+        let kademlia = DualKademlia::new(local_peer_id);
 
         // Configure Bitswap for block exchange (Go compatibility).
         // iroh-bitswap implements the standard IPFS bitswap protocols.
@@ -375,13 +360,7 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             Toggle::from(None)
         };
 
-        // Configure Kademlia DHT for peer discovery — same Go-parity knobs
-        // as the production constructor (concurrency=10, auto mode).
-        let kad_store = MemoryStore::new(local_peer_id);
-        let mut kad_config = kad::Config::default();
-        kad_config.set_parallelism(KAD_PARALLELISM);
-        let mut kademlia = kad::Behaviour::with_config(local_peer_id, kad_store, kad_config);
-        kademlia.set_mode(None);
+        let kademlia = DualKademlia::new(local_peer_id);
 
         // Configure Bitswap for block exchange
         let bitswap_config = BitswapConfig::default();
@@ -513,6 +492,14 @@ mod tests {
     use super::*;
     use crate::testutil::MockBitswapStore;
     use libp2p::identity::Keypair;
+    use libp2p::kad;
+    use libp2p::kad::store::RecordStore;
+
+    fn pk_record_key(peer_id: PeerId) -> Vec<u8> {
+        let mut key = b"/pk/".to_vec();
+        key.extend_from_slice(&peer_id.to_bytes());
+        key
+    }
 
     #[tokio::test]
     async fn test_behaviour_creation_with_signing() {
@@ -546,6 +533,35 @@ mod tests {
 
         let behaviour = DefraBehaviour::new_without_signing(peer_id, public_key, store, true).await;
         assert!(behaviour.is_ok());
+        let mut behaviour = behaviour.unwrap();
+
+        assert_eq!(
+            behaviour.kademlia.lan.protocol_names()[0].as_ref(),
+            LAN_KAD_PROTOCOL
+        );
+        assert_eq!(
+            behaviour.kademlia.wan.protocol_names()[0].as_ref(),
+            WAN_KAD_PROTOCOL
+        );
+
+        let record = kad::Record::new(b"/v/split".to_vec(), b"lan".to_vec());
+        let key = record.key.clone();
+        behaviour
+            .kademlia
+            .store_mut(KademliaNetwork::Lan)
+            .put(record)
+            .unwrap();
+
+        assert!(behaviour
+            .kademlia
+            .store_mut(KademliaNetwork::Lan)
+            .get(&key)
+            .is_some());
+        assert!(behaviour
+            .kademlia
+            .store_mut(KademliaNetwork::Wan)
+            .get(&key)
+            .is_none());
     }
 
     #[tokio::test]
@@ -571,5 +587,63 @@ mod tests {
         assert!(behaviour.is_ok());
         let behaviour = behaviour.unwrap();
         assert!(behaviour.gossipsub.as_ref().is_none());
+    }
+
+    #[test]
+    fn pk_namespaced_validator_accepts_matching_public_key() {
+        let keypair = Keypair::generate_ed25519();
+        let public_key = keypair.public();
+        let record = kad::Record::new(
+            pk_record_key(public_key.to_peer_id()),
+            public_key.encode_protobuf(),
+        );
+
+        assert_eq!(validate_pk_namespaced_record(&record), Ok(()));
+    }
+
+    #[test]
+    fn pk_namespaced_validator_rejects_mismatched_public_key() {
+        let keypair = Keypair::generate_ed25519();
+        let other_keypair = Keypair::generate_ed25519();
+        let record = kad::Record::new(
+            pk_record_key(keypair.public().to_peer_id()),
+            other_keypair.public().encode_protobuf(),
+        );
+
+        assert!(matches!(
+            validate_pk_namespaced_record(&record),
+            Err(PublicKeyRecordValidationError::PeerIdMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn pk_namespaced_validator_rejects_invalid_peer_id_key() {
+        let record = kad::Record::new(b"/pk/not-a-peer-id".to_vec(), b"not checked".to_vec());
+
+        assert!(matches!(
+            validate_pk_namespaced_record(&record),
+            Err(PublicKeyRecordValidationError::InvalidPeerId(_))
+        ));
+    }
+
+    #[test]
+    fn pk_namespaced_validator_rejects_invalid_public_key() {
+        let keypair = Keypair::generate_ed25519();
+        let record = kad::Record::new(
+            pk_record_key(keypair.public().to_peer_id()),
+            b"not protobuf".to_vec(),
+        );
+
+        assert!(matches!(
+            validate_pk_namespaced_record(&record),
+            Err(PublicKeyRecordValidationError::InvalidPublicKey(_))
+        ));
+    }
+
+    #[test]
+    fn pk_namespaced_validator_ignores_other_namespaces() {
+        let record = kad::Record::new(b"/v/hello".to_vec(), b"not a public key".to_vec());
+
+        assert_eq!(validate_pk_namespaced_record(&record), Ok(()));
     }
 }

--- a/crates/p2p/src/behaviour/dual_kademlia.rs
+++ b/crates/p2p/src/behaviour/dual_kademlia.rs
@@ -1,0 +1,310 @@
+//! LAN/WAN Kademlia composition and pk record validation.
+
+use std::num::NonZeroUsize;
+use std::ops::{Deref, DerefMut};
+use std::task::{Context, Poll};
+
+use libp2p::{
+    core::Endpoint,
+    identity::PublicKey,
+    kad::{self, store::MemoryStore},
+    swarm::{
+        ConnectionDenied, ConnectionId, FromSwarm, NetworkBehaviour, THandler, THandlerInEvent,
+        THandlerOutEvent, ToSwarm,
+    },
+    Multiaddr, PeerId, StreamProtocol,
+};
+
+/// Kademlia query parallelism. Matches Go's `dht.Concurrency(10)`
+/// (`go-p2p/host.go:44`). rust-libp2p defaults to `ALPHA_VALUE` = 3.
+const KAD_PARALLELISM: NonZeroUsize = match NonZeroUsize::new(10) {
+    Some(n) => n,
+    None => unreachable!(),
+};
+
+/// Go dualdht LAN protocol ID (`ProtocolExtension("/lan")`).
+pub const LAN_KAD_PROTOCOL: &str = "/ipfs/lan/kad/1.0.0";
+
+/// WAN protocol ID for the Rust dual-DHT split.
+///
+/// go-libp2p's dualdht keeps the WAN side on `/ipfs/kad/1.0.0` and uses
+/// address/query filters that rust-libp2p does not expose. We give the WAN DHT
+/// its own protocol ID so the two rust-libp2p routing tables remain explicit
+/// and non-overlapping.
+pub const WAN_KAD_PROTOCOL: &str = "/ipfs/wan/kad/1.0.0";
+
+const PK_RECORD_PREFIX: &[u8] = b"/pk/";
+
+/// Which side of the dual Kademlia routing split produced an event.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KademliaNetwork {
+    Lan,
+    Wan,
+}
+
+impl KademliaNetwork {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            KademliaNetwork::Lan => "lan",
+            KademliaNetwork::Wan => "wan",
+        }
+    }
+
+    fn protocol(self) -> &'static str {
+        match self {
+            KademliaNetwork::Lan => LAN_KAD_PROTOCOL,
+            KademliaNetwork::Wan => WAN_KAD_PROTOCOL,
+        }
+    }
+}
+
+/// A Kademlia event tagged with the routing table that emitted it.
+#[derive(Debug)]
+pub enum DefraKademliaEvent {
+    Lan(kad::Event),
+    Wan(kad::Event),
+}
+
+impl DefraKademliaEvent {
+    pub fn split(self) -> (KademliaNetwork, kad::Event) {
+        match self {
+            DefraKademliaEvent::Lan(event) => (KademliaNetwork::Lan, event),
+            DefraKademliaEvent::Wan(event) => (KademliaNetwork::Wan, event),
+        }
+    }
+}
+
+/// Kademlia behaviour wrapper that tags events with their LAN/WAN origin.
+pub struct DefraKademlia {
+    network: KademliaNetwork,
+    inner: kad::Behaviour<MemoryStore>,
+}
+
+impl DefraKademlia {
+    fn new(local_peer_id: PeerId, network: KademliaNetwork) -> Self {
+        let kad_store = MemoryStore::new(local_peer_id);
+        let mut kad_config = kad::Config::default();
+        // Match Go DefraDB's `dht.Concurrency(10)` (`go-p2p/host.go:44`).
+        // rust-libp2p defaults to ALPHA_VALUE = 3.
+        kad_config.set_parallelism(KAD_PARALLELISM);
+        kad_config.set_protocol_names(vec![StreamProtocol::new(network.protocol())]);
+        // rust-libp2p has no pluggable record validator. FilterBoth emits
+        // inbound records so the host can apply the pk namespace validator
+        // before explicitly storing accepted records.
+        kad_config.set_record_filtering(kad::StoreInserts::FilterBoth);
+
+        let mut inner = kad::Behaviour::with_config(local_peer_id, kad_store, kad_config);
+        // Auto mode mirrors Go's `dht.ModeAuto` (`go-p2p/host.go:45`):
+        // start as Client, swap to Server once an external address is
+        // confirmed. set_mode(None) is rust-libp2p's auto-mode opt-in.
+        inner.set_mode(None);
+
+        Self { network, inner }
+    }
+}
+
+// Deref is only for ergonomic access to kad methods; swarm dispatch uses the
+// explicit NetworkBehaviour impl below.
+impl Deref for DefraKademlia {
+    type Target = kad::Behaviour<MemoryStore>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for DefraKademlia {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl NetworkBehaviour for DefraKademlia {
+    type ConnectionHandler = <kad::Behaviour<MemoryStore> as NetworkBehaviour>::ConnectionHandler;
+    type ToSwarm = DefraKademliaEvent;
+
+    fn handle_pending_inbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        local_addr: &Multiaddr,
+        remote_addr: &Multiaddr,
+    ) -> Result<(), ConnectionDenied> {
+        self.inner
+            .handle_pending_inbound_connection(connection_id, local_addr, remote_addr)
+    }
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer: PeerId,
+        local_addr: &Multiaddr,
+        remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.inner.handle_established_inbound_connection(
+            connection_id,
+            peer,
+            local_addr,
+            remote_addr,
+        )
+    }
+
+    fn handle_pending_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        maybe_peer: Option<PeerId>,
+        addresses: &[Multiaddr],
+        effective_role: Endpoint,
+    ) -> Result<Vec<Multiaddr>, ConnectionDenied> {
+        self.inner.handle_pending_outbound_connection(
+            connection_id,
+            maybe_peer,
+            addresses,
+            effective_role,
+        )
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        connection_id: ConnectionId,
+        peer: PeerId,
+        addr: &Multiaddr,
+        role_override: Endpoint,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.inner
+            .handle_established_outbound_connection(connection_id, peer, addr, role_override)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm) {
+        self.inner.on_swarm_event(event);
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        event: THandlerOutEvent<Self>,
+    ) {
+        self.inner
+            .on_connection_handler_event(peer_id, connection_id, event);
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        self.inner.poll(cx).map(|event| {
+            event.map_out(|event| match self.network {
+                KademliaNetwork::Lan => DefraKademliaEvent::Lan(event),
+                KademliaNetwork::Wan => DefraKademliaEvent::Wan(event),
+            })
+        })
+    }
+}
+
+/// Separate LAN and WAN Kademlia routing tables.
+///
+/// This emulates go-libp2p's `dualdht.DHT` shape with two concrete DHTs.
+/// rust-libp2p 0.53 does not expose Go's public/private routing-table or
+/// query filters, so this split is limited to independent routing tables and
+/// protocol IDs. Addresses are inserted into both tables, which means the LAN
+/// table can contain WAN-only peers and the WAN table can contain LAN/private
+/// peers.
+#[derive(NetworkBehaviour)]
+#[behaviour(to_swarm = "DefraKademliaEvent")]
+pub struct DualKademlia {
+    pub lan: DefraKademlia,
+    pub wan: DefraKademlia,
+}
+
+impl DualKademlia {
+    pub(crate) fn new(local_peer_id: PeerId) -> Self {
+        Self {
+            lan: DefraKademlia::new(local_peer_id, KademliaNetwork::Lan),
+            wan: DefraKademlia::new(local_peer_id, KademliaNetwork::Wan),
+        }
+    }
+
+    /// Insert an address into both routing tables.
+    ///
+    /// go-libp2p dualdht classifies public/private addresses before routing
+    /// them to WAN/LAN tables. rust-libp2p 0.53 does not expose those filters,
+    /// so this emulation stores every address in both tables and accepts the
+    /// resulting query-routing divergence.
+    pub fn add_address(
+        &mut self,
+        peer: &PeerId,
+        address: Multiaddr,
+    ) -> (kad::RoutingUpdate, kad::RoutingUpdate) {
+        let lan = self.lan.add_address(peer, address.clone());
+        let wan = self.wan.add_address(peer, address);
+        (lan, wan)
+    }
+
+    pub fn bootstrap(&mut self) -> [(KademliaNetwork, Result<kad::QueryId, kad::NoKnownPeers>); 2] {
+        [
+            (KademliaNetwork::Lan, self.lan.bootstrap()),
+            (KademliaNetwork::Wan, self.wan.bootstrap()),
+        ]
+    }
+
+    pub fn store_mut(&mut self, network: KademliaNetwork) -> &mut MemoryStore {
+        match network {
+            KademliaNetwork::Lan => self.lan.store_mut(),
+            KademliaNetwork::Wan => self.wan.store_mut(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum PublicKeyRecordValidationError {
+    InvalidPeerId(String),
+    InvalidPublicKey(String),
+    PeerIdMismatch { expected: String, actual: String },
+}
+
+impl std::fmt::Display for PublicKeyRecordValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PublicKeyRecordValidationError::InvalidPeerId(error) => {
+                write!(f, "invalid pk record peer id: {error}")
+            }
+            PublicKeyRecordValidationError::InvalidPublicKey(error) => {
+                write!(f, "invalid pk record public key: {error}")
+            }
+            PublicKeyRecordValidationError::PeerIdMismatch { expected, actual } => write!(
+                f,
+                "pk record public key does not match key: expected {expected}, got {actual}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PublicKeyRecordValidationError {}
+
+/// Validate Go-compatible `/pk/<peer-id>` public-key records.
+///
+/// Records outside the `/pk/` namespace are accepted because Rust DefraDB does
+/// not yet have Go's full `NamespacedValidator` registry. Today only `/pk/`
+/// records are validated before explicit storage.
+pub fn validate_pk_namespaced_record(
+    record: &kad::Record,
+) -> Result<(), PublicKeyRecordValidationError> {
+    let Some(peer_id_bytes) = record.key.as_ref().strip_prefix(PK_RECORD_PREFIX) else {
+        return Ok(());
+    };
+
+    let expected = PeerId::from_bytes(peer_id_bytes)
+        .map_err(|error| PublicKeyRecordValidationError::InvalidPeerId(error.to_string()))?;
+    let public_key = PublicKey::try_decode_protobuf(&record.value)
+        .map_err(|error| PublicKeyRecordValidationError::InvalidPublicKey(error.to_string()))?;
+    let actual = public_key.to_peer_id();
+
+    if actual != expected {
+        return Err(PublicKeyRecordValidationError::PeerIdMismatch {
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+        });
+    }
+
+    Ok(())
+}

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -519,12 +519,24 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
     }
 
     fn run_kademlia_bootstrap(&mut self, reason: &'static str) {
-        match self.swarm.behaviour_mut().kademlia.bootstrap() {
-            Ok(query_id) => {
-                debug!(?query_id, reason, "Started Kademlia bootstrap");
-            }
-            Err(error) => {
-                debug!(?error, reason, "Skipped Kademlia bootstrap");
+        for (network, result) in self.swarm.behaviour_mut().kademlia.bootstrap() {
+            match result {
+                Ok(query_id) => {
+                    debug!(
+                        ?query_id,
+                        dht = network.as_str(),
+                        reason,
+                        "Started Kademlia bootstrap"
+                    );
+                }
+                Err(error) => {
+                    debug!(
+                        ?error,
+                        dht = network.as_str(),
+                        reason,
+                        "Skipped Kademlia bootstrap"
+                    );
+                }
             }
         }
     }

--- a/crates/p2p/src/host/p2p_host/protocols.rs
+++ b/crates/p2p/src/host/p2p_host/protocols.rs
@@ -1,9 +1,10 @@
 //! Protocol-specific event handlers (Identify, PushLog, GossipSub, Bitswap, Kademlia).
 
 use iroh_bitswap::{BitswapEvent, Store};
-use libp2p::{gossipsub, request_response, PeerId};
+use libp2p::{gossipsub, kad, kad::store::RecordStore, request_response, PeerId};
 use tracing::{debug, error, warn};
 
+use crate::behaviour::{DefraKademliaEvent, KademliaNetwork};
 use crate::error::Error;
 use crate::message::{PushLogBroadcast, PushLogReply, PushLogRequest};
 
@@ -321,8 +322,8 @@ impl<S: Store> P2PHost<S> {
     }
 
     /// Handle Kademlia DHT events.
-    pub(super) async fn handle_kademlia_event(&mut self, event: libp2p::kad::Event) {
-        use libp2p::kad;
+    pub(super) async fn handle_kademlia_event(&mut self, event: DefraKademliaEvent) {
+        let (network, event) = event.split();
 
         match event {
             kad::Event::RoutingUpdated {
@@ -331,36 +332,145 @@ impl<S: Store> P2PHost<S> {
                 debug!(
                     peer_id = %peer,
                     addresses = ?addresses,
+                    dht = network.as_str(),
                     "Kademlia routing table updated"
                 );
             }
 
             kad::Event::OutboundQueryProgressed { id, result, .. } => {
-                debug!(query_id = ?id, "Kademlia query progressed: {:?}", result);
+                debug!(query_id = ?id, dht = network.as_str(), "Kademlia query progressed: {:?}", result);
             }
 
             kad::Event::InboundRequest { request } => {
-                debug!("Kademlia inbound request: {:?}", request);
+                self.handle_kademlia_inbound_request(network, request);
             }
 
             kad::Event::RoutablePeer { peer, address } => {
-                debug!(peer_id = %peer, address = %address, "Found routable peer via Kademlia");
+                debug!(
+                    peer_id = %peer,
+                    address = %address,
+                    dht = network.as_str(),
+                    "Found routable peer via Kademlia"
+                );
             }
 
             kad::Event::PendingRoutablePeer { peer, address } => {
                 debug!(
                     peer_id = %peer,
                     address = %address,
+                    dht = network.as_str(),
                     "Found pending routable peer via Kademlia"
                 );
             }
 
             kad::Event::UnroutablePeer { peer } => {
-                debug!(peer_id = %peer, "Peer is unroutable via Kademlia");
+                debug!(peer_id = %peer, dht = network.as_str(), "Peer is unroutable via Kademlia");
             }
 
             kad::Event::ModeChanged { new_mode } => {
-                debug!(mode = ?new_mode, "Kademlia mode changed");
+                debug!(mode = ?new_mode, dht = network.as_str(), "Kademlia mode changed");
+            }
+        }
+    }
+
+    fn handle_kademlia_inbound_request(
+        &mut self,
+        network: KademliaNetwork,
+        request: kad::InboundRequest,
+    ) {
+        match request {
+            kad::InboundRequest::PutRecord { source, record, .. } => {
+                let Some(record) = record else {
+                    debug!(
+                        peer_id = %source,
+                        dht = network.as_str(),
+                        "Kademlia inbound put-record request"
+                    );
+                    return;
+                };
+
+                // Only /pk/ has a Rust-side validator today. Other namespaces
+                // are stored as an intentional divergence from Go's full
+                // NamespacedValidator registry.
+                if let Err(error) = crate::behaviour::validate_pk_namespaced_record(&record) {
+                    warn!(
+                        peer_id = %source,
+                        dht = network.as_str(),
+                        error = %error,
+                        "Rejected invalid Kademlia pk record"
+                    );
+                    return;
+                }
+
+                let key = record.key.clone();
+                match self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut(network)
+                    .put(record)
+                {
+                    Ok(()) => {
+                        debug!(
+                            peer_id = %source,
+                            dht = network.as_str(),
+                            record = ?key,
+                            "Stored validated Kademlia record"
+                        );
+                    }
+                    Err(error) => {
+                        warn!(
+                            peer_id = %source,
+                            dht = network.as_str(),
+                            record = ?key,
+                            error = %error,
+                            "Failed to store validated Kademlia record"
+                        );
+                    }
+                }
+            }
+            kad::InboundRequest::AddProvider { record } => {
+                let Some(record) = record else {
+                    debug!(
+                        dht = network.as_str(),
+                        "Kademlia inbound add-provider request"
+                    );
+                    return;
+                };
+
+                let key = record.key.clone();
+                let provider = record.provider;
+                match self
+                    .swarm
+                    .behaviour_mut()
+                    .kademlia
+                    .store_mut(network)
+                    .add_provider(record)
+                {
+                    Ok(()) => {
+                        debug!(
+                            peer_id = %provider,
+                            dht = network.as_str(),
+                            provider_key = ?key,
+                            "Stored Kademlia provider record"
+                        );
+                    }
+                    Err(error) => {
+                        warn!(
+                            peer_id = %provider,
+                            dht = network.as_str(),
+                            provider_key = ?key,
+                            error = %error,
+                            "Failed to store Kademlia provider record"
+                        );
+                    }
+                }
+            }
+            request => {
+                debug!(
+                    dht = network.as_str(),
+                    "Kademlia inbound request: {:?}", request
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replaces the single Kademlia behaviour with a composed LAN+WAN dual-DHT equivalent using two independent rust-libp2p `kad::Behaviour<MemoryStore>` instances.
- Uses distinct protocol IDs: `/ipfs/lan/kad/1.0.0` and `/ipfs/wan/kad/1.0.0`.
- Enables record filtering and validates inbound `/pk` records by decoding the protobuf `PublicKey` and checking it matches the `PeerId` encoded in the key before storing.

## Option chosen
Option (a). rust-libp2p 0.53 exposes `set_protocol_names` and `set_record_filtering`, but not go-libp2p dualdht's public/private query or routing-table address filters. Composing two behaviours gives separate routing tables and protocol namespaces while documenting that limitation in code.

## Known parity limits
- Address routing is not public/private filtered: `DualKademlia::add_address` inserts every peer address into both LAN and WAN tables, so LAN can contain WAN-only peers and WAN can contain LAN/private peers.
- Only `/pk/` records have a Rust-side validator today. Other Kademlia record namespaces are accepted and explicitly stored after `FilterBoth`, which is an intentional divergence from Go's full `NamespacedValidator` registry.

Refs #831.

## Validation
- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test -p p2p`
- `PATH="/Users/johnzampolin/go/bin:$PATH" cargo test -p integration-test --test p2p`
