### PR TITLE
fix(lens): disable Wasmtime Mach ports on macOS

### DIFF
--- a/crates/lens/src/wasm.rs
+++ b/crates/lens/src/wasm.rs
@@ -73,6 +73,12 @@ impl WasmTransformStore {
     /// Create a WASM transform store with optional sandboxing.
     pub fn with_sandbox(sandbox: Option<WasmSandboxConfig>) -> Result<Self> {
         let mut config = Config::new();
+        #[cfg(target_os = "macos")]
+        {
+            // Fork-capable embedders can crash when Wasmtime's Mach-port
+            // exception handler is initialized before spawning child processes.
+            config.macos_use_mach_ports(false);
+        }
         if let Some(ref sb) = sandbox {
             if sb.fuel_budget.is_some() {
                 config.consume_fuel(true);


### PR DESCRIPTION
## Summary

Closes #984 by configuring DefraDB's native Wasmtime lens engine to use Unix signal handling instead of macOS Mach-port exception handling.

## Why

DefraDB native DB startup eagerly creates a lens `WasmTransformStore`, even for embedded workloads that do not explicitly use lenses. On macOS, Wasmtime enables Mach-port exception handling by default, and that mode is not fork-friendly.

Fork-capable embedders like `defra-agent` can spawn child processes after initializing DefraDB, which can intermittently abort in Wasmtime's Mach-port handler. The issue's diagnostic patch showed that disabling Mach ports in `crates/lens/src/wasm.rs` eliminated the downstream crash loop.

## Changes

| Area | Change |
|---|---|
| Lens runtime | Disable `Config::macos_use_mach_ports` on macOS before constructing the Wasmtime engine |
| Platform scope | Keep the change behind `#[cfg(target_os = "macos")]` so non-macOS behavior is unchanged |
| Context | Add a short comment explaining why fork-capable embedders need this setting |

## Out of scope

- No new lens or DefraDB configuration knob.
- No change to Wasmtime settings on Linux, Windows, or WASM builds.
- No lazy initialization of the lens engine.
- No changes to lens sandbox fuel, epoch interruption, or memory limits.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p lens`
- [x] `cargo clippy -p lens --all-targets -- -D warnings`