### PR TITLE
fix(p2p): use CBOR for gossip broadcasts

### DIFF
--- a/crates/p2p/src/host/command_handler/pubsub.rs
+++ b/crates/p2p/src/host/command_handler/pubsub.rs
@@ -65,7 +65,8 @@ impl<S: Store> P2PHost<S> {
         response: tokio::sync::oneshot::Sender<Result<libp2p::gossipsub::MessageId>>,
     ) {
         let ident_topic = topic.to_ident_topic();
-        let result = serde_cbor::to_vec(&message)
+        let result = message
+            .encode_gossip_payload()
             .map_err(|e| Error::CborSerialization(e.to_string()))
             .and_then(|data| {
                 self.swarm

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -817,8 +817,9 @@ fn handle_publish(
     let gossip = gossip.clone();
     let initial_peers: Vec<iroh::EndpointId> = peer_map.lock().endpoint_ids().collect();
     let message_id = MessageId::new(uuid::Uuid::new_v4().to_string());
-    let payload = postcard::to_allocvec(&msg)
-        .map_err(|error| crate::error::Error::Codec(error.to_string()))?;
+    let payload = msg
+        .encode_gossip_payload()
+        .map_err(|error| crate::error::Error::CborSerialization(error.to_string()))?;
 
     let task = tokio::spawn(async move {
         let sender = if let Some(sender) = sender {

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -324,9 +324,9 @@ pub struct PushLogBroadcast {
 /// Encoding variant accepted when decoding gossip payloads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PushLogGossipPayloadEncoding {
-    PostcardBroadcast,
-    CborRequest,
     CborBroadcast,
+    CborRequest,
+    PostcardBroadcast,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -452,13 +452,13 @@ impl PushLogBroadcast {
 
     /// Decode a gossip payload using the set of encodings accepted across P2P transports.
     ///
-    /// We prefer the native Iroh wire encoding first, then fall back to request-shaped
-    /// payloads and the legacy CBOR variants accepted by libp2p.
+    /// CBOR is the canonical gossip encoding because it is self-describing and
+    /// tolerates added fields. Postcard remains accepted for older Iroh peers.
     pub fn decode_gossip_payload(
         payload: &[u8],
     ) -> Result<(Self, PushLogGossipPayloadEncoding), String> {
-        if let Ok(broadcast) = postcard::from_bytes::<Self>(payload) {
-            return Ok((broadcast, PushLogGossipPayloadEncoding::PostcardBroadcast));
+        if let Ok(broadcast) = serde_cbor::from_slice::<Self>(payload) {
+            return Ok((broadcast, PushLogGossipPayloadEncoding::CborBroadcast));
         }
 
         serde_cbor::from_slice::<PushLogRequest>(payload)
@@ -469,10 +469,15 @@ impl PushLogBroadcast {
                 )
             })
             .or_else(|_| {
-                serde_cbor::from_slice::<Self>(payload)
-                    .map(|broadcast| (broadcast, PushLogGossipPayloadEncoding::CborBroadcast))
+                postcard::from_bytes::<Self>(payload)
+                    .map(|broadcast| (broadcast, PushLogGossipPayloadEncoding::PostcardBroadcast))
             })
             .map_err(|error| error.to_string())
+    }
+
+    /// Encode a gossip payload using the canonical, self-describing wire format.
+    pub fn encode_gossip_payload(&self) -> Result<Vec<u8>, serde_cbor::Error> {
+        serde_cbor::to_vec(self)
     }
 
     pub(crate) fn inspect_gossip_payload(payload: &[u8]) -> PushLogGossipPayloadDebugInfo {
@@ -552,5 +557,69 @@ mod tests {
             PushLogBroadcast::decode_gossip_payload(&encoded).expect("decode via gossip path");
         assert_eq!(encoding, PushLogGossipPayloadEncoding::PostcardBroadcast);
         assert_eq!(via_decode_gossip, broadcast);
+    }
+
+    #[test]
+    fn canonical_gossip_payload_is_cbor_broadcast() {
+        let broadcast = PushLogBroadcast::new(
+            "doc-cbor".to_string(),
+            Bytes::from_static(&[1, 2, 3]),
+            "collection-cbor".to_string(),
+            "creator-cbor".to_string(),
+            Bytes::from_static(&[4, 5, 6]),
+            None,
+        );
+
+        let encoded = broadcast
+            .encode_gossip_payload()
+            .expect("canonical gossip payload should encode");
+        let (decoded, encoding) =
+            PushLogBroadcast::decode_gossip_payload(&encoded).expect("decode canonical payload");
+
+        assert_eq!(encoding, PushLogGossipPayloadEncoding::CborBroadcast);
+        assert_eq!(decoded, broadcast);
+    }
+
+    #[test]
+    fn cbor_gossip_payload_tolerates_unknown_future_fields() {
+        #[derive(Serialize)]
+        struct FutureBroadcast {
+            #[serde(rename = "DocID")]
+            doc_id: String,
+            #[serde(rename = "CID", with = "super::super::cbor::bytes_as_cbor")]
+            cid: Bytes,
+            #[serde(rename = "CollectionID")]
+            collection_id: String,
+            #[serde(rename = "Creator")]
+            creator: String,
+            #[serde(rename = "Block", with = "super::super::cbor::bytes_as_cbor")]
+            block: Bytes,
+            #[serde(rename = "ACPActorRelationships")]
+            acp_actor_relationships: Option<ReplicatedDocActorRelationships>,
+            #[serde(rename = "FutureField")]
+            future_field: String,
+        }
+
+        let future = FutureBroadcast {
+            doc_id: "doc-future".to_string(),
+            cid: Bytes::from_static(&[9, 8, 7]),
+            collection_id: "collection-future".to_string(),
+            creator: "creator-future".to_string(),
+            block: Bytes::from_static(&[6, 5, 4]),
+            acp_actor_relationships: None,
+            future_field: "ignored by older decoders".to_string(),
+        };
+
+        let encoded = serde_cbor::to_vec(&future).expect("future payload should encode");
+        let (decoded, encoding) = PushLogBroadcast::decode_gossip_payload(&encoded)
+            .expect("future payload should decode as broadcast");
+
+        assert_eq!(encoding, PushLogGossipPayloadEncoding::CborBroadcast);
+        assert_eq!(decoded.doc_id, future.doc_id);
+        assert_eq!(decoded.collection_id, future.collection_id);
+        assert_eq!(decoded.creator, future.creator);
+        assert_eq!(decoded.cid, future.cid);
+        assert_eq!(decoded.block, future.block);
+        assert!(decoded.acp_actor_relationships.is_none());
     }
 }

--- a/crates/p2p/src/message/pushlog.rs
+++ b/crates/p2p/src/message/pushlog.rs
@@ -453,20 +453,22 @@ impl PushLogBroadcast {
     /// Decode a gossip payload using the set of encodings accepted across P2P transports.
     ///
     /// CBOR is the canonical gossip encoding because it is self-describing and
-    /// tolerates added fields. Postcard remains accepted for older Iroh peers.
+    /// tolerates added fields. Request-shaped CBOR must be checked before the
+    /// lighter broadcast shape because serde ignores unknown map fields.
+    /// Postcard remains accepted for older Iroh peers.
     pub fn decode_gossip_payload(
         payload: &[u8],
     ) -> Result<(Self, PushLogGossipPayloadEncoding), String> {
-        if let Ok(broadcast) = serde_cbor::from_slice::<Self>(payload) {
-            return Ok((broadcast, PushLogGossipPayloadEncoding::CborBroadcast));
-        }
-
         serde_cbor::from_slice::<PushLogRequest>(payload)
             .map(|request| {
                 (
                     Self::from_request(&request),
                     PushLogGossipPayloadEncoding::CborRequest,
                 )
+            })
+            .or_else(|_| {
+                serde_cbor::from_slice::<Self>(payload)
+                    .map(|broadcast| (broadcast, PushLogGossipPayloadEncoding::CborBroadcast))
             })
             .or_else(|_| {
                 postcard::from_bytes::<Self>(payload)

--- a/crates/p2p/tests/message_tests.rs
+++ b/crates/p2p/tests/message_tests.rs
@@ -501,6 +501,27 @@ fn test_decode_gossip_payload_from_postcard_broadcast() {
 }
 
 #[test]
+fn test_encode_gossip_payload_uses_cbor_broadcast() {
+    let broadcast = PushLogBroadcast::new(
+        "doc-canonical".to_string(),
+        Bytes::from(vec![1, 3, 5]),
+        "collection-canonical".to_string(),
+        "creator-canonical".to_string(),
+        Bytes::from(vec![2, 4, 6]),
+        None,
+    );
+
+    let encoded = broadcast
+        .encode_gossip_payload()
+        .expect("canonical encode should succeed");
+    let (decoded, encoding) =
+        PushLogBroadcast::decode_gossip_payload(&encoded).expect("decode failed");
+
+    assert_eq!(encoding, PushLogGossipPayloadEncoding::CborBroadcast);
+    assert_eq!(decoded, broadcast);
+}
+
+#[test]
 fn test_decode_gossip_payload_from_cbor_broadcast() {
     let broadcast = PushLogBroadcast::new(
         "doc-cbor-broadcast".to_string(),


### PR DESCRIPTION
## Summary

Closes #876 by making CBOR the canonical PushLog gossip payload encoding across libp2p and Iroh, while keeping legacy postcard decoding for older Iroh peers.

## Why

Iroh gossip was still publishing postcard-encoded `PushLogBroadcast` payloads. Postcard is compact, but it is schema-position dependent, so optional fields such as `ACPActorRelationships` make mixed-build gossip payloads more likely to fail with opaque decode errors like `Hit the end of buffer, expected more data`.

The shared P2P message layer already treats CBOR as the compatibility-oriented wire format. Using it consistently for gossip broadcasts gives us a self-describing payload that tolerates added fields and keeps the fast gossip path healthier across supported peers.

## Changes

| Area | Change |
|---|---|
| PushLog gossip | Add `PushLogBroadcast::encode_gossip_payload()` as the shared canonical encoder |
| Wire format | Prefer CBOR broadcast decoding before request-shaped CBOR and legacy postcard fallback |
| Iroh publish | Publish CBOR gossip payloads instead of postcard payloads |
| Libp2p publish | Route publish encoding through the shared PushLog gossip encoder |
| Compatibility | Continue accepting legacy postcard `PushLogBroadcast` payloads |
| Tests | Add coverage for canonical CBOR gossip encoding and unknown future CBOR fields |

## Out of scope

- No removal of legacy postcard decode support.
- No change to gossip topic naming.
- No change to PushLog request/response semantics.
- No broader Iroh diagnostics redesign beyond the wire-format hardening.

## Test plan

- [x] `cargo test -p p2p message::pushlog`
- [x] `cargo test -p p2p test_encode_gossip_payload_uses_cbor_broadcast --test message_tests`
- [x] `cargo test -p p2p --features iroh-transport message::pushlog`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo clippy -p p2p --all-targets --features iroh-transport -- -D warnings`
