### PR TITLE
feat(p2p): libp2p ResourceManager config + FD validation (#831 P-22, S-14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8907,7 +8907,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "storage",
- "sysinfo 0.37.2",
+ "sysinfo 0.29.11",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,6 +6955,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
+ "libp2p-memory-connection-limits",
  "libp2p-metrics",
  "libp2p-noise",
  "libp2p-ping",
@@ -7160,6 +7161,21 @@ dependencies = [
  "smallvec",
  "socket2 0.5.10",
  "tokio",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "libp2p-memory-connection-limits"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63ec429a224821a9915f31613743566846c6d20078af9736975a60bea4a9293"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "memory-stats",
+ "sysinfo 0.29.11",
  "tracing",
  "void",
 ]
@@ -7699,6 +7715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8874,12 +8900,14 @@ dependencies = [
  "parking_lot 0.12.5",
  "postcard",
  "rand 0.9.2",
+ "rlimit",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
  "sha2 0.10.9",
  "storage",
+ "sysinfo 0.37.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -12203,6 +12231,21 @@ name = "sysinfo"
 version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.29.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -53,7 +53,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 rlimit = "0.9"
-sysinfo = "0.37"
+sysinfo = "0.29"
 
 # Bytes
 bytes = { workspace = true }

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -19,7 +19,7 @@ identity = { path = "../identity" }
 acp = { path = "../acp" }
 
 # P2P
-libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad", "relay", "dns", "quic", "websocket"] }
+libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad", "relay", "dns", "quic", "websocket", "memory-connection-limits"] }
 iroh-bitswap = { workspace = true }
 libp2p-stream = { workspace = true }
 multiaddr = { workspace = true }
@@ -52,6 +52,8 @@ libipld = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+rlimit = "0.9"
+sysinfo = "0.37"
 
 # Bytes
 bytes = { workspace = true }

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -119,13 +119,13 @@ pub struct DefraBehaviour<S: Store> {
 
     /// Process-memory guard approximating Go's ResourceManager system scope.
     ///
-    /// #831: rust-libp2p 0.53 does not expose go-libp2p ResourceManager
-    /// scopes for transient, per-peer, service, or protocol memory/FD
-    /// accounting. This behaviour can only refuse new connections once
-    /// process physical memory exceeds the Go-compatible system budget.
-    /// Existing connection count limits cover pending/per-peer counts, but
-    /// the Go transient 25% byte scope and service/protocol/peer byte scopes
-    /// have no Rust equivalent here.
+    /// rust-libp2p 0.53 does not expose go-libp2p ResourceManager scopes for
+    /// transient, per-peer, service, or protocol memory/FD accounting. This
+    /// behaviour can only refuse new connections once process physical memory
+    /// exceeds the Go-compatible system budget. Existing connection count
+    /// limits cover pending/per-peer counts, but the Go transient 25% byte
+    /// scope and service/protocol/peer byte scopes have no Rust equivalent
+    /// here.
     pub memory_connection_limits: memory_connection_limits::Behaviour,
 }
 

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -33,7 +33,7 @@ use iroh_bitswap::{Bitswap, BitswapEvent, Config as BitswapConfig, Store};
 use libp2p::{
     connection_limits::{self, ConnectionLimits},
     gossipsub::{self, MessageAuthenticity, MessageId, ValidationMode},
-    identify, relay,
+    identify, memory_connection_limits, relay,
     request_response::{self, ProtocolSupport},
     swarm::{behaviour::toggle::Toggle, NetworkBehaviour},
     PeerId, StreamProtocol,
@@ -116,6 +116,17 @@ pub struct DefraBehaviour<S: Store> {
     /// peers are not rejected before the Go-compatible low/high-water pruner
     /// can trim older connections.
     pub connection_limits: connection_limits::Behaviour,
+
+    /// Process-memory guard approximating Go's ResourceManager system scope.
+    ///
+    /// #831: rust-libp2p 0.53 does not expose go-libp2p ResourceManager
+    /// scopes for transient, per-peer, service, or protocol memory/FD
+    /// accounting. This behaviour can only refuse new connections once
+    /// process physical memory exceeds the Go-compatible system budget.
+    /// Existing connection count limits cover pending/per-peer counts, but
+    /// the Go transient 25% byte scope and service/protocol/peer byte scopes
+    /// have no Rust equivalent here.
+    pub memory_connection_limits: memory_connection_limits::Behaviour,
 }
 
 /// Events emitted by the DefraDB network behaviour.
@@ -187,8 +198,8 @@ impl From<()> for DefraEvent {
 
 impl From<void::Void> for DefraEvent {
     fn from(v: void::Void) -> Self {
-        // connection_limits::Behaviour emits Void — it never actually fires events,
-        // it only enforces limits by refusing connections at the transport layer.
+        // Resource-limit behaviours emit Void — they never actually fire events,
+        // they only enforce limits by refusing connections at the transport layer.
         void::unreachable(v)
     }
 }
@@ -225,6 +236,7 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
         replicators: Arc<ReplicatorRegistry>,
         enable_pubsub: bool,
         config: &super::P2PHostConfig,
+        resource_manager_system_memory_budget_bytes: usize,
     ) -> Result<Self, crate::error::Error> {
         // Configure identify behaviour
         let identify_config =
@@ -296,6 +308,9 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             .with_max_pending_outgoing(Some(MAX_PENDING_OUTGOING_CONNECTIONS))
             .with_max_established_per_peer(Some(config.max_connections_per_peer));
         let connection_limits = connection_limits::Behaviour::new(limits);
+        let memory_connection_limits = memory_connection_limits::Behaviour::with_max_bytes(
+            resource_manager_system_memory_budget_bytes,
+        );
 
         Ok(Self {
             identify,
@@ -306,6 +321,7 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             relay: Toggle::from(None),
             stream,
             connection_limits,
+            memory_connection_limits,
         })
     }
 
@@ -376,6 +392,8 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             .with_max_pending_outgoing(Some(100))
             .with_max_established_per_peer(Some(4));
         let connection_limits = connection_limits::Behaviour::new(limits);
+        let memory_connection_limits =
+            memory_connection_limits::Behaviour::with_max_bytes(usize::MAX);
 
         Ok(Self {
             identify,
@@ -386,6 +404,7 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             relay: Toggle::from(None),
             stream,
             connection_limits,
+            memory_connection_limits,
         })
     }
 
@@ -519,6 +538,7 @@ mod tests {
             registry,
             true,
             &config,
+            usize::MAX,
         )
         .await;
         assert!(behaviour.is_ok());
@@ -582,6 +602,7 @@ mod tests {
             registry,
             false,
             &config,
+            usize::MAX,
         )
         .await;
         assert!(behaviour.is_ok());

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -18,7 +18,7 @@ use libp2p::{
     identity::Keypair, noise, request_response, swarm::behaviour::toggle::Toggle, tcp, yamux,
     Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
-use sysinfo::{MemoryRefreshKind, RefreshKind, System};
+use sysinfo::{RefreshKind, System, SystemExt};
 use tokio::{
     sync::mpsc,
     time::{self, Instant, MissedTickBehavior},
@@ -70,7 +70,6 @@ const GO_RESOURCE_MANAGER_TRANSIENT_MEMORY_DIVISOR: u64 = 4;
 struct ResourceManagerRuntimeLimits {
     fd_limit: u64,
     system_memory_budget_bytes: u64,
-    transient_memory_budget_bytes: u64,
 }
 
 impl ResourceManagerRuntimeLimits {
@@ -83,9 +82,11 @@ impl ResourceManagerRuntimeLimits {
         Ok(Self {
             fd_limit,
             system_memory_budget_bytes,
-            transient_memory_budget_bytes: system_memory_budget_bytes
-                / GO_RESOURCE_MANAGER_TRANSIENT_MEMORY_DIVISOR,
         })
+    }
+
+    fn transient_memory_budget_bytes(&self) -> u64 {
+        self.system_memory_budget_bytes / GO_RESOURCE_MANAGER_TRANSIENT_MEMORY_DIVISOR
     }
 
     fn system_memory_budget_usize(&self) -> usize {
@@ -96,9 +97,7 @@ impl ResourceManagerRuntimeLimits {
 }
 
 fn total_system_memory_bytes() -> u64 {
-    let system = System::new_with_specifics(
-        RefreshKind::nothing().with_memory(MemoryRefreshKind::nothing().with_ram()),
-    );
+    let system = System::new_with_specifics(RefreshKind::new().with_memory());
     system.total_memory()
 }
 
@@ -125,7 +124,7 @@ fn current_fd_limit() -> Result<u64> {
 fn validate_resource_manager_startup_limits(fd_limit: u64, memory_budget_bytes: u64) -> Result<()> {
     if fd_limit < GO_RESOURCE_MANAGER_MIN_FD_LIMIT {
         return Err(Error::InvalidConfig(format!(
-            "libp2p ResourceManager requires at least {} file descriptors; current soft limit is {fd_limit}",
+            "libp2p ResourceManager requires at least {} file descriptors; current soft limit is {fd_limit}; raise the soft limit with `ulimit -n 1024` or an equivalent service/container limit",
             GO_RESOURCE_MANAGER_MIN_FD_LIMIT
         )));
     }
@@ -385,7 +384,7 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             fd_limit = resource_limits.fd_limit,
             system_memory_budget_mib = resource_limits.system_memory_budget_bytes / 1024 / 1024,
             transient_memory_budget_mib =
-                resource_limits.transient_memory_budget_bytes / 1024 / 1024,
+                resource_limits.transient_memory_budget_bytes() / 1024 / 1024,
             "Configured libp2p ResourceManager parity limits"
         );
 
@@ -720,6 +719,29 @@ mod tests {
             err.to_string().contains("file descriptors"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn resource_manager_startup_validation_rejects_low_memory_budget() {
+        let err = validate_resource_manager_startup_limits(
+            GO_RESOURCE_MANAGER_MIN_FD_LIMIT,
+            GO_RESOURCE_MANAGER_MIN_MEMORY_BYTES - 1,
+        )
+        .expect_err("memory below the Go minimum must fail startup validation");
+
+        assert!(
+            err.to_string().contains("memory budget"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resource_manager_startup_validation_accepts_go_minimums() {
+        validate_resource_manager_startup_limits(
+            GO_RESOURCE_MANAGER_MIN_FD_LIMIT,
+            GO_RESOURCE_MANAGER_MIN_MEMORY_BYTES,
+        )
+        .expect("Go minimum FD and memory limits must be accepted");
     }
 
     #[test]

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -18,6 +18,7 @@ use libp2p::{
     identity::Keypair, noise, request_response, swarm::behaviour::toggle::Toggle, tcp, yamux,
     Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
+use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 use tokio::{
     sync::mpsc,
     time::{self, Instant, MissedTickBehavior},
@@ -52,6 +53,93 @@ const DEFAULT_CONNECTION_MANAGER_GRACE_PERIOD: Duration = Duration::from_secs(20
 
 /// Frequency for checking whether the active connection set should be pruned.
 const CONNECTION_PRUNE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Go ResourceManager minimum FD cap. See go-libp2p resource-manager defaults.
+const GO_RESOURCE_MANAGER_MIN_FD_LIMIT: u64 = 256;
+
+/// Go ResourceManager minimum memory budget.
+const GO_RESOURCE_MANAGER_MIN_MEMORY_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Go DefraDB gives libp2p half of system RAM by default.
+const GO_RESOURCE_MANAGER_SYSTEM_MEMORY_DIVISOR: u64 = 2;
+
+/// Go's transient ResourceManager scope is capped at 25% of the system scope.
+const GO_RESOURCE_MANAGER_TRANSIENT_MEMORY_DIVISOR: u64 = 4;
+
+#[derive(Debug, Clone, Copy)]
+struct ResourceManagerRuntimeLimits {
+    fd_limit: u64,
+    system_memory_budget_bytes: u64,
+    transient_memory_budget_bytes: u64,
+}
+
+impl ResourceManagerRuntimeLimits {
+    fn detect() -> Result<Self> {
+        let fd_limit = current_fd_limit()?;
+        let system_memory_budget_bytes =
+            total_system_memory_bytes() / GO_RESOURCE_MANAGER_SYSTEM_MEMORY_DIVISOR;
+        validate_resource_manager_startup_limits(fd_limit, system_memory_budget_bytes)?;
+
+        Ok(Self {
+            fd_limit,
+            system_memory_budget_bytes,
+            transient_memory_budget_bytes: system_memory_budget_bytes
+                / GO_RESOURCE_MANAGER_TRANSIENT_MEMORY_DIVISOR,
+        })
+    }
+
+    fn system_memory_budget_usize(&self) -> usize {
+        self.system_memory_budget_bytes
+            .try_into()
+            .unwrap_or(usize::MAX)
+    }
+}
+
+fn total_system_memory_bytes() -> u64 {
+    let system = System::new_with_specifics(
+        RefreshKind::nothing().with_memory(MemoryRefreshKind::nothing().with_ram()),
+    );
+    system.total_memory()
+}
+
+#[cfg(unix)]
+fn current_fd_limit() -> Result<u64> {
+    let (soft_limit, _) = rlimit::Resource::NOFILE.get().map_err(|error| {
+        Error::InvalidConfig(format!(
+            "failed to read NOFILE resource limit for libp2p ResourceManager validation: {error}"
+        ))
+    })?;
+    Ok(soft_limit)
+}
+
+#[cfg(windows)]
+fn current_fd_limit() -> Result<u64> {
+    Ok(u64::from(rlimit::getmaxstdio()))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn current_fd_limit() -> Result<u64> {
+    Ok(GO_RESOURCE_MANAGER_MIN_FD_LIMIT)
+}
+
+fn validate_resource_manager_startup_limits(fd_limit: u64, memory_budget_bytes: u64) -> Result<()> {
+    if fd_limit < GO_RESOURCE_MANAGER_MIN_FD_LIMIT {
+        return Err(Error::InvalidConfig(format!(
+            "libp2p ResourceManager requires at least {} file descriptors; current soft limit is {fd_limit}",
+            GO_RESOURCE_MANAGER_MIN_FD_LIMIT
+        )));
+    }
+
+    if memory_budget_bytes < GO_RESOURCE_MANAGER_MIN_MEMORY_BYTES {
+        return Err(Error::InvalidConfig(format!(
+            "libp2p ResourceManager requires at least {} MiB memory budget; computed budget is {} MiB",
+            GO_RESOURCE_MANAGER_MIN_MEMORY_BYTES / 1024 / 1024,
+            memory_budget_bytes / 1024 / 1024
+        )));
+    }
+
+    Ok(())
+}
 
 /// Tracks the one-time first-connection bootstrap that complements periodic DHT refresh.
 ///
@@ -292,6 +380,15 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
 
         info!("Local peer ID: {}", local_peer_id);
 
+        let resource_limits = ResourceManagerRuntimeLimits::detect()?;
+        info!(
+            fd_limit = resource_limits.fd_limit,
+            system_memory_budget_mib = resource_limits.system_memory_budget_bytes / 1024 / 1024,
+            transient_memory_budget_mib =
+                resource_limits.transient_memory_budget_bytes / 1024 / 1024,
+            "Configured libp2p ResourceManager parity limits"
+        );
+
         // Replicator registry is constructed up-front because the Bitswap
         // access filter (installed at behaviour construction time) needs
         // the same Arc that SyncCoordinator will later populate.
@@ -307,6 +404,7 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             Arc::clone(&replicators),
             config.enable_pubsub,
             &config,
+            resource_limits.system_memory_budget_usize(),
         )
         .await?;
 
@@ -608,6 +706,20 @@ mod tests {
     #[test]
     fn default_config_enables_relay() {
         assert!(P2PHostConfig::default().enable_relay);
+    }
+
+    #[test]
+    fn resource_manager_startup_validation_rejects_low_fd_limit() {
+        let err = validate_resource_manager_startup_limits(
+            GO_RESOURCE_MANAGER_MIN_FD_LIMIT - 1,
+            GO_RESOURCE_MANAGER_MIN_MEMORY_BYTES,
+        )
+        .expect_err("fd limits below the Go minimum must fail startup validation");
+
+        assert!(
+            err.to_string().contains("file descriptors"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Refs #831.

## Summary
- Enables rust-libp2p's `memory-connection-limits` behaviour and wires it into the p2p `NetworkBehaviour` with a Go-compatible system memory budget: half of detected system RAM.
- Adds startup validation matching Go's ResourceManager minimums: FD soft limit must be at least 256 and the computed system memory budget must be at least 128 MiB.
- Computes/logs the Go transient-scope budget at 25% of the system scope for parity visibility.

## Rust mapping notes
- Mapped: system memory cap via `libp2p::memory_connection_limits::Behaviour::with_max_bytes(...)`.
- Mapped: connection-count caps remain covered by the existing `libp2p::connection_limits` behaviour.
- Not mapped: go-libp2p's transient ResourceManager byte scope has no rust-libp2p 0.53 equivalent; the 25% budget is logged but cannot be enforced separately.
- Not mapped: go-libp2p per-peer, per-service, and per-protocol ResourceManager memory/FD scopes have no rust-libp2p 0.53 equivalent.
- Not mapped: go-libp2p's FD accounting caps have no rust-libp2p ResourceManager equivalent; this PR mirrors Go's startup minimum validation only.

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --all -- -D warnings`
- `cargo test -p p2p`
- `cargo test -p integration-test --test p2p` with the v1.0.0-rc1 Go `defradb` release binary on `PATH`: 37 passed, 11 ignored

Note: the first integration run failed all Go-backed cases because no `defradb` binary was present on `PATH`; rerunning with the v1.0.0-rc1 release binary passed.
