### PR TITLE
fix(db): clean up idle HTTP transactions

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -184,6 +184,14 @@ pub struct StartArgs {
     #[arg(long)]
     pub query_timeout: Option<u64>,
 
+    /// Max idle age for explicit HTTP transactions in seconds (0 = disabled, default: 600)
+    #[arg(long)]
+    pub transaction_idle_timeout: Option<u64>,
+
+    /// Interval between explicit HTTP transaction cleanup sweeps in seconds (default: 60)
+    #[arg(long)]
+    pub transaction_cleanup_interval: Option<u64>,
+
     /// Max GraphQL selection nesting depth (0 = unlimited, default: 20)
     #[arg(long)]
     pub query_max_depth: Option<usize>,
@@ -487,6 +495,12 @@ impl StartArgs {
         if let Some(timeout) = self.query_timeout {
             config.api.query_timeout = timeout;
         }
+        if let Some(timeout) = self.transaction_idle_timeout {
+            config.api.transaction_idle_timeout = timeout;
+        }
+        if let Some(interval) = self.transaction_cleanup_interval {
+            config.api.transaction_cleanup_interval = interval;
+        }
         if let Some(depth) = self.query_max_depth {
             config.api.query_max_depth = depth;
         }
@@ -523,6 +537,7 @@ impl StartArgs {
         if let Some(ref api_key_env) = self.embedding_api_key_env {
             config.embedding.api_key_env = api_key_env.clone();
         }
+        config.api.validate()?;
         Ok(())
     }
 }

--- a/crates/cli/src/commands/start/node.rs
+++ b/crates/cli/src/commands/start/node.rs
@@ -39,6 +39,7 @@ pub struct Node {
     pub(super) p2p_handle: Option<p2p::P2PHostHandle>,
     pub(super) p2p_tasks: Option<P2PTasks>,
     pub(super) downsample_task: Option<JoinHandle<()>>,
+    pub(super) txn_cleanup_task: Option<JoinHandle<()>>,
     pub(super) http_server: Option<defra_http::Server>,
     pub(super) pg_server: Option<pg_compat::PgServer>,
     /// Shutdown signal sender (for tests)
@@ -75,7 +76,7 @@ impl Node {
             };
 
         // Initialize storage, database, and set up P2P and HTTP server
-        let (p2p_handle, p2p_tasks, downsample_task, http_server, pg_server) =
+        let (p2p_handle, p2p_tasks, downsample_task, txn_cleanup_task, http_server, pg_server) =
             match config.datastore.store {
                 DatastoreType::Memory => {
                     info!("Using in-memory datastore");
@@ -203,6 +204,7 @@ impl Node {
             p2p_handle,
             p2p_tasks,
             downsample_task,
+            txn_cleanup_task,
             http_server: Some(http_server),
             pg_server,
             shutdown_tx,

--- a/crates/cli/src/commands/start/run.rs
+++ b/crates/cli/src/commands/start/run.rs
@@ -146,6 +146,12 @@ impl Node {
             let _ = tokio::time::timeout(std::time::Duration::from_secs(1), task).await;
         }
 
+        if let Some(task) = self.txn_cleanup_task.take() {
+            info!("Stopping transaction idle cleanup worker...");
+            task.abort();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(1), task).await;
+        }
+
         // Shutdown P2P tasks first, then the handle
         if let Some(tasks) = self.p2p_tasks.take() {
             info!("Stopping P2P background tasks...");

--- a/crates/cli/src/commands/start/server.rs
+++ b/crates/cli/src/commands/start/server.rs
@@ -1,6 +1,7 @@
 //! Store and server initialization
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tracing::{info, warn};
 
@@ -16,7 +17,7 @@ impl Node {
     /// This function creates the database, loads collections, sets up the query
     /// runner with proper transaction support, and returns the HTTP server.
     ///
-    /// Returns a tuple of (P2PHostHandle, P2PTasks, downsample task, HTTP Server)
+    /// Returns a tuple of (P2PHostHandle, P2PTasks, background tasks, HTTP Server)
     /// where the background tasks are tracked for graceful shutdown.
     pub(super) async fn init_store_and_server<S>(
         store: Arc<S>,
@@ -29,6 +30,7 @@ impl Node {
     ) -> Result<(
         Option<p2p::P2PHostHandle>,
         Option<P2PTasks>,
+        Option<tokio::task::JoinHandle<()>>,
         Option<tokio::task::JoinHandle<()>>,
         defra_http::Server,
         Option<pg_compat::PgServer>,
@@ -172,6 +174,31 @@ impl Node {
             p2p_setup.txn_broadcaster.clone(),
         );
 
+        let txn_cleanup_task = if config.api.transaction_idle_timeout > 0 {
+            if config.api.transaction_cleanup_interval == 0 {
+                return Err(Error::InvalidConfig(
+                    "api.transaction_cleanup_interval must be > 0 when transaction_idle_timeout is enabled"
+                        .to_string(),
+                ));
+            }
+
+            let max_idle_age = Duration::from_secs(config.api.transaction_idle_timeout);
+            let sweep_interval = Duration::from_secs(config.api.transaction_cleanup_interval);
+            info!(
+                max_idle_age_secs = config.api.transaction_idle_timeout,
+                sweep_interval_secs = config.api.transaction_cleanup_interval,
+                "Transaction idle cleanup worker enabled"
+            );
+            Some(
+                query_setup
+                    .registry
+                    .start_stale_transaction_cleanup(max_idle_age, sweep_interval),
+            )
+        } else {
+            info!("Transaction idle cleanup worker disabled");
+            None
+        };
+
         let zanzibar_store_for_pg = zanzibar_store.clone();
         let http_server = Self::build_http_server(HttpServerArgs {
             database: database.clone(),
@@ -197,6 +224,7 @@ impl Node {
             p2p_setup.host_handle,
             p2p_setup.p2p_tasks,
             downsample_task,
+            txn_cleanup_task,
             http_server,
             pg_server,
         ))

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -2,6 +2,7 @@
 
 use std::net::SocketAddr;
 
+use db::{DEFAULT_TRANSACTION_CLEANUP_INTERVAL, DEFAULT_TRANSACTION_IDLE_TIMEOUT};
 use serde::{Deserialize, Serialize};
 
 use query::{DEFAULT_MAX_FILTER_DEPTH, DEFAULT_MAX_QUERY_DEPTH, DEFAULT_MAX_QUERY_WIDTH};
@@ -67,6 +68,12 @@ pub struct ApiConfig {
     /// Query execution timeout in seconds (0 = no timeout). Default: 30.
     #[serde(default = "default_query_timeout")]
     pub query_timeout: u64,
+    /// Max idle age for explicit HTTP transactions in seconds (0 = disabled). Default: 600.
+    #[serde(default = "default_transaction_idle_timeout")]
+    pub transaction_idle_timeout: u64,
+    /// Interval between explicit HTTP transaction cleanup sweeps in seconds. Default: 60.
+    #[serde(default = "default_transaction_cleanup_interval")]
+    pub transaction_cleanup_interval: u64,
     /// Max GraphQL selection nesting depth (0 = unlimited). Default: 20.
     #[serde(default = "default_query_max_depth")]
     pub query_max_depth: usize,
@@ -91,6 +98,14 @@ fn default_max_concurrent() -> usize {
 
 fn default_query_timeout() -> u64 {
     30
+}
+
+fn default_transaction_idle_timeout() -> u64 {
+    DEFAULT_TRANSACTION_IDLE_TIMEOUT.as_secs()
+}
+
+fn default_transaction_cleanup_interval() -> u64 {
+    DEFAULT_TRANSACTION_CLEANUP_INTERVAL.as_secs()
 }
 
 fn default_query_max_depth() -> usize {
@@ -118,6 +133,8 @@ impl Default for ApiConfig {
             request_timeout: default_request_timeout(),
             max_concurrent_requests: default_max_concurrent(),
             query_timeout: default_query_timeout(),
+            transaction_idle_timeout: default_transaction_idle_timeout(),
+            transaction_cleanup_interval: default_transaction_cleanup_interval(),
             query_max_depth: default_query_max_depth(),
             query_max_width: default_query_max_width(),
             query_max_filter_depth: default_query_max_filter_depth(),
@@ -137,6 +154,13 @@ impl ApiConfig {
         let has_priv = !self.privkey_path.is_empty();
         if has_pub != has_priv {
             return Err(Error::IncompleteTlsConfig);
+        }
+
+        if self.transaction_idle_timeout > 0 && self.transaction_cleanup_interval == 0 {
+            return Err(Error::InvalidConfig(
+                "api.transaction_cleanup_interval must be > 0 when transaction_idle_timeout is enabled"
+                    .to_string(),
+            ));
         }
 
         Ok(())

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -45,6 +45,8 @@ fn default_start_args() -> StartArgs {
         p2p_rate_limit_rate: None,
         max_merge_depth: None,
         query_timeout: None,
+        transaction_idle_timeout: None,
+        transaction_cleanup_interval: None,
         query_max_depth: None,
         query_max_width: None,
         query_max_filter_depth: None,
@@ -80,6 +82,19 @@ fn test_apply_to_config_valid_store_succeeds() {
     let result = args.apply_to_config(&mut config);
     assert!(result.is_ok());
     assert_eq!(config.datastore.store, DatastoreType::Memory);
+}
+
+#[test]
+fn test_apply_to_config_rejects_zero_transaction_cleanup_interval_when_enabled() {
+    let mut config = Config::default();
+    let mut args = default_start_args();
+    args.transaction_idle_timeout = Some(600);
+    args.transaction_cleanup_interval = Some(0);
+
+    let result = args.apply_to_config(&mut config);
+    assert!(
+        matches!(result, Err(Error::InvalidConfig(message)) if message.contains("transaction_cleanup_interval"))
+    );
 }
 
 #[test]
@@ -137,6 +152,8 @@ fn test_apply_to_config_all_flags() {
         p2p_rate_limit_rate: Some(4.5),
         max_merge_depth: Some(2048),
         query_timeout: Some(45),
+        transaction_idle_timeout: Some(900),
+        transaction_cleanup_interval: Some(30),
         query_max_depth: Some(12),
         query_max_width: Some(64),
         query_max_filter_depth: Some(24),
@@ -187,6 +204,8 @@ fn test_apply_to_config_all_flags() {
     assert!(config.datastore.no_searchable_encryption);
     assert_eq!(config.replicator_retry_intervals, vec![10, 20, 30]);
     assert_eq!(config.api.query_timeout, 45);
+    assert_eq!(config.api.transaction_idle_timeout, 900);
+    assert_eq!(config.api.transaction_cleanup_interval, 30);
     assert_eq!(config.api.query_max_depth, 12);
     assert_eq!(config.api.query_max_width, 64);
     assert_eq!(config.api.query_max_filter_depth, 24);

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -129,7 +129,10 @@ pub use schema_loader::{
 };
 pub use txn::DbTxn;
 pub use txn_context::DbTransactionContext;
-pub use txn_registry::{CleanupResult, DbTransactionRegistry};
+pub use txn_registry::{
+    CleanupResult, DbTransactionRegistry, DEFAULT_TRANSACTION_CLEANUP_INTERVAL,
+    DEFAULT_TRANSACTION_IDLE_TIMEOUT,
+};
 pub use versioned_fetcher::VersionedFetcher;
 pub use view_ops::RefreshViewsOptions;
 

--- a/crates/db/src/txn_context.rs
+++ b/crates/db/src/txn_context.rs
@@ -4,8 +4,8 @@ use query::fetcher::CollectionProvider;
 use query::mutator::DocMutator;
 use query::runner::DocFetcher;
 use query::txn::{DeferredAcpMutations, TransactionContext};
-use std::sync::Arc;
-use std::time::Instant;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use storage::corekv::Store;
 
 use crate::collection_provider::TxnCollectionProvider;
@@ -28,6 +28,7 @@ pub struct DbTransactionContext<S: Store> {
     broadcaster: Option<Arc<dyn crate::event_emission::TxnBroadcaster>>,
     action_lock: Arc<async_lock::Mutex<()>>,
     created_at: Instant,
+    last_request_seen: Mutex<Instant>,
 }
 
 impl<S: Store> DbTransactionContext<S> {
@@ -41,6 +42,7 @@ impl<S: Store> DbTransactionContext<S> {
         deferred_acp_mutations: Arc<DeferredAcpMutations>,
         broadcaster: Option<Arc<dyn crate::event_emission::TxnBroadcaster>>,
     ) -> Self {
+        let now = Instant::now();
         Self {
             db,
             id,
@@ -49,13 +51,40 @@ impl<S: Store> DbTransactionContext<S> {
             deferred_acp_mutations,
             broadcaster,
             action_lock: Arc::new(async_lock::Mutex::new(())),
-            created_at: Instant::now(),
+            created_at: now,
+            last_request_seen: Mutex::new(now),
         }
     }
 
     /// Get the instant when this transaction was created.
     pub fn created_at(&self) -> Instant {
         self.created_at
+    }
+
+    /// Mark that a request used this transaction.
+    pub(crate) fn touch(&self) {
+        match self.last_request_seen.lock() {
+            Ok(mut last_request_seen) => {
+                *last_request_seen = Instant::now();
+            }
+            Err(poisoned) => {
+                let mut last_request_seen = poisoned.into_inner();
+                *last_request_seen = Instant::now();
+            }
+        }
+    }
+
+    /// Get the instant when this transaction last saw a request.
+    pub fn last_request_seen(&self) -> Instant {
+        match self.last_request_seen.lock() {
+            Ok(last_request_seen) => *last_request_seen,
+            Err(poisoned) => *poisoned.into_inner(),
+        }
+    }
+
+    /// Get how long this transaction has been idle.
+    pub fn idle_for(&self, now: Instant) -> Duration {
+        now.duration_since(self.last_request_seen())
     }
 }
 

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -24,7 +24,7 @@ use query::txn::{
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use storage::corekv::Store;
 use tracing::{error, warn};
 
@@ -34,6 +34,12 @@ use crate::error::{Error, Result};
 use crate::lensed_fetcher::LensedDocFetcher;
 use crate::txn_context::DbTransactionContext;
 use crate::txn_lens_store::TxnLensStore;
+
+/// Default max idle age for explicit HTTP transactions.
+pub const DEFAULT_TRANSACTION_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Default interval between explicit HTTP transaction cleanup sweeps.
+pub const DEFAULT_TRANSACTION_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Result of a stale transaction cleanup operation.
 ///
@@ -185,7 +191,13 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
     /// Returns `Err(LockPoisoned)` if the lock is poisoned (indicates a panic elsewhere).
     pub fn get_ctx(&self, txn_id: &str) -> Result<Option<Arc<DbTransactionContext<S>>>> {
         match self.transactions.read() {
-            Ok(guard) => Ok(guard.get(txn_id).cloned()),
+            Ok(guard) => {
+                let ctx = guard.get(txn_id).cloned();
+                if let Some(ctx) = &ctx {
+                    ctx.touch();
+                }
+                Ok(ctx)
+            }
             Err(poisoned) => {
                 error!(
                     txn_id = %txn_id,
@@ -237,11 +249,13 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
             .map_err(Error::Query)
     }
 
-    /// Cleanup transactions older than the given duration.
+    /// Cleanup transactions idle for longer than the given duration.
     ///
-    /// This method finds all transactions that were created more than `max_age` ago
-    /// and rolls them back, freeing resources. This should be called periodically
-    /// by a background task to prevent resource leaks from dropped `TransactionGuard`s.
+    /// This method finds all transactions whose last observed request was more
+    /// than `max_idle_age` ago and rolls them back, freeing resources. This
+    /// should be called periodically by a background task to prevent resource
+    /// leaks from dropped `TransactionGuard`s or orphaned HTTP transaction
+    /// handles.
     ///
     /// Returns a `CleanupResult` containing both successfully cleaned transactions
     /// and any failures. Check `result.is_complete()` to verify all cleanups succeeded.
@@ -249,41 +263,67 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
     /// # Errors
     ///
     /// Returns an error if the lock is poisoned, indicating a panic elsewhere.
-    pub async fn cleanup_stale_transactions(&self, max_age: Duration) -> Result<CleanupResult> {
-        let now = std::time::Instant::now();
+    pub async fn cleanup_stale_transactions(
+        &self,
+        max_idle_age: Duration,
+    ) -> Result<CleanupResult> {
+        let now = Instant::now();
 
-        // Collect stale transaction IDs while holding the read lock briefly
-        let stale_ids: Vec<String> = {
+        // Collect stale transaction candidates while holding the read lock briefly.
+        // Each candidate is re-checked after acquiring the transaction action lock
+        // so a request that arrives during cleanup can refresh the idle clock.
+        let stale_candidates: Vec<(String, Arc<DbTransactionContext<S>>)> = {
             let guard = self.transactions.read().map_err(|_| {
                 Error::LockPoisoned("failed to acquire read lock during cleanup".to_string())
             })?;
 
             guard
                 .iter()
-                .filter(|(_, ctx)| now.duration_since(ctx.created_at()) > max_age)
-                .map(|(id, _)| id.clone())
+                .filter(|(_, ctx)| ctx.idle_for(now) > max_idle_age)
+                .map(|(id, ctx)| (id.clone(), ctx.clone()))
                 .collect()
         };
 
         let mut result = CleanupResult::default();
-        for txn_id in stale_ids {
-            // Remove and rollback each stale transaction
+        for (txn_id, candidate_ctx) in stale_candidates {
+            let action_lock = candidate_ctx.action_lock();
+            let _action_guard = action_lock.lock().await;
+
+            let now = Instant::now();
+            if candidate_ctx.idle_for(now) <= max_idle_age {
+                continue;
+            }
+
+            // Remove and rollback each stale transaction. Re-check while holding
+            // the write lock so a concurrent request that touched the context
+            // after candidate collection cannot lose its transaction.
             let ctx = {
                 let mut guard = self.transactions.write().map_err(|_| {
                     Error::LockPoisoned("failed to acquire write lock during cleanup".to_string())
                 })?;
-                guard.remove(&txn_id)
+
+                // Holding the registry write lock blocks new get()/get_ctx()
+                // touches while we do the final idle re-check and remove.
+                // The idle timestamp itself is protected by the context mutex,
+                // so a request cannot refresh it between this check and removal.
+                match guard.get(&txn_id) {
+                    Some(current)
+                        if Arc::ptr_eq(current, &candidate_ctx)
+                            && current.idle_for(Instant::now()) > max_idle_age =>
+                    {
+                        guard.remove(&txn_id)
+                    }
+                    _ => None,
+                }
             };
 
             if let Some(ctx) = ctx {
+                let idle_secs = ctx.idle_for(Instant::now()).as_secs();
                 warn!(
                     txn_id = %txn_id,
-                    age_secs = ?now.duration_since(ctx.created_at()).as_secs(),
-                    "Cleaning up stale transaction (leaked TransactionGuard?)"
+                    idle_secs,
+                    "Cleaning up idle transaction (orphaned HTTP handle or leaked TransactionGuard?)"
                 );
-
-                let action_lock = ctx.action_lock();
-                let _action_guard = action_lock.lock().await;
 
                 // Try to take and discard the transaction
                 if let Some(txn) = ctx.take_txn().await {
@@ -305,6 +345,58 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         }
 
         Ok(result)
+    }
+
+    /// Start a periodic task that cleans up transactions idle for longer than
+    /// `max_idle_age`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `sweep_interval` is zero.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native"))]
+    pub fn start_stale_transaction_cleanup(
+        self: &Arc<Self>,
+        max_idle_age: Duration,
+        sweep_interval: Duration,
+    ) -> tokio::task::JoinHandle<()> {
+        assert!(
+            !sweep_interval.is_zero(),
+            "transaction cleanup sweep interval must be non-zero"
+        );
+
+        let registry = Arc::clone(self);
+
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(sweep_interval).await;
+
+                match registry.cleanup_stale_transactions(max_idle_age).await {
+                    Ok(result) if result.attempted() > 0 && result.is_complete() => {
+                        tracing::info!(
+                            cleaned = result.cleaned,
+                            max_idle_age_secs = max_idle_age.as_secs(),
+                            "Cleaned up idle transactions"
+                        );
+                    }
+                    Ok(result) if result.attempted() > 0 => {
+                        tracing::warn!(
+                            cleaned = result.cleaned,
+                            failed = result.failed.len(),
+                            max_idle_age_secs = max_idle_age.as_secs(),
+                            "Idle transaction cleanup completed with failures"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            max_idle_age_secs = max_idle_age.as_secs(),
+                            "Idle transaction cleanup failed"
+                        );
+                    }
+                }
+            }
+        })
     }
 
     /// Get the number of active transactions in the registry.
@@ -674,7 +766,10 @@ impl<S: Store + 'static> TransactionRegistry for DbTransactionRegistry<S> {
     fn get(&self, handle: &TransactionHandle) -> GetTransactionResult {
         match self.transactions.read() {
             Ok(guard) => match guard.get(handle.as_str()).cloned() {
-                Some(ctx) => GetTransactionResult::Found(ctx as Arc<dyn TransactionContext>),
+                Some(ctx) => {
+                    ctx.touch();
+                    GetTransactionResult::Found(ctx as Arc<dyn TransactionContext>)
+                }
                 None => GetTransactionResult::NotFound,
             },
             Err(poisoned) => {

--- a/crates/db/src/txn_registry_tests.rs
+++ b/crates/db/src/txn_registry_tests.rs
@@ -791,6 +791,61 @@ async fn test_cleanup_only_old_transactions() {
 }
 
 #[tokio::test]
+async fn test_cleanup_uses_idle_age_not_creation_age() {
+    let db = test_db_with_collections().await;
+    let registry = DbTransactionRegistry::new(db);
+
+    let txn = registry.begin(true).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+    assert!(registry.get(&txn).is_found());
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let result = registry
+        .cleanup_stale_transactions(std::time::Duration::from_millis(40))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.cleaned, 0,
+        "Recently used transaction should not be cleaned by creation age"
+    );
+    assert!(registry.get(&txn).is_found());
+
+    tokio::time::sleep(std::time::Duration::from_millis(45)).await;
+
+    let result = registry
+        .cleanup_stale_transactions(std::time::Duration::from_millis(40))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.cleaned, 1,
+        "Transaction should be cleaned after it is idle past the limit"
+    );
+    assert_eq!(registry.active_transaction_count().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn test_periodic_cleanup_task_removes_idle_transactions() {
+    let db = test_db_with_collections().await;
+    let registry = Arc::new(DbTransactionRegistry::new(db));
+
+    let _txn = registry.begin(true).await.unwrap();
+    assert_eq!(registry.active_transaction_count().unwrap(), 1);
+
+    let cleanup_task = registry.start_stale_transaction_cleanup(
+        std::time::Duration::from_millis(100),
+        std::time::Duration::from_millis(25),
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    cleanup_task.abort();
+
+    assert_eq!(registry.active_transaction_count().unwrap(), 0);
+}
+
+#[tokio::test]
 async fn test_active_transaction_count() {
     let db = test_db_with_collections().await;
     let registry = DbTransactionRegistry::new(db);

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -1,5 +1,11 @@
 //! Configuration types for the embedded DefraDB node.
 
+#[cfg(feature = "http")]
+use std::time::Duration;
+
+#[cfg(feature = "http")]
+use db::{DEFAULT_TRANSACTION_CLEANUP_INTERVAL, DEFAULT_TRANSACTION_IDLE_TIMEOUT};
+
 /// Document ACP configuration.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[non_exhaustive]
@@ -22,23 +28,40 @@ pub struct SourceHubConfig {
 #[cfg(feature = "http")]
 pub struct HttpConfig {
     pub address: std::net::SocketAddr,
+    pub(crate) transaction_idle_timeout: Duration,
+    pub(crate) transaction_cleanup_interval: Duration,
     pub(crate) extra_routes: Option<axum::Router>,
 }
 
 #[cfg(feature = "http")]
 impl HttpConfig {
     pub fn new(port: u16) -> Self {
-        Self {
-            address: std::net::SocketAddr::from(([127, 0, 0, 1], port)),
-            extra_routes: None,
-        }
+        Self::with_addr(std::net::SocketAddr::from(([127, 0, 0, 1], port)))
     }
 
     pub fn with_addr(addr: impl Into<std::net::SocketAddr>) -> Self {
         Self {
             address: addr.into(),
+            transaction_idle_timeout: DEFAULT_TRANSACTION_IDLE_TIMEOUT,
+            transaction_cleanup_interval: DEFAULT_TRANSACTION_CLEANUP_INTERVAL,
             extra_routes: None,
         }
+    }
+
+    /// Set the max idle age for explicit HTTP transactions.
+    ///
+    /// `Duration::ZERO` disables idle transaction cleanup.
+    pub fn with_transaction_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.transaction_idle_timeout = timeout;
+        self
+    }
+
+    /// Set the interval between explicit HTTP transaction cleanup sweeps.
+    ///
+    /// Must be non-zero when transaction idle cleanup is enabled.
+    pub fn with_transaction_cleanup_interval(mut self, interval: Duration) -> Self {
+        self.transaction_cleanup_interval = interval;
+        self
     }
 
     pub fn with_extra_routes(mut self, extra: axum::Router) -> Self {

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -23,6 +23,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 #[cfg(feature = "p2p")]
 use std::sync::Mutex;
+#[cfg(feature = "http")]
+use std::time::Duration;
 
 use defra_core::signing::SigningConfig;
 use identity::{Identity as _, IdentityKeyType, RawIdentity};
@@ -76,6 +78,8 @@ pub struct EmbeddedNode {
     schema_ops: Arc<dyn SchemaOps>,
     embedding_config: db::EmbeddingClientConfig,
     node_identity_did: Option<String>,
+    #[cfg(feature = "http")]
+    txn_cleanup_task: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     #[cfg(feature = "p2p")]
     p2p_ops: Option<Arc<dyn defra_http::P2POperations>>,
     #[cfg(feature = "p2p")]
@@ -116,6 +120,13 @@ impl P2PLifecycle {
             inner.shutdown().await;
         }
     }
+}
+
+#[cfg(feature = "http")]
+#[derive(Clone, Copy)]
+struct TransactionCleanupConfig {
+    max_idle_age: Duration,
+    sweep_interval: Duration,
 }
 
 #[cfg(feature = "p2p")]
@@ -375,6 +386,12 @@ impl EmbeddedNode {
 
     /// Gracefully stop background services owned by this embedded node.
     pub async fn shutdown(&self) {
+        #[cfg(feature = "http")]
+        if let Some(task) = self.txn_cleanup_task.lock().await.take() {
+            task.abort();
+            let _ = tokio::time::timeout(Duration::from_secs(1), task).await;
+        }
+
         #[cfg(feature = "p2p")]
         if let Some(lifecycle) = &self.p2p_lifecycle {
             lifecycle.shutdown().await;
@@ -491,6 +508,8 @@ struct StoreBuildArgs {
     event_bus: Arc<dyn events::Bus>,
     node_identity_did: Option<String>,
     query_limits: QueryLimits,
+    #[cfg(feature = "http")]
+    transaction_cleanup_config: Option<TransactionCleanupConfig>,
     #[cfg(feature = "p2p")]
     p2p_config: Option<P2PConfig>,
 }
@@ -601,6 +620,23 @@ impl NodeBuilder {
         // 2. Extract configs before moving self
         #[cfg(feature = "http")]
         let http_config = self.http_config;
+        #[cfg(feature = "http")]
+        let transaction_cleanup_config = match http_config.as_ref() {
+            Some(config) if config.transaction_idle_timeout.is_zero() => None,
+            Some(config) => {
+                if config.transaction_cleanup_interval.is_zero() {
+                    anyhow::bail!(
+                        "transaction cleanup interval must be non-zero when idle cleanup is enabled"
+                    );
+                }
+
+                Some(TransactionCleanupConfig {
+                    max_idle_age: config.transaction_idle_timeout,
+                    sweep_interval: config.transaction_cleanup_interval,
+                })
+            }
+            None => None,
+        };
         #[cfg(feature = "p2p")]
         let p2p_config = self.p2p_config;
         let query_limits = self.query_limits;
@@ -635,6 +671,8 @@ impl NodeBuilder {
                             event_bus,
                             node_identity_did: node_identity_did.clone(),
                             query_limits,
+                            #[cfg(feature = "http")]
+                            transaction_cleanup_config,
                             #[cfg(feature = "p2p")]
                             p2p_config,
                         },
@@ -665,6 +703,8 @@ impl NodeBuilder {
                             event_bus,
                             node_identity_did: node_identity_did.clone(),
                             query_limits,
+                            #[cfg(feature = "http")]
+                            transaction_cleanup_config,
                             #[cfg(feature = "p2p")]
                             p2p_config,
                         },
@@ -696,6 +736,8 @@ impl NodeBuilder {
                     event_bus,
                     node_identity_did: node_identity_did.clone(),
                     query_limits,
+                    #[cfg(feature = "http")]
+                    transaction_cleanup_config,
                     #[cfg(feature = "p2p")]
                     p2p_config,
                 },
@@ -780,6 +822,8 @@ impl NodeBuilder {
             event_bus,
             node_identity_did,
             query_limits,
+            #[cfg(feature = "http")]
+            transaction_cleanup_config,
             #[cfg(feature = "p2p")]
             p2p_config,
         } = args;
@@ -832,6 +876,17 @@ impl NodeBuilder {
             Some(b) => db::DbTransactionRegistry::with_broadcaster(database.clone(), b),
             None => db::DbTransactionRegistry::new(database.clone()),
         });
+
+        #[cfg(feature = "http")]
+        let txn_cleanup_task = transaction_cleanup_config.map(|cleanup| {
+            tracing::info!(
+                max_idle_age_secs = cleanup.max_idle_age.as_secs(),
+                sweep_interval_secs = cleanup.sweep_interval.as_secs(),
+                "Transaction idle cleanup worker enabled"
+            );
+            registry.start_stale_transaction_cleanup(cleanup.max_idle_age, cleanup.sweep_interval)
+        });
+
         let (document_acp, _strict_replicated_doc_access) =
             node_acp::create_document_acp(acp_store, &document_acp_config).await?;
 
@@ -867,6 +922,8 @@ impl NodeBuilder {
             schema_ops,
             embedding_config,
             node_identity_did,
+            #[cfg(feature = "http")]
+            txn_cleanup_task: tokio::sync::Mutex::new(txn_cleanup_task),
             #[cfg(feature = "p2p")]
             p2p_ops,
             #[cfg(feature = "p2p")]
@@ -1313,10 +1370,16 @@ mod tests {
     #[cfg(feature = "http")]
     #[test]
     fn http_config_accepts_extra_routes() {
+        use std::time::Duration;
+
         let config = HttpConfig::new(9182)
+            .with_transaction_idle_timeout(Duration::from_secs(900))
+            .with_transaction_cleanup_interval(Duration::from_secs(30))
             .with_extra_routes(Router::new().route("/healthz", get(|| async { "ok" })));
 
         assert_eq!(config.address.port(), 9182);
+        assert_eq!(config.transaction_idle_timeout, Duration::from_secs(900));
+        assert_eq!(config.transaction_cleanup_interval, Duration::from_secs(30));
         assert!(config.extra_routes.is_some());
     }
 

--- a/crates/query/src/txn/guard.rs
+++ b/crates/query/src/txn/guard.rs
@@ -13,9 +13,9 @@ use super::TransactionHandle;
 ///
 /// If dropped without explicit `commit()` or `rollback()`, the guard will log
 /// an error but **cannot perform async rollback**. The transaction will remain
-/// in the registry until cleaned up by `cleanup_stale_transactions()`. Always
-/// ensure you call `commit()` or `rollback()` explicitly before the guard goes
-/// out of scope.
+/// in the registry until cleaned up by the idle transaction cleanup policy.
+/// Always ensure you call `commit()` or `rollback()` explicitly before the
+/// guard goes out of scope.
 ///
 /// # Example
 ///
@@ -108,8 +108,8 @@ impl<E: crate::QueryExecutor + ?Sized> Drop for TransactionGuard<'_, E> {
         if let Some(handle) = &self.handle {
             // Transaction was not finalized - this is a bug in user code.
             // We can't do async rollback in drop, so we log an error.
-            // The transaction will remain in the registry until it times out
-            // or is explicitly cleaned up.
+            // The transaction will remain in the registry until idle cleanup
+            // or explicit cleanup removes it.
             tracing::error!(
                 txn_id = %handle,
                 "TransactionGuard dropped without commit/rollback - transaction leaked! \


### PR DESCRIPTION
Closes #986.

## Summary
- Track explicit transaction last-request timestamps and clean up by idle age instead of creation age.
- Add a periodic stale transaction cleanup worker with a 600s default idle timeout and 60s sweep interval.
- Wire cleanup into CLI and defra-node HTTP startup, with CLI config/flags and tests.

## Verification
- `cargo test -p db test_cleanup -- --nocapture`
- `cargo test -p db test_periodic_cleanup -- --nocapture`
- `cargo test -p cli --test start_tests -- --nocapture`
- `cargo check -p defra-node --features http`
- `cargo test -p defra-node --features http http_config_accepts_extra_routes -- --nocapture`
- `cargo check -p defra-node`
- `git diff --check`