### PR TITLE
fix(ffi): restore SE replay options for P2P replicators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,6 +3819,7 @@ dependencies = [
  "storage",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -8,6 +8,7 @@ mod node_tasks;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+pub use defra_p2p_adapter::{ReplicatorPushOptions, ReplicatorPushOptionsState};
 
 pub use node::{build_with_store, EmbeddedNode, NodeBuilder};
 pub use node_tasks::BackgroundTasks;
@@ -117,6 +118,7 @@ pub enum TransportKind {
 pub struct ManagedP2PSystem {
     kind: TransportKind,
     ops: Arc<dyn defra_http::P2POperations>,
+    replicator_push_options: ReplicatorPushOptionsState,
     shutdown: node::ShutdownHandle,
 }
 
@@ -126,9 +128,24 @@ impl ManagedP2PSystem {
         ops: Arc<dyn defra_http::P2POperations>,
         shutdown: node::ShutdownHandle,
     ) -> Self {
+        Self::with_replicator_push_options(
+            kind,
+            ops,
+            shutdown,
+            ReplicatorPushOptionsState::default(),
+        )
+    }
+
+    pub fn with_replicator_push_options(
+        kind: TransportKind,
+        ops: Arc<dyn defra_http::P2POperations>,
+        shutdown: node::ShutdownHandle,
+        replicator_push_options: ReplicatorPushOptionsState,
+    ) -> Self {
         Self {
             kind,
             ops,
+            replicator_push_options,
             shutdown,
         }
     }
@@ -139,6 +156,17 @@ impl ManagedP2PSystem {
 
     pub fn ops(&self) -> &Arc<dyn defra_http::P2POperations> {
         &self.ops
+    }
+
+    pub fn set_replicator_push_options(
+        &self,
+        options: ReplicatorPushOptions,
+    ) -> Result<(), String> {
+        self.replicator_push_options.store(options)
+    }
+
+    pub fn replicator_push_options(&self) -> ReplicatorPushOptions {
+        self.replicator_push_options.load()
     }
 
     pub async fn shutdown(&self) {

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -11,7 +11,9 @@ use crate::node_tasks::{
     spawn_replication_loop,
 };
 use crate::{Libp2pConfig, ManagedP2PSystem, TransportKind};
-use defra_p2p_adapter::{DbDocPusher, DbVersionSyncer, DocPusher, P2PAdapter};
+use defra_p2p_adapter::{
+    DbDocPusher, DbVersionSyncer, DocPusher, P2PAdapter, ReplicatorPushOptionsState,
+};
 
 pub(crate) struct P2PSetup<S: storage::corekv::Store + 'static> {
     pub system: Arc<ManagedP2PSystem>,
@@ -154,17 +156,19 @@ where
     restore_libp2p_replicators(&handle, &restore_peerstore).await;
     let restored_doc_ids = restore_libp2p_documents(&handle, &restore_peerstore).await;
 
+    let replicator_push_options = ReplicatorPushOptionsState::default();
     let adapter = P2PAdapter::with_full_context(
         handle.clone(),
         coordinator.clone(),
         doc_pusher,
         event_bus,
         version_syncer,
-    );
+    )
+    .with_replicator_push_options_state(replicator_push_options.clone());
     adapter.set_initial_tracked_documents(restored_doc_ids);
     let coordinator_for_acp = coordinator.clone();
     let broadcast_mutator_for_acp = replication.broadcast_mutator.clone();
-    let system = Arc::new(ManagedP2PSystem::new(
+    let system = Arc::new(ManagedP2PSystem::with_replicator_push_options(
         TransportKind::Libp2p,
         Arc::new(adapter) as Arc<dyn defra_http::P2POperations>,
         crate::node::ShutdownHandle::libp2p(
@@ -177,6 +181,7 @@ where
                 retry_loop_task.abort_handle(),
             ],
         ),
+        replicator_push_options,
     ));
 
     Ok(P2PSetup {
@@ -278,24 +283,25 @@ where
         database.clone(),
         transport.clone(),
     ));
-    let retry_loop_task =
-        spawn_iroh_retry_loop(store.clone(), transport.clone(), doc_pusher.clone());
+    let retry_loop_task = spawn_iroh_retry_loop(store.clone(), doc_pusher.clone());
 
     let restore_peerstore = Peerstore::new(store.clone());
     restore_iroh_replicators(&coordinator, &restore_peerstore).await;
     let restored_doc_ids = restore_iroh_documents(&transport, &restore_peerstore).await;
 
+    let replicator_push_options = ReplicatorPushOptionsState::default();
     let adapter = IrohP2PAdapter::with_full_context(
         transport.clone(),
         coordinator.clone(),
         doc_pusher,
         event_bus,
         version_syncer,
-    );
+    )
+    .with_replicator_push_options_state(replicator_push_options.clone());
     adapter.set_initial_tracked_documents(restored_doc_ids);
     let coordinator_for_acp = coordinator.clone();
     let broadcast_mutator_for_acp = replication.broadcast_mutator.clone();
-    let system = Arc::new(ManagedP2PSystem::new(
+    let system = Arc::new(ManagedP2PSystem::with_replicator_push_options(
         TransportKind::Iroh,
         Arc::new(adapter) as Arc<dyn defra_http::P2POperations>,
         crate::node::ShutdownHandle::iroh(
@@ -309,6 +315,7 @@ where
                 retry_loop_task.abort_handle(),
             ],
         ),
+        replicator_push_options,
     ));
 
     Ok(P2PSetup {

--- a/crates/embedded/src/node_tasks.rs
+++ b/crates/embedded/src/node_tasks.rs
@@ -350,7 +350,6 @@ pub(crate) fn spawn_libp2p_retry_loop<S: storage::corekv::Store + 'static>(
 #[cfg(feature = "iroh")]
 pub(crate) fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
     store: Arc<S>,
-    transport: p2p::iroh::IrohTransport,
     doc_pusher: Arc<dyn defra_p2p_adapter::TransportDocPusher>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {

--- a/crates/ffi/src/acp/identity.rs
+++ b/crates/ffi/src/acp/identity.rs
@@ -260,16 +260,18 @@ pub extern "C" fn node_set_default_identity(node_ptr: usize, did: *const c_char)
             } else {
                 Some(did_str.clone())
             };
+            state.sync_replicator_push_options()
         });
 
         match updated {
-            Some(()) => {
+            Some(Ok(())) => {
                 if did_str.is_empty() {
                     FfiResult::success("{}".to_string())
                 } else {
                     FfiResult::success(serde_json::json!({ "did": did_str }).to_string())
                 }
             }
+            Some(Err(error)) => FfiResult::error(error),
             None => FfiResult::error(crate::ERR_INVALID_NODE_HANDLE),
         }
     }

--- a/crates/ffi/src/p2p/replicator.rs
+++ b/crates/ffi/src/p2p/replicator.rs
@@ -45,6 +45,9 @@ pub unsafe extern "C" fn p2p_add_replicator(
                     Some(p2p) => p2p,
                     None => return Err(FfiP2PError::no_p2p_system()),
                 };
+                state
+                    .sync_replicator_push_options()
+                    .map_err(FfiP2PError::internal)?;
 
                 let addr = addr_str.clone();
                 let collections = collections.clone();

--- a/crates/ffi/src/se_key.rs
+++ b/crates/ffi/src/se_key.rs
@@ -40,14 +40,15 @@ pub unsafe extern "C" fn set_se_encryption_key(
         // valid for 32 bytes.
         let key = Zeroizing::new(std::slice::from_raw_parts(key_ptr, key_len).to_vec());
 
-        let found = NODES.get_mut(node_ptr, |state| {
+        let result = NODES.get_mut(node_ptr, |state| {
             state.se_encryption_key = Some(key);
+            state.sync_replicator_push_options()
         });
 
-        if found.is_none() {
-            return FfiResult::error(crate::ERR_INVALID_NODE_HANDLE);
+        match result {
+            Some(Ok(())) => FfiResult::ok(),
+            Some(Err(error)) => FfiResult::error(error),
+            None => FfiResult::error(crate::ERR_INVALID_NODE_HANDLE),
         }
-
-        FfiResult::ok()
     }
 }

--- a/crates/ffi/src/state/mod.rs
+++ b/crates/ffi/src/state/mod.rs
@@ -123,6 +123,26 @@ pub struct NodeState {
     pub se_encryption_key: Option<Zeroizing<Vec<u8>>>,
 }
 
+impl NodeState {
+    pub fn replicator_push_options(&self) -> embedded::ReplicatorPushOptions {
+        embedded::ReplicatorPushOptions {
+            se_encryption_key: self.se_encryption_key.as_ref().map(|key| key.to_vec()),
+            se_identity_pubkey: self
+                .node_identity_did
+                .as_ref()
+                .map(|identity| identity.as_bytes().to_vec()),
+        }
+    }
+
+    pub fn sync_replicator_push_options(&self) -> Result<(), String> {
+        let Some(p2p) = &self.p2p else {
+            return Ok(());
+        };
+        p2p.system
+            .set_replicator_push_options(self.replicator_push_options())
+    }
+}
+
 /// State held for each FFI subscription.
 pub struct SubscriptionState {
     /// The underlying events subscription.

--- a/crates/ffi/src/state/mod.rs
+++ b/crates/ffi/src/state/mod.rs
@@ -126,7 +126,10 @@ pub struct NodeState {
 impl NodeState {
     pub fn replicator_push_options(&self) -> embedded::ReplicatorPushOptions {
         embedded::ReplicatorPushOptions {
-            se_encryption_key: self.se_encryption_key.as_ref().map(|key| key.to_vec()),
+            se_encryption_key: self
+                .se_encryption_key
+                .as_ref()
+                .map(|key| Zeroizing::new(key.to_vec())),
             se_identity_pubkey: self
                 .node_identity_did
                 .as_ref()

--- a/crates/p2p-adapter/Cargo.toml
+++ b/crates/p2p-adapter/Cargo.toml
@@ -32,6 +32,7 @@ serde_ipld_dagcbor.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing.workspace = true
+zeroize = "1"
 
 [features]
 default = ["iroh", "libp2p"]

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -9,6 +9,7 @@ use crate::transport_version_syncer::TransportVersionSyncer;
 use crate::{
     ExplicitReplayCapabilityInput, P2PError, P2PErrorExt as _, P2POperations, P2PResult,
     P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo, ReplicatorPushOptions,
+    ReplicatorPushOptionsState,
 };
 
 use p2p::iroh::{
@@ -25,7 +26,7 @@ pub struct IrohP2PAdapter<B: Blockstore + 'static> {
     doc_pusher: Option<Arc<dyn TransportDocPusher>>,
     event_bus: Option<Arc<dyn events::Bus>>,
     version_syncer: Option<Arc<dyn TransportVersionSyncer>>,
-    replicator_push_options: ReplicatorPushOptions,
+    replicator_push_options: ReplicatorPushOptionsState,
     peer_addresses: Arc<std::sync::RwLock<HashMap<String, String>>>,
     tracked_documents: Arc<std::sync::RwLock<HashSet<String>>>,
 }
@@ -76,13 +77,21 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
             doc_pusher: Some(doc_pusher),
             event_bus: Some(event_bus),
             version_syncer,
-            replicator_push_options: ReplicatorPushOptions::default(),
+            replicator_push_options: ReplicatorPushOptionsState::default(),
             peer_addresses: Arc::new(std::sync::RwLock::new(HashMap::new())),
             tracked_documents: Arc::new(std::sync::RwLock::new(HashSet::new())),
         }
     }
 
     pub fn with_replicator_push_options(mut self, options: ReplicatorPushOptions) -> Self {
+        self.replicator_push_options = ReplicatorPushOptionsState::new(options);
+        self
+    }
+
+    pub fn with_replicator_push_options_state(
+        mut self,
+        options: ReplicatorPushOptionsState,
+    ) -> Self {
         self.replicator_push_options = options;
         self
     }
@@ -323,7 +332,8 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 let push_pusher = Arc::clone(pusher);
                 let push_event_bus = self.event_bus.clone();
                 let push_peer = peer_id;
-                let push_se_key = self.replicator_push_options.se_encryption_key.clone();
+                let push_options = self.replicator_push_options.load();
+                let push_se_key = push_options.se_encryption_key;
 
                 tracing::info!(
                     peer_id = %push_peer,

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -346,7 +346,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                         .push_existing_docs(
                             &push_peer,
                             &new_collection_names,
-                            push_se_key.as_deref(),
+                            push_se_key.as_ref().map(|key| key.as_slice()),
                         )
                         .await
                     {

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -2,6 +2,8 @@
 
 use std::sync::{Arc, RwLock};
 
+use zeroize::Zeroizing;
+
 #[cfg(feature = "iroh")]
 mod iroh;
 #[cfg(feature = "libp2p")]
@@ -36,11 +38,21 @@ pub use defra_http::router::{
 };
 
 /// Optional inputs used when pushing existing documents to replicators.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub struct ReplicatorPushOptions {
-    pub se_encryption_key: Option<Vec<u8>>,
+    pub se_encryption_key: Option<Zeroizing<Vec<u8>>>,
     pub se_identity_pubkey: Option<Vec<u8>>,
 }
+
+impl PartialEq for ReplicatorPushOptions {
+    fn eq(&self, other: &Self) -> bool {
+        self.se_encryption_key.as_ref().map(|key| key.as_slice())
+            == other.se_encryption_key.as_ref().map(|key| key.as_slice())
+            && self.se_identity_pubkey == other.se_identity_pubkey
+    }
+}
+
+impl Eq for ReplicatorPushOptions {}
 
 #[derive(Debug, Clone, Default)]
 pub struct ReplicatorPushOptionsState {
@@ -109,6 +121,7 @@ impl P2PErrorExt for P2PError {
 #[cfg(test)]
 mod tests {
     use super::{ReplicatorPushOptions, ReplicatorPushOptionsState};
+    use zeroize::Zeroizing;
 
     #[test]
     fn replicator_push_options_state_stores_latest_snapshot() {
@@ -116,7 +129,7 @@ mod tests {
 
         state
             .store(ReplicatorPushOptions {
-                se_encryption_key: Some(vec![7; 32]),
+                se_encryption_key: Some(Zeroizing::new(vec![7; 32])),
                 se_identity_pubkey: Some(b"did:key:zTest".to_vec()),
             })
             .unwrap();
@@ -124,7 +137,7 @@ mod tests {
         assert_eq!(
             state.load(),
             ReplicatorPushOptions {
-                se_encryption_key: Some(vec![7; 32]),
+                se_encryption_key: Some(Zeroizing::new(vec![7; 32])),
                 se_identity_pubkey: Some(b"did:key:zTest".to_vec()),
             }
         );

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -1,5 +1,7 @@
 //! Shared P2P adapters implementing the HTTP P2P operation surface.
 
+use std::sync::{Arc, RwLock};
+
 #[cfg(feature = "iroh")]
 mod iroh;
 #[cfg(feature = "libp2p")]
@@ -40,6 +42,35 @@ pub struct ReplicatorPushOptions {
     pub se_identity_pubkey: Option<Vec<u8>>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ReplicatorPushOptionsState {
+    inner: Arc<RwLock<ReplicatorPushOptions>>,
+}
+
+impl ReplicatorPushOptionsState {
+    pub fn new(options: ReplicatorPushOptions) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(options)),
+        }
+    }
+
+    pub fn load(&self) -> ReplicatorPushOptions {
+        self.inner
+            .read()
+            .map(|options| options.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn store(&self, options: ReplicatorPushOptions) -> Result<(), String> {
+        let mut guard = self
+            .inner
+            .write()
+            .map_err(|_| "replicator push options lock poisoned".to_string())?;
+        *guard = options;
+        Ok(())
+    }
+}
+
 pub(crate) trait P2PErrorExt {
     fn invalid_input(message: impl Into<String>) -> Self;
     fn not_found(message: impl Into<String>) -> Self;
@@ -72,5 +103,30 @@ impl P2PErrorExt for P2PError {
 
     fn internal(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReplicatorPushOptions, ReplicatorPushOptionsState};
+
+    #[test]
+    fn replicator_push_options_state_stores_latest_snapshot() {
+        let state = ReplicatorPushOptionsState::default();
+
+        state
+            .store(ReplicatorPushOptions {
+                se_encryption_key: Some(vec![7; 32]),
+                se_identity_pubkey: Some(b"did:key:zTest".to_vec()),
+            })
+            .unwrap();
+
+        assert_eq!(
+            state.load(),
+            ReplicatorPushOptions {
+                se_encryption_key: Some(vec![7; 32]),
+                se_identity_pubkey: Some(b"did:key:zTest".to_vec()),
+            }
+        );
     }
 }

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -373,7 +373,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                             &push_handle,
                             peer_id,
                             &new_collection_names,
-                            push_se_key.as_deref(),
+                            push_se_key.as_ref().map(|key| key.as_slice()),
                             push_identity.as_deref(),
                         )
                         .await

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -8,6 +8,7 @@ use crate::libp2p_doc_pusher::DocPusher;
 use crate::{
     ExplicitReplayCapabilityInput, P2PError, P2PErrorExt as _, P2POperations, P2PResult,
     P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo, ReplicatorPushOptions,
+    ReplicatorPushOptionsState,
 };
 
 use p2p::sync::Libp2pSyncCoordinator;
@@ -37,7 +38,7 @@ pub struct P2PAdapter<B: Blockstore + 'static> {
     doc_pusher: Option<Arc<dyn DocPusher>>,
     event_bus: Option<Arc<dyn events::Bus>>,
     version_syncer: Option<Arc<dyn VersionSyncer>>,
-    replicator_push_options: ReplicatorPushOptions,
+    replicator_push_options: ReplicatorPushOptionsState,
     peer_addresses: Arc<std::sync::RwLock<HashMap<String, String>>>,
     tracked_documents: Arc<std::sync::RwLock<HashSet<String>>>,
 }
@@ -88,13 +89,21 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
             doc_pusher: Some(doc_pusher),
             event_bus: Some(event_bus),
             version_syncer,
-            replicator_push_options: ReplicatorPushOptions::default(),
+            replicator_push_options: ReplicatorPushOptionsState::default(),
             peer_addresses: Arc::new(std::sync::RwLock::new(HashMap::new())),
             tracked_documents: Arc::new(std::sync::RwLock::new(HashSet::new())),
         }
     }
 
     pub fn with_replicator_push_options(mut self, options: ReplicatorPushOptions) -> Self {
+        self.replicator_push_options = ReplicatorPushOptionsState::new(options);
+        self
+    }
+
+    pub fn with_replicator_push_options_state(
+        mut self,
+        options: ReplicatorPushOptionsState,
+    ) -> Self {
         self.replicator_push_options = options;
         self
     }
@@ -348,8 +357,9 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 let push_handle = self.handle.clone();
                 let push_pusher = Arc::clone(pusher);
                 let push_event_bus = self.event_bus.clone();
-                let push_se_key = self.replicator_push_options.se_encryption_key.clone();
-                let push_identity = self.replicator_push_options.se_identity_pubkey.clone();
+                let push_options = self.replicator_push_options.load();
+                let push_se_key = push_options.se_encryption_key;
+                let push_identity = push_options.se_identity_pubkey;
 
                 tracing::info!(
                     peer_id = %peer_id,


### PR DESCRIPTION
## Summary

Closes #865 by restoring FFI searchable-encryption replay options for P2P initial replicator replay without widening the shared HTTP `P2POperations` contract.

## Why

PR #864 unified embedded and node P2P handling around the shared HTTP operation surface, which removed the embedded-only `ReplicatorPushOptions` argument from `add_replicator`.

That left FFI/mobile unable to pass the SE replay key and identity material into initial document replay. Constructor-only wiring is not enough because FFI sets the SE key after node creation, so the adapter needs runtime-visible replay option state.

## Changes

| Area | Change |
|---|---|
| P2P adapter | Add `ReplicatorPushOptionsState` for shared, snapshot-based replay option storage |
| Libp2p replay | Load the latest SE key and identity snapshot immediately before spawning initial replay |
| Iroh replay | Load the latest SE key snapshot immediately before spawning initial replay |
| Embedded P2P | Store replay option state on `ManagedP2PSystem` and wire the same state into adapters |
| FFI state | Derive replay options from `se_encryption_key` and `node_identity_did` |
| FFI updates | Refresh adapter replay options when `set_se_encryption_key`, `node_set_default_identity`, or `p2p_add_replicator` runs |
| Tests | Add direct unit coverage for replay option state updates |
| Cleanup | Remove an unused Iroh retry-loop argument surfaced by feature linting |

## Out of scope

- No new HTTP replay-options API.
- No FFI ABI changes.
- No change to explicit replay capability semantics.
- No change to SE artifact generation.
- No change to Iroh identity-specific SE behavior; the Iroh path still uses the SE key only.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p defra-p2p-adapter -p embedded -p ffi --lib`
- [x] `cargo test -p ffi --features iroh --lib`
- [x] `cargo clippy -p defra-p2p-adapter -p embedded -p ffi --all-targets -- -D warnings`
- [x] `cargo clippy -p ffi --features iroh --all-targets -- -D warnings`