### PR TITLE
feat(p2p): make libp2p transport optional

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ storage = { path = "../storage" }
 blockstore = { path = "../blockstore" }
 crypto = { path = "../crypto" }
 identity = { path = "../identity" }
-p2p = { path = "../p2p" }
+p2p = { path = "../p2p", features = ["libp2p-transport"] }
 defra-http = { path = "../http" }
 query = { path = "../query" }
 db = { path = "../db" }

--- a/crates/db-merge/Cargo.toml
+++ b/crates/db-merge/Cargo.toml
@@ -58,7 +58,7 @@ defra-core = { path = "../defra-core" }
 identity = { path = "../identity" }
 acp = { path = "../acp", default-features = false }
 events = { path = "../events", default-features = false }
-p2p = { path = "../p2p" }
+p2p = { path = "../p2p", features = ["libp2p-transport"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -10,7 +10,7 @@ description = "DefraDB database and collection management"
 
 [features]
 default = ["p2p", "native"]
-p2p = ["dep:p2p", "dep:libp2p"]
+p2p = ["dep:p2p", "dep:libp2p", "p2p/libp2p-transport"]
 native = ["dep:tokio", "lens/wasmtime-runtime", "events/channel", "acp/native"]
 redb = ["storage/redb", "acp/redb", "db-nac/redb"]
 

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -21,7 +21,7 @@ document = { path = "../document" }
 events = { path = "../events" }
 identity = { path = "../identity" }
 lens = { path = "../lens" }
-p2p = { path = "../p2p" }
+p2p = { path = "../p2p", features = ["libp2p-transport"] }
 query = { path = "../query" }
 schema = { path = "../schema" }
 sourcehub = { path = "../sourcehub" }

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -65,7 +65,7 @@ identity = { path = "../identity" }
 acp = { path = "../acp" }
 sourcehub = { path = "../sourcehub" }
 lens = { path = "../lens" }
-p2p = { path = "../p2p" }
+p2p = { path = "../p2p", features = ["libp2p-transport"] }
 blockstore = { path = "../blockstore" }
 embedded = { path = "../embedded" }
 

--- a/crates/p2p-adapter/Cargo.toml
+++ b/crates/p2p-adapter/Cargo.toml
@@ -25,7 +25,7 @@ async-trait.workspace = true
 bytes.workspace = true
 cid.workspace = true
 hex.workspace = true
-libp2p.workspace = true
+libp2p = { workspace = true, optional = true }
 serde.workspace = true
 serde_bytes.workspace = true
 serde_ipld_dagcbor.workspace = true
@@ -37,7 +37,7 @@ zeroize = "1"
 [features]
 default = ["iroh", "libp2p"]
 iroh = ["p2p/iroh-transport"]
-libp2p = []
+libp2p = ["dep:libp2p", "p2p/libp2p-transport"]
 
 [lints]
 workspace = true

--- a/crates/p2p-adapter/src/replicator_status.rs
+++ b/crates/p2p-adapter/src/replicator_status.rs
@@ -66,8 +66,7 @@ mod tests {
     async fn status_update_persists_first_transition_only() {
         let store = Arc::new(MemoryStore::new());
         let peerstore = storage::stores::Peerstore::new(store);
-        let peer_id = p2p::PeerId::random();
-        let info = p2p::ReplicatorInfo::new(peer_id, vec!["users".to_string()]).unwrap();
+        let info = p2p::ReplicatorInfo::new("peer-1", vec!["users".to_string()]).unwrap();
         peerstore
             .create_replicator(info.peer_id_str(), &info.to_bytes().unwrap())
             .await

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -18,11 +18,11 @@ storage = { path = "../storage" }
 identity = { path = "../identity" }
 acp = { path = "../acp" }
 
-# P2P
-libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad", "relay", "dns", "quic", "websocket", "memory-connection-limits"] }
-iroh-bitswap = { workspace = true }
-libp2p-stream = { workspace = true }
-multiaddr = { workspace = true }
+# libp2p transport
+libp2p = { workspace = true, features = ["tcp", "noise", "yamux", "identify", "request-response", "macros", "tokio", "gossipsub", "kad", "relay", "dns", "quic", "websocket", "memory-connection-limits"], optional = true }
+iroh-bitswap = { workspace = true, optional = true }
+libp2p-stream = { workspace = true, optional = true }
+multiaddr = { workspace = true, optional = true }
 
 # Async
 tokio = { workspace = true, features = ["sync", "rt", "macros", "fs"] }
@@ -52,8 +52,8 @@ libipld = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
-rlimit = "0.9"
-sysinfo = "0.29"
+rlimit = { version = "0.9", optional = true }
+sysinfo = { version = "0.29", optional = true }
 
 # Bytes
 bytes = { workspace = true }
@@ -65,7 +65,7 @@ unsigned-varint = "0.8"
 parking_lot = { workspace = true }
 
 # Void type used by libp2p connection-limits behaviour (never emits events)
-void = "1.0.2"
+void = { version = "1.0.2", optional = true }
 
 # Iroh transport (optional)
 iroh = { workspace = true, optional = true }
@@ -77,7 +77,16 @@ blake3 = { version = "1", optional = true }
 
 [features]
 default = []
-test-utils = []
+test-utils = ["libp2p-transport"]
+libp2p-transport = [
+    "dep:iroh-bitswap",
+    "dep:libp2p",
+    "dep:libp2p-stream",
+    "dep:multiaddr",
+    "dep:rlimit",
+    "dep:sysinfo",
+    "dep:void",
+]
 iroh-transport = ["dep:iroh", "dep:iroh-gossip", "dep:iroh-blobs", "dep:iroh-tickets", "dep:rand", "dep:blake3"]
 
 [dev-dependencies]

--- a/crates/p2p/src/bitswap/mod.rs
+++ b/crates/p2p/src/bitswap/mod.rs
@@ -24,11 +24,15 @@
 //! missing DAG links and fetches them via Bitswap.
 
 mod access;
+#[cfg(feature = "libp2p-transport")]
 mod filter;
 mod registry;
+#[cfg(feature = "libp2p-transport")]
 mod store;
 
 pub use access::AccessMode;
+#[cfg(feature = "libp2p-transport")]
 pub use filter::make_peer_block_access_filter;
 pub use registry::ReplicatorRegistry;
+#[cfg(feature = "libp2p-transport")]
 pub use store::BitswapStoreAdapter;

--- a/crates/p2p/src/error.rs
+++ b/crates/p2p/src/error.rs
@@ -380,12 +380,14 @@ impl From<serde_cbor::Error> for Error {
     }
 }
 
+#[cfg(feature = "libp2p-transport")]
 impl From<libp2p::TransportError<io::Error>> for Error {
     fn from(e: libp2p::TransportError<io::Error>) -> Self {
         Error::Transport(e.to_string())
     }
 }
 
+#[cfg(feature = "libp2p-transport")]
 impl From<libp2p::multiaddr::Error> for Error {
     fn from(e: libp2p::multiaddr::Error) -> Self {
         Error::InvalidMultiaddr(e.to_string())

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -53,29 +53,36 @@
 //! - Protocol ID: `/defra/0.0.1` (multicodec 961)
 //! - Messages: CBOR encoded using serde
 
+#[cfg(feature = "libp2p-transport")]
 pub mod address;
+#[cfg(feature = "libp2p-transport")]
 pub mod behaviour;
 pub mod bitswap;
+#[cfg(feature = "libp2p-transport")]
 pub mod codec;
 pub mod error;
 mod explicit_replay;
+#[cfg(feature = "libp2p-transport")]
 pub mod host;
 pub mod message;
 pub mod protocol;
+#[cfg(feature = "libp2p-transport")]
 pub mod pubsub_rpc;
 pub mod replicator;
 pub mod signing;
 pub mod sync;
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(all(any(test, feature = "test-utils"), feature = "libp2p-transport"))]
 pub mod testutil;
 pub mod topics;
 pub mod transport;
+#[cfg(feature = "libp2p-transport")]
 pub mod two_stream;
 
 #[cfg(feature = "iroh-transport")]
 pub mod iroh;
 
 // Re-export address parsing
+#[cfg(feature = "libp2p-transport")]
 pub use address::{parse_multiaddr_with_peer_id, ParsedMultiaddr};
 
 // Re-export main types for convenience
@@ -91,6 +98,7 @@ pub use explicit_replay::{
     DEFAULT_CAPABILITY_TTL as DEFAULT_EXPLICIT_REPLAY_CAPABILITY_TTL,
     MAX_CAPABILITY_TTL as MAX_EXPLICIT_REPLAY_CAPABILITY_TTL,
 };
+#[cfg(feature = "libp2p-transport")]
 pub use host::{
     convert_host_event, HostCommand, HostEvent, Libp2pTransport, P2PHost, P2PHostConfig,
     P2PHostHandle, ResponseChannel,
@@ -106,7 +114,9 @@ pub use protocol::{
 pub use protocol::{PUSHLOG_REQUEST_PROTOCOL, PUSHLOG_RESPONSE_PROTOCOL};
 
 // Re-export signing functions
-pub use signing::{sign_message, sign_message_cloned, sign_with_transport, verify_message};
+pub use signing::sign_with_transport;
+#[cfg(feature = "libp2p-transport")]
+pub use signing::{sign_message, sign_message_cloned, verify_message};
 
 // Re-export topic types
 pub use topics::{DefraTopic, DOC_SYNC_TOPIC, ENCRYPTION_TOPIC, SYNC_BRANCHABLE_TOPIC};
@@ -117,14 +127,19 @@ pub use transport::{P2PTransport, TransportEvent};
 // Re-export sync types
 #[cfg(feature = "iroh-transport")]
 pub use sync::IrohSyncCoordinator;
+#[cfg(feature = "libp2p-transport")]
+pub use sync::Libp2pSyncCoordinator;
 pub use sync::{
     Broadcaster, CreateReplicatorResult, DagSync, DagSyncConfig, DagSyncState,
-    Libp2pSyncCoordinator, LoadReplicatorsResult, NeedsFetchData, PeerStateTracker, ProcessQueue,
-    SyncConfig, SyncCoordinator, SyncEvent, SyncManager, SyncPlan,
+    LoadReplicatorsResult, NeedsFetchData, PeerStateTracker, ProcessQueue, SyncConfig,
+    SyncCoordinator, SyncEvent, SyncManager, SyncPlan,
 };
 
 // Re-export bitswap types
-pub use bitswap::{AccessMode, BitswapStoreAdapter, ReplicatorRegistry};
+#[cfg(feature = "libp2p-transport")]
+pub use bitswap::BitswapStoreAdapter;
+pub use bitswap::{AccessMode, ReplicatorRegistry};
+#[cfg(feature = "libp2p-transport")]
 pub use iroh_bitswap::Store as BitswapStore;
 
 /// Query ID for tracking Bitswap operations.
@@ -136,9 +151,11 @@ pub struct QueryId(pub u64);
 pub use replicator::{ReplicatorInfo, ReplicatorStatus};
 
 // Re-export two-stream protocol types
+#[cfg(feature = "libp2p-transport")]
 pub use two_stream::{TwoStreamEvent, TwoStreamHandler, TwoStreamRunner};
 
 // Re-export commonly used libp2p types
+#[cfg(feature = "libp2p-transport")]
 pub use libp2p::{gossipsub, identity::Keypair, Multiaddr, PeerId};
 
 #[cfg(test)]

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -330,14 +330,30 @@ pub enum PushLogGossipPayloadEncoding {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+    allow(dead_code)
+)]
 pub(crate) struct PushLogGossipPayloadDebugInfo {
     pub payload_fingerprint: String,
     pub payload_shape_hint: String,
 }
 
+#[cfg_attr(
+    not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+    allow(dead_code)
+)]
 const GOSSIP_TEXT_PREFIX_CHARS: usize = 48;
+#[cfg_attr(
+    not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+    allow(dead_code)
+)]
 const GOSSIP_PAYLOAD_FINGERPRINT_BYTES: usize = 8;
 
+#[cfg_attr(
+    not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+    allow(dead_code)
+)]
 fn truncated_text_prefix(text: &str) -> String {
     let mut prefix = String::new();
     let mut chars = text.chars();
@@ -353,6 +369,10 @@ fn truncated_text_prefix(text: &str) -> String {
     prefix
 }
 
+#[cfg_attr(
+    not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+    allow(dead_code)
+)]
 fn describe_cbor_value(value: &serde_cbor::Value) -> String {
     match value {
         serde_cbor::Value::Map(entries) => {
@@ -384,6 +404,10 @@ fn describe_cbor_value(value: &serde_cbor::Value) -> String {
     }
 }
 
+#[cfg_attr(
+    not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+    allow(dead_code)
+)]
 fn describe_gossip_payload_shape(payload: &[u8]) -> String {
     if payload.is_empty() {
         return "empty".to_string();
@@ -482,6 +506,10 @@ impl PushLogBroadcast {
         serde_cbor::to_vec(self)
     }
 
+    #[cfg_attr(
+        not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+        allow(dead_code)
+    )]
     pub(crate) fn inspect_gossip_payload(payload: &[u8]) -> PushLogGossipPayloadDebugInfo {
         let digest = Sha256::digest(payload);
         PushLogGossipPayloadDebugInfo {

--- a/crates/p2p/src/protocol.rs
+++ b/crates/p2p/src/protocol.rs
@@ -10,6 +10,7 @@
 //! - Request protocol: `/defradb/<name>_req/<version>`
 //! - Response protocol: `/defradb/<name>_resp/<version>`
 
+#[cfg(feature = "libp2p-transport")]
 use libp2p::StreamProtocol;
 
 /// The protocol name/slug representing DefraDB.
@@ -70,41 +71,49 @@ pub const IDENTITY_REQUEST_PROTOCOL: &str = "/defradb/ident_req/0.0.1";
 pub const IDENTITY_RESPONSE_PROTOCOL: &str = "/defradb/ident_resp/0.0.1";
 
 /// StreamProtocol for the SE request protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn se_request_protocol() -> StreamProtocol {
     StreamProtocol::new(SE_REQUEST_PROTOCOL)
 }
 
 /// StreamProtocol for the SE response protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn se_response_protocol() -> StreamProtocol {
     StreamProtocol::new(SE_RESPONSE_PROTOCOL)
 }
 
 /// StreamProtocol for the SE query request protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn se_query_request_protocol() -> StreamProtocol {
     StreamProtocol::new(SE_QUERY_REQUEST_PROTOCOL)
 }
 
 /// StreamProtocol for the SE query response protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn se_query_response_protocol() -> StreamProtocol {
     StreamProtocol::new(SE_QUERY_RESPONSE_PROTOCOL)
 }
 
 /// StreamProtocol for the CAR request protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn car_request_protocol() -> StreamProtocol {
     StreamProtocol::new(CAR_REQUEST_PROTOCOL)
 }
 
 /// StreamProtocol for the CAR response protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn car_response_protocol() -> StreamProtocol {
     StreamProtocol::new(CAR_RESPONSE_PROTOCOL)
 }
 
 /// StreamProtocol for the identity request protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn identity_request_protocol() -> StreamProtocol {
     StreamProtocol::new(IDENTITY_REQUEST_PROTOCOL)
 }
 
 /// StreamProtocol for the identity response protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn identity_response_protocol() -> StreamProtocol {
     StreamProtocol::new(IDENTITY_RESPONSE_PROTOCOL)
 }
@@ -116,22 +125,26 @@ pub const PUSHLOG_REQUEST_PROTOCOL: &str = REP_REQUEST_PROTOCOL;
 pub const PUSHLOG_RESPONSE_PROTOCOL: &str = REP_RESPONSE_PROTOCOL;
 
 /// StreamProtocol for the replicator request protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn rep_request_protocol() -> StreamProtocol {
     StreamProtocol::new(REP_REQUEST_PROTOCOL)
 }
 
 /// StreamProtocol for the replicator response protocol.
+#[cfg(feature = "libp2p-transport")]
 pub fn rep_response_protocol() -> StreamProtocol {
     StreamProtocol::new(REP_RESPONSE_PROTOCOL)
 }
 
 // Legacy aliases
 #[deprecated(note = "Use rep_request_protocol instead")]
+#[cfg(feature = "libp2p-transport")]
 pub fn pushlog_request_protocol() -> StreamProtocol {
     rep_request_protocol()
 }
 
 #[deprecated(note = "Use rep_response_protocol instead")]
+#[cfg(feature = "libp2p-transport")]
 pub fn pushlog_response_protocol() -> StreamProtocol {
     rep_response_protocol()
 }
@@ -151,12 +164,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "libp2p-transport")]
     fn test_rep_protocols() {
         assert_eq!(rep_request_protocol().as_ref(), "/defradb/rep_req/0.0.1");
         assert_eq!(rep_response_protocol().as_ref(), "/defradb/rep_resp/0.0.1");
     }
 
     #[test]
+    #[cfg(feature = "libp2p-transport")]
     fn test_se_query_protocols() {
         assert_eq!(
             se_query_request_protocol().as_ref(),

--- a/crates/p2p/src/replicator.rs
+++ b/crates/p2p/src/replicator.rs
@@ -12,6 +12,7 @@
 //! path) can round-trip between implementations.
 
 use chrono::{DateTime, NaiveDate, SecondsFormat, Utc};
+#[cfg(feature = "libp2p-transport")]
 use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
@@ -163,7 +164,7 @@ impl ReplicatorInfo {
     /// replicator with nothing to replicate, which is never a valid state.
     /// Use [`ReplicatorInfo::from_raw`] when reconstructing from storage or
     /// test fixtures where validation is not desired.
-    pub fn new(peer_id: PeerId, collections: Vec<String>) -> Result<Self, ReplicatorError> {
+    pub fn new(peer_id: impl ToString, collections: Vec<String>) -> Result<Self, ReplicatorError> {
         if collections.is_empty() {
             return Err(ReplicatorError::EmptyCollections);
         }
@@ -194,6 +195,7 @@ impl ReplicatorInfo {
     }
 
     /// Get the peer ID. Returns `None` if the stored ID is not a valid libp2p PeerId.
+    #[cfg(feature = "libp2p-transport")]
     pub fn peer_id(&self) -> Option<PeerId> {
         self.id.parse().ok()
     }
@@ -204,6 +206,7 @@ impl ReplicatorInfo {
     }
 
     /// Try to get the peer ID, returning an error if invalid.
+    #[cfg(feature = "libp2p-transport")]
     pub fn try_peer_id(&self) -> Result<PeerId, ReplicatorError> {
         self.id
             .parse()
@@ -211,6 +214,7 @@ impl ReplicatorInfo {
     }
 
     /// Parsed addresses. Invalid entries are filtered out.
+    #[cfg(feature = "libp2p-transport")]
     pub fn addresses(&self) -> Vec<Multiaddr> {
         self.addresses
             .iter()

--- a/crates/p2p/src/signing.rs
+++ b/crates/p2p/src/signing.rs
@@ -20,9 +20,13 @@
 //! 2. Verify peer ID matches public key
 //! 3. Clear signature, serialize, verify signature
 
+#[cfg(feature = "libp2p-transport")]
 use libp2p::identity::{Keypair, PublicKey};
+#[cfg(feature = "libp2p-transport")]
 use libp2p::PeerId;
-use serde::{de::DeserializeOwned, Serialize};
+#[cfg(feature = "libp2p-transport")]
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use uuid::Uuid;
 
 use crate::error::{Error, Result};
@@ -50,6 +54,7 @@ use crate::protocol::MESSAGE_VERSION;
 /// # Wire Compatibility
 ///
 /// This function matches Go's `signAndSetMetaData` from `message/message.go`.
+#[cfg(feature = "libp2p-transport")]
 pub fn sign_message<M>(keypair: &Keypair, msg: &mut M) -> Result<()>
 where
     M: Message + Serialize,
@@ -115,6 +120,7 @@ where
 /// # Wire Compatibility
 ///
 /// This function matches Go's `verifyMessage` from `message/message.go`.
+#[cfg(feature = "libp2p-transport")]
 pub fn verify_message<M>(msg: &M) -> Result<()>
 where
     M: Message + Serialize + Clone,
@@ -160,6 +166,7 @@ where
 ///
 /// This is a convenience function that clones the message, signs it,
 /// and returns the signed copy.
+#[cfg(feature = "libp2p-transport")]
 pub fn sign_message_cloned<M>(keypair: &Keypair, msg: &M) -> Result<M>
 where
     M: Message + Serialize + Clone + DeserializeOwned,

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 use blockstore::Blockstore;
 use tokio::sync::mpsc;
 
-use super::authorizer::{AccessAuthorizer, RuntimeAuthorizer};
+#[cfg(feature = "libp2p-transport")]
+use super::authorizer::AccessAuthorizer;
+use super::authorizer::RuntimeAuthorizer;
 use super::{
     DagFetchLimiter, SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState,
 };
@@ -119,6 +121,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             Arc::clone(&replicators),
             access_mode,
         ));
+        #[cfg(feature = "libp2p-transport")]
         let pubsub_services = super::pubsub_services::PubsubServices::try_new(
             &local_peer_id,
             Arc::clone(&head_provider),
@@ -155,6 +158,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 },
                 authorizer,
                 document_acp: std::sync::OnceLock::new(),
+                #[cfg(feature = "libp2p-transport")]
                 pubsub_services,
             },
             events,

--- a/crates/p2p/src/sync/coordinator/event_handler/pubsub_raw.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/pubsub_raw.rs
@@ -2,14 +2,18 @@
 //! pubsub_rpc gossipsub payloads to the appropriate `TopicHandler`.
 
 use blockstore::Blockstore;
-use tracing::{debug, warn};
+use tracing::debug;
+#[cfg(feature = "libp2p-transport")]
+use tracing::warn;
 
 use super::super::SyncCoordinator;
 use crate::error::Result;
+#[cfg(feature = "libp2p-transport")]
 use crate::pubsub_rpc::DeliveryOutcome;
 use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
+    #[cfg(feature = "libp2p-transport")]
     pub(super) async fn handle_gossip_raw_message(
         &self,
         propagation_source: PeerId,
@@ -70,5 +74,19 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 Ok(())
             }
         }
+    }
+
+    #[cfg(not(feature = "libp2p-transport"))]
+    pub(super) async fn handle_gossip_raw_message(
+        &self,
+        _propagation_source: PeerId,
+        topic: String,
+        _data: Vec<u8>,
+    ) -> Result<()> {
+        debug!(
+            topic = %topic,
+            "GossipRawMessage received without libp2p transport support; dropping"
+        );
+        Ok(())
     }
 }

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -48,7 +48,9 @@ mod constructor;
 pub(crate) mod dag_context;
 pub(crate) mod dag_fetcher;
 mod event_handler;
+#[cfg(feature = "libp2p-transport")]
 mod pubsub_client;
+#[cfg(feature = "libp2p-transport")]
 mod pubsub_services;
 mod replicators;
 mod result_types;
@@ -315,6 +317,7 @@ pub struct SyncCoordinator<B: Blockstore, T: P2PTransport> {
 
     /// Pubsub_rpc DocSync/BranchableSync services (#828). `None` on
     /// transports whose local peer id isn't a libp2p PeerId (e.g. iroh).
+    #[cfg(feature = "libp2p-transport")]
     pub(super) pubsub_services: Option<pubsub_services::PubsubServices>,
 }
 
@@ -328,6 +331,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     }
 
     pub async fn shutdown(&self) {
+        #[cfg(feature = "libp2p-transport")]
         if let Some(services) = self.pubsub_services.as_ref() {
             services.set_ready(false);
             let cancelled = services.cancel_in_flight();
@@ -363,6 +367,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 }
 
 /// Type alias for SyncCoordinator using the libp2p transport.
+#[cfg(feature = "libp2p-transport")]
 pub type Libp2pSyncCoordinator<B> =
     SyncCoordinator<B, crate::host::libp2p_transport::Libp2pTransport>;
 

--- a/crates/p2p/src/sync/manager/diagnostics.rs
+++ b/crates/p2p/src/sync/manager/diagnostics.rs
@@ -73,11 +73,19 @@ pub struct GossipDecodeFailureSample {
 /// Crate-internal: only the libp2p and iroh transport paths call this.
 /// Downstream consumers read the total via `SyncDiagnostics::snapshot()`
 /// rather than synthesizing failures.
+#[cfg_attr(
+    not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+    allow(dead_code)
+)]
 pub(crate) fn record_gossip_decode_failure() -> u64 {
     GOSSIP_DECODE_FAILURES.fetch_add(1, Ordering::Relaxed) + 1
 }
 
 /// Record a gossip payload decode failure and retain a deduplicated sample.
+#[cfg_attr(
+    not(any(feature = "libp2p-transport", feature = "iroh-transport")),
+    allow(dead_code)
+)]
 pub(crate) fn record_gossip_decode_failure_sample(mut sample: GossipDecodeFailureSample) -> u64 {
     let total = record_gossip_decode_failure();
     let mut recent = RECENT_GOSSIP_DECODE_FAILURES.lock();

--- a/crates/p2p/src/sync/manager/mod.rs
+++ b/crates/p2p/src/sync/manager/mod.rs
@@ -24,6 +24,7 @@ pub use config::{
     DEFAULT_MAX_CONCURRENT_PUSH_TASKS, DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS,
     DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
 };
+#[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
 pub(crate) use diagnostics::record_gossip_decode_failure_sample;
 pub use diagnostics::{
     GossipDecodeFailureSample, GossipTransport, SyncDiagnostics, SyncDiagnosticsSnapshot,

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -24,12 +24,14 @@ pub use broadcaster::{BroadcastResult, Broadcaster};
 pub use collection_store::{NoOpCollectionStorage, P2PCollectionStorage, P2PCollectionStore};
 #[cfg(feature = "iroh-transport")]
 pub use coordinator::IrohSyncCoordinator;
+#[cfg(feature = "libp2p-transport")]
+pub use coordinator::Libp2pSyncCoordinator;
 pub use coordinator::{
-    CreateReplicatorResult, Libp2pSyncCoordinator, LoadReplicatorsResult, PushFailure,
-    SyncCoordinator, SyncShutdownHandle,
+    CreateReplicatorResult, LoadReplicatorsResult, PushFailure, SyncCoordinator, SyncShutdownHandle,
 };
 pub use dag_sync::{DagSync, DagSyncConfig, DagSyncState, NeedsFetchData, SyncPlan};
 pub use head_provider::{DocumentHeadProvider, NoOpHeadProvider};
+#[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
 pub(crate) use manager::record_gossip_decode_failure_sample;
 pub use manager::{
     default_rate_limit_backoff, GossipDecodeFailureSample, GossipTransport, SyncConfig,

--- a/crates/p2p/src/topics.rs
+++ b/crates/p2p/src/topics.rs
@@ -7,6 +7,7 @@
 //! - `{collection_id}`: Collection-specific updates
 //! - `{doc_id}`: Document-specific updates
 
+#[cfg(feature = "libp2p-transport")]
 use libp2p::gossipsub::IdentTopic;
 
 /// Well-known topic for general document synchronization.
@@ -49,6 +50,7 @@ pub enum DefraTopic {
 
 impl DefraTopic {
     /// Convert to libp2p IdentTopic.
+    #[cfg(feature = "libp2p-transport")]
     pub fn to_ident_topic(&self) -> IdentTopic {
         IdentTopic::new(self.topic_string())
     }
@@ -170,6 +172,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "libp2p-transport")]
     fn test_to_ident_topic() {
         let topic = DefraTopic::DocSync;
         let ident = topic.to_ident_topic();

--- a/crates/p2p/src/transport.rs
+++ b/crates/p2p/src/transport.rs
@@ -43,12 +43,14 @@ impl fmt::Display for PeerId {
     }
 }
 
+#[cfg(feature = "libp2p-transport")]
 impl From<libp2p::PeerId> for PeerId {
     fn from(peer_id: libp2p::PeerId) -> Self {
         Self(peer_id.to_string())
     }
 }
 
+#[cfg(feature = "libp2p-transport")]
 impl From<&libp2p::PeerId> for PeerId {
     fn from(peer_id: &libp2p::PeerId) -> Self {
         Self(peer_id.to_string())
@@ -82,6 +84,7 @@ impl fmt::Display for PeerAddr {
     }
 }
 
+#[cfg(feature = "libp2p-transport")]
 impl From<libp2p::Multiaddr> for PeerAddr {
     fn from(addr: libp2p::Multiaddr) -> Self {
         Self(addr.to_string())
@@ -108,6 +111,7 @@ impl fmt::Display for MessageId {
     }
 }
 
+#[cfg(feature = "libp2p-transport")]
 impl From<libp2p::gossipsub::MessageId> for MessageId {
     fn from(id: libp2p::gossipsub::MessageId) -> Self {
         Self(id.to_string())


### PR DESCRIPTION
## Summary

Make the libp2p transport stack optional behind a new `p2p/libp2p-transport` feature.

Closes #532.

## Why

The `p2p` crate already supports Iroh as an alternate transport, but libp2p-specific dependencies and modules were still pulled in unconditionally. That means Iroh-only consumers paid for the libp2p stack even when they only needed the shared sync/message surfaces plus Iroh transport support.

This makes the feature boundary explicit so Iroh-only builds can avoid libp2p and related Bitswap/host dependencies.

## Changes

| Area | Change |
| --- | --- |
| `p2p` features | Add `libp2p-transport` and move libp2p-only deps behind it |
| Public API | Gate libp2p-only modules/re-exports such as host, behaviour, codec, pubsub_rpc, two_stream, libp2p address parsing, and libp2p signing helpers |
| Shared sync/types | Keep transport-generic sync, messages, topics, replicator info, and Iroh transport available without libp2p |
| Downstream crates | Explicitly enable `p2p/libp2p-transport` where existing crates still use libp2p APIs |
| Adapter crate | Make `defra-p2p-adapter`'s direct `libp2p` dependency optional behind its `libp2p` feature |
| Replicators | Let `ReplicatorInfo::new` accept string-like peer IDs so non-libp2p consumers do not need `from_raw` for normal construction |

## Out of scope

- No behavior changes to libp2p transport runtime behavior.
- No changes to Iroh transport behavior.
- No removal of libp2p support from existing CLI/embedded/FFI paths; those crates now opt in explicitly.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo check -p p2p --no-default-features`
- [x] `cargo check -p p2p --no-default-features --features iroh-transport`
- [x] `cargo tree -p p2p --no-default-features --features iroh-transport --edges normal -i libp2p`
- [x] `cargo tree -p p2p --no-default-features --features iroh-transport --edges normal -i iroh-bitswap`
- [x] `cargo test -p p2p --no-default-features --features libp2p-transport,iroh-transport --lib`
- [x] `cargo check -p db-merge`
- [x] `cargo check -p embedded --features iroh`
- [x] `cargo check -p cli --features iroh`
- [x] `cargo check -p ffi --features iroh`
- [x] `cargo clippy -p p2p --no-default-features --lib -- -D warnings`
- [x] `cargo clippy -p p2p --no-default-features --features libp2p-transport,iroh-transport --lib -- -D warnings`
- [x] `cargo clippy -p defra-p2p-adapter --no-default-features --features iroh --lib -- -D warnings`
- [x] `cargo clippy -p defra-p2p-adapter --lib -- -D warnings`
