### PR TITLE
feat(cli,db,http): port DeleteCollection CLI + Go upstream survey (Go #4688)

### DIFF
--- a/SURVEY.md
+++ b/SURVEY.md
@@ -1,0 +1,69 @@
+# Go upstream survey — 2026-04-18 → 2026-05-18
+
+Survey of Go DefraDB upstream commits on `origin/develop` since 2026-04-18, classified for the Rust port (defradb.rs v1.0-rc1 tracking Go v1.0.0-rc1).
+
+Sources:
+- Go repo: `/Users/johnzampolin/go/src/github.com/sourcenetwork/defradb` @ `origin/develop`
+- Window: `git log origin/develop --since="2026-04-18"` (23 commits)
+
+## Summary
+
+| Category | Count |
+|---|---|
+| already-ported | 2 |
+| already-tracked in another worktree | 1 |
+| not-applicable (no equivalent stack in Rust) | 3 |
+| not-applicable (Go-test-infra / dependabot / JS / build flag) | 13 |
+| **port-needed** | **2** |
+| **low-priority doc-only (track but don't port)** | **2** |
+
+## Per-PR classification
+
+| Go commit | Go PR | Title | Status | Rationale / Pointer |
+|---|---|---|---|---|
+| `1fab9fb3` | #4778 | fix: KMS lookup under NAC for encrypted DAG sync | **not-applicable** | Rust has no KMS service. Encryption uses a shared hardcoded key today; integration tests are `#[ignore]`'d pending KMS work. Port only relevant once KMS lands. |
+| `6c874754` | #4794 | feat: Support querying with multiple cids | **already-tracked** | Tracked as Rust issue #972; separate worktree (`../defradb.rs-972-multi-cid-query`). |
+| `cc6eb7a3` | #4810 | bot: Update dependencies (bulk dependabot) | not-applicable | Rust crate updates run on their own cadence. |
+| `046e6caa` | #4809 | feat: Gate commit queries with DAC | **already-ported** | Rust commit `3ffc3e88` (Feb 23) — added per-doc ACP filtering at `crates/query/src/runner/commits.rs:710-792`. Test coverage in `tools/integration-test/tests/acp/audit.rs::cid_time_travel_acp_bypass_test`. Caveat: Go organizes commit-ACP tests in `tests/integration/acp/dac/commits/`; Rust consolidates them in `audit.rs`. Optional follow-up: split into `tests/acp/commits/` subdir for parity. |
+| `ee87a529` | #4796 | test(i): Exclude LevelDB from multi-txn test | not-applicable | Documents a Go-side LevelDB limitation (#4795). Rust storage backends (redb, fjall, rocksdb, memory) — none are LevelDB. |
+| `04a2d1eb` | #4688 | feat: Add syntax sugar `DeleteCollection` cmd | **port-needed** | Underlying `delete_collection` already exists in Rust at `crates/db/src/collection_ops/delete.rs:68`; HTTP DELETE route wired at `crates/http/src/handlers/collections.rs` + `routes.rs:81`. CLI wrapper missing. Add `Delete(CollectionDeleteArgs)` to `CollectionCommand` in `crates/cli/src/commands/client/collection/mod.rs:37`, plus HTTP client helper. |
+| `f550ce2b` | #4767 | bot: Update dependencies | not-applicable | Dependabot bulk update. |
+| `83b141c4` | #4681 | fix: Fix cli commands markdown output | not-applicable | Go-specific cobra markdown generation; Rust CLI (clap) doesn't use this tooling. |
+| `702aee24` | #4737 | test: Document incremental lens migration bug under indexes | **low-priority doc-only** | Documents Go bug #4736 with skipped tests. Track as future Rust issue if/when lens+index combo is implemented; no immediate port. |
+| `630f4f30` | #4763 | fix: Prevent txn-actions from executing concurrently | **already-ported** | Rust commit `b6255b00` in PR #951 ("fix: serialize actions per transaction"). Per-txn `action_lock: Arc<async_lock::Mutex<()>>` at `crates/db/src/txn_context.rs:29`, acquired in `crates/query/src/runner/executor.rs:302-306` and `crates/db/src/txn_registry.rs`. Test: `execute_in_txn_serializes_concurrent_actions_on_same_handle`. |
+| `5d03d037` | #4775 | refactor: Use JS txn directly instead of context | not-applicable | JS-client-specific refactor; Rust has no JS client. |
+| `4ac67d81` | #4761 | fix: Make silent build tag work on Android and Linux | not-applicable | Go build-tag specific. |
+| `84b2398f` | #4765 | test: Introduce C binding smoke test | not-applicable | Out of FFI scope (Rust FFI is client-only per [feedback_ffi_scope](../../.claude/projects/-Users-johnzampolin-go-src-github-com-sourcenetwork-defradb-rs/memory/feedback_ffi_scope.md)). |
+| `bf43a593` | #4747 | bot: Update dependencies | not-applicable | Dependabot bulk update. |
+| `0374a801` | #4755 | fix: Persist test state for change detector | not-applicable | Go-specific test-harness "change detector" feature; Rust test harness is structurally different. |
+| `30cf74a9` | #4746 | test: Add signed-docs test multiplier | **file as sub-issue** | Rust already has focused signing coverage (`tools/integration-test/tests/encryption/block_verify.rs`, `tests/p2p_iroh/connection/signature.rs`). Go's multiplier value is regression-detection across the whole suite via `DEFRA_MULTIPLIERS=signed-docs`. Porting requires extending `defra-harness` (external repo `sourcenetwork/backbone`), so track separately. |
+| `ac820098` | #4754 | test: Migrate commit txn action to testo | not-applicable | Go test-framework migration to "testo"; Rust uses a different structure (`tools/integration-test/tests/*`). |
+| `7ca3b280` | #4749 | test: Migrate UpdateDoc action to new system | not-applicable | Same as above. |
+| `dc575858` | #4750 | fix: Seed CollectionVersions from DB | not-applicable | Go fix is for a test-harness reconstruction issue (change detector across process boundaries). Rust auto-loads collection versions during `DB::open_with_options()` via `load_collections()` in `crates/db/src/collection_ops/mod.rs:56-243`. Underlying durability is already correct. |
+| `43250ed7` | #4723 | chore: Collection version templates in tests | not-applicable | Go test-template feature; doesn't map to Rust test layout. |
+| `83af37a9` | #4639 | fix: Reduce telemetry logs | not-applicable | Go fix attaches an `otel.SetErrorHandler` to dedupe OTLP collector "connection refused" spam. Rust has **no OTEL exporter setup** today — there are no `opentelemetry`/`otlp` crate uses in `crates/*/Cargo.toml`. Nothing in the Rust codebase emits these errors. Port becomes relevant only if/when an OTEL exporter is added in Rust. |
+| `a81825d4` | #4701 | chore: Fix the C binding Linux build command | not-applicable | Out of FFI scope. |
+| `ce014761` | #4714 | test(i): Fix npx tests | not-applicable | JS-client-specific. |
+
+## Port plan
+
+This worktree (`sync/go-upstream-survey`):
+- **#4688 DeleteCollection CLI** — ported. Adds `defradb client collection delete <names> [--active-only]`, Go-compatible `DELETE /api/v0/collections?name=...&active-only=...` HTTP route, and a new `DB::delete_collections(names, active_only)` orchestrator over the existing `delete_collection_versions_batch`.
+
+Filed as tracking issues on `sourcenetwork/defradb.rs`:
+- **[#976](https://github.com/sourcenetwork/defradb.rs/issues/976)** — Port KMS-under-NAC (Go #4778). Blocked on KMS infrastructure.
+- **[#977](https://github.com/sourcenetwork/defradb.rs/issues/977)** — Port OTEL telemetry log dedup (Go #4639). Blocked on OTEL exporter.
+- **[#978](https://github.com/sourcenetwork/defradb.rs/issues/978)** — Port signed-docs test multiplier (Go #4746). Needs `defra-harness` changes in `sourcenetwork/backbone`.
+- **[#979](https://github.com/sourcenetwork/defradb.rs/issues/979)** — Track Go incremental-lens-under-indexes bug (Go #4737). Re-evaluate when Rust grows the same feature combination.
+
+Optional follow-up (not filed):
+- **#4809 commit-ACP test reorg** — split consolidated tests into `tests/acp/commits/` subdir for parity with Go layout. Pure test reorg; the functional port already landed in Rust commit `3ffc3e88`.
+
+Out of scope here:
+- Anything Go-test-infra (#4754, #4749, #4723, #4755, #4767-style dependabot, #4796 LevelDB, #4737 lens-index doc-only).
+- JS / FFI-C / build-flag fixes that have no Rust equivalent.
+
+## Notes for next survey window
+
+- Run `git -C /Users/johnzampolin/go/src/github.com/sourcenetwork/defradb fetch origin develop && git log origin/develop --since="2026-05-18" --oneline` to start the next sync.
+- The 30-day window 2026-04-18 → 2026-05-18 produced 23 upstream commits; of those, only 2 needed Rust ports. The bulk of upstream churn was Go-internal (test framework, dependabot, build tooling). Future surveys can confidently skip those categories at first glance.

--- a/crates/cli/src/collection_mgmt_adapter.rs
+++ b/crates/cli/src/collection_mgmt_adapter.rs
@@ -127,4 +127,15 @@ impl<S: Store + 'static> CollectionManagementOperations for CollectionManagement
             .await
             .map_err(|e| format!("{}", e))
     }
+
+    async fn delete_collections(
+        &self,
+        names: Vec<String>,
+        active_only: bool,
+    ) -> Result<(), String> {
+        self.database
+            .delete_collections(names, active_only)
+            .await
+            .map_err(|e| format!("{}", e))
+    }
 }

--- a/crates/cli/src/commands/client/collection/document.rs
+++ b/crates/cli/src/commands/client/collection/document.rs
@@ -1,6 +1,6 @@
 //! Collection operation command implementations
 
-use super::{CollectionPatchArgs, SetActiveArgs, TruncateArgs};
+use super::{CollectionDeleteArgs, CollectionPatchArgs, SetActiveArgs, TruncateArgs};
 use crate::commands::client::http_client::HttpClient;
 use crate::commands::client::ClientContext;
 use crate::commands::client::{get_data_from_args, validate_identifier};
@@ -44,6 +44,40 @@ impl TruncateArgs {
 
         client.collection_truncate(collection).await?;
         println!("Truncated collection {}", collection);
+        Ok(())
+    }
+}
+
+impl CollectionDeleteArgs {
+    pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let names: Vec<String> = self
+            .names
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if names.is_empty() {
+            return Err(Error::MissingInput(
+                "at least one collection name is required".to_string(),
+            ));
+        }
+
+        for name in &names {
+            validate_identifier(name)?;
+        }
+
+        let client = HttpClient::new(&ctx.url)?
+            .with_auth_token(ctx.auth_token.clone())
+            .with_verbose(ctx.verbose);
+
+        client.collection_delete(&names, self.active_only).await?;
+
+        if names.len() == 1 {
+            println!("Deleted collection {}", names[0]);
+        } else {
+            println!("Deleted collections {}", names.join(", "));
+        }
         Ok(())
     }
 }

--- a/crates/cli/src/commands/client/collection/mod.rs
+++ b/crates/cli/src/commands/client/collection/mod.rs
@@ -39,6 +39,8 @@ pub struct CollectionArgs {
 pub enum CollectionCommand {
     /// Add a new collection from an SDL definition
     Add(CollectionAddArgs),
+    /// Delete one or more collections by name
+    Delete(CollectionDeleteArgs),
     /// Describe a collection
     Describe(CollectionDescribeArgs),
     /// List all collections
@@ -103,6 +105,23 @@ pub struct SetActiveArgs {
 #[derive(Args, Debug)]
 pub struct TruncateArgs {}
 
+/// Arguments for delete command (Go #4688 parity).
+#[derive(Args, Debug)]
+pub struct CollectionDeleteArgs {
+    /// One or more collection names. A single name, or a comma-separated list
+    /// (e.g. `Users,Books`) may be provided. All named collections are removed
+    /// atomically in a single operation, which lets you delete collections that
+    /// reference each other via relations.
+    #[arg(value_name = "COLLECTION_NAMES")]
+    pub names: String,
+
+    /// Delete only the active head version of each named collection, keeping
+    /// earlier versions intact. By default, every version of each named
+    /// collection is deleted.
+    #[arg(long)]
+    pub active_only: bool,
+}
+
 impl CollectionAddArgs {
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
         let mut sdl_parts = Vec::new();
@@ -142,6 +161,7 @@ impl CollectionArgs {
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
         match &self.command {
             CollectionCommand::Add(args) => args.execute(ctx).await,
+            CollectionCommand::Delete(args) => args.execute(ctx).await,
             CollectionCommand::Describe(args) => args.execute(ctx, self.name.as_deref()).await,
             CollectionCommand::List(args) => args.execute(ctx).await,
             CollectionCommand::Patch(args) => args.execute(ctx).await,

--- a/crates/cli/src/commands/client/http_client/collection.rs
+++ b/crates/cli/src/commands/client/http_client/collection.rs
@@ -51,4 +51,21 @@ impl HttpClient {
         );
         self.request_void("DELETE", &url, None).await
     }
+
+    /// Delete one or more collections by name via Go-compatible
+    /// `DELETE /collections?name=Users,Books&active-only=true`.
+    pub async fn collection_delete(&self, names: &[String], active_only: bool) -> Result<()> {
+        let joined = names
+            .iter()
+            .map(|n| n.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+        let url = format!(
+            "{}/api/v0/collections?name={}&active-only={}",
+            self.base_url,
+            encode(&joined),
+            active_only
+        );
+        self.request_void("DELETE", &url, None).await
+    }
 }

--- a/crates/db/src/collection_ops/delete.rs
+++ b/crates/db/src/collection_ops/delete.rs
@@ -94,6 +94,69 @@ impl<S: Store> crate::database::DB<S> {
         }
     }
 
+    /// Delete one or more collections by name in a single call (Go #4688 parity).
+    ///
+    /// - If `active_only` is true, only the active head version of each named
+    ///   collection is removed; earlier versions are kept intact.
+    /// - If `active_only` is false (Go's default), every version of each named
+    ///   collection is removed.
+    ///
+    /// Names are deduplicated. Name resolution happens up-front: if any name
+    /// is unknown, no deletion is performed. Validation (no documents, no
+    /// orphan child versions outside the batch) is delegated to
+    /// `delete_collection_versions_batch`.
+    pub async fn delete_collections(&self, names: Vec<String>, active_only: bool) -> Result<()> {
+        if names.is_empty() {
+            return Err(Error::InvalidPatch(
+                "collection name required: pass at least one name to delete".into(),
+            ));
+        }
+
+        let mut seen_names = std::collections::HashSet::new();
+        let unique_names: Vec<String> = names
+            .into_iter()
+            .filter(|n| !n.is_empty() && seen_names.insert(n.clone()))
+            .collect();
+
+        if unique_names.is_empty() {
+            return Err(Error::InvalidPatch(
+                "collection name required: every supplied name was empty".into(),
+            ));
+        }
+
+        let mut version_ids: Vec<String> = Vec::new();
+        let mut seen_versions = std::collections::HashSet::new();
+
+        if active_only {
+            for name in &unique_names {
+                let col = self
+                    .get_collection(name)?
+                    .ok_or_else(|| Error::CollectionNotFound(name.clone()))?;
+                let vid = col.version_id().to_string();
+                if seen_versions.insert(vid.clone()) {
+                    version_ids.push(vid);
+                }
+            }
+        } else {
+            let all_versions = self.get_all_collection_versions().await?;
+            for name in &unique_names {
+                let col = self
+                    .get_collection(name)?
+                    .ok_or_else(|| Error::CollectionNotFound(name.clone()))?;
+                let collection_id = col.collection_id().to_string();
+                for v in &all_versions {
+                    if v.collection_id == collection_id
+                        && seen_versions.insert(v.version_id.clone())
+                    {
+                        version_ids.push(v.version_id.clone());
+                    }
+                }
+            }
+        }
+
+        self.delete_collection_versions_batch(version_ids).await
+    }
+
     /// Truncate a collection: delete all documents, heads, blocks, and index entries
     /// while preserving the collection schema.
     ///

--- a/crates/db/tests/delete_collections_tests.rs
+++ b/crates/db/tests/delete_collections_tests.rs
@@ -1,0 +1,124 @@
+//! Tests for the multi-collection delete orchestrator (Go #4688 parity).
+
+use db::database::DB;
+use schema::{CollectionVersion, FieldDescription, FieldKind};
+use storage::backends::MemoryStore;
+
+fn user_schema() -> CollectionVersion {
+    CollectionVersion::new(
+        "Users",
+        "v-users-1",
+        "col-users",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+        ],
+    )
+}
+
+fn book_schema() -> CollectionVersion {
+    CollectionVersion::new(
+        "Books",
+        "v-books-1",
+        "col-books",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "title", FieldKind::string()),
+        ],
+    )
+}
+
+#[tokio::test]
+async fn delete_collections_removes_single_name() {
+    let db = DB::new(MemoryStore::new()).unwrap();
+    db.create_collections_atomic(vec![user_schema()])
+        .await
+        .unwrap();
+
+    db.delete_collections(vec!["Users".into()], true)
+        .await
+        .unwrap();
+
+    assert!(
+        db.get_collection("Users").unwrap().is_none(),
+        "Users collection should be gone after delete_collections"
+    );
+}
+
+#[tokio::test]
+async fn delete_collections_removes_multiple_names_atomically() {
+    let db = DB::new(MemoryStore::new()).unwrap();
+    db.create_collections_atomic(vec![user_schema(), book_schema()])
+        .await
+        .unwrap();
+
+    db.delete_collections(vec!["Users".into(), "Books".into()], true)
+        .await
+        .unwrap();
+
+    assert!(
+        db.get_collection("Users").unwrap().is_none(),
+        "Users collection should be gone"
+    );
+    assert!(
+        db.get_collection("Books").unwrap().is_none(),
+        "Books collection should be gone"
+    );
+}
+
+#[tokio::test]
+async fn delete_collections_errors_on_empty_names() {
+    let db = DB::new(MemoryStore::new()).unwrap();
+    let err = db
+        .delete_collections(vec![], true)
+        .await
+        .expect_err("expected error for empty names");
+
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("name") || msg.contains("empty") || msg.contains("required"),
+        "unexpected error message: {err}"
+    );
+}
+
+#[tokio::test]
+async fn delete_collections_errors_on_unknown_name() {
+    let db = DB::new(MemoryStore::new()).unwrap();
+    db.create_collections_atomic(vec![user_schema()])
+        .await
+        .unwrap();
+
+    let err = db
+        .delete_collections(vec!["Users".into(), "Ghost".into()], true)
+        .await
+        .expect_err("expected error for unknown collection name");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Ghost") || msg.to_lowercase().contains("not found"),
+        "unexpected error message: {err}"
+    );
+
+    // Atomicity: because Ghost failed before any state changed, Users must still exist.
+    assert!(
+        db.get_collection("Users").unwrap().is_some(),
+        "Users should not have been deleted when batch validation failed"
+    );
+}
+
+#[tokio::test]
+async fn delete_collections_dedupes_repeated_names() {
+    let db = DB::new(MemoryStore::new()).unwrap();
+    db.create_collections_atomic(vec![user_schema()])
+        .await
+        .unwrap();
+
+    db.delete_collections(vec!["Users".into(), "Users".into()], true)
+        .await
+        .expect("duplicate names should be deduplicated, not error");
+
+    assert!(
+        db.get_collection("Users").unwrap().is_none(),
+        "Users collection should be gone"
+    );
+}

--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -5,8 +5,10 @@
 //!
 //! All endpoints enforce NAC permissions when NAC is enabled.
 
+use std::collections::HashMap;
+
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     Json,
 };
@@ -358,6 +360,58 @@ pub async fn delete_collection(
         .map_err(http_error_from_backend_message)?;
 
     Ok(Json(serde_json::json!({})))
+}
+
+/// Delete one or more collections by name (Go #4688 parity).
+///
+/// DELETE /api/v0/collections?name=Users,Books&active-only=true
+///
+/// Query parameters:
+/// - `name` (required): comma-separated list of collection names.
+/// - `active-only` (optional, default false): if true, deletes only the active
+///   head version of each named collection; if false, deletes every version.
+///
+/// Requires `CollectionPatch` permission when NAC is enabled.
+pub async fn delete_collections_by_names(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<StatusCode, HttpError> {
+    require_permission(&state, &identity, NodePermission::CollectionPatch).await?;
+
+    let raw_names = params
+        .get("name")
+        .ok_or_else(|| HttpError::BadRequest("missing required 'name' query parameter".into()))?;
+
+    let names: Vec<String> = raw_names
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if names.is_empty() {
+        return Err(HttpError::BadRequest(
+            "'name' query parameter must contain at least one non-empty name".into(),
+        ));
+    }
+
+    let active_only = match params.get("active-only") {
+        Some(raw) => raw.parse::<bool>().map_err(|_| {
+            HttpError::BadRequest(format!(
+                "'active-only' must be true or false, got '{}'",
+                raw
+            ))
+        })?,
+        None => false,
+    };
+
+    let collection_mgmt = state.require_collection_mgmt()?;
+    collection_mgmt
+        .delete_collections(names, active_only)
+        .await
+        .map_err(http_error_from_backend_message)?;
+
+    Ok(StatusCode::OK)
 }
 
 #[cfg(test)]

--- a/crates/http/src/handlers/collections_tests.rs
+++ b/crates/http/src/handlers/collections_tests.rs
@@ -1,10 +1,16 @@
 use super::*;
 use crate::identity_extractor::ExtractIdentity;
-use crate::mock::{FailingMockRestOperations, MockQueryExecutor, MockRestOperations};
-use crate::router::AppStateBuilder;
+use crate::mock::{
+    FailingMockRestOperations, MockCollectionManagementOperations, MockQueryExecutor,
+    MockRestOperations,
+};
+use crate::router::{AppStateBuilder, CollectionManagementOperations};
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
 use query::executor::QueryExecutor;
 use query::rest::RestOperations;
 use std::sync::Arc;
+use tower::ServiceExt;
 
 fn create_state() -> AppState {
     AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
@@ -47,4 +53,76 @@ async fn test_list_collections_error() {
     let identity = ExtractIdentity::anonymous();
     let result = list_collections(State(state), identity).await;
     assert!(result.is_err());
+}
+
+fn router_with_collection_mgmt() -> axum::Router {
+    let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+        .with_collection_mgmt(Arc::new(MockCollectionManagementOperations::new())
+            as Arc<dyn CollectionManagementOperations>)
+        .build();
+    crate::router::create_router_with_state(state)
+}
+
+#[tokio::test]
+async fn delete_collections_by_query_returns_ok_for_single_name() {
+    let router = router_with_collection_mgmt();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/v0/collections?name=Users")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn delete_collections_by_query_returns_ok_for_csv_names() {
+    let router = router_with_collection_mgmt();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/v0/collections?name=Users,Books&active-only=true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn delete_collections_by_query_rejects_missing_name_param() {
+    let router = router_with_collection_mgmt();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/v0/collections")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn delete_collections_by_query_rejects_invalid_active_only() {
+    let router = router_with_collection_mgmt();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::DELETE)
+                .uri("/api/v0/collections?name=Users&active-only=not-a-bool")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -37,8 +37,8 @@ pub use graphql::{
 
 // Re-export REST handlers
 pub use collections::{
-    collection_exists, delete_collection, delete_collection_versions, describe_collection,
-    find_collection_by_id, get_all_collections, get_collection_by_version_id, list_collections,
-    patch_collection, set_active, truncate_collection, CollectionsResponse,
+    collection_exists, delete_collection, delete_collection_versions, delete_collections_by_names,
+    describe_collection, find_collection_by_id, get_all_collections, get_collection_by_version_id,
+    list_collections, patch_collection, set_active, truncate_collection, CollectionsResponse,
 };
 pub use documents::{create_document, delete_document, get_document, update_document};

--- a/crates/http/src/mock/collections.rs
+++ b/crates/http/src/mock/collections.rs
@@ -82,4 +82,12 @@ impl CollectionManagementOperations for MockCollectionManagementOperations {
     async fn delete_collection(&self, _name: &str) -> Result<(), String> {
         Ok(())
     }
+
+    async fn delete_collections(
+        &self,
+        _names: Vec<String>,
+        _active_only: bool,
+    ) -> Result<(), String> {
+        Ok(())
+    }
 }

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -61,7 +61,8 @@ pub fn create_router_with_state(state: AppState) -> Router {
             "/",
             get(handlers::list_collections)
                 .post(handlers::schema::add_schema)
-                .patch(handlers::patch_collection),
+                .patch(handlers::patch_collection)
+                .delete(handlers::delete_collections_by_names),
         )
         .route("/default", post(handlers::set_active))
         .route(

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -550,6 +550,14 @@ pub trait CollectionManagementOperations: Send + Sync {
 
     /// Delete a collection by name.
     async fn delete_collection(&self, name: &str) -> Result<(), String>;
+
+    /// Delete one or more collections by name (Go #4688 parity).
+    ///
+    /// When `active_only` is true, only the active head version of each named
+    /// collection is removed. When false (Go's default), every version of each
+    /// named collection is removed.
+    async fn delete_collections(&self, names: Vec<String>, active_only: bool)
+        -> Result<(), String>;
 }
 
 /// Trait for lens migration operations.


### PR DESCRIPTION
## Summary

- **Survey** ([SURVEY.md](https://github.com/sourcenetwork/defradb.rs/blob/sync/go-upstream-survey/SURVEY.md)) of 23 Go DefraDB upstream commits on `origin/develop` since 2026-04-18. Result: 2 already ported, 3 not applicable (no equivalent Rust stack), 13 not applicable (Go test infra / dependabot / JS / build flag), 1 tracked elsewhere (#972), 4 filed as sub-issues (#976, #977, #978, #979), **1 ported here**.
- **Port** of Go [#4688](https://github.com/sourcenetwork/defradb/pull/4688) — `defradb client collection delete <names> [--active-only]`. Mirrors Go's exact CLI surface and HTTP query-param shape.

## What's new

`db::DB::delete_collections(names, active_only)` — name-based orchestrator over the existing `delete_collection_versions_batch`. Resolves all names to version IDs up-front so unknown names fail before any mutation; dedupes; then delegates atomic delete to the existing batch deleter (which already handles topo-sorted version deletion with batch-aware orphan-child validation).

Surface:
- CLI: `defra client collection delete Users,Books [--active-only]`
- HTTP: `DELETE /api/v0/collections?name=Users,Books&active-only=true` (Go-compatible)
- Trait: `CollectionManagementOperations::delete_collections(names, active_only)`

The pre-existing `DELETE /collections/{name}` (single name) and `DELETE /collections/versions` (JSON body of version IDs) routes are unchanged — this PR adds the missing Go-shaped multi-name route alongside them.

## Test plan

- [x] 5 new `db` unit tests in `crates/db/tests/delete_collections_tests.rs`:
  - single name, multiple names atomic, empty names error, unknown name error (with atomicity check), duplicate names deduped
- [x] 4 new HTTP handler tests in `crates/http/src/handlers/collections_tests.rs`:
  - single name → 200, CSV names → 200, missing `name` param → 400, invalid `active-only` → 400
- [x] `cargo test --workspace --exclude integration-test` — 133 test bins, all pass
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test -p integration-test --test basic` — 21 Rust tests pass (9 `go_*` parity tests fail with environmental \"Go defradb binary not found\" — unrelated to this change, no Go binary in this worktree)
- [x] CLI smoke: `defra client collection delete --help` renders correct usage

## Sub-issues filed from the survey

| Sub-issue | Go PR | Rust blocker |
|---|---|---|
| [#976](https://github.com/sourcenetwork/defradb.rs/issues/976) | [#4778](https://github.com/sourcenetwork/defradb/pull/4778) KMS-under-NAC | KMS infra not yet in Rust |
| [#977](https://github.com/sourcenetwork/defradb.rs/issues/977) | [#4639](https://github.com/sourcenetwork/defradb/pull/4639) OTEL log dedup | No OTEL exporter in Rust |
| [#978](https://github.com/sourcenetwork/defradb.rs/issues/978) | [#4746](https://github.com/sourcenetwork/defradb/pull/4746) signed-docs multiplier | Needs `defra-harness` changes |
| [#979](https://github.com/sourcenetwork/defradb.rs/issues/979) | [#4737](https://github.com/sourcenetwork/defradb/pull/4737) lens-under-indexes bug | Documentation tracker |

🤖 Generated with [Claude Code](https://claude.com/claude-code)