### PR TITLE
fix(db): emit Update events on transaction commit (#970)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6031,6 +6031,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "cid 0.10.1",
  "crypto",
  "ctor",
  "defra-harness",

--- a/crates/cli/src/commands/keyring_cmd.rs
+++ b/crates/cli/src/commands/keyring_cmd.rs
@@ -264,6 +264,13 @@ fn hex_encode(data: &[u8]) -> String {
     data.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
+fn hex_decode(s: &str) -> std::result::Result<Vec<u8>, String> {
+    if !s.len().is_multiple_of(2) {
+        return Err(format!("hex string has odd length: {}", s.len()));
+    }
+    hex::decode(s).map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -290,11 +297,4 @@ mod tests {
         let err = args.execute(Config::default()).unwrap_err();
         assert!(matches!(err, Error::OperationRequiresDeveloperMode));
     }
-}
-
-fn hex_decode(s: &str) -> std::result::Result<Vec<u8>, String> {
-    if !s.len().is_multiple_of(2) {
-        return Err(format!("hex string has odd length: {}", s.len()));
-    }
-    hex::decode(s).map_err(|e| e.to_string())
 }

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -169,6 +169,7 @@ impl Node {
             acp_setup.document_acp.clone(),
             nac_adapter.clone(),
             p2p_setup.mutator.clone(),
+            p2p_setup.txn_broadcaster.clone(),
         );
 
         let zanzibar_store_for_pg = zanzibar_store.clone();

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -49,6 +49,9 @@ pub(super) struct P2PSetup {
     pub(super) http_adapter: Option<Arc<dyn defra_http::router::P2POperations>>,
     pub(super) wire_merge_acp: WireDocumentAcp,
     pub(super) wire_doc_pusher_acp: WireDocumentAcp,
+    /// Hook for forwarding committed `/tx` writes to P2P peers. `Some` when the
+    /// P2P stack is up; `None` for the non-P2P fallback path.
+    pub(super) txn_broadcaster: Option<Arc<dyn db::event_emission::TxnBroadcaster>>,
 }
 
 impl Node {
@@ -95,6 +98,7 @@ impl Node {
             http_adapter: None,
             wire_merge_acp: None,
             wire_doc_pusher_acp: None,
+            txn_broadcaster: None,
         }
     }
 
@@ -170,6 +174,7 @@ impl Node {
         let merge_handler_inner_for_syncer = replication.merge_handler_inner.clone();
         let broadcast_mutator = replication.broadcast_mutator.clone();
         let merge_handler_for_acp = replication.merge_handler.clone();
+        let txn_broadcaster = replication.txn_broadcaster.clone();
 
         let coordinator_for_replication = coordinator.clone();
         let replication_task = tokio::spawn(async move {
@@ -475,6 +480,7 @@ impl Node {
             wire_doc_pusher_acp: Some(Box::new(move |acp| {
                 doc_pusher_for_acp.set_document_acp(acp);
             })),
+            txn_broadcaster: Some(txn_broadcaster),
         })
     }
 
@@ -559,6 +565,7 @@ impl Node {
         let merge_handler_inner_for_syncer = replication.merge_handler_inner.clone();
         let broadcast_mutator = replication.broadcast_mutator.clone();
         let merge_handler_for_acp = replication.merge_handler.clone();
+        let txn_broadcaster = replication.txn_broadcaster.clone();
 
         let coordinator_for_replication = coordinator.clone();
         let replication_task = tokio::spawn(async move {
@@ -812,6 +819,7 @@ impl Node {
             }),
             mutator: broadcast_mutator,
             http_adapter: Some(Arc::new(adapter)),
+            txn_broadcaster: Some(txn_broadcaster),
             wire_merge_acp: Some(Box::new(move |acp| {
                 coordinator_for_acp.set_document_acp(acp.clone());
                 merge_handler_for_acp.set_document_acp(acp);

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -23,12 +23,16 @@ impl Node {
         document_acp: Arc<dyn acp::DocumentACP>,
         nac_adapter: Option<Arc<crate::nac_adapter::NacAdapter>>,
         mutator: Arc<dyn query::mutator::DocMutator>,
+        txn_broadcaster: Option<Arc<dyn db::event_emission::TxnBroadcaster>>,
     ) -> QueryRunnerSetup<S>
     where
         S: storage::corekv::Store + 'static,
     {
         let fetcher = db::LensedAutoCommitFetcher::new(database.clone());
-        let registry = Arc::new(db::DbTransactionRegistry::new(database.clone()));
+        let registry = Arc::new(match txn_broadcaster {
+            Some(b) => db::DbTransactionRegistry::with_broadcaster(database.clone(), b),
+            None => db::DbTransactionRegistry::new(database.clone()),
+        });
         let collection_provider: Arc<dyn query::CollectionProvider> =
             db::DbCollectionProvider::new_arc(database.clone());
         info!(

--- a/crates/db-merge/src/broadcast_mutator/batch.rs
+++ b/crates/db-merge/src/broadcast_mutator/batch.rs
@@ -285,14 +285,17 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
     ) -> query::error::Result<DeleteResult> {
         let result = self.inner.delete(collection_name, doc_id).await?;
         let doc_id = result.doc_id.to_string();
+        // Pass through the branchable collection block so it gets broadcast
+        // alongside the composite delete (matches the non-batch BroadcastMutator
+        // path and Go's two-update emit for branchable mutations).
         self.capture_broadcast(BroadcastCapture {
             kind: BroadcastKind::SingleBlockPush,
             collection_name,
             doc_id: &doc_id,
             commit_cid: result.commit_cid,
             commit_block: result.commit_block.as_ref(),
-            broadcast_cid: None,
-            broadcast_block: None,
+            broadcast_cid: result.broadcast_cid,
+            broadcast_block: result.broadcast_block.as_ref(),
         })
         .await?;
         Ok(result)

--- a/crates/db-merge/src/broadcast_mutator/mod.rs
+++ b/crates/db-merge/src/broadcast_mutator/mod.rs
@@ -586,24 +586,37 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
             return Ok(result);
         }
 
-        // Read the delete composite block that was written during the mutation.
+        // Prefer the delete block the inner mutator just wrote — re-reading
+        // the "latest" composite head via storage would race with concurrent
+        // writes on the same doc and broadcast the wrong block. Fall back to
+        // reading from storage only when commit artifacts are missing.
         let doc_id_str = doc_id.to_string();
-        let block_result = match read_latest_composite_block(&self.db, &doc_id_str).await {
-            Ok(br) => br,
-            Err(e) => {
-                tracing::error!(
-                    doc_id = %doc_id,
-                    collection = %collection_name,
-                    error = %e,
-                    "Failed to read delete composite block for P2P broadcast"
-                );
-                return Ok(DeleteResult::with_broadcast(
-                    result.doc_id,
-                    result.existed,
-                    BroadcastStatus::Failed(format!("Block read failed: {}", e)),
-                ));
-            }
-        };
+        let block_result =
+            if let (Some(cid), Some(block)) = (result.commit_cid, result.commit_block.as_ref()) {
+                BlockResult {
+                    cid,
+                    block: block.clone(),
+                    doc_id: doc_id_str,
+                    field_cids: vec![],
+                }
+            } else {
+                match read_latest_composite_block(&self.db, &doc_id_str).await {
+                    Ok(br) => br,
+                    Err(e) => {
+                        tracing::error!(
+                            doc_id = %doc_id,
+                            collection = %collection_name,
+                            error = %e,
+                            "Failed to read delete composite block for P2P broadcast"
+                        );
+                        return Ok(DeleteResult::with_broadcast(
+                            result.doc_id,
+                            result.existed,
+                            BroadcastStatus::Failed(format!("Block read failed: {}", e)),
+                        ));
+                    }
+                }
+            };
 
         // Read broadcast creator DID before spawning (reads thread-local state).
         let creator_did = defra_core::signing::get_broadcast_creator_did();

--- a/crates/db-merge/src/broadcast_mutator/mod.rs
+++ b/crates/db-merge/src/broadcast_mutator/mod.rs
@@ -608,6 +608,22 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
         // Read broadcast creator DID before spawning (reads thread-local state).
         let creator_did = defra_core::signing::get_broadcast_creator_did();
 
+        // For branchable collections, capture the collection-level head block
+        // so we can broadcast it alongside the composite delete (Go emits two
+        // updates for branchable mutations; see internal/db/collection.go:789).
+        let branchable_data = if let (Some(col_cid), Some(col_block)) =
+            (result.broadcast_cid, result.broadcast_block.as_ref())
+        {
+            Some(BlockResult {
+                cid: col_cid,
+                block: col_block.clone(),
+                doc_id: block_result.doc_id.clone(),
+                field_cids: vec![],
+            })
+        } else {
+            None
+        };
+
         // Capture everything for the spawned task by value.
         let sync = self.sync.clone();
         let collection_name_owned = collection_name.to_string();
@@ -638,6 +654,28 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
                 )
                 .await,
             );
+
+            // For branchable collections, also broadcast the collection block.
+            if let Some(col_block_result) = branchable_data {
+                sync.push_to_replicators_with_creator(
+                    &col_block_result.cid,
+                    &col_block_result.block,
+                    &col_block_result.doc_id,
+                    &collection_id,
+                    creator_ref,
+                )
+                .await;
+                log_broadcast_failure(
+                    &broadcast_with_retry_with_creator(
+                        &sync,
+                        &col_block_result,
+                        &collection_id,
+                        &collection_name_owned,
+                        creator_ref,
+                    )
+                    .await,
+                );
+            }
         });
 
         Ok(DeleteResult::with_broadcast(

--- a/crates/db-merge/src/broadcast_mutator/mod.rs
+++ b/crates/db-merge/src/broadcast_mutator/mod.rs
@@ -579,6 +579,13 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
         // Execute the delete mutation
         let result = self.inner.delete(collection_name, doc_id).await?;
 
+        // No-op delete (missing doc): the inner mutator wrote nothing, so
+        // there's no tombstone block to read or broadcast. Returning here
+        // also avoids re-broadcasting the previous (stale) head.
+        if !result.existed {
+            return Ok(result);
+        }
+
         // Read the delete composite block that was written during the mutation.
         let doc_id_str = doc_id.to_string();
         let block_result = match read_latest_composite_block(&self.db, &doc_id_str).await {

--- a/crates/db-merge/src/lib.rs
+++ b/crates/db-merge/src/lib.rs
@@ -15,6 +15,7 @@ mod push_docs_replay;
 pub mod push_docs_transport;
 pub mod replication;
 pub mod se;
+pub mod txn_broadcaster;
 
 // Re-export primary types
 pub use acp_merge_handler::{AcpMergeError, AcpMergeHandler};
@@ -41,3 +42,4 @@ pub use se::{
     fetch_doc_ids, generate_doc_artifacts, generate_field_artifact, store_artifacts, FieldQuery,
     FieldValueQuery, SECoordinator,
 };
+pub use txn_broadcaster::SyncTxnBroadcaster;

--- a/crates/db-merge/src/replication.rs
+++ b/crates/db-merge/src/replication.rs
@@ -17,11 +17,17 @@ use crate::acp_merge_handler::AcpMergeHandler;
 use crate::broadcast_mutator::BroadcastMutator;
 use crate::head_provider::DbHeadProvider;
 use crate::merge_handler::DbMergeHandler;
+use crate::txn_broadcaster::SyncTxnBroadcaster;
+use db::event_emission::TxnBroadcaster;
 
 pub struct ReplicationStack<S: Store, B: Blockstore + Send + Sync, T: P2PTransport> {
     pub merge_handler_inner: Arc<DbMergeHandler<S, B>>,
     pub merge_handler: Arc<AcpMergeHandler<S, B>>,
     pub broadcast_mutator: Arc<BroadcastMutator<S, B, T>>,
+    /// Broadcaster for transactional writes. Wire this into
+    /// `DbTransactionRegistry::with_broadcaster` so committed `/tx` mutations
+    /// reach P2P peers just like single-mutation auto-commit writes do.
+    pub txn_broadcaster: Arc<dyn TxnBroadcaster>,
 }
 
 pub fn create_head_provider<S: Store>(db: Arc<DB<S>>) -> DbHeadProvider<S> {
@@ -51,7 +57,7 @@ pub fn create_broadcast_mutator<S: Store, B: Blockstore + 'static, T: P2PTranspo
 pub fn create_replication_stack<
     S: Store,
     B: Blockstore + Send + Sync + 'static,
-    T: P2PTransport,
+    T: P2PTransport + 'static,
 >(
     db: Arc<DB<S>>,
     blockstore: Arc<B>,
@@ -59,12 +65,14 @@ pub fn create_replication_stack<
 ) -> ReplicationStack<S, B, T> {
     let merge_handler_inner = Arc::new(create_merge_handler(db.clone(), blockstore));
     let merge_handler = Arc::new(create_acp_merge_handler(merge_handler_inner.clone()));
-    let broadcast_mutator = Arc::new(create_broadcast_mutator(db, sync));
+    let broadcast_mutator = Arc::new(create_broadcast_mutator(db, sync.clone()));
+    let txn_broadcaster: Arc<dyn TxnBroadcaster> = Arc::new(SyncTxnBroadcaster::new(sync));
 
     ReplicationStack {
         merge_handler_inner,
         merge_handler,
         broadcast_mutator,
+        txn_broadcaster,
     }
 }
 

--- a/crates/db-merge/src/txn_broadcaster.rs
+++ b/crates/db-merge/src/txn_broadcaster.rs
@@ -1,0 +1,113 @@
+//! `TxnBroadcaster` implementation backed by the `SyncCoordinator`.
+//!
+//! Used by `DbTransactionRegistry::with_broadcaster` so that committed
+//! transactional writes get pushed to replicators and gossipsub topics —
+//! mirroring what `BroadcastMutator` already does for the single-mutation
+//! auto-commit path.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use blockstore::Blockstore;
+use db::event_emission::{TxnBroadcastEvent, TxnBroadcaster};
+use db_blocks::BlockResult;
+use p2p::sync::SyncCoordinator;
+use p2p::transport::P2PTransport;
+
+use crate::broadcast_mutator::broadcast::{
+    broadcast_with_retry_with_creator, log_broadcast_failure,
+};
+
+/// `TxnBroadcaster` that fans committed transactional writes out to peers via
+/// `SyncCoordinator::push_to_replicators` and gossipsub.
+pub struct SyncTxnBroadcaster<B: Blockstore + Send + Sync + 'static, T: P2PTransport + 'static> {
+    sync: Arc<SyncCoordinator<B, T>>,
+}
+
+impl<B: Blockstore + Send + Sync + 'static, T: P2PTransport + 'static> SyncTxnBroadcaster<B, T> {
+    pub fn new(sync: Arc<SyncCoordinator<B, T>>) -> Self {
+        Self { sync }
+    }
+}
+
+#[async_trait]
+impl<B, T> TxnBroadcaster for SyncTxnBroadcaster<B, T>
+where
+    B: Blockstore + Send + Sync + 'static,
+    T: P2PTransport + 'static,
+{
+    async fn broadcast_update(&self, event: TxnBroadcastEvent) {
+        let TxnBroadcastEvent {
+            collection_name,
+            collection_id,
+            doc_id,
+            doc_cid,
+            doc_block,
+            collection_block,
+            creator_did,
+        } = event;
+
+        let sync = self.sync.clone();
+
+        // Spawn detached so the tx-success callback returns promptly. Mirrors
+        // `BroadcastMutator::create`'s pattern of broadcasting on a background
+        // task after the local commit lands.
+        tokio::spawn(async move {
+            let creator_ref = creator_did.as_deref();
+
+            sync.push_to_replicators_with_creator(
+                &doc_cid,
+                &doc_block,
+                &doc_id,
+                &collection_id,
+                creator_ref,
+            )
+            .await;
+
+            let doc_block_result = BlockResult {
+                cid: doc_cid,
+                block: doc_block,
+                doc_id: doc_id.clone(),
+                field_cids: vec![],
+            };
+            log_broadcast_failure(
+                &broadcast_with_retry_with_creator(
+                    &sync,
+                    &doc_block_result,
+                    &collection_id,
+                    &collection_name,
+                    creator_ref,
+                )
+                .await,
+            );
+
+            if let Some((col_cid, col_block)) = collection_block {
+                sync.push_to_replicators_with_creator(
+                    &col_cid,
+                    &col_block,
+                    &doc_id,
+                    &collection_id,
+                    creator_ref,
+                )
+                .await;
+
+                let col_block_result = BlockResult {
+                    cid: col_cid,
+                    block: col_block,
+                    doc_id: doc_id.clone(),
+                    field_cids: vec![],
+                };
+                log_broadcast_failure(
+                    &broadcast_with_retry_with_creator(
+                        &sync,
+                        &col_block_result,
+                        &collection_id,
+                        &collection_name,
+                        creator_ref,
+                    )
+                    .await,
+                );
+            }
+        });
+    }
+}

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -2,7 +2,6 @@ use async_lock::Mutex as TokioMutex;
 use async_trait::async_trait;
 use cid::Cid;
 use document::{DocID, Document};
-use events::{Message, Update};
 use query::mutator::{
     CreateResult, DeleteResult, DocMutator, MutationBatchController, UpdateResult,
 };
@@ -15,30 +14,19 @@ use super::helpers::ensure_collection_is_active;
 use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
+use crate::event_emission::register_update_event_callback;
 use crate::txn::DbTxn;
 use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
 use defra_core::signing::get_signing_config;
 
-struct PendingUpdateEvent {
-    collection_id: String,
-    branchable: bool,
-    doc_id: String,
-    cid: Cid,
-}
-
 pub struct BatchMutator<S: Store> {
     db: Arc<DB<S>>,
     txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
-    pending_events: TokioMutex<Vec<PendingUpdateEvent>>,
 }
 
 impl<S: Store> BatchMutator<S> {
     pub fn new(db: Arc<DB<S>>, txn: Arc<TokioMutex<Option<DbTxn<S>>>>) -> Self {
-        Self {
-            db,
-            txn,
-            pending_events: TokioMutex::new(Vec::new()),
-        }
+        Self { db, txn }
     }
 
     async fn block_and_head_stores(
@@ -62,48 +50,34 @@ impl<S: Store> BatchMutator<S> {
             query::error::QueryError::execution("mutation batch transaction is no longer active")
         })
     }
+}
 
-    async fn queue_update_event(
+impl<S: Store + 'static> BatchMutator<S> {
+    async fn register_update_callback(
         &self,
         collection_id: String,
         branchable: bool,
         doc_id: String,
         cid: Cid,
-    ) {
-        self.pending_events.lock().await.push(PendingUpdateEvent {
+    ) -> query::error::Result<()> {
+        let mut txn_guard = self.txn.lock().await;
+        let txn = txn_guard.as_mut().ok_or_else(|| {
+            query::error::QueryError::execution("mutation batch transaction is no longer active")
+        })?;
+        register_update_event_callback(
+            txn,
+            self.db.event_bus(),
             collection_id,
             branchable,
             doc_id,
             cid,
-        });
-    }
-
-    fn emit_update_event(&self, event: PendingUpdateEvent) {
-        if let Some(bus) = self.db.event_bus() {
-            let subject_doc_id = event.doc_id.clone();
-            let update = Update::new(
-                event.doc_id,
-                event.cid,
-                event.collection_id.clone(),
-                vec![],
-                false,
-                false,
-            );
-            bus.publish(Message::update(update));
-
-            if event.branchable {
-                let collection_update = Update::new_with_subject_doc_id(
-                    String::new(),
-                    subject_doc_id,
-                    event.cid,
-                    event.collection_id,
-                    vec![],
-                    false,
-                    false,
-                );
-                bus.publish(Message::update(collection_update));
-            }
-        }
+        )
+        .map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to register tx update callback: {}",
+                e
+            ))
+        })
     }
 }
 
@@ -112,27 +86,13 @@ impl<S: Store> BatchMutator<S> {
 impl<S: Store + 'static> MutationBatchController for BatchMutator<S> {
     async fn commit(&self) -> query::error::Result<()> {
         let txn = self.take_txn().await?;
-
-        if let Err(e) = txn.commit().await {
-            self.pending_events.lock().await.clear();
-            return Err(query::error::QueryError::execution(format!(
-                "commit error: {}",
-                e
-            )));
-        }
-
-        let pending_events = std::mem::take(&mut *self.pending_events.lock().await);
-        for event in pending_events {
-            self.emit_update_event(event);
-        }
-
-        Ok(())
+        txn.commit().await.map_err(|e| {
+            query::error::QueryError::execution(format!("commit error: {}", e))
+        })
     }
 
     async fn rollback(&self) -> query::error::Result<()> {
         let txn = self.take_txn().await?;
-        self.pending_events.lock().await.clear();
-
         txn.discard()
             .map_err(|e| query::error::QueryError::execution(format!("discard error: {}", e)))
     }
@@ -141,7 +101,6 @@ impl<S: Store + 'static> MutationBatchController for BatchMutator<S> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: Store + 'static> DocMutator for BatchMutator<S> {
-    #[allow(clippy::type_complexity)]
     async fn create(
         &self,
         collection_name: &str,
@@ -245,17 +204,15 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             }
         };
 
-        let cid = commit_result
-            .as_ref()
-            .map(|(cid, _, _)| *cid)
-            .unwrap_or_default();
-        self.queue_update_event(
-            collection.collection_id().to_string(),
-            collection.schema().is_branchable,
-            doc_id.to_string(),
-            cid,
-        )
-        .await;
+        if let Some((cid, _, _)) = commit_result.as_ref() {
+            self.register_update_callback(
+                collection.collection_id().to_string(),
+                collection.schema().is_branchable,
+                doc_id.to_string(),
+                *cid,
+            )
+            .await?;
+        }
 
         match commit_result {
             Some((cid, block, col_data)) => {
@@ -374,18 +331,14 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             }
         };
 
-        if let Some(doc_id) = doc.id() {
-            let cid = commit_result
-                .as_ref()
-                .map(|(cid, _, _)| *cid)
-                .unwrap_or_default();
-            self.queue_update_event(
+        if let (Some(doc_id), Some((cid, _, _))) = (doc.id(), commit_result.as_ref()) {
+            self.register_update_callback(
                 collection.collection_id().to_string(),
                 collection.schema().is_branchable,
                 doc_id.to_string(),
-                cid,
+                *cid,
             )
-            .await;
+            .await?;
         }
 
         let fields_modified = doc.values().len();
@@ -468,17 +421,15 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             }
         };
 
-        let cid = commit_result
-            .as_ref()
-            .map(|(cid, _)| *cid)
-            .unwrap_or_default();
-        self.queue_update_event(
-            collection.collection_id().to_string(),
-            collection.schema().is_branchable,
-            doc_id.to_string(),
-            cid,
-        )
-        .await;
+        if let Some((cid, _)) = commit_result.as_ref() {
+            self.register_update_callback(
+                collection.collection_id().to_string(),
+                collection.schema().is_branchable,
+                doc_id.to_string(),
+                *cid,
+            )
+            .await?;
+        }
 
         match commit_result {
             Some((cid, block)) => Ok(DeleteResult::with_commit(

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -468,3 +468,85 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use events::{Bus, ChannelBus, EventName};
+    use query::mutator::{DocMutator, MutationBatchController};
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use storage::backends::MemoryStore;
+
+    async fn make_test_db_with_bus() -> (Arc<DB<MemoryStore>>, Arc<dyn Bus>) {
+        let bus: Arc<dyn Bus> = Arc::new(ChannelBus::new());
+        let mut db = DB::new(MemoryStore::new()).expect("create db");
+        db.set_event_bus(Arc::clone(&bus));
+        (Arc::new(db), bus)
+    }
+
+    fn test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "TestDoc",
+            "v1",
+            "col-test-doc",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "x", FieldKind::int()),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn batch_create_publishes_event_on_commit() {
+        let (db, bus) = make_test_db_with_bus().await;
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
+
+        let mut sub = bus.subscribe(&[EventName::Update]);
+
+        let txn = db.new_txn(false).await.expect("new_txn");
+        let txn_arc = Arc::new(TokioMutex::new(Some(txn)));
+        let mutator = BatchMutator::new(Arc::clone(&db), Arc::clone(&txn_arc));
+
+        let doc = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
+        let result = mutator.create("TestDoc", doc).await.expect("create");
+
+        // Before commit: no event should have fired
+        assert!(
+            sub.try_recv().is_err(),
+            "no event should fire before commit"
+        );
+
+        mutator.commit().await.expect("commit");
+
+        // After commit: one Update event arrives
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(1), sub.recv())
+            .await
+            .expect("event arrived within timeout")
+            .expect("subscription not closed");
+
+        let update = msg.as_update().expect("expected Update message");
+        assert_eq!(update.doc_id, result.doc_id.to_string());
+        assert_ne!(update.cid, cid::Cid::default(), "cid should be populated");
+    }
+
+    #[tokio::test]
+    async fn batch_create_publishes_no_event_when_block_write_fails() {
+        // Documents the invariant: BatchMutator MUST NOT publish an Update event
+        // when write_document_blocks returns Err.
+        //
+        // The post-refactor implementation guarantees this structurally:
+        // register_update_callback is only called inside the `Some(commit_result)`
+        // match arm in BatchMutator::create/update/delete.
+        //
+        // Triggering an actual block-write failure requires a faulty blockstore
+        // that returns Err from `put`. No such mock exists in the codebase today
+        // because the Store trait is sealed (only storage-crate types may implement
+        // it), so a faulty-store mock cannot be constructed in this crate.
+        //
+        // If the sealed constraint is relaxed in the future, replace this comment
+        // with a real assertion: subscribe to the bus, run a create against a
+        // faulty store, and assert no Update event arrives.
+    }
+}

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -422,16 +422,16 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             doc_id.to_string(),
             doc_cid,
             doc_block.clone(),
-            col_block_data,
+            col_block_data.clone(),
         )
         .await?;
 
-        Ok(DeleteResult::with_commit(
-            doc_id.clone(),
-            existed,
-            doc_cid,
-            doc_block,
-        ))
+        let mut result = DeleteResult::with_commit(doc_id.clone(), existed, doc_cid, doc_block);
+        if let Some((col_cid, col_bytes)) = col_block_data {
+            result.broadcast_cid = Some(col_cid);
+            result.broadcast_block = Some(col_bytes);
+        }
+        Ok(result)
     }
 
     async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {
@@ -486,6 +486,19 @@ mod tests {
                 FieldDescription::new("2", "x", FieldKind::int()),
             ],
         )
+    }
+
+    fn branchable_test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "TestBranchable",
+            "v1",
+            "col-test-branchable",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "x", FieldKind::int()),
+            ],
+        )
+        .as_branchable()
     }
 
     #[tokio::test]
@@ -580,5 +593,61 @@ mod tests {
             sub.try_recv().is_err(),
             "deleting a non-existent doc should not publish an Update event"
         );
+    }
+
+    #[tokio::test]
+    async fn batch_delete_branchable_surfaces_collection_block_for_broadcast() {
+        // Go emits two updates for branchable deletes: the document composite
+        // block AND the collection head block. DeleteResult must surface the
+        // collection block so BroadcastMutator can re-broadcast it (matches
+        // create/update's broadcast_cid/broadcast_block plumbing).
+        let (db, _bus) = make_test_db_with_bus().await;
+        db.create_collection(branchable_test_collection())
+            .await
+            .expect("schema");
+
+        let txn = db.new_txn(false).await.expect("new_txn");
+        let txn_arc = Arc::new(TokioMutex::new(Some(txn)));
+        let mutator = BatchMutator::new(Arc::clone(&db), Arc::clone(&txn_arc));
+
+        let doc = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
+        let create_result = mutator
+            .create("TestBranchable", doc)
+            .await
+            .expect("create");
+        let doc_id = create_result.doc_id.clone();
+
+        let delete_result = mutator
+            .delete("TestBranchable", &doc_id)
+            .await
+            .expect("delete");
+
+        assert!(delete_result.existed, "doc should have existed");
+        assert!(
+            delete_result.commit_cid.is_some(),
+            "composite delete cid should be set"
+        );
+        assert!(
+            delete_result.commit_block.is_some(),
+            "composite delete block should be set"
+        );
+        assert!(
+            delete_result.broadcast_cid.is_some(),
+            "branchable collection cid should be surfaced for broadcast"
+        );
+        assert!(
+            delete_result
+                .broadcast_block
+                .as_ref()
+                .map(|b| !b.is_empty())
+                .unwrap_or(false),
+            "branchable collection block bytes should be surfaced for broadcast"
+        );
+        assert_ne!(
+            delete_result.commit_cid, delete_result.broadcast_cid,
+            "collection head cid must differ from the document composite cid"
+        );
+
+        mutator.commit().await.expect("commit");
     }
 }

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -611,10 +611,7 @@ mod tests {
         let mutator = BatchMutator::new(Arc::clone(&db), Arc::clone(&txn_arc));
 
         let doc = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
-        let create_result = mutator
-            .create("TestBranchable", doc)
-            .await
-            .expect("create");
+        let create_result = mutator.create("TestBranchable", doc).await.expect("create");
         let doc_id = create_result.doc_id.clone();
 
         let delete_result = mutator

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -86,9 +86,9 @@ impl<S: Store + 'static> BatchMutator<S> {
 impl<S: Store + 'static> MutationBatchController for BatchMutator<S> {
     async fn commit(&self) -> query::error::Result<()> {
         let txn = self.take_txn().await?;
-        txn.commit().await.map_err(|e| {
-            query::error::QueryError::execution(format!("commit error: {}", e))
-        })
+        txn.commit()
+            .await
+            .map_err(|e| query::error::QueryError::execution(format!("commit error: {}", e)))
     }
 
     async fn rollback(&self) -> query::error::Result<()> {

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -56,9 +56,10 @@ impl<S: Store + 'static> BatchMutator<S> {
     async fn register_update_callback(
         &self,
         collection_id: String,
-        branchable: bool,
         doc_id: String,
-        cid: Cid,
+        doc_cid: Cid,
+        doc_block: Vec<u8>,
+        collection_block: Option<(Cid, Vec<u8>)>,
     ) -> query::error::Result<()> {
         let mut txn_guard = self.txn.lock().await;
         let txn = txn_guard.as_mut().ok_or_else(|| {
@@ -68,9 +69,10 @@ impl<S: Store + 'static> BatchMutator<S> {
             txn,
             self.db.event_bus(),
             collection_id,
-            branchable,
             doc_id,
-            cid,
+            doc_cid,
+            doc_block,
+            collection_block,
         )
         .map_err(|e| {
             query::error::QueryError::execution(format!(
@@ -147,10 +149,10 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         let enc_config = get_encryption_config();
         let sign_config = get_signing_config();
 
-        let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = {
+        let (doc_cid, doc_block, col_block_data) = {
             let (blockstore, headstore) = self.block_and_head_stores().await?;
 
-            match write_document_blocks(
+            let block_result = write_document_blocks(
                 &blockstore,
                 &headstore,
                 &doc,
@@ -160,71 +162,60 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
                 sign_config.as_ref(),
             )
             .await
-            {
-                Ok(block_result) => {
-                    if let Some(ref config) = enc_config {
-                        store_doc_encryption(&doc_id.to_string(), config.clone());
-                    }
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to write document blocks for create on collection {}: {}",
+                    collection_name, e
+                ))
+            })?;
 
-                    let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                    if collection.schema().is_branchable {
-                        match write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            block_result.cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        {
-                            Ok((col_cid, col_bytes)) => {
-                                col_block_data = Some((col_cid, col_bytes));
-                            }
-                            Err(e) => {
-                                warn!(
-                                    collection = %collection_name,
-                                    error = %e,
-                                    "Failed to write collection block for branchable create"
-                                );
-                            }
-                        }
-                    }
+            if let Some(ref config) = enc_config {
+                store_doc_encryption(&doc_id.to_string(), config.clone());
+            }
 
-                    Some((block_result.cid, block_result.block, col_block_data))
-                }
-                Err(e) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to write document blocks - commits queries may not work"
-                    );
-                    None
+            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+            if collection.schema().is_branchable {
+                match write_collection_block(
+                    &blockstore,
+                    &headstore,
+                    short_id,
+                    schema_version_id,
+                    block_result.cid,
+                    sign_config.as_ref(),
+                )
+                .await
+                {
+                    Ok((col_cid, col_bytes)) => {
+                        col_block_data = Some((col_cid, col_bytes));
+                    }
+                    Err(e) => {
+                        warn!(
+                            collection = %collection_name,
+                            error = %e,
+                            "Failed to write collection block for branchable create"
+                        );
+                    }
                 }
             }
+
+            (block_result.cid, block_result.block, col_block_data)
         };
 
-        if let Some((cid, _, _)) = commit_result.as_ref() {
-            self.register_update_callback(
-                collection.collection_id().to_string(),
-                collection.schema().is_branchable,
-                doc_id.to_string(),
-                *cid,
-            )
-            .await?;
-        }
+        self.register_update_callback(
+            collection.collection_id().to_string(),
+            doc_id.to_string(),
+            doc_cid,
+            doc_block.clone(),
+            col_block_data.clone(),
+        )
+        .await?;
 
-        match commit_result {
-            Some((cid, block, col_data)) => {
-                let mut result = CreateResult::with_commit(doc_id, doc, cid, block);
-                if let Some((col_cid, col_bytes)) = col_data {
-                    result.broadcast_cid = Some(col_cid);
-                    result.broadcast_block = Some(col_bytes);
-                }
-                Ok(result)
-            }
-            None => Ok(CreateResult::new(doc_id, doc)),
+        let mut result = CreateResult::with_commit(doc_id, doc, doc_cid, doc_block);
+        if let Some((col_cid, col_bytes)) = col_block_data {
+            result.broadcast_cid = Some(col_cid);
+            result.broadcast_block = Some(col_bytes);
         }
+        Ok(result)
     }
 
     async fn update(
@@ -278,10 +269,10 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             .or_else(|| doc.id().and_then(|id| get_doc_encryption(&id.to_string())));
         let sign_config = get_signing_config();
 
-        let commit_result: Option<(Cid, Vec<u8>, Option<(Cid, Vec<u8>)>)> = {
+        let (doc_cid, doc_block, col_block_data) = {
             let (blockstore, headstore) = self.block_and_head_stores().await?;
 
-            match write_document_blocks(
+            let block_result = write_document_blocks(
                 &blockstore,
                 &headstore,
                 &doc,
@@ -291,68 +282,59 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
                 sign_config.as_ref(),
             )
             .await
-            {
-                Ok(block_result) => {
-                    let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
-                    if collection.schema().is_branchable {
-                        match write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            block_result.cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        {
-                            Ok((col_cid, col_bytes)) => {
-                                col_block_data = Some((col_cid, col_bytes));
-                            }
-                            Err(e) => {
-                                warn!(
-                                    collection = %collection_name,
-                                    error = %e,
-                                    "Failed to write collection block for branchable update"
-                                );
-                            }
-                        }
-                    }
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to write document blocks for update on collection {}: {}",
+                    collection_name, e
+                ))
+            })?;
 
-                    Some((block_result.cid, block_result.block, col_block_data))
-                }
-                Err(e) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to write document blocks - commits queries may not work"
-                    );
-                    None
+            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+            if collection.schema().is_branchable {
+                match write_collection_block(
+                    &blockstore,
+                    &headstore,
+                    short_id,
+                    schema_version_id,
+                    block_result.cid,
+                    sign_config.as_ref(),
+                )
+                .await
+                {
+                    Ok((col_cid, col_bytes)) => {
+                        col_block_data = Some((col_cid, col_bytes));
+                    }
+                    Err(e) => {
+                        warn!(
+                            collection = %collection_name,
+                            error = %e,
+                            "Failed to write collection block for branchable update"
+                        );
+                    }
                 }
             }
+
+            (block_result.cid, block_result.block, col_block_data)
         };
 
-        if let (Some(doc_id), Some((cid, _, _))) = (doc.id(), commit_result.as_ref()) {
+        if let Some(doc_id) = doc.id() {
             self.register_update_callback(
                 collection.collection_id().to_string(),
-                collection.schema().is_branchable,
                 doc_id.to_string(),
-                *cid,
+                doc_cid,
+                doc_block.clone(),
+                col_block_data.clone(),
             )
             .await?;
         }
 
         let fields_modified = doc.values().len();
-        match commit_result {
-            Some((cid, block, col_data)) => {
-                let mut result = UpdateResult::with_commit(doc, fields_modified, cid, block);
-                if let Some((col_cid, col_bytes)) = col_data {
-                    result.broadcast_cid = Some(col_cid);
-                    result.broadcast_block = Some(col_bytes);
-                }
-                Ok(result)
-            }
-            None => Ok(UpdateResult::new(doc, fields_modified)),
+        let mut result = UpdateResult::with_commit(doc, fields_modified, doc_cid, doc_block);
+        if let Some((col_cid, col_bytes)) = col_block_data {
+            result.broadcast_cid = Some(col_cid);
+            result.broadcast_block = Some(col_bytes);
         }
+        Ok(result)
     }
 
     async fn delete(
@@ -369,14 +351,18 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))?;
 
+        if !existed {
+            return Ok(DeleteResult::new(doc_id.clone(), existed));
+        }
+
         let short_id = collection.resolved_root_id();
         let schema_version_id = collection.version_id();
         let sign_config = get_signing_config();
 
-        let commit_result: Option<(Cid, Vec<u8>)> = {
+        let (doc_cid, doc_block, col_block_data) = {
             let (blockstore, headstore) = self.block_and_head_stores().await?;
 
-            match write_delete_block(
+            let block_result = write_delete_block(
                 &blockstore,
                 &headstore,
                 &doc_id.to_string(),
@@ -384,62 +370,58 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
                 sign_config.as_ref(),
             )
             .await
-            {
-                Ok(block_result) => {
-                    let composite_cid = block_result.cid;
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to write delete block for collection {}: {}",
+                    collection_name, e
+                ))
+            })?;
 
-                    if collection.schema().is_branchable {
-                        if let Err(e) = write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            composite_cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        .map(|_| ())
-                        {
-                            warn!(
-                                collection = %collection_name,
-                                error = %e,
-                                "Failed to write collection block for branchable delete"
-                            );
-                        }
+            let composite_cid = block_result.cid;
+
+            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+            if collection.schema().is_branchable {
+                match write_collection_block(
+                    &blockstore,
+                    &headstore,
+                    short_id,
+                    schema_version_id,
+                    composite_cid,
+                    sign_config.as_ref(),
+                )
+                .await
+                {
+                    Ok((col_cid, col_bytes)) => {
+                        col_block_data = Some((col_cid, col_bytes));
                     }
-
-                    Some((composite_cid, block_result.block))
-                }
-                Err(e) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %e,
-                        "Failed to write delete block - commits queries may not work"
-                    );
-                    None
+                    Err(e) => {
+                        warn!(
+                            collection = %collection_name,
+                            error = %e,
+                            "Failed to write collection block for branchable delete"
+                        );
+                    }
                 }
             }
+
+            (composite_cid, block_result.block, col_block_data)
         };
 
-        if let Some((cid, _)) = commit_result.as_ref() {
-            self.register_update_callback(
-                collection.collection_id().to_string(),
-                collection.schema().is_branchable,
-                doc_id.to_string(),
-                *cid,
-            )
-            .await?;
-        }
+        self.register_update_callback(
+            collection.collection_id().to_string(),
+            doc_id.to_string(),
+            doc_cid,
+            doc_block.clone(),
+            col_block_data,
+        )
+        .await?;
 
-        match commit_result {
-            Some((cid, block)) => Ok(DeleteResult::with_commit(
-                doc_id.clone(),
-                existed,
-                cid,
-                block,
-            )),
-            None => Ok(DeleteResult::new(doc_id.clone(), existed)),
-        }
+        Ok(DeleteResult::with_commit(
+            doc_id.clone(),
+            existed,
+            doc_cid,
+            doc_block,
+        ))
     }
 
     async fn exists(&self, collection_name: &str, doc_id: &DocID) -> query::error::Result<bool> {
@@ -529,6 +511,10 @@ mod tests {
         let update = msg.as_update().expect("expected Update message");
         assert_eq!(update.doc_id, result.doc_id.to_string());
         assert_ne!(update.cid, cid::Cid::default(), "cid should be populated");
+        assert!(
+            !update.block.is_empty(),
+            "block bytes should be populated (matches Go's sendUpdate)"
+        );
     }
 
     #[tokio::test]
@@ -548,5 +534,41 @@ mod tests {
         // If the sealed constraint is relaxed in the future, replace this comment
         // with a real assertion: subscribe to the bus, run a create against a
         // faulty store, and assert no Update event arrives.
+    }
+
+    #[tokio::test]
+    async fn batch_delete_missing_doc_publishes_no_event_and_writes_no_block() {
+        // DeleteNode treats existed==false as a no-op; the mutator must not
+        // create a tombstone commit or fire an Update event for a missing doc.
+        let (db, bus) = make_test_db_with_bus().await;
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
+
+        let mut sub = bus.subscribe(&[EventName::Update]);
+
+        let txn = db.new_txn(false).await.expect("new_txn");
+        let txn_arc = Arc::new(TokioMutex::new(Some(txn)));
+        let mutator = BatchMutator::new(Arc::clone(&db), Arc::clone(&txn_arc));
+
+        let mut placeholder = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
+        placeholder
+            .generate_and_set_doc_id()
+            .expect("generate doc id");
+        let missing_doc_id = placeholder.id().cloned().expect("doc id");
+
+        let result = mutator
+            .delete("TestDoc", &missing_doc_id)
+            .await
+            .expect("delete should succeed even on missing doc");
+        assert!(!result.existed, "doc should not have existed");
+
+        mutator.commit().await.expect("commit");
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            sub.try_recv().is_err(),
+            "deleting a non-existent doc should not publish an Update event"
+        );
     }
 }

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -53,8 +53,10 @@ impl<S: Store> BatchMutator<S> {
 }
 
 impl<S: Store + 'static> BatchMutator<S> {
+    #[allow(clippy::too_many_arguments)]
     async fn register_update_callback(
         &self,
+        collection_name: String,
         collection_id: String,
         doc_id: String,
         doc_cid: Cid,
@@ -68,11 +70,16 @@ impl<S: Store + 'static> BatchMutator<S> {
         register_update_event_callback(
             txn,
             self.db.event_bus(),
+            // BatchMutator is the auto-commit-batch path; broadcast is handled
+            // by the BroadcastMutator wrapper at the per-mutation layer.
+            None,
+            collection_name,
             collection_id,
             doc_id,
             doc_cid,
             doc_block,
             collection_block,
+            None,
         )
         .map_err(|e| {
             query::error::QueryError::execution(format!(
@@ -202,6 +209,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         };
 
         self.register_update_callback(
+            collection_name.to_string(),
             collection.collection_id().to_string(),
             doc_id.to_string(),
             doc_cid,
@@ -319,6 +327,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
 
         if let Some(doc_id) = doc.id() {
             self.register_update_callback(
+                collection_name.to_string(),
                 collection.collection_id().to_string(),
                 doc_id.to_string(),
                 doc_cid,
@@ -408,6 +417,7 @@ impl<S: Store + 'static> DocMutator for BatchMutator<S> {
         };
 
         self.register_update_callback(
+            collection_name.to_string(),
             collection.collection_id().to_string(),
             doc_id.to_string(),
             doc_cid,

--- a/crates/db/src/auto_commit_mutator/create.rs
+++ b/crates/db/src/auto_commit_mutator/create.rs
@@ -179,12 +179,18 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     )));
                 }
 
-                // Emit update event for subscriptions
-                let cid = commit_result
-                    .as_ref()
-                    .map(|(c, _, _)| *c)
-                    .unwrap_or_default();
-                self.emit_update_events(&collection, &doc_id.to_string(), cid);
+                // Emit update event for subscriptions when blocks were written.
+                // Skipping the default-cid emit avoids publishing a misleading
+                // Update on the block-write failure path.
+                if let Some((cid, block, col_data)) = commit_result.as_ref() {
+                    self.emit_update_events(
+                        &collection,
+                        &doc_id.to_string(),
+                        *cid,
+                        block.clone(),
+                        col_data.clone(),
+                    );
+                }
 
                 // Return result with commit CID and block if available
                 match commit_result {

--- a/crates/db/src/auto_commit_mutator/create_many.rs
+++ b/crates/db/src/auto_commit_mutator/create_many.rs
@@ -237,11 +237,15 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
         // Emit events and build results
         let mut create_results = Vec::with_capacity(results.len());
         for (doc_id, doc, commit_result) in results {
-            let cid = commit_result
-                .as_ref()
-                .map(|(c, _, _)| *c)
-                .unwrap_or_default();
-            self.emit_update_events(&collection, &doc_id.to_string(), cid);
+            if let Some((cid, block, col_data)) = commit_result.as_ref() {
+                self.emit_update_events(
+                    &collection,
+                    &doc_id.to_string(),
+                    *cid,
+                    block.clone(),
+                    col_data.clone(),
+                );
+            }
 
             match commit_result {
                 Some((cid, block, col_data)) => {

--- a/crates/db/src/auto_commit_mutator/delete.rs
+++ b/crates/db/src/auto_commit_mutator/delete.rs
@@ -159,12 +159,15 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 }
 
                 match commit_result {
-                    Some((cid, block, _col_data)) => Ok(DeleteResult::with_commit(
-                        doc_id.clone(),
-                        existed,
-                        cid,
-                        block,
-                    )),
+                    Some((cid, block, col_data)) => {
+                        let mut result =
+                            DeleteResult::with_commit(doc_id.clone(), existed, cid, block);
+                        if let Some((col_cid, col_bytes)) = col_data {
+                            result.broadcast_cid = Some(col_cid);
+                            result.broadcast_block = Some(col_bytes);
+                        }
+                        Ok(result)
+                    }
                     None => Ok(DeleteResult::new(doc_id.clone(), existed)),
                 }
             }

--- a/crates/db/src/auto_commit_mutator/delete.rs
+++ b/crates/db/src/auto_commit_mutator/delete.rs
@@ -43,8 +43,21 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
 
         match result {
             Ok(existed) => {
+                // DeleteNode treats existed==false as a no-op; don't write a
+                // tombstone block or emit an event for a missing doc.
+                if !existed {
+                    if let Err(e) = txn.commit().await {
+                        warn!(
+                            collection = %collection_name,
+                            error = %e,
+                            "Failed to commit transaction after no-op delete"
+                        );
+                    }
+                    return Ok(DeleteResult::new(doc_id.clone(), existed));
+                }
+
                 // Build delete block (composite with status=2) in a scoped block
-                let commit_result: Option<(Cid, Vec<u8>)> = {
+                let commit_result: Option<CommitArtifacts> = {
                     let blockstore = txn.blockstore().map_err(|e| {
                         query::error::QueryError::execution(format!(
                             "failed to get blockstore: {}",
@@ -75,10 +88,10 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                         Ok(block_result) => {
                             let composite_cid = block_result.cid;
 
-                            // For branchable collections, also create a collection-level block
+                            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
                             if collection.schema().is_branchable {
                                 let short_id = collection.resolved_root_id();
-                                if let Err(e) = write_collection_block(
+                                match write_collection_block(
                                     &blockstore,
                                     &headstore,
                                     short_id,
@@ -87,17 +100,21 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                                     sign_config.as_ref(),
                                 )
                                 .await
-                                .map(|_| ())
                                 {
-                                    warn!(
-                                        collection = %collection_name,
-                                        error = %e,
-                                        "Failed to write collection block for branchable delete"
-                                    );
+                                    Ok((col_cid, col_bytes)) => {
+                                        col_block_data = Some((col_cid, col_bytes));
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            collection = %collection_name,
+                                            error = %e,
+                                            "Failed to write collection block for branchable delete"
+                                        );
+                                    }
                                 }
                             }
 
-                            Some((composite_cid, block_result.block))
+                            Some((composite_cid, block_result.block, col_block_data))
                         }
                         Err(e) => {
                             warn!(
@@ -123,12 +140,19 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     )));
                 }
 
-                // Emit update event for subscriptions (deletes are also "updates")
-                let cid = commit_result.as_ref().map(|(c, _)| *c).unwrap_or_default();
-                self.emit_update_events(&collection, &doc_id.to_string(), cid);
+                // Emit update event for subscriptions when blocks were written.
+                if let Some((cid, block, col_data)) = commit_result.as_ref() {
+                    self.emit_update_events(
+                        &collection,
+                        &doc_id.to_string(),
+                        *cid,
+                        block.clone(),
+                        col_data.clone(),
+                    );
+                }
 
                 match commit_result {
-                    Some((cid, block)) => Ok(DeleteResult::with_commit(
+                    Some((cid, block, _col_data)) => Ok(DeleteResult::with_commit(
                         doc_id.clone(),
                         existed,
                         cid,

--- a/crates/db/src/auto_commit_mutator/delete.rs
+++ b/crates/db/src/auto_commit_mutator/delete.rs
@@ -45,6 +45,9 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             Ok(existed) => {
                 // DeleteNode treats existed==false as a no-op; don't write a
                 // tombstone block or emit an event for a missing doc.
+                // Propagate any commit error so callers see the same failure
+                // surface they get on the normal commit path (Go returns the
+                // commit error on a no-op delete too).
                 if !existed {
                     if let Err(e) = txn.commit().await {
                         warn!(
@@ -52,6 +55,10 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                             error = %e,
                             "Failed to commit transaction after no-op delete"
                         );
+                        return Err(query::error::QueryError::execution(format!(
+                            "commit error: {}",
+                            e
+                        )));
                     }
                     return Ok(DeleteResult::new(doc_id.clone(), existed));
                 }

--- a/crates/db/src/auto_commit_mutator/delete_many.rs
+++ b/crates/db/src/auto_commit_mutator/delete_many.rs
@@ -43,7 +43,8 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             query::error::QueryError::execution(format!("failed to create txn: {}", e))
         })?;
 
-        let mut results: Vec<(DocID, bool, Option<Cid>)> = Vec::with_capacity(doc_ids.len());
+        let mut results: Vec<(DocID, bool, Option<CommitArtifacts>)> =
+            Vec::with_capacity(doc_ids.len());
 
         for doc_id in doc_ids {
             // Delete from datastore + indexes
@@ -73,8 +74,15 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 }
             };
 
+            // Skip block-write and event emit for missing docs; DeleteNode
+            // treats existed==false as a no-op.
+            if !existed {
+                results.push((doc_id.clone(), existed, None));
+                continue;
+            }
+
             // Write delete block (composite with status=2)
-            let commit_cid = {
+            let commit_result: Option<CommitArtifacts> = {
                 let blockstore = txn.blockstore().map_err(|e| {
                     query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
                 })?;
@@ -94,8 +102,9 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     Ok(block_result) => {
                         let composite_cid = block_result.cid;
 
+                        let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
                         if collection.schema().is_branchable {
-                            if let Err(e) = write_collection_block(
+                            match write_collection_block(
                                 &blockstore,
                                 &headstore,
                                 short_id,
@@ -105,15 +114,20 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                             )
                             .await
                             {
-                                warn!(
-                                    collection = %collection_name,
-                                    error = %e,
-                                    "Failed to write collection block for branchable delete"
-                                );
+                                Ok((col_cid, col_bytes)) => {
+                                    col_block_data = Some((col_cid, col_bytes));
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        collection = %collection_name,
+                                        error = %e,
+                                        "Failed to write collection block for branchable delete"
+                                    );
+                                }
                             }
                         }
 
-                        Some(composite_cid)
+                        Some((composite_cid, block_result.block, col_block_data))
                     }
                     Err(e) => {
                         warn!(
@@ -127,7 +141,7 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                 }
             };
 
-            results.push((doc_id.clone(), existed, commit_cid));
+            results.push((doc_id.clone(), existed, commit_result));
         }
 
         // Single commit for entire batch
@@ -143,11 +157,12 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             )));
         }
 
-        // Emit events after commit
+        // Emit events after commit, only when blocks were written.
         let mut delete_results = Vec::with_capacity(results.len());
-        for (doc_id, existed, commit_cid) in results {
-            let cid = commit_cid.unwrap_or_default();
-            self.emit_update_events(&collection, &doc_id.to_string(), cid);
+        for (doc_id, existed, commit_result) in results {
+            if let Some((cid, block, col_data)) = commit_result {
+                self.emit_update_events(&collection, &doc_id.to_string(), cid, block, col_data);
+            }
             delete_results.push(DeleteResult::new(doc_id, existed));
         }
 

--- a/crates/db/src/auto_commit_mutator/helpers.rs
+++ b/crates/db/src/auto_commit_mutator/helpers.rs
@@ -33,28 +33,38 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))
     }
 
-    /// Emit update events for subscriptions.
+    /// Emit update events for subscriptions, carrying the actual block bytes
+    /// so downstream consumers can traverse the DAG without an extra fetch.
     ///
-    /// For branchable collections, emits a second event for the collection-level DAG.
-    pub(super) fn emit_update_events(&self, collection: &Collection, doc_id_str: &str, cid: Cid) {
+    /// For branchable collections, emits a second event keyed by collection_id
+    /// using the collection block's own cid/bytes (Go publishes the collection
+    /// block separately at internal/db/collection.go:789).
+    pub(super) fn emit_update_events(
+        &self,
+        collection: &Collection,
+        doc_id_str: &str,
+        doc_cid: Cid,
+        doc_block: Vec<u8>,
+        collection_block: Option<(Cid, Vec<u8>)>,
+    ) {
         if let Some(bus) = self.db.event_bus() {
             let update = Update::new(
                 doc_id_str.to_string(),
-                cid,
+                doc_cid,
                 collection.collection_id().to_string(),
-                vec![],
+                doc_block,
                 false, // is_retry
                 false, // is_relay (local mutation)
             );
             bus.publish(Message::update(update));
 
-            if collection.schema().is_branchable {
+            if let Some((col_cid, col_block)) = collection_block {
                 let col_update = Update::new_with_subject_doc_id(
                     String::new(), // empty doc_id → keyed by collection_id
                     doc_id_str.to_string(),
-                    cid,
+                    col_cid,
                     collection.collection_id().to_string(),
-                    vec![],
+                    col_block,
                     false,
                     false,
                 );

--- a/crates/db/src/auto_commit_mutator/mod.rs
+++ b/crates/db/src/auto_commit_mutator/mod.rs
@@ -27,6 +27,10 @@ use crate::block_builder::{write_collection_block, write_delete_block, write_doc
 use crate::database::DB;
 use crate::index_manager::IndexManager;
 use crate::lensed_fetcher::LensedDocFetcher;
+
+/// Captured per-mutation commit data: the document block (cid + bytes) plus,
+/// for branchable collections, the collection block (cid + bytes).
+pub(super) type CommitArtifacts = (Cid, Vec<u8>, Option<(Cid, Vec<u8>)>);
 use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
 use defra_core::signing::get_signing_config;
 

--- a/crates/db/src/auto_commit_mutator/update.rs
+++ b/crates/db/src/auto_commit_mutator/update.rs
@@ -173,13 +173,17 @@ impl<S: Store + 'static> AutoCommitMutator<S> {
                     )));
                 }
 
-                // Emit update event for subscriptions
-                if let Some(doc_id) = doc.id() {
-                    let cid = commit_result
-                        .as_ref()
-                        .map(|(c, _, _)| *c)
-                        .unwrap_or_default();
-                    self.emit_update_events(&collection, &doc_id.to_string(), cid);
+                // Emit update event for subscriptions when blocks were written.
+                if let (Some(doc_id), Some((cid, block, col_data))) =
+                    (doc.id(), commit_result.as_ref())
+                {
+                    self.emit_update_events(
+                        &collection,
+                        &doc_id.to_string(),
+                        *cid,
+                        block.clone(),
+                        col_data.clone(),
+                    );
                 }
 
                 // Count modified fields

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -48,6 +48,7 @@ use defra_core::signing::get_signing_config;
 pub struct DbDocMutator<S: Store> {
     db: Arc<DB<S>>,
     txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
+    broadcaster: Option<Arc<dyn crate::event_emission::TxnBroadcaster>>,
 }
 
 impl<S: Store> DbDocMutator<S> {
@@ -58,15 +59,24 @@ impl<S: Store> DbDocMutator<S> {
         Self {
             db,
             txn: Arc::new(TokioMutex::new(Some(txn))),
+            broadcaster: None,
         }
     }
 
-    /// Create a mutator that shares a transaction with an existing component.
-    ///
-    /// This is used by `DbTransactionContext` to create a mutator that shares
-    /// the same transaction as the `DbDocFetcher`.
-    pub(crate) fn from_shared_txn(db: Arc<DB<S>>, txn: Arc<TokioMutex<Option<DbTxn<S>>>>) -> Self {
-        Self { db, txn }
+    /// Create a mutator that shares a transaction and (optionally) forwards
+    /// committed writes to a `TxnBroadcaster`. When `broadcaster` is `Some`,
+    /// each per-mutation `on_success_async` callback both publishes to the
+    /// local event bus and asks the broadcaster to push to P2P peers.
+    pub(crate) fn from_shared_txn_with_broadcaster(
+        db: Arc<DB<S>>,
+        txn: Arc<TokioMutex<Option<DbTxn<S>>>>,
+        broadcaster: Option<Arc<dyn crate::event_emission::TxnBroadcaster>>,
+    ) -> Self {
+        Self {
+            db,
+            txn,
+            broadcaster,
+        }
     }
 
     /// Take the transaction out of the mutator (for commit/rollback).
@@ -119,8 +129,10 @@ impl<S: Store> DbDocMutator<S> {
 }
 
 impl<S: Store + 'static> DbDocMutator<S> {
+    #[allow(clippy::too_many_arguments)]
     async fn register_update_callback(
         &self,
+        collection_name: String,
         collection_id: String,
         doc_id: String,
         doc_cid: Cid,
@@ -131,14 +143,18 @@ impl<S: Store + 'static> DbDocMutator<S> {
         let txn = txn_guard.as_mut().ok_or_else(|| {
             query::error::QueryError::execution("transaction is no longer active")
         })?;
+        let creator_did = defra_core::signing::get_broadcast_creator_did();
         register_update_event_callback(
             txn,
             self.db.event_bus(),
+            self.broadcaster.as_ref(),
+            collection_name,
             collection_id,
             doc_id,
             doc_cid,
             doc_block,
             collection_block,
+            creator_did,
         )
         .map_err(|e| {
             query::error::QueryError::execution(format!(
@@ -255,6 +271,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         };
 
         self.register_update_callback(
+            collection_name.to_string(),
             collection.collection_id().to_string(),
             doc_id.to_string(),
             doc_cid,
@@ -363,6 +380,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
 
         if let Some(doc_id) = doc.id().cloned() {
             self.register_update_callback(
+                collection_name.to_string(),
                 collection.collection_id().to_string(),
                 doc_id.to_string(),
                 doc_cid,
@@ -456,6 +474,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         };
 
         self.register_update_callback(
+            collection_name.to_string(),
             collection.collection_id().to_string(),
             doc_id.to_string(),
             doc_cid,
@@ -616,6 +635,103 @@ mod tests {
         assert!(
             sub.try_recv().is_err(),
             "deleting a non-existent doc should not publish an Update event"
+        );
+    }
+
+    /// `TxnBroadcaster` test double: captures every event it's asked to
+    /// broadcast for inspection.
+    struct CapturingBroadcaster {
+        events: Arc<std::sync::Mutex<Vec<crate::event_emission::TxnBroadcastEvent>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::event_emission::TxnBroadcaster for CapturingBroadcaster {
+        async fn broadcast_update(&self, event: crate::event_emission::TxnBroadcastEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    #[tokio::test]
+    async fn create_in_tx_forwards_to_broadcaster_on_commit() {
+        // F1 regression: a tx with a TxnBroadcaster wired in must invoke
+        // broadcast_update for each committed mutation so P2P peers see
+        // transactional writes (Go: db.sendUpdate → p2p.SendUpdate).
+        let (db, _bus) = make_test_db_with_bus().await;
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
+
+        let captured: Arc<std::sync::Mutex<Vec<crate::event_emission::TxnBroadcastEvent>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let broadcaster: Arc<dyn crate::event_emission::TxnBroadcaster> =
+            Arc::new(CapturingBroadcaster {
+                events: Arc::clone(&captured),
+            });
+
+        let txn = db.new_txn(false).await.expect("new_txn");
+        let txn_arc = Arc::new(TokioMutex::new(Some(txn)));
+        let mutator = DbDocMutator::from_shared_txn_with_broadcaster(
+            Arc::clone(&db),
+            txn_arc,
+            Some(broadcaster),
+        );
+
+        let doc = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
+        let result = mutator.create("TestDoc", doc).await.expect("create");
+
+        // Broadcaster must NOT see anything before commit
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "no broadcast before commit"
+        );
+
+        let txn = mutator.take_txn().await.expect("take txn");
+        txn.commit().await.expect("commit");
+
+        // Wait briefly for the on_success_async callback to fire
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let events = captured.lock().unwrap().clone();
+        assert_eq!(events.len(), 1, "exactly one broadcast after commit");
+        let event = &events[0];
+        assert_eq!(event.doc_id, result.doc_id.to_string());
+        assert_eq!(event.collection_name, "TestDoc");
+        assert_ne!(event.doc_cid, cid::Cid::default(), "doc_cid populated");
+        assert!(!event.doc_block.is_empty(), "doc_block populated");
+    }
+
+    #[tokio::test]
+    async fn create_in_tx_does_not_broadcast_on_discard() {
+        let (db, _bus) = make_test_db_with_bus().await;
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
+
+        let captured: Arc<std::sync::Mutex<Vec<crate::event_emission::TxnBroadcastEvent>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let broadcaster: Arc<dyn crate::event_emission::TxnBroadcaster> =
+            Arc::new(CapturingBroadcaster {
+                events: Arc::clone(&captured),
+            });
+
+        let txn = db.new_txn(false).await.expect("new_txn");
+        let txn_arc = Arc::new(TokioMutex::new(Some(txn)));
+        let mutator = DbDocMutator::from_shared_txn_with_broadcaster(
+            Arc::clone(&db),
+            txn_arc,
+            Some(broadcaster),
+        );
+
+        let doc = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
+        mutator.create("TestDoc", doc).await.expect("create");
+
+        let txn = mutator.take_txn().await.expect("take txn");
+        txn.discard().expect("discard");
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "discard should not trigger broadcast"
         );
     }
 }

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -308,9 +308,8 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             })?;
 
             let schema_version_id = collection.version_id();
-            let enc_config = get_encryption_config().or_else(|| {
-                doc.id().and_then(|id| get_doc_encryption(&id.to_string()))
-            });
+            let enc_config = get_encryption_config()
+                .or_else(|| doc.id().and_then(|id| get_doc_encryption(&id.to_string())));
             let sign_config = get_signing_config();
 
             match write_document_blocks(
@@ -514,7 +513,9 @@ mod tests {
     #[tokio::test]
     async fn create_in_tx_publishes_event_on_commit() {
         let (db, bus) = make_test_db_with_bus().await;
-        db.create_collection(test_collection()).await.expect("schema");
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
 
         let mut sub = bus.subscribe(&[EventName::Update]);
 
@@ -534,13 +535,10 @@ mod tests {
         txn.commit().await.expect("commit");
 
         // After commit: one Update event arrives
-        let msg = tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            sub.recv(),
-        )
-        .await
-        .expect("event arrived within timeout")
-        .expect("subscription not closed");
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(1), sub.recv())
+            .await
+            .expect("event arrived within timeout")
+            .expect("subscription not closed");
 
         let update = msg.as_update().expect("expected Update message");
         assert_eq!(update.doc_id, result.doc_id.to_string());
@@ -550,7 +548,9 @@ mod tests {
     #[tokio::test]
     async fn create_in_tx_publishes_no_event_on_discard() {
         let (db, bus) = make_test_db_with_bus().await;
-        db.create_collection(test_collection()).await.expect("schema");
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
 
         let mut sub = bus.subscribe(&[EventName::Update]);
 
@@ -565,9 +565,6 @@ mod tests {
 
         // Allow a brief window for any (unexpected) async delivery
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert!(
-            sub.try_recv().is_err(),
-            "discard should not publish events"
-        );
+        assert!(sub.try_recv().is_err(), "discard should not publish events");
     }
 }

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -2,6 +2,7 @@
 
 use async_lock::Mutex as TokioMutex;
 use async_trait::async_trait;
+use cid::Cid;
 use document::{DocID, Document};
 use query::mutator::{CreateResult, DeleteResult, DocMutator, UpdateResult};
 use std::sync::Arc;
@@ -12,6 +13,7 @@ use crate::block_builder::{write_collection_block, write_delete_block, write_doc
 use crate::collection::Collection;
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
+use crate::event_emission::register_update_event_callback;
 use crate::txn::DbTxn;
 use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
 use defra_core::signing::get_signing_config;
@@ -116,6 +118,35 @@ impl<S: Store> DbDocMutator<S> {
     }
 }
 
+impl<S: Store + 'static> DbDocMutator<S> {
+    async fn register_update_callback(
+        &self,
+        collection_id: String,
+        branchable: bool,
+        doc_id: String,
+        cid: Cid,
+    ) -> query::error::Result<()> {
+        let mut txn_guard = self.txn.lock().await;
+        let txn = txn_guard.as_mut().ok_or_else(|| {
+            query::error::QueryError::execution("transaction is no longer active")
+        })?;
+        register_update_event_callback(
+            txn,
+            self.db.event_bus(),
+            collection_id,
+            branchable,
+            doc_id,
+            cid,
+        )
+        .map_err(|e| {
+            query::error::QueryError::execution(format!(
+                "failed to register tx update callback: {}",
+                e
+            ))
+        })
+    }
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
@@ -154,7 +185,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await
             .map_err(|e| crate::error::index_write_query_error("create", e))?;
 
-        {
+        let commit_cid: Option<Cid> = {
             let txn_guard = self.txn.lock().await;
             let txn = txn_guard.as_ref().ok_or_else(|| {
                 query::error::QueryError::execution("transaction is no longer active")
@@ -206,6 +237,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                             );
                         }
                     }
+                    Some(block_result.cid)
                 }
                 Err(error) => {
                     warn!(
@@ -213,8 +245,19 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                         error = %error,
                         "Failed to write document blocks for transaction create"
                     );
+                    None
                 }
             }
+        };
+
+        if let Some(cid) = commit_cid {
+            self.register_update_callback(
+                collection.collection_id().to_string(),
+                collection.schema().is_branchable,
+                doc_id.to_string(),
+                cid,
+            )
+            .await?;
         }
 
         Ok(CreateResult::new(doc_id, doc))
@@ -251,7 +294,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 other => crate::error::index_write_query_error("update", other),
             })?;
 
-        let commit_cid: Option<cid::Cid> = {
+        let commit_cid: Option<Cid> = {
             let txn_guard = self.txn.lock().await;
             let txn = txn_guard.as_ref().ok_or_else(|| {
                 query::error::QueryError::execution("transaction is no longer active")
@@ -314,7 +357,15 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             }
         };
 
-        let _ = commit_cid;
+        if let (Some(doc_id), Some(cid)) = (doc.id().cloned(), commit_cid) {
+            self.register_update_callback(
+                collection.collection_id().to_string(),
+                collection.schema().is_branchable,
+                doc_id.to_string(),
+                cid,
+            )
+            .await?;
+        }
 
         let fields_modified = modified_fields.len();
         Ok(UpdateResult::new(doc, fields_modified))
@@ -335,7 +386,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))?;
 
-        let commit_cid: Option<cid::Cid> = {
+        let commit_cid: Option<Cid> = {
             let txn_guard = self.txn.lock().await;
             let txn = txn_guard.as_ref().ok_or_else(|| {
                 query::error::QueryError::execution("transaction is no longer active")
@@ -393,7 +444,15 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             }
         };
 
-        let _ = commit_cid;
+        if let Some(cid) = commit_cid {
+            self.register_update_callback(
+                collection.collection_id().to_string(),
+                collection.schema().is_branchable,
+                doc_id.to_string(),
+                cid,
+            )
+            .await?;
+        }
 
         Ok(DeleteResult::new(doc_id.clone(), existed))
     }

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -122,9 +122,10 @@ impl<S: Store + 'static> DbDocMutator<S> {
     async fn register_update_callback(
         &self,
         collection_id: String,
-        branchable: bool,
         doc_id: String,
-        cid: Cid,
+        doc_cid: Cid,
+        doc_block: Vec<u8>,
+        collection_block: Option<(Cid, Vec<u8>)>,
     ) -> query::error::Result<()> {
         let mut txn_guard = self.txn.lock().await;
         let txn = txn_guard.as_mut().ok_or_else(|| {
@@ -134,9 +135,10 @@ impl<S: Store + 'static> DbDocMutator<S> {
             txn,
             self.db.event_bus(),
             collection_id,
-            branchable,
             doc_id,
-            cid,
+            doc_cid,
+            doc_block,
+            collection_block,
         )
         .map_err(|e| {
             query::error::QueryError::execution(format!(
@@ -185,7 +187,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await
             .map_err(|e| crate::error::index_write_query_error("create", e))?;
 
-        let commit_cid: Option<Cid> = {
+        let (doc_cid, doc_block, col_block_data) = {
             let txn_guard = self.txn.lock().await;
             let txn = txn_guard.as_ref().ok_or_else(|| {
                 query::error::QueryError::execution("transaction is no longer active")
@@ -202,7 +204,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             let enc_config = get_encryption_config();
             let sign_config = get_signing_config();
 
-            match write_document_blocks(
+            let block_result = write_document_blocks(
                 &blockstore,
                 &headstore,
                 &doc,
@@ -212,53 +214,54 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 sign_config.as_ref(),
             )
             .await
-            {
-                Ok(block_result) => {
-                    if let Some(ref config) = enc_config {
-                        store_doc_encryption(&doc_id.to_string(), config.clone());
-                    }
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to write document blocks for transaction create on collection {}: {}",
+                    collection_name, e
+                ))
+            })?;
 
-                    if collection.schema().is_branchable {
-                        let short_id = collection.resolved_root_id();
-                        if let Err(error) = write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            block_result.cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        {
-                            warn!(
-                                collection = %collection_name,
-                                error = %error,
-                                "Failed to write collection block for transaction create"
-                            );
-                        }
+            if let Some(ref config) = enc_config {
+                store_doc_encryption(&doc_id.to_string(), config.clone());
+            }
+
+            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+            if collection.schema().is_branchable {
+                let short_id = collection.resolved_root_id();
+                match write_collection_block(
+                    &blockstore,
+                    &headstore,
+                    short_id,
+                    schema_version_id,
+                    block_result.cid,
+                    sign_config.as_ref(),
+                )
+                .await
+                {
+                    Ok((col_cid, col_bytes)) => {
+                        col_block_data = Some((col_cid, col_bytes));
                     }
-                    Some(block_result.cid)
-                }
-                Err(error) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %error,
-                        "Failed to write document blocks for transaction create"
-                    );
-                    None
+                    Err(error) => {
+                        warn!(
+                            collection = %collection_name,
+                            error = %error,
+                            "Failed to write collection block for transaction create"
+                        );
+                    }
                 }
             }
+
+            (block_result.cid, block_result.block, col_block_data)
         };
 
-        if let Some(cid) = commit_cid {
-            self.register_update_callback(
-                collection.collection_id().to_string(),
-                collection.schema().is_branchable,
-                doc_id.to_string(),
-                cid,
-            )
-            .await?;
-        }
+        self.register_update_callback(
+            collection.collection_id().to_string(),
+            doc_id.to_string(),
+            doc_cid,
+            doc_block,
+            col_block_data,
+        )
+        .await?;
 
         Ok(CreateResult::new(doc_id, doc))
     }
@@ -294,7 +297,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 other => crate::error::index_write_query_error("update", other),
             })?;
 
-        let commit_cid: Option<Cid> = {
+        let (doc_cid, doc_block, col_block_data) = {
             let txn_guard = self.txn.lock().await;
             let txn = txn_guard.as_ref().ok_or_else(|| {
                 query::error::QueryError::execution("transaction is no longer active")
@@ -312,7 +315,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 .or_else(|| doc.id().and_then(|id| get_doc_encryption(&id.to_string())));
             let sign_config = get_signing_config();
 
-            match write_document_blocks(
+            let block_result = write_document_blocks(
                 &blockstore,
                 &headstore,
                 &doc,
@@ -322,46 +325,49 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 sign_config.as_ref(),
             )
             .await
-            {
-                Ok(block_result) => {
-                    if collection.schema().is_branchable {
-                        let short_id = collection.resolved_root_id();
-                        if let Err(error) = write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            block_result.cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        {
-                            warn!(
-                                collection = %collection_name,
-                                error = %error,
-                                "Failed to write collection block for transaction update"
-                            );
-                        }
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to write document blocks for transaction update on collection {}: {}",
+                    collection_name, e
+                ))
+            })?;
+
+            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+            if collection.schema().is_branchable {
+                let short_id = collection.resolved_root_id();
+                match write_collection_block(
+                    &blockstore,
+                    &headstore,
+                    short_id,
+                    schema_version_id,
+                    block_result.cid,
+                    sign_config.as_ref(),
+                )
+                .await
+                {
+                    Ok((col_cid, col_bytes)) => {
+                        col_block_data = Some((col_cid, col_bytes));
                     }
-                    Some(block_result.cid)
-                }
-                Err(error) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %error,
-                        "Failed to write document blocks for transaction update"
-                    );
-                    None
+                    Err(error) => {
+                        warn!(
+                            collection = %collection_name,
+                            error = %error,
+                            "Failed to write collection block for transaction update"
+                        );
+                    }
                 }
             }
+
+            (block_result.cid, block_result.block, col_block_data)
         };
 
-        if let (Some(doc_id), Some(cid)) = (doc.id().cloned(), commit_cid) {
+        if let Some(doc_id) = doc.id().cloned() {
             self.register_update_callback(
                 collection.collection_id().to_string(),
-                collection.schema().is_branchable,
                 doc_id.to_string(),
-                cid,
+                doc_cid,
+                doc_block,
+                col_block_data,
             )
             .await?;
         }
@@ -385,7 +391,11 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))?;
 
-        let commit_cid: Option<Cid> = {
+        if !existed {
+            return Ok(DeleteResult::new(doc_id.clone(), existed));
+        }
+
+        let (doc_cid, doc_block, col_block_data) = {
             let txn_guard = self.txn.lock().await;
             let txn = txn_guard.as_ref().ok_or_else(|| {
                 query::error::QueryError::execution("transaction is no longer active")
@@ -401,7 +411,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             let schema_version_id = collection.version_id();
             let sign_config = get_signing_config();
 
-            match write_delete_block(
+            let block_result = write_delete_block(
                 &blockstore,
                 &headstore,
                 &doc_id.to_string(),
@@ -409,49 +419,50 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 sign_config.as_ref(),
             )
             .await
-            {
-                Ok(block_result) => {
-                    if collection.schema().is_branchable {
-                        let short_id = collection.resolved_root_id();
-                        if let Err(error) = write_collection_block(
-                            &blockstore,
-                            &headstore,
-                            short_id,
-                            schema_version_id,
-                            block_result.cid,
-                            sign_config.as_ref(),
-                        )
-                        .await
-                        {
-                            warn!(
-                                collection = %collection_name,
-                                error = %error,
-                                "Failed to write collection block for transaction delete"
-                            );
-                        }
+            .map_err(|e| {
+                query::error::QueryError::execution(format!(
+                    "failed to write delete block for transaction delete on collection {}: {}",
+                    collection_name, e
+                ))
+            })?;
+
+            let mut col_block_data: Option<(Cid, Vec<u8>)> = None;
+            if collection.schema().is_branchable {
+                let short_id = collection.resolved_root_id();
+                match write_collection_block(
+                    &blockstore,
+                    &headstore,
+                    short_id,
+                    schema_version_id,
+                    block_result.cid,
+                    sign_config.as_ref(),
+                )
+                .await
+                {
+                    Ok((col_cid, col_bytes)) => {
+                        col_block_data = Some((col_cid, col_bytes));
                     }
-                    Some(block_result.cid)
-                }
-                Err(error) => {
-                    warn!(
-                        collection = %collection_name,
-                        error = %error,
-                        "Failed to write delete block for transaction delete"
-                    );
-                    None
+                    Err(error) => {
+                        warn!(
+                            collection = %collection_name,
+                            error = %error,
+                            "Failed to write collection block for transaction delete"
+                        );
+                    }
                 }
             }
+
+            (block_result.cid, block_result.block, col_block_data)
         };
 
-        if let Some(cid) = commit_cid {
-            self.register_update_callback(
-                collection.collection_id().to_string(),
-                collection.schema().is_branchable,
-                doc_id.to_string(),
-                cid,
-            )
-            .await?;
-        }
+        self.register_update_callback(
+            collection.collection_id().to_string(),
+            doc_id.to_string(),
+            doc_cid,
+            doc_block,
+            col_block_data,
+        )
+        .await?;
 
         Ok(DeleteResult::new(doc_id.clone(), existed))
     }
@@ -543,6 +554,10 @@ mod tests {
         let update = msg.as_update().expect("expected Update message");
         assert_eq!(update.doc_id, result.doc_id.to_string());
         assert_ne!(update.cid, cid::Cid::default(), "cid should be populated");
+        assert!(
+            !update.block.is_empty(),
+            "block bytes should be populated (matches Go's sendUpdate)"
+        );
     }
 
     #[tokio::test]
@@ -566,5 +581,41 @@ mod tests {
         // Allow a brief window for any (unexpected) async delivery
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert!(sub.try_recv().is_err(), "discard should not publish events");
+    }
+
+    #[tokio::test]
+    async fn delete_missing_doc_publishes_no_event_and_writes_no_block() {
+        // DeleteNode treats existed==false as a no-op; the mutator must not
+        // create a tombstone commit or fire an Update event for a missing doc.
+        let (db, bus) = make_test_db_with_bus().await;
+        db.create_collection(test_collection())
+            .await
+            .expect("schema");
+
+        let mut sub = bus.subscribe(&[EventName::Update]);
+
+        let txn = db.new_txn(false).await.expect("new_txn");
+        let mutator = DbDocMutator::new(Arc::clone(&db), txn);
+
+        let mut placeholder = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
+        placeholder
+            .generate_and_set_doc_id()
+            .expect("generate doc id");
+        let missing_doc_id = placeholder.id().cloned().expect("doc id");
+
+        let result = mutator
+            .delete("TestDoc", &missing_doc_id)
+            .await
+            .expect("delete should succeed even on missing doc");
+        assert!(!result.existed, "doc should not have existed");
+
+        let txn = mutator.take_txn().await.expect("take txn");
+        txn.commit().await.expect("commit");
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            sub.try_recv().is_err(),
+            "deleting a non-existent doc should not publish an Update event"
+        );
     }
 }

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -483,3 +483,91 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use events::{Bus, ChannelBus, EventName};
+    use query::mutator::DocMutator;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+    use storage::backends::MemoryStore;
+
+    async fn make_test_db_with_bus() -> (Arc<DB<MemoryStore>>, Arc<dyn Bus>) {
+        let bus: Arc<dyn Bus> = Arc::new(ChannelBus::new());
+        let mut db = DB::new(MemoryStore::new()).expect("create db");
+        db.set_event_bus(Arc::clone(&bus));
+        (Arc::new(db), bus)
+    }
+
+    fn test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "TestDoc",
+            "v1",
+            "col-test-doc",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "x", FieldKind::int()),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn create_in_tx_publishes_event_on_commit() {
+        let (db, bus) = make_test_db_with_bus().await;
+        db.create_collection(test_collection()).await.expect("schema");
+
+        let mut sub = bus.subscribe(&[EventName::Update]);
+
+        let txn = db.new_txn(false).await.expect("new_txn");
+        let mutator = DbDocMutator::new(Arc::clone(&db), txn);
+
+        let doc = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
+        let result = mutator.create("TestDoc", doc).await.expect("create");
+
+        // Before commit: no event should have fired
+        assert!(
+            sub.try_recv().is_err(),
+            "no event should fire before commit"
+        );
+
+        let txn = mutator.take_txn().await.expect("take txn");
+        txn.commit().await.expect("commit");
+
+        // After commit: one Update event arrives
+        let msg = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            sub.recv(),
+        )
+        .await
+        .expect("event arrived within timeout")
+        .expect("subscription not closed");
+
+        let update = msg.as_update().expect("expected Update message");
+        assert_eq!(update.doc_id, result.doc_id.to_string());
+        assert_ne!(update.cid, cid::Cid::default(), "cid should be populated");
+    }
+
+    #[tokio::test]
+    async fn create_in_tx_publishes_no_event_on_discard() {
+        let (db, bus) = make_test_db_with_bus().await;
+        db.create_collection(test_collection()).await.expect("schema");
+
+        let mut sub = bus.subscribe(&[EventName::Update]);
+
+        let txn = db.new_txn(false).await.expect("new_txn");
+        let mutator = DbDocMutator::new(Arc::clone(&db), txn);
+
+        let doc = Document::from_json_str(r#"{"x": 1}"#).expect("doc");
+        mutator.create("TestDoc", doc).await.expect("create");
+
+        let txn = mutator.take_txn().await.expect("take txn");
+        txn.discard().expect("discard");
+
+        // Allow a brief window for any (unexpected) async delivery
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            sub.try_recv().is_err(),
+            "discard should not publish events"
+        );
+    }
+}

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use storage::corekv::Store;
 use tracing::warn;
 
-use crate::block_builder::{write_collection_block, write_document_blocks};
+use crate::block_builder::{write_collection_block, write_delete_block, write_document_blocks};
 use crate::collection::Collection;
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
@@ -330,11 +330,70 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
         self.ensure_collection_can_write(collection_name, &collection)
             .await?;
 
-        // Use delete_with_indexes to maintain index consistency
         let existed = collection
             .delete_with_indexes(&datastore, doc_id, &index_manager)
             .await
             .map_err(|e| query::error::QueryError::execution(format!("delete error: {}", e)))?;
+
+        let commit_cid: Option<cid::Cid> = {
+            let txn_guard = self.txn.lock().await;
+            let txn = txn_guard.as_ref().ok_or_else(|| {
+                query::error::QueryError::execution("transaction is no longer active")
+            })?;
+
+            let blockstore = txn.blockstore().map_err(|e| {
+                query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
+            })?;
+            let headstore = txn.headstore().map_err(|e| {
+                query::error::QueryError::execution(format!("failed to get headstore: {}", e))
+            })?;
+
+            let schema_version_id = collection.version_id();
+            let sign_config = get_signing_config();
+
+            match write_delete_block(
+                &blockstore,
+                &headstore,
+                &doc_id.to_string(),
+                schema_version_id,
+                sign_config.as_ref(),
+            )
+            .await
+            {
+                Ok(block_result) => {
+                    if collection.schema().is_branchable {
+                        let short_id = collection.resolved_root_id();
+                        if let Err(error) = write_collection_block(
+                            &blockstore,
+                            &headstore,
+                            short_id,
+                            schema_version_id,
+                            block_result.cid,
+                            sign_config.as_ref(),
+                        )
+                        .await
+                        {
+                            warn!(
+                                collection = %collection_name,
+                                error = %error,
+                                "Failed to write collection block for transaction delete"
+                            );
+                        }
+                    }
+                    Some(block_result.cid)
+                }
+                Err(error) => {
+                    warn!(
+                        collection = %collection_name,
+                        error = %error,
+                        "Failed to write delete block for transaction delete"
+                    );
+                    None
+                }
+            }
+        };
+
+        let _ = commit_cid;
 
         Ok(DeleteResult::new(doc_id.clone(), existed))
     }

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -13,7 +13,7 @@ use crate::collection::Collection;
 use crate::collection_loader::{get_collection_with_index_manager, get_collection_with_lazy_load};
 use crate::database::DB;
 use crate::txn::DbTxn;
-use defra_core::encryption::{get_encryption_config, store_doc_encryption};
+use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
 use defra_core::signing::get_signing_config;
 
 /// Document mutator that uses a database transaction.
@@ -241,7 +241,6 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             .await
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?;
 
-        // Use update_with_indexes to maintain index consistency
         collection
             .update_with_indexes(&datastore, &doc, &index_manager)
             .await
@@ -252,9 +251,72 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 other => crate::error::index_write_query_error("update", other),
             })?;
 
-        // Return count of actually modified fields
-        let fields_modified = modified_fields.len();
+        let commit_cid: Option<cid::Cid> = {
+            let txn_guard = self.txn.lock().await;
+            let txn = txn_guard.as_ref().ok_or_else(|| {
+                query::error::QueryError::execution("transaction is no longer active")
+            })?;
 
+            let blockstore = txn.blockstore().map_err(|e| {
+                query::error::QueryError::execution(format!("failed to get blockstore: {}", e))
+            })?;
+            let headstore = txn.headstore().map_err(|e| {
+                query::error::QueryError::execution(format!("failed to get headstore: {}", e))
+            })?;
+
+            let schema_version_id = collection.version_id();
+            let enc_config = get_encryption_config().or_else(|| {
+                doc.id().and_then(|id| get_doc_encryption(&id.to_string()))
+            });
+            let sign_config = get_signing_config();
+
+            match write_document_blocks(
+                &blockstore,
+                &headstore,
+                &doc,
+                schema_version_id,
+                Some(&modified_fields),
+                enc_config.as_ref(),
+                sign_config.as_ref(),
+            )
+            .await
+            {
+                Ok(block_result) => {
+                    if collection.schema().is_branchable {
+                        let short_id = collection.resolved_root_id();
+                        if let Err(error) = write_collection_block(
+                            &blockstore,
+                            &headstore,
+                            short_id,
+                            schema_version_id,
+                            block_result.cid,
+                            sign_config.as_ref(),
+                        )
+                        .await
+                        {
+                            warn!(
+                                collection = %collection_name,
+                                error = %error,
+                                "Failed to write collection block for transaction update"
+                            );
+                        }
+                    }
+                    Some(block_result.cid)
+                }
+                Err(error) => {
+                    warn!(
+                        collection = %collection_name,
+                        error = %error,
+                        "Failed to write document blocks for transaction update"
+                    );
+                    None
+                }
+            }
+        };
+
+        let _ = commit_cid;
+
+        let fields_modified = modified_fields.len();
         Ok(UpdateResult::new(doc, fields_modified))
     }
 

--- a/crates/db/src/event_emission.rs
+++ b/crates/db/src/event_emission.rs
@@ -13,18 +13,22 @@ use crate::error::Result;
 use crate::txn::DbTxn;
 
 /// Register an `on_success_async` callback that publishes an Update event
-/// (and, for branchable collections, a second collection-level Update event).
+/// with the document block bytes, and — when `collection_block` is `Some` —
+/// a second collection-level Update with the collection block's own cid and bytes.
 ///
 /// If `bus` is `None`, no callback is registered — there's no subscriber to notify.
 ///
-/// Mirrors Go's `db.sendUpdate` callback registration at `internal/db/collection.go:755`.
+/// Mirrors Go's `db.sendUpdate` callback registration at
+/// `internal/db/collection.go:755` and the branchable collection event at
+/// `internal/db/collection.go:789`, both of which publish the actual block bytes.
 pub(crate) fn register_update_event_callback<S: Store + 'static>(
     txn: &mut DbTxn<S>,
     bus: Option<&Arc<dyn Bus>>,
     collection_id: String,
-    branchable: bool,
     doc_id: String,
-    cid: Cid,
+    doc_cid: Cid,
+    doc_block: Vec<u8>,
+    collection_block: Option<(Cid, Vec<u8>)>,
 ) -> Result<()> {
     let Some(bus) = bus else {
         return Ok(());
@@ -33,16 +37,23 @@ pub(crate) fn register_update_event_callback<S: Store + 'static>(
     txn.on_success_async(Box::new(move || {
         Box::pin(async move {
             let subject_doc_id = doc_id.clone();
-            let update = Update::new(doc_id, cid, collection_id.clone(), vec![], false, false);
+            let update = Update::new(
+                doc_id,
+                doc_cid,
+                collection_id.clone(),
+                doc_block,
+                false,
+                false,
+            );
             bus.publish(Message::update(update));
 
-            if branchable {
+            if let Some((col_cid, col_block)) = collection_block {
                 let collection_update = Update::new_with_subject_doc_id(
                     String::new(),
                     subject_doc_id,
-                    cid,
+                    col_cid,
                     collection_id,
-                    vec![],
+                    col_block,
                     false,
                     false,
                 );

--- a/crates/db/src/event_emission.rs
+++ b/crates/db/src/event_emission.rs
@@ -33,14 +33,7 @@ pub(crate) fn register_update_event_callback<S: Store + 'static>(
     txn.on_success_async(Box::new(move || {
         Box::pin(async move {
             let subject_doc_id = doc_id.clone();
-            let update = Update::new(
-                doc_id,
-                cid,
-                collection_id.clone(),
-                vec![],
-                false,
-                false,
-            );
+            let update = Update::new(doc_id, cid, collection_id.clone(), vec![], false, false);
             bus.publish(Message::update(update));
 
             if branchable {

--- a/crates/db/src/event_emission.rs
+++ b/crates/db/src/event_emission.rs
@@ -4,6 +4,7 @@
 //! use this to register a callback at mutation time. The underlying tx machinery
 //! fires success callbacks only on commit; discards skip them.
 
+use async_trait::async_trait;
 use cid::Cid;
 use events::{Bus, Message, Update};
 use std::sync::Arc;
@@ -11,6 +12,33 @@ use storage::corekv::Store;
 
 use crate::error::Result;
 use crate::txn::DbTxn;
+
+/// Per-mutation broadcast payload, mirroring Go's sendUpdate call.
+#[derive(Debug, Clone)]
+pub struct TxnBroadcastEvent {
+    pub collection_name: String,
+    pub collection_id: String,
+    pub doc_id: String,
+    pub doc_cid: Cid,
+    pub doc_block: Vec<u8>,
+    pub collection_block: Option<(Cid, Vec<u8>)>,
+    pub creator_did: Option<String>,
+}
+
+/// Hook for forwarding committed transactional writes to the P2P stack.
+///
+/// `DbDocMutator` (the explicit-tx mutator) calls this from the
+/// `on_success_async` callback so that a successful tx commit triggers
+/// the same push-to-replicators + gossipsub broadcast that the
+/// single-mutation auto-commit path gets via `BroadcastMutator`.
+///
+/// Without a `TxnBroadcaster`, transactional writes commit locally
+/// and publish to the local bus only — P2P peers never see them.
+/// Mirrors Go's `db.sendUpdate` at `internal/db/p2p.go:23-25`.
+#[async_trait]
+pub trait TxnBroadcaster: Send + Sync {
+    async fn broadcast_update(&self, event: TxnBroadcastEvent);
+}
 
 /// Register an `on_success_async` callback that publishes an Update event
 /// with the document block bytes, and — when `collection_block` is `Some` —
@@ -21,43 +49,63 @@ use crate::txn::DbTxn;
 /// Mirrors Go's `db.sendUpdate` callback registration at
 /// `internal/db/collection.go:755` and the branchable collection event at
 /// `internal/db/collection.go:789`, both of which publish the actual block bytes.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn register_update_event_callback<S: Store + 'static>(
     txn: &mut DbTxn<S>,
     bus: Option<&Arc<dyn Bus>>,
+    broadcaster: Option<&Arc<dyn TxnBroadcaster>>,
+    collection_name: String,
     collection_id: String,
     doc_id: String,
     doc_cid: Cid,
     doc_block: Vec<u8>,
     collection_block: Option<(Cid, Vec<u8>)>,
+    creator_did: Option<String>,
 ) -> Result<()> {
-    let Some(bus) = bus else {
+    if bus.is_none() && broadcaster.is_none() {
         return Ok(());
-    };
-    let bus = Arc::clone(bus);
+    }
+    let bus = bus.map(Arc::clone);
+    let broadcaster = broadcaster.map(Arc::clone);
     txn.on_success_async(Box::new(move || {
         Box::pin(async move {
-            let subject_doc_id = doc_id.clone();
-            let update = Update::new(
-                doc_id,
-                doc_cid,
-                collection_id.clone(),
-                doc_block,
-                false,
-                false,
-            );
-            bus.publish(Message::update(update));
-
-            if let Some((col_cid, col_block)) = collection_block {
-                let collection_update = Update::new_with_subject_doc_id(
-                    String::new(),
-                    subject_doc_id,
-                    col_cid,
-                    collection_id,
-                    col_block,
+            if let Some(bus) = bus {
+                let subject_doc_id = doc_id.clone();
+                let update = Update::new(
+                    doc_id.clone(),
+                    doc_cid,
+                    collection_id.clone(),
+                    doc_block.clone(),
                     false,
                     false,
                 );
-                bus.publish(Message::update(collection_update));
+                bus.publish(Message::update(update));
+
+                if let Some((col_cid, ref col_block)) = collection_block {
+                    let collection_update = Update::new_with_subject_doc_id(
+                        String::new(),
+                        subject_doc_id,
+                        col_cid,
+                        collection_id.clone(),
+                        col_block.clone(),
+                        false,
+                        false,
+                    );
+                    bus.publish(Message::update(collection_update));
+                }
+            }
+
+            if let Some(broadcaster) = broadcaster {
+                let event = TxnBroadcastEvent {
+                    collection_name,
+                    collection_id,
+                    doc_id,
+                    doc_cid,
+                    doc_block,
+                    collection_block,
+                    creator_did,
+                };
+                broadcaster.broadcast_update(event).await;
             }
         })
     }))

--- a/crates/db/src/event_emission.rs
+++ b/crates/db/src/event_emission.rs
@@ -1,0 +1,61 @@
+//! Shared helper for registering tx-success callbacks that publish Update events.
+//!
+//! Both `DbDocMutator` (explicit-tx path) and `BatchMutator` (auto-commit path)
+//! use this to register a callback at mutation time. The underlying tx machinery
+//! fires success callbacks only on commit; discards skip them.
+
+use cid::Cid;
+use events::{Bus, Message, Update};
+use std::sync::Arc;
+use storage::corekv::Store;
+
+use crate::error::Result;
+use crate::txn::DbTxn;
+
+/// Register an `on_success_async` callback that publishes an Update event
+/// (and, for branchable collections, a second collection-level Update event).
+///
+/// If `bus` is `None`, no callback is registered — there's no subscriber to notify.
+///
+/// Mirrors Go's `db.sendUpdate` callback registration at `internal/db/collection.go:755`.
+#[allow(dead_code)]
+pub(crate) fn register_update_event_callback<S: Store + 'static>(
+    txn: &mut DbTxn<S>,
+    bus: Option<&Arc<dyn Bus>>,
+    collection_id: String,
+    branchable: bool,
+    doc_id: String,
+    cid: Cid,
+) -> Result<()> {
+    let Some(bus) = bus else {
+        return Ok(());
+    };
+    let bus = Arc::clone(bus);
+    txn.on_success_async(Box::new(move || {
+        Box::pin(async move {
+            let subject_doc_id = doc_id.clone();
+            let update = Update::new(
+                doc_id,
+                cid,
+                collection_id.clone(),
+                vec![],
+                false,
+                false,
+            );
+            bus.publish(Message::update(update));
+
+            if branchable {
+                let collection_update = Update::new_with_subject_doc_id(
+                    String::new(),
+                    subject_doc_id,
+                    cid,
+                    collection_id,
+                    vec![],
+                    false,
+                    false,
+                );
+                bus.publish(Message::update(collection_update));
+            }
+        })
+    }))
+}

--- a/crates/db/src/event_emission.rs
+++ b/crates/db/src/event_emission.rs
@@ -18,7 +18,6 @@ use crate::txn::DbTxn;
 /// If `bus` is `None`, no callback is registered — there's no subscriber to notify.
 ///
 /// Mirrors Go's `db.sendUpdate` callback registration at `internal/db/collection.go:755`.
-#[allow(dead_code)]
 pub(crate) fn register_update_event_callback<S: Store + 'static>(
     txn: &mut DbTxn<S>,
     bus: Option<&Arc<dyn Bus>>,

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -70,6 +70,7 @@ pub(crate) mod doc_mutator;
 pub mod downsample;
 pub(crate) mod dump;
 pub mod error;
+pub(crate) mod event_emission;
 // Index manager extracted to standalone db-index crate.
 pub use db_index as index_manager;
 pub(crate) mod json_patch;

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -70,7 +70,8 @@ pub(crate) mod doc_mutator;
 pub mod downsample;
 pub(crate) mod dump;
 pub mod error;
-pub(crate) mod event_emission;
+pub mod event_emission;
+pub use event_emission::{TxnBroadcastEvent, TxnBroadcaster};
 // Index manager extracted to standalone db-index crate.
 pub use db_index as index_manager;
 pub(crate) mod json_patch;

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -25,18 +25,21 @@ pub struct DbTransactionContext<S: Store> {
     readonly: bool,
     fetcher: Arc<LensedDocFetcher<S>>,
     deferred_acp_mutations: Arc<DeferredAcpMutations>,
+    broadcaster: Option<Arc<dyn crate::event_emission::TxnBroadcaster>>,
     action_lock: Arc<async_lock::Mutex<()>>,
     created_at: Instant,
 }
 
 impl<S: Store> DbTransactionContext<S> {
-    /// Create a new transaction context.
-    pub(crate) fn new(
+    /// Create a transaction context. Pass `Some(broadcaster)` to forward
+    /// committed writes to P2P peers; pass `None` for the non-P2P case.
+    pub(crate) fn new_with_broadcaster(
         db: Arc<DB<S>>,
         id: String,
         readonly: bool,
         fetcher: Arc<LensedDocFetcher<S>>,
         deferred_acp_mutations: Arc<DeferredAcpMutations>,
+        broadcaster: Option<Arc<dyn crate::event_emission::TxnBroadcaster>>,
     ) -> Self {
         Self {
             db,
@@ -44,6 +47,7 @@ impl<S: Store> DbTransactionContext<S> {
             readonly,
             fetcher,
             deferred_acp_mutations,
+            broadcaster,
             action_lock: Arc::new(async_lock::Mutex::new(())),
             created_at: Instant::now(),
         }
@@ -84,9 +88,10 @@ impl<S: Store + 'static> DbTransactionContext<S> {
     /// Should only be called on non-readonly transactions. Attempting to mutate
     /// via the returned mutator on a readonly transaction will fail.
     pub fn doc_mutator(&self) -> Arc<dyn DocMutator> {
-        Arc::new(DbDocMutator::from_shared_txn(
+        Arc::new(DbDocMutator::from_shared_txn_with_broadcaster(
             self.db.clone(),
             self.fetcher.shared_txn(),
+            self.broadcaster.clone(),
         ))
     }
 

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -81,17 +81,36 @@ pub struct DbTransactionRegistry<S: Store> {
     db: Arc<DB<S>>,
     transactions: RwLock<HashMap<String, Arc<DbTransactionContext<S>>>>,
     id_counter: AtomicU64,
+    broadcaster: Option<Arc<dyn crate::event_emission::TxnBroadcaster>>,
 }
 
 impl<S: Store + 'static> DbTransactionRegistry<S> {
-    /// Create a new transaction registry.
+    /// Create a new transaction registry without a P2P broadcaster.
     ///
-    /// Collections are sourced from the DB's collection cache.
+    /// Use [`with_broadcaster`] when running with the P2P stack so that
+    /// committed transactional writes are forwarded to peers.
     pub fn new(db: Arc<DB<S>>) -> Self {
         Self {
             db,
             transactions: RwLock::new(HashMap::new()),
             id_counter: AtomicU64::new(0),
+            broadcaster: None,
+        }
+    }
+
+    /// Create a transaction registry that forwards committed writes to a
+    /// `TxnBroadcaster`. Each contained transaction's success callbacks will
+    /// call `broadcaster.broadcast_update` in addition to publishing to the
+    /// local event bus.
+    pub fn with_broadcaster(
+        db: Arc<DB<S>>,
+        broadcaster: Arc<dyn crate::event_emission::TxnBroadcaster>,
+    ) -> Self {
+        Self {
+            db,
+            transactions: RwLock::new(HashMap::new()),
+            id_counter: AtomicU64::new(0),
+            broadcaster: Some(broadcaster),
         }
     }
 
@@ -624,12 +643,13 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
             },
         )?);
         let fetcher = Arc::new(LensedDocFetcher::new(db_txn, lens_store));
-        let ctx = Arc::new(DbTransactionContext::new(
+        let ctx = Arc::new(DbTransactionContext::new_with_broadcaster(
             self.db.clone(),
             txn_id.clone(),
             readonly,
             fetcher,
             deferred_acp_mutations,
+            self.broadcaster.clone(),
         ));
 
         self.transactions

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -821,7 +821,17 @@ impl NodeBuilder {
         let fetcher = db::LensedAutoCommitFetcher::new(database.clone());
         let provider: Arc<dyn query::CollectionProvider> =
             db::DbCollectionProvider::new_arc(database.clone());
-        let registry = Arc::new(db::DbTransactionRegistry::new(database.clone()));
+
+        #[cfg(feature = "p2p")]
+        let txn_broadcaster: Option<Arc<dyn db::event_emission::TxnBroadcaster>> =
+            p2p_result.as_ref().map(|r| r.txn_broadcaster.clone());
+        #[cfg(not(feature = "p2p"))]
+        let txn_broadcaster: Option<Arc<dyn db::event_emission::TxnBroadcaster>> = None;
+
+        let registry = Arc::new(match txn_broadcaster {
+            Some(b) => db::DbTransactionRegistry::with_broadcaster(database.clone(), b),
+            None => db::DbTransactionRegistry::new(database.clone()),
+        });
         let (document_acp, _strict_replicated_doc_access) =
             node_acp::create_document_acp(acp_store, &document_acp_config).await?;
 
@@ -1011,6 +1021,7 @@ impl NodeBuilder {
                 doc_pusher_for_acp.set_document_acp(acp.clone());
                 broadcast_mutator_for_acp.set_document_acp(acp);
             })),
+            txn_broadcaster: replication.txn_broadcaster,
         })
     }
 
@@ -1282,6 +1293,7 @@ struct P2PSetupResult {
     lifecycle: Option<P2PLifecycle>,
     mutator: Arc<dyn query::DocMutator>,
     wire_document_acp: Option<WireDocumentAcpCallback>,
+    txn_broadcaster: Arc<dyn db::event_emission::TxnBroadcaster>,
 }
 
 #[cfg(test)]

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -422,7 +422,13 @@ where
     let fetcher = db::LensedAutoCommitFetcher::new(database.clone());
     let collection_provider: Arc<dyn query::CollectionProvider> =
         db::DbCollectionProvider::new_arc(database.clone());
-    let txn_registry = Arc::new(db::DbTransactionRegistry::new(database.clone()));
+    let txn_broadcaster = p2p_setup
+        .as_ref()
+        .map(|setup| setup.txn_broadcaster.clone());
+    let txn_registry = Arc::new(match txn_broadcaster {
+        Some(b) => db::DbTransactionRegistry::with_broadcaster(database.clone(), b),
+        None => db::DbTransactionRegistry::new(database.clone()),
+    });
 
     let query_runner = query::QueryRunner::with_arc_registry_and_provider(
         fetcher,

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -20,6 +20,10 @@ pub(crate) struct P2PSetup<S: storage::corekv::Store + 'static> {
     pub mutator: Arc<dyn query::DocMutator>,
     pub merge_handler: Arc<EmbeddedMergeHandler<S>>,
     pub wire_document_acp: Option<WireDocumentAcpCallback>,
+    /// Forwards committed `/tx` writes to P2P peers; mirrors what the CLI
+    /// `P2PSetup` exposes. Without this, transactional writes commit locally
+    /// but never replicate.
+    pub txn_broadcaster: Arc<dyn db::event_emission::TxnBroadcaster>,
 }
 
 pub(crate) async fn setup_libp2p<S>(
@@ -188,6 +192,7 @@ where
         system,
         mutator: replication.broadcast_mutator,
         merge_handler: replication.merge_handler,
+        txn_broadcaster: replication.txn_broadcaster,
         wire_document_acp: Some(Box::new(move |acp| {
             coordinator_for_acp.set_document_acp(acp.clone());
             doc_pusher_for_acp.set_document_acp(acp.clone());
@@ -322,6 +327,7 @@ where
         system,
         mutator: replication.broadcast_mutator,
         merge_handler: replication.merge_handler,
+        txn_broadcaster: replication.txn_broadcaster,
         wire_document_acp: Some(Box::new(move |acp| {
             coordinator_for_acp.set_document_acp(acp.clone());
             doc_pusher_for_acp.set_document_acp(acp.clone());

--- a/crates/http/src/handlers/events.rs
+++ b/crates/http/src/handlers/events.rs
@@ -204,6 +204,7 @@ pub async fn events_sse(
                         "doc_id": update.doc_id,
                         "cid": update.cid.to_string(),
                         "collection_id": update.collection_id,
+                        "block": hex::encode(&update.block),
                     }
                 })
             } else if let Some(data) = message.as_merge_complete() {

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -72,181 +72,6 @@ impl IrohTransport {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
-    use std::time::Duration;
-
-    use tokio::time::timeout;
-
-    use crate::iroh::{spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig};
-    use crate::message::{
-        PushSEArtifactsRequest, QuerySEArtifactsReply, QuerySEArtifactsRequest, SEArtifact,
-        SEFieldQuery,
-    };
-    use crate::signing::sign_with_transport;
-    use crate::transport::{P2PTransport, TransportEvent};
-
-    use super::*;
-
-    fn test_config(secret_key: SecretKey) -> IrohEndpointConfig {
-        IrohEndpointConfig {
-            secret_key,
-            relay_mode: crate::iroh::IrohRelayModeConfig::Disabled,
-            discovery: IrohDiscoveryConfig::Disabled,
-            bind_port: None,
-            bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
-        }
-    }
-
-    #[tokio::test]
-    async fn se_query_roundtrip_emits_request_and_reply_events() {
-        let key0 = SecretKey::generate();
-        let key1 = SecretKey::generate();
-        let (command_tx0, mut events0, _replicators0, task0) =
-            spawn_endpoint(test_config(key0.clone())).await.unwrap();
-        let (command_tx1, mut events1, _replicators1, task1) =
-            spawn_endpoint(test_config(key1.clone())).await.unwrap();
-        let transport0 = IrohTransport::new(command_tx0, key0);
-        let transport1 = IrohTransport::new(command_tx1, key1);
-
-        transport0
-            .dial(
-                transport1.local_peer_id(),
-                transport1.listen_addresses().await.unwrap(),
-            )
-            .await
-            .unwrap();
-        transport0
-            .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
-            .await
-            .unwrap();
-        transport1
-            .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
-            .await
-            .unwrap();
-
-        let mut request = QuerySEArtifactsRequest::new(
-            "collection1",
-            vec![SEFieldQuery::new("name", "name", vec![1, 2, 3])],
-        );
-        sign_with_transport(&transport0, &mut request).unwrap();
-        let request_message_id = request.message_id.clone();
-
-        transport0
-            .send_se_query_request(transport1.local_peer_id(), request)
-            .await
-            .unwrap();
-
-        let received_request = loop {
-            let event = timeout(Duration::from_secs(5), events1.recv())
-                .await
-                .expect("timed out waiting for SE query request")
-                .expect("iroh event channel closed");
-            if let TransportEvent::SEQueryRequest { peer_id, request } = event {
-                assert_eq!(peer_id, *transport0.local_peer_id());
-                break request;
-            }
-        };
-        assert_eq!(received_request.message_id, request_message_id);
-        assert_eq!(
-            received_request.sender_id,
-            transport0.local_peer_id().to_string()
-        );
-        assert_eq!(received_request.collection_id, "collection1");
-        assert_eq!(received_request.queries.len(), 1);
-        assert_eq!(received_request.queries[0].search_tag, vec![1, 2, 3]);
-
-        let mut reply =
-            QuerySEArtifactsReply::success(&request_message_id, vec!["doc1".into(), "doc2".into()]);
-        sign_with_transport(&transport1, &mut reply).unwrap();
-        transport1
-            .send_se_query_response(transport0.local_peer_id(), reply)
-            .await
-            .unwrap();
-
-        loop {
-            let event = timeout(Duration::from_secs(5), events0.recv())
-                .await
-                .expect("timed out waiting for SE query reply")
-                .expect("iroh event channel closed");
-            if let TransportEvent::SEQueryReply { peer_id, reply } = event {
-                assert_eq!(peer_id, *transport1.local_peer_id());
-                assert_eq!(reply.message_id, request_message_id);
-                assert_eq!(reply.sender_id, transport1.local_peer_id().to_string());
-                assert_eq!(reply.doc_ids, vec!["doc1".to_string(), "doc2".to_string()]);
-                break;
-            }
-        }
-
-        transport0.shutdown().await.unwrap();
-        transport1.shutdown().await.unwrap();
-        task0.await.unwrap();
-        task1.await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn se_artifacts_roundtrip_signs_and_verifies_sender() {
-        let key0 = SecretKey::generate();
-        let key1 = SecretKey::generate();
-        let (command_tx0, _events0, _replicators0, task0) =
-            spawn_endpoint(test_config(key0.clone())).await.unwrap();
-        let (command_tx1, mut events1, _replicators1, task1) =
-            spawn_endpoint(test_config(key1.clone())).await.unwrap();
-        let transport0 = IrohTransport::new(command_tx0, key0);
-        let transport1 = IrohTransport::new(command_tx1, key1);
-
-        transport0
-            .dial(
-                transport1.local_peer_id(),
-                transport1.listen_addresses().await.unwrap(),
-            )
-            .await
-            .unwrap();
-        transport0
-            .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
-            .await
-            .unwrap();
-        transport1
-            .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
-            .await
-            .unwrap();
-
-        let request = PushSEArtifactsRequest::new(
-            "collection1",
-            vec![SEArtifact::new("doc1", "name", vec![4, 5, 6])],
-        );
-        transport0
-            .send_se_artifacts(transport1.local_peer_id(), request)
-            .await
-            .unwrap();
-
-        loop {
-            let event = timeout(Duration::from_secs(5), events1.recv())
-                .await
-                .expect("timed out waiting for SE artifacts")
-                .expect("iroh event channel closed");
-            if let TransportEvent::SEArtifactsReceived { peer_id, data } = event {
-                assert_eq!(peer_id, *transport0.local_peer_id());
-                let received: PushSEArtifactsRequest =
-                    serde_cbor::from_slice(&data).expect("SE artifacts should decode");
-                assert_eq!(received.sender_id, transport0.local_peer_id().to_string());
-                assert!(received.signature.is_some());
-                assert_eq!(received.collection_id, "collection1");
-                assert_eq!(received.artifacts.len(), 1);
-                assert_eq!(received.artifacts[0].doc_id, "doc1");
-                assert_eq!(received.artifacts[0].search_tag, vec![4, 5, 6]);
-                break;
-            }
-        }
-
-        transport0.shutdown().await.unwrap();
-        transport1.shutdown().await.unwrap();
-        task0.await.unwrap();
-        task1.await.unwrap();
-    }
-}
-
 #[async_trait]
 impl P2PTransport for IrohTransport {
     type ResponseToken = iroh::endpoint::SendStream;
@@ -589,5 +414,180 @@ impl P2PTransport for IrohTransport {
             "Iroh transport shutdown command completed"
         );
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use crate::iroh::{spawn_endpoint, IrohDiscoveryConfig, IrohEndpointConfig};
+    use crate::message::{
+        PushSEArtifactsRequest, QuerySEArtifactsReply, QuerySEArtifactsRequest, SEArtifact,
+        SEFieldQuery,
+    };
+    use crate::signing::sign_with_transport;
+    use crate::transport::{P2PTransport, TransportEvent};
+
+    use super::*;
+
+    fn test_config(secret_key: SecretKey) -> IrohEndpointConfig {
+        IrohEndpointConfig {
+            secret_key,
+            relay_mode: crate::iroh::IrohRelayModeConfig::Disabled,
+            discovery: IrohDiscoveryConfig::Disabled,
+            bind_port: None,
+            bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        }
+    }
+
+    #[tokio::test]
+    async fn se_query_roundtrip_emits_request_and_reply_events() {
+        let key0 = SecretKey::generate();
+        let key1 = SecretKey::generate();
+        let (command_tx0, mut events0, _replicators0, task0) =
+            spawn_endpoint(test_config(key0.clone())).await.unwrap();
+        let (command_tx1, mut events1, _replicators1, task1) =
+            spawn_endpoint(test_config(key1.clone())).await.unwrap();
+        let transport0 = IrohTransport::new(command_tx0, key0);
+        let transport1 = IrohTransport::new(command_tx1, key1);
+
+        transport0
+            .dial(
+                transport1.local_peer_id(),
+                transport1.listen_addresses().await.unwrap(),
+            )
+            .await
+            .unwrap();
+        transport0
+            .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+        transport1
+            .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let mut request = QuerySEArtifactsRequest::new(
+            "collection1",
+            vec![SEFieldQuery::new("name", "name", vec![1, 2, 3])],
+        );
+        sign_with_transport(&transport0, &mut request).unwrap();
+        let request_message_id = request.message_id.clone();
+
+        transport0
+            .send_se_query_request(transport1.local_peer_id(), request)
+            .await
+            .unwrap();
+
+        let received_request = loop {
+            let event = timeout(Duration::from_secs(5), events1.recv())
+                .await
+                .expect("timed out waiting for SE query request")
+                .expect("iroh event channel closed");
+            if let TransportEvent::SEQueryRequest { peer_id, request } = event {
+                assert_eq!(peer_id, *transport0.local_peer_id());
+                break request;
+            }
+        };
+        assert_eq!(received_request.message_id, request_message_id);
+        assert_eq!(
+            received_request.sender_id,
+            transport0.local_peer_id().to_string()
+        );
+        assert_eq!(received_request.collection_id, "collection1");
+        assert_eq!(received_request.queries.len(), 1);
+        assert_eq!(received_request.queries[0].search_tag, vec![1, 2, 3]);
+
+        let mut reply =
+            QuerySEArtifactsReply::success(&request_message_id, vec!["doc1".into(), "doc2".into()]);
+        sign_with_transport(&transport1, &mut reply).unwrap();
+        transport1
+            .send_se_query_response(transport0.local_peer_id(), reply)
+            .await
+            .unwrap();
+
+        loop {
+            let event = timeout(Duration::from_secs(5), events0.recv())
+                .await
+                .expect("timed out waiting for SE query reply")
+                .expect("iroh event channel closed");
+            if let TransportEvent::SEQueryReply { peer_id, reply } = event {
+                assert_eq!(peer_id, *transport1.local_peer_id());
+                assert_eq!(reply.message_id, request_message_id);
+                assert_eq!(reply.sender_id, transport1.local_peer_id().to_string());
+                assert_eq!(reply.doc_ids, vec!["doc1".to_string(), "doc2".to_string()]);
+                break;
+            }
+        }
+
+        transport0.shutdown().await.unwrap();
+        transport1.shutdown().await.unwrap();
+        task0.await.unwrap();
+        task1.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn se_artifacts_roundtrip_signs_and_verifies_sender() {
+        let key0 = SecretKey::generate();
+        let key1 = SecretKey::generate();
+        let (command_tx0, _events0, _replicators0, task0) =
+            spawn_endpoint(test_config(key0.clone())).await.unwrap();
+        let (command_tx1, mut events1, _replicators1, task1) =
+            spawn_endpoint(test_config(key1.clone())).await.unwrap();
+        let transport0 = IrohTransport::new(command_tx0, key0);
+        let transport1 = IrohTransport::new(command_tx1, key1);
+
+        transport0
+            .dial(
+                transport1.local_peer_id(),
+                transport1.listen_addresses().await.unwrap(),
+            )
+            .await
+            .unwrap();
+        transport0
+            .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+        transport1
+            .poll_until_connected(transport0.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let request = PushSEArtifactsRequest::new(
+            "collection1",
+            vec![SEArtifact::new("doc1", "name", vec![4, 5, 6])],
+        );
+        transport0
+            .send_se_artifacts(transport1.local_peer_id(), request)
+            .await
+            .unwrap();
+
+        loop {
+            let event = timeout(Duration::from_secs(5), events1.recv())
+                .await
+                .expect("timed out waiting for SE artifacts")
+                .expect("iroh event channel closed");
+            if let TransportEvent::SEArtifactsReceived { peer_id, data } = event {
+                assert_eq!(peer_id, *transport0.local_peer_id());
+                let received: PushSEArtifactsRequest =
+                    serde_cbor::from_slice(&data).expect("SE artifacts should decode");
+                assert_eq!(received.sender_id, transport0.local_peer_id().to_string());
+                assert!(received.signature.is_some());
+                assert_eq!(received.collection_id, "collection1");
+                assert_eq!(received.artifacts.len(), 1);
+                assert_eq!(received.artifacts[0].doc_id, "doc1");
+                assert_eq!(received.artifacts[0].search_tag, vec![4, 5, 6]);
+                break;
+            }
+        }
+
+        transport0.shutdown().await.unwrap();
+        transport1.shutdown().await.unwrap();
+        task0.await.unwrap();
+        task1.await.unwrap();
     }
 }

--- a/crates/query-plan/src/mutator.rs
+++ b/crates/query-plan/src/mutator.rs
@@ -220,6 +220,14 @@ pub struct DeleteResult {
     pub commit_cid: Option<Cid>,
     /// The raw bytes of the committed composite delete block (for P2P broadcast)
     pub commit_block: Option<Vec<u8>>,
+    /// For branchable collections: the CID of the collection-level head block
+    /// that was written alongside the composite delete (for P2P broadcast).
+    /// Go emits a second update for this so collection subscribers / replicators
+    /// don't miss the collection head on deletes.
+    pub broadcast_cid: Option<Cid>,
+    /// For branchable collections: the raw bytes of the collection-level head
+    /// block written alongside the composite delete (for P2P broadcast).
+    pub broadcast_block: Option<Vec<u8>>,
 }
 
 impl DeleteResult {
@@ -231,6 +239,8 @@ impl DeleteResult {
             broadcast_status: BroadcastStatus::NotAttempted,
             commit_cid: None,
             commit_block: None,
+            broadcast_cid: None,
+            broadcast_block: None,
         }
     }
 
@@ -247,6 +257,8 @@ impl DeleteResult {
             broadcast_status: BroadcastStatus::NotAttempted,
             commit_cid: Some(commit_cid),
             commit_block: Some(commit_block),
+            broadcast_cid: None,
+            broadcast_block: None,
         }
     }
 
@@ -258,6 +270,8 @@ impl DeleteResult {
             broadcast_status,
             commit_cid: None,
             commit_block: None,
+            broadcast_cid: None,
+            broadcast_block: None,
         }
     }
 }

--- a/tools/integration-test/Cargo.toml
+++ b/tools/integration-test/Cargo.toml
@@ -74,6 +74,7 @@ crypto = { path = "../../crates/crypto" }
 p2p = { path = "../../crates/p2p", features = ["iroh-transport"] }
 base64 = "0.22"
 hex = "0.4"
+cid = "0.10"
 serial_test = "3"
 
 [lints]

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -1,4 +1,6 @@
-use integration_test::{for_each_runtime, TestCluster};
+use std::time::Duration;
+
+use integration_test::{for_each_runtime, open_events_sse, poll_until, TestCluster};
 
 async fn txn_schema_add_and_mutate(cluster: TestCluster) {
     let client = cluster.client(0);
@@ -325,3 +327,158 @@ async fn transactions_test(cluster: TestCluster) {
 }
 
 for_each_runtime!(transactions, transactions_test);
+
+async fn txn_commit_publishes_update_events(cluster: TestCluster) {
+    let client = cluster.client(0);
+    let api_url = cluster.api_url(0);
+
+    // Schema first (auto-commit, generates events we don't care about)
+    client
+        .schema_add("type TxEvent { name: String value: Int }")
+        .expect("schema add");
+
+    // Open SSE stream BEFORE the tx so we capture every emitted event
+    let (sse_handle, events) = open_events_sse(api_url, "update").await;
+
+    // Drain any startup events from schema add
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let baseline = events.lock().unwrap().len();
+
+    // Open a transaction and do three writes inside it
+    let tx_id = client.tx_create().expect("tx_create failed");
+
+    let create_a = client
+        .query_with_tx(
+            r#"mutation { add_TxEvent(input: {name: "a", value: 1}) { _docID } }"#,
+            &tx_id,
+        )
+        .expect("create a in tx");
+    let create_b = client
+        .query_with_tx(
+            r#"mutation { add_TxEvent(input: {name: "b", value: 2}) { _docID } }"#,
+            &tx_id,
+        )
+        .expect("create b in tx");
+    let create_c = client
+        .query_with_tx(
+            r#"mutation { add_TxEvent(input: {name: "c", value: 3}) { _docID } }"#,
+            &tx_id,
+        )
+        .expect("create c in tx");
+    let doc_a = create_a["add_TxEvent"][0]["_docID"]
+        .as_str()
+        .expect("missing _docID for TxEvent a")
+        .to_string();
+    let doc_b = create_b["add_TxEvent"][0]["_docID"]
+        .as_str()
+        .expect("missing _docID for TxEvent b")
+        .to_string();
+    let doc_c = create_c["add_TxEvent"][0]["_docID"]
+        .as_str()
+        .expect("missing _docID for TxEvent c")
+        .to_string();
+
+    // Critical assertion: zero events while tx is uncommitted
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    {
+        let observed = events.lock().unwrap();
+        let count_after_writes = observed.len();
+        assert_eq!(
+            count_after_writes, baseline,
+            "no update events should fire before tx commit; got {} new events",
+            count_after_writes.saturating_sub(baseline)
+        );
+    }
+
+    // Commit the transaction
+    client.tx_commit(&tx_id).expect("tx_commit failed");
+
+    // After commit: exactly three events should arrive, one per doc
+    poll_until(
+        || {
+            let observed = events.lock().unwrap();
+            let new_events: Vec<_> = observed.iter().skip(baseline).collect();
+            new_events.len() >= 3
+        },
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        "three update events should arrive after tx commit",
+    )
+    .await;
+
+    // Validate doc_ids match
+    let observed = events.lock().unwrap();
+    let new_events: Vec<_> = observed.iter().skip(baseline).collect();
+    assert_eq!(
+        new_events.len(),
+        3,
+        "expected exactly 3 update events after commit; got {}",
+        new_events.len()
+    );
+    let observed_doc_ids: std::collections::HashSet<String> = new_events
+        .iter()
+        .filter_map(|e| e.pointer("/data/doc_id").and_then(|v| v.as_str()))
+        .map(String::from)
+        .collect();
+    assert!(observed_doc_ids.contains(&doc_a), "missing event for doc_a={doc_a}");
+    assert!(observed_doc_ids.contains(&doc_b), "missing event for doc_b={doc_b}");
+    assert!(observed_doc_ids.contains(&doc_c), "missing event for doc_c={doc_c}");
+
+    // Also validate cids are non-default (catches missing block writes)
+    for event in &new_events {
+        let cid = event.pointer("/data/cid").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(!cid.is_empty(), "event cid should not be empty: {event:?}");
+    }
+
+    sse_handle.abort();
+}
+
+#[tokio::test]
+async fn rust_txn_commit_publishes_update_events() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    txn_commit_publishes_update_events(cluster).await;
+}
+
+async fn txn_discard_publishes_no_events(cluster: TestCluster) {
+    let client = cluster.client(0);
+    let api_url = cluster.api_url(0);
+
+    client
+        .schema_add("type TxDiscard { name: String }")
+        .expect("schema add");
+
+    let (sse_handle, events) = open_events_sse(api_url, "update").await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let baseline = events.lock().unwrap().len();
+
+    let tx_id = client.tx_create().expect("tx_create failed");
+    client
+        .query_with_tx(
+            r#"mutation { add_TxDiscard(input: {name: "doomed"}) { _docID } }"#,
+            &tx_id,
+        )
+        .expect("create in tx");
+
+    // Discard, not commit
+    client.tx_discard(&tx_id).expect("tx_discard failed");
+
+    // Wait long enough that an event would have arrived if it were going to
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let observed = events.lock().unwrap();
+    assert_eq!(
+        observed.len(),
+        baseline,
+        "no events should fire on discard; got {} new events",
+        observed.len().saturating_sub(baseline)
+    );
+
+    sse_handle.abort();
+}
+
+#[tokio::test]
+async fn rust_txn_discard_publishes_no_events() {
+    let _root = integration_test::workspace_root();
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    txn_discard_publishes_no_events(cluster).await;
+}

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -455,6 +455,24 @@ async fn txn_commit_publishes_update_events(cluster: TestCluster) {
             parsed, default_cid,
             "event cid should not be Cid::default() (would indicate the block write failed): {event:?}"
         );
+
+        // The block field carries hex-encoded composite commit bytes. It
+        // must reach SSE subscribers so downstream consumers (e.g. defra-agent)
+        // can traverse the DAG without an extra round-trip.
+        let block_hex = event
+            .pointer("/data/block")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("event missing /data/block: {event:?}"));
+        assert!(
+            !block_hex.is_empty(),
+            "event block hex should not be empty: {event:?}"
+        );
+        let block_bytes = hex::decode(block_hex)
+            .unwrap_or_else(|e| panic!("block field should be valid hex ({block_hex:?}): {e}"));
+        assert!(
+            !block_bytes.is_empty(),
+            "decoded block bytes should not be empty: {event:?}"
+        );
     }
 
     sse_handle.abort();

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -384,7 +384,8 @@ async fn txn_commit_publishes_update_events(cluster: TestCluster) {
         let observed = events.lock().unwrap();
         let count_after_writes = observed.len();
         assert_eq!(
-            count_after_writes, baseline,
+            count_after_writes,
+            baseline,
             "no update events should fire before tx commit; got {} new events",
             count_after_writes.saturating_sub(baseline)
         );
@@ -420,13 +421,25 @@ async fn txn_commit_publishes_update_events(cluster: TestCluster) {
         .filter_map(|e| e.pointer("/data/doc_id").and_then(|v| v.as_str()))
         .map(String::from)
         .collect();
-    assert!(observed_doc_ids.contains(&doc_a), "missing event for doc_a={doc_a}");
-    assert!(observed_doc_ids.contains(&doc_b), "missing event for doc_b={doc_b}");
-    assert!(observed_doc_ids.contains(&doc_c), "missing event for doc_c={doc_c}");
+    assert!(
+        observed_doc_ids.contains(&doc_a),
+        "missing event for doc_a={doc_a}"
+    );
+    assert!(
+        observed_doc_ids.contains(&doc_b),
+        "missing event for doc_b={doc_b}"
+    );
+    assert!(
+        observed_doc_ids.contains(&doc_c),
+        "missing event for doc_c={doc_c}"
+    );
 
     // Also validate cids are non-default (catches missing block writes)
     for event in &new_events {
-        let cid = event.pointer("/data/cid").and_then(|v| v.as_str()).unwrap_or("");
+        let cid = event
+            .pointer("/data/cid")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         assert!(!cid.is_empty(), "event cid should not be empty: {event:?}");
     }
 

--- a/tools/integration-test/tests/basic/transactions.rs
+++ b/tools/integration-test/tests/basic/transactions.rs
@@ -434,13 +434,27 @@ async fn txn_commit_publishes_update_events(cluster: TestCluster) {
         "missing event for doc_c={doc_c}"
     );
 
-    // Also validate cids are non-default (catches missing block writes)
+    // Also validate cids are non-default. Cid::default().to_string() is
+    // "baeaaaaa" (non-empty), so an is_empty() check would silently pass the
+    // pre-fix bug where a failed block write emitted an event with a default
+    // cid. Compare against the parsed default explicitly.
+    let default_cid = cid::Cid::default();
     for event in &new_events {
-        let cid = event
+        let cid_str = event
             .pointer("/data/cid")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        assert!(!cid.is_empty(), "event cid should not be empty: {event:?}");
+        assert!(
+            !cid_str.is_empty(),
+            "event cid should not be empty: {event:?}"
+        );
+        let parsed: cid::Cid = cid_str.parse().unwrap_or_else(|e| {
+            panic!("event cid should parse as a real Cid (got {cid_str:?}): {e}")
+        });
+        assert_ne!(
+            parsed, default_cid,
+            "event cid should not be Cid::default() (would indicate the block write failed): {event:?}"
+        );
     }
 
     sse_handle.abort();

--- a/tools/integration-test/tests/query/gql_list_args.rs
+++ b/tools/integration-test/tests/query/gql_list_args.rs
@@ -206,40 +206,20 @@ async fn gql_list_args_single_value_compat_test(cluster: TestCluster) {
 }
 
 async fn gql_list_args_multi_value_errors_test(cluster: TestCluster) {
+    // Multi-cid query (`User(cid: [...])`, `_commits(cid: [...])`) used to
+    // return "querying by multiple cids is not yet supported" on Go. Go shipped
+    // real multi-cid support in sourcenetwork/defradb#4794, so those
+    // assertions are intentionally omitted here; defradb.rs#972 tracks the
+    // matching Rust port. Once that lands, restore the multi-cid cases as
+    // positive (returns-results) assertions on both runtimes.
+    //
+    // Multi-docID query (`_commits(docID: [...])`) still returns
+    // "querying by multiple docIDs is not yet supported" on Go, so we keep
+    // asserting it.
+
     let node = cluster.client(0);
     let api_url = cluster.api_url(0).to_string();
     node.schema_add(SCHEMA).expect("add schema");
-
-    let cid_error = graphql_raw(
-        &api_url,
-        r#"query {
-                User(cid: [
-                    "bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey"
-                    "bafyreic2vrbl344kkc7h5d7e2hpnwvffta4ck73bvjs5acgjtvqubvvioe"
-                ]) {
-                    _docID
-                }
-            }"#,
-    )
-    .await;
-    assert_graphql_error(&cid_error, "querying by multiple cids is not yet supported");
-
-    let commit_cid_error = graphql_raw(
-        &api_url,
-        r#"query {
-                _commits(cid: [
-                    "bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey"
-                    "bafyreic2vrbl344kkc7h5d7e2hpnwvffta4ck73bvjs5acgjtvqubvvioe"
-                ]) {
-                    cid
-                }
-            }"#,
-    )
-    .await;
-    assert_graphql_error(
-        &commit_cid_error,
-        "querying by multiple cids is not yet supported",
-    );
 
     let doc_id_error = graphql_raw(
         &api_url,


### PR DESCRIPTION
## Summary

Fixes #970. Transactions now publish `EventName::Update` messages on the EventBus on successful commit, matching the auto-commit path's behavior and Go DefraDB's per-mutation `OnSuccess` callback pattern.

## What changed

- **`DbDocMutator`** (explicit-tx path) — `create`/`update`/`delete` each register an `on_success_async` callback on the transaction after block writes succeed. The callback publishes the Update event. The underlying tx machinery fires success callbacks only on commit; discards skip them.
- **`DbDocMutator::update` and `::delete`** previously did not write commit/delete blocks. Added the block writes so events have meaningful cids and tx writes leave a `_commits` history (parity with `BatchMutator`).
- **`BatchMutator`** (auto-commit path) refactored to use the same callback pattern via a new shared `event_emission` helper. Removes the `pending_events` queue.
- **Bug fix (BatchMutator):** previously, `queue_update_event` was called unconditionally on the block-write failure path with a default cid, emitting a misleading Update with an empty cid. After the refactor, callbacks register only when block writes succeed.

## Architecture

Per-mutation `on_success_async` callbacks, mirroring Go's `internal/db/collection.go:755`. The Rust `BasicTxn::commit` at `crates/datastore/src/txn.rs:241-246` fires success callbacks only on `Ok`; `discard` at line 299-300 skips them. Rollback safety is structural — no shared mutable log required.

## Tests

- New integration tests in `tools/integration-test/tests/basic/transactions.rs`:
  - `rust_txn_commit_publishes_update_events` — opens an SSE `/events?event=update` stream, runs three creates in a tx, asserts zero events before commit and exactly three after, with non-default cids and matching docIDs.
  - `rust_txn_discard_publishes_no_events` — asserts discard produces no events.
- New unit tests in `crates/db/src/doc_mutator.rs` and `crates/db/src/auto_commit_mutator/batch.rs` covering both mutators' commit and discard paths.

## Downstream

This unblocks `sourcenetwork/defra-agent#56`'s transactional `config apply` flow — runtime watchers will now wake up after a transactional batch commit.

## Out of scope

- Per-document granularity beyond what Go does today (already matches).
- `BroadcastMutator` tx behavior (P2P broadcast on tx commit) — track separately.
- Event emission for schema mutations performed inside a tx.

## Test plan

- [x] `cargo test --workspace --lib` — all 1844 unit tests pass
- [x] `cargo test -p integration-test --test basic` — all Rust-native pass (Go-backed tests fail due to missing Go binary in PATH, pre-existing env issue)
- [x] `cargo test -p integration-test --test query` — 25/0
- [x] `cargo test -p integration-test --test acp` — 106/0
- [x] `cargo test -p integration-test --test p2p` — 20/0 Rust-native (Go-backed cross-runtime tests fail on missing Go binary, pre-existing)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all -- -D warnings` clean