### PR TITLE
chore(p2p): enable relay client by default (#831 P-24)

### DIFF
--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -224,6 +224,8 @@ pub struct NetConfig {
     #[serde(default)]
     pub peers: Vec<String>,
     pub pubsub_enabled: bool,
+    /// Enable libp2p relay client support. Default: true.
+    #[serde(default = "default_true")]
     pub relay_enabled: bool,
     /// Max P2P protocol message size in bytes. Default: 16 MiB.
     #[serde(default = "default_max_msg_size")]
@@ -325,7 +327,7 @@ impl Default for NetConfig {
             p2p_addresses: vec!["/ip4/127.0.0.1/tcp/9171".to_string()],
             peers: Vec::new(),
             pubsub_enabled: true,
-            relay_enabled: false,
+            relay_enabled: true,
             max_msg_size: default_max_msg_size(),
             max_car_size: default_max_car_size(),
             stream_timeout: default_stream_timeout(),

--- a/crates/cli/tests/config_sections_tests.rs
+++ b/crates/cli/tests/config_sections_tests.rs
@@ -52,7 +52,7 @@ fn test_net_config_defaults() {
     assert_eq!(config.p2p_addresses, vec!["/ip4/127.0.0.1/tcp/9171"]);
     assert!(config.peers.is_empty());
     assert!(config.pubsub_enabled);
-    assert!(!config.relay_enabled);
+    assert!(config.relay_enabled);
 }
 
 #[test]

--- a/tools/integration-test/tests/p2p/management.rs
+++ b/tools/integration-test/tests/p2p/management.rs
@@ -2,6 +2,52 @@ use std::time::Duration;
 
 use integration_test::{for_each_p2p_topology, poll_until, TestCluster};
 
+const RELAY_CLIENT_ENABLED_LOG: &str = "Relay client transport enabled";
+
+#[tokio::test]
+async fn rust_p2p_default_enables_relay_client() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+
+    // defra-harness lays each node out as <node_dir>/data and <node_dir>/logs.
+    // RunningNode exposes rootdir but not log_dir, so derive stdout from the sibling logs directory.
+    let stdout = cluster.nodes[0]
+        .rootdir
+        .parent()
+        .expect("node rootdir has parent")
+        .join("logs/stdout.log");
+
+    let metadata = std::fs::metadata(&stdout).unwrap_or_else(|error| {
+        panic!("expected node stdout log at {}: {error}", stdout.display())
+    });
+    assert!(
+        metadata.is_file(),
+        "expected node stdout log at {} to be a file",
+        stdout.display()
+    );
+
+    poll_until(
+        || {
+            std::fs::read_to_string(&stdout)
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "failed to read node stdout log at {}: {error}",
+                        stdout.display()
+                    )
+                })
+                .contains(RELAY_CLIENT_ENABLED_LOG)
+        },
+        Duration::from_secs(15),
+        Duration::from_millis(100),
+        "default Rust P2P startup did not enable the relay client",
+    )
+    .await;
+}
+
 async fn p2p_management_test(cluster: TestCluster) {
     let node0 = cluster.client(0);
     let node1 = cluster.client(1);


### PR DESCRIPTION
## Summary

Part of #831 P-24. `P2PHostConfig::default().enable_relay` is already `true` on current `main` via #911, but the CLI startup path still built `P2PHostConfig` from `NetConfig::default().relay_enabled = false`. This PR makes normal Rust node startup relay-enabled by default too.

## Changes

- Set `NetConfig::default().relay_enabled` to `true`.
- Add a serde default so config files missing `net.relay_enabled` use relay-on behavior.
- Update the CLI default assertion.
- Add a Rust-only p2p integration test that starts a default p2p node and confirms the relay client startup log is emitted.

## Explicit false updates

No test/config needed an explicit `false` update for this branch. The only false default found was the CLI `NetConfig` default, and that was the remaining startup-default parity gap this PR changes.

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test -p p2p`
- [x] `cargo test -p integration-test --test p2p management::rust_p2p_default_enables_relay_client -- --nocapture`
- [x] `cargo test -p integration-test --test p2p` was run; all Rust-only p2p variants passed, but Go-backed variants failed locally because the Go `defradb` binary is not available in `PATH`.
