### PR TITLE
chore(p2p): audit follow-ups (#962-#968)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6039,6 +6039,7 @@ dependencies = [
  "hex",
  "hub-harness",
  "identity",
+ "p2p",
  "paste",
  "reqwest 0.12.28",
  "serde_json",

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -20,6 +20,8 @@ use p2p::P2PTransport;
 use crate::transport_doc_pusher::TransportDocPusher;
 use crate::transport_version_syncer::TransportVersionSyncer;
 
+const DOC_SYNC_DISPATCH_PARALLELISM: usize = 16;
+
 /// P2POperations implementation for iroh transport.
 pub struct IrohP2PAdapter<B: Blockstore + 'static> {
     transport: IrohTransport,
@@ -67,6 +69,50 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
         if let Ok(mut tracked) = self.tracked_documents.write() {
             *tracked = docs;
         }
+    }
+
+    async fn send_doc_sync_requests_concurrently(
+        &self,
+        peers: &[p2p::transport::PeerId],
+        request: p2p::message::DocSyncRequest,
+    ) -> bool {
+        let mut peer_iter = peers.iter().cloned();
+        let mut tasks = tokio::task::JoinSet::new();
+        let mut any_sent = false;
+
+        loop {
+            while tasks.len() < DOC_SYNC_DISPATCH_PARALLELISM {
+                let Some(peer) = peer_iter.next() else {
+                    break;
+                };
+                let transport = self.transport.clone();
+                let request = request.clone();
+                tasks.spawn(async move {
+                    let result = transport.send_doc_sync_request(&peer, request).await;
+                    (peer, result)
+                });
+            }
+
+            if tasks.is_empty() {
+                break;
+            }
+
+            match tasks.join_next().await {
+                Some(Ok((peer, Ok(())))) => {
+                    any_sent = true;
+                    tracing::debug!(peer_id = %peer, "sent DocSync request");
+                }
+                Some(Ok((peer, Err(error)))) => {
+                    tracing::warn!(peer_id = %peer, error = %error, "failed to send DocSync request");
+                }
+                Some(Err(error)) => {
+                    tracing::warn!(error = %error, "DocSync dispatch task failed");
+                }
+                None => break,
+            }
+        }
+
+        any_sent
     }
 }
 
@@ -622,19 +668,9 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 )));
             }
 
-            let mut any_sent = false;
-            for peer in &connected_peers {
-                match self
-                    .transport
-                    .send_doc_sync_request(peer, request.clone())
-                    .await
-                {
-                    Ok(()) => any_sent = true,
-                    Err(e) => {
-                        tracing::warn!(peer_id = %peer, error = %e, "failed to send DocSync request")
-                    }
-                }
-            }
+            let any_sent = self
+                .send_doc_sync_requests_concurrently(&connected_peers, request)
+                .await;
 
             // No peers accepted the request; no MergeComplete events will arrive.
             if !any_sent {

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -29,16 +29,28 @@
 //! - `DELETE /api/v1/collections/{name}/document/{docID}` - Delete document
 //!
 //! ## P2P (requires P2POperations)
-//! - `GET /api/v1/p2p/info` - Get P2P node info
-//! - `GET /api/v1/p2p/shareable-address` - Get the single best shareable P2P address
-//! - `GET /api/v1/p2p/peers` - List connected peers
-//! - `POST /api/v1/p2p/peers` - Connect to peer
-//! - `GET /api/v1/p2p/replicator` - List replicators
-//! - `POST /api/v1/p2p/replicator` - Add replicator
-//! - `DELETE /api/v1/p2p/replicator` - Remove replicator
-//! - `GET /api/v1/p2p/collections` - List P2P collections
-//! - `POST /api/v1/p2p/collections` - Add P2P collections
-//! - `DELETE /api/v1/p2p/collections` - Remove P2P collections
+//! The same routes are mounted under `/api/v0` for backwards compatibility.
+//! - `GET /api/v1/p2p/info` - Get P2P node info (`handlers/p2p/peers.rs`)
+//! - `GET /api/v1/p2p/shareable-address` - Get the single best shareable P2P address (`handlers/p2p/peers.rs`)
+//! - `GET /api/v1/p2p/active-peers` - List connected peers in Go-compatible format (`handlers/p2p/peers.rs`)
+//! - `POST /api/v1/p2p/connect` - Connect to peers in Go-compatible format (`handlers/p2p/peers.rs`)
+//! - `GET /api/v1/p2p/peers` - List connected peers (`handlers/p2p/peers.rs`)
+//! - `POST /api/v1/p2p/peers` - Connect to peer (`handlers/p2p/peers.rs`)
+//! - `GET /api/v1/p2p/replicators` - List replicators (`handlers/p2p/replicators.rs`)
+//! - `POST /api/v1/p2p/replicators` - Add replicator (`handlers/p2p/replicators.rs`)
+//! - `DELETE /api/v1/p2p/replicators` - Remove replicator (`handlers/p2p/replicators.rs`)
+//! - `GET /api/v1/p2p/replicator` - Legacy alias for listing replicators (`handlers/p2p/replicators.rs`)
+//! - `POST /api/v1/p2p/replicator` - Legacy alias for adding a replicator (`handlers/p2p/replicators.rs`)
+//! - `DELETE /api/v1/p2p/replicator` - Legacy alias for removing a replicator (`handlers/p2p/replicators.rs`)
+//! - `GET /api/v1/p2p/collections` - List P2P collections (`handlers/p2p/collections.rs`)
+//! - `POST /api/v1/p2p/collections` - Add P2P collections (`handlers/p2p/collections.rs`)
+//! - `DELETE /api/v1/p2p/collections` - Remove P2P collections (`handlers/p2p/collections.rs`)
+//! - `POST /api/v1/p2p/collections/sync-versions` - Sync collection versions (`handlers/p2p/collections.rs`)
+//! - `POST /api/v1/p2p/collections/sync-branchable` - Sync branchable collection heads (`handlers/p2p/collections.rs`)
+//! - `GET /api/v1/p2p/documents` - List P2P documents (`handlers/p2p/documents.rs`)
+//! - `POST /api/v1/p2p/documents` - Add P2P documents (`handlers/p2p/documents.rs`)
+//! - `DELETE /api/v1/p2p/documents` - Remove P2P documents (`handlers/p2p/documents.rs`)
+//! - `POST /api/v1/p2p/documents/sync` - Sync specific documents (`handlers/p2p/documents.rs`)
 //!
 //! ## ACP (requires AcpOperations)
 //! - `POST /api/v1/acp/policy` - Add policy

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -475,7 +475,7 @@ mod tests {
         let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
         let router = create_router_with_state(state);
 
-        let mut response_task = tokio::spawn(
+        let response_task = tokio::spawn(
             router.oneshot(
                 Request::builder()
                     .method(Method::POST)
@@ -490,9 +490,7 @@ mod tests {
             .await
             .expect("P2P operation should start");
         assert!(
-            tokio::time::timeout(Duration::from_millis(50), &mut response_task)
-                .await
-                .is_err(),
+            !response_task.is_finished(),
             "handler responded before P2P operation completed"
         );
 

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -274,9 +274,109 @@ pub fn create_router_with_state(state: AppState) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock::MockQueryExecutor;
-    use axum::{body::Body, http::Request};
+    use crate::mock::{FailingMockP2POperations, MockQueryExecutor};
+    use crate::router::{
+        P2POperations, P2PResult, P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo,
+    };
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+    };
+    use std::time::Duration;
+    use tokio::sync::Notify;
     use tower::ServiceExt;
+
+    struct BlockingAddCollectionsP2P {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl P2POperations for BlockingAddCollectionsP2P {
+        async fn local_peer_id(&self) -> P2PResult<String> {
+            Ok("blocking-peer".into())
+        }
+
+        async fn listen_addresses(&self) -> P2PResult<Vec<String>> {
+            Ok(vec![])
+        }
+
+        async fn connected_peers(&self) -> P2PResult<Vec<String>> {
+            Ok(vec![])
+        }
+
+        async fn connect_peer(&self, _addr: &str) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
+            Ok(vec![])
+        }
+
+        async fn add_replicator(
+            &self,
+            _collections: Vec<String>,
+            _addr: Option<&str>,
+            _explicit_replay_capabilities: Vec<crate::router::ExplicitReplayCapabilityInput>,
+            _expected_authorizer_did: Option<&str>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn remove_replicator(
+            &self,
+            _collections: Vec<String>,
+            _addr: Option<&str>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn get_collections(&self) -> P2PResult<Vec<String>> {
+            Ok(vec![])
+        }
+
+        async fn add_collections(&self, _collections: Vec<String>) -> P2PResult<()> {
+            self.started.notify_one();
+            self.release.notified().await;
+            Ok(())
+        }
+
+        async fn remove_collections(&self, _collections: Vec<String>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn get_documents(&self) -> P2PResult<Vec<P2pDocumentInfo>> {
+            Ok(vec![])
+        }
+
+        async fn add_documents(&self, _docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn remove_documents(&self, _docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn republish_document(&self, _collection_name: &str, _doc_id: &str) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn sync_documents(
+            &self,
+            _collection_name: &str,
+            _doc_ids: Vec<String>,
+        ) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn sync_branchable_collection(&self, _collection_id: &str) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn sync_collection_versions(&self, _version_ids: Vec<String>) -> P2PResult<()> {
+            Ok(())
+        }
+    }
 
     async fn status_for(path: &str) -> axum::http::StatusCode {
         let router = create_router(Arc::new(MockQueryExecutor::new()));
@@ -285,6 +385,26 @@ mod tests {
                 Request::builder()
                     .uri(path)
                     .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("router should respond")
+            .status()
+    }
+
+    async fn status_for_p2p_request(method: Method, path: &str, body: &'static str) -> StatusCode {
+        let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+        let p2p = Arc::new(FailingMockP2POperations::new("injected p2p failure"))
+            as Arc<dyn P2POperations>;
+        let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+        let router = create_router_with_state(state);
+        router
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(path)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
                     .expect("request should build"),
             )
             .await
@@ -333,5 +453,66 @@ mod tests {
             status_for("/api/v1/collections/Users").await,
             axum::http::StatusCode::METHOD_NOT_ALLOWED
         );
+    }
+
+    #[tokio::test]
+    async fn p2p_collection_add_does_not_ack_when_operation_fails() {
+        let status =
+            status_for_p2p_request(Method::POST, "/api/v0/p2p/collections", r#"["Users"]"#).await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn p2p_collection_add_waits_for_operation_before_ack() {
+        let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let p2p = Arc::new(BlockingAddCollectionsP2P {
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        }) as Arc<dyn P2POperations>;
+        let state = AppStateBuilder::new(executor).with_p2p(p2p).build();
+        let router = create_router_with_state(state);
+
+        let mut response_task = tokio::spawn(
+            router.oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v0/p2p/collections")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"["Users"]"#))
+                    .expect("request should build"),
+            ),
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), started.notified())
+            .await
+            .expect("P2P operation should start");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut response_task)
+                .await
+                .is_err(),
+            "handler responded before P2P operation completed"
+        );
+
+        release.notify_one();
+        let response = response_task
+            .await
+            .expect("router task should join")
+            .expect("router should respond");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn p2p_replicator_add_does_not_ack_when_operation_fails() {
+        let status = status_for_p2p_request(
+            Method::POST,
+            "/api/v0/p2p/replicators",
+            r#"{"Collections":["Users"]}"#,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -19,6 +19,8 @@ use p2p::sync::IrohSyncCoordinator;
 use p2p::topics::DefraTopic;
 use p2p::P2PTransport;
 
+const DOC_SYNC_DISPATCH_PARALLELISM: usize = 16;
+
 /// P2P operations implementation for the iroh transport.
 pub struct IrohP2PAdapter<B: Blockstore + 'static> {
     transport: IrohTransport,
@@ -116,6 +118,50 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
         if let Ok(mut tracked) = self.tracked_documents.write() {
             *tracked = docs;
         }
+    }
+
+    async fn send_doc_sync_requests_concurrently(
+        &self,
+        peers: &[p2p::transport::PeerId],
+        request: p2p::message::DocSyncRequest,
+    ) -> bool {
+        let mut peer_iter = peers.iter().cloned();
+        let mut tasks = tokio::task::JoinSet::new();
+        let mut any_sent = false;
+
+        loop {
+            while tasks.len() < DOC_SYNC_DISPATCH_PARALLELISM {
+                let Some(peer) = peer_iter.next() else {
+                    break;
+                };
+                let transport = self.transport.clone();
+                let request = request.clone();
+                tasks.spawn(async move {
+                    let result = transport.send_doc_sync_request(&peer, request).await;
+                    (peer, result)
+                });
+            }
+
+            if tasks.is_empty() {
+                break;
+            }
+
+            match tasks.join_next().await {
+                Some(Ok((peer, Ok(())))) => {
+                    any_sent = true;
+                    tracing::debug!(peer_id = %peer, "sent DocSync request");
+                }
+                Some(Ok((peer, Err(error)))) => {
+                    tracing::warn!(peer_id = %peer, error = %error, "failed to send DocSync request");
+                }
+                Some(Err(error)) => {
+                    tracing::warn!(error = %error, "DocSync dispatch task failed");
+                }
+                None => break,
+            }
+        }
+
+        any_sent
     }
 }
 
@@ -680,19 +726,9 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 )));
             }
 
-            let mut any_sent = false;
-            for peer in &connected_peers {
-                match self
-                    .transport
-                    .send_doc_sync_request(peer, request.clone())
-                    .await
-                {
-                    Ok(()) => any_sent = true,
-                    Err(error) => {
-                        tracing::warn!(peer_id = %peer, error = %error, "failed to send DocSync request");
-                    }
-                }
-            }
+            let any_sent = self
+                .send_doc_sync_requests_concurrently(&connected_peers, request)
+                .await;
             if !any_sent {
                 break;
             }

--- a/crates/p2p/src/iroh/README.md
+++ b/crates/p2p/src/iroh/README.md
@@ -1,0 +1,43 @@
+# Iroh Transport Notes
+
+DefraDB's Iroh transport uses the same `P2PTransport` surface as libp2p, but the
+wire mechanics are intentionally different where Iroh has different primitives.
+
+## Direct streams instead of `pubsub_rpc`
+
+DocSync and BranchableSync use Iroh QUIC bidirectional streams rather than the
+`pubsub_rpc` layer introduced for libp2p in #828. The `pubsub_rpc` topic model is
+tied to libp2p peer IDs and gossipsub topic meshes. Iroh peers are addressed by
+`EndpointId`, so reusing the libp2p response-topic convention would require a
+peer-id translation layer that does not exist on the Go-compatible wire path.
+
+Iroh therefore maps request/response traffic onto dedicated ALPNs:
+
+- `/defra-iroh/docsync/0.1` and `/defra-iroh/docsync/0.1/resp`
+- `/defra-iroh/branchable/0.1` and `/defra-iroh/branchable/0.1/resp`
+- `/defra-iroh/se-query/0.1/req` and `/defra-iroh/se-query/0.1/resp`
+
+The CBOR message structs stay shared with libp2p; only the transport envelope is
+Iroh-specific.
+
+## Libp2p-only transport methods
+
+These `P2PTransport` methods are libp2p-only by design:
+
+- `publish_raw`
+- `subscribe_raw`
+- `register_pubsub_rpc_topic`
+
+They exist for libp2p's `pubsub_rpc` dispatcher and are left as the default
+not-supported/no-op behavior on Iroh.
+
+`topic_peers()` is also not a full libp2p equivalent on Iroh. libp2p can ask
+gossipsub for all peers known for a topic. `iroh-gossip` exposes the direct
+neighbors of a joined topic, so Iroh returns those topic-scoped neighbors rather
+than all connected peers. This keeps the result topic-specific, but callers must
+not treat it as complete topic membership.
+
+## Audit follow-up references
+
+This file documents the Iroh transport decisions behind #965, #966, #967, and
+#968, and the surrounding P2P audit work tracked by #962 through #968.

--- a/crates/p2p/src/iroh/README.md
+++ b/crates/p2p/src/iroh/README.md
@@ -15,10 +15,13 @@ Iroh therefore maps request/response traffic onto dedicated ALPNs:
 
 - `/defra-iroh/docsync/0.1` and `/defra-iroh/docsync/0.1/resp`
 - `/defra-iroh/branchable/0.1` and `/defra-iroh/branchable/0.1/resp`
+- `/defra-iroh/se/0.1`
 - `/defra-iroh/se-query/0.1/req` and `/defra-iroh/se-query/0.1/resp`
 
 The CBOR message structs stay shared with libp2p; only the transport envelope is
-Iroh-specific.
+Iroh-specific. Iroh SE push and SE query messages are signed with the sending
+transport identity and are verified against the QUIC peer that opened the stream
+before transport events are emitted.
 
 ## Libp2p-only transport methods
 
@@ -35,7 +38,9 @@ not-supported/no-op behavior on Iroh.
 gossipsub for all peers known for a topic. `iroh-gossip` exposes the direct
 neighbors of a joined topic, so Iroh returns those topic-scoped neighbors rather
 than all connected peers. This keeps the result topic-specific, but callers must
-not treat it as complete topic membership.
+not treat it as complete topic membership. If the local node has not subscribed
+to the topic, Iroh returns an empty list; callers that relied on the previous
+all-connected fallback should subscribe first or use `connected_peers()`.
 
 ## Audit follow-up references
 

--- a/crates/p2p/src/iroh/command.rs
+++ b/crates/p2p/src/iroh/command.rs
@@ -6,7 +6,8 @@ use tokio::sync::oneshot;
 
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
-    PushLogReply, PushLogRequest, PushSEArtifactsRequest,
+    PushLogReply, PushLogRequest, PushSEArtifactsRequest, QuerySEArtifactsReply,
+    QuerySEArtifactsRequest,
 };
 use crate::replicator::ReplicatorInfo;
 use crate::transport::{MessageId, PeerAddr, PeerId};
@@ -50,6 +51,10 @@ pub enum IrohCommand {
         topic: crate::topics::DefraTopic,
         msg: PushLogBroadcast,
         reply: oneshot::Sender<crate::error::Result<MessageId>>,
+    },
+    TopicPeers {
+        topic: crate::topics::DefraTopic,
+        reply: oneshot::Sender<crate::error::Result<Vec<PeerId>>>,
     },
 
     // Messaging
@@ -111,6 +116,16 @@ pub enum IrohCommand {
     SendSEArtifacts {
         peer_id: PeerId,
         request: PushSEArtifactsRequest,
+        reply: oneshot::Sender<crate::error::Result<()>>,
+    },
+    SendSEQueryRequest {
+        peer_id: PeerId,
+        request: QuerySEArtifactsRequest,
+        reply: oneshot::Sender<crate::error::Result<()>>,
+    },
+    SendSEQueryResponse {
+        peer_id: PeerId,
+        reply_msg: QuerySEArtifactsReply,
         reply: oneshot::Sender<crate::error::Result<()>>,
     },
 

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -5,7 +5,7 @@
 //! - Gossip events from iroh-gossip
 //! - Commands from the `IrohTransport` facade
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use iroh::{Endpoint, EndpointId};
@@ -34,6 +34,7 @@ const MAX_COMMAND_BATCH: usize = 16;
 pub(super) struct TopicSubscription {
     pub(super) sender: iroh_gossip::api::GossipSender,
     pub(super) reader_task: JoinHandle<()>,
+    pub(super) neighbors: Arc<parking_lot::Mutex<HashSet<EndpointId>>>,
 }
 
 pub(super) type SubscriptionSenders = Vec<(String, iroh_gossip::api::GossipSender)>;

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -1,6 +1,6 @@
 //! Command handlers for the iroh endpoint event loop.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -112,6 +112,20 @@ pub(super) async fn handle_command(
         IrohCommand::Publish { topic, msg, reply } => {
             let result = handle_publish(gossip, subscriptions, peer_map, topic, msg, spawned_tasks);
             let _ = reply.send(result);
+        }
+        IrohCommand::TopicPeers { topic, reply } => {
+            let topic_str = topic.to_string();
+            let peers = subscriptions
+                .get(&topic_str)
+                .map(|sub| {
+                    sub.neighbors
+                        .lock()
+                        .iter()
+                        .map(endpoint_id_to_peer_id)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let _ = reply.send(Ok(peers));
         }
         IrohCommand::SendPushLogResponse {
             mut send_stream,
@@ -431,6 +445,50 @@ pub(super) async fn handle_command(
             });
             track_task(spawned_tasks, task);
         }
+        IrohCommand::SendSEQueryRequest {
+            peer_id,
+            request,
+            reply,
+        } => {
+            let direct_addr = peer_direct_addr(peer_map, &peer_id);
+            let endpoint = endpoint.clone();
+            let connection_cache = Arc::clone(connection_cache);
+            let task = tokio::spawn(async move {
+                let result = handle_fire_and_forget(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_SE_QUERY_REQ,
+                    &request,
+                    direct_addr,
+                    &connection_cache,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
+            track_task(spawned_tasks, task);
+        }
+        IrohCommand::SendSEQueryResponse {
+            peer_id,
+            reply_msg,
+            reply,
+        } => {
+            let direct_addr = peer_direct_addr(peer_map, &peer_id);
+            let endpoint = endpoint.clone();
+            let connection_cache = Arc::clone(connection_cache);
+            let task = tokio::spawn(async move {
+                let result = handle_fire_and_forget(
+                    &endpoint,
+                    &peer_id,
+                    protocols::ALPN_SE_QUERY_RESP,
+                    &reply_msg,
+                    direct_addr,
+                    &connection_cache,
+                )
+                .await;
+                let _ = reply.send(result);
+            });
+            track_task(spawned_tasks, task);
+        }
         IrohCommand::SyncBlocks {
             root,
             providers,
@@ -607,9 +665,13 @@ pub(super) async fn handle_subscribe(
         .map_err(|e| crate::error::Error::GossipSubSubscription(e.to_string()))?;
 
     let (sender, mut receiver) = gossip_topic.split();
+    let neighbors = Arc::new(parking_lot::Mutex::new(
+        receiver.neighbors().collect::<HashSet<_>>(),
+    ));
 
     let event_tx = event_tx.clone();
     let topic_str_clone = topic_str.clone();
+    let reader_neighbors = Arc::clone(&neighbors);
     let reader_task = tokio::spawn(async move {
         while let Some(result) = receiver.next().await {
             match result {
@@ -693,6 +755,7 @@ pub(super) async fn handle_subscribe(
                         }
                     }
                     iroh_gossip::api::Event::NeighborUp(id) => {
+                        reader_neighbors.lock().insert(id);
                         if event_tx
                             .send(TransportEvent::PeerSubscribed {
                                 peer_id: endpoint_id_to_peer_id(&id),
@@ -705,6 +768,7 @@ pub(super) async fn handle_subscribe(
                         }
                     }
                     iroh_gossip::api::Event::NeighborDown(id) => {
+                        reader_neighbors.lock().remove(&id);
                         if event_tx
                             .send(TransportEvent::PeerUnsubscribed {
                                 peer_id: endpoint_id_to_peer_id(&id),
@@ -736,6 +800,7 @@ pub(super) async fn handle_subscribe(
         TopicSubscription {
             sender,
             reader_task,
+            neighbors,
         },
     );
     Ok(true)

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -118,11 +118,8 @@ pub(super) async fn handle_command(
             let peers = subscriptions
                 .get(&topic_str)
                 .map(|sub| {
-                    sub.neighbors
-                        .lock()
-                        .iter()
-                        .map(endpoint_id_to_peer_id)
-                        .collect()
+                    let snapshot: Vec<_> = sub.neighbors.lock().iter().copied().collect();
+                    snapshot.iter().map(endpoint_id_to_peer_id).collect()
                 })
                 .unwrap_or_default();
             let _ = reply.send(Ok(peers));

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -10,7 +10,8 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
-use crate::message::PushLogReply;
+use crate::error::Error;
+use crate::message::{Message, PushLogReply};
 use crate::transport::{PeerId, TransportEvent};
 
 use super::endpoint::{
@@ -369,11 +370,111 @@ async fn dispatch_stream(
                 artifact_count = request.artifacts.len(),
                 "Received SE artifacts"
             );
-            // SE artifact processing is handled at the database layer
+            let data = serde_cbor::to_vec(&request)
+                .map_err(|e| crate::error::Error::Codec(e.to_string()))?;
+            if event_tx
+                .send(TransportEvent::SEArtifactsReceived {
+                    peer_id: peer_id.clone(),
+                    data,
+                })
+                .await
+                .is_err()
+            {
+                warn!("Event channel closed, cannot emit SEArtifactsReceived");
+            }
+        }
+        x if x == protocols::ALPN_SE_QUERY_REQ => {
+            let request: crate::message::QuerySEArtifactsRequest =
+                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
+            verify_iroh_message(&request)?;
+            ensure_iroh_signed_sender(peer_id, request.sender_id.as_str())?;
+            debug!(
+                peer_id = %peer_id,
+                message_id = %request.message_id,
+                collection_id = %request.collection_id,
+                query_count = request.queries.len(),
+                "Received SE query request"
+            );
+            if event_tx
+                .send(TransportEvent::SEQueryRequest {
+                    peer_id: peer_id.clone(),
+                    request,
+                })
+                .await
+                .is_err()
+            {
+                warn!("Event channel closed, cannot emit SEQueryRequest");
+            }
+        }
+        x if x == protocols::ALPN_SE_QUERY_RESP => {
+            let reply: crate::message::QuerySEArtifactsReply =
+                protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
+            verify_iroh_message(&reply)?;
+            ensure_iroh_signed_sender(peer_id, reply.sender_id.as_str())?;
+            debug!(
+                peer_id = %peer_id,
+                message_id = %reply.message_id,
+                doc_count = reply.doc_ids.len(),
+                "Received SE query response"
+            );
+            if event_tx
+                .send(TransportEvent::SEQueryReply {
+                    peer_id: peer_id.clone(),
+                    reply,
+                })
+                .await
+                .is_err()
+            {
+                warn!("Event channel closed, cannot emit SEQueryReply");
+            }
         }
         _ => {
             debug!("Unknown ALPN: {:?}", String::from_utf8_lossy(alpn));
         }
     }
     Ok(())
+}
+
+fn ensure_iroh_signed_sender(peer_id: &PeerId, sender_id: &str) -> crate::error::Result<()> {
+    if sender_id == peer_id.as_str() {
+        Ok(())
+    } else {
+        Err(crate::error::Error::Transport(format!(
+            "transport peer {} did not match signed sender {}",
+            peer_id, sender_id
+        )))
+    }
+}
+
+fn verify_iroh_message<M>(msg: &M) -> crate::error::Result<()>
+where
+    M: Message + serde::Serialize + Clone,
+{
+    let signature = msg.signature().ok_or(Error::MissingSignature)?;
+
+    let sender_id: iroh::EndpointId = msg
+        .sender_id()
+        .parse()
+        .map_err(|error: iroh::KeyParsingError| Error::InvalidPeerId(error.to_string()))?;
+
+    let pubkey_bytes: [u8; 32] = msg
+        .pubkey()
+        .try_into()
+        .map_err(|_| Error::PublicKeyDecode("expected 32-byte iroh public key".into()))?;
+    let pubkey = iroh::PublicKey::from_bytes(&pubkey_bytes)
+        .map_err(|error| Error::PublicKeyDecode(error.to_string()))?;
+
+    if pubkey != sender_id {
+        return Err(Error::PubkeyPeerIdMismatch);
+    }
+
+    let signature = iroh::Signature::try_from(signature).map_err(|_| Error::InvalidSignature)?;
+    let mut msg_for_verify = msg.clone();
+    msg_for_verify.set_signature(None);
+    let bytes =
+        serde_cbor::to_vec(&msg_for_verify).map_err(|e| Error::CborSerialization(e.to_string()))?;
+
+    pubkey
+        .verify(&bytes, &signature)
+        .map_err(|_| Error::InvalidSignature)
 }

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -364,6 +364,8 @@ async fn dispatch_stream(
         x if x == protocols::ALPN_SE => {
             let request: crate::message::PushSEArtifactsRequest =
                 protocols::read_message(recv, protocols::MAX_MESSAGE_SIZE).await?;
+            verify_iroh_message(&request)?;
+            ensure_iroh_signed_sender(peer_id, request.sender_id.as_str())?;
             debug!(
                 peer_id = %peer_id,
                 collection_id = %request.collection_id,

--- a/crates/p2p/src/iroh/protocols.rs
+++ b/crates/p2p/src/iroh/protocols.rs
@@ -26,6 +26,12 @@ pub const ALPN_CAR_RESP: &[u8] = b"/defra-iroh/car/0.1/resp";
 /// ALPN for searchable encryption artifacts.
 pub const ALPN_SE: &[u8] = b"/defra-iroh/se/0.1";
 
+/// ALPN for searchable encryption artifact query requests.
+pub const ALPN_SE_QUERY_REQ: &[u8] = b"/defra-iroh/se-query/0.1/req";
+
+/// ALPN for searchable encryption artifact query responses.
+pub const ALPN_SE_QUERY_RESP: &[u8] = b"/defra-iroh/se-query/0.1/resp";
+
 /// ALPN for two-stream push protocol.
 pub const ALPN_TWOSTREAM: &[u8] = b"/defra-iroh/twostream/0.1";
 
@@ -42,6 +48,8 @@ pub const ALL_ALPNS: &[&[u8]] = &[
     ALPN_CAR,
     ALPN_CAR_RESP,
     ALPN_SE,
+    ALPN_SE_QUERY_REQ,
+    ALPN_SE_QUERY_RESP,
     ALPN_TWOSTREAM,
     ALPN_TWOSTREAM_RESP,
 ];

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -14,7 +14,8 @@ use tokio::sync::{mpsc, oneshot};
 use crate::error::{Error, Result};
 use crate::message::{
     BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
-    PushLogReply, PushLogRequest, PushSEArtifactsRequest,
+    PushLogReply, PushLogRequest, PushSEArtifactsRequest, QuerySEArtifactsReply,
+    QuerySEArtifactsRequest,
 };
 use crate::replicator::ReplicatorInfo;
 use crate::topics::DefraTopic;
@@ -68,6 +69,117 @@ impl IrohTransport {
     pub async fn network_change(&self) -> Result<()> {
         self.send_command(|reply| IrohCommand::NetworkChange { reply })
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use crate::iroh::{spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig};
+    use crate::message::{QuerySEArtifactsReply, QuerySEArtifactsRequest, SEFieldQuery};
+    use crate::signing::sign_with_transport;
+    use crate::transport::{P2PTransport, TransportEvent};
+
+    use super::*;
+
+    fn test_config(secret_key: SecretKey) -> IrohEndpointConfig {
+        IrohEndpointConfig {
+            secret_key,
+            relay_mode: crate::iroh::IrohRelayModeConfig::Disabled,
+            discovery: IrohDiscoveryConfig::Disabled,
+            bind_port: None,
+            bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        }
+    }
+
+    #[tokio::test]
+    async fn se_query_roundtrip_emits_request_and_reply_events() {
+        let key0 = SecretKey::generate();
+        let key1 = SecretKey::generate();
+        let (command_tx0, mut events0, _replicators0, task0) =
+            spawn_endpoint(test_config(key0.clone())).await.unwrap();
+        let (command_tx1, mut events1, _replicators1, task1) =
+            spawn_endpoint(test_config(key1.clone())).await.unwrap();
+        let transport0 = IrohTransport::new(command_tx0, key0);
+        let transport1 = IrohTransport::new(command_tx1, key1);
+
+        transport0
+            .dial(
+                transport1.local_peer_id(),
+                transport1.listen_addresses().await.unwrap(),
+            )
+            .await
+            .unwrap();
+        transport0
+            .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+        transport1
+            .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let mut request = QuerySEArtifactsRequest::new(
+            "collection1",
+            vec![SEFieldQuery::new("name", "name", vec![1, 2, 3])],
+        );
+        sign_with_transport(&transport0, &mut request).unwrap();
+        let request_message_id = request.message_id.clone();
+
+        transport0
+            .send_se_query_request(transport1.local_peer_id(), request)
+            .await
+            .unwrap();
+
+        let received_request = loop {
+            let event = timeout(Duration::from_secs(5), events1.recv())
+                .await
+                .expect("timed out waiting for SE query request")
+                .expect("iroh event channel closed");
+            if let TransportEvent::SEQueryRequest { peer_id, request } = event {
+                assert_eq!(peer_id, *transport0.local_peer_id());
+                break request;
+            }
+        };
+        assert_eq!(received_request.message_id, request_message_id);
+        assert_eq!(
+            received_request.sender_id,
+            transport0.local_peer_id().to_string()
+        );
+        assert_eq!(received_request.collection_id, "collection1");
+        assert_eq!(received_request.queries.len(), 1);
+        assert_eq!(received_request.queries[0].search_tag, vec![1, 2, 3]);
+
+        let mut reply =
+            QuerySEArtifactsReply::success(&request_message_id, vec!["doc1".into(), "doc2".into()]);
+        sign_with_transport(&transport1, &mut reply).unwrap();
+        transport1
+            .send_se_query_response(transport0.local_peer_id(), reply)
+            .await
+            .unwrap();
+
+        loop {
+            let event = timeout(Duration::from_secs(5), events0.recv())
+                .await
+                .expect("timed out waiting for SE query reply")
+                .expect("iroh event channel closed");
+            if let TransportEvent::SEQueryReply { peer_id, reply } = event {
+                assert_eq!(peer_id, *transport1.local_peer_id());
+                assert_eq!(reply.message_id, request_message_id);
+                assert_eq!(reply.sender_id, transport1.local_peer_id().to_string());
+                assert_eq!(reply.doc_ids, vec!["doc1".to_string(), "doc2".to_string()]);
+                break;
+            }
+        }
+
+        transport0.shutdown().await.unwrap();
+        transport1.shutdown().await.unwrap();
+        task0.await.unwrap();
+        task1.await.unwrap();
     }
 }
 
@@ -131,10 +243,9 @@ impl P2PTransport for IrohTransport {
             .await
     }
 
-    async fn topic_peers(&self, _topic: DefraTopic) -> Result<Vec<PeerId>> {
-        // Iroh doesn't have topic-based peer tracking like GossipSub.
-        // Return connected peers as best-effort approximation.
-        self.connected_peers().await
+    async fn topic_peers(&self, topic: DefraTopic) -> Result<Vec<PeerId>> {
+        self.send_command(|reply| IrohCommand::TopicPeers { topic, reply })
+            .await
     }
 
     async fn subscribe(&self, topic: DefraTopic) -> Result<bool> {
@@ -298,6 +409,32 @@ impl P2PTransport for IrohTransport {
         self.send_command(|reply| IrohCommand::SendSEArtifacts {
             peer_id: peer_id.clone(),
             request: req,
+            reply,
+        })
+        .await
+    }
+
+    async fn send_se_query_request(
+        &self,
+        peer_id: &PeerId,
+        req: QuerySEArtifactsRequest,
+    ) -> Result<()> {
+        self.send_command(|reply| IrohCommand::SendSEQueryRequest {
+            peer_id: peer_id.clone(),
+            request: req,
+            reply,
+        })
+        .await
+    }
+
+    async fn send_se_query_response(
+        &self,
+        peer_id: &PeerId,
+        reply_msg: QuerySEArtifactsReply,
+    ) -> Result<()> {
+        self.send_command(|reply| IrohCommand::SendSEQueryResponse {
+            peer_id: peer_id.clone(),
+            reply_msg,
             reply,
         })
         .await

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -80,7 +80,10 @@ mod tests {
     use tokio::time::timeout;
 
     use crate::iroh::{spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig};
-    use crate::message::{QuerySEArtifactsReply, QuerySEArtifactsRequest, SEFieldQuery};
+    use crate::message::{
+        PushSEArtifactsRequest, QuerySEArtifactsReply, QuerySEArtifactsRequest, SEArtifact,
+        SEFieldQuery,
+    };
     use crate::signing::sign_with_transport;
     use crate::transport::{P2PTransport, TransportEvent};
 
@@ -172,6 +175,67 @@ mod tests {
                 assert_eq!(reply.message_id, request_message_id);
                 assert_eq!(reply.sender_id, transport1.local_peer_id().to_string());
                 assert_eq!(reply.doc_ids, vec!["doc1".to_string(), "doc2".to_string()]);
+                break;
+            }
+        }
+
+        transport0.shutdown().await.unwrap();
+        transport1.shutdown().await.unwrap();
+        task0.await.unwrap();
+        task1.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn se_artifacts_roundtrip_signs_and_verifies_sender() {
+        let key0 = SecretKey::generate();
+        let key1 = SecretKey::generate();
+        let (command_tx0, _events0, _replicators0, task0) =
+            spawn_endpoint(test_config(key0.clone())).await.unwrap();
+        let (command_tx1, mut events1, _replicators1, task1) =
+            spawn_endpoint(test_config(key1.clone())).await.unwrap();
+        let transport0 = IrohTransport::new(command_tx0, key0);
+        let transport1 = IrohTransport::new(command_tx1, key1);
+
+        transport0
+            .dial(
+                transport1.local_peer_id(),
+                transport1.listen_addresses().await.unwrap(),
+            )
+            .await
+            .unwrap();
+        transport0
+            .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+        transport1
+            .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let request = PushSEArtifactsRequest::new(
+            "collection1",
+            vec![SEArtifact::new("doc1", "name", vec![4, 5, 6])],
+        );
+        transport0
+            .send_se_artifacts(transport1.local_peer_id(), request)
+            .await
+            .unwrap();
+
+        loop {
+            let event = timeout(Duration::from_secs(5), events1.recv())
+                .await
+                .expect("timed out waiting for SE artifacts")
+                .expect("iroh event channel closed");
+            if let TransportEvent::SEArtifactsReceived { peer_id, data } = event {
+                assert_eq!(peer_id, *transport0.local_peer_id());
+                let received: PushSEArtifactsRequest =
+                    serde_cbor::from_slice(&data).expect("SE artifacts should decode");
+                assert_eq!(received.sender_id, transport0.local_peer_id().to_string());
+                assert!(received.signature.is_some());
+                assert_eq!(received.collection_id, "collection1");
+                assert_eq!(received.artifacts.len(), 1);
+                assert_eq!(received.artifacts[0].doc_id, "doc1");
+                assert_eq!(received.artifacts[0].search_tag, vec![4, 5, 6]);
                 break;
             }
         }
@@ -405,7 +469,12 @@ impl P2PTransport for IrohTransport {
         Ok(())
     }
 
-    async fn send_se_artifacts(&self, peer_id: &PeerId, req: PushSEArtifactsRequest) -> Result<()> {
+    async fn send_se_artifacts(
+        &self,
+        peer_id: &PeerId,
+        mut req: PushSEArtifactsRequest,
+    ) -> Result<()> {
+        crate::signing::sign_with_transport(self, &mut req)?;
         self.send_command(|reply| IrohCommand::SendSEArtifacts {
             peer_id: peer_id.clone(),
             request: req,

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -215,6 +215,7 @@ mod tests {
         peer_id: PeerId,
         pubkey: Vec<u8>,
         subscribed: Arc<Mutex<HashSet<String>>>,
+        fail_subscribe: Arc<Mutex<HashSet<String>>>,
         replicators: Arc<Mutex<HashMap<String, Vec<String>>>>,
     }
 
@@ -224,8 +225,17 @@ mod tests {
                 peer_id: PeerId::new(peer_id.to_string()),
                 pubkey: vec![1, 2, 3],
                 subscribed: Arc::new(Mutex::new(HashSet::new())),
+                fail_subscribe: Arc::new(Mutex::new(HashSet::new())),
                 replicators: Arc::new(Mutex::new(HashMap::new())),
             }
+        }
+
+        fn fail_subscribe(self, topic: &str) -> Self {
+            self.fail_subscribe
+                .lock()
+                .unwrap()
+                .insert(topic.to_string());
+            self
         }
 
         fn subscribed_topics(&self) -> Vec<String> {
@@ -280,7 +290,13 @@ mod tests {
         }
 
         async fn subscribe(&self, topic: DefraTopic) -> crate::Result<bool> {
-            Ok(self.subscribed.lock().unwrap().insert(topic.topic_string()))
+            let topic = topic.topic_string();
+            if self.fail_subscribe.lock().unwrap().contains(&topic) {
+                return Err(crate::error::Error::Transport(format!(
+                    "injected subscribe failure for {topic}"
+                )));
+            }
+            Ok(self.subscribed.lock().unwrap().insert(topic))
         }
 
         async fn unsubscribe(&self, topic: DefraTopic) -> crate::Result<bool> {
@@ -515,6 +531,45 @@ mod tests {
         assert_eq!(
             restarted.get_subscribed_collections().await.unwrap(),
             vec!["users".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_collection_rolls_back_persistence_when_transport_subscribe_fails() {
+        let store = Arc::new(MemoryStore::new());
+        let failing_transport = RecordingTransport::new("failing-peer").fail_subscribe("users");
+        let failing = new_test_coordinator(store.clone(), failing_transport.clone()).await;
+
+        let error = failing
+            .subscribe_collection("users")
+            .await
+            .expect_err("transport subscribe failure should be returned");
+
+        assert!(
+            error.to_string().contains("injected subscribe failure"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            failing
+                .get_subscribed_collections()
+                .await
+                .unwrap()
+                .is_empty(),
+            "failed subscription should not remain in memory"
+        );
+        assert!(
+            failing_transport.subscribed_topics().is_empty(),
+            "failing transport should not record a subscription"
+        );
+
+        let restarted_transport = RecordingTransport::new("restarted-peer");
+        let restarted = new_test_coordinator(store, restarted_transport.clone()).await;
+        let restored = restarted.load_p2p_collections().await.unwrap();
+
+        assert_eq!(restored, 0, "rolled-back subscription must not reload");
+        assert!(
+            restarted_transport.subscribed_topics().is_empty(),
+            "rolled-back subscription must not persist"
         );
     }
 }

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -71,6 +71,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3.17"
 identity = { path = "../../crates/identity" }
 crypto = { path = "../../crates/crypto" }
+p2p = { path = "../../crates/p2p", features = ["iroh-transport"] }
 base64 = "0.22"
 hex = "0.4"
 serial_test = "3"

--- a/tools/integration-test/tests/p2p_iroh/connection/mod.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/mod.rs
@@ -2,5 +2,6 @@
 
 mod connection;
 mod management;
+mod se_query;
 mod signature;
 mod smoke;

--- a/tools/integration-test/tests/p2p_iroh/connection/se_query.rs
+++ b/tools/integration-test/tests/p2p_iroh/connection/se_query.rs
@@ -1,0 +1,115 @@
+//! Iroh direct-stream SE query transport tests.
+//!
+//! Run with:
+//!   cargo test -p integration-test --test p2p_iroh -- connection::se_query
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+
+use p2p::iroh::{
+    load_or_generate_secret_key, spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig,
+    IrohRelayModeConfig, IrohTransport,
+};
+use p2p::message::{QuerySEArtifactsReply, QuerySEArtifactsRequest, SEFieldQuery};
+use p2p::{sign_with_transport, P2PTransport, TransportEvent};
+use tokio::time::timeout;
+
+async fn test_config() -> IrohEndpointConfig {
+    IrohEndpointConfig {
+        secret_key: load_or_generate_secret_key(None)
+            .await
+            .expect("generate iroh key"),
+        relay_mode: IrohRelayModeConfig::Disabled,
+        discovery: IrohDiscoveryConfig::Disabled,
+        bind_port: None,
+        bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+    }
+}
+
+#[tokio::test]
+async fn roundtrip_emits_request_and_reply_events() {
+    let config0 = test_config().await;
+    let config1 = test_config().await;
+    let key0 = config0.secret_key.clone();
+    let key1 = config1.secret_key.clone();
+    let (command_tx0, mut events0, _replicators0, task0) =
+        spawn_endpoint(config0).await.expect("spawn endpoint 0");
+    let (command_tx1, mut events1, _replicators1, task1) =
+        spawn_endpoint(config1).await.expect("spawn endpoint 1");
+    let transport0 = IrohTransport::new(command_tx0, key0);
+    let transport1 = IrohTransport::new(command_tx1, key1);
+
+    transport0
+        .dial(
+            transport1.local_peer_id(),
+            transport1.listen_addresses().await.expect("listen addrs 1"),
+        )
+        .await
+        .expect("dial endpoint 1");
+    transport0
+        .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("endpoint 0 sees endpoint 1");
+    transport1
+        .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
+        .await
+        .expect("endpoint 1 sees endpoint 0");
+
+    let mut request = QuerySEArtifactsRequest::new(
+        "collection1",
+        vec![SEFieldQuery::new("name", "name", vec![1, 2, 3])],
+    );
+    sign_with_transport(&transport0, &mut request).expect("sign request");
+    let request_message_id = request.message_id.clone();
+
+    transport0
+        .send_se_query_request(transport1.local_peer_id(), request)
+        .await
+        .expect("send request");
+
+    let received_request = loop {
+        let event = timeout(Duration::from_secs(5), events1.recv())
+            .await
+            .expect("timed out waiting for SE query request")
+            .expect("iroh event channel closed");
+        if let TransportEvent::SEQueryRequest { peer_id, request } = event {
+            assert_eq!(peer_id, *transport0.local_peer_id());
+            break request;
+        }
+    };
+    assert_eq!(received_request.message_id, request_message_id);
+    assert_eq!(
+        received_request.sender_id,
+        transport0.local_peer_id().to_string()
+    );
+    assert_eq!(received_request.collection_id, "collection1");
+    assert_eq!(received_request.queries.len(), 1);
+    assert_eq!(received_request.queries[0].search_tag, vec![1, 2, 3]);
+
+    let mut reply =
+        QuerySEArtifactsReply::success(&request_message_id, vec!["doc1".into(), "doc2".into()]);
+    sign_with_transport(&transport1, &mut reply).expect("sign reply");
+    transport1
+        .send_se_query_response(transport0.local_peer_id(), reply)
+        .await
+        .expect("send reply");
+
+    loop {
+        let event = timeout(Duration::from_secs(5), events0.recv())
+            .await
+            .expect("timed out waiting for SE query reply")
+            .expect("iroh event channel closed");
+        if let TransportEvent::SEQueryReply { peer_id, reply } = event {
+            assert_eq!(peer_id, *transport1.local_peer_id());
+            assert_eq!(reply.message_id, request_message_id);
+            assert_eq!(reply.sender_id, transport1.local_peer_id().to_string());
+            assert_eq!(reply.doc_ids, vec!["doc1".to_string(), "doc2".to_string()]);
+            break;
+        }
+    }
+
+    transport0.shutdown().await.expect("shutdown endpoint 0");
+    transport1.shutdown().await.expect("shutdown endpoint 1");
+    task0.await.expect("endpoint task 0");
+    task1.await.expect("endpoint task 1");
+}

--- a/tools/integration-test/tests/p2p_iroh/replication/collection_sub.rs
+++ b/tools/integration-test/tests/p2p_iroh/replication/collection_sub.rs
@@ -64,6 +64,52 @@ async fn collection_add_get_single() {
     assert_eq!(arr.len(), 1, "should have 1 collection");
 }
 
+#[tokio::test]
+#[serial]
+async fn collection_subscription_persists_after_restart() {
+    let mut cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_iroh_transport()
+        .with_store("badger")
+        .build()
+        .await
+        .unwrap();
+    cluster
+        .wait_for_log(0, "p2p_listening", P2P_TIMEOUT)
+        .await
+        .expect("P2P listener did not start");
+
+    let node = cluster.client(0);
+    node.schema_add(SCHEMA_USERS).expect("schema Users");
+    node.p2p_collection_add(&["Users"]).expect("add Users");
+
+    let before = node.p2p_collection_list().expect("list before restart");
+    assert_eq!(
+        before.as_array().expect("not array").len(),
+        1,
+        "collection should be subscribed before restart"
+    );
+
+    cluster
+        .restart_node(0, Duration::from_secs(30))
+        .await
+        .expect("restart node");
+    cluster
+        .wait_for_log(0, "p2p_listening", P2P_TIMEOUT)
+        .await
+        .expect("P2P listener did not restart");
+
+    let node_after_restart = cluster.client(0);
+    let after = node_after_restart
+        .p2p_collection_list()
+        .expect("list after restart");
+    assert_eq!(
+        after.as_array().expect("not array").len(),
+        1,
+        "collection subscription should persist across restart"
+    );
+}
+
 /// Port: TestP2PCollectionAddGetMultiple
 /// Add and verify multiple collection subscriptions.
 #[tokio::test]


### PR DESCRIPTION
## Summary
- closes #962 by covering P2P collection subscription persistence on libp2p and Iroh plus rollback on transport subscribe failure
- closes #963 by proving HTTP P2P handlers wait for P2P operations before ACK and return non-2xx on operation failure
- closes #964 and #968 with updated HTTP P2P route docs and Iroh transport design notes
- closes #965 by wiring Iroh `topic_peers()` to topic-scoped gossip neighbors instead of all connected peers
- closes #966 with Iroh SE query request/reply direct streams and round-trip integration coverage
- closes #967 by changing Iroh DocSync fan-out to bounded concurrent dispatch in both adapters

Closes #962
Closes #963
Closes #964
Closes #965
Closes #966
Closes #967
Closes #968

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --all -- -D warnings`
- `cargo check -p cli -p defra-p2p-adapter`
- `cargo test -p p2p --features iroh-transport se_query_roundtrip_emits_request_and_reply_events`
- `cargo test -p p2p subscribe_collection_rolls_back_persistence_when_transport_subscribe_fails`
- `cargo test -p defra-http p2p_`
- `cargo test -p integration-test --test p2p_iroh` (220 passed, 7 ignored)

## Known local verification limitation
- `cargo test` and `cargo test -p integration-test --test p2p` were run, but Go-backed integration cases failed because no Go `defradb` binary is available on `PATH` in this environment (`command -v defradb` is empty). Rust/Rust P2P cases in the `p2p` target passed before those Go-binary failures caused the target to exit non-zero.
