### PR TITLE
fix(p2p): cross-runtime DAG fetch fairness under saturation

### DIFF
--- a/crates/db-blocks/src/collection.rs
+++ b/crates/db-blocks/src/collection.rs
@@ -52,8 +52,8 @@ pub async fn write_collection_block(
 
     let priority: u64 = max_priority + 1;
 
-    // Sort heads by CID string representation to match Go's Block.New() sorting
-    col_heads.sort_by_key(|a| a.to_bytes());
+    // Sort heads by CID string representation to match Go's Block.New() sorting.
+    col_heads.sort_by_cached_key(|a| a.to_string());
 
     // Create the Collection delta payload
     let collection_payload = CollectionDeltaPayload {

--- a/crates/db-blocks/src/lib.rs
+++ b/crates/db-blocks/src/lib.rs
@@ -253,8 +253,8 @@ pub async fn get_all_field_heads(
         }
     }
 
-    // Sort by CID string representation to match Go's Block.New() sorting
-    entries.sort_by_key(|a| a.cid.to_bytes());
+    // Sort by CID string representation to match Go's Block.New() sorting.
+    entries.sort_by_cached_key(|a| a.cid.to_string());
     Ok(entries)
 }
 
@@ -313,7 +313,7 @@ impl DocHeadsSnapshot {
 
         // Sort each field's entries by CID string to match Go's deterministic ordering.
         for entries in entries_by_field.values_mut() {
-            entries.sort_by_key(|a| a.cid.to_bytes());
+            entries.sort_by_cached_key(|a| a.cid.to_string());
         }
 
         Ok(Self {

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -55,7 +55,7 @@ pub struct Block {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub heads: Option<Vec<Cid>>,
 
-    /// Named links to other blocks (sorted lexicographically by CID)
+    /// Named links to other blocks (sorted lexicographically by CID string)
     ///
     /// Used for field-level links in composite blocks. Empty for field-level blocks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -78,9 +78,9 @@ impl Block {
     /// - Sorts links lexicographically by CID string
     /// - Converts empty slices to `None` for space efficiency
     pub fn new(delta: CrdtDelta, heads: Vec<Cid>, links: Vec<DAGLink>) -> Self {
-        // Sort and normalize heads
+        // Sort and normalize heads. Go sorts by CID string, not raw CID bytes.
         let mut sorted_heads = heads;
-        sorted_heads.sort_unstable();
+        sorted_heads.sort_by_cached_key(|cid| cid.to_string());
         let heads = if sorted_heads.is_empty() {
             None
         } else {
@@ -224,9 +224,12 @@ impl PartialOrd for DAGLink {
 
 impl Ord for DAGLink {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // DefraDB block links are CIDv1 DAG-CBOR SHA2-256 values, so native CID ordering
-        // matches the prior multibase string ordering without allocating.
-        self.link.cmp(&other.link)
+        // Go sorts DAG links by CID string. Raw CID byte ordering is not equivalent
+        // for all CID values and changes block CIDs for those schemas.
+        self.link
+            .to_string()
+            .cmp(&other.link.to_string())
+            .then_with(|| self.name.cmp(&other.name))
     }
 }
 

--- a/crates/defra-core/tests/block_tests.rs
+++ b/crates/defra-core/tests/block_tests.rs
@@ -393,26 +393,38 @@ fn test_block_new_sorts_links_by_cid_string() {
 }
 
 #[test]
-fn test_cid_order_matches_string_order_for_block_sort_inputs() {
-    let mut sorted_by_cid = vec![
-        test_cid(),
-        test_cid2(),
-        Cid::from_str(GO_LWW_SIMPLE_CID).unwrap(),
-        Cid::from_str(GO_LWW_HIGH_PRIORITY_CID).unwrap(),
-        Cid::from_str(GO_COUNTER_CID).unwrap(),
-        Cid::from_str(GO_COMPOSITE_ACTIVE_CID).unwrap(),
-        Cid::from_str(GO_COMPOSITE_DELETED_CID).unwrap(),
-        Cid::from_str(GO_COLLECTION_CID).unwrap(),
-        Cid::from_str(GO_LWW_DELETION_CID).unwrap(),
-        Cid::from_str(GO_BLOCK_WITH_ONE_HEAD_CID).unwrap(),
-        Cid::from_str(GO_COMPOSITE_BLOCK_WITH_LINKS_CID).unwrap(),
-    ];
-    let mut sorted_by_string = sorted_by_cid.clone();
+fn test_block_new_uses_string_order_when_cid_byte_order_differs() {
+    let doc_id =
+        Cid::from_str("bafyreihqzhiz3iwro4jozp6kphq4sosg6ccoqcbiaf7rg5dmvea7aux55a").unwrap();
+    let data =
+        Cid::from_str("bafyreih2uk7uwfnwfmffmokgrecoikhuk2sxsfwilwpcazzsi2u37m3tmu").unwrap();
+    let idx = Cid::from_str("bafyreibqvnx5ibtgidcmcpljhzrcct76sxtgxctxiatmnakz2zeztss3ru").unwrap();
 
-    sorted_by_cid.sort_unstable();
-    sorted_by_string.sort_by_cached_key(|cid| cid.to_string());
+    let mut by_bytes = [doc_id, data, idx];
+    by_bytes.sort_unstable();
+    assert_ne!(
+        by_bytes,
+        [idx, data, doc_id],
+        "fixture should cover a CID set where native byte order differs from Go string order",
+    );
 
-    assert_eq!(sorted_by_cid, sorted_by_string);
+    let block = Block::new(
+        test_lww_delta(),
+        vec![data, idx, doc_id],
+        vec![
+            DAGLink::new("_docID", doc_id),
+            DAGLink::new("data", data),
+            DAGLink::new("idx", idx),
+        ],
+    );
+
+    let heads = block.heads.unwrap();
+    assert_eq!(heads, vec![idx, data, doc_id]);
+
+    let links = block.links.unwrap();
+    assert_eq!(links[0].link, idx);
+    assert_eq!(links[1].link, data);
+    assert_eq!(links[2].link, doc_id);
 }
 
 #[test]

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -35,7 +35,7 @@ use parking_lot::RwLock;
 
 use super::authorizer::RuntimeAuthorizer;
 use super::{
-    SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState,
+    DagFetchLimiter, SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState,
     DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
 };
 
@@ -139,9 +139,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
             transport,
             broadcaster,
             failure_tx: None,
-            dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(
-                DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
-            )),
+            dag_fetch_limiter: DagFetchLimiter::new(DEFAULT_MAX_CONCURRENT_DAG_FETCHES),
             push_semaphore: Arc::new(tokio::sync::Semaphore::new(
                 DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
             )),

--- a/crates/p2p/src/sync/coordinator/accessors.rs
+++ b/crates/p2p/src/sync/coordinator/accessors.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use acp::{DocumentACP, ReplicatedDocActorRelationships};
 use blockstore::Blockstore;
 
-use super::{SyncCoordinator, SyncShutdownHandle};
+use super::{DagFetchLimiter, SyncCoordinator, SyncShutdownHandle};
 use crate::bitswap::ReplicatorRegistry;
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::manager::SyncManager;
@@ -46,6 +46,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Get the shutdown handle for coordinator-owned background tasks.
     pub fn background_shutdown_handle(&self) -> SyncShutdownHandle {
         self.runtime.shutdown.clone()
+    }
+
+    /// Get the shared DAG fetch limiter.
+    pub(crate) fn dag_fetch_limiter(&self) -> DagFetchLimiter {
+        self.runtime.dag_fetch_limiter.clone()
     }
 
     /// Get the sync manager reference.

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -7,7 +7,9 @@ use blockstore::Blockstore;
 use tokio::sync::mpsc;
 
 use super::authorizer::{AccessAuthorizer, RuntimeAuthorizer};
-use super::{SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState};
+use super::{
+    DagFetchLimiter, SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState,
+};
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Result;
 use crate::sync::broadcaster::Broadcaster;
@@ -129,7 +131,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     transport,
                     broadcaster,
                     failure_tx: None,
-                    dag_fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(max_dag_fetches)),
+                    dag_fetch_limiter: DagFetchLimiter::new(max_dag_fetches),
                     push_semaphore: Arc::new(tokio::sync::Semaphore::new(max_push_tasks)),
                     rate_limiter: Arc::new(PeerRateLimiter::with_backoff_steps(
                         rate_limit_burst,

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -183,20 +183,20 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             let transport = self.runtime.transport.clone();
             let blockstore = self.manager.blockstore().clone();
             let event_tx = self.manager.event_sender();
-            let semaphore = self.runtime.dag_fetch_semaphore.clone();
+            let limiter = self.runtime.dag_fetch_limiter.clone();
 
             for root_cid in cids_to_fetch {
                 let transport = transport.clone();
                 let blockstore = blockstore.clone();
                 let event_tx = event_tx.clone();
                 let collection_id = reply.collection_id.clone();
-                let semaphore = semaphore.clone();
+                let limiter = limiter.clone();
                 let source_peer = peer_id.clone();
                 let is_explicit_replicator =
                     self.is_registered_replicator(peer_id.as_str(), &collection_id);
 
                 self.spawn_background_task("branchable_sync_reply_fetch_dag", async move {
-                    let Ok(_permit) = semaphore.acquire_owned().await else {
+                    let Some(_permits) = limiter.acquire(&source_peer).await else {
                         return;
                     };
                     super::super::dag_fetcher::poll_fetch_dag(

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -353,7 +353,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             let transport = self.runtime.transport.clone();
             let blockstore = self.manager.blockstore().clone();
             let event_tx = self.manager.event_sender();
-            let semaphore = self.runtime.dag_fetch_semaphore.clone();
+            let limiter = self.runtime.dag_fetch_limiter.clone();
 
             for (root_cid, doc_id) in cids_to_fetch {
                 tracing::debug!(
@@ -365,13 +365,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 let transport = transport.clone();
                 let blockstore = blockstore.clone();
                 let event_tx = event_tx.clone();
-                let semaphore = semaphore.clone();
+                let limiter = limiter.clone();
                 let source_peer = peer_id.clone();
                 let explicit_replicator_collections =
                     self.access.replicators.get_collections(peer_id.as_str());
 
                 self.spawn_background_task("doc_sync_reply_fetch_dag", async move {
-                    let Ok(_permit) = semaphore.acquire_owned().await else {
+                    let Some(_permits) = limiter.acquire(&source_peer).await else {
                         return;
                     };
                     super::super::dag_fetcher::poll_fetch_dag(

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -54,6 +54,7 @@ mod subscriptions;
 
 pub use result_types::{CreateReplicatorResult, LoadReplicatorsResult};
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -62,10 +63,11 @@ use acp::DocumentACP;
 use blockstore::Blockstore;
 use cid::Cid;
 use parking_lot::Mutex;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
-use crate::transport::P2PTransport;
+use crate::transport::{P2PTransport, PeerId};
 
 use super::broadcaster::Broadcaster;
 use super::collection_store::P2PCollectionStorage;
@@ -95,6 +97,64 @@ struct SyncShutdownState {
 }
 
 const BACKGROUND_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Shared limiter for poll-based DAG fetches.
+///
+/// The global semaphore bounds total resource usage, while the per-peer
+/// semaphore prevents one source peer from queueing enough fetches to occupy
+/// every global permit.
+#[derive(Clone)]
+pub(crate) struct DagFetchLimiter {
+    global: Arc<Semaphore>,
+    per_peer: Arc<Mutex<HashMap<String, Arc<Semaphore>>>>,
+    peer_limit: usize,
+}
+
+pub(crate) struct DagFetchPermits {
+    _global: OwnedSemaphorePermit,
+    _peer: OwnedSemaphorePermit,
+}
+
+impl DagFetchLimiter {
+    pub(crate) fn new(global_limit: usize) -> Self {
+        let global_limit = global_limit.max(1);
+        Self {
+            global: Arc::new(Semaphore::new(global_limit)),
+            per_peer: Arc::new(Mutex::new(HashMap::new())),
+            peer_limit: global_limit.saturating_sub(1).max(1),
+        }
+    }
+
+    pub(crate) async fn acquire(&self, source_peer: &PeerId) -> Option<DagFetchPermits> {
+        let peer_key = source_peer.to_string();
+        let peer_semaphore = {
+            let mut per_peer = self.per_peer.lock();
+            per_peer
+                .entry(peer_key)
+                .or_insert_with(|| Arc::new(Semaphore::new(self.peer_limit)))
+                .clone()
+        };
+
+        let Ok(peer_permit) = peer_semaphore.acquire_owned().await else {
+            return None;
+        };
+        let Ok(global_permit) = self.global.clone().acquire_owned().await else {
+            return None;
+        };
+
+        Some(DagFetchPermits {
+            _global: global_permit,
+            _peer: peer_permit,
+        })
+    }
+
+    fn close(&self) {
+        self.global.close();
+        for semaphore in self.per_peer.lock().values() {
+            semaphore.close();
+        }
+    }
+}
 
 /// Shared shutdown state for coordinator-owned background replication work.
 #[derive(Clone)]
@@ -183,8 +243,8 @@ pub(super) struct SyncRuntime<T: P2PTransport> {
     /// Channel for reporting push failures to the FFI layer for retry tracking.
     pub(super) failure_tx: Option<tokio::sync::mpsc::Sender<PushFailure>>,
 
-    /// Semaphore limiting concurrent DAG fetch tasks (configurable via SyncConfig).
-    pub(super) dag_fetch_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Limiter for concurrent DAG fetch tasks (configurable via SyncConfig).
+    pub(super) dag_fetch_limiter: DagFetchLimiter,
 
     /// Semaphore limiting concurrent push tasks (configurable via SyncConfig).
     pub(super) push_semaphore: Arc<tokio::sync::Semaphore>,
@@ -276,7 +336,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 );
             }
         }
-        self.runtime.dag_fetch_semaphore.close();
+        self.runtime.dag_fetch_limiter.close();
         self.runtime.push_semaphore.close();
         self.runtime.shutdown.shutdown().await;
     }
@@ -310,6 +370,41 @@ pub type IrohSyncCoordinator<B> = SyncCoordinator<B, crate::iroh::IrohTransport>
 
 #[cfg(test)]
 mod access_tests;
+
+#[cfg(test)]
+mod dag_fetch_limiter_tests {
+    use super::DagFetchLimiter;
+    use crate::transport::PeerId;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn single_peer_cannot_hold_every_global_permit() {
+        let limiter = DagFetchLimiter::new(4);
+        let flooder = PeerId::new("flooder".to_string());
+        let legitimate = PeerId::new("legitimate".to_string());
+
+        let mut flooder_permits = Vec::new();
+        for _ in 0..3 {
+            flooder_permits.push(limiter.acquire(&flooder).await.expect("flooder permit"));
+        }
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), limiter.acquire(&flooder))
+                .await
+                .is_err(),
+            "one peer should be capped below the global limit"
+        );
+
+        let legitimate_permit =
+            tokio::time::timeout(Duration::from_millis(20), limiter.acquire(&legitimate))
+                .await
+                .expect("legitimate peer should get reserved capacity")
+                .expect("limiter open");
+
+        drop(legitimate_permit);
+        drop(flooder_permits);
+    }
+}
 
 #[cfg(test)]
 mod shutdown_tests {

--- a/crates/p2p/src/sync/manager/config.rs
+++ b/crates/p2p/src/sync/manager/config.rs
@@ -44,8 +44,8 @@ pub struct SyncConfig {
 
     /// Maximum number of concurrent DAG fetch tasks spawned by the coordinator.
     ///
-    /// Caps fan-out from DocSync and BranchableSync replies to prevent resource
-    /// exhaustion from a peer advertising a large number of head CIDs.
+    /// Caps fan-out from DocSync, BranchableSync, and push-driven DAG recovery to
+    /// prevent resource exhaustion from a peer advertising a large number of head CIDs.
     pub max_concurrent_dag_fetches: usize,
 
     /// Maximum number of concurrent push tasks for sending blocks to replicators.

--- a/crates/p2p/src/sync/replication/handlers.rs
+++ b/crates/p2p/src/sync/replication/handlers.rs
@@ -128,13 +128,18 @@ where
         let transport = coordinator.transport().clone();
         let blockstore = coordinator.blockstore().clone();
         let event_tx = coordinator.manager().event_sender();
+        let limiter = coordinator.dag_fetch_limiter();
         let source_peer = crate::transport::PeerId::new(source_peer);
+        let permit_peer = source_peer.clone();
         let context = DagFetchContext::new(doc_id, collection_id, creator, source_peer)
             .with_explicit_replicator(is_explicit_replicator)
             .with_explicit_replay_authorization(explicit_replay_authorization)
             .with_acp_actor_relationships(acp_actor_relationships);
 
         coordinator.spawn_background_task("pushlog_fetch_dag", async move {
+            let Some(_permits) = limiter.acquire(&permit_peer).await else {
+                return;
+            };
             crate::sync::coordinator::dag_fetcher::poll_fetch_dag(
                 transport, blockstore, event_tx, root_cid, context,
             )

--- a/crates/query-parse/src/sdl_parse/helpers.rs
+++ b/crates/query-parse/src/sdl_parse/helpers.rs
@@ -340,7 +340,7 @@ pub(super) fn generate_collection_id(
             }
         }
     }
-    head_cids.sort_by_key(|c| c.to_bytes());
+    head_cids.sort_by_cached_key(|c| c.to_string());
 
     let priority = max_height + 1;
 

--- a/crates/query-parse/src/sdl_parse/parser_tests.rs
+++ b/crates/query-parse/src/sdl_parse/parser_tests.rs
@@ -669,6 +669,25 @@ fn test_collection_ids_are_deterministic() {
 }
 
 #[test]
+fn test_collection_id_matches_go_when_link_string_order_differs_from_cid_order() {
+    let collections = parse_sdl(
+        r#"
+        type Block {
+            data: String
+            idx: Int
+        }
+    "#,
+    )
+    .unwrap();
+
+    let block = &collections[0];
+    assert_eq!(
+        block.collection_id,
+        "bafyreiajfzj23wjpiiborrteeh3h6fmazttq2svb6vzmhxu3n3o2jyk4me",
+    );
+}
+
+#[test]
 fn test_field_ids_are_deterministic() {
     let string_kind = FieldKind::Scalar(ScalarKind::String);
     let id1 = generate_field_id("name", &string_kind, CType::LwwRegister);

--- a/tools/integration-test/tests/p2p/resilience.rs
+++ b/tools/integration-test/tests/p2p/resilience.rs
@@ -281,7 +281,8 @@ for_each_p2p_topology_3_ignored!(rate_limiter_saturation, rate_limiter_saturatio
 /// (node2) to still get its document fetched promptly.
 ///
 /// Topology: node1 → node0 ← node2
-/// 16+ concurrent DAG fetches from node1 must not starve node2.
+/// A burst exceeding the Rust DAG-fetch concurrency limit from node1 must not
+/// starve node2.
 async fn dag_semaphore_exhaustion_test(cluster: TestCluster) {
     let node0 = cluster.client(0);
     let node1 = cluster.client(1);
@@ -297,8 +298,8 @@ async fn dag_semaphore_exhaustion_test(cluster: TestCluster) {
     // node2 → node0: legitimate peer pushes into target
     setup_replication_link(&cluster, 2, 0, &["Block"]).await;
 
-    // Create 20 documents on node1 rapidly — exceeds MAX_CONCURRENT_DAG_FETCHES=16
-    // to ensure the semaphore is fully occupied when node2's doc arrives.
+    // Create 20 documents on node1 rapidly — exceeds Rust's default DAG-fetch
+    // concurrency limit to ensure the limiter is occupied when node2's doc arrives.
     const FLOOD_COUNT: usize = 20;
     for i in 0..FLOOD_COUNT {
         node1


### PR DESCRIPTION
## Summary
- Match Go's block CID construction order by sorting block heads/links by CID string, fixing the `Block { data, idx }` schema CID divergence.
- Replace the single DAG-fetch semaphore with a global + per-peer limiter so one peer cannot consume every DAG fetch slot.
- Apply the limiter to reply-triggered and push-triggered DAG recovery, and keep the DAG semaphore stress test on the original `Block` schema.

Closes #973

## Verification
- `cargo fmt --check`
- `cargo check -p p2p`
- `cargo test -p defra-core`
- `cargo test -p query-parse sdl_parse::parser::tests`
- `cargo test -p db-blocks`
- `cargo test -p p2p dag_fetch_limiter_tests --lib`
- `PATH="$HOME/go/bin:$PATH" cargo test -p integration-test --test p2p -- resilience::go_rust_dag_semaphore_exhaustion --ignored --nocapture`
- `PATH="$HOME/go/bin:$PATH" cargo test -p integration-test --test p2p -- dag_semaphore_exhaustion --ignored --nocapture`

Also verified a fresh Rust node now emits Go's `Block` collection CID: `bafyreiajfzj23wjpiiborrteeh3h6fmazttq2svb6vzmhxu3n3o2jyk4me`.
