### PR TITLE
Add Rust lens host CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6814,6 +6814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lens-host"
+version = "0.5.0"
+dependencies = [
+ "lens",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/wasm",
     "crates/pg-compat",
     "crates/defra-node",
+    "tools/lens-host",
     "tools/ffi-test",
     "tools/integration-test",
 ]

--- a/crates/lens/src/config.rs
+++ b/crates/lens/src/config.rs
@@ -33,7 +33,7 @@ pub struct LensConfig {
     /// The Lens modules to apply, in execution order.
     ///
     /// Go's model.Lens embeds this as a flat `Lenses` array.
-    #[serde(rename = "Lenses", alias = "Lens", default)]
+    #[serde(rename = "Lenses", alias = "Lens", alias = "lenses", default)]
     pub lenses: Vec<LensModule>,
 }
 
@@ -75,11 +75,16 @@ pub struct LensModule {
     /// Path to the WASM module file.
     ///
     /// The WASM module must remain at this location as long as the migration is active.
-    #[serde(rename = "Path", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "Path",
+        alias = "path",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub path: Option<String>,
 
     /// Whether to inverse the module transform.
-    #[serde(rename = "Inverse", default)]
+    #[serde(rename = "Inverse", alias = "inverse", default)]
     pub inverse: bool,
 
     /// Raw WASM module bytes (alternative to path).
@@ -92,7 +97,12 @@ pub struct LensModule {
     pub module: Option<Vec<u8>>,
 
     /// Arguments passed to the WASM module.
-    #[serde(rename = "Arguments", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "Arguments",
+        alias = "arguments",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub arguments: Option<serde_json::Value>,
 }
 
@@ -209,6 +219,30 @@ mod tests {
         assert_eq!(
             parsed.lenses[0].path,
             Some("/path/to/transform.wasm".to_string())
+        );
+    }
+
+    #[test]
+    fn test_lens_config_cli_format() {
+        let json = r#"{
+            "lenses": [
+                {
+                    "path": "/path/to/transform.wasm",
+                    "inverse": true,
+                    "arguments": {"src": "Name", "dst": "FullName"}
+                }
+            ]
+        }"#;
+        let parsed: LensConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.lenses.len(), 1);
+        assert_eq!(
+            parsed.lenses[0].path,
+            Some("/path/to/transform.wasm".to_string())
+        );
+        assert!(parsed.lenses[0].inverse);
+        assert_eq!(
+            parsed.lenses[0].arguments,
+            Some(serde_json::json!({"src": "Name", "dst": "FullName"}))
         );
     }
 

--- a/crates/lens/src/wasm.rs
+++ b/crates/lens/src/wasm.rs
@@ -49,14 +49,16 @@ impl WasmSandboxConfig {
 /// Manages WASM module instances and executes transforms.
 pub struct WasmTransformStore {
     engine: Engine,
-    modules: RwLock<HashMap<TransformId, CompiledModule>>,
+    modules: RwLock<HashMap<TransformId, Vec<CompiledModule>>>,
     configs: RwLock<HashMap<TransformId, LensConfig>>,
     sandbox: Option<WasmSandboxConfig>,
 }
 
+#[derive(Clone)]
 struct CompiledModule {
     module: Module,
     arguments: Option<serde_json::Value>,
+    inverse: bool,
 }
 
 impl WasmTransformStore {
@@ -90,14 +92,6 @@ impl WasmTransformStore {
         })
     }
 
-    /// Build store limits when memory sandboxing is configured.
-    fn store_limits(&self) -> Option<StoreLimits> {
-        self.sandbox.as_ref().and_then(|sb| {
-            sb.max_memory_bytes
-                .map(|max| StoreLimitsBuilder::new().memory_size(max).build())
-        })
-    }
-
     /// Load a WASM module from the given lens configuration.
     ///
     /// When loading from a file path, validates the path to prevent traversal
@@ -123,6 +117,66 @@ impl WasmTransformStore {
                 "lens module must have either path or module bytes".to_string(),
             ))
         }
+    }
+
+    fn compile_modules(&self, lenses: &[LensModule]) -> Result<Vec<CompiledModule>> {
+        lenses
+            .iter()
+            .map(|lens| {
+                Ok(CompiledModule {
+                    module: self.load_module(lens)?,
+                    arguments: lens.arguments.clone(),
+                    inverse: lens.inverse,
+                })
+            })
+            .collect()
+    }
+
+    /// Transform JSON values using a registered lens pipeline.
+    ///
+    /// This mirrors the standalone host contract where top-level inputs and
+    /// outputs are JSON arrays, including `null` items.
+    pub fn transform_json(
+        &self,
+        id: &TransformId,
+        values: Vec<serde_json::Value>,
+    ) -> Result<Vec<serde_json::Value>> {
+        let modules = self.modules.read();
+        let compiled_modules = modules
+            .get(id)
+            .cloned()
+            .ok_or_else(|| Error::TransformNotFound(id.to_string()))?;
+        drop(modules);
+
+        execute_pipeline_values(
+            &self.engine,
+            compiled_modules,
+            values,
+            self.sandbox.clone(),
+            false,
+        )
+    }
+
+    /// Inverse transform JSON values using a registered lens pipeline.
+    pub fn inverse_json(
+        &self,
+        id: &TransformId,
+        values: Vec<serde_json::Value>,
+    ) -> Result<Vec<serde_json::Value>> {
+        let modules = self.modules.read();
+        let compiled_modules = modules
+            .get(id)
+            .cloned()
+            .ok_or_else(|| Error::TransformNotFound(id.to_string()))?;
+        drop(modules);
+
+        execute_pipeline_values(
+            &self.engine,
+            compiled_modules,
+            values,
+            self.sandbox.clone(),
+            true,
+        )
     }
 
     /// Validate a WASM module file path to prevent path traversal.
@@ -185,23 +239,11 @@ impl TransformStore for WasmTransformStore {
             }
         }
 
-        let first_lens = config.lens().cloned().unwrap_or_default();
-        info!(
-            path = ?first_lens.path,
-            has_module_bytes = first_lens.module.is_some(),
-            has_arguments = first_lens.arguments.is_some(),
-            "Loading WASM module"
-        );
-
-        let module = self.load_module(&first_lens)?;
+        info!("Loading WASM modules");
+        let compiled_modules = self.compile_modules(&config.lenses)?;
         info!(transform_id = %id, "WASM module compiled successfully");
 
-        let compiled = CompiledModule {
-            module,
-            arguments: first_lens.arguments.clone(),
-        };
-
-        self.modules.write().insert(id.clone(), compiled);
+        self.modules.write().insert(id.clone(), compiled_modules);
         self.configs.write().insert(id.clone(), config);
 
         info!(transform_id = %id, "Transform added to store");
@@ -220,15 +262,9 @@ impl TransformStore for WasmTransformStore {
             }
         }
 
-        let first_lens = config.lens().cloned().unwrap_or_default();
-        let module = self.load_module(&first_lens)?;
+        let compiled_modules = self.compile_modules(&config.lenses)?;
 
-        let compiled = CompiledModule {
-            module,
-            arguments: first_lens.arguments.clone(),
-        };
-
-        self.modules.write().insert(id.clone(), compiled);
+        self.modules.write().insert(id.clone(), compiled_modules);
         self.configs.write().insert(id.clone(), config);
 
         info!(transform_id = %id, "Transform added with explicit ID");
@@ -248,7 +284,7 @@ impl TransformStore for WasmTransformStore {
         info!(transform_id = %id, "WasmTransformStore::transform called");
 
         let modules = self.modules.read();
-        let compiled = modules.get(id).ok_or_else(|| {
+        let compiled_modules = modules.get(id).cloned().ok_or_else(|| {
             warn!(
                 transform_id = %id,
                 stored_ids = ?modules.keys().map(|k| k.to_string()).collect::<Vec<_>>(),
@@ -256,191 +292,39 @@ impl TransformStore for WasmTransformStore {
             );
             Error::TransformNotFound(id.to_string())
         })?;
-        let module = compiled.module.clone();
-        let arguments = compiled.arguments.clone();
         drop(modules);
 
         info!(
             transform_id = %id,
-            has_arguments = arguments.is_some(),
+            modules_count = compiled_modules.len(),
             "Transform found, creating execution stream"
         );
 
-        let engine = self.engine.clone();
-        let limits = self.store_limits();
-        let sandbox = self.sandbox.clone();
-
         info!(transform_id = %id, "Executing forward WASM transform (batch mode)");
-
-        enum Phase {
-            Collecting {
-                engine: Engine,
-                module: Module,
-                arguments: Option<serde_json::Value>,
-                docs: LensDocStream,
-                limits: Option<StoreLimits>,
-                sandbox: Option<WasmSandboxConfig>,
-            },
-            Yielding {
-                results: Vec<LensDoc>,
-                index: usize,
-            },
-        }
-
-        let initial = Phase::Collecting {
-            engine,
-            module,
-            arguments,
+        Ok(execute_pipeline_stream(
+            self.engine.clone(),
+            compiled_modules,
             docs,
-            limits,
-            sandbox,
-        };
-
-        Ok(Box::pin(futures::stream::unfold(initial, |phase| async {
-            match phase {
-                Phase::Collecting {
-                    engine,
-                    module,
-                    arguments,
-                    docs,
-                    limits,
-                    sandbox,
-                } => {
-                    let input_docs: Vec<LensDoc> = docs.collect().await;
-                    match execute_batch_transform(
-                        &engine, &module, input_docs, arguments, false, limits, &sandbox,
-                    ) {
-                        Ok(outputs) => {
-                            if outputs.is_empty() {
-                                None
-                            } else {
-                                let doc = outputs[0].clone();
-                                Some((
-                                    Ok(doc),
-                                    Phase::Yielding {
-                                        results: outputs,
-                                        index: 1,
-                                    },
-                                ))
-                            }
-                        }
-                        Err(e) => Some((
-                            Err(e),
-                            Phase::Yielding {
-                                results: Vec::new(),
-                                index: 0,
-                            },
-                        )),
-                    }
-                }
-                Phase::Yielding { results, index } => {
-                    if index < results.len() {
-                        let doc = results[index].clone();
-                        Some((
-                            Ok(doc),
-                            Phase::Yielding {
-                                results,
-                                index: index + 1,
-                            },
-                        ))
-                    } else {
-                        None
-                    }
-                }
-            }
-        })))
+            self.sandbox.clone(),
+            false,
+        ))
     }
 
     fn inverse(&self, id: &TransformId, docs: LensDocStream) -> Result<LensDocResultStream> {
         let modules = self.modules.read();
-        let compiled = modules
+        let compiled_modules = modules
             .get(id)
+            .cloned()
             .ok_or_else(|| Error::TransformNotFound(id.to_string()))?;
-        let module = compiled.module.clone();
-        let arguments = compiled.arguments.clone();
         drop(modules);
 
-        let engine = self.engine.clone();
-        let limits = self.store_limits();
-        let sandbox = self.sandbox.clone();
-
-        enum Phase {
-            Collecting {
-                engine: Engine,
-                module: Module,
-                arguments: Option<serde_json::Value>,
-                docs: LensDocStream,
-                limits: Option<StoreLimits>,
-                sandbox: Option<WasmSandboxConfig>,
-            },
-            Yielding {
-                results: Vec<LensDoc>,
-                index: usize,
-            },
-        }
-
-        let initial = Phase::Collecting {
-            engine,
-            module,
-            arguments,
+        Ok(execute_pipeline_stream(
+            self.engine.clone(),
+            compiled_modules,
             docs,
-            limits,
-            sandbox,
-        };
-
-        Ok(Box::pin(futures::stream::unfold(initial, |phase| async {
-            match phase {
-                Phase::Collecting {
-                    engine,
-                    module,
-                    arguments,
-                    docs,
-                    limits,
-                    sandbox,
-                } => {
-                    let input_docs: Vec<LensDoc> = docs.collect().await;
-                    match execute_batch_transform(
-                        &engine, &module, input_docs, arguments, true, limits, &sandbox,
-                    ) {
-                        Ok(outputs) => {
-                            if outputs.is_empty() {
-                                None
-                            } else {
-                                let doc = outputs[0].clone();
-                                Some((
-                                    Ok(doc),
-                                    Phase::Yielding {
-                                        results: outputs,
-                                        index: 1,
-                                    },
-                                ))
-                            }
-                        }
-                        Err(e) => Some((
-                            Err(e),
-                            Phase::Yielding {
-                                results: Vec::new(),
-                                index: 0,
-                            },
-                        )),
-                    }
-                }
-                Phase::Yielding { results, index } => {
-                    if index < results.len() {
-                        let doc = results[index].clone();
-                        Some((
-                            Ok(doc),
-                            Phase::Yielding {
-                                results,
-                                index: index + 1,
-                            },
-                        ))
-                    } else {
-                        None
-                    }
-                }
-            }
-        })))
+            self.sandbox.clone(),
+            true,
+        ))
     }
 
     fn has_transform(&self, id: &TransformId) -> bool {
@@ -453,6 +337,160 @@ impl TransformStore for WasmTransformStore {
         }
         self.configs.write().remove(id);
         Ok(())
+    }
+}
+
+fn execute_pipeline_stream(
+    engine: Engine,
+    mut modules: Vec<CompiledModule>,
+    docs: LensDocStream,
+    sandbox: Option<WasmSandboxConfig>,
+    inverse: bool,
+) -> LensDocResultStream {
+    enum Phase {
+        Collecting {
+            engine: Engine,
+            modules: Vec<CompiledModule>,
+            docs: LensDocStream,
+            sandbox: Option<WasmSandboxConfig>,
+        },
+        Yielding {
+            results: Vec<LensDoc>,
+            index: usize,
+        },
+    }
+
+    if inverse {
+        modules.reverse();
+        for module in &mut modules {
+            module.inverse = !module.inverse;
+        }
+    }
+
+    let initial = Phase::Collecting {
+        engine,
+        modules,
+        docs,
+        sandbox,
+    };
+
+    Box::pin(futures::stream::unfold(initial, |phase| async {
+        match phase {
+            Phase::Collecting {
+                engine,
+                modules,
+                docs,
+                sandbox,
+            } => {
+                let current_docs: Vec<serde_json::Value> = docs
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .map(serde_json::Value::Object)
+                    .collect();
+
+                let current_docs =
+                    match execute_pipeline_values(&engine, modules, current_docs, sandbox, false) {
+                        Ok(outputs) => outputs,
+                        Err(e) => {
+                            return Some((
+                                Err(e),
+                                Phase::Yielding {
+                                    results: Vec::new(),
+                                    index: 0,
+                                },
+                            ));
+                        }
+                    };
+
+                let mut results = Vec::with_capacity(current_docs.len());
+                for value in current_docs {
+                    match value {
+                        serde_json::Value::Object(doc) => results.push(doc),
+                        other => {
+                            return Some((
+                                Err(Error::WasmExecution(format!(
+                                    "expected JSON object output, got {}",
+                                    json_value_type(&other)
+                                ))),
+                                Phase::Yielding {
+                                    results: Vec::new(),
+                                    index: 0,
+                                },
+                            ));
+                        }
+                    }
+                }
+
+                if results.is_empty() {
+                    None
+                } else {
+                    let doc = results[0].clone();
+                    Some((Ok(doc), Phase::Yielding { results, index: 1 }))
+                }
+            }
+            Phase::Yielding { results, index } => {
+                if index < results.len() {
+                    let doc = results[index].clone();
+                    Some((
+                        Ok(doc),
+                        Phase::Yielding {
+                            results,
+                            index: index + 1,
+                        },
+                    ))
+                } else {
+                    None
+                }
+            }
+        }
+    }))
+}
+
+fn execute_pipeline_values(
+    engine: &Engine,
+    mut modules: Vec<CompiledModule>,
+    mut current_docs: Vec<serde_json::Value>,
+    sandbox: Option<WasmSandboxConfig>,
+    inverse: bool,
+) -> Result<Vec<serde_json::Value>> {
+    if inverse {
+        modules.reverse();
+        for module in &mut modules {
+            module.inverse = !module.inverse;
+        }
+    }
+
+    for module in modules {
+        current_docs = execute_batch_transform(
+            engine,
+            &module.module,
+            current_docs,
+            module.arguments,
+            module.inverse,
+            store_limits(&sandbox),
+            &sandbox,
+        )?;
+    }
+
+    Ok(current_docs)
+}
+
+fn store_limits(sandbox: &Option<WasmSandboxConfig>) -> Option<StoreLimits> {
+    sandbox.as_ref().and_then(|sb| {
+        sb.max_memory_bytes
+            .map(|max| StoreLimitsBuilder::new().memory_size(max).build())
+    })
+}
+
+fn json_value_type(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
     }
 }
 

--- a/crates/lens/src/wasm_runtime.rs
+++ b/crates/lens/src/wasm_runtime.rs
@@ -7,17 +7,17 @@ use wasmtime::{
 };
 
 use super::wasm::WasmSandboxConfig;
-use crate::{Error, LensDoc, Result};
+use crate::{Error, Result};
 
 /// Host state for batch transforms that feed multiple docs via lens::next.
 pub(crate) struct BatchHostState {
-    input_docs: Vec<LensDoc>,
+    input_docs: Vec<serde_json::Value>,
     current_index: usize,
     pub(crate) limits: Option<StoreLimits>,
 }
 
 impl BatchHostState {
-    pub(crate) fn new(docs: Vec<LensDoc>, limits: Option<StoreLimits>) -> Self {
+    pub(crate) fn new(docs: Vec<serde_json::Value>, limits: Option<StoreLimits>) -> Self {
         Self {
             input_docs: docs,
             current_index: 0,
@@ -25,7 +25,7 @@ impl BatchHostState {
         }
     }
 
-    pub(crate) fn next_input(&mut self) -> Option<LensDoc> {
+    pub(crate) fn next_input(&mut self) -> Option<serde_json::Value> {
         if self.current_index < self.input_docs.len() {
             let doc = self.input_docs[self.current_index].clone();
             self.current_index += 1;
@@ -45,12 +45,12 @@ impl BatchHostState {
 pub(crate) fn execute_batch_transform(
     engine: &Engine,
     module: &Module,
-    input_docs: Vec<LensDoc>,
+    input_docs: Vec<serde_json::Value>,
     arguments: Option<serde_json::Value>,
     inverse: bool,
     limits: Option<StoreLimits>,
     sandbox: &Option<WasmSandboxConfig>,
-) -> Result<Vec<LensDoc>> {
+) -> Result<Vec<serde_json::Value>> {
     let mut store = WasmStore::new(engine, BatchHostState::new(input_docs, limits));
 
     // Apply opt-in resource limits
@@ -163,14 +163,18 @@ pub(crate) fn execute_batch_transform(
 
     // Set parameters if provided
     if let Some(params) = arguments {
-        let alloc_fn: Option<TypedFunc<i32, i32>> = instance
-            .get_typed_func(store.as_context_mut(), "alloc")
-            .ok();
-        let set_param_fn: Option<TypedFunc<i32, i32>> = instance
-            .get_typed_func(store.as_context_mut(), "set_param")
-            .ok();
+        let has_params = !matches!(&params, serde_json::Value::Object(map) if map.is_empty());
 
-        if let (Some(alloc), Some(set_param)) = (alloc_fn, set_param_fn) {
+        if has_params {
+            let alloc: TypedFunc<i32, i32> = instance
+                .get_typed_func(store.as_context_mut(), "alloc")
+                .map_err(|e| Error::WasmExecution(format!("alloc func not found: {}", e)))?;
+            let set_param: TypedFunc<i32, i32> = instance
+                .get_typed_func(store.as_context_mut(), "set_param")
+                .map_err(|_| {
+                    Error::WasmExecution("Export `set_param` does not exist".to_string())
+                })?;
+
             let param_json = serde_json::to_vec(&params)
                 .map_err(|e| Error::WasmExecution(format!("failed to serialize params: {}", e)))?;
 
@@ -192,9 +196,44 @@ pub(crate) fn execute_batch_transform(
                 .write(store.as_context_mut(), (offset + 5) as usize, &param_json)
                 .map_err(|e| Error::WasmExecution(format!("write data failed: {}", e)))?;
 
-            let _ = set_param
+            let result_offset = set_param
                 .call(store.as_context_mut(), offset)
                 .map_err(|e| Error::WasmExecution(format!("set_param failed: {}", e)))?;
+            let mut type_id_buf = [0u8; 1];
+            memory
+                .read(store.as_context(), result_offset as usize, &mut type_id_buf)
+                .map_err(|e| {
+                    Error::WasmExecution(format!("read set_param type_id failed: {}", e))
+                })?;
+
+            let type_id = type_id_buf[0] as i8;
+            if type_id < 0 {
+                let mut len_buf = [0u8; 4];
+                memory
+                    .read(
+                        store.as_context(),
+                        (result_offset + 1) as usize,
+                        &mut len_buf,
+                    )
+                    .map_err(|e| {
+                        Error::WasmExecution(format!("read set_param error len failed: {}", e))
+                    })?;
+                let len = u32::from_le_bytes(len_buf) as usize;
+
+                let mut error_bytes = vec![0u8; len];
+                memory
+                    .read(
+                        store.as_context(),
+                        (result_offset + 5) as usize,
+                        &mut error_bytes,
+                    )
+                    .map_err(|e| {
+                        Error::WasmExecution(format!("read set_param error failed: {}", e))
+                    })?;
+
+                let error_str = String::from_utf8_lossy(&error_bytes);
+                return Err(Error::WasmExecution(format!("WASM error: {}", error_str)));
+            }
         }
     }
 
@@ -202,7 +241,13 @@ pub(crate) fn execute_batch_transform(
     let func_name = if inverse { "inverse" } else { "transform" };
     let transform_fn: TypedFunc<(), i32> = instance
         .get_typed_func(store.as_context_mut(), func_name)
-        .map_err(|e| Error::WasmExecution(format!("{} func not found: {}", func_name, e)))?;
+        .map_err(|e| {
+            if inverse && e.to_string().contains("failed to find function export") {
+                Error::WasmExecution("Export `inverse` does not exist".to_string())
+            } else {
+                Error::WasmExecution(format!("{} func not found: {}", func_name, e))
+            }
+        })?;
 
     // Call transform repeatedly until EOS to collect all output docs
     let mut output_docs = Vec::new();
@@ -252,6 +297,11 @@ pub(crate) fn execute_batch_transform(
             return Err(Error::WasmExecution(format!("WASM error: {}", error_str)));
         }
 
+        if type_id == 0 {
+            output_docs.push(serde_json::Value::Null);
+            continue;
+        }
+
         if type_id != 1 {
             return Err(Error::WasmExecution(format!(
                 "unexpected type_id: {}",
@@ -279,7 +329,7 @@ pub(crate) fn execute_batch_transform(
             )
             .map_err(|e| Error::WasmExecution(format!("read data failed: {}", e)))?;
 
-        let doc: LensDoc = serde_json::from_slice(&result_bytes)
+        let doc: serde_json::Value = serde_json::from_slice(&result_bytes)
             .map_err(|e| Error::WasmExecution(e.to_string()))?;
         output_docs.push(doc);
     }

--- a/tools/lens-host/Cargo.toml
+++ b/tools/lens-host/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "lens-host"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Lens host CLI backed by the Rust WASM runtime"
+
+[dependencies]
+lens = { path = "../../crates/lens", features = ["wasmtime-runtime"] }
+serde_json.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/tools/lens-host/src/main.rs
+++ b/tools/lens-host/src/main.rs
@@ -1,0 +1,79 @@
+use std::error::Error;
+use std::io::{Error as IoError, ErrorKind};
+use std::path::PathBuf;
+
+use lens::{LensConfig, TransformStore, WasmTransformStore};
+use tokio::io::AsyncReadExt;
+
+type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = run().await {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
+    let config_path = config_path()?;
+    let config_bytes = tokio::fs::read(config_path).await?;
+    let config: LensConfig = serde_json::from_slice(&config_bytes)?;
+
+    let input = read_stdin_json_array().await?;
+    validate_input_values(&input)?;
+
+    if config.lenses.is_empty() {
+        write_json_array(input)?;
+        return Ok(());
+    }
+
+    let store = WasmTransformStore::new()?;
+    let transform_id = store.add(config).await?;
+    let output = store.transform_json(&transform_id, input)?;
+
+    write_json_array(output)?;
+    Ok(())
+}
+
+fn config_path() -> Result<PathBuf> {
+    let mut args = std::env::args_os();
+    let _program = args.next();
+    let path = args.next().ok_or_else(|| {
+        IoError::new(ErrorKind::InvalidInput, "missing lens config path argument")
+    })?;
+
+    Ok(path.into())
+}
+
+async fn read_stdin_json_array() -> Result<Vec<serde_json::Value>> {
+    let mut input_bytes = Vec::new();
+    tokio::io::stdin().read_to_end(&mut input_bytes).await?;
+
+    match serde_json::from_slice::<serde_json::Value>(&input_bytes)? {
+        serde_json::Value::Array(values) => Ok(values),
+        _ => Err(IoError::new(ErrorKind::InvalidInput, "stdin must be a JSON array").into()),
+    }
+}
+
+fn validate_input_values(values: &[serde_json::Value]) -> Result<()> {
+    for value in values {
+        if !matches!(
+            value,
+            serde_json::Value::Object(_) | serde_json::Value::Null
+        ) {
+            return Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "input array elements must be JSON objects",
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn write_json_array(output: Vec<serde_json::Value>) -> Result<()> {
+    let stdout = std::io::stdout();
+    serde_json::to_writer(stdout.lock(), &output)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `tools/lens-host`, a standalone Rust CLI for the Lens host contract
- support lowercase Lens CLI config fields used by upstream Go tests
- fix Rust WASM Lens runtime parity for multi-module pipelines, per-module inverse, params, and null transport values

## Lens CLI tests passing against Rust host
- TestSimple
- TestSimpleWithNoModules
- TestSimpleWithEmptyItem
- TestSimpleWithNilItem
- TestSimpleWithModules
- TestSimpleWithModulesRepeated
- TestWithParams
- TestWithParamsReturnsErrorGivenBadParam
- TestWithParamsReturnsErrorGivenNilParam
- TestWithModulesWithParams
- TestInverse
- TestInverseErrorsGivenNoInverseAvailable
- TestInverseWithModules
- TestWithFilter
- TestWithNormalize
- TestWithMem
- TestWithModulesWithNormalizeWithParams
- TestWithState
- TestWithStateDuplicated

## Verification
- `cargo fmt --all --check`
- `cargo clippy --all -- -D warnings`
- `cargo build -p lens-host --release`
- `cargo test -p lens`
- `make deps:test` in sourcenetwork/lens
- `DEFRADB_RS_LENS_HOST_BIN=/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb.rs-lens-tests/target/release/lens-host go test ./tests/integration/cli/...`
- `DEFRADB_RS_LENS_HOST_BIN=/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb.rs-lens-tests/target/release/lens-host go test -v ./tests/integration/cli/...`