### PR TITLE
feat(acp): allow benchmark setup to use full Zanzibar policies

### DIFF
--- a/crates/acp/src/policy_yaml/validate.rs
+++ b/crates/acp/src/policy_yaml/validate.rs
@@ -41,13 +41,13 @@ pub fn validate_policy_expressions(policy: &ParsedPolicy) -> Result<(), String> 
                             continue;
                         }
 
-                        // Check that the relation exists in this resource
-                        if !resource.has_relation(name) {
+                        // Check that the relation or computed permission exists in this resource.
+                        if !resource.has_relation(name) && !resource.has_permission(name) {
                             // Check if it exists in another resource (cross-resource error)
-                            let exists_elsewhere = policy
-                                .resources
-                                .iter()
-                                .any(|r| r.name != resource.name && r.has_relation(name));
+                            let exists_elsewhere = policy.resources.iter().any(|r| {
+                                r.name != resource.name
+                                    && (r.has_relation(name) || r.has_permission(name))
+                            });
                             if exists_elsewhere {
                                 return Err("resource does not have relation".to_string());
                             }
@@ -290,6 +290,34 @@ resources:
   - name: reader
     types: [actor]
   - name: writer
+    types: [actor]
+"#;
+
+        assert_policy_loads(yaml);
+    }
+
+    #[test]
+    fn test_computed_permission_expression_loads() {
+        let yaml = r#"
+name: computed_permission_reference
+resources:
+- name: site
+  permissions:
+  - name: local_read
+    expr: site_operator + site_manager
+  - name: audit_read
+    expr: local_read + compliance
+  - name: read
+    expr: audit_read
+  - name: update
+    expr: site_manager
+  - name: delete
+  relations:
+  - name: site_operator
+    types: [actor]
+  - name: site_manager
+    types: [actor]
+  - name: compliance
     types: [actor]
 "#;
 

--- a/crates/cli/src/acp_adapter.rs
+++ b/crates/cli/src/acp_adapter.rs
@@ -27,6 +27,21 @@ impl AcpAdapter {
     }
 }
 
+fn allow_full_zanzibar_policies() -> bool {
+    std::env::var("DEFRA_ACP_ALLOW_FULL_ZANZIBAR_POLICIES")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+fn policy_store_options() -> StorePolicyOptions {
+    let options = StorePolicyOptions::new().with_validation();
+    if allow_full_zanzibar_policies() {
+        options
+    } else {
+        options.with_dpi_enforcement()
+    }
+}
+
 /// Convert a Zanzibar Policy to an HTTP PolicyInfo.
 fn policy_to_info(policy: &Policy) -> PolicyInfo {
     let resources = serde_json::to_value(&policy.resources).ok();
@@ -56,9 +71,7 @@ impl AcpOperations for AcpAdapter {
             .map_err(|e| format!("invalid policy: {}", e))?;
         let policy_id = policy.id.clone();
 
-        let options = StorePolicyOptions::new()
-            .with_validation()
-            .with_dpi_enforcement();
+        let options = policy_store_options();
 
         self.store
             .store_policy_with_options(&policy, &options)


### PR DESCRIPTION
## Summary

Two changes packaged together:

1. **Policy validation: recognize computed permissions in cross-resource lookups**
   `validate_policy_expressions` previously only checked `has_relation(name)` when resolving an expression name. Computed permissions (e.g. a `read` permission whose `expr` references another permission like `audit_read`) were rejected. The check is widened to `has_relation(name) || has_permission(name)` for both same-resource and cross-resource lookups. Adds `test_computed_permission_expression_loads`.

2. **`DEFRA_ACP_ALLOW_FULL_ZANZIBAR_POLICIES` env-var escape hatch**
   `AcpAdapter::add_policy` always applied `with_dpi_enforcement()`, which restricts policies to the DefraDB DPI subset of Zanzibar. The new env var (accepting `1`, `true`, `TRUE`, `yes`, `YES`) drops DPI enforcement so benchmarks can load full Zanzibar policies. Default behavior unchanged.

## Why

Benchmark suites need to exercise the full Zanzibar permission model — including computed permissions and cross-resource references — without being constrained by DPI enforcement. The validation fix is a real bug in its own right: any policy whose expressions chain through computed permissions was incorrectly rejected.

## Out of scope

- No change to default behavior for production / standard policies.
- No new CLI flag — env-var-only, since this is benchmark-only configuration.
- No removal of DPI enforcement as the default.

## Test plan

- [ ] `cargo test -p acp policy_yaml::validate::tests::test_computed_permission_expression_loads`
- [ ] `cargo test -p acp`
- [ ] `cargo test -p cli`
- [ ] `cargo clippy -p acp -p cli --all-targets -- -D warnings`