### PR TITLE
Port Go query planner correctness fixes

### DIFF
--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use storage::corekv::Store;
 use tracing::warn;
 
+use super::helpers::ensure_collection_is_active;
 use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
@@ -148,6 +149,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
     ) -> query::error::Result<CreateResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
+        ensure_collection_is_active(&self.db, collection_name, &collection)?;
         let embedding_config = self.db.options().embedding_config();
 
         db_search::set_embedding(
@@ -276,6 +278,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
     ) -> query::error::Result<UpdateResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
+        ensure_collection_is_active(&self.db, collection_name, &collection)?;
         let embedding_config = self.db.options().embedding_config();
 
         let generated = db_search::set_embedding(
@@ -406,6 +409,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
     ) -> query::error::Result<DeleteResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
+        ensure_collection_is_active(&self.db, collection_name, &collection)?;
 
         let existed = collection
             .delete_with_indexes(&datastore, doc_id, &index_manager)

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -1,3 +1,4 @@
+use super::helpers::ensure_collection_is_active;
 use super::*;
 
 #[allow(clippy::type_complexity)]
@@ -8,6 +9,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         mut doc: Document,
     ) -> query::error::Result<CreateResult> {
         let collection = self.get_collection_or_err(collection_name)?;
+        ensure_collection_is_active(&self.db, collection_name, &collection)?;
 
         // Create a write transaction
         let txn = self.db.new_txn(false).await.map_err(|e| {

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -1,3 +1,4 @@
+use super::helpers::ensure_collection_is_active;
 use super::*;
 
 use crate::block_builder::{compute_document_blocks, insert_computed_blocks, ComputedBlocks};
@@ -23,6 +24,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         }
 
         let collection = self.get_collection_or_err(collection_name)?;
+        ensure_collection_is_active(&self.db, collection_name, &collection)?;
 
         let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id().to_string();

--- a/crates/db/src/auto_commit_mutator/delete.rs
+++ b/crates/db/src/auto_commit_mutator/delete.rs
@@ -1,3 +1,4 @@
+use super::helpers::ensure_collection_is_active;
 use super::*;
 
 impl<S: Store + 'static> AutoCommitMutator<S> {
@@ -7,6 +8,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         doc_id: &DocID,
     ) -> query::error::Result<DeleteResult> {
         let collection = self.get_collection_or_err(collection_name)?;
+        ensure_collection_is_active(&self.db, collection_name, &collection)?;
 
         // Create a write transaction
         let txn = self.db.new_txn(false).await.map_err(|e| {

--- a/crates/db/src/auto_commit_mutator/delete_many.rs
+++ b/crates/db/src/auto_commit_mutator/delete_many.rs
@@ -1,3 +1,4 @@
+use super::helpers::ensure_collection_is_active;
 use super::*;
 
 impl<S: Store + 'static> AutoCommitMutator<S> {
@@ -24,6 +25,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         }
 
         let collection = self.get_collection_or_err(collection_name)?;
+        ensure_collection_is_active(&self.db, collection_name, &collection)?;
         let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id().to_string();
         let sign_config = get_signing_config();

--- a/crates/db/src/auto_commit_mutator/helpers.rs
+++ b/crates/db/src/auto_commit_mutator/helpers.rs
@@ -2,6 +2,25 @@ use super::*;
 
 use crate::collection::Collection;
 
+pub(super) fn ensure_collection_is_active<S: Store>(
+    db: &DB<S>,
+    collection_name: &str,
+    collection: &Collection,
+) -> query::error::Result<()> {
+    let is_active = db
+        .find_collection_by_id(collection.collection_id())
+        .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+        .is_some();
+
+    if is_active {
+        Ok(())
+    } else {
+        Err(query::error::QueryError::collection_not_found(
+            collection_name,
+        ))
+    }
+}
+
 impl<S: Store + 'static> AutoCommitMutator<S> {
     /// Get collection from DB cache or return a not-found error.
     pub(super) fn get_collection_or_err(

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -1,3 +1,4 @@
+use super::helpers::ensure_collection_is_active;
 use super::*;
 
 #[allow(clippy::type_complexity)]
@@ -9,6 +10,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         modified_fields: std::collections::HashSet<String>,
     ) -> query::error::Result<UpdateResult> {
         let collection = self.get_collection_or_err(collection_name)?;
+        ensure_collection_is_active(&self.db, collection_name, &collection)?;
 
         // Generate embeddings if source fields were modified
         let mut doc = doc;

--- a/crates/db/src/collection_ops/create.rs
+++ b/crates/db/src/collection_ops/create.rs
@@ -238,6 +238,7 @@ impl<S: Store> crate::database::DB<S> {
 
         // Add to transaction's cache
         txn.cache_collection(Collection::new(schema.clone()));
+        txn.mark_collection_created(collection_id.clone());
 
         tracing::info!(
             collection_name = %name,

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -9,6 +9,7 @@ use storage::corekv::Store;
 use tracing::warn;
 
 use crate::block_builder::{write_collection_block, write_document_blocks};
+use crate::collection::Collection;
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
 use crate::txn::DbTxn;
@@ -81,6 +82,38 @@ impl<S: Store> DbDocMutator<S> {
     pub async fn is_consumed(&self) -> bool {
         self.txn.lock().await.is_none()
     }
+
+    async fn ensure_collection_can_write(
+        &self,
+        collection_name: &str,
+        collection: &Collection,
+    ) -> query::error::Result<()> {
+        let was_created_in_txn = {
+            let txn_guard = self.txn.lock().await;
+            let txn = txn_guard.as_ref().ok_or_else(|| {
+                query::error::QueryError::execution("transaction is no longer active")
+            })?;
+            txn.was_collection_created(collection.collection_id())
+        };
+
+        if was_created_in_txn {
+            return Ok(());
+        }
+
+        let is_active = self
+            .db
+            .find_collection_by_id(collection.collection_id())
+            .map_err(|e| query::error::QueryError::execution(format!("db error: {}", e)))?
+            .is_some();
+
+        if is_active {
+            Ok(())
+        } else {
+            Err(query::error::QueryError::collection_not_found(
+                collection_name,
+            ))
+        }
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -93,6 +126,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
     ) -> query::error::Result<CreateResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
+        self.ensure_collection_can_write(collection_name, &collection)
+            .await?;
 
         // Generate document ID if not present.
         // Track whether ID was just generated for blind create optimization.
@@ -193,6 +228,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
     ) -> query::error::Result<UpdateResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
+        self.ensure_collection_can_write(collection_name, &collection)
+            .await?;
 
         self.db
             .validate_downsample_write(
@@ -228,6 +265,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
     ) -> query::error::Result<DeleteResult> {
         let (collection, datastore, index_manager) =
             get_collection_with_index_manager(&self.txn, collection_name).await?;
+        self.ensure_collection_can_write(collection_name, &collection)
+            .await?;
 
         // Use delete_with_indexes to maintain index consistency
         let existed = collection

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -9,6 +9,7 @@ use crate::collection_cache::CollectionCache;
 use crate::error::{Error, Result};
 use datastore::{AsyncCallback, BasicTxn, NamespaceView, RootView, TxnCallback};
 use schema::CollectionVersion;
+use std::collections::HashSet;
 use storage::corekv::{IterOptions, Key, Store};
 use storage::keys::systemstore::{CollectionKey, CollectionNameKey};
 
@@ -39,6 +40,8 @@ pub struct DbTxn<S: Store> {
     explicit: bool,
     /// Transaction-scoped collection cache (lazy loading from SystemStore).
     collection_cache: CollectionCache,
+    /// Collection IDs created inside this transaction.
+    locally_created_collection_ids: HashSet<String>,
     /// Phantom data for the store type.
     _marker: std::marker::PhantomData<S>,
 }
@@ -50,6 +53,7 @@ impl<S: Store> DbTxn<S> {
             txn: Some(txn),
             explicit: false,
             collection_cache: CollectionCache::new(),
+            locally_created_collection_ids: HashSet::new(),
             _marker: std::marker::PhantomData,
         }
     }
@@ -60,6 +64,7 @@ impl<S: Store> DbTxn<S> {
             txn: Some(txn),
             explicit: true,
             collection_cache: CollectionCache::new(),
+            locally_created_collection_ids: HashSet::new(),
             _marker: std::marker::PhantomData,
         }
     }
@@ -464,6 +469,17 @@ impl<S: Store> DbTxn<S> {
     /// Use this for advanced cache manipulation (e.g., populate from snapshot).
     pub fn collection_cache_mut(&mut self) -> &mut CollectionCache {
         &mut self.collection_cache
+    }
+
+    /// Mark a collection as created inside this transaction.
+    pub fn mark_collection_created(&mut self, collection_id: impl Into<String>) {
+        self.locally_created_collection_ids
+            .insert(collection_id.into());
+    }
+
+    /// Check whether a collection was created inside this transaction.
+    pub fn was_collection_created(&self, collection_id: &str) -> bool {
+        self.locally_created_collection_ids.contains(collection_id)
     }
 
     // =========================================================================

--- a/crates/query-parse/src/sdl_parse/builder.rs
+++ b/crates/query-parse/src/sdl_parse/builder.rs
@@ -24,11 +24,13 @@ use super::helpers::{
 };
 use super::parser::{ParsedTypeDef, SdlParser};
 
+type PrimaryDirectiveMap = std::collections::HashMap<(String, String, String), bool>;
+
 impl<'a> SdlParser<'a> {
     pub(super) fn collect_primary_directives(
         &self,
         type_names: &std::collections::HashSet<String>,
-    ) -> std::collections::HashMap<(String, String), bool> {
+    ) -> PrimaryDirectiveMap {
         let mut result = std::collections::HashMap::new();
 
         for (type_name, type_def) in &self.type_defs {
@@ -37,11 +39,12 @@ impl<'a> SdlParser<'a> {
 
                 // Only consider relations to other types in the schema
                 if type_names.contains(target) {
-                    // Key: (source_type, target_type) -> has_primary directive
-                    // Use OR logic: if ANY field in this (source, target) pair has @primary, it's true.
-                    // This handles self-referencing types where multiple fields share the same key.
+                    let relation_name = self.relation_name_for_field(type_name, field);
+                    // Key: (source_type, target_type, relation_name) -> has_primary directive.
+                    // The relation name is required because the same pair of collection types can
+                    // participate in multiple independent relations with different primary sides.
                     let entry = result
-                        .entry((type_name.clone(), target.clone()))
+                        .entry((type_name.clone(), target.clone(), relation_name))
                         .or_insert(false);
                     if field.directives.is_primary {
                         *entry = true;
@@ -51,6 +54,16 @@ impl<'a> SdlParser<'a> {
         }
 
         result
+    }
+
+    pub(super) fn relation_name_for_field(
+        &self,
+        source_type: &str,
+        field: &super::parser::ParsedField,
+    ) -> String {
+        field.directives.relation_name.clone().unwrap_or_else(|| {
+            generate_relation_name(source_type, &field.name, &field.field_type.base_type)
+        })
     }
 
     /// Validate parsed types before building collections.
@@ -140,8 +153,9 @@ impl<'a> SdlParser<'a> {
                 }
 
                 let has_primary = field.directives.is_primary;
+                let relation_name = self.relation_name_for_field(type_name, field);
                 let counterpart_has_primary = primary_directives
-                    .get(&(target.clone(), type_name.clone()))
+                    .get(&(target.clone(), type_name.clone(), relation_name))
                     .copied()
                     .unwrap_or(false);
 
@@ -335,7 +349,7 @@ impl<'a> SdlParser<'a> {
         type_names: &std::collections::HashSet<String>,
         collection_set: &std::collections::HashMap<String, (i32, usize)>,
         known_collection_ids: &std::collections::HashMap<String, String>,
-        primary_directives: &std::collections::HashMap<(String, String), bool>,
+        primary_directives: &PrimaryDirectiveMap,
         headstore: &HashMap<String, (Cid, u64)>,
     ) -> Result<CollectionVersion> {
         // collection_id will be generated after fields are created (like Go)
@@ -394,8 +408,9 @@ impl<'a> SdlParser<'a> {
                 let has_primary_directive = parsed_field.directives.is_primary;
 
                 // Check if counterpart has @primary directive
+                let relation_name = self.relation_name_for_field(&type_def.name, parsed_field);
                 let counterpart_has_primary = primary_directives
-                    .get(&(target_type.clone(), source_type.clone()))
+                    .get(&(target_type.clone(), source_type.clone(), relation_name))
                     .copied()
                     .unwrap_or(false);
 

--- a/crates/query-parse/src/sdl_parse/builder_cycles.rs
+++ b/crates/query-parse/src/sdl_parse/builder_cycles.rs
@@ -2,6 +2,8 @@
 
 use super::parser::SdlParser;
 
+type PrimaryDirectiveMap = std::collections::HashMap<(String, String, String), bool>;
+
 impl<'a> SdlParser<'a> {
     /// Detect types that form circular relation sets.
     /// Returns a map from type name to its sorted index within its connected cycle group.
@@ -17,44 +19,53 @@ impl<'a> SdlParser<'a> {
     pub(super) fn detect_collection_set(
         &self,
         type_names: &std::collections::HashSet<String>,
-        primary_directives: &std::collections::HashMap<(String, String), bool>,
+        primary_directives: &PrimaryDirectiveMap,
     ) -> (
         std::collections::HashMap<String, (i32, usize)>,
         Vec<Vec<String>>,
     ) {
         // Helper to check if a relation field from source->target is actually primary
         // (will be included in CID calculation)
-        let is_field_primary = |source: &str, target: &str, is_array: bool| -> bool {
-            if is_array {
-                // Arrays are always secondary
-                return false;
-            }
+        let is_field_primary =
+            |source: &str, target: &str, relation_name: &str, is_array: bool| -> bool {
+                if is_array {
+                    // Arrays are always secondary
+                    return false;
+                }
 
-            // Check if this field has @primary directive
-            let has_primary = primary_directives
-                .get(&(source.to_string(), target.to_string()))
-                .copied()
-                .unwrap_or(false);
+                // Check if this field has @primary directive
+                let has_primary = primary_directives
+                    .get(&(
+                        source.to_string(),
+                        target.to_string(),
+                        relation_name.to_string(),
+                    ))
+                    .copied()
+                    .unwrap_or(false);
 
-            if has_primary {
-                return true;
-            }
+                if has_primary {
+                    return true;
+                }
 
-            // Check if the counterpart (target->source) has @primary
-            // If it does, this side is SECONDARY
-            let counterpart_has_primary = primary_directives
-                .get(&(target.to_string(), source.to_string()))
-                .copied()
-                .unwrap_or(false);
+                // Check if the counterpart (target->source) has @primary
+                // If it does, this side is SECONDARY
+                let counterpart_has_primary = primary_directives
+                    .get(&(
+                        target.to_string(),
+                        source.to_string(),
+                        relation_name.to_string(),
+                    ))
+                    .copied()
+                    .unwrap_or(false);
 
-            if counterpart_has_primary {
-                // Counterpart has @primary, so this side is secondary
-                return false;
-            }
+                if counterpart_has_primary {
+                    // Counterpart has @primary, so this side is secondary
+                    return false;
+                }
 
-            // Neither side has @primary - single-object relation defaults to primary
-            true
-        };
+                // Neither side has @primary - single-object relation defaults to primary
+                true
+            };
 
         // Build relation graph: which types reference which other types via PRIMARY relations only
         let mut references: std::collections::HashMap<String, std::collections::HashSet<String>> =
@@ -67,8 +78,9 @@ impl<'a> SdlParser<'a> {
                 // Only consider relations to other types that are:
                 // 1. In the current schema (type_names)
                 // 2. Actually PRIMARY (will be included in CID)
+                let relation_name = self.relation_name_for_field(type_name, field);
                 if type_names.contains(target)
-                    && is_field_primary(type_name, target, field.field_type.is_list)
+                    && is_field_primary(type_name, target, &relation_name, field.field_type.is_list)
                 {
                     refs.insert(target.clone());
                 }

--- a/crates/query-parse/src/sdl_parse/builder_field_kinds.rs
+++ b/crates/query-parse/src/sdl_parse/builder_field_kinds.rs
@@ -36,8 +36,21 @@ impl<'a> SdlParser<'a> {
 
         // Check if it's a self-reference (same type or "Self" keyword)
         if base == current_type || base == "Self" {
-            // For self-references (type pointing to itself), Go ALWAYS uses empty RelativeID
-            // The RelativeID indices are only used for cross-type references within a collection set
+            // Single-collection self-ref sets omit RelativeID, but a self-reference inside
+            // a multi-collection set must use this collection's relative ID so nested
+            // self-relations resolve against the correct collection-set member.
+            if let Some(&(relative_id, group_idx)) = collection_set.get(current_type) {
+                let is_multi_collection_set =
+                    collection_set.iter().any(|(name, &(_, other_group_idx))| {
+                        name != current_type && other_group_idx == group_idx
+                    });
+                if is_multi_collection_set {
+                    return Ok(FieldKind::self_ref(
+                        relative_id.to_string(),
+                        parsed_type.is_list,
+                    ));
+                }
+            }
             return Ok(FieldKind::self_ref("", parsed_type.is_list));
         }
 

--- a/crates/query-plan/src/planner/index_selection/conditions.rs
+++ b/crates/query-plan/src/planner/index_selection/conditions.rs
@@ -1,6 +1,7 @@
 //! Condition analysis and scoring for index selection.
 
-use schema::IndexDescription;
+use document::NormalValue;
+use schema::{FieldKind, IndexDescription};
 use serde_json::Map;
 use serde_json::Value as JsonValue;
 
@@ -10,7 +11,11 @@ use super::types::{ConditionValue, FieldCondition};
 
 /// Determines if a filter condition should force a fallback to full scan instead of using the index.
 /// Matches Go's `shouldFallbackToFullScan` in indexer_iterators.go.
-pub(super) fn should_fallback_to_full_scan(cond: &FieldCondition, is_json_field: bool) -> bool {
+pub(super) fn should_fallback_to_full_scan(
+    cond: &FieldCondition,
+    is_json_field: bool,
+    field_kind: Option<&FieldKind>,
+) -> bool {
     let is_null = matches!(
         &cond.value,
         ConditionValue::Single(document::NormalValue::Null)
@@ -39,6 +44,28 @@ pub(super) fn should_fallback_to_full_scan(cond: &FieldCondition, is_json_field:
     // JSON indexes only store leaf values (scalars), not objects or arrays.
     // If the filter value is a complex type, fall back to full scan.
     if is_json_field {
+        // JSON ordering operators only work with numeric values. Non-numeric
+        // values must take the normal scan path so filter evaluation returns
+        // the correct type error.
+        if matches!(
+            cond.op,
+            FilterOp::Gt | FilterOp::Gte | FilterOp::Lt | FilterOp::Lte
+        ) && !is_numeric_filter_value(&cond.value)
+        {
+            return true;
+        }
+
+        // Root-level JSON LIKE filters need all documents. JSON indexes only
+        // store leaf values, so objects and arrays without leaf index entries
+        // would otherwise be missed.
+        if matches!(
+            cond.op,
+            FilterOp::Like | FilterOp::Nlike | FilterOp::Ilike | FilterOp::Nilike
+        ) && !has_nested_path
+        {
+            return true;
+        }
+
         // _in/_nin with empty values (all objects were filtered out) → fallback
         if matches!(cond.op, FilterOp::In | FilterOp::Nin) {
             if let ConditionValue::Multiple(vs) = &cond.value {
@@ -49,7 +76,23 @@ pub(super) fn should_fallback_to_full_scan(cond: &FieldCondition, is_json_field:
         }
     }
 
+    if field_kind.map(|kind| kind.is_array()).unwrap_or(false)
+        && matches!(cond.op, FilterOp::Eq | FilterOp::Ne)
+        && matches!(cond.value, ConditionValue::Multiple(_))
+    {
+        return true;
+    }
+
     false
+}
+
+fn is_numeric_filter_value(value: &ConditionValue) -> bool {
+    matches!(
+        value,
+        ConditionValue::Single(NormalValue::Int(_))
+            | ConditionValue::Single(NormalValue::Float32(_))
+            | ConditionValue::Single(NormalValue::Float64(_))
+    )
 }
 
 /// Extract field conditions from a filter.

--- a/crates/query-plan/src/planner/index_selection/filter_to_scan.rs
+++ b/crates/query-plan/src/planner/index_selection/filter_to_scan.rs
@@ -53,9 +53,11 @@ pub fn filter_to_index_scan(
     let first_field = &index.fields[0].name;
 
     // Check if the first index field is JSON-typed
-    let first_field_is_json = collection_fields
+    let first_field_kind = collection_fields
         .iter()
-        .any(|f| &f.name == first_field && matches!(f.kind, FieldKind::Scalar(ScalarKind::Json)));
+        .find(|f| &f.name == first_field)
+        .map(|f| &f.kind);
+    let first_field_is_json = matches!(first_field_kind, Some(FieldKind::Scalar(ScalarKind::Json)));
 
     // Find conditions on the first index field
     // For JSON fields, ensure top-level conditions get an empty json_path
@@ -81,7 +83,7 @@ pub fn filter_to_index_scan(
     // Check if any condition requires falling back to full scan (matches Go's shouldFallbackToFullScan).
     // Returns None to skip index when the index cannot produce correct results.
     for cond in &first_field_conditions {
-        if should_fallback_to_full_scan(cond, first_field_is_json) {
+        if should_fallback_to_full_scan(cond, first_field_is_json, first_field_kind) {
             return None;
         }
     }

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -108,6 +108,25 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             documents
         };
 
+        let documents = if let Some(ref filter) = select.filter {
+            let mut filtered = Vec::with_capacity(documents.len());
+            for document in documents {
+                let json_obj = JsonValue::Object(
+                    document
+                        .to_map()
+                        .map_err(|err| QueryError::internal(err.to_string()))?
+                        .into_iter()
+                        .collect(),
+                );
+                if filter.matches_json_object(&json_obj)? {
+                    filtered.push(document);
+                }
+            }
+            filtered
+        } else {
+            documents
+        };
+
         // Separate nested selects (relation fields) from scalar fields.
         // build_mapping can't handle nested selects, so we strip them and resolve relations separately.
         let mut nested_selects: Vec<&Select> = Vec::new();

--- a/tools/integration-test/tests/basic.rs
+++ b/tools/integration-test/tests/basic.rs
@@ -8,6 +8,8 @@ mod collection_management;
 mod document_lifecycle;
 #[path = "basic/multi_collection.rs"]
 mod multi_collection;
+#[path = "basic/patch_secondary_relation_4709.rs"]
+mod patch_secondary_relation_4709;
 #[path = "basic/self_ref_relations_4712.rs"]
 mod self_ref_relations_4712;
 #[path = "basic/smoke.rs"]

--- a/tools/integration-test/tests/basic.rs
+++ b/tools/integration-test/tests/basic.rs
@@ -8,6 +8,8 @@ mod collection_management;
 mod document_lifecycle;
 #[path = "basic/multi_collection.rs"]
 mod multi_collection;
+#[path = "basic/self_ref_relations_4712.rs"]
+mod self_ref_relations_4712;
 #[path = "basic/smoke.rs"]
 mod smoke;
 #[path = "basic/transactions.rs"]

--- a/tools/integration-test/tests/basic.rs
+++ b/tools/integration-test/tests/basic.rs
@@ -1,5 +1,7 @@
 #[path = "basic/batch_mutations.rs"]
 mod batch_mutations;
+#[path = "basic/collection_delete_4657.rs"]
+mod collection_delete_4657;
 #[path = "basic/collection_management.rs"]
 mod collection_management;
 #[path = "basic/document_lifecycle.rs"]

--- a/tools/integration-test/tests/basic/collection_delete_4657.rs
+++ b/tools/integration-test/tests/basic/collection_delete_4657.rs
@@ -1,0 +1,51 @@
+use integration_test::TestCluster;
+
+async fn stale_transaction_cannot_write_after_collection_delete_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+
+    client
+        .schema_add("type Users { name: String }")
+        .expect("add schema");
+
+    let tx_id = client.tx_create().expect("create transaction");
+
+    client
+        .collection_patch(r#"[{"op": "remove", "path": "/Users"}]"#)
+        .expect("delete collection");
+
+    assert!(
+        client.query("query { Users { name } }").is_err(),
+        "deleted collection should not be queryable outside the stale transaction"
+    );
+
+    let stale_write = client.query_with_tx(
+        r#"mutation { add_Users(input: {name: "stale"}) { _docID } }"#,
+        &tx_id,
+    );
+    let stale_err = stale_write.expect_err("stale transaction write should fail");
+    assert!(
+        stale_err.to_string().contains("collection not found")
+            || stale_err.to_string().contains("Cannot query field")
+            || stale_err.to_string().contains("Users"),
+        "unexpected stale write error: {stale_err}"
+    );
+
+    client
+        .tx_discard(&tx_id)
+        .expect("discard stale transaction");
+
+    let commits = client
+        .query("query { _commits { cid } }")
+        .expect("query commits");
+    assert_eq!(
+        commits["_commits"],
+        serde_json::json!([]),
+        "stale write must not leave document commits behind"
+    );
+}
+
+#[tokio::test]
+async fn rust_stale_transaction_cannot_write_after_collection_delete() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    stale_transaction_cannot_write_after_collection_delete_test(cluster).await;
+}

--- a/tools/integration-test/tests/basic/patch_secondary_relation_4709.rs
+++ b/tools/integration-test/tests/basic/patch_secondary_relation_4709.rs
@@ -1,0 +1,37 @@
+use integration_test::TestCluster;
+
+const SCHEMA: &str = r#"
+type Book {
+    publisher: Publisher @primary
+}
+
+type Publisher {
+    book: Book
+}
+"#;
+
+async fn patch_new_field_with_existing_secondary_relation_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+    client.schema_add(SCHEMA).expect("add schema");
+
+    client
+        .collection_patch(
+            r#"[{"op":"add","path":"/Publisher/Fields/-","value":{"Name":"name","Kind":"String"}}]"#,
+        )
+        .expect("patch Publisher.name");
+
+    client
+        .query(r#"mutation { add_Publisher(input: {name: "Penguin Books"}) { name } }"#)
+        .expect("add Publisher after patch");
+
+    let data = client
+        .query("query { Publisher { name } }")
+        .expect("query Publisher");
+    assert_eq!(data["Publisher"][0]["name"], "Penguin Books");
+}
+
+#[tokio::test]
+async fn rust_patch_new_field_with_existing_secondary_relation() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    patch_new_field_with_existing_secondary_relation_test(cluster).await;
+}

--- a/tools/integration-test/tests/basic/self_ref_relations_4712.rs
+++ b/tools/integration-test/tests/basic/self_ref_relations_4712.rs
@@ -1,0 +1,69 @@
+use integration_test::TestCluster;
+use serde_json::Value;
+
+const SCHEMA: &str = r#"
+type Dev_RC_Domain {
+    routes: [Dev_RC_RedirectRoute]
+    firstRoute: Dev_RC_RedirectRoute @primary @relation(name: "domain_first_route")
+}
+
+type Dev_RC_RedirectRoute {
+    firstForDomain: Dev_RC_Domain @relation(name: "domain_first_route")
+
+    domain: Dev_RC_Domain
+    after: Dev_RC_RedirectRoute
+}
+"#;
+
+fn field<'a>(collection: &'a Value, name: &str) -> &'a Value {
+    collection["Fields"]
+        .as_array()
+        .expect("Fields should be an array")
+        .iter()
+        .find(|field| field["Name"] == name)
+        .unwrap_or_else(|| panic!("missing field {name} in collection {collection:?}"))
+}
+
+fn assert_relative_id(collection: &Value, field_name: &str, expected: &str) {
+    let field = field(collection, field_name);
+    let actual = &field["Kind"]["RelativeID"];
+    assert_eq!(
+        actual, expected,
+        "unexpected RelativeID for {field_name}: {field:?}"
+    );
+}
+
+async fn multi_layer_self_ref_relations_test(cluster: TestCluster) {
+    let client = cluster.client(0);
+    client.schema_add(SCHEMA).expect("add schema");
+
+    let collections: Vec<Value> = reqwest::get(format!(
+        "{}/api/v0/collections/versions",
+        cluster.api_url(0)
+    ))
+    .await
+    .expect("get collection versions")
+    .json()
+    .await
+    .expect("decode collection versions");
+    let domain = collections
+        .iter()
+        .find(|collection| collection["Name"] == "Dev_RC_Domain")
+        .expect("missing Dev_RC_Domain");
+    let route = collections
+        .iter()
+        .find(|collection| collection["Name"] == "Dev_RC_RedirectRoute")
+        .expect("missing Dev_RC_RedirectRoute");
+
+    assert_relative_id(domain, "firstRoute", "1");
+    assert_relative_id(domain, "routes", "1");
+    assert_relative_id(route, "firstForDomain", "0");
+    assert_relative_id(route, "domain", "0");
+    assert_relative_id(route, "after", "1");
+}
+
+#[tokio::test]
+async fn rust_multi_layer_self_ref_relations() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    multi_layer_self_ref_relations_test(cluster).await;
+}

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -20,6 +20,8 @@ mod lens;
 mod lens_persistence;
 #[path = "query/limits.rs"]
 mod limits;
+#[path = "query/planner_4656.rs"]
+mod planner_4656;
 #[path = "query/sdl_generate.rs"]
 mod sdl_generate;
 #[path = "query/subscription_docid.rs"]

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -22,6 +22,8 @@ mod lens_persistence;
 mod limits;
 #[path = "query/planner_4656.rs"]
 mod planner_4656;
+#[path = "query/planner_4684.rs"]
+mod planner_4684;
 #[path = "query/sdl_generate.rs"]
 mod sdl_generate;
 #[path = "query/subscription_docid.rs"]

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -8,10 +8,14 @@ mod continuous_rollup;
 mod downsample;
 #[path = "query/downsample_gc.rs"]
 mod downsample_gc;
+#[path = "query/exhaustive_orphans_4454.rs"]
+mod exhaustive_orphans_4454;
 #[path = "query/explain_nested.rs"]
 mod explain_nested;
 #[path = "query/gql_list_args.rs"]
 mod gql_list_args;
+#[path = "query/index_fallback_4633.rs"]
+mod index_fallback_4633;
 #[path = "query/index_management.rs"]
 mod index_management;
 #[path = "query/lens.rs"]
@@ -20,8 +24,6 @@ mod lens;
 mod lens_persistence;
 #[path = "query/limits.rs"]
 mod limits;
-#[path = "query/index_fallback_4633.rs"]
-mod index_fallback_4633;
 #[path = "query/planner_4656.rs"]
 mod planner_4656;
 #[path = "query/planner_4684.rs"]

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -20,6 +20,8 @@ mod lens;
 mod lens_persistence;
 #[path = "query/limits.rs"]
 mod limits;
+#[path = "query/index_fallback_4633.rs"]
+mod index_fallback_4633;
 #[path = "query/planner_4656.rs"]
 mod planner_4656;
 #[path = "query/planner_4684.rs"]

--- a/tools/integration-test/tests/query/exhaustive_orphans_4454.rs
+++ b/tools/integration-test/tests/query/exhaustive_orphans_4454.rs
@@ -1,0 +1,134 @@
+use integration_test::TestCluster;
+
+async fn exhaustive_relation_order_includes_orphans_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+
+    node.schema_add(
+        r#"
+        type Author {
+            name: String
+            published: [Book]
+        }
+
+        type Book {
+            title: String
+            author: Author
+            publisher: Publisher
+        }
+
+        type Publisher {
+            name: String
+            establishedYear: Int @index
+            book: Book @primary
+        }
+        "#,
+    )
+    .expect("add schema");
+
+    let author = node
+        .query(r#"mutation { add_Author(input: {name: "John"}) { _docID } }"#)
+        .expect("add author");
+    let author_id = author["add_Author"][0]["_docID"].as_str().unwrap();
+
+    let add_book = |title: &str| {
+        let result = node
+            .query(&format!(
+                r#"mutation {{ add_Book(input: {{title: "{title}", author: "{author_id}"}}) {{ _docID }} }}"#
+            ))
+            .expect("add book");
+        result["add_Book"][0]["_docID"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+
+    let book_2020 = add_book("Book2020");
+    let book_2010 = add_book("Book2010");
+    let book_2000 = add_book("Book2000");
+    add_book("OrphanBook");
+
+    let add_publisher = |name: &str, year: i64, book_id: &str| {
+        node.query(&format!(
+            r#"mutation {{ add_Publisher(input: {{name: "{name}", establishedYear: {year}, book: "{book_id}"}}) {{ _docID }} }}"#
+        ))
+        .expect("add publisher");
+    };
+
+    add_publisher("Publisher2020", 2020, &book_2020);
+    add_publisher("Publisher2010", 2010, &book_2010);
+    add_publisher("Publisher2000", 2000, &book_2000);
+
+    let default_result = node
+        .query(
+            r#"
+            query {
+                Book(order: {publisher: {establishedYear: ASC}}) {
+                    title
+                }
+            }
+            "#,
+        )
+        .expect("query non-exhaustive books");
+    assert_eq!(
+        default_result["Book"],
+        serde_json::json!([
+            {"title": "Book2000"},
+            {"title": "Book2010"},
+            {"title": "Book2020"}
+        ])
+    );
+
+    let exhaustive_result = node
+        .query(
+            r#"
+            query @exhaustive {
+                Book(order: {publisher: {establishedYear: ASC}}) {
+                    title
+                }
+            }
+            "#,
+        )
+        .expect("query exhaustive books");
+    assert_eq!(
+        exhaustive_result["Book"],
+        serde_json::json!([
+            {"title": "OrphanBook"},
+            {"title": "Book2000"},
+            {"title": "Book2010"},
+            {"title": "Book2020"}
+        ])
+    );
+
+    let nested_result = node
+        .query(
+            r#"
+            query @exhaustive {
+                Author {
+                    name
+                    published(order: {publisher: {establishedYear: ASC}}, limit: 2) {
+                        title
+                    }
+                }
+            }
+            "#,
+        )
+        .expect("query exhaustive nested books");
+    assert_eq!(
+        nested_result["Author"],
+        serde_json::json!([
+            {
+                "name": "John",
+                "published": [
+                    {"title": "OrphanBook"},
+                    {"title": "Book2000"}
+                ]
+            }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn rust_exhaustive_relation_order_includes_orphans() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    exhaustive_relation_order_includes_orphans_test(cluster).await;
+}

--- a/tools/integration-test/tests/query/index_fallback_4633.rs
+++ b/tools/integration-test/tests/query/index_fallback_4633.rs
@@ -1,0 +1,150 @@
+use std::collections::BTreeSet;
+
+use integration_test::TestCluster;
+
+async fn unsupported_index_filters_fall_back_to_scan_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+
+    node.schema_add(
+        r#"
+        type Users {
+            name: String
+            custom: JSON @index
+            likedIndexes: [Boolean] @index
+        }
+        "#,
+    )
+    .expect("add schema");
+
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "Dany", custom: "Daenerys Stormborn", likedIndexes: [false]}) { _docID }
+        }"#,
+    )
+    .expect("add Dany");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "Viserys", custom: "Viserys I Targaryen", likedIndexes: [false]}) { _docID }
+        }"#,
+    )
+    .expect("add Viserys");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "Object", custom: {one: 1}, likedIndexes: [false]}) { _docID }
+        }"#,
+    )
+    .expect("add object");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "Array", custom: [1, 2], likedIndexes: [false]}) { _docID }
+        }"#,
+    )
+    .expect("add array");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "EmptyObject", custom: {}, likedIndexes: [false]}) { _docID }
+        }"#,
+    )
+    .expect("add empty object");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "EmptyArray", custom: [], likedIndexes: [false]}) { _docID }
+        }"#,
+    )
+    .expect("add empty array");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "Boolean", custom: false, likedIndexes: [false]}) { _docID }
+        }"#,
+    )
+    .expect("add bool");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "Number", custom: 32, likedIndexes: [false]}) { _docID }
+        }"#,
+    )
+    .expect("add number");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "Shahzad", custom: "array owner", likedIndexes: [true, false]}) { _docID }
+        }"#,
+    )
+    .expect("add Shahzad");
+    node.query(
+        r#"mutation {
+            add_Users(input: {name: "Fred", custom: "array miss", likedIndexes: [true, true]}) { _docID }
+        }"#,
+    )
+    .expect("add Fred");
+
+    let nlike_result = node
+        .query(
+            r#"
+            query {
+                Users(filter: {custom: {_nlike: "%Stormborn%"}}) {
+                    name
+                }
+            }
+            "#,
+        )
+        .expect("query JSON _nlike");
+    let names: BTreeSet<_> = nlike_result["Users"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|user| user["name"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        names,
+        BTreeSet::from([
+            "Array".to_string(),
+            "Boolean".to_string(),
+            "EmptyArray".to_string(),
+            "EmptyObject".to_string(),
+            "Fred".to_string(),
+            "Number".to_string(),
+            "Object".to_string(),
+            "Shahzad".to_string(),
+            "Viserys".to_string(),
+        ])
+    );
+
+    let array_eq_result = node
+        .query(
+            r#"
+            query {
+                Users(filter: {likedIndexes: {_eq: [true, false]}}) {
+                    name
+                }
+            }
+            "#,
+        )
+        .expect("query array literal equality");
+    assert_eq!(
+        array_eq_result["Users"],
+        serde_json::json!([{ "name": "Shahzad" }])
+    );
+
+    let err = node
+        .query(
+            r#"
+            query {
+                Users(filter: {custom: {_gt: false}}) {
+                    name
+                }
+            }
+            "#,
+        )
+        .expect_err("non-numeric JSON ordering filter should be rejected");
+    assert!(
+        err.to_string()
+            .contains("unexpected type. Property: condition, Actual: bool"),
+        "unexpected non-numeric JSON ordering error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn rust_unsupported_index_filters_fall_back_to_scan() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    unsupported_index_filters_fall_back_to_scan_test(cluster).await;
+}

--- a/tools/integration-test/tests/query/planner_4656.rs
+++ b/tools/integration-test/tests/query/planner_4656.rs
@@ -1,0 +1,91 @@
+use integration_test::TestCluster;
+
+async fn inverted_join_scalar_and_relation_filters_are_anded_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+
+    node.schema_add(
+        r#"
+        type Author {
+            name: String @index
+            published: [Book]
+        }
+
+        type Book {
+            title: String
+            rating: Float
+            genre: String
+            author: Author
+        }
+        "#,
+    )
+    .expect("add schema");
+
+    let john = node
+        .query(r#"mutation { add_Author(input: {name: "John Grisham"}) { _docID } }"#)
+        .expect("add John");
+    let john_id = john["add_Author"][0]["_docID"].as_str().unwrap();
+    let cornelia = node
+        .query(r#"mutation { add_Author(input: {name: "Cornelia Funke"}) { _docID } }"#)
+        .expect("add Cornelia");
+    let cornelia_id = cornelia["add_Author"][0]["_docID"].as_str().unwrap();
+
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{title: "Painted House", rating: 4.9, genre: "drama", author: "{}"}}) {{ _docID }} }}"#,
+        john_id
+    ))
+    .expect("add Painted House");
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{title: "A Time to Kill", rating: 4.0, genre: "thriller", author: "{}"}}) {{ _docID }} }}"#,
+        john_id
+    ))
+    .expect("add A Time to Kill");
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{title: "The Firm", rating: 4.5, genre: "thriller", author: "{}"}}) {{ _docID }} }}"#,
+        john_id
+    ))
+    .expect("add The Firm");
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{title: "The Thief Lord", rating: 4.8, genre: "fantasy", author: "{}"}}) {{ _docID }} }}"#,
+        cornelia_id
+    ))
+    .expect("add The Thief Lord");
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Book(
+                    filter: {
+                        genre: {_eq: "thriller"}
+                        rating: {_gt: 4.0}
+                        author: {name: {_eq: "John Grisham"}}
+                    }
+                ) {
+                    title
+                    rating
+                    genre
+                    author { name }
+                }
+            }
+            "#,
+        )
+        .expect("query books");
+
+    assert_eq!(
+        result["Book"],
+        serde_json::json!([
+            {
+                "title": "The Firm",
+                "rating": 4.5,
+                "genre": "thriller",
+                "author": {"name": "John Grisham"}
+            }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn rust_inverted_join_scalar_and_relation_filters_are_anded() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    inverted_join_scalar_and_relation_filters_are_anded_test(cluster).await;
+}

--- a/tools/integration-test/tests/query/planner_4684.rs
+++ b/tools/integration-test/tests/query/planner_4684.rs
@@ -1,0 +1,271 @@
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use futures::StreamExt;
+use integration_test::TestCluster;
+use serde_json::Value;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+fn subscription_timeout() -> Duration {
+    std::env::var("DEFRADB_TEST_SUBSCRIPTION_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(Duration::from_secs(5))
+}
+
+fn subscription_settle_timeout() -> Duration {
+    std::env::var("DEFRADB_TEST_SUBSCRIPTION_SETTLE_MS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(Duration::from_millis(250))
+}
+
+fn open_subscription(
+    api_url: &str,
+    query: &str,
+) -> (
+    JoinHandle<()>,
+    oneshot::Receiver<()>,
+    Arc<Mutex<Vec<Value>>>,
+) {
+    let url = format!("{}/api/v0/graphql", api_url);
+    let body = serde_json::json!({ "query": query });
+    let events: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_clone = events.clone();
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let handle = tokio::spawn(async move {
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&url)
+            .header("Accept", "text/event-stream")
+            .json(&body)
+            .send()
+            .await
+            .expect("SSE request failed")
+            .error_for_status()
+            .expect("SSE request returned error status");
+        let _ = ready_tx.send(());
+
+        let mut buf = String::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.expect("SSE chunk error");
+            buf.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(pos) = buf.find("\n\n") {
+                let block = buf[..pos].to_string();
+                buf = buf[pos + 2..].to_string();
+
+                let mut event_type = "";
+                let mut data = "";
+                for line in block.lines() {
+                    if let Some(rest) = line.strip_prefix("event:") {
+                        event_type = rest.trim();
+                    } else if let Some(rest) = line.strip_prefix("data:") {
+                        data = rest.trim();
+                    }
+                }
+
+                if event_type == "next" {
+                    if let Ok(value) = serde_json::from_str::<Value>(data) {
+                        events_clone.lock().unwrap().push(value);
+                    }
+                }
+            }
+        }
+    });
+
+    (handle, ready_rx, events)
+}
+
+async fn wait_for_exact_subscription_events(events: &Arc<Mutex<Vec<Value>>>, expected_len: usize) {
+    let timeout = subscription_timeout();
+    let deadline = Instant::now() + timeout;
+    let settle_timeout = subscription_settle_timeout();
+    let mut expected_since = None;
+
+    loop {
+        let current_len = events.lock().unwrap().len();
+        if current_len == expected_len {
+            let since = expected_since.get_or_insert_with(Instant::now);
+            if since.elapsed() >= settle_timeout {
+                return;
+            }
+        } else {
+            expected_since = None;
+            if current_len > expected_len {
+                let collected = events.lock().unwrap();
+                panic!("expected {expected_len} subscription events, got {collected:?}");
+            }
+        }
+        if Instant::now() >= deadline {
+            let collected = events.lock().unwrap();
+            panic!(
+                "timed out after {timeout:?} waiting for {expected_len} subscription events, got {collected:?}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn subscription_with_indexed_filter_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let api_url = cluster.api_url(0);
+
+    node.schema_add(
+        r#"
+        type User {
+            name: String
+            age: Int @index
+        }
+        "#,
+    )
+    .expect("add schema");
+
+    let sub_query = r#"
+        subscription {
+            User(filter: {age: {_lt: 30}}) {
+                _docID
+                name
+                age
+            }
+        }
+    "#;
+    let (handle, ready, events) = open_subscription(api_url, sub_query);
+    tokio::time::timeout(subscription_timeout(), ready)
+        .await
+        .expect("subscription did not open before timeout")
+        .expect("subscription task ended before opening");
+
+    node.query(r#"mutation { add_User(input: {name: "John", age: 27}) { _docID } }"#)
+        .expect("add matching user");
+    node.query(r#"mutation { add_User(input: {name: "Addo", age: 31}) { _docID } }"#)
+        .expect("add nonmatching user");
+
+    wait_for_exact_subscription_events(&events, 1).await;
+    handle.abort();
+
+    let collected = events.lock().unwrap();
+    assert_eq!(
+        collected.len(),
+        1,
+        "expected one indexed-filter subscription event, got {collected:?}"
+    );
+    let user = collected[0]
+        .pointer("/data/User/0")
+        .or_else(|| collected[0].pointer("/User/0"))
+        .unwrap_or_else(|| {
+            panic!(
+                "subscription event missing User payload: {:?}",
+                collected[0]
+            )
+        });
+    assert_eq!(user["name"], "John");
+    assert_eq!(user["age"], 27);
+}
+
+async fn inverted_one_to_many_parent_filter_with_child_order_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+
+    node.schema_add(
+        r#"
+        type Author {
+            name: String
+            age: Int
+            published: [Book]
+        }
+
+        type Book {
+            title: String
+            rating: Float @index
+            author: Author
+        }
+        "#,
+    )
+    .expect("add schema");
+
+    let alice = node
+        .query(r#"mutation { add_Author(input: {name: "Alice", age: 41}) { _docID } }"#)
+        .expect("add Alice");
+    let alice_id = alice["add_Author"][0]["_docID"].as_str().unwrap();
+    let bob = node
+        .query(r#"mutation { add_Author(input: {name: "Bob", age: 42}) { _docID } }"#)
+        .expect("add Bob");
+    let bob_id = bob["add_Author"][0]["_docID"].as_str().unwrap();
+
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{title: "Book A1", rating: 4.8, author: "{}"}}) {{ _docID }} }}"#,
+        alice_id
+    ))
+    .expect("add Alice book 1");
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{title: "Book A2", rating: 3.5, author: "{}"}}) {{ _docID }} }}"#,
+        alice_id
+    ))
+    .expect("add Alice book 2");
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{title: "Book B1", rating: 4.0, author: "{}"}}) {{ _docID }} }}"#,
+        bob_id
+    ))
+    .expect("add Bob book 1");
+    node.query(&format!(
+        r#"mutation {{ add_Book(input: {{title: "Book B2", rating: 2.5, author: "{}"}}) {{ _docID }} }}"#,
+        bob_id
+    ))
+    .expect("add Bob book 2");
+
+    let result = node
+        .query(
+            r#"
+            query {
+                Author(
+                    filter: {published: {rating: {_geq: 4.0}}}
+                    order: {age: ASC}
+                ) {
+                    name
+                    published(order: {rating: DESC}) {
+                        title
+                        rating
+                    }
+                }
+            }
+            "#,
+        )
+        .expect("query authors");
+
+    assert_eq!(
+        result["Author"],
+        serde_json::json!([
+            {
+                "name": "Alice",
+                "published": [
+                    {"title": "Book A1", "rating": 4.8},
+                    {"title": "Book A2", "rating": 3.5}
+                ]
+            },
+            {
+                "name": "Bob",
+                "published": [
+                    {"title": "Book B1", "rating": 4},
+                    {"title": "Book B2", "rating": 2.5}
+                ]
+            }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn rust_subscription_with_indexed_filter_receives_matching_update() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    subscription_with_indexed_filter_test(cluster).await;
+}
+
+#[tokio::test]
+async fn rust_inverted_one_to_many_parent_filter_with_child_order() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    inverted_one_to_many_parent_filter_with_child_order_test(cluster).await;
+}


### PR DESCRIPTION
## Summary

Ports the seven Go query-engine correctness fixes from the sync plan:

- `09c050f4` / #4656: multiple filters as AND on inverted joins. Rust already behaved correctly; added regression coverage.
- `9590e105` / #4684: secondary index edge cases for subscriptions with CID filters and inverted 1-to-many ordering. Rust already behaved correctly; added regression coverage.
- `9f9d7de7` / #4633: fall back to scan node for unsupported index filters. Added planner fallback fix plus regression coverage.
- `31a03b77` / #4454: fetch orphan parent docs with `@exhaustive`. Rust already had the needed `@exhaustive` behavior; added regression coverage.
- `aec4717b` / #4657: prevent document writes after collection deletion. Added active-collection write guards plus regression coverage.
- `b486aecd` / #4712: multi-layered self-referencing relations. Fixed SDL relation resolution plus regression coverage.
- `7d011d6e` / #4709: patch new fields on collections with secondary relations. Rust already behaved correctly; added regression coverage.

## Verification

- `cargo fmt --all`
- `cargo clippy --all -- -D warnings`
- `cargo test -p query`
- `cargo test -p db`
- `PATH="/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb/build:/Users/johnzampolin/go/bin:$PATH" cargo test -p integration-test --test query --test basic`
