### PR TITLE
fix: port Go transaction correctness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9963,6 +9963,7 @@ version = "0.5.0"
 dependencies = [
  "acp",
  "async-graphql",
+ "async-lock",
  "async-trait",
  "base64 0.22.1",
  "blockstore",

--- a/crates/cli/src/commands/client/collection/mod.rs
+++ b/crates/cli/src/commands/client/collection/mod.rs
@@ -131,7 +131,7 @@ impl CollectionAddArgs {
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);
 
-        let result = client.schema_add(&sdl).await?;
+        let result = client.schema_add(&sdl, ctx.tx_id.as_deref()).await?;
         println!("{}", serde_json::to_string_pretty(&result)?);
         Ok(())
     }

--- a/crates/cli/src/commands/client/http_client/acp.rs
+++ b/crates/cli/src/commands/client/http_client/acp.rs
@@ -60,7 +60,7 @@ pub struct NacRelationshipRequest {
 impl HttpClient {
     pub async fn acp_add_policy(&self, policy: &str) -> Result<AcpAddPolicyResponse> {
         let url = format!("{}/api/v0/acp/policy", self.base_url);
-        let response = self.post_text(&url, policy).await?;
+        let response = self.post_text(&url, policy, None).await?;
         if !response.status().is_success() {
             let status = response.status();
             let body_text = response

--- a/crates/cli/src/commands/client/http_client/collection.rs
+++ b/crates/cli/src/commands/client/http_client/collection.rs
@@ -36,7 +36,7 @@ impl HttpClient {
     pub async fn collection_set_active(&self, version_id: Option<&str>) -> Result<()> {
         let url = format!("{}/api/v0/collections/default", self.base_url);
         let text = version_id.unwrap_or("");
-        let response = self.post_text(&url, text).await?;
+        let response = self.post_text(&url, text, None).await?;
         if !response.status().is_success() {
             return Err(Self::extract_error(response).await);
         }

--- a/crates/cli/src/commands/client/http_client/graphql.rs
+++ b/crates/cli/src/commands/client/http_client/graphql.rs
@@ -39,9 +39,9 @@ impl HttpClient {
     }
 
     /// Add a schema definition (SDL text)
-    pub async fn schema_add(&self, sdl: &str) -> Result<JsonValue> {
+    pub async fn schema_add(&self, sdl: &str, txn_id: Option<&str>) -> Result<JsonValue> {
         let url = format!("{}/api/v0/collections", self.base_url);
-        let response = self.post_text(&url, sdl).await?;
+        let response = self.post_text(&url, sdl, txn_id).await?;
 
         if !response.status().is_success() {
             return Err(Self::extract_error(response).await);

--- a/crates/cli/src/commands/client/http_client/lens.rs
+++ b/crates/cli/src/commands/client/http_client/lens.rs
@@ -14,9 +14,23 @@ pub struct LensSetMigrationResponse {
 }
 
 impl HttpClient {
-    pub async fn lens_set_migration(&self, config: &str) -> Result<LensSetMigrationResponse> {
+    pub async fn lens_set_migration(
+        &self,
+        config: &str,
+        txn_id: Option<&str>,
+    ) -> Result<LensSetMigrationResponse> {
         let url = format!("{}/api/v0/collections/migrations", self.base_url);
-        self.request_json("POST", &url, Some(config)).await
+        if txn_id.is_none() {
+            return self.request_json("POST", &url, Some(config)).await;
+        }
+
+        let response = self.post_json_text(&url, config, txn_id).await?;
+
+        if !response.status().is_success() {
+            return Err(Self::extract_error(response).await);
+        }
+
+        Ok(response.json().await?)
     }
 
     pub async fn lens_add(&self, config: &str) -> Result<LensSetMigrationResponse> {

--- a/crates/cli/src/commands/client/http_client/mod.rs
+++ b/crates/cli/src/commands/client/http_client/mod.rs
@@ -283,11 +283,14 @@ impl HttpClient {
     }
 
     /// Helper for POST requests with plain text body
-    async fn post_text(&self, url: &str, text: &str) -> Result<Response> {
-        let request = self
+    async fn post_text(&self, url: &str, text: &str, txn_id: Option<&str>) -> Result<Response> {
+        let mut request = self
             .add_auth_header(self.client.post(url))
             .header("Content-Type", "text/plain")
             .body(text.to_string());
+        if let Some(txn_id) = txn_id {
+            request = request.header("x-defradb-tx", txn_id);
+        }
 
         if self.verbose {
             eprintln!(">>> POST {}", url);
@@ -326,6 +329,35 @@ impl HttpClient {
 
         let result: T = response.json().await?;
         Ok(result)
+    }
+
+    /// Helper for POST requests with a pre-serialized JSON body and optional txn header.
+    async fn post_json_text(
+        &self,
+        url: &str,
+        text: &str,
+        txn_id: Option<&str>,
+    ) -> Result<Response> {
+        let mut request = self
+            .add_auth_header(self.client.post(url))
+            .header("Content-Type", "application/json")
+            .body(text.to_string());
+        if let Some(txn_id) = txn_id {
+            request = request.header("x-defradb-tx", txn_id);
+        }
+
+        if self.verbose {
+            eprintln!(">>> POST {}", url);
+            eprintln!(">>> Body: {}", text);
+        }
+
+        let response = request.send().await.map_err(Error::HttpRequest)?;
+
+        if self.verbose {
+            eprintln!("<<< HTTP {}", response.status());
+        }
+
+        Ok(response)
     }
 
     async fn request_json<T: DeserializeOwned>(

--- a/crates/cli/src/commands/client/http_client/transaction.rs
+++ b/crates/cli/src/commands/client/http_client/transaction.rs
@@ -16,17 +16,6 @@ impl HttpClient {
         self.request_json("POST", &url, None).await
     }
 
-    /// Begin a new concurrent transaction.
-    ///
-    /// POST /api/v0/tx/concurrent?read_only=true
-    pub async fn tx_begin_concurrent(&self, read_only: bool) -> Result<TxBeginResponse> {
-        let mut url = format!("{}/api/v0/tx/concurrent", self.base_url);
-        if read_only {
-            url.push_str("?read_only=true");
-        }
-        self.request_json("POST", &url, None).await
-    }
-
     /// Commit a transaction.
     ///
     /// POST /api/v0/tx/{id}

--- a/crates/cli/src/commands/client/lens.rs
+++ b/crates/cli/src/commands/client/lens.rs
@@ -139,7 +139,9 @@ impl LensSetArgs {
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);
 
-        let response = client.lens_set_migration(&body.to_string()).await?;
+        let response = client
+            .lens_set_migration(&body.to_string(), ctx.tx_id.as_deref())
+            .await?;
         println!("{}", serde_json::to_string_pretty(&response)?);
         Ok(())
     }

--- a/crates/cli/src/commands/client/tx.rs
+++ b/crates/cli/src/commands/client/tx.rs
@@ -31,10 +31,6 @@ pub struct TxNewArgs {
     /// Create a read-only transaction
     #[arg(long = "read-only")]
     pub read_only: bool,
-
-    /// Create a concurrent transaction
-    #[arg(long)]
-    pub concurrent: bool,
 }
 
 /// Arguments for tx commit command
@@ -70,11 +66,7 @@ impl TxNewArgs {
         let client = HttpClient::new(&ctx.url)?
             .with_auth_token(ctx.auth_token.clone())
             .with_verbose(ctx.verbose);
-        let response = if self.concurrent {
-            client.tx_begin_concurrent(self.read_only).await?
-        } else {
-            client.tx_begin(self.read_only).await?
-        };
+        let response = client.tx_begin(self.read_only).await?;
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({ "id": response.id }))?
@@ -111,12 +103,8 @@ mod tests {
 
     #[test]
     fn test_tx_new_args_default() {
-        let args = TxNewArgs {
-            read_only: false,
-            concurrent: false,
-        };
+        let args = TxNewArgs { read_only: false };
         assert!(!args.read_only);
-        assert!(!args.concurrent);
     }
 
     #[test]

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -25,6 +25,7 @@ pub struct DbTransactionContext<S: Store> {
     readonly: bool,
     fetcher: Arc<LensedDocFetcher<S>>,
     deferred_acp_mutations: Arc<DeferredAcpMutations>,
+    action_lock: Arc<async_lock::Mutex<()>>,
     created_at: Instant,
 }
 
@@ -43,6 +44,7 @@ impl<S: Store> DbTransactionContext<S> {
             readonly,
             fetcher,
             deferred_acp_mutations,
+            action_lock: Arc::new(async_lock::Mutex::new(())),
             created_at: Instant::now(),
         }
     }
@@ -99,6 +101,10 @@ impl<S: Store + 'static> DbTransactionContext<S> {
     pub(crate) fn lens_store(&self) -> Arc<dyn lens::TransformStore> {
         self.fetcher.lens_store()
     }
+
+    pub(crate) fn action_lock(&self) -> Arc<async_lock::Mutex<()>> {
+        self.action_lock.clone()
+    }
 }
 
 impl<S: Store + 'static> TransactionContext for DbTransactionContext<S> {
@@ -131,5 +137,9 @@ impl<S: Store + 'static> TransactionContext for DbTransactionContext<S> {
 
     fn deferred_acp_mutations(&self) -> Option<Arc<DeferredAcpMutations>> {
         Some(self.deferred_acp_mutations.clone())
+    }
+
+    fn action_lock(&self) -> Option<Arc<async_lock::Mutex<()>>> {
+        Some(self.action_lock.clone())
     }
 }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -186,6 +186,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         ctx.doc_fetcher()
             .get_all(collection_name)
@@ -206,6 +208,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         ctx.doc_fetcher()
             .get_by_ids(collection_name, doc_ids)
@@ -258,6 +262,9 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
                     age_secs = ?now.duration_since(ctx.created_at()).as_secs(),
                     "Cleaning up stale transaction (leaked TransactionGuard?)"
                 );
+
+                let action_lock = ctx.action_lock();
+                let _action_guard = action_lock.lock().await;
 
                 // Try to take and discard the transaction
                 if let Some(txn) = ctx.take_txn().await {
@@ -314,6 +321,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         // Get the shared transaction from the fetcher
         let shared_txn = ctx.fetcher_shared_txn();
@@ -396,6 +405,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         let shared_txn = ctx.fetcher_shared_txn();
         let mut txn_guard = shared_txn.lock().await;
@@ -442,6 +453,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         let shared_txn = ctx.fetcher_shared_txn();
         let mut txn_guard = shared_txn.lock().await;
@@ -490,6 +503,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         let shared_txn = ctx.fetcher_shared_txn();
         let txn_guard = shared_txn.lock().await;
@@ -516,6 +531,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         ctx.lens_store()
             .list()
@@ -535,6 +552,8 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         let shared_txn = ctx.fetcher_shared_txn();
         let txn_guard = shared_txn.lock().await;
@@ -655,6 +674,8 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .ok_or_else(|| {
                 TransactionError::not_found(format!("transaction '{}' not found", handle))
             })?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         let txn = ctx.take_txn().await.ok_or_else(|| {
             TransactionError::already_finalized(format!(
@@ -685,6 +706,8 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             .ok_or_else(|| {
                 TransactionError::not_found(format!("transaction '{}' not found", handle))
             })?;
+        let action_lock = ctx.action_lock();
+        let _action_guard = action_lock.lock().await;
 
         let txn = ctx.take_txn().await.ok_or_else(|| {
             TransactionError::already_finalized(format!(

--- a/crates/http/src/handlers/graphql/mod.rs
+++ b/crates/http/src/handlers/graphql/mod.rs
@@ -22,6 +22,5 @@ pub use query::{
     TransactionalQueryRequest,
 };
 pub use transactions::{
-    tx_begin, tx_begin_concurrent, tx_commit, tx_discard, TxBeginQuery, TxBeginResponse,
-    TxPathParam,
+    tx_begin, tx_commit, tx_discard, TxBeginQuery, TxBeginResponse, TxPathParam,
 };

--- a/crates/http/src/handlers/graphql/transactions.rs
+++ b/crates/http/src/handlers/graphql/transactions.rs
@@ -75,41 +75,6 @@ pub async fn tx_begin(
     })
 }
 
-/// Begin a new concurrent transaction (Go-compatible).
-///
-/// POST /api/v0/tx/concurrent?read_only=true
-///
-/// Concurrent transactions allow multiple transactions to run in parallel.
-///
-/// No NAC check — permissions are enforced per-operation within the transaction.
-pub async fn tx_begin_concurrent(
-    State(state): State<AppState>,
-    Query(query): Query<TxBeginQuery>,
-) -> Result<impl IntoResponse, HttpError> {
-    Ok(match state.executor.begin_txn(query.read_only).await {
-        Ok(handle) => {
-            let id: u64 = handle.to_string().parse().unwrap_or(0);
-            tracing::info!(
-                txn_id = id,
-                readonly = query.read_only,
-                concurrent = true,
-                "Concurrent transaction started"
-            );
-            (StatusCode::OK, Json(TxBeginResponse { id })).into_response()
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to begin concurrent transaction");
-            (
-                StatusCode::BAD_REQUEST,
-                Json(crate::error::ErrorResponse {
-                    error: format!("Failed to begin transaction: {}", e),
-                }),
-            )
-                .into_response()
-        }
-    })
-}
-
 /// Commit a transaction (Go-compatible).
 ///
 /// POST /api/v0/tx/{id}

--- a/crates/http/src/handlers/lens.rs
+++ b/crates/http/src/handlers/lens.rs
@@ -10,10 +10,12 @@
 //! dev_mode is enabled. Only inline module bytes are allowed.
 
 use axum::extract::State;
+use axum::http::HeaderMap;
 use axum::Json;
 use serde::Serialize;
 
 use crate::error::HttpError;
+use crate::handlers::txn_header::txn_id_from_headers;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
 use crate::router::{AppState, NodePermission};
@@ -48,11 +50,10 @@ pub struct SetMigrationResponse {
 pub async fn set_migration(
     State(state): State<AppState>,
     identity: ExtractIdentity,
+    headers: HeaderMap,
     body: String,
 ) -> Result<Json<SetMigrationResponse>, HttpError> {
     require_permission(&state, &identity, NodePermission::MigrationSet).await?;
-
-    let lens = state.require_lens()?;
 
     if body.trim().is_empty() {
         return Err(HttpError::BadRequest(
@@ -68,10 +69,18 @@ pub async fn set_migration(
             .map_err(|e| HttpError::BadRequest(e.to_string()))?;
     }
 
-    let lens_id = lens
-        .set_migration(&body)
-        .await
-        .map_err(HttpError::BadRequest)?;
+    let lens_id = if let Some(txn_id) = txn_id_from_headers(&headers)? {
+        let txn_ops = state.require_txn_ops()?;
+        txn_ops
+            .set_migration_in_txn(txn_id, &body)
+            .await
+            .map_err(HttpError::BadRequest)?
+    } else {
+        let lens = state.require_lens()?;
+        lens.set_migration(&body)
+            .await
+            .map_err(HttpError::BadRequest)?
+    };
 
     Ok(Json(SetMigrationResponse { lens_id }))
 }
@@ -161,6 +170,15 @@ pub async fn list_lenses(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::extract::State;
+    use axum::http::{HeaderMap, HeaderValue};
+    use query::executor::QueryExecutor;
+    use std::sync::Arc;
+
+    use crate::handlers::graphql::TX_HEADER_NAME;
+    use crate::identity_extractor::ExtractIdentity;
+    use crate::mock::{MockQueryExecutor, MockTransactionOperations};
+    use crate::router::AppStateBuilder;
 
     #[test]
     fn test_set_migration_response_serialize() {
@@ -170,5 +188,27 @@ mod tests {
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("lensId"));
         assert!(json.contains("lens-123"));
+    }
+
+    #[tokio::test]
+    async fn set_migration_uses_tx_header_without_global_lens_ops() {
+        let state =
+            AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+                .with_txn_ops(Arc::new(MockTransactionOperations::new()))
+                .build();
+        let mut headers = HeaderMap::new();
+        headers.insert(TX_HEADER_NAME, HeaderValue::from_static("txn-123"));
+
+        let response = set_migration(
+            State(state),
+            ExtractIdentity::anonymous(),
+            headers,
+            r#"{"SourceCollectionVersionID":"v1","DestinationCollectionVersionID":"v2","Lenses":[]}"#
+                .to_string(),
+        )
+        .await
+        .expect("set migration via transaction header should succeed");
+
+        assert_eq!(response.0.lens_id, "mock-transform-id");
     }
 }

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -23,6 +23,7 @@ pub mod lens;
 pub mod nac;
 pub mod p2p;
 pub mod schema;
+mod txn_header;
 pub mod txn_ops;
 pub mod utility;
 pub mod views;

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -31,8 +31,8 @@ pub mod views;
 // Re-export GraphQL handlers for backwards compatibility
 pub use graphql::{
     graphql, graphql_get, graphql_transactional, graphql_ws_handler, health_check, schema,
-    tx_begin, tx_begin_concurrent, tx_commit, tx_discard, version, GraphqlQueryParams,
-    TransactionalQueryRequest, TxBeginQuery, TxBeginResponse, TxPathParam,
+    tx_begin, tx_commit, tx_discard, version, GraphqlQueryParams, TransactionalQueryRequest,
+    TxBeginQuery, TxBeginResponse, TxPathParam,
 };
 
 // Re-export REST handlers

--- a/crates/http/src/handlers/schema.rs
+++ b/crates/http/src/handlers/schema.rs
@@ -5,9 +5,10 @@
 //!
 //! All endpoints enforce NAC permissions when NAC is enabled.
 
-use axum::{extract::State, Json};
+use axum::{extract::State, http::HeaderMap, Json};
 
 use crate::error::HttpError;
+use crate::handlers::txn_header::txn_id_from_headers;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
 use crate::router::{AppState, NodePermission};
@@ -24,9 +25,20 @@ use schema::CollectionVersion;
 pub async fn add_schema(
     State(state): State<AppState>,
     identity: ExtractIdentity,
+    headers: HeaderMap,
     body: String,
 ) -> Result<Json<Vec<CollectionVersion>>, HttpError> {
     require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
+
+    if let Some(txn_id) = txn_id_from_headers(&headers)? {
+        let txn_ops = state.require_txn_ops()?;
+        let collections = txn_ops
+            .add_schema_in_txn(txn_id, &body)
+            .await
+            .map_err(HttpError::BadRequest)?;
+
+        return Ok(Json(collections));
+    }
 
     let schema_ops = state.require_schema()?;
 

--- a/crates/http/src/handlers/txn_header.rs
+++ b/crates/http/src/handlers/txn_header.rs
@@ -1,0 +1,27 @@
+//! Shared transaction header handling for HTTP endpoints.
+
+use axum::http::HeaderMap;
+
+use crate::error::HttpError;
+use crate::handlers::graphql::TX_HEADER_NAME;
+
+/// Extract the Go-compatible transaction header.
+///
+/// New HTTP handlers should prefer this header form for client parity. The
+/// path-scoped `/tx/{id}/...` endpoints remain available where already exposed.
+pub(crate) fn txn_id_from_headers(headers: &HeaderMap) -> Result<Option<&str>, HttpError> {
+    let Some(txn_id) = headers.get(TX_HEADER_NAME) else {
+        return Ok(None);
+    };
+
+    let txn_id = txn_id
+        .to_str()
+        .map_err(|_| HttpError::BadRequest("invalid transaction id header".to_string()))?;
+
+    if txn_id.is_empty() {
+        tracing::debug!("ignoring empty x-defradb-tx header");
+        return Ok(None);
+    }
+
+    Ok(Some(txn_id))
+}

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -60,7 +60,6 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
         // Transactions (permissions enforced per-operation within tx)
         // =====================================================================
         "/api/v0/tx" => RoutePermission::IdentityOnly,
-        "/api/v0/tx/concurrent" => RoutePermission::IdentityOnly,
         "/api/v0/tx/:id" => RoutePermission::IdentityOnly,
         "/api/v0/tx/:id/lens" => RoutePermission::Required(NodePermission::CollectionPatch),
         "/api/v0/tx/:id/collections" => RoutePermission::Required(NodePermission::CollectionGet),
@@ -326,11 +325,6 @@ mod tests {
             ),
             // Transactions
             ("/api/v0/tx", Method::POST, RoutePermission::IdentityOnly),
-            (
-                "/api/v0/tx/concurrent",
-                Method::POST,
-                RoutePermission::IdentityOnly,
-            ),
             (
                 "/api/v0/tx/:id",
                 Method::POST,

--- a/crates/http/src/route_permissions_tests.rs
+++ b/crates/http/src/route_permissions_tests.rs
@@ -34,10 +34,6 @@ mod tests {
             RoutePermission::IdentityOnly
         );
         assert_eq!(
-            route_permission("/api/v0/tx/concurrent", &Method::POST),
-            RoutePermission::IdentityOnly
-        );
-        assert_eq!(
             route_permission("/api/v0/tx/:id", &Method::POST),
             RoutePermission::IdentityOnly
         );
@@ -213,11 +209,6 @@ mod tests {
             ),
             // Transactions
             ("/api/v0/tx", Method::POST, RoutePermission::IdentityOnly),
-            (
-                "/api/v0/tx/concurrent",
-                Method::POST,
-                RoutePermission::IdentityOnly,
-            ),
             (
                 "/api/v0/tx/:id",
                 Method::POST,

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -41,12 +41,10 @@ pub fn create_router_with_state(state: AppState) -> Router {
     // Transaction routes (Go-compatible)
     // Go DefraDB:
     //   POST /tx - begin transaction (query param: ?read_only=true)
-    //   POST /tx/concurrent - begin concurrent transaction
     //   POST /tx/{id} - commit transaction
     //   DELETE /tx/{id} - discard transaction
     let tx_routes = Router::new()
         .route("/", post(handlers::tx_begin))
-        .route("/concurrent", post(handlers::tx_begin_concurrent))
         .route("/{id}", post(handlers::tx_commit))
         .route("/{id}", delete(handlers::tx_discard))
         .route("/{id}/lens", post(handlers::txn_ops::set_migration_in_txn))

--- a/crates/query-plan/src/txn/context.rs
+++ b/crates/query-plan/src/txn/context.rs
@@ -393,6 +393,15 @@ pub trait TransactionContext: MaybeSendSync {
         None
     }
 
+    /// Get the mutex that serializes top-level actions on this transaction.
+    ///
+    /// Implementations that share one underlying storage transaction across
+    /// multiple public calls should override this so callers can prevent
+    /// concurrent use of that handle.
+    fn action_lock(&self) -> Option<Arc<async_lock::Mutex<()>>> {
+        None
+    }
+
     /// Check if the transaction is still active (not yet committed or rolled back).
     ///
     /// Returns `true` if the transaction can still be used for queries.

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -24,6 +24,7 @@ lens = { path = "../lens", default-features = false }
 
 # Async runtime
 async-trait.workspace = true
+async-lock.workspace = true
 futures.workspace = true
 
 # Serialization

--- a/crates/query/src/runner/executor.rs
+++ b/crates/query/src/runner/executor.rs
@@ -299,6 +299,11 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryExecutor for QueryRun
                 ));
             }
         };
+        let action_lock = txn_ctx.action_lock();
+        let _action_guard = match action_lock.as_ref() {
+            Some(lock) => Some(lock.lock().await),
+            None => None,
+        };
 
         // Convert variables from JSON to HashMap format for the parser
         let variables = convert_variables(&request.variables);
@@ -538,9 +543,12 @@ mod tests {
     use async_trait::async_trait;
     use document::Document;
     use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     use crate::fetcher::{DocFetcher, FetchByIdsResult};
     use crate::test_utils::{MockFetcher, MockTxnRegistry};
+    use crate::txn::{GetTransactionResult, TransactionContext, TransactionRegistry};
 
     struct ChangingFetcher {
         call_count: std::sync::atomic::AtomicUsize,
@@ -596,6 +604,163 @@ mod tests {
         doc.generate_and_set_doc_id().expect("doc id");
         doc.set("name", serde_json::Value::String(name.to_string()));
         doc
+    }
+
+    struct SerialOnlyFetcher {
+        in_flight: AtomicUsize,
+    }
+
+    impl SerialOnlyFetcher {
+        fn new() -> Self {
+            Self {
+                in_flight: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    struct InFlightGuard<'a>(&'a AtomicUsize);
+
+    impl Drop for InFlightGuard<'_> {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl DocFetcher for SerialOnlyFetcher {
+        async fn get_all(&self, _collection_name: &str) -> Result<Vec<Document>> {
+            let active = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            let _guard = InFlightGuard(&self.in_flight);
+            if active > 1 {
+                return Err(crate::error::QueryError::execution(
+                    "transaction action overlapped",
+                ));
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            Ok(vec![make_users_doc("serial")])
+        }
+
+        async fn get_by_ids(
+            &self,
+            collection_name: &str,
+            _doc_ids: &[String],
+        ) -> Result<FetchByIdsResult> {
+            let docs = self.get_all(collection_name).await?;
+            Ok(FetchByIdsResult::all_found(docs))
+        }
+
+        async fn get_by_field_value(
+            &self,
+            collection_name: &str,
+            _field_name: &str,
+            _value: &str,
+        ) -> Result<Vec<Document>> {
+            self.get_all(collection_name).await
+        }
+    }
+
+    struct SerialTxnContext {
+        id: String,
+        fetcher: Arc<dyn DocFetcher>,
+        action_lock: Arc<async_lock::Mutex<()>>,
+    }
+
+    impl TransactionContext for SerialTxnContext {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        fn is_readonly(&self) -> bool {
+            true
+        }
+
+        fn doc_fetcher(&self) -> Arc<dyn DocFetcher> {
+            self.fetcher.clone()
+        }
+
+        fn action_lock(&self) -> Option<Arc<async_lock::Mutex<()>>> {
+            Some(self.action_lock.clone())
+        }
+    }
+
+    struct SerialTxnRegistry {
+        ctx: Arc<SerialTxnContext>,
+    }
+
+    impl SerialTxnRegistry {
+        fn new(fetcher: SerialOnlyFetcher) -> Self {
+            Self {
+                ctx: Arc::new(SerialTxnContext {
+                    id: "serial-txn".to_string(),
+                    fetcher: Arc::new(fetcher),
+                    action_lock: Arc::new(async_lock::Mutex::new(())),
+                }),
+            }
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl TransactionRegistry for SerialTxnRegistry {
+        async fn begin(
+            &self,
+            _readonly: bool,
+        ) -> std::result::Result<TransactionHandle, TransactionError> {
+            Ok(TransactionHandle::new(self.ctx.id.clone()))
+        }
+
+        fn get(&self, handle: &TransactionHandle) -> GetTransactionResult {
+            if handle.as_str() == self.ctx.id {
+                GetTransactionResult::Found(self.ctx.clone())
+            } else {
+                GetTransactionResult::NotFound
+            }
+        }
+
+        async fn commit(
+            &self,
+            _handle: &TransactionHandle,
+        ) -> std::result::Result<(), TransactionError> {
+            Ok(())
+        }
+
+        async fn rollback(
+            &self,
+            _handle: &TransactionHandle,
+        ) -> std::result::Result<(), TransactionError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_in_txn_serializes_concurrent_actions_on_same_handle() {
+        let collections = crate::parse_sdl("type Users { name: String }").expect("schema");
+        let txn_fetcher = SerialOnlyFetcher::new();
+
+        let runner = QueryRunner::with_registry(
+            MockFetcher::new(),
+            collections,
+            SerialTxnRegistry::new(txn_fetcher),
+        );
+        let handle = runner.begin_txn(true).await.expect("begin txn");
+
+        let (first, second) = tokio::join!(
+            runner.execute_in_txn(QueryRequest::new("query { Users { name } }"), &handle),
+            runner.execute_in_txn(QueryRequest::new("query { Users { name } }"), &handle)
+        );
+
+        assert!(
+            !first.has_errors(),
+            "first transaction action failed: {:?}",
+            first.errors
+        );
+        assert!(
+            !second.has_errors(),
+            "second transaction action failed: {:?}",
+            second.errors
+        );
     }
 
     #[tokio::test]

--- a/crates/query/src/runner/explain/mutation.rs
+++ b/crates/query/src/runner/explain/mutation.rs
@@ -166,8 +166,10 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     } else if let Some(ref doc_ids) = mutation.doc_ids {
                         node = node.with_doc_ids(doc_ids.clone());
                     }
-                    if let Some(ref filter) = mutation.filter {
-                        node = node.with_filter(filter.clone());
+                    if resolved_doc_ids.is_none() && mutation.doc_ids.is_none() {
+                        if let Some(ref filter) = mutation.filter {
+                            node = node.with_filter(filter.clone());
+                        }
                     }
                     Box::new(node)
                 }

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -547,10 +547,13 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     node = node.with_doc_ids(doc_ids.clone());
                 }
 
-                // Always pass filter: for node-level resolution when no doc_ids,
-                // and for re-filtering results after update (Go compatibility)
-                if let Some(ref filter) = mutation.filter {
-                    node = node.with_filter(filter.clone());
+                // Pass the filter only when the node still needs to resolve it.
+                // If it was already resolved to doc IDs above, the filter must
+                // not be applied again to post-update document state.
+                if resolved_doc_ids.is_none() && mutation.doc_ids.is_none() {
+                    if let Some(ref filter) = mutation.filter {
+                        node = node.with_filter(filter.clone());
+                    }
                 }
 
                 Box::new(node)

--- a/crates/query/src/test_utils.rs
+++ b/crates/query/src/test_utils.rs
@@ -102,15 +102,22 @@ pub struct MockTxnContext {
     id: String,
     readonly: bool,
     fetcher: Arc<dyn DocFetcher>,
+    action_lock: Arc<async_lock::Mutex<()>>,
 }
 
 impl MockTxnContext {
     /// Create a new mock transaction context.
-    pub fn new(id: String, readonly: bool, fetcher: Arc<dyn DocFetcher>) -> Self {
+    pub fn new(
+        id: String,
+        readonly: bool,
+        fetcher: Arc<dyn DocFetcher>,
+        action_lock: Arc<async_lock::Mutex<()>>,
+    ) -> Self {
         Self {
             id,
             readonly,
             fetcher,
+            action_lock,
         }
     }
 }
@@ -126,6 +133,10 @@ impl TransactionContext for MockTxnContext {
 
     fn doc_fetcher(&self) -> Arc<dyn DocFetcher> {
         self.fetcher.clone()
+    }
+
+    fn action_lock(&self) -> Option<Arc<async_lock::Mutex<()>>> {
+        Some(self.action_lock.clone())
     }
 }
 
@@ -161,6 +172,7 @@ impl TransactionRegistry for MockTxnRegistry {
             txn_id.clone(),
             readonly,
             self.fetcher.clone(),
+            Arc::new(async_lock::Mutex::new(())),
         ));
 
         self.transactions

--- a/tools/integration-test/tests/basic/document_lifecycle.rs
+++ b/tools/integration-test/tests/basic/document_lifecycle.rs
@@ -157,3 +157,91 @@ async fn document_lifecycle_test(cluster: TestCluster) {
 }
 
 for_each_runtime!(document_lifecycle, document_lifecycle_test);
+
+async fn filter_mutations_return_post_update_docs(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type FilterMutationUser { name: String  age: Int }")
+        .expect("failed to add schema");
+
+    client
+        .query(r#"mutation { add_FilterMutationUser(input: {name: "Alice", age: 20}) { _docID } }"#)
+        .expect("create Alice");
+
+    let update = client
+        .query(
+            r#"mutation {
+                update_FilterMutationUser(
+                    filter: {age: {_lt: 30}},
+                    input: {age: 50}
+                ) {
+                    name
+                    age
+                }
+            }"#,
+        )
+        .expect("update by filter");
+    let updated = update["update_FilterMutationUser"]
+        .as_array()
+        .expect("update result not array");
+    assert_eq!(updated.len(), 1, "expected updated doc to be returned");
+    assert_eq!(updated[0]["name"], "Alice");
+    assert_eq!(updated[0]["age"], 50);
+
+    let no_longer_matching = client
+        .query("query { FilterMutationUser(filter: {age: {_lt: 30}}) { name age } }")
+        .expect("query age filter after update");
+    assert_eq!(
+        no_longer_matching["FilterMutationUser"]
+            .as_array()
+            .expect("query result not array")
+            .len(),
+        0,
+        "updated doc should no longer match the original update filter"
+    );
+
+    client
+        .query(r#"mutation { add_FilterMutationUser(input: {name: "Bob", age: 25}) { _docID } }"#)
+        .expect("create Bob");
+
+    let upsert = client
+        .query(
+            r#"mutation {
+                upsert_FilterMutationUser(
+                    filter: {name: {_eq: "Bob"}},
+                    add: {name: "Bob", age: 25},
+                    update: {name: "Robert", age: 51}
+                ) {
+                    name
+                    age
+                }
+            }"#,
+        )
+        .expect("upsert by filter");
+    let upserted = upsert["upsert_FilterMutationUser"]
+        .as_array()
+        .expect("upsert result not array");
+    assert_eq!(upserted.len(), 1, "expected upserted doc to be returned");
+    assert_eq!(upserted[0]["name"], "Robert");
+    assert_eq!(upserted[0]["age"], 51);
+
+    let old_name = client
+        .query(r#"query { FilterMutationUser(filter: {name: {_eq: "Bob"}}) { name age } }"#)
+        .expect("query old name after upsert");
+    assert_eq!(
+        old_name["FilterMutationUser"]
+            .as_array()
+            .expect("old-name query result not array")
+            .len(),
+        0,
+        "upserted doc should no longer match the original upsert filter"
+    );
+}
+
+#[tokio::test]
+async fn rust_filter_mutations_return_post_update_docs() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    filter_mutations_return_post_update_docs(cluster).await;
+}

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -124,6 +124,30 @@ async fn rust_txn_schema_add_via_header_is_scoped() {
     txn_schema_add_via_header_is_scoped(cluster).await;
 }
 
+async fn concurrent_txn_endpoint_is_not_exposed(cluster: TestCluster) {
+    let api_url = cluster.api_url(0);
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/v0/tx/concurrent", api_url))
+        .send()
+        .await
+        .expect("tx concurrent request failed");
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+
+    assert_eq!(status, reqwest::StatusCode::BAD_REQUEST);
+    assert!(
+        body.contains("invalid transaction id"),
+        "expected invalid transaction id error, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn rust_concurrent_txn_endpoint_is_not_exposed() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    concurrent_txn_endpoint_is_not_exposed(cluster).await;
+}
+
 async fn transactions_test(cluster: TestCluster) {
     let client = cluster.client(0);
 

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -75,6 +75,55 @@ async fn rust_txn_schema_add_and_mutate() {
     txn_schema_add_and_mutate(cluster).await;
 }
 
+async fn txn_schema_add_via_header_is_scoped(cluster: TestCluster) {
+    let client = cluster.client(0);
+    let api_url = cluster.api_url(0);
+    let tx_id = client.tx_create().expect("tx_create failed");
+
+    let http_client = reqwest::Client::new();
+    let resp = http_client
+        .post(format!("{}/api/v0/collections", api_url))
+        .header("x-defradb-tx", &tx_id)
+        .body("type HeaderWidget { name: String }")
+        .send()
+        .await
+        .expect("schema add request failed");
+    assert!(
+        resp.status().is_success(),
+        "schema add in tx failed with status: {} body: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+
+    let in_tx = client
+        .query_with_tx(
+            r#"mutation { add_HeaderWidget(input: {name: "scoped"}) { name } }"#,
+            &tx_id,
+        )
+        .expect("create HeaderWidget in tx");
+    assert_eq!(in_tx["add_HeaderWidget"][0]["name"], "scoped");
+
+    let outside = client.query("query { HeaderWidget { name } }");
+    assert!(
+        outside.is_err(),
+        "schema created with x-defradb-tx should not be visible outside the transaction"
+    );
+
+    client.tx_commit(&tx_id).expect("tx_commit failed");
+
+    let after_commit = client
+        .query("query { HeaderWidget { name } }")
+        .expect("query HeaderWidget after commit");
+    assert_eq!(after_commit["HeaderWidget"][0]["name"], "scoped");
+}
+
+#[tokio::test]
+async fn rust_txn_schema_add_via_header_is_scoped() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    txn_schema_add_via_header_is_scoped(cluster).await;
+}
+
 async fn transactions_test(cluster: TestCluster) {
     let client = cluster.client(0);
 

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -148,6 +148,62 @@ async fn rust_concurrent_txn_endpoint_is_not_exposed() {
     concurrent_txn_endpoint_is_not_exposed(cluster).await;
 }
 
+async fn update_with_filter_sees_txn_scoped_state(cluster: TestCluster) {
+    let client = cluster.client(0);
+    let api_url = cluster.api_url(0);
+    let tx_id = client.tx_create().expect("tx_create failed");
+
+    let http_client = reqwest::Client::new();
+    let resp = http_client
+        .post(format!("{}/api/v0/tx/{}/schema", api_url, tx_id))
+        .body("type TxnFilterUser { name: String  age: Int }")
+        .send()
+        .await
+        .expect("schema add in txn request failed");
+    assert!(
+        resp.status().is_success(),
+        "schema add in txn failed with status: {} body: {}",
+        resp.status(),
+        resp.text().await.unwrap_or_default()
+    );
+
+    client
+        .query_with_tx(
+            r#"mutation { add_TxnFilterUser(input: {name: "John", age: 27}) { _docID } }"#,
+            &tx_id,
+        )
+        .expect("create TxnFilterUser in tx");
+
+    let update = client
+        .query_with_tx(
+            r#"mutation { update_TxnFilterUser(filter: {name: {_eq: "John"}}, input: {name: "Chris"}) { name age } }"#,
+            &tx_id,
+        )
+        .expect("update TxnFilterUser by filter in tx");
+
+    let updated = update["update_TxnFilterUser"]
+        .as_array()
+        .expect("update result not array");
+    assert_eq!(updated.len(), 1, "expected one filtered update result");
+    assert_eq!(updated[0]["name"], "Chris");
+    assert_eq!(updated[0]["age"], 27);
+
+    client.tx_commit(&tx_id).expect("tx_commit failed");
+
+    let after_commit = client
+        .query("query { TxnFilterUser { name age } }")
+        .expect("query TxnFilterUser after commit");
+    assert_eq!(after_commit["TxnFilterUser"][0]["name"], "Chris");
+    assert_eq!(after_commit["TxnFilterUser"][0]["age"], 27);
+}
+
+#[tokio::test]
+async fn rust_update_with_filter_sees_txn_scoped_state() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    update_with_filter_sees_txn_scoped_state(cluster).await;
+}
+
 async fn transactions_test(cluster: TestCluster) {
     let client = cluster.client(0);
 


### PR DESCRIPTION
## Summary
- propagate transaction headers through REST schema-add, migration-set, CLI schema-add, and CLI lens-set so txn-local schema/migration state stays scoped until commit
- remove the separate concurrent transaction endpoint/CLI surface
- serialize top-level actions on a shared transaction handle and wait for in-flight actions before commit/rollback/cleanup
- add txn-scoped update-with-filter regression coverage
- avoid carrying an already-resolved update filter into post-update plan execution, with update/upsert result regressions

## Go SHAs Ported
- 6bc16f7e Fix broken transaction behavior (#4587)
- 6123e549 Remove 'concurrent' transaction concept (#4692)
- 630f4f30 Prevent txn-actions from executing concurrently (#4763)
- aac9b5aa Fix transactional behavior in updateWithFilter (#4643)
- 3c911995 Remove duplicate filter on update/upsert operations (#4283)

## Verification
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings
- cargo test -p db
- cargo test -p query
- cargo build -p cli
- PATH="/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb/build:$PATH" cargo test -p integration-test --test basic --test acp --test query -- --test-threads=1

## Additional Workspace Check
- Attempted full `cargo test --all` with local `hubd`, `sourcehubd`, and Go `defradb` binaries configured. The run hit an integration harness port collision in `integration-test --test acp`; the exact failed case was rerun and passed: `cargo test -p integration-test --test acp relationship::rust_acp_rel_add_dummy_defined_is_noop -- --exact`.