### PR TITLE
fix(query): stabilize downsample rollup test under parallel load

### DIFF
--- a/tools/integration-test/tests/query/downsample.rs
+++ b/tools/integration-test/tests/query/downsample.rs
@@ -38,6 +38,8 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const BUCKET_MS: i64 = 1_000;
 const PARENT_BUCKET_MS: i64 = 2_000;
 const BASE_OFFSET_BUCKETS: i64 = 3;
+const FIRST_WINDOW_SETTLE_MS: i64 = 350;
+const FINAL_WINDOW_SETTLE_MS: i64 = 350;
 
 fn format_timestamp(timestamp: DateTime<Utc>) -> String {
     if timestamp.timestamp_subsec_nanos() == 0 {
@@ -333,7 +335,7 @@ async fn downsample_test(cluster: TestCluster) {
         "Metric2Rollup should stay empty before the first time bucket closes",
     );
 
-    sleep_until(first_window_end + ChronoDuration::milliseconds(350)).await;
+    sleep_until(first_window_end + ChronoDuration::milliseconds(FIRST_WINDOW_SETTLE_MS)).await;
 
     let first_rollup = wait_for_rollup(
         &client,
@@ -373,6 +375,13 @@ async fn downsample_test(cluster: TestCluster) {
         ))
         .expect("update metric to 30");
 
+    client
+        .query(&format!(
+            r#"mutation {{ update_Metric(docID: "{source_doc_id}", input: {{ts: "{}", value: 40}}) {{ _docID }} }}"#,
+            format_timestamp(t4)
+        ))
+        .expect("update metric to 40");
+
     let stale_rollup = query_rollup(&client, "Metric2Rollup", &source_doc_id)
         .expect("Metric2Rollup row should still exist during an incomplete bucket");
     assert_rollup_row(
@@ -388,14 +397,7 @@ async fn downsample_test(cluster: TestCluster) {
         20,
     );
 
-    client
-        .query(&format!(
-            r#"mutation {{ update_Metric(docID: "{source_doc_id}", input: {{ts: "{}", value: 40}}) {{ _docID }} }}"#,
-            format_timestamp(t4)
-        ))
-        .expect("update metric to 40");
-
-    sleep_until(second_window_end + ChronoDuration::milliseconds(350)).await;
+    sleep_until(second_window_end + ChronoDuration::milliseconds(FINAL_WINDOW_SETTLE_MS)).await;
 
     let second_rollup = wait_for_rollup(
         &client,


### PR DESCRIPTION
## Summary

- fixes a test race in `rust_downsample_updates_stable_rollup_docs` by issuing the second bucket's `t3` and `t4` writes back-to-back before asserting the stale first rollup
- keeps the original `1000ms`/`2000ms` downsample intervals and `20s` wait timeout, avoiding the timeout/bucket-widening stopgap
- names the existing first/final window settle delays so the timing assumptions are explicit

## Investigation

The reproduced failure was consistent with the worker materializing the second bucket after only the `t3` update when the test paused between `t3` and `t4` long enough for the second bucket's wall-clock boundary to close. Moving both writes before the stale-rollup assertion removes that race without changing the runtime timing budget.

I also checked the downsample event-bus drop/rebuild path under the parallel-suite repro using the existing warnings around `check_and_reset_dropped()`. The debug-log scan found no `Subscriber buffer full`, downsample dropped-event rebuild, process, refresh, or bootstrap warnings.

Fixes #974.

## Verification

- `PATH="$HOME/go/bin:$PATH" cargo test -p integration-test --test query downsample::rust_downsample_updates_stable_rollup_docs -- --exact --nocapture`
- parallel-suite repro with `basic`, `query`, `acp`, and `p2p` all passing; `query` passed 39 tests including `downsample::rust_downsample_updates_stable_rollup_docs`
- `git diff --check`
