### PR TITLE
Persist P2P collection subscriptions in systemstore

### DIFF
--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -143,12 +143,6 @@ impl Node {
         let coordinator = Arc::new(coordinator);
         let coordinator_for_acp = coordinator.clone();
 
-        // Start pubsub_rpc doc-sync / sync-branchable services (#828) so
-        // this node can interoperate with Go DefraDB peers over gossipsub.
-        if let Err(e) = coordinator.start_pubsub_services().await {
-            warn!("Failed to start pubsub_rpc services: {}", e);
-        }
-
         match db_merge::load_persisted_collections(&coordinator).await {
             Ok(count) => {
                 if count > 0 {
@@ -158,6 +152,12 @@ impl Node {
             Err(e) => {
                 warn!("Failed to load persisted P2P collections: {}", e);
             }
+        }
+
+        // Start pubsub_rpc doc-sync / sync-branchable services (#828) so
+        // this node can interoperate with Go DefraDB peers over gossipsub.
+        if let Err(e) = coordinator.start_pubsub_services().await {
+            warn!("Failed to start pubsub_rpc services: {}", e);
         }
 
         let merge_blockstore_for_syncer = merge_blockstore.clone();
@@ -532,12 +532,6 @@ impl Node {
         let coordinator = Arc::new(coordinator);
         let coordinator_for_acp = coordinator.clone();
 
-        // Start pubsub_rpc doc-sync / sync-branchable services (#828) so
-        // this node can interoperate with Go DefraDB peers over gossipsub.
-        if let Err(e) = coordinator.start_pubsub_services().await {
-            warn!("Failed to start pubsub_rpc services: {}", e);
-        }
-
         match db_merge::load_persisted_collections(&coordinator).await {
             Ok(count) => {
                 if count > 0 {
@@ -547,6 +541,12 @@ impl Node {
             Err(e) => {
                 warn!("Failed to load persisted P2P collections: {}", e);
             }
+        }
+
+        // Start pubsub_rpc doc-sync / sync-branchable services (#828) so
+        // this node can interoperate with Go DefraDB peers over gossipsub.
+        if let Err(e) = coordinator.start_pubsub_services().await {
+            warn!("Failed to start pubsub_rpc services: {}", e);
         }
 
         let merge_blockstore_for_syncer = merge_blockstore.clone();

--- a/crates/p2p/src/sync/collection_store.rs
+++ b/crates/p2p/src/sync/collection_store.rs
@@ -6,52 +6,12 @@
 use crate::error::{Error, Result};
 use async_trait::async_trait;
 use std::sync::Arc;
-use storage::corekv::{IterOptions, Iterator, Key, Reader, Store};
+use storage::corekv::{IterOptions, Key, Reader, Store};
+use storage::keys::systemstore::P2PCollectionKey;
+use storage::stores::Systemstore;
 
 /// Marker byte for collection subscription (matches Go's marker = byte(0xff))
 const COLLECTION_MARKER: u8 = 0xff;
-
-/// Prefix for P2P collection keys
-const P2P_COLLECTION_PREFIX: &[u8] = b"/p2p/collection/";
-
-/// Key for P2P collection subscriptions.
-///
-/// Structure: /p2p/collection/{collectionID}
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct P2PCollectionKey {
-    pub collection_id: String,
-}
-
-impl P2PCollectionKey {
-    /// Create a new P2PCollectionKey
-    pub fn new(collection_id: impl Into<String>) -> Self {
-        Self {
-            collection_id: collection_id.into(),
-        }
-    }
-
-    /// Parse a collection ID from a key
-    pub fn parse_collection_id(key: &[u8]) -> Option<String> {
-        if key.starts_with(P2P_COLLECTION_PREFIX) {
-            let id_bytes = &key[P2P_COLLECTION_PREFIX.len()..];
-            String::from_utf8(id_bytes.to_vec()).ok()
-        } else {
-            None
-        }
-    }
-}
-
-impl Key for P2PCollectionKey {
-    fn bytes(&self) -> Vec<u8> {
-        let mut key = P2P_COLLECTION_PREFIX.to_vec();
-        key.extend(self.collection_id.as_bytes());
-        key
-    }
-
-    fn to_string(&self) -> String {
-        format!("/p2p/collection/{}", self.collection_id)
-    }
-}
 
 /// Trait for P2P collection storage operations.
 #[async_trait]
@@ -71,13 +31,15 @@ pub trait P2PCollectionStorage: Send + Sync {
 
 /// Implementation of P2P collection storage backed by a key-value store.
 pub struct P2PCollectionStore<S: Store> {
-    store: Arc<S>,
+    systemstore: Systemstore<S>,
 }
 
 impl<S: Store> P2PCollectionStore<S> {
     /// Create a new P2P collection store.
     pub fn new(store: Arc<S>) -> Self {
-        Self { store }
+        Self {
+            systemstore: Systemstore::new(store),
+        }
     }
 }
 
@@ -86,7 +48,7 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
     async fn add_collection(&self, collection_id: &str) -> Result<()> {
         let key = P2PCollectionKey::new(collection_id);
         let mut txn = self
-            .store
+            .systemstore
             .new_txn(false)
             .await
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -105,7 +67,7 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
     async fn remove_collection(&self, collection_id: &str) -> Result<()> {
         let key = P2PCollectionKey::new(collection_id);
         let mut txn = self
-            .store
+            .systemstore
             .new_txn(false)
             .await
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -123,7 +85,7 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
 
     async fn get_all_collections(&self) -> Result<Vec<String>> {
         let txn = self
-            .store
+            .systemstore
             .new_txn(true)
             .await
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -131,7 +93,7 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
         let mut collections = Vec::new();
 
         // Iterate over all keys with the P2P collection prefix
-        let opts = IterOptions::new().with_prefix(P2P_COLLECTION_PREFIX.to_vec());
+        let opts = IterOptions::new().with_prefix(P2PCollectionKey::p2p_collection_prefix());
         let mut iter = txn
             .iterator(opts)
             .await
@@ -142,7 +104,7 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
             .await
             .map_err(|e| Error::Storage(e.to_string()))?
         {
-            if let Some(collection_id) = P2PCollectionKey::parse_collection_id(&kv.key) {
+            if let Some(collection_id) = parse_collection_id(&kv.key) {
                 collections.push(collection_id);
             }
         }
@@ -157,7 +119,7 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
     async fn is_subscribed(&self, collection_id: &str) -> Result<bool> {
         let key = P2PCollectionKey::new(collection_id);
         let txn = self
-            .store
+            .systemstore
             .new_txn(true)
             .await
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -169,6 +131,13 @@ impl<S: Store + 'static> P2PCollectionStorage for P2PCollectionStore<S> {
 
         Ok(value.is_some())
     }
+}
+
+fn parse_collection_id(key: &[u8]) -> Option<String> {
+    let prefix = P2PCollectionKey::p2p_collection_prefix();
+    key.strip_prefix(prefix.as_slice())
+        .and_then(|id_bytes| String::from_utf8(id_bytes.to_vec()).ok())
+        .filter(|id| !id.is_empty())
 }
 
 /// No-op implementation for when persistent storage is not available.
@@ -206,10 +175,65 @@ mod tests {
 
     #[test]
     fn test_parse_collection_id() {
-        let id = P2PCollectionKey::parse_collection_id(b"/p2p/collection/users");
+        let id = parse_collection_id(b"/p2p/collection/users");
         assert_eq!(id, Some("users".to_string()));
 
-        let id = P2PCollectionKey::parse_collection_id(b"/other/key");
+        let id = parse_collection_id(b"/other/key");
         assert_eq!(id, None);
+    }
+
+    #[tokio::test]
+    async fn stores_collection_state_in_systemstore_namespace() {
+        use storage::backends::MemoryStore;
+
+        let store = Arc::new(MemoryStore::new());
+        let p2p_store = P2PCollectionStore::new(store.clone());
+
+        p2p_store.add_collection("users").await.unwrap();
+
+        let systemstore = Systemstore::new(store.clone());
+        let system_txn = systemstore.new_txn(true).await.unwrap();
+        assert_eq!(
+            system_txn
+                .get(&P2PCollectionKey::new("users").bytes())
+                .await
+                .unwrap(),
+            Some(vec![COLLECTION_MARKER])
+        );
+
+        let root_txn = store.new_txn(true).await.unwrap();
+        assert_eq!(
+            root_txn
+                .get(&P2PCollectionKey::new("users").bytes())
+                .await
+                .unwrap(),
+            None,
+            "Go-compatible P2P collection state must live in Systemstore, not the raw root store"
+        );
+    }
+
+    #[tokio::test]
+    async fn loads_collection_state_written_like_go_systemstore() {
+        use storage::backends::MemoryStore;
+
+        let store = Arc::new(MemoryStore::new());
+        let systemstore = Systemstore::new(store.clone());
+        let mut system_txn = systemstore.new_txn(false).await.unwrap();
+        system_txn
+            .set(
+                &P2PCollectionKey::new("users").bytes(),
+                &[COLLECTION_MARKER],
+            )
+            .await
+            .unwrap();
+        system_txn.commit().await.unwrap();
+
+        let p2p_store = P2PCollectionStore::new(store);
+
+        assert!(p2p_store.is_subscribed("users").await.unwrap());
+        assert_eq!(
+            p2p_store.get_all_collections().await.unwrap(),
+            vec!["users".to_string()]
+        );
     }
 }

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -65,25 +65,29 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
     /// Unsubscribe from a collection.
     pub async fn unsubscribe_collection(&self, collection_id: &str) -> Result<bool> {
+        let mut subscribed_collections = self.subscriptions.subscribed_collections.write().await;
+
+        // Persist the desired unsubscribe intent first. If the live transport
+        // leave fails, the in-process topic may linger until retry or restart,
+        // but durable restore must not re-install it.
+        self.subscriptions
+            .collection_store
+            .remove_collection(collection_id)
+            .await?;
+
         let result = self
             .runtime
             .broadcaster
             .unsubscribe_collection(collection_id)
-            .await?;
+            .await;
+        subscribed_collections.remove(collection_id);
+
+        let result = result?;
+
         if result {
-            self.subscriptions
-                .collection_store
-                .remove_collection(collection_id)
-                .await?;
-
-            self.subscriptions
-                .subscribed_collections
-                .write()
-                .await
-                .remove(collection_id);
-
             tracing::debug!(collection_id = %collection_id, "Unsubscribed from collection (persisted)");
         }
+
         Ok(result)
     }
 
@@ -99,6 +103,10 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     }
 
     /// Load and subscribe to all persisted P2P collections.
+    ///
+    /// This can run before pubsub_rpc services start: collection topic
+    /// subscription is a transport-level operation independent of the base
+    /// doc-sync / sync-branchable service topics.
     pub async fn load_p2p_collections(&self) -> Result<usize> {
         let collections = self
             .subscriptions
@@ -172,5 +180,341 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Get all unmerged block CIDs.
     pub async fn get_unmerged(&self) -> Result<Vec<Cid>> {
         self.manager.get_unmerged().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use blockstore::DefraBlockstore;
+    use cid::Cid;
+    use storage::backends::MemoryStore;
+
+    use crate::bitswap::AccessMode;
+    use crate::message::{
+        BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
+        PushLogReply, PushLogRequest, PushSEArtifactsRequest, QuerySEArtifactsReply,
+        QuerySEArtifactsRequest,
+    };
+    use crate::sync::collection_store::P2PCollectionStore;
+    use crate::sync::manager::SyncConfig;
+    use crate::topics::DefraTopic;
+    use crate::transport::{MessageId, P2PTransport, PeerAddr, PeerId};
+    use crate::{QueryId, ReplicatorInfo};
+
+    use super::SyncCoordinator;
+
+    type TestBlockstore = DefraBlockstore<MemoryStore>;
+
+    #[derive(Clone)]
+    struct RecordingTransport {
+        peer_id: PeerId,
+        pubkey: Vec<u8>,
+        subscribed: Arc<Mutex<HashSet<String>>>,
+        replicators: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    }
+
+    impl RecordingTransport {
+        fn new(peer_id: &str) -> Self {
+            Self {
+                peer_id: PeerId::new(peer_id.to_string()),
+                pubkey: vec![1, 2, 3],
+                subscribed: Arc::new(Mutex::new(HashSet::new())),
+                replicators: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        fn subscribed_topics(&self) -> Vec<String> {
+            let mut topics: Vec<_> = self.subscribed.lock().unwrap().iter().cloned().collect();
+            topics.sort();
+            topics
+        }
+    }
+
+    #[async_trait]
+    impl P2PTransport for RecordingTransport {
+        type ResponseToken = ();
+
+        fn local_peer_id(&self) -> &PeerId {
+            &self.peer_id
+        }
+
+        fn local_public_key_proto(&self) -> &[u8] {
+            &self.pubkey
+        }
+
+        fn sign(&self, _data: &[u8]) -> crate::Result<Vec<u8>> {
+            Ok(vec![0])
+        }
+
+        async fn dial(&self, _peer_id: &PeerId, _addrs: Vec<PeerAddr>) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn listen(&self, _addr: PeerAddr) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn connected_peers(&self) -> crate::Result<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn listen_addresses(&self) -> crate::Result<Vec<PeerAddr>> {
+            Ok(Vec::new())
+        }
+
+        async fn poll_until_connected(
+            &self,
+            _peer_id: &PeerId,
+            _timeout: Duration,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn peer_addresses(&self) -> crate::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn subscribe(&self, topic: DefraTopic) -> crate::Result<bool> {
+            Ok(self.subscribed.lock().unwrap().insert(topic.topic_string()))
+        }
+
+        async fn unsubscribe(&self, topic: DefraTopic) -> crate::Result<bool> {
+            Ok(self
+                .subscribed
+                .lock()
+                .unwrap()
+                .remove(&topic.topic_string()))
+        }
+
+        async fn publish(
+            &self,
+            _topic: DefraTopic,
+            _msg: PushLogBroadcast,
+        ) -> crate::Result<MessageId> {
+            Ok(MessageId::new("message".to_string()))
+        }
+
+        async fn topic_peers(&self, _topic: DefraTopic) -> crate::Result<Vec<PeerId>> {
+            Ok(Vec::new())
+        }
+
+        async fn send_pushlog_response(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: PushLogReply,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_two_stream_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushLogRequest,
+        ) -> crate::Result<PushLogReply> {
+            Ok(PushLogReply::success("ok"))
+        }
+
+        async fn send_two_stream_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: PushLogReply,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: DocSyncRequest,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: DocSyncReply,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: BranchableSyncRequest,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: BranchableSyncReply,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_car_request(&self, _peer_id: &PeerId, _root_cid: Cid) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_car_response(
+            &self,
+            _peer_id: &PeerId,
+            _car_data: Vec<u8>,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_car_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _car_data: Vec<u8>,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_doc_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: DocSyncReply,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_branchable_sync_response_token(
+            &self,
+            _token: Self::ResponseToken,
+            _reply: BranchableSyncReply,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_se_artifacts(
+            &self,
+            _peer_id: &PeerId,
+            _req: PushSEArtifactsRequest,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_se_query_request(
+            &self,
+            _peer_id: &PeerId,
+            _req: QuerySEArtifactsRequest,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn send_se_query_response(
+            &self,
+            _peer_id: &PeerId,
+            _reply: QuerySEArtifactsReply,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn sync_blocks(
+            &self,
+            _root: Cid,
+            _providers: Vec<PeerId>,
+            _missing: Vec<Cid>,
+        ) -> crate::Result<QueryId> {
+            Ok(QueryId(1))
+        }
+
+        async fn cancel_sync(&self, _query_id: QueryId) -> crate::Result<bool> {
+            Ok(true)
+        }
+
+        async fn create_replicator(
+            &self,
+            peer_id: &PeerId,
+            collections: Vec<String>,
+        ) -> crate::Result<()> {
+            self.replicators
+                .lock()
+                .unwrap()
+                .insert(peer_id.to_string(), collections);
+            Ok(())
+        }
+
+        async fn delete_replicator(&self, peer_id: &PeerId) -> crate::Result<()> {
+            self.replicators.lock().unwrap().remove(peer_id.as_str());
+            Ok(())
+        }
+
+        async fn list_replicators(&self) -> crate::Result<Vec<ReplicatorInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_replicator(&self, _peer_id: &PeerId) -> crate::Result<Option<ReplicatorInfo>> {
+            Ok(None)
+        }
+
+        async fn remove_replicator_collections(
+            &self,
+            _peer_id: &PeerId,
+            _collections: Vec<String>,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        async fn shutdown(&self) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    async fn new_test_coordinator(
+        store: Arc<MemoryStore>,
+        transport: RecordingTransport,
+    ) -> SyncCoordinator<TestBlockstore, RecordingTransport> {
+        let blockstore = Arc::new(DefraBlockstore::new(store.clone(), true));
+        let collection_store = Arc::new(P2PCollectionStore::new(store));
+        let (coordinator, _events) = SyncCoordinator::with_collection_store(
+            transport,
+            blockstore,
+            SyncConfig::default(),
+            AccessMode::Controlled,
+            collection_store,
+        )
+        .await
+        .unwrap();
+        coordinator
+    }
+
+    #[tokio::test]
+    async fn load_p2p_collections_reinstalls_subscriptions_after_restart() {
+        let store = Arc::new(MemoryStore::new());
+        let initial_transport = RecordingTransport::new("initial-peer");
+        let initial = new_test_coordinator(store.clone(), initial_transport.clone()).await;
+
+        assert!(initial.subscribe_collection("users").await.unwrap());
+        assert_eq!(initial_transport.subscribed_topics(), vec!["users"]);
+
+        let restarted_transport = RecordingTransport::new("restarted-peer");
+        let restarted = new_test_coordinator(store, restarted_transport.clone()).await;
+        assert!(
+            restarted
+                .get_subscribed_collections()
+                .await
+                .unwrap()
+                .is_empty(),
+            "a fresh coordinator starts with an empty in-memory subscription cache"
+        );
+
+        let restored = restarted.load_p2p_collections().await.unwrap();
+
+        assert_eq!(restored, 1);
+        assert_eq!(restarted_transport.subscribed_topics(), vec!["users"]);
+        assert_eq!(
+            restarted.get_subscribed_collections().await.unwrap(),
+            vec!["users".to_string()]
+        );
     }
 }

--- a/tools/integration-test/tests/p2p/management.rs
+++ b/tools/integration-test/tests/p2p/management.rs
@@ -215,3 +215,79 @@ async fn p2p_management_test(cluster: TestCluster) {
 }
 
 for_each_p2p_topology!(p2p_management, p2p_management_test, .with_p2p());
+
+async fn p2p_collection_subscription_persists_after_restart_test(mut cluster: TestCluster) {
+    let timeout = Duration::from_secs(15);
+    cluster
+        .wait_for_log(0, "p2p_listening", timeout)
+        .await
+        .expect("node0 P2P listener did not start");
+    cluster
+        .wait_for_log(1, "p2p_listening", timeout)
+        .await
+        .expect("node1 P2P listener did not start");
+
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0
+        .schema_add("type Users { name: String }")
+        .expect("schema add node0");
+    node1
+        .schema_add("type Users { name: String }")
+        .expect("schema add node1");
+
+    let info1 = node1.p2p_info().expect("p2p_info node1");
+    let addr1 = info1
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("node1 has no P2P address")
+        .to_string();
+    node0.p2p_connect(&[&addr1]).expect("p2p_connect");
+
+    node1
+        .p2p_collection_add(&["Users"])
+        .expect("p2p_collection_add node1");
+    let before_restart = node1
+        .p2p_collection_list()
+        .expect("p2p_collection_list before restart");
+    assert_eq!(
+        before_restart
+            .as_array()
+            .expect("collection_list not array")
+            .len(),
+        1,
+        "expected receiver collection subscription before restart"
+    );
+
+    cluster
+        .restart_node(1, Duration::from_secs(30))
+        .await
+        .expect("restart node1");
+    cluster
+        .wait_for_log(1, "p2p_listening", timeout)
+        .await
+        .expect("node1 P2P listener did not restart");
+
+    let node1_after_restart = cluster.client(1);
+    let after_restart = node1_after_restart
+        .p2p_collection_list()
+        .expect("p2p_collection_list after restart");
+    assert_eq!(
+        after_restart
+            .as_array()
+            .expect("collection_list not array")
+            .len(),
+        1,
+        "receiver collection subscription should persist across restart"
+    );
+}
+
+for_each_p2p_topology!(
+    p2p_collection_subscription_persists_after_restart,
+    p2p_collection_subscription_persists_after_restart_test,
+    // This macro runs Rust and Go topologies with one store string. Go requires
+    // badger, and Rust accepts badger as its persistent redb-compatible alias.
+    .with_p2p().with_store("badger")
+);


### PR DESCRIPTION
## Summary
- persist P2P collection subscription intent in Rust Systemstore using the Go-compatible `/p2p/collection/{collectionID}` key shape and `0xff` marker
- restore persisted collection subscriptions before pubsub services report ready in CLI libp2p and iroh startup
- add unit and Backbone binary-network regression coverage for collection subscription persistence across restart

Fixes #957.

## Verification
- `cargo fmt --check`
- `cargo test -p p2p sync::collection_store --no-default-features`
- `cargo test -p p2p load_p2p_collections_reinstalls_subscriptions_after_restart --no-default-features`
- `cargo check -p cli`
- `cargo build --release -p ffi`
- `CGO_ENABLED=1 DEFRA_CLIENT_RUST_FFI=true GOCACHE=/tmp/gocache-defradb-rustffi-p2p-collection go test -tags rust_ffi ./tests/integration/net/simple/peer/subscribe/collection -count=1 -timeout 600s -v`
- `cargo test -p integration-test --test p2p rust_rust_p2p_collection_subscription_persists_after_restart -- --nocapture`
- `PATH="/tmp:$PATH" cargo test -p integration-test --test p2p go_go_p2p_collection_subscription_persists_after_restart -- --nocapture`
- `PATH="/tmp:$PATH" cargo test -p integration-test --test p2p go_rust_p2p_collection_subscription_persists_after_restart -- --nocapture`