### PR TITLE
feat(query): support multi-cid queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,36 +165,55 @@ jobs:
           chmod +x target/ci/defra target/ci/defra-iroh
           target/ci/defra version --format json
 
-      - name: Download Go DefraDB binary
-        if: matrix.needs_go
-        run: |
-          GO_TAG=$(grep 'pub const GO_COMPAT_TAG' crates/defra-version/src/lib.rs | sed "s/.*\"\(.*\)\".*/\1/")
-          if [ -z "$GO_TAG" ]; then
-            echo "::error::GO_COMPAT_TAG is empty in crates/defra-version/src/lib.rs"
-            exit 1
-          fi
-          VER_NUM="${GO_TAG#v}"
-          ASSET="defradb_${VER_NUM}_darwin_arm64"
-          URL="https://github.com/sourcenetwork/defradb/releases/download/${GO_TAG}/${ASSET}"
-          CACHE_DIR="$HOME/.cache/defra-harness/${GO_TAG}"
-          mkdir -p "$CACHE_DIR"
-          if [ ! -x "$CACHE_DIR/defradb" ]; then
-            echo "Downloading Go DefraDB ${GO_TAG}..."
-            curl -fSL -o "$CACHE_DIR/defradb" "$URL"
-            chmod +x "$CACHE_DIR/defradb"
-          fi
-          echo "$CACHE_DIR" >> "$GITHUB_PATH"
-          "$CACHE_DIR/defradb" version --format json
-
-      # The self-hosted macOS ARM64 runner ships without a Go toolchain —
-      # the `go-compat` suite normally uses a prebuilt defradb binary.
-      # The fixture drift step below needs `go run`, so install Go on
-      # demand for that suite only.
-      - name: Install Go toolchain (fixture drift guard only)
+      - name: Install Go toolchain
         if: matrix.suite == 'go-compat'
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
+
+      - name: Prepare Go DefraDB binary
+        if: matrix.needs_go
+        run: |
+          GO_REF=$(grep 'pub const GO_COMPAT_COMMIT' crates/defra-version/src/lib.rs | sed "s/.*\"\(.*\)\".*/\1/")
+          GO_BRANCH=$(grep 'pub const GO_COMPAT_BRANCH' crates/defra-version/src/lib.rs | sed "s/.*\"\(.*\)\".*/\1/")
+          GO_TAG=$(grep 'pub const GO_COMPAT_TAG' crates/defra-version/src/lib.rs | sed "s/.*\"\(.*\)\".*/\1/")
+
+          if [ -n "$GO_TAG" ]; then
+            VER_NUM="${GO_TAG#v}"
+            ASSET="defradb_${VER_NUM}_darwin_arm64"
+            URL="https://github.com/sourcenetwork/defradb/releases/download/${GO_TAG}/${ASSET}"
+            CACHE_DIR="$HOME/.cache/defra-harness/${GO_TAG}"
+            mkdir -p "$CACHE_DIR"
+            if [ ! -x "$CACHE_DIR/defradb" ]; then
+              echo "Downloading Go DefraDB ${GO_TAG}..."
+              curl -fSL -o "$CACHE_DIR/defradb" "$URL"
+              chmod +x "$CACHE_DIR/defradb"
+            fi
+          else
+            if [ -z "$GO_REF" ]; then
+              echo "::error::GO_COMPAT_COMMIT is empty in crates/defra-version/src/lib.rs"
+              exit 1
+            fi
+            if [ -z "$GO_BRANCH" ]; then
+              echo "::error::GO_COMPAT_BRANCH is empty in crates/defra-version/src/lib.rs"
+              exit 1
+            fi
+
+            CACHE_DIR="$HOME/.cache/defra-harness/${GO_REF}"
+            mkdir -p "$CACHE_DIR"
+            if [ ! -x "$CACHE_DIR/defradb" ]; then
+              echo "Building Go DefraDB ${GO_REF} from ${GO_BRANCH}..."
+              WORK_DIR="$RUNNER_TEMP/defradb-${GO_REF}"
+              rm -rf "$WORK_DIR"
+              git clone --filter=blob:none --branch "$GO_BRANCH" https://github.com/sourcenetwork/defradb "$WORK_DIR"
+              git -C "$WORK_DIR" checkout "$GO_REF"
+              make -C "$WORK_DIR" build path="$CACHE_DIR/defradb"
+              chmod +x "$CACHE_DIR/defradb"
+            fi
+          fi
+
+          echo "$CACHE_DIR" >> "$GITHUB_PATH"
+          "$CACHE_DIR/defradb" version --format json
 
       # Guards against silent drift between the committed Go-parity hex
       # constants in `crates/p2p/src/**` and what upstream Go actually
@@ -263,8 +282,8 @@ jobs:
 
       # go-compat runs the `go_*` half of every dual-runtime test against
       # the upstream Go DefraDB binary. Catches cross-implementation
-      # regressions at PR time. Each binary added here was verified
-      # against defradb commit d5a5a879 (2026-04-10) before landing.
+      # regressions at PR time. The binary is selected by GO_COMPAT_TAG
+      # when a release exists, otherwise it is built from GO_COMPAT_COMMIT.
       #
       # The 5 `link_collection::go_acp_link_collection_*_reject` tests
       # cover #746 (Rust schema loader silently accepts invalid DRIs).

--- a/crates/defra-version/src/lib.rs
+++ b/crates/defra-version/src/lib.rs
@@ -1,11 +1,11 @@
 use serde::Serialize;
 
 /// Go upstream commit we last synced with.
-pub const GO_COMPAT_COMMIT: &str = "4b8993f8";
+pub const GO_COMPAT_COMMIT: &str = "6c874754";
 /// Go upstream branch.
 pub const GO_COMPAT_BRANCH: &str = "develop";
 /// Go release tag (empty until Go cuts a release).
-pub const GO_COMPAT_TAG: &str = "v1.0.0-rc1";
+pub const GO_COMPAT_TAG: &str = "";
 
 /// Go compatibility metadata.
 #[derive(Debug, Clone, Serialize)]

--- a/crates/query-parse/src/query_parse/parser.rs
+++ b/crates/query-parse/src/query_parse/parser.rs
@@ -686,11 +686,6 @@ fn parse_field_to_select(
                 // null means "no cid filter" (skip setting it)
                 if !matches!(arg_value, Value::Null) {
                     let cids = parse_cid_value(arg_value, variables)?;
-                    if cids.len() > 1 {
-                        return Err(QueryError::parse(
-                            "querying by multiple cids is not yet supported",
-                        ));
-                    }
                     select.cid = Some(cids);
                 }
             }

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -10,6 +10,7 @@
 use document::Document;
 use identity::Did;
 use serde_json::Value as JsonValue;
+use std::collections::HashSet;
 
 use crate::error::Result;
 use crate::mapper::{Aggregate, AggregateType, Requestable, Select};
@@ -689,9 +690,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         }
 
         // Build options from the select
-        let options = CommitsQueryOptions {
+        let base_options = CommitsQueryOptions {
             doc_id: select.doc_ids.as_ref().and_then(|ids| ids.first().cloned()),
-            cid: select.cid.as_ref().and_then(|cids| cids.first().cloned()),
+            cid: None,
             depth: select.depth,
             height_start: match &height_range {
                 HeightRangeExtraction::Range(range) => Some(range.start),
@@ -705,7 +706,33 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         };
 
         // Fetch commits using the fetcher
-        let mut commits = self.fetcher.get_commits(&options).await?;
+        let mut commits = Vec::new();
+        if let Some(ref cids) = select.cid {
+            let mut seen_commit_cids = HashSet::new();
+            let mut seen_input_cids = HashSet::new();
+
+            for cid in cids {
+                if !seen_input_cids.insert(cid.clone()) {
+                    continue;
+                }
+
+                let options = CommitsQueryOptions {
+                    cid: Some(cid.clone()),
+                    ..base_options.clone()
+                };
+                for commit in self.fetcher.get_commits(&options).await? {
+                    let Some(commit_cid) = commit.get("cid").and_then(|value| value.as_str())
+                    else {
+                        continue;
+                    };
+                    if seen_commit_cids.insert(commit_cid.to_string()) {
+                        commits.push(commit);
+                    }
+                }
+            }
+        } else {
+            commits = self.fetcher.get_commits(&base_options).await?;
+        }
 
         // ACP filtering: check read permission for each commit's document.
         // _commits must enforce the same ACP rules as regular document queries.

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -9,6 +9,7 @@ use acp::{DocumentPermission, Identity};
 use identity::Did;
 use schema::CollectionVersion;
 use serde_json::Value as JsonValue;
+use std::collections::HashSet;
 
 use crate::error::{QueryError, Result};
 use crate::mapper::{Requestable, Select};
@@ -38,31 +39,43 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let cids = select.cid.as_ref().ok_or_else(|| {
             QueryError::internal("execute_cid_query called without CID - this is a bug")
         })?;
-        let cid = cids.first().ok_or_else(|| {
-            QueryError::internal("execute_cid_query called with empty CID array - this is a bug")
-        })?;
+        if cids.is_empty() {
+            return Err(QueryError::internal(
+                "execute_cid_query called with empty CID array - this is a bug",
+            ));
+        }
 
         // Get expected docID from select.doc_ids (optional validation)
         let expected_doc_id = select.doc_ids.as_ref().and_then(|ids| ids.first());
 
-        // Fetch document(s) at the specified CID.
+        // Fetch document(s) at the specified CIDs.
         // For collection-level CIDs (branchable), this returns multiple documents.
         // For document-level CIDs, this returns a single document.
-        let documents = match fetcher
-            .get_documents_at_cid(cid, expected_doc_id.map(|s| s.as_str()))
-            .await
-        {
-            Ok(docs) => docs,
-            Err(e) => {
-                let err_msg = e.to_string();
-                // docID mismatch: Go returns empty results
-                if err_msg.contains("cid either does not exist or belong to document") {
-                    return Ok(JsonValue::Array(vec![]));
-                }
-                // Block not found in blockstore: propagate as error (Go does the same)
-                return Err(e);
+        let mut seen_cids = HashSet::new();
+        let mut documents = Vec::new();
+        for cid in cids {
+            if !seen_cids.insert(cid.clone()) {
+                continue;
             }
-        };
+
+            match fetcher
+                .get_documents_at_cid(cid, expected_doc_id.map(|s| s.as_str()))
+                .await
+            {
+                Ok(docs) => {
+                    documents.extend(docs.into_iter().map(|doc| (doc, cid.clone())));
+                }
+                Err(e) => {
+                    let err_msg = e.to_string();
+                    // docID mismatch: Go returns empty results
+                    if err_msg.contains("cid either does not exist or belong to document") {
+                        continue;
+                    }
+                    // Block not found in blockstore: propagate as error (Go does the same)
+                    return Err(e);
+                }
+            }
+        }
 
         // Get collection schema for building the mapping
         let collection = self.get_collection(&select.collection_name).await?;
@@ -73,7 +86,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         let documents = if let Some(ref policy) = collection.policy {
             let identity = Identity::from(caller_identity);
             let mut permitted = Vec::with_capacity(documents.len());
-            for doc in documents {
+            for (doc, cid) in documents {
                 let doc_id = match doc.id() {
                     Some(id) => id.to_string(),
                     None => continue,
@@ -88,7 +101,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 )
                 .await
                 {
-                    Ok(true) => permitted.push(doc),
+                    Ok(true) => permitted.push((doc, cid)),
                     Ok(false) => {
                         tracing::debug!(
                             target: "acp::audit",
@@ -110,7 +123,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
 
         let documents = if let Some(ref filter) = select.filter {
             let mut filtered = Vec::with_capacity(documents.len());
-            for document in documents {
+            for (document, cid) in documents {
                 let json_obj = JsonValue::Object(
                     document
                         .to_map()
@@ -119,7 +132,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                         .collect(),
                 );
                 if filter.matches_json_object(&json_obj)? {
-                    filtered.push(document);
+                    filtered.push((document, cid));
                 }
             }
             filtered
@@ -157,7 +170,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
         // Process each document into a JSON object
         let mut result_array = Vec::new();
 
-        for document in &documents {
+        for (document, cid) in &documents {
             // Convert the document to JSON with only the requested scalar fields
             let mut obj = serde_json::Map::new();
 
@@ -231,7 +244,12 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 let doc_id = document.id().map(|id| id.to_string());
                 if let Some(doc_id_str) = doc_id {
                     let version_data = self
-                        .fetch_version_data(fetcher, &doc_id_str, version_select, Some(cid))
+                        .fetch_version_data(
+                            fetcher,
+                            &doc_id_str,
+                            version_select,
+                            Some(cid.as_str()),
+                        )
                         .await?;
                     let output_name = version_select.field.output_name();
                     obj.insert(output_name.to_string(), version_data);

--- a/crates/query/tests/query_parse_tests.rs
+++ b/crates/query/tests/query_parse_tests.rs
@@ -84,15 +84,25 @@ fn test_parse_query_with_cid_list_of_one() {
 }
 
 #[test]
-fn test_parse_query_with_multiple_cids_returns_error() {
+fn test_parse_query_with_multiple_cids() {
     let query = r#"{ Users(cid: ["bafy-one", "bafy-two"]) { _docID name } }"#;
-    let result = parse_query(query);
+    let selects = parse_query(query).unwrap();
 
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("querying by multiple cids is not yet supported"));
+    assert_eq!(
+        selects[0].cid,
+        Some(vec!["bafy-one".to_string(), "bafy-two".to_string()])
+    );
+}
+
+#[test]
+fn test_parse_commits_with_multiple_cids() {
+    let query = r#"{ _commits(cid: ["bafy-one", "bafy-two"]) { cid } }"#;
+    let selects = parse_query(query).unwrap();
+
+    assert_eq!(
+        selects[0].cid,
+        Some(vec!["bafy-one".to_string(), "bafy-two".to_string()])
+    );
 }
 
 #[test]

--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -24,6 +24,8 @@ mod lens;
 mod lens_persistence;
 #[path = "query/limits.rs"]
 mod limits;
+#[path = "query/multi_cid_vectors.rs"]
+mod multi_cid_vectors;
 #[path = "query/planner_4656.rs"]
 mod planner_4656;
 #[path = "query/planner_4684.rs"]

--- a/tools/integration-test/tests/query/gql_list_args.rs
+++ b/tools/integration-test/tests/query/gql_list_args.rs
@@ -205,21 +205,98 @@ async fn gql_list_args_single_value_compat_test(cluster: TestCluster) {
     }
 }
 
-async fn gql_list_args_multi_value_errors_test(cluster: TestCluster) {
-    // Multi-cid query (`User(cid: [...])`, `_commits(cid: [...])`) used to
-    // return "querying by multiple cids is not yet supported" on Go. Go shipped
-    // real multi-cid support in sourcenetwork/defradb#4794, so those
-    // assertions are intentionally omitted here; defradb.rs#972 tracks the
-    // matching Rust port. Once that lands, restore the multi-cid cases as
-    // positive (returns-results) assertions on both runtimes.
-    //
-    // Multi-docID query (`_commits(docID: [...])`) still returns
-    // "querying by multiple docIDs is not yet supported" on Go, so we keep
-    // asserting it.
-
+async fn gql_list_args_multi_value_test(cluster: TestCluster) {
     let node = cluster.client(0);
     let api_url = cluster.api_url(0).to_string();
     node.schema_add(SCHEMA).expect("add schema");
+
+    let alice = node
+        .query(r#"mutation { add_User(input: {name: "Alice", age: 30}) { _docID } }"#)
+        .expect("create alice");
+    let alice_id = extract_doc_id(&alice, "add_User");
+
+    let bob = node
+        .query(r#"mutation { add_User(input: {name: "Bob", age: 31}) { _docID } }"#)
+        .expect("create bob");
+    let bob_id = extract_doc_id(&bob, "add_User");
+
+    let alice_commits = node
+        .query(&format!(
+            r#"query {{
+                _commits(docID: ["{alice_id}"], filter: {{fieldName: {{_eq: "_C"}}}}) {{
+                    cid
+                    height
+                    docID
+                }}
+            }}"#,
+        ))
+        .expect("query alice commits");
+    let alice_cid = commit_cid(&alice_commits);
+
+    let bob_commits = node
+        .query(&format!(
+            r#"query {{
+                _commits(docID: ["{bob_id}"], filter: {{fieldName: {{_eq: "_C"}}}}) {{
+                    cid
+                    height
+                    docID
+                }}
+            }}"#,
+        ))
+        .expect("query bob commits");
+    let bob_cid = commit_cid(&bob_commits);
+
+    let users_by_cid = node
+        .query(&format!(
+            r#"query {{
+                User(cid: ["{alice_cid}", "{bob_cid}"]) {{
+                    _docID
+                    name
+                }}
+            }}"#,
+        ))
+        .expect("query users by multiple cids");
+    let user_names: std::collections::BTreeSet<_> = rows(&users_by_cid, "User")
+        .iter()
+        .map(|user| {
+            user["name"]
+                .as_str()
+                .expect("missing user name")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        user_names,
+        ["Alice".to_string(), "Bob".to_string()]
+            .into_iter()
+            .collect(),
+        "unexpected User(cid: [...]) result: {users_by_cid}"
+    );
+
+    let commits_by_cid = node
+        .query(&format!(
+            r#"query {{
+                _commits(cid: ["{alice_cid}", "{bob_cid}"]) {{
+                    cid
+                    docID
+                }}
+            }}"#,
+        ))
+        .expect("query commits by multiple cids");
+    let commit_cids: std::collections::BTreeSet<_> = rows(&commits_by_cid, "_commits")
+        .iter()
+        .map(|commit| {
+            commit["cid"]
+                .as_str()
+                .expect("missing commit cid")
+                .to_string()
+        })
+        .collect();
+    assert_eq!(
+        commit_cids,
+        [alice_cid.clone(), bob_cid.clone()].into_iter().collect(),
+        "unexpected _commits(cid: [...]) result: {commits_by_cid}"
+    );
 
     let doc_id_error = graphql_raw(
         &api_url,
@@ -244,7 +321,4 @@ for_each_runtime!(
     gql_list_args_single_value_compat,
     gql_list_args_single_value_compat_test
 );
-for_each_runtime!(
-    gql_list_args_multi_value_errors,
-    gql_list_args_multi_value_errors_test
-);
+for_each_runtime!(gql_list_args_multi_value, gql_list_args_multi_value_test);

--- a/tools/integration-test/tests/query/multi_cid_vectors.rs
+++ b/tools/integration-test/tests/query/multi_cid_vectors.rs
@@ -1,0 +1,326 @@
+use integration_test::{for_each_runtime, generate_identity, TestCluster};
+use serde_json::Value;
+
+// Mirrors the multi-CID vector cases added in Go PR #4794. Document CID tests
+// use the same literal CIDs; _commits tests derive runtime CIDs because commit
+// CID bytes are not stable across the Rust and Go integration harness paths.
+const SIMPLE_USERS_SCHEMA: &str = "type Users { name: String }";
+const COMMIT_USERS_SCHEMA: &str = "type Users { name: String  age: Int  verified: Boolean }";
+
+const SIMPLE_JOHN_CID: &str = "bafyreifldhofx6cwi6ashk24rcefsuiqje5a2rziwcyte54z27wmgv4pey";
+const SIMPLE_FRED_CID: &str = "bafyreihufziq5m2i6sgw2ls45uratin7eudhjplfg23qtj2lv6g6knevha";
+const SIMPLE_JOHNNN_CID: &str = "bafyreiecis4aqmvr4effzlb74cwflphkykfnibpdnnftdyp6o2cneqy57q";
+
+const USERS_ACP_POLICY: &str = r#"description: a test policy which marks a collection in a database as a resource
+name: test
+resources:
+- name: users
+  permissions:
+  - name: delete
+  - expr: reader
+    name: read
+  - name: update
+  relations:
+  - manages:
+    - reader
+    name: admin
+    types:
+    - actor
+  - name: reader
+    types:
+    - actor"#;
+
+fn rows<'a>(data: &'a Value, field: &str) -> &'a [Value] {
+    data[field]
+        .as_array()
+        .unwrap_or_else(|| panic!("{field} array missing from response: {data}"))
+        .as_slice()
+}
+
+fn extract_doc_id(data: &Value, mutation_name: &str) -> String {
+    data[mutation_name]
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|value| value["_docID"].as_str())
+        .or_else(|| data[mutation_name]["_docID"].as_str())
+        .unwrap_or_else(|| panic!("missing _docID in {data}"))
+        .to_string()
+}
+
+fn extract_policy_id(data: &Value) -> String {
+    data["PolicyID"]
+        .as_str()
+        .or_else(|| data["policyID"].as_str())
+        .unwrap_or_else(|| panic!("missing PolicyID in {data}"))
+        .to_string()
+}
+
+fn users_policy_schema(policy_id: &str) -> String {
+    format!(
+        r#"type Users @policy(id: "{}", resource: "users") {{ name: String  age: Int }}"#,
+        policy_id
+    )
+}
+
+fn names(data: &Value) -> Vec<String> {
+    rows(data, "Users")
+        .iter()
+        .map(|user| {
+            user["name"]
+                .as_str()
+                .unwrap_or_else(|| panic!("missing name in {user}"))
+                .to_string()
+        })
+        .collect()
+}
+
+fn commit_cids(data: &Value) -> Vec<String> {
+    rows(data, "_commits")
+        .iter()
+        .map(|commit| {
+            commit["cid"]
+                .as_str()
+                .unwrap_or_else(|| panic!("missing cid in {commit}"))
+                .to_string()
+        })
+        .collect()
+}
+
+fn commit_cid_at_height(data: &Value, height: u64) -> String {
+    rows(data, "_commits")
+        .iter()
+        .find(|commit| commit["height"].as_u64() == Some(height))
+        .and_then(|commit| commit["cid"].as_str())
+        .unwrap_or_else(|| panic!("missing commit cid at height {height} in {data}"))
+        .to_string()
+}
+
+fn add_simple_user(node: &integration_test::DefraClient, name: &str) -> Value {
+    node.query(&format!(
+        r#"mutation {{ add_Users(input: {{name: "{name}"}}) {{ _docID name }} }}"#
+    ))
+    .unwrap_or_else(|err| panic!("add {name}: {err:#}"))
+}
+
+fn add_commit_user(node: &integration_test::DefraClient, name: &str, age: i64) -> Value {
+    node.query(&format!(
+        r#"mutation {{ add_Users(input: {{name: "{name}", age: {age}}}) {{ _docID name age }} }}"#
+    ))
+    .unwrap_or_else(|err| panic!("add {name}: {err:#}"))
+}
+
+fn commit_cid_for_doc_field(
+    node: &integration_test::DefraClient,
+    doc_id: &str,
+    field_name: &str,
+    height: u64,
+) -> String {
+    let result = node
+        .query(&format!(
+            r#"query {{
+                _commits(docID: ["{doc_id}"], filter: {{fieldName: {{_eq: "{field_name}"}}}}) {{
+                    cid
+                    height
+                }}
+            }}"#
+        ))
+        .expect("query doc commit cid");
+    commit_cid_at_height(&result, height)
+}
+
+fn create_commit_cid_for_doc(node: &integration_test::DefraClient, doc_id: &str) -> String {
+    commit_cid_for_doc_field(node, doc_id, "_C", 1)
+}
+
+async fn multi_cid_simple_multiple_cids_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add(SIMPLE_USERS_SCHEMA).expect("add schema");
+
+    add_simple_user(&node, "John");
+    add_simple_user(&node, "Fred");
+    add_simple_user(&node, "Shahzad");
+
+    let result = node
+        .query(&format!(
+            r#"query {{
+                Users(cid: ["{SIMPLE_JOHN_CID}", "{SIMPLE_FRED_CID}"]) {{
+                    name
+                }}
+            }}"#
+        ))
+        .expect("query Users by multiple CIDs");
+
+    assert_eq!(names(&result), ["John", "Fred"]);
+}
+
+async fn multi_cid_simple_duplicate_cids_for_same_doc_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add(SIMPLE_USERS_SCHEMA).expect("add schema");
+
+    add_simple_user(&node, "John");
+    add_simple_user(&node, "Fred");
+
+    let result = node
+        .query(&format!(
+            r#"query {{
+                Users(cid: ["{SIMPLE_JOHN_CID}", "{SIMPLE_JOHN_CID}"]) {{
+                    name
+                }}
+            }}"#
+        ))
+        .expect("query Users by duplicate CIDs");
+
+    assert_eq!(names(&result), ["John"]);
+}
+
+async fn multi_cid_simple_multiple_cids_for_same_doc_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add(SIMPLE_USERS_SCHEMA).expect("add schema");
+
+    let created = add_simple_user(&node, "John");
+    let john_id = extract_doc_id(&created, "add_Users");
+    node.query(&format!(
+        r#"mutation {{ update_Users(docID: "{john_id}", input: {{name: "Johnnn"}}) {{ _docID name }} }}"#
+    ))
+    .expect("update John");
+    add_simple_user(&node, "Fred");
+
+    let result = node
+        .query(&format!(
+            r#"query {{
+                Users(cid: ["{SIMPLE_JOHN_CID}", "{SIMPLE_JOHNNN_CID}"]) {{
+                    name
+                }}
+            }}"#
+        ))
+        .expect("query Users by multiple CIDs for one doc");
+
+    assert_eq!(names(&result), ["John", "Johnnn"]);
+}
+
+async fn multi_cid_commits_different_docs_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add(COMMIT_USERS_SCHEMA).expect("add schema");
+
+    let john = add_commit_user(&node, "John", 21);
+    let john_id = extract_doc_id(&john, "add_Users");
+    let fred = add_commit_user(&node, "Fred", 21);
+    let fred_id = extract_doc_id(&fred, "add_Users");
+    let john_cid = create_commit_cid_for_doc(&node, &john_id);
+    let fred_cid = create_commit_cid_for_doc(&node, &fred_id);
+
+    let result = node
+        .query(&format!(
+            r#"query {{
+                _commits(cid: ["{john_cid}", "{fred_cid}"]) {{
+                    cid
+                }}
+            }}"#
+        ))
+        .expect("query _commits by multiple CIDs");
+
+    assert_eq!(commit_cids(&result), [john_cid, fred_cid]);
+}
+
+async fn multi_cid_commits_same_doc_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add(COMMIT_USERS_SCHEMA).expect("add schema");
+
+    let created = add_commit_user(&node, "John", 21);
+    let john_id = extract_doc_id(&created, "add_Users");
+    node.query(&format!(
+        r#"mutation {{ update_Users(docID: "{john_id}", input: {{age: 22}}) {{ _docID age }} }}"#
+    ))
+    .expect("update John");
+    let create_cid = create_commit_cid_for_doc(&node, &john_id);
+    let update_cid = commit_cid_for_doc_field(&node, &john_id, "age", 2);
+
+    let result = node
+        .query(&format!(
+            r#"query {{
+                _commits(cid: ["{create_cid}", "{update_cid}"]) {{
+                    cid
+                }}
+            }}"#
+        ))
+        .expect("query _commits by multiple CIDs for one doc");
+
+    assert_eq!(commit_cids(&result), [create_cid, update_cid]);
+}
+
+async fn multi_cid_commits_filters_unreadable_cid_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    let owner = generate_identity(node.binary_path()).expect("owner identity");
+
+    let policy = node
+        .acp_policy_add(USERS_ACP_POLICY, &owner.private_key_hex)
+        .expect("add policy");
+    let schema = users_policy_schema(&extract_policy_id(&policy));
+    node.schema_add_with_identity(&schema, &owner.private_key_hex)
+        .expect("add schema");
+
+    let public = node
+        .query(r#"mutation { add_Users(input: {name: "John", age: 21}) { _docID } }"#)
+        .expect("add public doc");
+    let public_id = extract_doc_id(&public, "add_Users");
+    let private = node
+        .query_with_identity(
+            r#"mutation { add_Users(input: {name: "Fred", age: 21}) { _docID } }"#,
+            &owner.private_key_hex,
+        )
+        .expect("add protected doc");
+    let private_id = extract_doc_id(&private, "add_Users");
+
+    let public_cid = create_commit_cid_for_doc(&node, &public_id);
+    let private_cid = {
+        let result = node
+            .query_with_identity(
+                &format!(
+                    r#"query {{
+                        _commits(docID: ["{private_id}"], filter: {{fieldName: {{_eq: "_C"}}}}) {{
+                            cid
+                            height
+                        }}
+                    }}"#
+                ),
+                &owner.private_key_hex,
+            )
+            .expect("query private doc commit cid");
+        commit_cid_at_height(&result, 1)
+    };
+
+    let result = node
+        .query(&format!(
+            r#"query {{
+                _commits(cid: ["{public_cid}", "{private_cid}"]) {{
+                    cid
+                }}
+            }}"#
+        ))
+        .expect("query _commits with unreadable CID");
+
+    assert_eq!(commit_cids(&result), [public_cid]);
+}
+
+for_each_runtime!(
+    multi_cid_simple_multiple_cids,
+    multi_cid_simple_multiple_cids_test
+);
+for_each_runtime!(
+    multi_cid_simple_duplicate_cids_for_same_doc,
+    multi_cid_simple_duplicate_cids_for_same_doc_test
+);
+for_each_runtime!(
+    multi_cid_simple_multiple_cids_for_same_doc,
+    multi_cid_simple_multiple_cids_for_same_doc_test
+);
+for_each_runtime!(
+    multi_cid_commits_different_docs,
+    multi_cid_commits_different_docs_test
+);
+for_each_runtime!(multi_cid_commits_same_doc, multi_cid_commits_same_doc_test);
+for_each_runtime!(
+    multi_cid_commits_filters_unreadable_cid,
+    multi_cid_commits_filters_unreadable_cid_test,
+    .with_acp_local()
+);

--- a/tools/integration-test/tests/query/multi_cid_vectors.rs
+++ b/tools/integration-test/tests/query/multi_cid_vectors.rs
@@ -150,7 +150,11 @@ async fn multi_cid_simple_multiple_cids_test(cluster: TestCluster) {
         ))
         .expect("query Users by multiple CIDs");
 
-    assert_eq!(names(&result), ["John", "Fred"]);
+    assert_eq!(
+        names(&result),
+        ["John", "Fred"],
+        "unexpected Users result for CIDs {SIMPLE_JOHN_CID}, {SIMPLE_FRED_CID}: {result}"
+    );
 }
 
 async fn multi_cid_simple_duplicate_cids_for_same_doc_test(cluster: TestCluster) {
@@ -170,7 +174,11 @@ async fn multi_cid_simple_duplicate_cids_for_same_doc_test(cluster: TestCluster)
         ))
         .expect("query Users by duplicate CIDs");
 
-    assert_eq!(names(&result), ["John"]);
+    assert_eq!(
+        names(&result),
+        ["John"],
+        "unexpected Users result for duplicate CID {SIMPLE_JOHN_CID}: {result}"
+    );
 }
 
 async fn multi_cid_simple_multiple_cids_for_same_doc_test(cluster: TestCluster) {
@@ -195,7 +203,11 @@ async fn multi_cid_simple_multiple_cids_for_same_doc_test(cluster: TestCluster) 
         ))
         .expect("query Users by multiple CIDs for one doc");
 
-    assert_eq!(names(&result), ["John", "Johnnn"]);
+    assert_eq!(
+        names(&result),
+        ["John", "Johnnn"],
+        "unexpected Users result for CIDs {SIMPLE_JOHN_CID}, {SIMPLE_JOHNNN_CID}: {result}"
+    );
 }
 
 async fn multi_cid_commits_different_docs_test(cluster: TestCluster) {
@@ -219,7 +231,11 @@ async fn multi_cid_commits_different_docs_test(cluster: TestCluster) {
         ))
         .expect("query _commits by multiple CIDs");
 
-    assert_eq!(commit_cids(&result), [john_cid, fred_cid]);
+    assert_eq!(
+        commit_cids(&result),
+        [john_cid, fred_cid],
+        "unexpected _commits result: {result}"
+    );
 }
 
 async fn multi_cid_commits_same_doc_test(cluster: TestCluster) {
@@ -245,7 +261,42 @@ async fn multi_cid_commits_same_doc_test(cluster: TestCluster) {
         ))
         .expect("query _commits by multiple CIDs for one doc");
 
-    assert_eq!(commit_cids(&result), [create_cid, update_cid]);
+    assert_eq!(
+        commit_cids(&result),
+        [create_cid, update_cid],
+        "unexpected _commits result: {result}"
+    );
+}
+
+async fn multi_cid_commits_overlapping_depth_dedups_test(cluster: TestCluster) {
+    let node = cluster.client(0);
+    node.schema_add(COMMIT_USERS_SCHEMA).expect("add schema");
+
+    let created = add_commit_user(&node, "John", 21);
+    let john_id = extract_doc_id(&created, "add_Users");
+    node.query(&format!(
+        r#"mutation {{ update_Users(docID: "{john_id}", input: {{age: 22}}) {{ _docID age }} }}"#
+    ))
+    .expect("update John");
+
+    let age_create_cid = commit_cid_for_doc_field(&node, &john_id, "age", 1);
+    let age_update_cid = commit_cid_for_doc_field(&node, &john_id, "age", 2);
+
+    let result = node
+        .query(&format!(
+            r#"query {{
+                _commits(cid: ["{age_update_cid}", "{age_create_cid}"], depth: 2) {{
+                    cid
+                }}
+            }}"#
+        ))
+        .expect("query _commits by overlapping CIDs");
+
+    assert_eq!(
+        commit_cids(&result),
+        [age_update_cid, age_create_cid],
+        "unexpected _commits overlap result: {result}"
+    );
 }
 
 async fn multi_cid_commits_filters_unreadable_cid_test(cluster: TestCluster) {
@@ -299,7 +350,11 @@ async fn multi_cid_commits_filters_unreadable_cid_test(cluster: TestCluster) {
         ))
         .expect("query _commits with unreadable CID");
 
-    assert_eq!(commit_cids(&result), [public_cid]);
+    assert_eq!(
+        commit_cids(&result),
+        [public_cid],
+        "unexpected _commits ACP-filtered result: {result}"
+    );
 }
 
 for_each_runtime!(
@@ -319,6 +374,10 @@ for_each_runtime!(
     multi_cid_commits_different_docs_test
 );
 for_each_runtime!(multi_cid_commits_same_doc, multi_cid_commits_same_doc_test);
+for_each_runtime!(
+    multi_cid_commits_overlapping_depth_dedups,
+    multi_cid_commits_overlapping_depth_dedups_test
+);
 for_each_runtime!(
     multi_cid_commits_filters_unreadable_cid,
     multi_cid_commits_filters_unreadable_cid_test,


### PR DESCRIPTION
## Summary

Ports Go DefraDB multi-CID query support from sourcenetwork/defradb#4794.

- Accept `cid: [..]` in GraphQL parsing for normal document queries and `_commits`
- Execute document CID queries by fetching each unique CID and merging rendered results
- Execute `_commits(cid: [..])` by fanning out per CID and deduping returned commit CIDs
- Keep `_commits(docID: [..])` unsupported for parity with Go
- Restore cross-runtime integration coverage for multi-value `cid` list args
- Add mirrored Go #4794 vector coverage for duplicate CIDs, multiple versions of one doc, multiple commit CIDs, ACP-filtered commit CIDs, and overlapping depth traversal
- Update go-compat CI to build the Go binary from synced commit `6c874754` when no release tag contains the needed Go feature

Closes #972.

## Verification

- `cargo fmt --all`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml ok"'`
- `cargo test -p defra-version`
- `cargo test -p query --test query_parse_tests -- --nocapture`
- `cargo test -p integration-test --test query rust_gql_list_args_multi_value -- --nocapture`
- `PATH="../defradb/build:$PATH" cargo test -p integration-test --test query gql_list_args_multi_value -- --nocapture`
- `PATH="../defradb/build:$PATH" cargo test -p integration-test --test query multi_cid -- --nocapture --test-threads=1` (14 passed)
- Built Go DefraDB from exact commit `6c874754`; `PATH="/tmp/defradb-go-compat-bin-6c874754:$PATH" cargo test -p integration-test --test query go_ -- --test-threads=1` (18 passed, 3 ignored)
- `rg "querying by multiple cids" crates tools` returns no matches

Note: earlier cross-runtime integration commands used a Go `defradb` binary built from `../defradb` with `make build`; the CI reproduction command used an exact `6c874754` build.
