### PR TITLE
feat(rest): paginate collection doc id listing

### DIFF
--- a/crates/http/src/handlers/collections.rs
+++ b/crates/http/src/handlers/collections.rs
@@ -12,6 +12,7 @@ use axum::{
     http::StatusCode,
     Json,
 };
+use query::rest::{CollectionDocIdsPage, CollectionDocIdsPagination};
 use serde::Serialize;
 
 use crate::error::{http_error_from_backend_message, HttpError};
@@ -19,10 +20,67 @@ use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
 use crate::router::{AppState, NodePermission};
 
+const DEFAULT_DOC_IDS_LIMIT: usize = 100;
+const MAX_DOC_IDS_LIMIT: usize = 1000;
+
 /// Response for listing collections.
 #[derive(Debug, Clone, Serialize)]
 pub struct CollectionsResponse {
     pub collections: Vec<String>,
+}
+
+/// Response for listing document IDs in a collection.
+#[derive(Debug, Clone, Serialize)]
+pub struct CollectionDocIdsResponse {
+    pub doc_ids: Vec<String>,
+    pub total: usize,
+    pub has_more: bool,
+    pub offset: usize,
+    pub limit: usize,
+}
+
+impl From<CollectionDocIdsPage> for CollectionDocIdsResponse {
+    fn from(page: CollectionDocIdsPage) -> Self {
+        Self {
+            has_more: page.has_more(),
+            doc_ids: page.doc_ids,
+            total: page.total,
+            offset: page.offset,
+            limit: page.limit,
+        }
+    }
+}
+
+fn parse_collection_doc_ids_pagination(
+    params: &HashMap<String, String>,
+) -> Result<CollectionDocIdsPagination, HttpError> {
+    let limit = match params.get("limit") {
+        Some(raw) => {
+            let limit = raw.parse::<usize>().map_err(|_| {
+                HttpError::BadRequest(format!("'limit' must be a positive integer, got '{}'", raw))
+            })?;
+            if limit == 0 || limit > MAX_DOC_IDS_LIMIT {
+                return Err(HttpError::BadRequest(format!(
+                    "'limit' must be between 1 and {}",
+                    MAX_DOC_IDS_LIMIT
+                )));
+            }
+            limit
+        }
+        None => DEFAULT_DOC_IDS_LIMIT,
+    };
+
+    let offset = match params.get("offset") {
+        Some(raw) => raw.parse::<usize>().map_err(|_| {
+            HttpError::BadRequest(format!(
+                "'offset' must be a non-negative integer, got '{}'",
+                raw
+            ))
+        })?,
+        None => 0,
+    };
+
+    Ok(CollectionDocIdsPagination { limit, offset })
 }
 
 /// List all collection names.
@@ -45,6 +103,39 @@ pub async fn list_collections(
         Ok(collections) => Ok(Json(CollectionsResponse { collections })),
         Err(e) => {
             tracing::warn!(error = %e, "Failed to list collections");
+            Err(e.into())
+        }
+    }
+}
+
+/// Get document IDs in a collection.
+///
+/// GET /api/v0/collections/{name}?limit=100&offset=0
+///
+/// Returns a bounded page of document IDs and pagination metadata.
+///
+/// Requires `CollectionGet` permission when NAC is enabled.
+pub async fn get_collection_doc_ids(
+    State(state): State<AppState>,
+    identity: ExtractIdentity,
+    Path(name): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<CollectionDocIdsResponse>, HttpError> {
+    require_permission(&state, &identity, NodePermission::CollectionGet).await?;
+
+    let pagination = parse_collection_doc_ids_pagination(&params)?;
+    let rest = state
+        .rest
+        .as_ref()
+        .ok_or_else(|| HttpError::Internal("REST operations not configured".into()))?;
+
+    match rest
+        .get_collection_doc_ids_page(&name, pagination, identity.did())
+        .await
+    {
+        Ok(page) => Ok(Json(page.into())),
+        Err(e) => {
+            tracing::warn!(collection = %name, error = %e, "Failed to list collection document IDs");
             Err(e.into())
         }
     }

--- a/crates/http/src/handlers/collections_tests.rs
+++ b/crates/http/src/handlers/collections_tests.rs
@@ -5,10 +5,11 @@ use crate::mock::{
     MockRestOperations,
 };
 use crate::router::{AppStateBuilder, CollectionManagementOperations};
-use axum::body::Body;
+use axum::body::{to_bytes, Body};
 use axum::http::{Method, Request, StatusCode};
 use query::executor::QueryExecutor;
 use query::rest::RestOperations;
+use serde_json::json;
 use std::sync::Arc;
 use tower::ServiceExt;
 
@@ -61,6 +62,85 @@ fn router_with_collection_mgmt() -> axum::Router {
             as Arc<dyn CollectionManagementOperations>)
         .build();
     crate::router::create_router_with_state(state)
+}
+
+fn router_with_rest() -> axum::Router {
+    let state = AppStateBuilder::new(Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>)
+        .with_rest(Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>)
+        .build();
+    crate::router::create_router_with_state(state)
+}
+
+#[tokio::test]
+async fn collection_doc_ids_returns_paginated_metadata() {
+    let router = router_with_rest();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v0/collections/Users?limit=1&offset=0")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "doc_ids": ["bae-123"],
+            "total": 2,
+            "has_more": true,
+            "offset": 0,
+            "limit": 1
+        })
+    );
+}
+
+#[tokio::test]
+async fn collection_doc_ids_uses_default_limit() {
+    let router = router_with_rest();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v0/collections/Users")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["doc_ids"], json!(["bae-123", "bae-456"]));
+    assert_eq!(value["total"], json!(2));
+    assert_eq!(value["has_more"], json!(false));
+    assert_eq!(value["offset"], json!(0));
+    assert_eq!(value["limit"], json!(100));
+}
+
+#[tokio::test]
+async fn collection_doc_ids_rejects_limit_above_max() {
+    let router = router_with_rest();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v0/collections/Users?limit=1001")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/crates/http/src/handlers/mod.rs
+++ b/crates/http/src/handlers/mod.rs
@@ -39,6 +39,7 @@ pub use graphql::{
 pub use collections::{
     collection_exists, delete_collection, delete_collection_versions, delete_collections_by_names,
     describe_collection, find_collection_by_id, get_all_collections, get_collection_by_version_id,
-    list_collections, patch_collection, set_active, truncate_collection, CollectionsResponse,
+    get_collection_doc_ids, list_collections, patch_collection, set_active, truncate_collection,
+    CollectionDocIdsResponse, CollectionsResponse,
 };
 pub use documents::{create_document, delete_document, get_document, update_document};

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -24,6 +24,7 @@
 //! ## REST Collections (requires RestOperations)
 //! - `GET /api/v1/collections` - List all collections
 //! - `POST /api/v1/collections/{name}` - Create document(s)
+//! - `GET /api/v1/collections/{name}` - List collection document IDs
 //! - `GET /api/v1/collections/{name}/document/{docID}` - Get document
 //! - `PATCH /api/v1/collections/{name}/document/{docID}` - Update document
 //! - `DELETE /api/v1/collections/{name}/document/{docID}` - Delete document

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -79,7 +79,9 @@ pub fn create_router_with_state(state: AppState) -> Router {
         .route("/indexes", get(handlers::index::go_list_all_indexes))
         .route(
             "/{name}",
-            post(handlers::create_document).delete(handlers::delete_collection),
+            get(handlers::get_collection_doc_ids)
+                .post(handlers::create_document)
+                .delete(handlers::delete_collection),
         )
         .route("/{name}/describe", get(handlers::describe_collection))
         .route("/{name}/exists", get(handlers::collection_exists))
@@ -276,7 +278,9 @@ pub fn create_router_with_state(state: AppState) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock::{FailingMockP2POperations, MockDocumentAcpOperations, MockQueryExecutor};
+    use crate::mock::{
+        FailingMockP2POperations, MockDocumentAcpOperations, MockQueryExecutor, MockRestOperations,
+    };
     use crate::router::{
         DocumentAcpOperations, P2POperations, P2PResult, P2pDocumentInfo, P2pDocumentRequest,
         ReplicatorInfo,
@@ -447,15 +451,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collection_doc_ids_route_is_not_available() {
-        assert_eq!(
-            status_for("/api/v0/collections/Users").await,
-            axum::http::StatusCode::METHOD_NOT_ALLOWED
-        );
-        assert_eq!(
-            status_for("/api/v1/collections/Users").await,
-            axum::http::StatusCode::METHOD_NOT_ALLOWED
-        );
+    async fn collection_doc_ids_route_is_available_with_rest() {
+        let executor = Arc::new(MockQueryExecutor::new()) as Arc<dyn QueryExecutor>;
+        let rest = Arc::new(MockRestOperations::new()) as Arc<dyn RestOperations>;
+        let router = create_router_with_rest(executor, rest);
+
+        for path in ["/api/v0/collections/Users", "/api/v1/collections/Users"] {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .body(Body::empty())
+                        .expect("request should build"),
+                )
+                .await
+                .expect("router should respond");
+
+            assert_eq!(response.status(), axum::http::StatusCode::OK);
+        }
     }
 
     #[tokio::test]

--- a/crates/http/src/server.rs
+++ b/crates/http/src/server.rs
@@ -198,6 +198,7 @@ impl Server {
     /// When REST operations are configured, the server enables additional endpoints:
     /// - `GET /api/v1/collections` - List all collections
     /// - `POST /api/v1/collections/{name}` - Create document(s)
+    /// - `GET /api/v1/collections/{name}` - List collection document IDs
     /// - `GET /api/v1/collections/{name}/document/{docID}` - Get document
     /// - `PATCH /api/v1/collections/{name}/document/{docID}` - Update document
     /// - `DELETE /api/v1/collections/{name}/document/{docID}` - Delete document

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -72,7 +72,10 @@ pub use query_parse::{
     parse_mutations, parse_mutations_with_limits, parse_query, parse_query_with_limits,
     parse_request, parse_request_with_limits, ExplainType, ParsedOperation,
 };
-pub use rest::{RestError, RestOperations, RestOperationsImpl, RestResult};
+pub use rest::{
+    CollectionDocIdsPage, CollectionDocIdsPagination, RestError, RestOperations,
+    RestOperationsImpl, RestResult,
+};
 pub use runner::{DocFetcher, FetchByIdsResult, NacChecker, QueryRunner};
 pub use sdl_parse::{parse_sdl, parse_sdl_with_known_types};
 pub use select_convert::select_to_go_json;

--- a/crates/query/src/rest/mod.rs
+++ b/crates/query/src/rest/mod.rs
@@ -9,7 +9,7 @@ mod trait_def;
 
 pub use error::{RestError, RestResult};
 pub use operations::RestOperationsImpl;
-pub use trait_def::RestOperations;
+pub use trait_def::{CollectionDocIdsPage, CollectionDocIdsPagination, RestOperations};
 
 #[cfg(test)]
 mod tests;

--- a/crates/query/src/rest/operations.rs
+++ b/crates/query/src/rest/operations.rs
@@ -11,7 +11,7 @@ use crate::runner::QueryRunner;
 use crate::txn::TransactionRegistry;
 
 use super::error::{RestError, RestResult};
-use super::trait_def::RestOperations;
+use super::trait_def::{CollectionDocIdsPage, CollectionDocIdsPagination, RestOperations};
 
 /// Production implementation of REST operations using QueryRunner.
 ///
@@ -55,9 +55,28 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperationsImpl<F, R> {
         }
     }
 
-    fn build_list_ids_query(&self, collection: &str) -> String {
+    fn build_list_ids_query(
+        &self,
+        collection: &str,
+        pagination: Option<CollectionDocIdsPagination>,
+    ) -> String {
+        match pagination {
+            Some(pagination) => format!(
+                r#"{{ {collection}(limit: {limit}, offset: {offset}) {{ _docID }} }}"#,
+                collection = collection,
+                limit = pagination.limit,
+                offset = pagination.offset
+            ),
+            None => format!(
+                r#"{{ {collection} {{ _docID }} }}"#,
+                collection = collection
+            ),
+        }
+    }
+
+    fn build_count_query(&self, collection: &str) -> String {
         format!(
-            r#"{{ {collection} {{ _docID }} }}"#,
+            r#"{{ total: COUNT({collection}: {{}}) }}"#,
             collection = collection
         )
     }
@@ -135,6 +154,30 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperationsImpl<F, R> {
             .collect())
     }
 
+    fn extract_doc_id_total(&self, result: &JsonValue, collection: &str) -> RestResult<usize> {
+        let total = result
+            .get("total")
+            .and_then(|value| value.as_u64())
+            .ok_or_else(|| {
+                tracing::warn!(
+                    collection = %collection,
+                    result = ?result,
+                    "Count query result missing numeric total"
+                );
+                RestError::internal(format!(
+                    "expected numeric total for collection '{}'",
+                    collection
+                ))
+            })?;
+
+        usize::try_from(total).map_err(|_| {
+            RestError::internal(format!(
+                "document count for collection '{}' exceeds platform limits",
+                collection
+            ))
+        })
+    }
+
     async fn fetch_full_document(
         &self,
         collection: &str,
@@ -203,12 +246,58 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> RestOperations for RestOpe
             return Err(RestError::collection_not_found(collection));
         }
 
-        let query = self.build_list_ids_query(collection);
+        let query = self.build_list_ids_query(collection, None);
         let result = self
             .runner
             .execute_query_with_identity(&query, identity.cloned())
             .await?;
         self.extract_doc_ids(&result, collection)
+    }
+
+    async fn get_collection_doc_ids_page(
+        &self,
+        collection: &str,
+        pagination: CollectionDocIdsPagination,
+        identity: Option<&Did>,
+    ) -> RestResult<CollectionDocIdsPage> {
+        if !self
+            .runner
+            .has_collection(collection)
+            .await
+            .map_err(|e| RestError::internal(e.to_string()))?
+        {
+            return Err(RestError::collection_not_found(collection));
+        }
+
+        let count_query = self.build_count_query(collection);
+        let count_result = self
+            .runner
+            .execute_query_with_identity(&count_query, identity.cloned())
+            .await?;
+        let total = self.extract_doc_id_total(&count_result, collection)?;
+
+        if pagination.offset >= total {
+            return Ok(CollectionDocIdsPage {
+                doc_ids: Vec::new(),
+                total,
+                limit: pagination.limit,
+                offset: pagination.offset,
+            });
+        }
+
+        let query = self.build_list_ids_query(collection, Some(pagination));
+        let result = self
+            .runner
+            .execute_query_with_identity(&query, identity.cloned())
+            .await?;
+        let doc_ids = self.extract_doc_ids(&result, collection)?;
+
+        Ok(CollectionDocIdsPage {
+            doc_ids,
+            total,
+            limit: pagination.limit,
+            offset: pagination.offset,
+        })
     }
 
     async fn get_document(

--- a/crates/query/src/rest/trait_def.rs
+++ b/crates/query/src/rest/trait_def.rs
@@ -7,6 +7,28 @@ use storage::corekv::MaybeSendSync;
 
 use super::error::RestResult;
 
+/// Pagination window for listing collection document IDs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CollectionDocIdsPagination {
+    pub limit: usize,
+    pub offset: usize,
+}
+
+/// Paginated document IDs for a collection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CollectionDocIdsPage {
+    pub doc_ids: Vec<String>,
+    pub total: usize,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+impl CollectionDocIdsPage {
+    pub fn has_more(&self) -> bool {
+        self.offset.saturating_add(self.limit) < self.total
+    }
+}
+
 /// REST operations trait for collection and document CRUD.
 ///
 /// This trait provides REST-specific operations separate from GraphQL execution.
@@ -31,6 +53,26 @@ pub trait RestOperations: MaybeSendSync {
         collection: &str,
         identity: Option<&Did>,
     ) -> RestResult<Vec<String>>;
+
+    /// Get a paginated page of document IDs in a collection.
+    async fn get_collection_doc_ids_page(
+        &self,
+        collection: &str,
+        pagination: CollectionDocIdsPagination,
+        identity: Option<&Did>,
+    ) -> RestResult<CollectionDocIdsPage> {
+        let doc_ids = self.get_collection_doc_ids(collection, identity).await?;
+        let total = doc_ids.len();
+        let start = pagination.offset.min(total);
+        let end = start.saturating_add(pagination.limit).min(total);
+
+        Ok(CollectionDocIdsPage {
+            doc_ids: doc_ids[start..end].to_vec(),
+            total,
+            limit: pagination.limit,
+            offset: pagination.offset,
+        })
+    }
 
     /// Get a single document by ID.
     async fn get_document(


### PR DESCRIPTION
## Summary

Closes #105 by adding paginated REST support for listing document IDs from a collection.

## Why

`GET /api/v0/collections/{name}` was not available in Rust, and the REST operations layer only exposed an all-doc-ID listing. Large collections need a bounded response shape so clients can page through IDs without forcing a single unbounded query/result into memory.

## Changes

| Area | Change |
|---|---|
| REST operations | Add `CollectionDocIdsPagination` and `CollectionDocIdsPage` to represent bounded doc-ID listings |
| Query-backed REST | Add a paginated implementation using GraphQL `limit`/`offset` plus a same-identity `COUNT` query for total metadata |
| HTTP handler | Add `GET /api/v0|v1/collections/{name}` with `limit` default `100`, max `1000`, and `offset` default `0` |
| Response shape | Return `doc_ids`, `total`, `has_more`, `offset`, and `limit` |
| Router/docs | Wire the route for both API versions and update REST endpoint docs |
| Tests | Cover route availability, default pagination, paginated metadata, and max-limit validation |

## Out of scope

- No cursor-based pagination.
- No change to GraphQL pagination behavior.
- No change to document CRUD routes.
- No change to REST collection listing at `GET /collections`.

## Test plan

- [x] `cargo fmt --all`
- [x] `git diff --check`
- [x] `cargo test -p defra-http`
- [x] `cargo test -p defra-http collection_doc_ids`
- [x] `cargo test -p query rest::`
- [x] `cargo clippy -p defra-http -p query --all-targets -- -D warnings`