### PR TITLE
Align CLI rename surface with Go upstream

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -88,6 +88,10 @@ pub struct Cli {
     #[arg(long, global = true, env = "DEFRA_SECRET_FILE")]
     pub secret_file: Option<String>,
 
+    /// Enables development mode features
+    #[arg(long, global = true, env = "DEFRA_DEVELOPMENT", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    pub development: Option<bool>,
+
     /// Enable Node Access Control (NAC).
     ///
     /// When enabled, node operations require authentication and authorization

--- a/crates/cli/src/commands/client/backup.rs
+++ b/crates/cli/src/commands/client/backup.rs
@@ -62,6 +62,8 @@ impl BackupArgs {
 impl BackupExportArgs {
     /// Execute the backup export command
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        require_development(ctx)?;
+
         // Validate collection names before making the request
         for col in &self.collections {
             validate_identifier(col)?;
@@ -94,6 +96,8 @@ impl BackupExportArgs {
 impl BackupImportArgs {
     /// Execute the backup import command
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        require_development(ctx)?;
+
         let data = tokio::fs::read_to_string(&self.file)
             .await
             .map_err(|e| Error::ReadFile {
@@ -112,9 +116,28 @@ impl BackupImportArgs {
     }
 }
 
+fn require_development(ctx: &ClientContext) -> Result<()> {
+    if ctx.development {
+        Ok(())
+    } else {
+        Err(Error::OperationRequiresDeveloperMode)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_context(development: bool) -> ClientContext {
+        ClientContext {
+            url: "http://localhost:9181".to_string(),
+            auth_token: None,
+            identity_key_bytes: None,
+            tx_id: None,
+            development,
+            verbose: false,
+        }
+    }
 
     #[test]
     fn test_backup_export_args() {
@@ -145,5 +168,27 @@ mod tests {
             file: PathBuf::from("backup.json"),
         };
         assert_eq!(args.file, PathBuf::from("backup.json"));
+    }
+
+    #[tokio::test]
+    async fn export_requires_development_mode() {
+        let args = BackupExportArgs {
+            file: PathBuf::from("backup.json"),
+            collections: vec![],
+            pretty: false,
+        };
+
+        let err = args.execute(&test_context(false)).await.unwrap_err();
+        assert!(matches!(err, Error::OperationRequiresDeveloperMode));
+    }
+
+    #[tokio::test]
+    async fn import_requires_development_mode() {
+        let args = BackupImportArgs {
+            file: PathBuf::from("missing.json"),
+        };
+
+        let err = args.execute(&test_context(false)).await.unwrap_err();
+        assert!(matches!(err, Error::OperationRequiresDeveloperMode));
     }
 }

--- a/crates/cli/src/commands/client/collection/mod.rs
+++ b/crates/cli/src/commands/client/collection/mod.rs
@@ -21,7 +21,7 @@ pub struct CollectionArgs {
     #[arg(long, global = true)]
     pub collection_id: Option<String>,
 
-    /// Schema version ID
+    /// Collection version ID
     #[arg(long, global = true)]
     pub version_id: Option<String>,
 
@@ -37,16 +37,14 @@ pub struct CollectionArgs {
 #[derive(Subcommand, Debug)]
 #[non_exhaustive]
 pub enum CollectionCommand {
-    /// Add a new collection from a schema definition (SDL)
+    /// Add a new collection from an SDL definition
     Add(CollectionAddArgs),
-    /// Describe a collection's schema
+    /// Describe a collection
     Describe(CollectionDescribeArgs),
     /// List all collections
     List(CollectionListArgs),
-    /// Patch a collection schema
+    /// Patch a collection
     Patch(CollectionPatchArgs),
-    /// Display the full GraphQL schema
-    Schema(CollectionSchemaArgs),
     /// Set a collection as active
     SetActive(SetActiveArgs),
     /// Truncate a collection
@@ -56,11 +54,11 @@ pub enum CollectionCommand {
 /// Arguments for collection add (schema definition) command
 #[derive(Args, Debug)]
 pub struct CollectionAddArgs {
-    /// The schema definition (SDL format)
+    /// The collection definition (SDL format)
     #[arg(value_name = "SDL")]
-    pub schema: Option<String>,
+    pub sdl: Option<String>,
 
-    /// Read schema from file(s)
+    /// Read collection definition from file(s)
     #[arg(long, short = 'f', value_name = "FILE")]
     pub file: Vec<PathBuf>,
 }
@@ -101,10 +99,6 @@ pub struct SetActiveArgs {
     pub version_id: Option<String>,
 }
 
-/// Arguments for displaying the full GraphQL schema
-#[derive(Args, Debug)]
-pub struct CollectionSchemaArgs {}
-
 /// Arguments for truncate command
 #[derive(Args, Debug)]
 pub struct TruncateArgs {}
@@ -113,8 +107,8 @@ impl CollectionAddArgs {
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
         let mut sdl_parts = Vec::new();
 
-        if let Some(ref schema) = self.schema {
-            sdl_parts.push(schema.clone());
+        if let Some(ref sdl) = self.sdl {
+            sdl_parts.push(sdl.clone());
         }
 
         for path in &self.file {
@@ -143,18 +137,6 @@ impl CollectionAddArgs {
     }
 }
 
-impl CollectionSchemaArgs {
-    /// Execute the collection schema command
-    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
-        let client = super::http_client::HttpClient::new(&ctx.url)?
-            .with_auth_token(ctx.auth_token.clone())
-            .with_verbose(ctx.verbose);
-        let schema = client.schema().await?;
-        println!("{schema}");
-        Ok(())
-    }
-}
-
 impl CollectionArgs {
     /// Execute the collection command
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
@@ -163,7 +145,6 @@ impl CollectionArgs {
             CollectionCommand::Describe(args) => args.execute(ctx, self.name.as_deref()).await,
             CollectionCommand::List(args) => args.execute(ctx).await,
             CollectionCommand::Patch(args) => args.execute(ctx).await,
-            CollectionCommand::Schema(args) => args.execute(ctx).await,
             CollectionCommand::SetActive(args) => args.execute(ctx).await,
             CollectionCommand::Truncate(args) => args.execute(ctx, self.name.as_deref()).await,
         }

--- a/crates/cli/src/commands/client/document.rs
+++ b/crates/cli/src/commands/client/document.rs
@@ -17,14 +17,14 @@ use crate::error::{Error, Result};
 #[derive(Args, Debug)]
 pub struct DocumentArgs {
     /// Collection name
-    #[arg(long = "collection-name", alias = "name", global = true)]
+    #[arg(long = "collection-name", global = true)]
     pub collection_name: Option<String>,
 
     /// Collection ID
     #[arg(long, global = true)]
     pub collection_id: Option<String>,
 
-    /// Schema version ID
+    /// Collection version ID
     #[arg(long, global = true)]
     pub version_id: Option<String>,
 

--- a/crates/cli/src/commands/client/encrypted_index.rs
+++ b/crates/cli/src/commands/client/encrypted_index.rs
@@ -17,23 +17,22 @@ pub struct EncryptedIndexArgs {
 #[derive(Subcommand, Debug)]
 #[non_exhaustive]
 pub enum EncryptedIndexCommand {
-    /// Add an encrypted index on a collection field
-    #[command(alias = "add")]
-    New(EncryptedIndexAddArgs),
+    /// Make a new encrypted index on a collection field
+    New(EncryptedIndexNewArgs),
     /// Delete an encrypted index from a collection field
     Delete(EncryptedIndexDeleteArgs),
     /// List encrypted indexes for a collection
     List(EncryptedIndexListArgs),
 }
 
-/// Arguments for encrypted-index add command
+/// Arguments for encrypted-index new command
 #[derive(Args, Debug)]
-pub struct EncryptedIndexAddArgs {
+pub struct EncryptedIndexNewArgs {
     /// Collection name
     #[arg(long, short = 'c')]
     pub collection: String,
 
-    /// Field name to add encrypted index on
+    /// Field name to make a new encrypted index on
     #[arg(long)]
     pub field: String,
 }
@@ -68,7 +67,7 @@ impl EncryptedIndexArgs {
     }
 }
 
-impl EncryptedIndexAddArgs {
+impl EncryptedIndexNewArgs {
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
         validate_identifier(&self.collection)?;
         validate_identifier(&self.field)?;

--- a/crates/cli/src/commands/client/index.rs
+++ b/crates/cli/src/commands/client/index.rs
@@ -17,19 +17,18 @@ pub struct IndexArgs {
 #[derive(Subcommand, Debug)]
 #[non_exhaustive]
 pub enum IndexCommand {
-    /// Create a new index on a collection
-    #[command(alias = "create")]
-    New(IndexCreateArgs),
+    /// Make a new index on a collection
+    New(IndexNewArgs),
     /// List indexes (optionally filtered by collection)
     List(IndexListArgs),
     /// Delete an index by name
     Delete(IndexDeleteArgs),
 }
 
-/// Arguments for index create command
+/// Arguments for index new command
 #[derive(Args, Debug)]
-pub struct IndexCreateArgs {
-    /// The collection to create the index on
+pub struct IndexNewArgs {
+    /// The collection to make the index on
     #[arg(long, short = 'c')]
     pub collection: String,
 
@@ -41,7 +40,7 @@ pub struct IndexCreateArgs {
     #[arg(long, short = 'n')]
     pub name: Option<String>,
 
-    /// Create a unique index
+    /// Make a unique index
     #[arg(long)]
     pub unique: bool,
 }
@@ -77,8 +76,8 @@ impl IndexArgs {
     }
 }
 
-impl IndexCreateArgs {
-    /// Execute the index create command
+impl IndexNewArgs {
+    /// Execute the index new command
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
         validate_identifier(&self.collection)?;
         for field in &self.fields {
@@ -147,8 +146,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_index_create_args() {
-        let args = IndexCreateArgs {
+    fn test_index_new_args() {
+        let args = IndexNewArgs {
             collection: "Users".to_string(),
             fields: vec!["name".to_string(), "email".to_string()],
             name: Some("idx_name_email".to_string()),
@@ -160,8 +159,8 @@ mod tests {
     }
 
     #[test]
-    fn test_index_create_args_minimal() {
-        let args = IndexCreateArgs {
+    fn test_index_new_args_minimal() {
+        let args = IndexNewArgs {
             collection: "Users".to_string(),
             fields: vec!["name".to_string()],
             name: None,

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -110,7 +110,6 @@ pub enum ClientCommand {
     /// Interact with blocks
     Block(BlockArgs),
     /// Interact with collections
-    #[command(alias = "schema")]
     Collection(CollectionArgs),
     /// Interact with documents
     Document(DocumentArgs),

--- a/crates/cli/src/commands/client/mod.rs
+++ b/crates/cli/src/commands/client/mod.rs
@@ -54,6 +54,8 @@ pub struct ClientContext {
     pub identity_key_bytes: Option<Vec<u8>>,
     /// Transaction ID
     pub tx_id: Option<String>,
+    /// Development mode
+    pub development: bool,
     /// Verbose mode
     pub verbose: bool,
 }
@@ -164,6 +166,7 @@ impl ClientArgs {
             auth_token,
             identity_key_bytes,
             tx_id: self.tx.map(|id| id.to_string()),
+            development: config.development,
             verbose: self.verbose,
         };
 

--- a/crates/cli/src/commands/client/tx.rs
+++ b/crates/cli/src/commands/client/tx.rs
@@ -18,17 +18,16 @@ pub struct TxArgs {
 #[non_exhaustive]
 pub enum TxCommand {
     /// Create a new transaction
-    #[command(alias = "create")]
-    New(TxCreateArgs),
+    New(TxNewArgs),
     /// Commit a transaction
     Commit(TxCommitArgs),
     /// Discard (rollback) a transaction
     Discard(TxDiscardArgs),
 }
 
-/// Arguments for tx create command
+/// Arguments for tx new command
 #[derive(Args, Debug)]
-pub struct TxCreateArgs {
+pub struct TxNewArgs {
     /// Create a read-only transaction
     #[arg(long = "read-only")]
     pub read_only: bool,
@@ -65,8 +64,8 @@ impl TxArgs {
     }
 }
 
-impl TxCreateArgs {
-    /// Execute the tx create command
+impl TxNewArgs {
+    /// Execute the tx new command
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
         let client = HttpClient::new(&ctx.url)?
             .with_auth_token(ctx.auth_token.clone())
@@ -111,8 +110,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_tx_create_args_default() {
-        let args = TxCreateArgs {
+    fn test_tx_new_args_default() {
+        let args = TxNewArgs {
             read_only: false,
             concurrent: false,
         };

--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -171,6 +171,8 @@ pub struct GetArgs {
 
 impl GetArgs {
     pub fn execute(self, config: Config) -> Result<()> {
+        require_development(&config)?;
+
         let keyring = super::open_keyring(&config)?;
 
         let key = keyring
@@ -203,6 +205,8 @@ pub struct AddArgs {
 
 impl AddArgs {
     pub fn execute(self, config: Config) -> Result<()> {
+        require_development(&config)?;
+
         let keyring = super::open_keyring(&config)?;
 
         let key = if let Some(ref hex_str) = self.key_hex {
@@ -248,8 +252,44 @@ impl ListArgs {
     }
 }
 
+fn require_development(config: &Config) -> Result<()> {
+    if config.development {
+        Ok(())
+    } else {
+        Err(Error::OperationRequiresDeveloperMode)
+    }
+}
+
 fn hex_encode(data: &[u8]) -> String {
     data.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_requires_development_mode() {
+        let args = AddArgs {
+            name: "test-key".to_string(),
+            key_hex: Some("deadbeef".to_string()),
+            stdin: false,
+        };
+
+        let err = args.execute(Config::default()).unwrap_err();
+        assert!(matches!(err, Error::OperationRequiresDeveloperMode));
+    }
+
+    #[test]
+    fn get_requires_development_mode() {
+        let args = GetArgs {
+            name: "test-key".to_string(),
+            raw: false,
+        };
+
+        let err = args.execute(Config::default()).unwrap_err();
+        assert!(matches!(err, Error::OperationRequiresDeveloperMode));
+    }
 }
 
 fn hex_decode(s: &str) -> std::result::Result<Vec<u8>, String> {

--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -18,17 +18,14 @@ pub struct KeyringArgs {
 #[derive(Subcommand, Debug)]
 #[non_exhaustive]
 pub enum KeyringCommand {
-    /// Generate a new key and store it in the keyring
-    #[command(alias = "generate")]
-    New(GenerateArgs),
+    /// Create new private keys
+    New(NewArgs),
 
-    /// Get (export) a key from the keyring
-    #[command(alias = "export")]
-    Get(ExportArgs),
+    /// Get a private key
+    Get(GetArgs),
 
-    /// Add (import) a key into the keyring
-    #[command(alias = "import")]
-    Add(ImportArgs),
+    /// Add a private key
+    Add(AddArgs),
 
     /// List all keys in the keyring
     List(ListArgs),
@@ -45,21 +42,21 @@ impl KeyringArgs {
     }
 }
 
-/// Generate a new cryptographic key
+/// Create a new cryptographic key
 #[derive(Args, Debug)]
-pub struct GenerateArgs {
-    /// Name of the key to generate (omit for Go-compatible mode: generates peer-key + encryption-key)
+pub struct NewArgs {
+    /// Name of the key to create (omit for Go-compatible mode: creates peer-key + encryption-key)
     pub name: Option<String>,
 
-    /// Key type to generate (ed25519, secp256k1, secp256r1, aes256) — only used with a named key
+    /// Key type to create (ed25519, secp256k1, secp256r1, aes256) — only used with a named key
     #[arg(short = 't', long = "key-type", default_value = "ed25519")]
     pub key_type: String,
 
-    /// Skip generating the encryption key (Go-compatible mode only)
+    /// Skip creating the encryption key (Go-compatible mode only)
     #[arg(long = "no-encryption")]
     pub no_encryption: bool,
 
-    /// Skip generating the peer key (Go-compatible mode only)
+    /// Skip creating the peer key (Go-compatible mode only)
     #[arg(long = "no-peer-key")]
     pub no_peer_key: bool,
 
@@ -68,7 +65,7 @@ pub struct GenerateArgs {
     pub force: bool,
 }
 
-impl GenerateArgs {
+impl NewArgs {
     pub fn execute(self, config: Config) -> Result<()> {
         use crypto::Key;
 
@@ -161,10 +158,10 @@ fn generate_key_bytes(key_type: &str) -> Result<Vec<u8>> {
     }
 }
 
-/// Export a key from the keyring
+/// Get a key from the keyring
 #[derive(Args, Debug)]
-pub struct ExportArgs {
-    /// Name of the key to export
+pub struct GetArgs {
+    /// Name of the key to get
     pub name: String,
 
     /// Output raw bytes instead of hex (Rust extension)
@@ -172,7 +169,7 @@ pub struct ExportArgs {
     pub raw: bool,
 }
 
-impl ExportArgs {
+impl GetArgs {
     pub fn execute(self, config: Config) -> Result<()> {
         let keyring = super::open_keyring(&config)?;
 
@@ -190,10 +187,10 @@ impl ExportArgs {
     }
 }
 
-/// Import a key into the keyring
+/// Add a key into the keyring
 #[derive(Args, Debug)]
-pub struct ImportArgs {
-    /// Name for the imported key
+pub struct AddArgs {
+    /// Name for the added key
     pub name: String,
 
     /// Hex-encoded private key (Go-compatible positional argument)
@@ -204,7 +201,7 @@ pub struct ImportArgs {
     pub stdin: bool,
 }
 
-impl ImportArgs {
+impl AddArgs {
     pub fn execute(self, config: Config) -> Result<()> {
         let keyring = super::open_keyring(&config)?;
 

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -71,10 +71,6 @@ pub struct StartArgs {
     #[arg(long)]
     pub privkeypath: Option<String>,
 
-    /// Enables development mode features
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
-    pub development: Option<bool>,
-
     /// Skip generating an encryption key. Encryption at rest will be disabled.
     #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_encryption: Option<bool>,
@@ -390,9 +386,6 @@ impl StartArgs {
         }
         if let Some(ref path) = self.privkeypath {
             config.api.privkey_path = path.clone();
-        }
-        if let Some(dev) = self.development {
-            config.development = dev;
         }
         if let Some(no_enc) = self.no_encryption {
             config.datastore.no_encryption = no_enc;

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -185,6 +185,9 @@ impl Config {
         if let Some(ref secret_file) = cli.secret_file {
             self.secret_file = secret_file.clone();
         }
+        if let Some(development) = cli.development {
+            self.development = development;
+        }
 
         // ACP
         if let Some(node_enable) = cli.acp_node_enable {

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -127,6 +127,9 @@ pub enum Error {
     #[error("invalid identifier: {0}")]
     InvalidIdentifier(String),
 
+    #[error("operation not permitted whilst development mode is disabled")]
+    OperationRequiresDeveloperMode,
+
     #[error("failed to initialize HTTP client: {0}")]
     HttpClientInit(String),
 

--- a/crates/cli/tests/cli_surface_tests.rs
+++ b/crates/cli/tests/cli_surface_tests.rs
@@ -1,0 +1,68 @@
+use clap::Parser;
+use cli::cli::Cli;
+
+fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
+    let mut argv = vec!["defra"];
+    argv.extend_from_slice(args);
+    Cli::try_parse_from(argv)
+}
+
+#[test]
+fn new_cli_rename_surface_parses() {
+    assert!(parse(&["client", "collection", "add", "type User { name: String }"]).is_ok());
+    assert!(parse(&[
+        "client",
+        "document",
+        "add",
+        "--collection-name",
+        "User",
+        r#"{"name":"Alice"}"#,
+    ])
+    .is_ok());
+    assert!(parse(&["client", "index", "new", "-c", "User", "-f", "name"]).is_ok());
+    assert!(parse(&[
+        "client",
+        "encrypted-index",
+        "new",
+        "-c",
+        "User",
+        "--field",
+        "name",
+    ])
+    .is_ok());
+    assert!(parse(&["client", "tx", "new"]).is_ok());
+    assert!(parse(&["keyring", "new"]).is_ok());
+    assert!(parse(&["--development", "keyring", "add", "test-key", "deadbeef"]).is_ok());
+    assert!(parse(&["--development", "keyring", "get", "test-key"]).is_ok());
+}
+
+#[test]
+fn old_cli_rename_aliases_are_rejected() {
+    assert!(parse(&["client", "schema", "add", "type User { name: String }"]).is_err());
+    assert!(parse(&["client", "collection", "schema"]).is_err());
+    assert!(parse(&["client", "collection", "docIDs"]).is_err());
+    assert!(parse(&["client", "index", "create", "-c", "User", "-f", "name"]).is_err());
+    assert!(parse(&[
+        "client",
+        "encrypted-index",
+        "add",
+        "-c",
+        "User",
+        "--field",
+        "name"
+    ])
+    .is_err());
+    assert!(parse(&["client", "tx", "create"]).is_err());
+    assert!(parse(&["keyring", "generate"]).is_err());
+    assert!(parse(&["keyring", "import", "test-key", "deadbeef"]).is_err());
+    assert!(parse(&["keyring", "export", "test-key"]).is_err());
+    assert!(parse(&[
+        "client",
+        "document",
+        "add",
+        "--name",
+        "User",
+        r#"{"name":"Alice"}"#,
+    ])
+    .is_err());
+}

--- a/crates/cli/tests/client_tests.rs
+++ b/crates/cli/tests/client_tests.rs
@@ -211,6 +211,7 @@ fn test_client_context_with_identity() {
         auth_token: auth_token.clone(),
         identity_key_bytes: None,
         tx_id: None,
+        development: false,
         verbose: false,
     };
 
@@ -230,6 +231,7 @@ fn test_client_context_without_identity() {
         auth_token: None,
         identity_key_bytes: None,
         tx_id: None,
+        development: false,
         verbose: false,
     };
 
@@ -244,6 +246,7 @@ fn test_client_context_with_tx() {
         auth_token: None,
         identity_key_bytes: None,
         tx_id: Some("12345".to_string()),
+        development: false,
         verbose: false,
     };
 

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -28,6 +28,7 @@ fn cli_with_defaults() -> Cli {
         source_hub_chain_id: None,
         hub_rs_address: None,
         secret_file: None,
+        development: None,
         acp_node_enable: None,
         acp_document_type: None,
         command: Command::Version(VersionArgs {
@@ -86,6 +87,7 @@ fn test_apply_cli_flags_valid_values_succeed() {
     cli.log_format = Some("json".to_string());
     cli.keyring_backend = Some("system".to_string());
     cli.url = Some("0.0.0.0:8080".to_string());
+    cli.development = Some(true);
 
     let result = config.apply_cli_flags(&cli);
     assert!(result.is_ok());
@@ -94,6 +96,7 @@ fn test_apply_cli_flags_valid_values_succeed() {
     assert_eq!(config.log.format, LogFormat::Json);
     assert_eq!(config.keyring.backend, KeyringBackend::System);
     assert_eq!(config.api.address, "0.0.0.0:8080");
+    assert!(config.development);
 }
 
 #[test]

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -16,7 +16,6 @@ fn default_start_args() -> StartArgs {
         allowed_origins: None,
         pubkeypath: None,
         privkeypath: None,
-        development: None,
         no_encryption: None,
         no_telemetry: None,
         no_signing: None,
@@ -105,7 +104,6 @@ fn test_apply_to_config_all_flags() {
         allowed_origins: Some(vec!["http://localhost:3000".to_string()]),
         pubkeypath: Some("/path/to/pub.key".to_string()),
         privkeypath: Some("/path/to/priv.key".to_string()),
-        development: Some(true),
         no_encryption: Some(true),
         no_telemetry: Some(true),
         no_signing: Some(true),
@@ -173,7 +171,6 @@ fn test_apply_to_config_all_flags() {
     assert_eq!(config.api.allowed_origins, vec!["http://localhost:3000"]);
     assert_eq!(config.api.pubkey_path, "/path/to/pub.key");
     assert_eq!(config.api.privkey_path, "/path/to/priv.key");
-    assert!(config.development);
     assert!(config.datastore.no_encryption);
     assert!(config.telemetry_disabled);
     assert!(config.datastore.no_signing);

--- a/crates/http/src/handlers/backup.rs
+++ b/crates/http/src/handlers/backup.rs
@@ -34,6 +34,9 @@ const MAX_IMPORT_SIZE: usize = 100 * 1024 * 1024;
 /// Maximum number of collections that can be specified in export request.
 const MAX_EXPORT_COLLECTIONS: usize = 100;
 
+const OPERATION_REQUIRES_DEVELOPER_MODE: &str =
+    "operation not permitted whilst development mode is disabled";
+
 /// Request body for export (Go-compatible format).
 #[derive(Debug, Clone, Deserialize)]
 pub struct ExportRequest {
@@ -86,8 +89,8 @@ pub async fn export(
     require_permission(&state, &identity, NodePermission::DocumentRead).await?;
 
     if !state.dev_mode {
-        return Err(HttpError::BadRequest(
-            "backup export is not permitted when development mode is disabled".into(),
+        return Err(HttpError::Forbidden(
+            OPERATION_REQUIRES_DEVELOPER_MODE.into(),
         ));
     }
 
@@ -171,8 +174,8 @@ pub async fn import(
     require_permission(&state, &identity, NodePermission::DocumentUpdate).await?;
 
     if !state.dev_mode {
-        return Err(HttpError::BadRequest(
-            "backup import is not permitted when development mode is disabled".into(),
+        return Err(HttpError::Forbidden(
+            OPERATION_REQUIRES_DEVELOPER_MODE.into(),
         ));
     }
 

--- a/tools/integration-test/tests/backup/dev_mode.rs
+++ b/tools/integration-test/tests/backup/dev_mode.rs
@@ -17,11 +17,7 @@ async fn export_requires_dev_mode_test(cluster: TestCluster) {
     );
 
     let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("development mode"),
-        "error should mention development mode, got: {}",
-        err_msg
-    );
+    assert_operation_requires_developer_mode(&err_msg);
 }
 
 async fn import_requires_dev_mode_test(cluster: TestCluster) {
@@ -43,12 +39,16 @@ async fn import_requires_dev_mode_test(cluster: TestCluster) {
     );
 
     let err_msg = result.unwrap_err().to_string();
-    assert!(
-        err_msg.contains("development mode"),
-        "error should mention development mode, got: {}",
-        err_msg
-    );
+    assert_operation_requires_developer_mode(&err_msg);
 }
 
 for_each_runtime!(export_requires_dev_mode, export_requires_dev_mode_test);
 for_each_runtime!(import_requires_dev_mode, import_requires_dev_mode_test);
+
+fn assert_operation_requires_developer_mode(err_msg: &str) {
+    assert!(
+        err_msg.contains("operation not permitted whilst development mode is disabled"),
+        "error should match developer-mode semantics, got: {}",
+        err_msg
+    );
+}

--- a/tools/integration-test/tests/backup/restore.rs
+++ b/tools/integration-test/tests/backup/restore.rs
@@ -1,4 +1,6 @@
-use integration_test::{for_each_runtime, TestCluster};
+use std::process::Command;
+
+use integration_test::{for_each_runtime, DefraClient, NodeKind, TestCluster};
 
 async fn backup_restore_test(cluster: TestCluster) {
     let client = cluster.client(0);
@@ -40,13 +42,12 @@ async fn backup_restore_test(cluster: TestCluster) {
 
     // Build backup paths inside the node's rootdir
     let node_dir = cluster.nodes[0].rootdir.to_str().unwrap().to_string();
+    let node_url = cluster.nodes[0].http_addr.as_str();
     let full_path = format!("{}/full.json", node_dir);
     let users_path = format!("{}/users.json", node_dir);
 
     // 3. Full backup export
-    client
-        .backup_export(&full_path, &[], true)
-        .expect("backup_export full failed");
+    backup_export(&client, node_url, &full_path, &[], true).expect("backup_export full failed");
 
     // Verify file exists with content
     let full_content = std::fs::read_to_string(&full_path).expect("failed to read full.json");
@@ -60,8 +61,7 @@ async fn backup_restore_test(cluster: TestCluster) {
     );
 
     // 4. Partial backup (Users only)
-    client
-        .backup_export(&users_path, &["User"], false)
+    backup_export(&client, node_url, &users_path, &["User"], false)
         .expect("backup_export users failed");
 
     let users_content = std::fs::read_to_string(&users_path).expect("failed to read users.json");
@@ -98,9 +98,7 @@ async fn backup_restore_test(cluster: TestCluster) {
     );
 
     // 7. Import full backup
-    client
-        .backup_import(&full_path)
-        .expect("backup_import full failed");
+    backup_import(&client, node_url, &full_path).expect("backup_import full failed");
 
     // 8. Verify restored data
     let restored_users = client
@@ -132,9 +130,7 @@ async fn backup_restore_test(cluster: TestCluster) {
         .expect("truncate User for partial restore");
 
     // 11. Partial restore (Users only)
-    client
-        .backup_import(&users_path)
-        .expect("backup_import users failed");
+    backup_import(&client, node_url, &users_path).expect("backup_import users failed");
 
     // 12. Verify: 2 users restored, 3 posts untouched
     let final_users = client
@@ -154,6 +150,51 @@ async fn backup_restore_test(cluster: TestCluster) {
         3,
         "expected 3 posts still present"
     );
+}
+
+fn backup_export(
+    client: &DefraClient,
+    node_url: &str,
+    file: &str,
+    collections: &[&str],
+    pretty: bool,
+) -> Result<String, String> {
+    let mut args = vec!["client", "backup", "export", file];
+    for collection in collections {
+        args.push("-c");
+        args.push(collection);
+    }
+    if pretty {
+        args.push("--pretty");
+    }
+    exec_with_development(client, node_url, &args)
+}
+
+fn backup_import(client: &DefraClient, node_url: &str, file: &str) -> Result<String, String> {
+    exec_with_development(client, node_url, &["client", "backup", "import", file])
+}
+
+fn exec_with_development(
+    client: &DefraClient,
+    node_url: &str,
+    args: &[&str],
+) -> Result<String, String> {
+    let mut command = Command::new(client.binary_path());
+    command.arg("--url").arg(node_url);
+    if client.kind() == NodeKind::Rust {
+        command.arg("--development");
+    }
+    let output = command.args(args).output().map_err(|err| err.to_string())?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(format!(
+            "command failed (exit {}): stderr={}, stdout={}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim(),
+            String::from_utf8_lossy(&output.stdout).trim()
+        ))
+    }
 }
 
 for_each_runtime!(backup_restore, backup_restore_test, .with_development());

--- a/tools/integration-test/tests/identity.rs
+++ b/tools/integration-test/tests/identity.rs
@@ -1,3 +1,5 @@
+#[path = "identity/keyring_dev_mode.rs"]
+mod keyring_dev_mode;
 #[path = "identity/keyring_lifecycle.rs"]
 mod keyring_lifecycle;
 #[path = "identity/lifecycle.rs"]

--- a/tools/integration-test/tests/identity/keyring_dev_mode.rs
+++ b/tools/integration-test/tests/identity/keyring_dev_mode.rs
@@ -1,0 +1,82 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("failed to canonicalize workspace root")
+}
+
+fn defra_binary() -> PathBuf {
+    workspace_root().join("target/debug/defra")
+}
+
+fn defra_keyring(binary: &Path, keyring_dir: &Path, args: &[&str]) -> Output {
+    Command::new(binary)
+        .arg("--keyring-backend")
+        .arg("file")
+        .arg("--keyring-path")
+        .arg(keyring_dir)
+        .arg("keyring")
+        .args(args)
+        .env("DEFRA_KEYRING_SECRET", "test-secret")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run defra binary")
+}
+
+fn combined_output(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_requires_development(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "command should fail without development mode"
+    );
+    assert!(
+        combined_output(output)
+            .contains("operation not permitted whilst development mode is disabled"),
+        "unexpected error: {}",
+        combined_output(output)
+    );
+}
+
+#[test]
+fn rust_add_and_get_require_development_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    let kr = tmp.path();
+    let binary = defra_binary();
+    let hex_key = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    let out = defra_keyring(&binary, kr, &["add", "dev-key", hex_key]);
+    assert_requires_development(&out);
+
+    let out = Command::new(&binary)
+        .arg("--development")
+        .arg("--keyring-backend")
+        .arg("file")
+        .arg("--keyring-path")
+        .arg(kr)
+        .arg("keyring")
+        .arg("new")
+        .env("DEFRA_KEYRING_SECRET", "test-secret")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run defra binary");
+    assert!(
+        out.status.success(),
+        "new failed: {}",
+        combined_output(&out)
+    );
+
+    let out = defra_keyring(&binary, kr, &["get", "peer-key"]);
+    assert_requires_development(&out);
+}

--- a/tools/integration-test/tests/identity/keyring_lifecycle.rs
+++ b/tools/integration-test/tests/identity/keyring_lifecycle.rs
@@ -12,6 +12,10 @@ fn defra_binary() -> PathBuf {
     workspace_root().join("target/debug/defra")
 }
 
+fn is_rust_binary(binary: &Path) -> bool {
+    binary.file_name().and_then(|name| name.to_str()) == Some("defra")
+}
+
 fn go_binary() -> Option<PathBuf> {
     Command::new("defradb")
         .arg("--help")
@@ -24,27 +28,42 @@ fn go_binary() -> Option<PathBuf> {
 }
 
 fn defra_keyring(binary: &Path, keyring_dir: &Path, args: &[&str]) -> Output {
-    Command::new(binary)
-        .arg("--keyring-backend")
+    defra_keyring_with_mode(binary, keyring_dir, args, true)
+}
+
+fn defra_keyring_with_mode(
+    binary: &Path,
+    keyring_dir: &Path,
+    args: &[&str],
+    add_development_flag: bool,
+) -> Output {
+    let mut cmd = Command::new(binary);
+    cmd.arg("--keyring-backend")
         .arg("file")
         .arg("--keyring-path")
-        .arg(keyring_dir)
-        .arg("keyring")
+        .arg(keyring_dir);
+    if add_development_flag && is_rust_binary(binary) && requires_development(args) {
+        cmd.arg("--development");
+    }
+    cmd.arg("keyring")
         .args(args)
         .env("DEFRA_KEYRING_SECRET", "test-secret")
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("failed to run defra binary")
+        .stderr(Stdio::piped());
+    cmd.output().expect("failed to run defra binary")
 }
 
 fn defra_keyring_stdin(binary: &Path, keyring_dir: &Path, args: &[&str], input: &str) -> Output {
     use std::io::Write;
-    let mut child = Command::new(binary)
-        .arg("--keyring-backend")
+    let mut cmd = Command::new(binary);
+    cmd.arg("--keyring-backend")
         .arg("file")
         .arg("--keyring-path")
-        .arg(keyring_dir)
+        .arg(keyring_dir);
+    if is_rust_binary(binary) && requires_development(args) {
+        cmd.arg("--development");
+    }
+    let mut child = cmd
         .arg("keyring")
         .args(args)
         .env("DEFRA_KEYRING_SECRET", "test-secret")
@@ -61,6 +80,10 @@ fn defra_keyring_stdin(binary: &Path, keyring_dir: &Path, args: &[&str], input: 
         .write_all(input.as_bytes())
         .unwrap();
     child.wait_with_output().unwrap()
+}
+
+fn requires_development(args: &[&str]) -> bool {
+    matches!(args.first().copied(), Some("add" | "get"))
 }
 
 fn stdout(output: &Output) -> String {


### PR DESCRIPTION
## Summary
- Align the Rust CLI rename surface with the 10 Go upstream commits: collection terminology, document ops at `client document`, `new`/`add` naming, keyring `new`/`add`/`get`, and no old-name aliases.
- Add global `--development` plumbing and enforce dev-mode gates for backup import/export and keyring add/get with Go-compatible error text.
- Add parser and integration coverage for the renamed surface and dev-mode failure semantics.

## Go upstream commits
- `8cf6ccd7` Schema -> Collection terminology
- `4a643220` Move document-level commands to top-level `client document`
- `05f064f7` Rename collection `create` to `add`
- `0f1cba86` Use action verb first where applicable in Go
- `2059686c` Rename keyring `generate`/`import`/`export` to `new`/`add`/`get`
- `30104b04` Rename `txn create` to `txn new`
- `c3f4229a` Rename `index add` to `index new`
- `3877e8dd` Rename `encrypted-index add` to `encrypted-index new`
- `33cc6dde` Require developer mode for backup import/export and keyring add/get
- `e7460727` Drop `collection docIDs`

## Notes
- Rust already used `collection add`, did not expose `collection docIDs`, and already had the affected command structure for `0f1cba86`; those no-op equivalents are noted in commit messages.
- Removed the Rust-only `client collection schema` subcommand; users should use GraphQL `__schema` introspection instead.
- `client collection list` remains because the Rust integration harness uses it.
- The Rust CLI-side dev-mode checks are intentional here for the renamed backup/keyring command surface; backup still also has the HTTP 403 server-side gate.
- Coordination with #951: whichever PR lands second should rebase and ensure the transaction slice removes `TxNewArgs.concurrent`, the `tx_begin_concurrent` branch, and the related tx parser test references.
- No `/api/v1/` URL blocker was observed in this slice.
- Full workspace `cargo test` and full `cargo test -p integration-test` are currently blocked outside this CLI rename surface by the `hubrs` integration environment/tests. With `defradb` and `hubd` binaries on `PATH`, the failure is in `tests/hubrs.rs` around SourceHub account/nonce/health setup rather than these CLI commands.

## Verification
Passed:
- `cargo fmt --all --check`
- `cargo clippy --all -- -D warnings`
- `cargo test -p cli`
- `PATH="/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb/build:$PATH" cargo test -p integration-test --test backup --test identity`
- `cargo run -p cli -- client --help`
- `cargo run -p cli -- keyring --help`
- `target/debug/defra client collection --help`
- `target/debug/defra client document --help`
- `target/debug/defra client index --help`
- `target/debug/defra client encrypted-index --help`
- `target/debug/defra client tx --help`
