### PR TITLE
test(query): pin index rebuild on lens migration registration

### DIFF
--- a/tools/integration-test/tests/query.rs
+++ b/tools/integration-test/tests/query.rs
@@ -22,6 +22,8 @@ mod index_management;
 mod lens;
 #[path = "query/lens_persistence.rs"]
 mod lens_persistence;
+#[path = "query/lens_reindex_secondary_index_979.rs"]
+mod lens_reindex_secondary_index_979;
 #[path = "query/limits.rs"]
 mod limits;
 #[path = "query/multi_cid_vectors.rs"]

--- a/tools/integration-test/tests/query/lens_reindex_secondary_index_979.rs
+++ b/tools/integration-test/tests/query/lens_reindex_secondary_index_979.rs
@@ -5,84 +5,157 @@
 //! Rust (defradb.rs#979). It does not — the *incremental* lens mode that #4736
 //! requires is not implemented in Rust, and the index/lens interaction here is
 //! kept consistent by `maybe_reindex_after_migration` in
-//! `crates/db/src/migration/reindex.rs`. The test pins that behavior so a
-//! future change cannot silently regress it.
+//! `crates/db/src/migration/reindex.rs`. The tests pin that behavior across
+//! single-field, composite, and multi-document scenarios.
 
-use integration_test::TestCluster;
+use integration_test::{DefraClient, TestCluster};
 use serde_json::Value;
 
-#[tokio::test]
-async fn lens_migration_rebuilds_secondary_index() {
-    let cluster = TestCluster::builder()
+const SCHEMA: &str = "type Users { name: String  verified: Boolean }";
+const PATCH_V1_TO_V2: &str =
+    r#"[{"op":"add","path":"/Users/Fields/-","value":{"Name":"placeholder","Kind":11}}]"#;
+
+async fn build_cluster() -> TestCluster {
+    TestCluster::builder()
         .rust_nodes(1)
         .with_development()
         .build()
         .await
-        .unwrap();
-    let node = cluster.client(0);
+        .unwrap()
+}
 
-    node.schema_add("type Users { name: String  verified: Boolean }")
-        .expect("schema add v1");
-
-    let v1 = node
+fn version_id(client: &DefraClient) -> String {
+    client
         .collection_describe_version("Users")
-        .expect("describe v1")["VersionID"]
+        .expect("describe Users")["VersionID"]
         .as_str()
-        .expect("v1 id")
-        .to_string();
+        .expect("VersionID")
+        .to_string()
+}
+
+fn set_default_config(dst: &str, value: Value) -> String {
+    let lens = integration_test::wasm_lens::wasm_lens_defra();
+    lens.build().expect("build set_default lens");
+    serde_json::json!({
+        "Lenses": [{
+            "Path": lens.module_path(),
+            "Arguments": {"dst": dst, "value": value}
+        }]
+    })
+    .to_string()
+}
+
+#[tokio::test]
+async fn single_field_index_rebuilt_after_lens_migration() {
+    let cluster = build_cluster().await;
+    let node = cluster.client(0);
+    node.schema_add(SCHEMA).expect("schema add");
+    let v1 = version_id(&node);
 
     node.query(r#"mutation { add_Users(input: {name: "John"}) { _docID } }"#)
-        .expect("create John at v1");
+        .expect("create John");
 
     node.index_create("Users", &["verified"], Some("idx_verified"), false)
         .expect("create idx_verified");
 
-    node.collection_patch(
-        r#"[{"op":"add","path":"/Users/Fields/-","value":{"Name":"placeholder","Kind":11}}]"#,
-    )
-    .expect("patch to v2");
+    node.collection_patch(PATCH_V1_TO_V2).expect("patch to v2");
+    let v2 = version_id(&node);
 
-    let v2 = node
-        .collection_describe_version("Users")
-        .expect("describe v2")["VersionID"]
-        .as_str()
-        .expect("v2 id")
-        .to_string();
+    let cfg = set_default_config("verified", Value::Bool(true));
+    node.lens_set(&v1, &v2, &cfg).expect("lens_set v1->v2");
 
-    let lens = integration_test::wasm_lens::wasm_lens_defra();
-    lens.build().expect("build set_default lens");
-    let lens_config = serde_json::json!({
-        "Lenses": [{
-            "Path": lens.module_path(),
-            "Arguments": {"dst": "verified", "value": true}
-        }]
-    })
-    .to_string();
-    node.lens_set(&v1, &v2, &lens_config)
-        .expect("lens_set v1->v2");
-
-    let scan = node
-        .query("query { Users { name verified } }")
-        .expect("scan query");
-    let scan_arr = scan["Users"].as_array().expect("scan users");
-    assert_eq!(scan_arr.len(), 1);
-    assert_eq!(scan_arr[0]["name"].as_str(), Some("John"));
-    assert_eq!(scan_arr[0]["verified"], Value::Bool(true));
-
-    let indexed = node
+    let result = node
         .query(r#"query { Users(filter: {verified: {_eq: true}}) { name verified } }"#)
         .expect("indexed query");
-    let indexed_arr = indexed["Users"].as_array().expect("indexed users");
-
+    let arr = result["Users"].as_array().expect("Users array");
     assert_eq!(
-        indexed_arr.len(),
+        arr.len(),
         1,
-        "indexed filter on lens-set field must match full scan: \
-         scan {} row(s), indexed {} row(s). If this fails, the reindex hook \
-         after `set_migration` has regressed.",
-        scan_arr.len(),
-        indexed_arr.len()
+        "indexed filter on lens-set field returned {} rows; expected 1",
+        arr.len()
     );
-    assert_eq!(indexed_arr[0]["name"].as_str(), Some("John"));
-    assert_eq!(indexed_arr[0]["verified"], Value::Bool(true));
+    assert_eq!(arr[0]["name"].as_str(), Some("John"));
+    assert_eq!(arr[0]["verified"], Value::Bool(true));
+}
+
+#[tokio::test]
+async fn multi_doc_collection_fully_reindexed_after_lens_migration() {
+    let cluster = build_cluster().await;
+    let node = cluster.client(0);
+    node.schema_add(SCHEMA).expect("schema add");
+    let v1 = version_id(&node);
+
+    for name in ["Alice", "Bob", "Charlie"] {
+        node.query(&format!(
+            r#"mutation {{ add_Users(input: {{name: "{}"}}) {{ _docID }} }}"#,
+            name
+        ))
+        .expect("create doc");
+    }
+
+    node.index_create("Users", &["verified"], Some("idx_verified"), false)
+        .expect("create idx_verified");
+
+    node.collection_patch(PATCH_V1_TO_V2).expect("patch to v2");
+    let v2 = version_id(&node);
+
+    let cfg = set_default_config("verified", Value::Bool(true));
+    node.lens_set(&v1, &v2, &cfg).expect("lens_set v1->v2");
+
+    let result = node
+        .query(r#"query { Users(filter: {verified: {_eq: true}}) { name } }"#)
+        .expect("indexed query");
+    let arr = result["Users"].as_array().expect("Users array");
+    assert_eq!(
+        arr.len(),
+        3,
+        "expected 3 reindexed docs, got {} — per-doc reindex loop dropped entries",
+        arr.len()
+    );
+    let mut names: Vec<String> = arr
+        .iter()
+        .map(|d| d["name"].as_str().expect("name").to_string())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["Alice", "Bob", "Charlie"]);
+}
+
+#[tokio::test]
+async fn composite_index_rebuilt_after_lens_migration() {
+    let cluster = build_cluster().await;
+    let node = cluster.client(0);
+    node.schema_add(SCHEMA).expect("schema add");
+    let v1 = version_id(&node);
+
+    node.query(r#"mutation { add_Users(input: {name: "John"}) { _docID } }"#)
+        .expect("create John");
+
+    node.index_create(
+        "Users",
+        &["name", "verified"],
+        Some("idx_name_verified"),
+        false,
+    )
+    .expect("create composite index");
+
+    node.collection_patch(PATCH_V1_TO_V2).expect("patch to v2");
+    let v2 = version_id(&node);
+
+    let cfg = set_default_config("verified", Value::Bool(true));
+    node.lens_set(&v1, &v2, &cfg).expect("lens_set v1->v2");
+
+    let result = node
+        .query(
+            r#"query { Users(filter: {name: {_eq: "John"}, verified: {_eq: true}}) { name verified } }"#,
+        )
+        .expect("indexed query");
+    let arr = result["Users"].as_array().expect("Users array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "composite-index query returned {} rows; expected 1",
+        arr.len()
+    );
+    assert_eq!(arr[0]["name"].as_str(), Some("John"));
+    assert_eq!(arr[0]["verified"], Value::Bool(true));
 }

--- a/tools/integration-test/tests/query/lens_reindex_secondary_index_979.rs
+++ b/tools/integration-test/tests/query/lens_reindex_secondary_index_979.rs
@@ -1,0 +1,88 @@
+//! Regression: secondary indexes are rebuilt when a lens migration is
+//! registered, so indexed queries reflect lens-transformed field values.
+//!
+//! Originally written to probe whether Go DefraDB issue #4736 reproduces in
+//! Rust (defradb.rs#979). It does not — the *incremental* lens mode that #4736
+//! requires is not implemented in Rust, and the index/lens interaction here is
+//! kept consistent by `maybe_reindex_after_migration` in
+//! `crates/db/src/migration/reindex.rs`. The test pins that behavior so a
+//! future change cannot silently regress it.
+
+use integration_test::TestCluster;
+use serde_json::Value;
+
+#[tokio::test]
+async fn lens_migration_rebuilds_secondary_index() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_development()
+        .build()
+        .await
+        .unwrap();
+    let node = cluster.client(0);
+
+    node.schema_add("type Users { name: String  verified: Boolean }")
+        .expect("schema add v1");
+
+    let v1 = node
+        .collection_describe_version("Users")
+        .expect("describe v1")["VersionID"]
+        .as_str()
+        .expect("v1 id")
+        .to_string();
+
+    node.query(r#"mutation { add_Users(input: {name: "John"}) { _docID } }"#)
+        .expect("create John at v1");
+
+    node.index_create("Users", &["verified"], Some("idx_verified"), false)
+        .expect("create idx_verified");
+
+    node.collection_patch(
+        r#"[{"op":"add","path":"/Users/Fields/-","value":{"Name":"placeholder","Kind":11}}]"#,
+    )
+    .expect("patch to v2");
+
+    let v2 = node
+        .collection_describe_version("Users")
+        .expect("describe v2")["VersionID"]
+        .as_str()
+        .expect("v2 id")
+        .to_string();
+
+    let lens = integration_test::wasm_lens::wasm_lens_defra();
+    lens.build().expect("build set_default lens");
+    let lens_config = serde_json::json!({
+        "Lenses": [{
+            "Path": lens.module_path(),
+            "Arguments": {"dst": "verified", "value": true}
+        }]
+    })
+    .to_string();
+    node.lens_set(&v1, &v2, &lens_config)
+        .expect("lens_set v1->v2");
+
+    let scan = node
+        .query("query { Users { name verified } }")
+        .expect("scan query");
+    let scan_arr = scan["Users"].as_array().expect("scan users");
+    assert_eq!(scan_arr.len(), 1);
+    assert_eq!(scan_arr[0]["name"].as_str(), Some("John"));
+    assert_eq!(scan_arr[0]["verified"], Value::Bool(true));
+
+    let indexed = node
+        .query(r#"query { Users(filter: {verified: {_eq: true}}) { name verified } }"#)
+        .expect("indexed query");
+    let indexed_arr = indexed["Users"].as_array().expect("indexed users");
+
+    assert_eq!(
+        indexed_arr.len(),
+        1,
+        "indexed filter on lens-set field must match full scan: \
+         scan {} row(s), indexed {} row(s). If this fails, the reindex hook \
+         after `set_migration` has regressed.",
+        scan_arr.len(),
+        indexed_arr.len()
+    );
+    assert_eq!(indexed_arr[0]["name"].as_str(), Some("John"));
+    assert_eq!(indexed_arr[0]["verified"], Value::Bool(true));
+}


### PR DESCRIPTION
## Summary

- Adds a regression test confirming that registering a lens migration triggers a secondary-index rebuild, so indexed queries return lens-transformed field values consistent with full-scan queries.
- Closes the investigation prompted by #979 (whether Go DefraDB bug #4736 reproduces in Rust — it does not).

## Why this test exists

The Go bug (#4736) requires *incremental* lens migration mode + a secondary index, where multiple `ConfigureMigration` calls leave a doc-version stamp stale. Rust does not implement incremental migration mode at all (the only mode is lazy on-read), so #4736's exact failure shape cannot occur.

A naive read of the index-maintenance code (`crates/db-index/src/index_manager/`) and the lensed fetcher (`crates/db/src/lensed_fetcher/`) suggests the index and the lens layers are independent — which would imply that an indexed query on a lens-rewritten field could return stale results. The test was originally written to probe that. It turns out the two layers are bridged by `crates/db/src/migration/reindex.rs`:

- `maybe_reindex_after_migration` (called from `migration/set_migration.rs:237`) re-applies lens transforms to all docs and rebuilds indexes after a migration is registered.
- `maybe_reindex_on_version_switch` (called from `patch/store.rs:487`) does the same on schema version switch via collection patch.

This PR pins that behavior so a future refactor cannot silently regress it.

## Test plan

- [x] `cargo test -p integration-test --test query -- lens_reindex_secondary_index_979` passes
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p integration-test --tests --no-deps` clean
- [ ] Reviewer confirms the test name / docstring accurately describe the behavior being pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)