### PR TITLE
feat(http): add document ACP decision endpoint

### DIFF
--- a/crates/cli/src/doc_acp_adapter.rs
+++ b/crates/cli/src/doc_acp_adapter.rs
@@ -93,6 +93,26 @@ impl<S: Store + 'static> DocumentAcpAdapter<S> {
 
 #[async_trait]
 impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
+    async fn check_doc_access(
+        &self,
+        actor: &identity::Did,
+        permission: acp::DocumentPermission,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<bool, String> {
+        self.acp
+            .check_doc_access(
+                &acp::Identity::Authenticated(actor.clone()),
+                permission,
+                policy_id,
+                resource_name,
+                doc_id,
+            )
+            .await
+            .map_err(|e| format!("{}", e))
+    }
+
     async fn add_doc_relationship(
         &self,
         requestor: &identity::Did,

--- a/crates/http/src/handlers/acp.rs
+++ b/crates/http/src/handlers/acp.rs
@@ -142,6 +142,81 @@ pub struct DocRelationshipResponse {
     pub existed_already: bool,
 }
 
+/// Request body for document ACP decision preview operations.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DocDecisionRequest {
+    pub actor: String,
+    pub permission: String,
+    #[serde(rename = "policyID", alias = "policy_id")]
+    pub policy_id: String,
+    #[serde(rename = "resourceName", alias = "resource_name")]
+    pub resource_name: String,
+    #[serde(rename = "docID", alias = "doc_id")]
+    pub doc_id: String,
+}
+
+/// Response for document ACP decision preview operations.
+#[derive(Debug, Clone, Serialize)]
+pub struct DocDecisionResponse {
+    pub allowed: bool,
+}
+
+fn parse_doc_permission(permission: &str) -> Result<acp::DocumentPermission, HttpError> {
+    match permission {
+        "read" => Ok(acp::DocumentPermission::Read),
+        "update" => Ok(acp::DocumentPermission::Update),
+        "delete" => Ok(acp::DocumentPermission::Delete),
+        _ => Err(HttpError::BadRequest(format!(
+            "invalid document permission '{}'",
+            permission
+        ))),
+    }
+}
+
+/// Check document ACP access without mutating relationships.
+///
+/// POST /api/v0/acp/document/decide
+///
+/// Requires `DacStatus` permission when NAC is enabled.
+pub async fn decide_doc_access(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Json(body): Json<DocDecisionRequest>,
+) -> Result<Json<DocDecisionResponse>, HttpError> {
+    require_permission(&state, &identity, NodePermission::DacStatus).await?;
+
+    if body.actor.is_empty()
+        || body.permission.is_empty()
+        || body.policy_id.is_empty()
+        || body.resource_name.is_empty()
+        || body.doc_id.is_empty()
+    {
+        return Err(HttpError::BadRequest(
+            "missing a required argument needed to decide doc access.".into(),
+        ));
+    }
+
+    let actor = body
+        .actor
+        .parse::<identity::Did>()
+        .map_err(|e| HttpError::BadRequest(format!("invalid actor DID: {}", e)))?;
+    let permission = parse_doc_permission(&body.permission)?;
+
+    let doc_acp = state.require_doc_acp()?;
+    let allowed = doc_acp
+        .check_doc_access(
+            &actor,
+            permission,
+            &body.policy_id,
+            &body.resource_name,
+            &body.doc_id,
+        )
+        .await
+        .map_err(http_error_from_backend_message)?;
+
+    Ok(Json(DocDecisionResponse { allowed }))
+}
+
 /// Add a document ACP relationship.
 ///
 /// POST /api/v0/acp/document/relationship
@@ -273,5 +348,56 @@ mod tests {
         assert!(json.contains("Test Policy"));
         // Should not contain null fields
         assert!(!json.contains("description"));
+    }
+
+    #[test]
+    fn test_doc_decision_request_accepts_camel_and_snake_case() {
+        let camel: DocDecisionRequest = serde_json::from_str(
+            r#"{
+                "actor": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+                "permission": "read",
+                "policyID": "policy",
+                "resourceName": "resource",
+                "docID": "doc"
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(camel.policy_id, "policy");
+        assert_eq!(camel.resource_name, "resource");
+        assert_eq!(camel.doc_id, "doc");
+
+        let snake: DocDecisionRequest = serde_json::from_str(
+            r#"{
+                "actor": "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+                "permission": "delete",
+                "policy_id": "policy",
+                "resource_name": "resource",
+                "doc_id": "doc"
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(snake.policy_id, "policy");
+        assert_eq!(snake.resource_name, "resource");
+        assert_eq!(snake.doc_id, "doc");
+    }
+
+    #[test]
+    fn test_parse_doc_permission() {
+        assert_eq!(
+            parse_doc_permission("read").unwrap(),
+            acp::DocumentPermission::Read
+        );
+        assert_eq!(
+            parse_doc_permission("update").unwrap(),
+            acp::DocumentPermission::Update
+        );
+        assert_eq!(
+            parse_doc_permission("delete").unwrap(),
+            acp::DocumentPermission::Delete
+        );
+        assert!(matches!(
+            parse_doc_permission("admin"),
+            Err(HttpError::BadRequest(_))
+        ));
     }
 }

--- a/crates/http/src/mock/doc_acp.rs
+++ b/crates/http/src/mock/doc_acp.rs
@@ -6,17 +6,40 @@ use identity::Did;
 use crate::router::DocumentAcpOperations;
 
 /// Mock document ACP operations for testing document relationship handlers.
-#[derive(Debug, Clone, Default)]
-pub struct MockDocumentAcpOperations;
+#[derive(Debug, Clone)]
+pub struct MockDocumentAcpOperations {
+    allowed: bool,
+}
 
 impl MockDocumentAcpOperations {
     pub fn new() -> Self {
-        Self
+        Self { allowed: true }
+    }
+
+    pub fn with_allowed(allowed: bool) -> Self {
+        Self { allowed }
+    }
+}
+
+impl Default for MockDocumentAcpOperations {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 #[async_trait]
 impl DocumentAcpOperations for MockDocumentAcpOperations {
+    async fn check_doc_access(
+        &self,
+        _actor: &Did,
+        _permission: acp::DocumentPermission,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> Result<bool, String> {
+        Ok(self.allowed)
+    }
+
     async fn add_doc_relationship(
         &self,
         _requestor: &Did,

--- a/crates/http/src/route_permissions.rs
+++ b/crates/http/src/route_permissions.rs
@@ -182,6 +182,7 @@ pub fn route_permission(path: &str, method: &Method) -> RoutePermission {
             _ => RoutePermission::Required(NodePermission::DacStatus),
         },
         "/api/v0/acp/policy/:id" => RoutePermission::Required(NodePermission::DacStatus),
+        "/api/v0/acp/document/decide" => RoutePermission::Required(NodePermission::DacStatus),
         "/api/v0/acp/document/relationship" => match *method {
             Method::POST => RoutePermission::Required(NodePermission::DacRelationAdd),
             Method::DELETE => RoutePermission::Required(NodePermission::DacRelationDelete),
@@ -490,6 +491,11 @@ mod tests {
             (
                 "/api/v0/acp/policy",
                 Method::GET,
+                RoutePermission::Required(NodePermission::DacStatus),
+            ),
+            (
+                "/api/v0/acp/document/decide",
+                Method::POST,
                 RoutePermission::Required(NodePermission::DacStatus),
             ),
             (

--- a/crates/http/src/route_permissions_tests.rs
+++ b/crates/http/src/route_permissions_tests.rs
@@ -163,6 +163,14 @@ mod tests {
     }
 
     #[test]
+    fn acp_document_decide_route_uses_dac_status_permission() {
+        assert_eq!(
+            route_permission("/api/v0/acp/document/decide", &Method::POST),
+            RoutePermission::Required(NodePermission::DacStatus)
+        );
+    }
+
+    #[test]
     fn unknown_route_gets_safe_default() {
         assert_eq!(
             route_permission("/api/v0/unknown", &Method::GET),
@@ -356,6 +364,11 @@ mod tests {
             (
                 "/api/v0/acp/policy",
                 Method::GET,
+                RoutePermission::Required(NodePermission::DacStatus),
+            ),
+            (
+                "/api/v0/acp/document/decide",
+                Method::POST,
                 RoutePermission::Required(NodePermission::DacStatus),
             ),
             (

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -150,6 +150,7 @@ pub fn create_router_with_state(state: AppState) -> Router {
         .route("/policy", post(handlers::acp::add_policy))
         .route("/policy", get(handlers::acp::list_policies))
         .route("/policy/{id}", get(handlers::acp::get_policy))
+        .route("/document/decide", post(handlers::acp::decide_doc_access))
         .route(
             "/document/relationship",
             post(handlers::acp::add_doc_relationship),
@@ -275,12 +276,13 @@ pub fn create_router_with_state(state: AppState) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock::{FailingMockP2POperations, MockQueryExecutor};
+    use crate::mock::{FailingMockP2POperations, MockDocumentAcpOperations, MockQueryExecutor};
     use crate::router::{
-        P2POperations, P2PResult, P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo,
+        DocumentAcpOperations, P2POperations, P2PResult, P2pDocumentInfo, P2pDocumentRequest,
+        ReplicatorInfo,
     };
     use axum::{
-        body::Body,
+        body::{to_bytes, Body},
         http::{Method, Request, StatusCode},
     };
     use std::time::Duration;
@@ -462,6 +464,41 @@ mod tests {
             status_for_p2p_request(Method::POST, "/api/v0/p2p/collections", r#"["Users"]"#).await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn document_acp_decide_route_returns_decision() {
+        let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+        let doc_acp = Arc::new(MockDocumentAcpOperations::with_allowed(false))
+            as Arc<dyn DocumentAcpOperations>;
+        let state = AppStateBuilder::new(executor).with_doc_acp(doc_acp).build();
+        let router = create_router_with_state(state);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v0/acp/document/decide")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{
+                            "actor":"did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+                            "permission":"read",
+                            "policy_id":"policy",
+                            "resource_name":"resource",
+                            "doc_id":"doc"
+                        }"#,
+                    ))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should be readable");
+        assert_eq!(&body[..], br#"{"allowed":false}"#);
     }
 
     #[tokio::test]

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -596,6 +596,19 @@ pub trait LensOperations: Send + Sync {
 /// read or write access to a specific document).
 #[async_trait::async_trait]
 pub trait DocumentAcpOperations: Send + Sync {
+    /// Check whether an actor has a document permission.
+    ///
+    /// This is a read-only preview of the current document ACP decision and
+    /// does not create or remove relationships.
+    async fn check_doc_access(
+        &self,
+        actor: &identity::Did,
+        permission: acp::DocumentPermission,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+    ) -> Result<bool, String>;
+
     /// Add an actor relationship to a document.
     ///
     /// Grants the `target_actor` the specified `relation` on the document


### PR DESCRIPTION
## Summary
- add POST /api/v0/acp/document/decide for read-only document ACP access decisions
- extend DocumentAcpOperations and the CLI document ACP adapter to call check_doc_access
- cover route registration, route permissions, request aliases, and mock ACP decisions

Supports sourcenetwork/defra-agent#280.

## Tests
- cargo fmt --check
- cargo test -p defra-http document_decide -- --nocapture
- cargo test -p defra-http document_acp_decide -- --nocapture
- cargo check -p cli