### PR TITLE
feat(telemetry): OpenTelemetry OTLP exporter with Go parity (#977)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,23 +99,18 @@ jobs:
 
       - run: cargo test --workspace --exclude integration-test --exclude ffi-test
 
-      # Cover OTel-only tests + a feature-on build of the CLI so the otel
-      # path is exercised under CI on every PR. The `metrics` feature build
-      # keeps the metric-exporter code path compiling. The cli otel test
-      # spawns a real node against an unreachable collector and asserts the
-      # dedup hint fires exactly once — the regression guard for the SDK's
-      # `internal-logs` feature (Docker-free). Issue #977 / #1004.
-      - run: cargo test -p telemetry --features otlp
-      - run: cargo test -p telemetry --features metrics
-      - run: cargo test -p cli --features otel --test telemetry_dedup
-
+      # Cache binaries BEFORE any feature-on rebuild. `cargo test --workspace`
+      # above left a default-feature `defra` at target/debug/defra; the otel
+      # steps below recompile it with `--features otel`, so caching must happen
+      # first or the integration matrix would restore a telemetry-enabled
+      # binary as its "standard" defra.
       - name: Cache pre-built binaries
         run: |
           HASH=$(git rev-parse HEAD)
           CACHE_DIR="$HOME/.sourcenetwork/bin/defradb.rs/$HASH"
           mkdir -p "$CACHE_DIR"
 
-          # Standard binary — already compiled by cargo test, just link
+          # Standard (default-feature) binary — compiled by cargo test above.
           cp target/debug/defra "$CACHE_DIR/defra"
 
           # Iroh binary — needs feature build
@@ -124,6 +119,16 @@ jobs:
 
           # Symlink for backbone CI consumption
           ln -sf "$CACHE_DIR/defra-iroh" "$HOME/.sourcenetwork/bin/defra-iroh"
+
+      # OTel-only tests, run AFTER caching so the otel rebuild of target/debug/defra
+      # never pollutes the cached standard binary. The `metrics` build keeps the
+      # metric-exporter path compiling; the cli otel test spawns a real node
+      # against an unreachable collector and asserts the dedup hint fires exactly
+      # once — the Docker-free regression guard for the SDK's `internal-logs`
+      # feature. Issue #977 / #1004.
+      - run: cargo test -p telemetry --features otlp
+      - run: cargo test -p telemetry --features metrics
+      - run: cargo test -p cli --features otel --test telemetry_dedup
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,13 @@ jobs:
 
       # Cover OTel-only tests + a feature-on build of the CLI so the otel
       # path is exercised under CI on every PR. The `metrics` feature build
-      # keeps the metric-exporter code path compiling. Issue #977.
+      # keeps the metric-exporter code path compiling. The cli otel test
+      # spawns a real node against an unreachable collector and asserts the
+      # dedup hint fires exactly once — the regression guard for the SDK's
+      # `internal-logs` feature (Docker-free). Issue #977 / #1004.
       - run: cargo test -p telemetry --features otlp
       - run: cargo test -p telemetry --features metrics
-      - run: cargo build -p cli --features otel
+      - run: cargo test -p cli --features otel --test telemetry_dedup
 
       - name: Cache pre-built binaries
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
 
       - run: cargo clippy --all -- -D warnings
 
+      # OTel feature paths are opt-in (mirror Go's `//go:build telemetry`),
+      # so the default clippy pass doesn't exercise them. These two checks
+      # keep the feature-gated code from rotting silently. Issue #977.
+      - run: cargo clippy -p telemetry --features otlp --all-targets -- -D warnings
+      - run: cargo clippy -p cli --features otel --all-targets -- -D warnings
+      - run: cargo clippy -p defra-node --features otel --all-targets -- -D warnings
+
       - name: Cleanup
         if: always()
         run: |
@@ -88,6 +95,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo test --workspace --exclude integration-test --exclude ffi-test
+
+      # Cover OTel-only tests + a feature-on build of the CLI so the otel
+      # path is exercised under CI on every PR. Issue #977.
+      - run: cargo test -p telemetry --features otlp
+      - run: cargo build -p cli --features otel
 
       - name: Cache pre-built binaries
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,12 @@ jobs:
       - run: cargo clippy --all -- -D warnings
 
       # OTel feature paths are opt-in (mirror Go's `//go:build telemetry`),
-      # so the default clippy pass doesn't exercise them. These two checks
-      # keep the feature-gated code from rotting silently. Issue #977.
+      # so the default clippy pass doesn't exercise them. These checks keep
+      # the feature-gated code from rotting silently. The `metrics` feature
+      # gates a whole separate code path (meter provider, metric exporter)
+      # that no other job builds. Issue #977.
       - run: cargo clippy -p telemetry --features otlp --all-targets -- -D warnings
+      - run: cargo clippy -p telemetry --features metrics --all-targets -- -D warnings
       - run: cargo clippy -p cli --features otel --all-targets -- -D warnings
       - run: cargo clippy -p defra-node --features otel --all-targets -- -D warnings
 
@@ -97,8 +100,10 @@ jobs:
       - run: cargo test --workspace --exclude integration-test --exclude ffi-test
 
       # Cover OTel-only tests + a feature-on build of the CLI so the otel
-      # path is exercised under CI on every PR. Issue #977.
+      # path is exercised under CI on every PR. The `metrics` feature build
+      # keeps the metric-exporter code path compiling. Issue #977.
       - run: cargo test -p telemetry --features otlp
+      - run: cargo test -p telemetry --features metrics
       - run: cargo build -p cli --features otel
 
       - name: Cache pre-built binaries

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ crates/ffi/defra.h
 # Test artifacts
 *.profraw
 *.profdata
+tools/otel-smoke/output/
 
 # Documentation
 /book/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12293,6 +12293,7 @@ dependencies = [
  "opentelemetry-otlp 0.32.0",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.32.1",
+ "reqwest 0.13.3",
  "thiserror 2.0.18",
  "tracing",
  "tracing-opentelemetry 0.33.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8736,6 +8736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12285,6 +12291,7 @@ version = "0.5.0"
 dependencies = [
  "opentelemetry 0.32.0",
  "opentelemetry-otlp 0.32.0",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.32.1",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,12 +1923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,6 +2156,7 @@ dependencies = [
  "serde_yaml",
  "sourcehub",
  "storage",
+ "telemetry",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2464,9 +2459,9 @@ dependencies = [
  "getrandom 0.2.17",
  "governor",
  "libc",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry-otlp 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "prometheus-client 0.24.0",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -2476,7 +2471,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.32.1",
  "tracing-subscriber",
 ]
 
@@ -4942,8 +4937,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5300,7 +5295,7 @@ dependencies = [
  "http 1.4.0",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "rand 0.10.1",
  "rustls 0.23.37",
  "thiserror 2.0.18",
@@ -5345,7 +5340,7 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "once_cell",
  "prefix-trie",
  "rand 0.10.1",
@@ -5389,7 +5384,7 @@ dependencies = [
  "hickory-proto 0.26.1",
  "ipconfig",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "moka",
  "ndk-context",
  "once_cell",
@@ -5677,7 +5672,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6537,22 +6532,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.0",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -6560,7 +6539,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -6580,12 +6559,6 @@ dependencies = [
  "simd_cesu8",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jni-sys"
@@ -8201,7 +8174,7 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "slab",
  "sorted-index-buffer",
  "thiserror 2.0.18",
@@ -8665,6 +8638,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8673,7 +8660,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.0",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "reqwest 0.12.28",
 ]
 
@@ -8684,14 +8671,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http 1.4.0",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry_sdk",
+ "opentelemetry-proto 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry 0.32.0",
+ "opentelemetry-proto 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost 0.14.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
 ]
 
 [[package]]
@@ -8700,8 +8704,21 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
+ "prost 0.14.3",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "prost 0.14.3",
  "tonic",
  "tonic-prost",
@@ -8716,8 +8733,26 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
@@ -10395,7 +10430,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -10563,7 +10598,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.23.37",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -10913,34 +10948,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.11",
- "security-framework 3.7.0",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls 0.23.37",
@@ -12256,6 +12270,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "telemetry"
+version = "0.5.0"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry-otlp 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry 0.33.0",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12784,11 +12812,13 @@ dependencies = [
  "socket2 0.6.3",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -12828,6 +12858,17 @@ dependencies = [
  "syn 2.0.117",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic",
 ]
 
 [[package]]
@@ -12942,7 +12983,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry",
+ "opentelemetry 0.31.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -14151,15 +14208,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -14201,21 +14249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -14286,12 +14319,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -14310,12 +14337,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -14331,12 +14352,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -14370,12 +14385,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -14391,12 +14400,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -14418,12 +14421,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -14439,12 +14436,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -14601,8 +14592,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8766,8 +8766,6 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -12289,7 +12287,6 @@ dependencies = [
  "opentelemetry-otlp 0.32.0",
  "opentelemetry_sdk 0.32.1",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "tracing-opentelemetry 0.33.0",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,6 +3712,7 @@ dependencies = [
  "serde_json",
  "sourcehub",
  "storage",
+ "telemetry",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8665,6 +8666,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry 0.32.0",
+ "reqwest 0.13.3",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8672,7 +8686,7 @@ checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http 1.4.0",
  "opentelemetry 0.31.0",
- "opentelemetry-http",
+ "opentelemetry-http 0.31.0",
  "opentelemetry-proto 0.31.0",
  "opentelemetry_sdk 0.31.0",
  "prost 0.14.3",
@@ -8689,13 +8703,12 @@ checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.0",
  "opentelemetry 0.32.0",
+ "opentelemetry-http 0.32.0",
  "opentelemetry-proto 0.32.0",
  "opentelemetry_sdk 0.32.1",
  "prost 0.14.3",
+ "reqwest 0.13.3",
  "thiserror 2.0.18",
- "tokio",
- "tonic",
- "tonic-types",
 ]
 
 [[package]]
@@ -8720,8 +8733,6 @@ dependencies = [
  "opentelemetry 0.32.0",
  "opentelemetry_sdk 0.32.1",
  "prost 0.14.3",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
@@ -10584,6 +10595,7 @@ checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.0",
@@ -12812,13 +12824,11 @@ dependencies = [
  "socket2 0.6.3",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -12858,17 +12868,6 @@ dependencies = [
  "syn 2.0.117",
  "tempfile",
  "tonic-build",
-]
-
-[[package]]
-name = "tonic-types"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
-dependencies = [
- "prost 0.14.3",
- "prost-types 0.14.3",
- "tonic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/wasm",
     "crates/pg-compat",
     "crates/defra-node",
+    "crates/telemetry",
     "tools/lens-host",
     "tools/ffi-test",
     "tools/integration-test",

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Metrics are a separate opt-in (the `metrics` feature on the `telemetry` crate). 
 | `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` | Override service name / extra attributes. |
 | `OTEL_TRACES_SAMPLER` | Configure sampling (default: parent-based always-on, matching Go). |
 
-When no collector is reachable, the OTel SDK's exporter-unreachable messages (`connection refused`, `HTTP export failed`, `network error`) are suppressed after the first occurrence of *each* pattern per layer — port of Go's `otel.SetErrorHandler + sync.Once` dedup (issue #977). Each pattern gets its own latch so a transient one doesn't silence a different failure later.
+When no collector is reachable, the OTel SDK's repeated export errors are suppressed and a single actionable hint — `OpenTelemetry export failed, ensure your OTLP collector is running and reachable` — is emitted once per process. This ports Go's `otel.SetErrorHandler + sync.Once` behavior (issue #977); genuine non-connectivity OTel errors still log normally.
 
 ### Embedded usage
 

--- a/README.md
+++ b/README.md
@@ -64,30 +64,46 @@ When no collector is reachable, repeat `"connection refused"` messages from the 
 
 ### Embedded usage
 
-Library consumers (via `defra-node`) can either let `NodeBuilder` initialize OTel themselves or bring a pre-built handle:
+Library consumers (via `defra-node`) own the OTel lifecycle and hand the resulting handle to the node. The node flushes it via `Drop` or via an explicit `shutdown()` — whichever happens first.
+
+Add `telemetry` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+defra-node = { version = "0.5", features = ["otel"] }
+telemetry  = { version = "0.5", features = ["otlp"] }
+```
 
 ```rust
-use defra_node::{EmbeddedNode, TelemetryConfig};
+use defra_node::EmbeddedNode;
+use telemetry::TelemetryConfig;
 
-// Option A — let the builder handle init
+// Convenience — let the node own init + shutdown
+let (handle, tracer) = telemetry::init(TelemetryConfig::new("my-service", env!("CARGO_PKG_VERSION")))?;
+// Compose the OTel bridge onto your own tracing subscriber so spans flow
+// to the collector. `otel_layer` is generic so type inference picks the
+// right S at the .with() site.
+tracing_subscriber::registry()
+    .with(tracing_subscriber::fmt::layer())
+    .with(telemetry::otel_layer(tracer))
+    .init();
 let node = EmbeddedNode::builder()
-    .with_telemetry(TelemetryConfig::new("my-service", env!("CARGO_PKG_VERSION")))
+    .with_telemetry(handle)
     .build()
     .await?;
 
-// Option B — bring your own (e.g. defra-agent runs its own OTel stack)
-let (handle, _tracer) = telemetry::init(TelemetryConfig::default())?;
-// ... compose your own subscriber with `telemetry::otel_layer(_tracer)` ...
-let node = EmbeddedNode::builder()
-    .with_external_telemetry(handle)
-    .build()
-    .await?;
+// If your host process already runs its own OTel stack and you don't want
+// `telemetry::init` to clobber your globals, set `install_global = false`:
+let (handle, tracer) = telemetry::init(
+    TelemetryConfig::new("my-service", "1.0.0").without_global()
+)?;
 
-// shutdown() flushes buffered spans (which Go DefraDB forgets to do).
+// shutdown() flushes the buffered batch (which Go DefraDB forgets to do).
+// Drop is a safety net for code paths that miss the explicit call.
 node.shutdown().await;
 ```
 
-Either way requires `defra-node` to be built with `--features otel`.
+`telemetry::init` requires a Tokio runtime to be active — its batch span processor and periodic metric reader call `Handle::current()` internally. Wrap in `Runtime::block_on` if calling from a sync context.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,53 @@ The CLI exposes GraphQL query guardrails on `defradb start`:
 | `--query-max-width` | `100` | Max fields at any GraphQL selection level (`0` = unlimited). |
 | `--query-max-filter-depth` | `50` | Max recursive filter nesting depth (`0` = unlimited). |
 
+## Telemetry (OpenTelemetry)
+
+Opt in at compile time with `--features otel`:
+
+```bash
+cargo build --release -p cli --features otel
+```
+
+Mirrors Go DefraDB's `//go:build telemetry` tag — when not compiled in, zero OTel dependencies and zero runtime cost. When compiled in, traces and metrics export to `http://localhost:4318` (OTLP/HTTP) **by default**, same as Go.
+
+| Flag / env var | Effect |
+| --- | --- |
+| `--no-telemetry` / `DEFRA_NO_TELEMETRY=true` | Disable exporters at runtime. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Override collector URL (standard OTel env var). |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Add headers, e.g. for auth. |
+| `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` | Override service name / extra attributes. |
+| `OTEL_TRACES_SAMPLER` | Configure sampling (default: parent-based always-on, matching Go). |
+
+When no collector is reachable, repeat `"connection refused"` messages from the OTel SDK are suppressed after the first — port of Go's `otel.SetErrorHandler + sync.Once` dedup (issue #977).
+
+### Embedded usage
+
+Library consumers (via `defra-node`) can either let `NodeBuilder` initialize OTel themselves or bring a pre-built handle:
+
+```rust
+use defra_node::{EmbeddedNode, TelemetryConfig};
+
+// Option A — let the builder handle init
+let node = EmbeddedNode::builder()
+    .with_telemetry(TelemetryConfig::new("my-service", env!("CARGO_PKG_VERSION")))
+    .build()
+    .await?;
+
+// Option B — bring your own (e.g. defra-agent runs its own OTel stack)
+let (handle, _tracer) = telemetry::init(TelemetryConfig::default())?;
+// ... compose your own subscriber with `telemetry::otel_layer(_tracer)` ...
+let node = EmbeddedNode::builder()
+    .with_external_telemetry(handle)
+    .build()
+    .await?;
+
+// shutdown() flushes buffered spans (which Go DefraDB forgets to do).
+node.shutdown().await;
+```
+
+Either way requires `defra-node` to be built with `--features otel`.
+
 ## Testing
 
 ### Integration Tests

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Mirrors Go DefraDB's `//go:build telemetry` tag — when not compiled in, zero O
 | `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` | Override service name / extra attributes. |
 | `OTEL_TRACES_SAMPLER` | Configure sampling (default: parent-based always-on, matching Go). |
 
-When no collector is reachable, repeat `"connection refused"` messages from the OTel SDK are suppressed after the first — port of Go's `otel.SetErrorHandler + sync.Once` dedup (issue #977).
+When no collector is reachable, the OTel SDK's exporter-unreachable messages (`connection refused`, `HTTP export failed`, `network error`) are suppressed after the first occurrence of *each* pattern per layer — port of Go's `otel.SetErrorHandler + sync.Once` dedup (issue #977). Each pattern gets its own latch so a transient one doesn't silence a different failure later.
 
 ### Embedded usage
 
-Library consumers (via `defra-node`) own the OTel lifecycle and hand the resulting handle to the node. The node flushes it via `Drop` or via an explicit `shutdown()` — whichever happens first.
+Library consumers (via `defra-node`) own the OTel lifecycle and hand the resulting handle to the node. The node flushes it via `Drop` or via an explicit `shutdown()` — explicit is preferred because `Drop` blocks for up to ~10 s on the SDK's batch-thread joins.
 
 Add `telemetry` to your `Cargo.toml`:
 
@@ -77,33 +77,44 @@ telemetry  = { version = "0.5", features = ["otlp"] }
 ```rust
 use defra_node::EmbeddedNode;
 use telemetry::TelemetryConfig;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-// Convenience — let the node own init + shutdown
-let (handle, tracer) = telemetry::init(TelemetryConfig::new("my-service", env!("CARGO_PKG_VERSION")))?;
-// Compose the OTel bridge onto your own tracing subscriber so spans flow
-// to the collector. `otel_layer` is generic so type inference picks the
-// right S at the .with() site.
+let (handle, tracer) = telemetry::init(
+    TelemetryConfig::new("my-service", env!("CARGO_PKG_VERSION"))
+)?;
+
+// Compose the OTel bridge onto your tracing subscriber so spans flow
+// to the collector. `try_init()` returns Err if a global subscriber is
+// already installed — preferred over `.init()` (which panics).
 tracing_subscriber::registry()
     .with(tracing_subscriber::fmt::layer())
     .with(telemetry::otel_layer(tracer))
-    .init();
+    .try_init()?;
+
 let node = EmbeddedNode::builder()
     .with_telemetry(handle)
     .build()
     .await?;
 
-// If your host process already runs its own OTel stack and you don't want
-// `telemetry::init` to clobber your globals, set `install_global = false`:
-let (handle, tracer) = telemetry::init(
-    TelemetryConfig::new("my-service", "1.0.0").without_global()
-)?;
+// ... use the node ...
 
-// shutdown() flushes the buffered batch (which Go DefraDB forgets to do).
-// Drop is a safety net for code paths that miss the explicit call.
+// Explicit shutdown flushes the buffered batch. Drop is a safety net,
+// but blocks the calling thread on SDK batch-thread joins (up to ~10 s
+// for traces + metrics combined); call shutdown() explicitly from an
+// async-aware path when possible. Note that the node should not be used
+// after shutdown — subsequent spans go to a no-op tracer.
 node.shutdown().await;
 ```
 
-`telemetry::init` requires a Tokio runtime to be active — its batch span processor and periodic metric reader call `Handle::current()` internally. Wrap in `Runtime::block_on` if calling from a sync context.
+If the host process already runs its own OTel stack and you don't want `telemetry::init` to clobber your globals, use `.without_global()`:
+
+```rust
+let (handle, _tracer) = telemetry::init(
+    TelemetryConfig::new("my-service", "1.0.0").without_global()
+)?;
+// You'd compose `_tracer` into a layer of your own choosing instead of
+// installing it as the process-wide global tracer.
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Opt in at compile time with `--features otel`:
 cargo build --release -p cli --features otel
 ```
 
-Mirrors Go DefraDB's `//go:build telemetry` tag — when not compiled in, zero OTel dependencies and zero runtime cost. When compiled in, traces and metrics export to `http://localhost:4318` (OTLP/HTTP) **by default**, same as Go.
+Mirrors Go DefraDB's `//go:build telemetry` tag — when not compiled in, zero OTel dependencies and zero runtime cost. When compiled in, **traces** export to `http://localhost:4318` (OTLP/HTTP) by default, same endpoint as Go.
+
+Metrics are a separate opt-in (the `metrics` feature on the `telemetry` crate). They're off by default because nothing in defradb.rs records metric instruments yet — enabling the metric pipeline would just export empty batches every 60 s. Turn it on once instruments exist.
 
 | Flag / env var | Effect |
 | --- | --- |
@@ -64,9 +66,9 @@ When no collector is reachable, the OTel SDK's exporter-unreachable messages (`c
 
 ### Embedded usage
 
-Library consumers (via `defra-node`) own the OTel lifecycle and hand the resulting handle to the node. The node flushes it via `Drop` or via an explicit `shutdown()` — explicit is preferred because `Drop` blocks for up to ~10 s on the SDK's batch-thread joins.
+Library consumers (via `defra-node`) own the OTel lifecycle and hand the resulting handle to the node. The node flushes it via `Drop` or via an explicit `shutdown()` — explicit is preferred because `Drop` blocks for up to ~5 s on the SDK's trace batch-thread join (double that if you also enable the `metrics` feature).
 
-Add `telemetry` to your `Cargo.toml`:
+Add `telemetry` to your `Cargo.toml` (add `"metrics"` alongside `"otlp"` if you record metric instruments):
 
 ```toml
 [dependencies]
@@ -99,10 +101,10 @@ let node = EmbeddedNode::builder()
 // ... use the node ...
 
 // Explicit shutdown flushes the buffered batch. Drop is a safety net,
-// but blocks the calling thread on SDK batch-thread joins (up to ~10 s
-// for traces + metrics combined); call shutdown() explicitly from an
-// async-aware path when possible. Note that the node should not be used
-// after shutdown — subsequent spans go to a no-op tracer.
+// but blocks the calling thread on the SDK batch-thread join (~5 s for
+// traces, double with the metrics feature); call shutdown() explicitly
+// from an async-aware path when possible. Note that the node should not
+// be used after shutdown — subsequent spans go to a no-op tracer.
 node.shutdown().await;
 ```
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -39,6 +39,7 @@ orbis = { path = "../orbis" }
 sourcehub = { path = "../sourcehub" }
 defra-version = { path = "../defra-version" }
 pg-compat = { path = "../pg-compat" }
+telemetry = { path = "../telemetry", default-features = false }
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
@@ -114,6 +115,10 @@ rocksdb = ["storage/rocksdb"]
 vendored-openssl = ["dep:openssl-sys"]
 iroh = ["p2p/iroh-transport", "dep:iroh-net", "dep:rand"]
 profiling = ["dep:tracing-chrome"]
+# OpenTelemetry OTLP exporter. Mirrors Go's `//go:build telemetry`: compile-time
+# opt-in. When built with this feature, runtime default is on (Go parity); use
+# `--no-telemetry` to disable at runtime.
+otel = ["telemetry/otlp"]
 
 [dev-dependencies]
 tempfile = "3.17"

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -8,6 +8,16 @@ use crate::commands::{
 use crate::config::Config;
 use crate::error::Result;
 
+/// Shared `value_parser` for the CLI's `Option<bool>` toggle flags. Accepts
+/// the usual shell-boolean idioms (`true`/`false`, `1`/`0`, `yes`/`no`,
+/// `on`/`off`, case-insensitive) so env-driven CI scripts using `=1`/`=0`
+/// work. Defined once and referenced from every `--no-*` / toggle flag in
+/// both this module and the `start` subcommand, so the convention can't
+/// drift per flag.
+pub(crate) fn bool_value_parser() -> clap::builder::BoolishValueParser {
+    clap::builder::BoolishValueParser::new()
+}
+
 /// DefraDB Edge Database
 ///
 /// DefraDB is the edge database to power the user-centric future.
@@ -33,11 +43,11 @@ pub struct Cli {
     pub log_format: Option<String>,
 
     /// Include stacktrace in error and fatal logs
-    #[arg(long, global = true, env = "DEFRA_LOG_STACKTRACE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, global = true, env = "DEFRA_LOG_STACKTRACE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = bool_value_parser())]
     pub log_stacktrace: Option<bool>,
 
     /// Include source location in logs
-    #[arg(long, global = true, env = "DEFRA_LOG_SOURCE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, global = true, env = "DEFRA_LOG_SOURCE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = bool_value_parser())]
     pub log_source: Option<bool>,
 
     /// Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
@@ -45,7 +55,7 @@ pub struct Cli {
     pub log_overrides: Option<String>,
 
     /// Disable colored log output
-    #[arg(long, global = true, env = "DEFRA_NO_LOG_COLOR", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, global = true, env = "DEFRA_NO_LOG_COLOR", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = bool_value_parser())]
     pub no_log_color: Option<bool>,
 
     /// URL of HTTP endpoint to listen on or connect to
@@ -65,7 +75,7 @@ pub struct Cli {
     pub keyring_path: Option<String>,
 
     /// Disable the keyring and generate ephemeral keys
-    #[arg(long, global = true, env = "DEFRA_NO_KEYRING", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, global = true, env = "DEFRA_NO_KEYRING", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = bool_value_parser())]
     pub no_keyring: Option<bool>,
 
     /// The SourceHub address authorized by the client to make SourceHub transactions
@@ -89,18 +99,18 @@ pub struct Cli {
     pub secret_file: Option<String>,
 
     /// Disable OpenTelemetry exporters (no-op unless the binary was built with `--features otel`).
-    #[arg(long, global = true, env = "DEFRA_NO_TELEMETRY", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, global = true, env = "DEFRA_NO_TELEMETRY", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = bool_value_parser())]
     pub no_telemetry: Option<bool>,
 
     /// Enables development mode features
-    #[arg(long, global = true, env = "DEFRA_DEVELOPMENT", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, global = true, env = "DEFRA_DEVELOPMENT", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = bool_value_parser())]
     pub development: Option<bool>,
 
     /// Enable Node Access Control (NAC).
     ///
     /// When enabled, node operations require authentication and authorization
     /// based on the node's identity from the keyring.
-    #[arg(long = "node-acp-enable", global = true, env = "DEFRA_ACP_NODE_ENABLE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long = "node-acp-enable", global = true, env = "DEFRA_ACP_NODE_ENABLE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = bool_value_parser())]
     pub acp_node_enable: Option<bool>,
 
     /// Document ACP type. Options are none, local, source-hub, or hub-rs

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -88,6 +88,10 @@ pub struct Cli {
     #[arg(long, global = true, env = "DEFRA_SECRET_FILE")]
     pub secret_file: Option<String>,
 
+    /// Disable OpenTelemetry exporters (no-op unless the binary was built with `--features otel`)
+    #[arg(long, global = true, env = "DEFRA_NO_TELEMETRY", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    pub no_telemetry: Option<bool>,
+
     /// Enables development mode features
     #[arg(long, global = true, env = "DEFRA_DEVELOPMENT", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub development: Option<bool>,

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -88,8 +88,21 @@ pub struct Cli {
     #[arg(long, global = true, env = "DEFRA_SECRET_FILE")]
     pub secret_file: Option<String>,
 
-    /// Disable OpenTelemetry exporters (no-op unless the binary was built with `--features otel`)
-    #[arg(long, global = true, env = "DEFRA_NO_TELEMETRY", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    /// Disable OpenTelemetry exporters (no-op unless the binary was built with `--features otel`).
+    ///
+    /// Accepts the usual shell-boolean idioms: `true`/`false`, `1`/`0`,
+    /// `yes`/`no`, `on`/`off`. Wider than the other bool flags here because
+    /// telemetry tends to be toggled via env in CI scripts that use the
+    /// `=1`/`=0` convention. Uses `clap::builder::BoolishValueParser`.
+    #[arg(
+        long,
+        global = true,
+        env = "DEFRA_NO_TELEMETRY",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        value_parser = clap::builder::BoolishValueParser::new(),
+    )]
     pub no_telemetry: Option<bool>,
 
     /// Enables development mode features

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -33,11 +33,11 @@ pub struct Cli {
     pub log_format: Option<String>,
 
     /// Include stacktrace in error and fatal logs
-    #[arg(long, global = true, env = "DEFRA_LOG_STACKTRACE", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, global = true, env = "DEFRA_LOG_STACKTRACE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub log_stacktrace: Option<bool>,
 
     /// Include source location in logs
-    #[arg(long, global = true, env = "DEFRA_LOG_SOURCE", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, global = true, env = "DEFRA_LOG_SOURCE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub log_source: Option<bool>,
 
     /// Logger config overrides. Format <name>,<key>=<val>,...;<name>,...
@@ -45,7 +45,7 @@ pub struct Cli {
     pub log_overrides: Option<String>,
 
     /// Disable colored log output
-    #[arg(long, global = true, env = "DEFRA_NO_LOG_COLOR", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, global = true, env = "DEFRA_NO_LOG_COLOR", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub no_log_color: Option<bool>,
 
     /// URL of HTTP endpoint to listen on or connect to
@@ -65,7 +65,7 @@ pub struct Cli {
     pub keyring_path: Option<String>,
 
     /// Disable the keyring and generate ephemeral keys
-    #[arg(long, global = true, env = "DEFRA_NO_KEYRING", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, global = true, env = "DEFRA_NO_KEYRING", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub no_keyring: Option<bool>,
 
     /// The SourceHub address authorized by the client to make SourceHub transactions
@@ -89,31 +89,18 @@ pub struct Cli {
     pub secret_file: Option<String>,
 
     /// Disable OpenTelemetry exporters (no-op unless the binary was built with `--features otel`).
-    ///
-    /// Accepts the usual shell-boolean idioms: `true`/`false`, `1`/`0`,
-    /// `yes`/`no`, `on`/`off`. Wider than the other bool flags here because
-    /// telemetry tends to be toggled via env in CI scripts that use the
-    /// `=1`/`=0` convention. Uses `clap::builder::BoolishValueParser`.
-    #[arg(
-        long,
-        global = true,
-        env = "DEFRA_NO_TELEMETRY",
-        num_args = 0..=1,
-        require_equals = true,
-        default_missing_value = "true",
-        value_parser = clap::builder::BoolishValueParser::new(),
-    )]
+    #[arg(long, global = true, env = "DEFRA_NO_TELEMETRY", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub no_telemetry: Option<bool>,
 
     /// Enables development mode features
-    #[arg(long, global = true, env = "DEFRA_DEVELOPMENT", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, global = true, env = "DEFRA_DEVELOPMENT", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub development: Option<bool>,
 
     /// Enable Node Access Control (NAC).
     ///
     /// When enabled, node operations require authentication and authorization
     /// based on the node's identity from the keyring.
-    #[arg(long = "node-acp-enable", global = true, env = "DEFRA_ACP_NODE_ENABLE", num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long = "node-acp-enable", global = true, env = "DEFRA_ACP_NODE_ENABLE", num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub acp_node_enable: Option<bool>,
 
     /// Document ACP type. Options are none, local, source-hub, or hub-rs

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -75,10 +75,6 @@ pub struct StartArgs {
     #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_encryption: Option<bool>,
 
-    /// Disable telemetry reporting
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
-    pub no_telemetry: Option<bool>,
-
     /// Disable signing of commits
     #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
     pub no_signing: Option<bool>,
@@ -413,9 +409,6 @@ impl StartArgs {
         }
         if let Some(no_enc) = self.no_encryption {
             config.datastore.no_encryption = no_enc;
-        }
-        if let Some(no_tel) = self.no_telemetry {
-            config.telemetry_disabled = no_tel;
         }
         if let Some(no_sign) = self.no_signing {
             config.datastore.no_signing = no_sign;

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -56,7 +56,7 @@ pub struct StartArgs {
     pub p2paddr: Option<Vec<String>>,
 
     /// Disable the peer-to-peer network synchronization system
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = crate::cli::bool_value_parser())]
     pub no_p2p: Option<bool>,
 
     /// List of origins to allow for CORS requests
@@ -72,11 +72,11 @@ pub struct StartArgs {
     pub privkeypath: Option<String>,
 
     /// Skip generating an encryption key. Encryption at rest will be disabled.
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = crate::cli::bool_value_parser())]
     pub no_encryption: Option<bool>,
 
     /// Disable signing of commits
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = crate::cli::bool_value_parser())]
     pub no_signing: Option<bool>,
 
     /// Default key type to generate new node identity
@@ -84,7 +84,7 @@ pub struct StartArgs {
     pub default_key_type: Option<String>,
 
     /// Skip generating a searchable encryption key
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = crate::cli::bool_value_parser())]
     pub no_searchable_encryption: Option<bool>,
 
     /// Hex formatted private key used to authenticate with ACP.

--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -56,7 +56,7 @@ pub struct StartArgs {
     pub p2paddr: Option<Vec<String>>,
 
     /// Disable the peer-to-peer network synchronization system
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub no_p2p: Option<bool>,
 
     /// List of origins to allow for CORS requests
@@ -72,11 +72,11 @@ pub struct StartArgs {
     pub privkeypath: Option<String>,
 
     /// Skip generating an encryption key. Encryption at rest will be disabled.
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub no_encryption: Option<bool>,
 
     /// Disable signing of commits
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub no_signing: Option<bool>,
 
     /// Default key type to generate new node identity
@@ -84,7 +84,7 @@ pub struct StartArgs {
     pub default_key_type: Option<String>,
 
     /// Skip generating a searchable encryption key
-    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true")]
+    #[arg(long, num_args = 0..=1, require_equals = true, default_missing_value = "true", value_parser = clap::builder::BoolishValueParser::new())]
     pub no_searchable_encryption: Option<bool>,
 
     /// Hex formatted private key used to authenticate with ACP.

--- a/crates/cli/src/config/mod.rs
+++ b/crates/cli/src/config/mod.rs
@@ -188,6 +188,9 @@ impl Config {
         if let Some(development) = cli.development {
             self.development = development;
         }
+        if let Some(no_telemetry) = cli.no_telemetry {
+            self.telemetry_disabled = no_telemetry;
+        }
 
         // ACP
         if let Some(node_enable) = cli.acp_node_enable {

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -154,7 +154,11 @@ where
     let (telemetry_handle, tracer) = if config.telemetry_disabled {
         (telemetry::TelemetryHandle::noop(), None)
     } else {
-        match telemetry::init(telemetry::TelemetryConfig::default()) {
+        // Source the service version from defra-version so OTLP receivers see
+        // the actual defra binary version, not the telemetry crate's own.
+        let telemetry_config =
+            telemetry::TelemetryConfig::new("DefraDB", defra_version::VersionInfo::new().version);
+        match telemetry::init(telemetry_config) {
             Ok((handle, tracer)) => (handle, Some(tracer)),
             Err(err) => {
                 eprintln!(

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -77,7 +77,17 @@ impl LoggingHandle {
 }
 
 /// Initialize logging based on configuration.
-pub fn init(config: &Config, enable_profiling: bool) -> Result<LoggingHandle> {
+///
+/// `enable_telemetry` gates the OTLP exporter independently of logging: only
+/// the `start` command sets it, matching Go (which configures telemetry only
+/// in `cli/start.go`). Ephemeral commands like `version` / `client` keep the
+/// fmt subscriber but never spin up the exporter thread or pay its shutdown
+/// cost.
+pub fn init(
+    config: &Config,
+    enable_profiling: bool,
+    enable_telemetry: bool,
+) -> Result<LoggingHandle> {
     let level = match config.log.level {
         LogLevel::Debug => Level::DEBUG,
         LogLevel::Info => Level::INFO,
@@ -108,24 +118,28 @@ pub fn init(config: &Config, enable_profiling: bool) -> Result<LoggingHandle> {
             filter,
             builder.json().with_writer(std::io::stdout),
             enable_profiling,
+            enable_telemetry,
             config,
         ),
         (LogFormat::Json, LogOutput::Stderr) => init_subscriber(
             filter,
             builder.json().with_writer(std::io::stderr),
             enable_profiling,
+            enable_telemetry,
             config,
         ),
         (LogFormat::Text, LogOutput::Stdout) => init_subscriber(
             filter,
             builder.with_writer(std::io::stdout),
             enable_profiling,
+            enable_telemetry,
             config,
         ),
         (LogFormat::Text, LogOutput::Stderr) => init_subscriber(
             filter,
             builder.with_writer(std::io::stderr),
             enable_profiling,
+            enable_telemetry,
             config,
         ),
     }
@@ -135,6 +149,7 @@ fn init_subscriber<L>(
     filter: EnvFilter,
     fmt_layer: L,
     enable_profiling: bool,
+    enable_telemetry: bool,
     config: &Config,
 ) -> Result<LoggingHandle>
 where
@@ -148,12 +163,13 @@ where
     }
 
     // Telemetry init. Mirrors Go's default-on behavior: when compiled with
-    // `--features otel`, the exporter is active unless `--no-telemetry` /
-    // `DEFRA_NO_TELEMETRY` / `telemetry_disabled` opts out. If exporter
-    // construction fails (e.g. malformed env var), we log and continue with
-    // no telemetry — matches Go's `log.ErrorContextE` + continue path.
+    // `--features otel`, the exporter is active for the `start` command
+    // (enable_telemetry) unless `--no-telemetry` / `DEFRA_NO_TELEMETRY` /
+    // `telemetry_disabled` opts out. If exporter construction fails (e.g.
+    // malformed env var), we log and continue with no telemetry — matches
+    // Go's `log.ErrorContextE` + continue path.
     #[cfg(feature = "otel")]
-    let (telemetry_handle, tracer) = if config.telemetry_disabled {
+    let (telemetry_handle, tracer) = if config.telemetry_disabled || !enable_telemetry {
         (telemetry::TelemetryHandle::noop(), None)
     } else {
         // Source the service version from defra-version so OTLP receivers see
@@ -173,7 +189,7 @@ where
 
     #[cfg(not(feature = "otel"))]
     let telemetry_handle = {
-        let _ = config; // suppress unused-binding warning when otel is off
+        let _ = (config, enable_telemetry); // unused when otel is off
         telemetry::TelemetryHandle::noop()
     };
 

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -37,6 +37,7 @@ fn with_default_transport_noise_filters(filter: EnvFilter) -> EnvFilter {
 pub struct LoggingHandle {
     #[cfg(feature = "profiling")]
     profiling: Option<ProfilingTrace>,
+    telemetry: telemetry::TelemetryHandle,
 }
 
 #[cfg(feature = "profiling")]
@@ -46,17 +47,19 @@ struct ProfilingTrace {
 }
 
 impl LoggingHandle {
-    fn none() -> Self {
+    fn new(telemetry: telemetry::TelemetryHandle) -> Self {
         Self {
             #[cfg(feature = "profiling")]
             profiling: None,
+            telemetry,
         }
     }
 
     #[cfg(feature = "profiling")]
-    fn with_profile(profiling: ProfilingTrace) -> Self {
+    fn with_profile(profiling: ProfilingTrace, telemetry: telemetry::TelemetryHandle) -> Self {
         Self {
             profiling: Some(profiling),
+            telemetry,
         }
     }
 
@@ -67,6 +70,7 @@ impl LoggingHandle {
             drop(profiling.guard);
             eprintln!("Chrome trace written to {}", path.display());
         }
+        self.telemetry.shutdown();
     }
 }
 
@@ -102,21 +106,25 @@ pub fn init(config: &Config, enable_profiling: bool) -> Result<LoggingHandle> {
             filter,
             builder.json().with_writer(std::io::stdout),
             enable_profiling,
+            config,
         ),
         (LogFormat::Json, LogOutput::Stderr) => init_subscriber(
             filter,
             builder.json().with_writer(std::io::stderr),
             enable_profiling,
+            config,
         ),
         (LogFormat::Text, LogOutput::Stdout) => init_subscriber(
             filter,
             builder.with_writer(std::io::stdout),
             enable_profiling,
+            config,
         ),
         (LogFormat::Text, LogOutput::Stderr) => init_subscriber(
             filter,
             builder.with_writer(std::io::stderr),
             enable_profiling,
+            config,
         ),
     }
 }
@@ -125,6 +133,7 @@ fn init_subscriber<L>(
     filter: EnvFilter,
     fmt_layer: L,
     enable_profiling: bool,
+    config: &Config,
 ) -> Result<LoggingHandle>
 where
     L: tracing_subscriber::Layer<Registry> + Send + Sync + 'static,
@@ -136,26 +145,61 @@ where
         ));
     }
 
+    // Telemetry init. Mirrors Go's default-on behavior: when compiled with
+    // `--features otel`, the exporter is active unless `--no-telemetry` /
+    // `DEFRA_NO_TELEMETRY` / `telemetry_disabled` opts out. If exporter
+    // construction fails (e.g. malformed env var), we log and continue with
+    // no telemetry — matches Go's `log.ErrorContextE` + continue path.
+    #[cfg(feature = "otel")]
+    let (telemetry_handle, tracer) = if config.telemetry_disabled {
+        (telemetry::TelemetryHandle::noop(), None)
+    } else {
+        match telemetry::init(telemetry::TelemetryConfig::default()) {
+            Ok((handle, tracer)) => (handle, Some(tracer)),
+            Err(err) => {
+                eprintln!(
+                    "warning: failed to configure OpenTelemetry, continuing without telemetry: {err}"
+                );
+                (telemetry::TelemetryHandle::noop(), None)
+            }
+        }
+    };
+
+    #[cfg(not(feature = "otel"))]
+    let telemetry_handle = {
+        let _ = config; // suppress unused-binding warning when otel is off
+        telemetry::TelemetryHandle::noop()
+    };
+
+    // Suppress repeat "connection refused" spam from OTEL exporter target.
+    // Only attach when otel feature is on (otherwise no events to dedup).
+    #[cfg(feature = "otel")]
+    let fmt_layer = fmt_layer.with_filter(telemetry::OtelDedupFilter::new());
+
     #[cfg(feature = "profiling")]
     if enable_profiling {
-        let (chrome_layer, profiling) =
-            build_chrome_layer::<tracing_subscriber::layer::Layered<L, Registry>>()?;
-        tracing_subscriber::registry()
+        let (chrome_layer, profiling) = build_chrome_layer()?;
+        let registry = tracing_subscriber::registry()
             .with(fmt_layer)
-            .with(chrome_layer)
+            .with(chrome_layer);
+        #[cfg(feature = "otel")]
+        let registry = registry.with(tracer.map(telemetry::otel_layer));
+        registry
             .with(filter)
             .try_init()
             .map_err(|error| Error::LoggingInit(error.to_string()))?;
-        return Ok(LoggingHandle::with_profile(profiling));
+        return Ok(LoggingHandle::with_profile(profiling, telemetry_handle));
     }
 
-    tracing_subscriber::registry()
-        .with(fmt_layer)
+    let registry = tracing_subscriber::registry().with(fmt_layer);
+    #[cfg(feature = "otel")]
+    let registry = registry.with(tracer.map(telemetry::otel_layer));
+    registry
         .with(filter)
         .try_init()
         .map_err(|error| Error::LoggingInit(error.to_string()))?;
 
-    Ok(LoggingHandle::none())
+    Ok(LoggingHandle::new(telemetry_handle))
 }
 
 #[cfg(feature = "profiling")]

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -6,6 +6,8 @@ use tracing_subscriber::layer::SubscriberExt;
 #[cfg(feature = "profiling")]
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
+#[cfg(feature = "otel")]
+use tracing_subscriber::Layer;
 use tracing_subscriber::{EnvFilter, Registry};
 
 #[cfg(feature = "profiling")]
@@ -175,19 +177,28 @@ where
         telemetry::TelemetryHandle::noop()
     };
 
-    // Suppress repeat "connection refused" spam from OTEL exporter target.
-    // Only attach when otel feature is on (otherwise no events to dedup).
+    // Suppress repeat exporter-unreachable spam on every layer that ingests
+    // OTel events. Each layer gets its own filter instance because Filter
+    // is a per-layer hook — sharing state via Arc would interleave the
+    // first-event decision across layers (first layer wins the lock,
+    // second layer sees the event as already-suppressed). With independent
+    // per-layer instances each layer logs the first occurrence and
+    // suppresses the rest.
     #[cfg(feature = "otel")]
     let fmt_layer = fmt_layer.with_filter(telemetry::OtelDedupFilter::new());
 
     #[cfg(feature = "profiling")]
     if enable_profiling {
         let (chrome_layer, profiling) = build_chrome_layer()?;
+        #[cfg(feature = "otel")]
+        let chrome_layer = chrome_layer.with_filter(telemetry::OtelDedupFilter::new());
         let registry = tracing_subscriber::registry()
             .with(fmt_layer)
             .with(chrome_layer);
         #[cfg(feature = "otel")]
-        let registry = registry.with(tracer.map(telemetry::otel_layer));
+        let registry = registry.with(
+            tracer.map(|t| telemetry::otel_layer(t).with_filter(telemetry::OtelDedupFilter::new())),
+        );
         registry
             .with(filter)
             .try_init()
@@ -197,7 +208,9 @@ where
 
     let registry = tracing_subscriber::registry().with(fmt_layer);
     #[cfg(feature = "otel")]
-    let registry = registry.with(tracer.map(telemetry::otel_layer));
+    let registry = registry.with(
+        tracer.map(|t| telemetry::otel_layer(t).with_filter(telemetry::OtelDedupFilter::new())),
+    );
     registry
         .with(filter)
         .try_init()

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -186,10 +186,14 @@ where
     let (telemetry_handle, tracer) = if config.telemetry_disabled || !enable_telemetry {
         (telemetry::TelemetryHandle::noop(), None)
     } else {
-        // Source the service version from defra-version so OTLP receivers see
-        // the actual defra binary version, not the telemetry crate's own.
-        let telemetry_config =
-            telemetry::TelemetryConfig::new("DefraDB", defra_version::VersionInfo::new().version);
+        // Source a Go-style descriptive build string for service.version
+        // (`defradb <ver> (<commit8> <date>) built with ...`) so OTLP
+        // receivers grouping on service.version see the same shape Go emits,
+        // not the telemetry crate's bare semver.
+        let telemetry_config = telemetry::TelemetryConfig::new(
+            "DefraDB",
+            defra_version::VersionInfo::new().descriptive(),
+        );
         match telemetry::init(telemetry_config) {
             Ok((handle, tracer)) => (handle, Some(tracer)),
             Err(err) => {
@@ -207,13 +211,11 @@ where
         telemetry::TelemetryHandle::noop()
     };
 
-    // Suppress repeat exporter-unreachable spam on every layer that ingests
-    // OTel events. Each layer gets its own filter instance because Filter
-    // is a per-layer hook — sharing state via Arc would interleave the
-    // first-event decision across layers (first layer wins the lock,
-    // second layer sees the event as already-suppressed). With independent
-    // per-layer instances each layer logs the first occurrence and
-    // suppresses the rest.
+    // Suppress exporter-unreachable spam on every layer that ingests OTel
+    // events. The filter is stateless and the one-shot operator hint it
+    // emits is guarded by a process-global latch, so attaching a fresh
+    // instance to each layer is fine — the hint still appears exactly once
+    // across all of them.
     #[cfg(feature = "otel")]
     let fmt_layer = fmt_layer.with_filter(telemetry::OtelDedupFilter::new());
 

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -22,6 +22,20 @@ use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
 use crate::config::{Config, LogFormat, LogLevel, LogOutput};
 use crate::error::{Error, Result};
 
+/// Build the OTLP bridge layer paired with a fresh dedup filter, for a given
+/// inner-subscriber type `S`. Generic over `S` because the registry's type
+/// differs between the profiling (fmt + chrome) and non-profiling (fmt only)
+/// branches — a plain `let` binding would fix `S` at first use and fail at
+/// the second, which is why this is a function rather than a hoisted local.
+/// Returns `None` when no tracer was configured (telemetry off/failed).
+#[cfg(feature = "otel")]
+fn otel_dedup_layer<S>(tracer: Option<telemetry::Tracer>) -> Option<impl Layer<S>>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    tracer.map(|t| telemetry::otel_layer(t).with_filter(telemetry::OtelDedupFilter::new()))
+}
+
 fn with_default_transport_noise_filters(filter: EnvFilter) -> EnvFilter {
     filter
         .add_directive(
@@ -212,9 +226,7 @@ where
             .with(fmt_layer)
             .with(chrome_layer);
         #[cfg(feature = "otel")]
-        let registry = registry.with(
-            tracer.map(|t| telemetry::otel_layer(t).with_filter(telemetry::OtelDedupFilter::new())),
-        );
+        let registry = registry.with(otel_dedup_layer(tracer));
         registry
             .with(filter)
             .try_init()
@@ -224,9 +236,7 @@ where
 
     let registry = tracing_subscriber::registry().with(fmt_layer);
     #[cfg(feature = "otel")]
-    let registry = registry.with(
-        tracer.map(|t| telemetry::otel_layer(t).with_filter(telemetry::OtelDedupFilter::new())),
-    );
+    let registry = registry.with(otel_dedup_layer(tracer));
     registry
         .with(filter)
         .try_init()

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -30,8 +30,10 @@ async fn run() -> Result<()> {
     // Load configuration (flags → env → config file → defaults)
     let config = Config::load(&cli)?;
 
-    // Initialize logging based on config
-    let logging = cli::logging::init(&config, should_profile(&cli))?;
+    // Initialize logging based on config. Telemetry only initializes for the
+    // `start` command (matching Go, which configures it only in start.go) so
+    // ephemeral commands like `version` / `client` don't spin up the exporter.
+    let logging = cli::logging::init(&config, should_profile(&cli), enable_telemetry(&cli))?;
 
     // Execute the command
     let result = cli.execute(config).await;
@@ -41,4 +43,8 @@ async fn run() -> Result<()> {
 
 fn should_profile(cli: &Cli) -> bool {
     matches!(&cli.command, Command::Start(args) if args.profile)
+}
+
+fn enable_telemetry(cli: &Cli) -> bool {
+    matches!(&cli.command, Command::Start(_))
 }

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -28,6 +28,7 @@ fn cli_with_defaults() -> Cli {
         source_hub_chain_id: None,
         hub_rs_address: None,
         secret_file: None,
+        no_telemetry: None,
         development: None,
         acp_node_enable: None,
         acp_document_type: None,

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -60,8 +60,14 @@ fn test_apply_cli_flags_no_telemetry_sets_telemetry_disabled() {
 }
 
 #[test]
-fn test_apply_cli_flags_no_telemetry_false_leaves_telemetry_enabled() {
-    let mut config = Config::default();
+fn test_apply_cli_flags_no_telemetry_false_re_enables_telemetry() {
+    // Seed with telemetry_disabled = true (e.g. from a config file) so the
+    // assertion actually exercises the write path: a CLI `--no-telemetry=false`
+    // must be able to override a disabled config back to enabled.
+    let mut config = Config {
+        telemetry_disabled: true,
+        ..Config::default()
+    };
     let mut cli = cli_with_defaults();
     cli.no_telemetry = Some(false);
 
@@ -70,7 +76,7 @@ fn test_apply_cli_flags_no_telemetry_false_leaves_telemetry_enabled() {
         .expect("apply_cli_flags should succeed");
     assert!(
         !config.telemetry_disabled,
-        "--no-telemetry=false should not flip config.telemetry_disabled"
+        "--no-telemetry=false should override a disabled config back to enabled"
     );
 }
 

--- a/crates/cli/tests/config_tests.rs
+++ b/crates/cli/tests/config_tests.rs
@@ -40,6 +40,41 @@ fn cli_with_defaults() -> Cli {
 }
 
 #[test]
+fn test_apply_cli_flags_no_telemetry_sets_telemetry_disabled() {
+    // Coverage for the global Cli::no_telemetry → config.telemetry_disabled
+    // plumbing. Issue #977 deleted the duplicate StartArgs version (which
+    // had its own assertion in start_tests.rs); this is the replacement
+    // covering the canonical path.
+    let mut config = Config::default();
+    assert!(!config.telemetry_disabled, "default expected to be false");
+    let mut cli = cli_with_defaults();
+    cli.no_telemetry = Some(true);
+
+    config
+        .apply_cli_flags(&cli)
+        .expect("apply_cli_flags should succeed");
+    assert!(
+        config.telemetry_disabled,
+        "--no-telemetry / DEFRA_NO_TELEMETRY=true should flip config.telemetry_disabled"
+    );
+}
+
+#[test]
+fn test_apply_cli_flags_no_telemetry_false_leaves_telemetry_enabled() {
+    let mut config = Config::default();
+    let mut cli = cli_with_defaults();
+    cli.no_telemetry = Some(false);
+
+    config
+        .apply_cli_flags(&cli)
+        .expect("apply_cli_flags should succeed");
+    assert!(
+        !config.telemetry_disabled,
+        "--no-telemetry=false should not flip config.telemetry_disabled"
+    );
+}
+
+#[test]
 fn test_apply_cli_flags_invalid_log_level_returns_error() {
     let mut config = Config::default();
     let mut cli = cli_with_defaults();

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -17,7 +17,6 @@ fn default_start_args() -> StartArgs {
         pubkeypath: None,
         privkeypath: None,
         no_encryption: None,
-        no_telemetry: None,
         no_signing: None,
         default_key_type: None,
         no_searchable_encryption: None,
@@ -124,7 +123,6 @@ fn test_apply_to_config_all_flags() {
         pubkeypath: Some("/path/to/pub.key".to_string()),
         privkeypath: Some("/path/to/priv.key".to_string()),
         no_encryption: Some(true),
-        no_telemetry: Some(true),
         no_signing: Some(true),
         default_key_type: Some("ed25519".to_string()),
         no_searchable_encryption: Some(true),
@@ -198,7 +196,6 @@ fn test_apply_to_config_all_flags() {
     assert_eq!(config.api.pubkey_path, "/path/to/pub.key");
     assert_eq!(config.api.privkey_path, "/path/to/priv.key");
     assert!(config.datastore.no_encryption);
-    assert!(config.telemetry_disabled);
     assert!(config.datastore.no_signing);
     assert_eq!(config.datastore.default_key_type, "ed25519");
     assert!(config.datastore.no_searchable_encryption);

--- a/crates/cli/tests/telemetry_dedup.rs
+++ b/crates/cli/tests/telemetry_dedup.rs
@@ -1,0 +1,158 @@
+//! End-to-end dedup test for the OTLP exporter (issue #977, follow-up #1004).
+//!
+//! Docker-free Rust-native port of `tools/otel-smoke/dedup.sh`: spawn the
+//! real `defra` binary (built with `--features otel`) pointed at an
+//! unreachable collector, drive a GraphQL query to produce an exported span,
+//! and assert that:
+//!   - the operator hint is emitted exactly once (proves the SDK's
+//!     `internal-logs` feature is on AND the dedup fires — this is the
+//!     regression guard), and
+//!   - the raw, repeated SDK export errors are suppressed (Go parity).
+//!
+//! Only meaningful when telemetry is compiled in, so the whole test is gated
+//! on the `otel` feature. Run with: `cargo test -p cli --features otel`.
+
+#![cfg(feature = "otel")]
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const HINT: &str =
+    "OpenTelemetry export failed, ensure your OTLP collector is running and reachable";
+
+/// Drain a child's piped stderr into a shared string on a background thread,
+/// so the child never blocks on a full pipe buffer.
+fn drain_stderr(stderr: std::process::ChildStderr) -> Arc<Mutex<String>> {
+    let buf = Arc::new(Mutex::new(String::new()));
+    let buf_thread = Arc::clone(&buf);
+    std::thread::spawn(move || {
+        let mut rdr = stderr;
+        let mut chunk = [0u8; 4096];
+        loop {
+            match rdr.read(&mut chunk) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    if let Ok(mut s) = buf_thread.lock() {
+                        s.push_str(&String::from_utf8_lossy(&chunk[..n]));
+                    }
+                }
+            }
+        }
+    });
+    buf
+}
+
+fn wait_for_port(port: u16, child: &mut std::process::Child) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return true;
+        }
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return false; // exited early
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+/// Fire a GraphQL query over a raw TCP socket. The `query.execute_request`
+/// span it produces is info-level, so it survives the default env filter and
+/// reaches the OTLP exporter (a plain HTTP GET would only make a debug-level
+/// span, which the filter drops before export).
+fn send_graphql(port: u16) {
+    let body = r#"{"query":"query { __typename }"}"#;
+    let req = format!(
+        "POST /api/v0/graphql HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    if let Ok(mut s) = TcpStream::connect(("127.0.0.1", port)) {
+        let _ = s.write_all(req.as_bytes());
+        let mut resp = String::new();
+        let _ = s.read_to_string(&mut resp);
+    }
+}
+
+#[test]
+fn exporter_unreachable_logs_hint_once_and_suppresses_raw() {
+    let http_port = portpicker::pick_unused_port().expect("free http port");
+    // A port nobody listens on → the HTTP exporter fails to reach it.
+    let dead_otlp_port = portpicker::pick_unused_port().expect("free otlp port");
+    let rootdir = tempfile::tempdir().expect("tempdir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_defra"))
+        .arg("start")
+        .arg("--rootdir")
+        .arg(rootdir.path())
+        .arg("--no-keyring")
+        .arg("--no-p2p")
+        .arg("--store")
+        .arg("memory")
+        .arg("--url")
+        .arg(format!("127.0.0.1:{http_port}"))
+        .env(
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            format!("http://127.0.0.1:{dead_otlp_port}"),
+        )
+        .env("OTEL_BSP_SCHEDULE_DELAY", "300") // ms — provoke export quickly
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn defra");
+
+    let stderr = drain_stderr(child.stderr.take().expect("piped stderr"));
+
+    let ready = wait_for_port(http_port, &mut child);
+    if !ready {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!(
+            "defra did not start serving on :{http_port}\n--- stderr ---\n{}",
+            stderr.lock().unwrap()
+        );
+    }
+
+    // Drive a few queries so the batch processor has spans to export, then
+    // give it time to attempt (and fail) an export and emit the hint.
+    for _ in 0..5 {
+        send_graphql(http_port);
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    std::thread::sleep(Duration::from_secs(2));
+
+    let _ = child.kill();
+    let _ = child.wait();
+    // Let the drain thread flush the tail of the pipe.
+    std::thread::sleep(Duration::from_millis(200));
+
+    let captured = stderr.lock().unwrap().clone();
+
+    let hint_count = captured.matches(HINT).count();
+    assert_eq!(
+        hint_count, 1,
+        "expected the operator hint exactly once (0 = internal-logs off / dedup dead; >1 = global once-latch broken).\n--- stderr ---\n{captured}"
+    );
+
+    // The raw SDK export-error lines must be suppressed in favor of the hint.
+    // (The single hint line itself carries the detail, so exclude it before
+    // counting raw lines.)
+    let raw_error_lines = captured
+        .lines()
+        .filter(|l| !l.contains(HINT))
+        .filter(|l| l.contains("ERROR"))
+        .filter(|l| l.contains("opentelemetry"))
+        .filter(|l| {
+            l.contains("connection refused")
+                || l.contains("HTTP export failed")
+                || l.contains("network error")
+        })
+        .count();
+    assert_eq!(
+        raw_error_lines, 0,
+        "raw exporter-error lines should be suppressed; found {raw_error_lines}.\n--- stderr ---\n{captured}"
+    );
+}

--- a/crates/cli/tests/telemetry_dedup.rs
+++ b/crates/cli/tests/telemetry_dedup.rs
@@ -81,7 +81,12 @@ fn send_graphql(port: u16) {
 fn exporter_unreachable_logs_hint_once_and_suppresses_raw() {
     let http_port = portpicker::pick_unused_port().expect("free http port");
     // A port nobody listens on → the HTTP exporter fails to reach it.
-    let dead_otlp_port = portpicker::pick_unused_port().expect("free otlp port");
+    // Guard against portpicker handing back the same port twice (the two
+    // calls bind-and-release independently, so equality is possible).
+    let dead_otlp_port = std::iter::repeat_with(portpicker::pick_unused_port)
+        .flatten()
+        .find(|&p| p != http_port)
+        .expect("free otlp port distinct from http port");
     let rootdir = tempfile::tempdir().expect("tempdir");
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_defra"))
@@ -99,6 +104,12 @@ fn exporter_unreachable_logs_hint_once_and_suppresses_raw() {
             format!("http://127.0.0.1:{dead_otlp_port}"),
         )
         .env("OTEL_BSP_SCHEDULE_DELAY", "300") // ms — provoke export quickly
+        // Pin the log level so the INFO-level `query.execute_request` span
+        // (which drives the export we're testing) survives the env filter.
+        // An inherited RUST_LOG/DEFRA_LOG_LEVEL=error would drop it and make
+        // the hint count 0 — a false failure.
+        .env("DEFRA_LOG_LEVEL", "info")
+        .env_remove("RUST_LOG")
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -17,6 +17,10 @@ http = ["dep:defra-http", "dep:axum"]
 p2p = ["dep:p2p", "dep:blockstore", "dep:defra-http", "dep:defra-p2p-adapter"]
 redb = ["storage/redb"]
 rocksdb = ["storage/rocksdb"]
+# Compile in OpenTelemetry exporter support. Mirrors the CLI's `otel` feature
+# and the underlying `telemetry/otlp` gate. Off by default — embedded users
+# who want OTel must opt in.
+otel = ["dep:telemetry", "telemetry/otlp"]
 
 [dependencies]
 db = { path = "../db" }
@@ -48,6 +52,9 @@ defra-http = { path = "../http", optional = true }
 p2p = { path = "../p2p", optional = true, features = ["iroh-transport"] }
 blockstore = { path = "../blockstore", optional = true }
 defra-p2p-adapter = { workspace = true, optional = true, default-features = false, features = ["iroh"] }
+
+# Optional — OpenTelemetry exporter (see the `otel` feature)
+telemetry = { path = "../telemetry", optional = true, default-features = false }
 
 [dev-dependencies]
 axum.workspace = true

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -388,6 +388,13 @@ impl EmbeddedNode {
     }
 
     /// Gracefully stop background services owned by this embedded node.
+    ///
+    /// **The node should not be used after this call.** When the `otel`
+    /// feature is on, `shutdown` calls `TelemetryHandle::shutdown` which
+    /// flushes and disables the global tracer provider. Subsequent calls
+    /// that emit spans (e.g. `execute`, `add_schema`) go to a no-op
+    /// tracer — they still work functionally, but observability is gone
+    /// with no error surfaced. Drop the node after shutdown completes.
     pub async fn shutdown(&self) {
         #[cfg(feature = "http")]
         if let Some(task) = self.txn_cleanup_task.lock().await.take() {

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -48,6 +48,8 @@ pub use lens::{LensConfig, LensModule, TransformId};
 pub use query::QueryLimits;
 pub use query::{QueryExecutor, QueryRequest, QueryResponse};
 pub use schema::CollectionVersion;
+#[cfg(feature = "otel")]
+pub use telemetry::{TelemetryConfig, TelemetryHandle};
 
 /// Type-erased schema operations so we can store DB<S> without leaking the Store generic.
 #[async_trait::async_trait]
@@ -83,6 +85,8 @@ pub struct EmbeddedNode {
     p2p_ops: Option<Arc<dyn defra_http::P2POperations>>,
     #[cfg(feature = "p2p")]
     p2p_lifecycle: Option<P2PLifecycle>,
+    #[cfg(feature = "otel")]
+    telemetry: std::sync::Mutex<Option<TelemetryHandle>>,
 }
 
 #[cfg(feature = "p2p")]
@@ -395,6 +399,20 @@ impl EmbeddedNode {
         if let Some(lifecycle) = &self.p2p_lifecycle {
             lifecycle.shutdown().await;
         }
+
+        // Flush buffered spans / metrics. Done after P2P shutdown so trailing
+        // shutdown spans are still captured. Go DefraDB never calls provider
+        // shutdown — we don't repeat that bug.
+        #[cfg(feature = "otel")]
+        {
+            let handle = match self.telemetry.lock() {
+                Ok(mut guard) => guard.take(),
+                Err(poisoned) => poisoned.into_inner().take(),
+            };
+            if let Some(handle) = handle {
+                handle.shutdown();
+            }
+        }
     }
 }
 
@@ -509,6 +527,17 @@ pub struct NodeBuilder {
     http_config: Option<HttpConfig>,
     #[cfg(feature = "p2p")]
     p2p_config: Option<P2PConfig>,
+    #[cfg(feature = "otel")]
+    telemetry_setup: Option<TelemetrySetup>,
+}
+
+/// Two ways an embedded user can wire OpenTelemetry: let `NodeBuilder` call
+/// `telemetry::init` for them at `build()` time, or hand in a handle they
+/// already built (so they can compose their own subscriber chain first).
+#[cfg(feature = "otel")]
+enum TelemetrySetup {
+    Owned(TelemetryConfig),
+    External(TelemetryHandle),
 }
 
 struct StoreBuildArgs {
@@ -523,6 +552,8 @@ struct StoreBuildArgs {
     transaction_cleanup_config: Option<TransactionCleanupConfig>,
     #[cfg(feature = "p2p")]
     p2p_config: Option<P2PConfig>,
+    #[cfg(feature = "otel")]
+    telemetry_handle: Option<TelemetryHandle>,
 }
 
 impl NodeBuilder {
@@ -604,6 +635,31 @@ impl NodeBuilder {
         self
     }
 
+    /// Enable OpenTelemetry exporters owned by the node. The handle's
+    /// `shutdown()` is called from [`EmbeddedNode::shutdown`].
+    ///
+    /// This does **not** install a `tracing` subscriber — the caller's
+    /// subscriber needs the OTel bridge layer composed onto it for spans
+    /// to flow. See [`telemetry::otel_layer`] and the crate docs for the
+    /// pattern. If you already have a configured subscriber and just want
+    /// the node to own shutdown, use [`Self::with_external_telemetry`].
+    #[cfg(feature = "otel")]
+    pub fn with_telemetry(mut self, config: TelemetryConfig) -> Self {
+        self.telemetry_setup = Some(TelemetrySetup::Owned(config));
+        self
+    }
+
+    /// Hand a pre-built telemetry handle to the node so it owns shutdown.
+    /// The caller is responsible for `telemetry::init` and subscriber
+    /// composition; this method just hooks lifetime to the node. Intended
+    /// for consumers (e.g. defra-agent) that run their own OTel stack and
+    /// don't want `NodeBuilder` touching globals.
+    #[cfg(feature = "otel")]
+    pub fn with_external_telemetry(mut self, handle: TelemetryHandle) -> Self {
+        self.telemetry_setup = Some(TelemetrySetup::External(handle));
+        self
+    }
+
     /// Build and start the embedded DefraDB node.
     pub async fn build(self) -> anyhow::Result<EmbeddedNode> {
         let node_identity_did = self.node_identity_did.clone();
@@ -661,6 +717,21 @@ impl NodeBuilder {
         let query_timeout = self.query_timeout;
         let query_limits = self.query_limits;
 
+        // Resolve the telemetry handle (lazy-init the owned variant — we
+        // need a Tokio runtime, which is guaranteed here since build() is
+        // async). Threaded through StoreBuildArgs to the actual EmbeddedNode
+        // construction site.
+        #[cfg(feature = "otel")]
+        let telemetry_handle: Option<TelemetryHandle> = match self.telemetry_setup {
+            Some(TelemetrySetup::Owned(config)) => {
+                let (handle, _tracer) = telemetry::init(config)
+                    .map_err(|e| anyhow::anyhow!("telemetry init failed: {e}"))?;
+                Some(handle)
+            }
+            Some(TelemetrySetup::External(handle)) => Some(handle),
+            None => None,
+        };
+
         // 3. Storage backend + database
         let node = if let Some(path) = self.data_path {
             tokio::fs::create_dir_all(&path).await?;
@@ -696,6 +767,8 @@ impl NodeBuilder {
                             transaction_cleanup_config,
                             #[cfg(feature = "p2p")]
                             p2p_config,
+                            #[cfg(feature = "otel")]
+                            telemetry_handle,
                         },
                     )
                     .await?
@@ -729,6 +802,8 @@ impl NodeBuilder {
                             transaction_cleanup_config,
                             #[cfg(feature = "p2p")]
                             p2p_config,
+                            #[cfg(feature = "otel")]
+                            telemetry_handle,
                         },
                     )
                     .await?
@@ -763,6 +838,8 @@ impl NodeBuilder {
                     transaction_cleanup_config,
                     #[cfg(feature = "p2p")]
                     p2p_config,
+                    #[cfg(feature = "otel")]
+                    telemetry_handle,
                 },
             )
             .await?
@@ -851,6 +928,8 @@ impl NodeBuilder {
             transaction_cleanup_config,
             #[cfg(feature = "p2p")]
             p2p_config,
+            #[cfg(feature = "otel")]
+            telemetry_handle,
         } = args;
 
         let embedding_config = db_options.embedding_config();
@@ -958,6 +1037,8 @@ impl NodeBuilder {
             p2p_ops,
             #[cfg(feature = "p2p")]
             p2p_lifecycle,
+            #[cfg(feature = "otel")]
+            telemetry: std::sync::Mutex::new(telemetry_handle),
         })
     }
 

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -528,16 +528,7 @@ pub struct NodeBuilder {
     #[cfg(feature = "p2p")]
     p2p_config: Option<P2PConfig>,
     #[cfg(feature = "otel")]
-    telemetry_setup: Option<TelemetrySetup>,
-}
-
-/// Two ways an embedded user can wire OpenTelemetry: let `NodeBuilder` call
-/// `telemetry::init` for them at `build()` time, or hand in a handle they
-/// already built (so they can compose their own subscriber chain first).
-#[cfg(feature = "otel")]
-enum TelemetrySetup {
-    Owned(TelemetryConfig),
-    External(TelemetryHandle),
+    telemetry_handle: Option<TelemetryHandle>,
 }
 
 struct StoreBuildArgs {
@@ -635,28 +626,20 @@ impl NodeBuilder {
         self
     }
 
-    /// Enable OpenTelemetry exporters owned by the node. The handle's
-    /// `shutdown()` is called from [`EmbeddedNode::shutdown`].
-    ///
-    /// This does **not** install a `tracing` subscriber — the caller's
-    /// subscriber needs the OTel bridge layer composed onto it for spans
-    /// to flow. See [`telemetry::otel_layer`] and the crate docs for the
-    /// pattern. If you already have a configured subscriber and just want
-    /// the node to own shutdown, use [`Self::with_external_telemetry`].
-    #[cfg(feature = "otel")]
-    pub fn with_telemetry(mut self, config: TelemetryConfig) -> Self {
-        self.telemetry_setup = Some(TelemetrySetup::Owned(config));
-        self
-    }
-
     /// Hand a pre-built telemetry handle to the node so it owns shutdown.
-    /// The caller is responsible for `telemetry::init` and subscriber
-    /// composition; this method just hooks lifetime to the node. Intended
-    /// for consumers (e.g. defra-agent) that run their own OTel stack and
-    /// don't want `NodeBuilder` touching globals.
+    ///
+    /// The caller is responsible for calling [`telemetry::init`] and
+    /// composing the bridge layer onto their `tracing` subscriber — this
+    /// method just transfers ownership of the lifecycle handle so the node
+    /// flushes providers when it shuts down. Because the handle is moved,
+    /// calling this twice is a compile error rather than a silent overwrite.
+    ///
+    /// For a one-call ergonomic version, callers can write
+    /// `.with_telemetry(telemetry::init(cfg)?.0)` — `init` requires a Tokio
+    /// runtime and returns `(TelemetryHandle, SdkTracer)`.
     #[cfg(feature = "otel")]
-    pub fn with_external_telemetry(mut self, handle: TelemetryHandle) -> Self {
-        self.telemetry_setup = Some(TelemetrySetup::External(handle));
+    pub fn with_telemetry(mut self, handle: TelemetryHandle) -> Self {
+        self.telemetry_handle = Some(handle);
         self
     }
 
@@ -717,20 +700,12 @@ impl NodeBuilder {
         let query_timeout = self.query_timeout;
         let query_limits = self.query_limits;
 
-        // Resolve the telemetry handle (lazy-init the owned variant — we
-        // need a Tokio runtime, which is guaranteed here since build() is
-        // async). Threaded through StoreBuildArgs to the actual EmbeddedNode
-        // construction site.
+        // Telemetry handle (if any) was moved into the builder via
+        // `with_telemetry`. Threaded through `StoreBuildArgs` to the
+        // `EmbeddedNode` construction site so its Drop / explicit
+        // `shutdown()` runs at the right point.
         #[cfg(feature = "otel")]
-        let telemetry_handle: Option<TelemetryHandle> = match self.telemetry_setup {
-            Some(TelemetrySetup::Owned(config)) => {
-                let (handle, _tracer) = telemetry::init(config)
-                    .map_err(|e| anyhow::anyhow!("telemetry init failed: {e}"))?;
-                Some(handle)
-            }
-            Some(TelemetrySetup::External(handle)) => Some(handle),
-            None => None,
-        };
+        let telemetry_handle: Option<TelemetryHandle> = self.telemetry_handle;
 
         // 3. Storage backend + database
         let node = if let Some(path) = self.data_path {

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -410,6 +410,10 @@ impl EmbeddedNode {
         // Flush buffered spans / metrics. Done after P2P shutdown so trailing
         // shutdown spans are still captured. Go DefraDB never calls provider
         // shutdown — we don't repeat that bug.
+        //
+        // `handle.shutdown()` synchronously joins the SDK batch-exporter
+        // thread (up to ~5 s, double with metrics), so run it on a blocking
+        // thread rather than stalling this Tokio worker / reactor.
         #[cfg(feature = "otel")]
         {
             let handle = match self.telemetry.lock() {
@@ -417,7 +421,7 @@ impl EmbeddedNode {
                 Err(poisoned) => poisoned.into_inner().take(),
             };
             if let Some(handle) = handle {
-                handle.shutdown();
+                let _ = tokio::task::spawn_blocking(move || handle.shutdown()).await;
             }
         }
     }

--- a/crates/defra-version/src/lib.rs
+++ b/crates/defra-version/src/lib.rs
@@ -58,6 +58,20 @@ impl VersionInfo {
         format!("defradb {}", self.version)
     }
 
+    /// Single-line descriptive build string, used as the OTLP
+    /// `service.version` resource attribute. Mirrors the shape of Go
+    /// DefraDB's version string (`defradb <ver> (<commit8> <date>) built
+    /// with ...`) so a collector grouping on `service.version` sees the
+    /// same cardinality/format across the two implementations. The commit
+    /// is truncated to 8 chars to match Go.
+    pub fn descriptive(&self) -> String {
+        let commit8: String = self.commit.chars().take(8).collect();
+        format!(
+            "defradb {} ({} {}) built with {}",
+            self.version, commit8, self.commit_date, self.rust
+        )
+    }
+
     /// Full human-readable text output.
     pub fn full(&self) -> String {
         let mut out = format!(
@@ -106,6 +120,16 @@ mod tests {
     fn short_format() {
         let info = VersionInfo::new();
         assert!(info.short().starts_with("defradb "));
+    }
+
+    #[test]
+    fn descriptive_format_matches_go_shape() {
+        let info = VersionInfo::new();
+        let d = info.descriptive();
+        // `defradb <ver> (<commit8> <date>) built with <rust>`
+        assert!(d.starts_with(&format!("defradb {} (", info.version)));
+        assert!(d.contains(") built with "));
+        assert!(d.ends_with(&info.rust));
     }
 
     #[test]

--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -296,6 +296,7 @@ impl P2PHostHandle {
     /// Returns the message ID on success.
     #[tracing::instrument(
         name = "p2p.gossip.publish",
+        level = "debug",
         skip(self, message),
         fields(topic = ?topic),
     )]
@@ -564,6 +565,7 @@ impl P2PHostHandle {
     /// This uses Go's two-stream pattern: request on one stream, response on another.
     #[tracing::instrument(
         name = "p2p.push_log.send",
+        level = "debug",
         skip(self, request),
         fields(peer = %peer_id),
     )]

--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -294,6 +294,11 @@ impl P2PHostHandle {
     /// Publish a message to a GossipSub topic.
     ///
     /// Returns the message ID on success.
+    #[tracing::instrument(
+        name = "p2p.gossip.publish",
+        skip(self, message),
+        fields(topic = ?topic),
+    )]
     pub async fn publish(
         &self,
         topic: DefraTopic,
@@ -557,6 +562,11 @@ impl P2PHostHandle {
     /// Send a PushLog request via two-stream protocol and wait for response.
     ///
     /// This uses Go's two-stream pattern: request on one stream, response on another.
+    #[tracing::instrument(
+        name = "p2p.push_log.send",
+        skip(self, request),
+        fields(peer = %peer_id),
+    )]
     pub async fn send_two_stream_request(
         &self,
         peer_id: PeerId,

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -17,6 +17,7 @@ otlp = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
+    "dep:opentelemetry-semantic-conventions",
     "dep:tracing-opentelemetry",
     "opentelemetry_sdk/trace",
     "opentelemetry-otlp/trace",
@@ -55,6 +56,9 @@ opentelemetry_sdk = { version = "0.32", default-features = false, features = ["e
 # the workspace's locked reqwest 0.13 (which has dropped the `webpki-roots`
 # feature that `opentelemetry-http` still asks for under the async client).
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-blocking-client"], optional = true }
+# Provides the `SCHEMA_URL` constant for the resource's schema declaration,
+# matching Go's `resource.WithSchemaURL(semconv.SchemaURL)`.
+opentelemetry-semantic-conventions = { version = "0.32", optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
 
 [lints]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -28,7 +28,12 @@ thiserror.workspace = true
 tokio = { workspace = true, optional = true }
 opentelemetry = { version = "0.32", optional = true }
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "trace", "metrics"], optional = true }
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace", "metrics", "tls-ring", "tls-webpki-roots"], optional = true }
+# OTLP over HTTP/proto, mirroring Go DefraDB's `otlptracehttp.New`. Default
+# endpoint is http://localhost:4318 — same default as the Go upstream.
+# `reqwest-blocking-client` runs on the SDK's batch-exporter thread, sidestepping
+# the workspace's locked reqwest 0.13 (which has dropped the `webpki-roots`
+# feature that `opentelemetry-http` still asks for under the async client).
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-blocking-client", "trace", "metrics"], optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
 
 [lints]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -9,16 +9,25 @@ repository.workspace = true
 
 [features]
 default = []
-# Compile in the OTLP gRPC exporters. Mirrors Go DefraDB's `//go:build telemetry`
-# tag — opt-in at compile time. When the feature is on, runtime behavior is
-# default-on (Go parity); use `--no-telemetry` to disable at runtime.
+# Compile in the OTLP exporter (traces). Mirrors Go DefraDB's
+# `//go:build telemetry` tag — opt-in at compile time. When this feature is on,
+# runtime behavior is default-on (Go parity); use `--no-telemetry` to disable
+# at runtime.
 otlp = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
     "dep:tokio",
+    "opentelemetry_sdk/trace",
+    "opentelemetry-otlp/trace",
 ]
+# Also compile in the OTLP metric exporter. Off by default because nothing in
+# defradb.rs records metric instruments today — leaving the metric pipeline on
+# spawns a `PeriodicReader` background task that wakes every 60 s to export an
+# empty batch (wasted bandwidth + collector ingest). Turn this on alongside
+# `otlp` once application code starts emitting instruments.
+metrics = ["otlp", "opentelemetry_sdk/metrics", "opentelemetry-otlp/metrics"]
 
 [dependencies]
 tracing.workspace = true
@@ -27,13 +36,13 @@ thiserror.workspace = true
 
 tokio = { workspace = true, optional = true }
 opentelemetry = { version = "0.32", optional = true }
-opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "trace", "metrics"], optional = true }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["rt-tokio"], optional = true }
 # OTLP over HTTP/proto, mirroring Go DefraDB's `otlptracehttp.New`. Default
 # endpoint is http://localhost:4318 — same default as the Go upstream.
 # `reqwest-blocking-client` runs on the SDK's batch-exporter thread, sidestepping
 # the workspace's locked reqwest 0.13 (which has dropped the `webpki-roots`
 # feature that `opentelemetry-http` still asks for under the async client).
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-blocking-client", "trace", "metrics"], optional = true }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-blocking-client"], optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
 
 [lints]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -36,7 +36,7 @@ otlp = [
 # spawns a `PeriodicReader` background task that wakes every 60 s to export an
 # empty batch (wasted bandwidth + collector ingest). Turn this on alongside
 # `otlp` once application code starts emitting instruments.
-metrics = ["otlp", "opentelemetry_sdk/metrics", "opentelemetry-otlp/metrics"]
+metrics = ["otlp", "opentelemetry_sdk/metrics", "opentelemetry-otlp/metrics", "dep:reqwest"]
 
 [dependencies]
 tracing.workspace = true
@@ -60,6 +60,11 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = ["
 # matching Go's `resource.WithSchemaURL(semconv.SchemaURL)`.
 opentelemetry-semantic-conventions = { version = "0.32", optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
+# Only used (under the `metrics` feature) to build a single blocking HTTP
+# client shared by the span + metric exporters. Pinned to 0.13 to match the
+# reqwest `opentelemetry-http` resolves; cargo unifies the `blocking` feature
+# with otlp's `reqwest-blocking-client`.
+reqwest = { version = "0.13", default-features = false, features = ["blocking"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -18,9 +18,17 @@ otlp = [
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
-    "dep:tokio",
     "opentelemetry_sdk/trace",
     "opentelemetry-otlp/trace",
+    # `internal-logs` is a default feature of both crates that
+    # `default-features = false` (below) turns off. Without it the SDK's
+    # `otel_error!` / `otel_warn!` macros compile to no-ops, so exporter
+    # failures emit no `tracing` events at all — which would make the
+    # OtelDedupFilter dead code AND hide every "collector unreachable"
+    # error. The whole point of #977 is to surface (and dedup) those, so
+    # it must stay on.
+    "opentelemetry_sdk/internal-logs",
+    "opentelemetry-otlp/internal-logs",
 ]
 # Also compile in the OTLP metric exporter. Off by default because nothing in
 # defradb.rs records metric instruments today — leaving the metric pipeline on
@@ -34,9 +42,13 @@ tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["registry", "std"] }
 thiserror.workspace = true
 
-tokio = { workspace = true, optional = true }
 opentelemetry = { version = "0.32", optional = true }
-opentelemetry_sdk = { version = "0.32", default-features = false, features = ["rt-tokio"], optional = true }
+# `experimental_async_runtime` (not `rt-tokio`) is all that's needed: with the
+# `reqwest-blocking-client` transport the OTLP exporter selects the `NoAsync`
+# runtime, and the batch processors run on dedicated `std::thread` workers — no
+# Tokio runtime is touched. `rt-tokio` would additionally pull tokio/rt,
+# tokio/time, and tokio-stream for nothing.
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["experimental_async_runtime"], optional = true }
 # OTLP over HTTP/proto, mirroring Go DefraDB's `otlptracehttp.New`. Default
 # endpoint is http://localhost:4318 — same default as the Go upstream.
 # `reqwest-blocking-client` runs on the SDK's batch-exporter thread, sidestepping

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "telemetry"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = []
+# Compile in the OTLP gRPC exporters. Mirrors Go DefraDB's `//go:build telemetry`
+# tag — opt-in at compile time. When the feature is on, runtime behavior is
+# default-on (Go parity); use `--no-telemetry` to disable at runtime.
+otlp = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:tracing-opentelemetry",
+    "dep:tokio",
+]
+
+[dependencies]
+tracing.workspace = true
+tracing-subscriber = { version = "0.3", features = ["registry", "std"] }
+thiserror.workspace = true
+
+tokio = { workspace = true, optional = true }
+opentelemetry = { version = "0.32", optional = true }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "trace", "metrics"], optional = true }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace", "metrics", "tls-ring", "tls-webpki-roots"], optional = true }
+tracing-opentelemetry = { version = "0.33", optional = true }
+
+[lints]
+workspace = true

--- a/crates/telemetry/src/config.rs
+++ b/crates/telemetry/src/config.rs
@@ -8,6 +8,13 @@
 pub struct TelemetryConfig {
     pub service_name: String,
     pub service_version: String,
+    /// When `true` (default) `init` registers the providers as the
+    /// process-wide globals via `opentelemetry::global::set_*`. Set to
+    /// `false` for embedded use where the host process owns its own OTel
+    /// globals and `init` would otherwise silently clobber them (e.g.
+    /// defra-agent runs its own OTel stack and just wants DefraDB-emitted
+    /// spans flushed at shutdown).
+    pub install_global: bool,
 }
 
 impl TelemetryConfig {
@@ -15,7 +22,15 @@ impl TelemetryConfig {
         Self {
             service_name: service_name.into(),
             service_version: service_version.into(),
+            install_global: true,
         }
+    }
+
+    /// Don't touch `opentelemetry::global::set_*`. The returned handle still
+    /// flushes its own providers on shutdown.
+    pub fn without_global(mut self) -> Self {
+        self.install_global = false;
+        self
     }
 }
 

--- a/crates/telemetry/src/config.rs
+++ b/crates/telemetry/src/config.rs
@@ -18,6 +18,10 @@ pub struct TelemetryConfig {
 }
 
 impl TelemetryConfig {
+    /// `service_name` should match what the operator's OTLP backend expects
+    /// to dimension on (Go DefraDB uses literal `"DefraDB"`).
+    /// `service_version` should be the actual binary version — sourcing it
+    /// from `defra_version::VersionInfo::new().version` is the convention.
     pub fn new(service_name: impl Into<String>, service_version: impl Into<String>) -> Self {
         Self {
             service_name: service_name.into(),
@@ -34,11 +38,7 @@ impl TelemetryConfig {
     }
 }
 
-impl Default for TelemetryConfig {
-    /// Defaults to Go DefraDB's service name (`"DefraDB"`) and the telemetry
-    /// crate's own version. Callers should override `service_version` with
-    /// the actual defra binary version (e.g. from `defra_version`).
-    fn default() -> Self {
-        Self::new("DefraDB", env!("CARGO_PKG_VERSION"))
-    }
-}
+// No `Default` impl: the only sensible default for `service_version` would
+// be the telemetry crate's own `CARGO_PKG_VERSION`, which never matches the
+// binary version the operator cares about. Forcing callers through `new`
+// keeps that mismatch from happening silently.

--- a/crates/telemetry/src/config.rs
+++ b/crates/telemetry/src/config.rs
@@ -20,7 +20,10 @@ impl TelemetryConfig {
 }
 
 impl Default for TelemetryConfig {
+    /// Defaults to Go DefraDB's service name (`"DefraDB"`) and the telemetry
+    /// crate's own version. Callers should override `service_version` with
+    /// the actual defra binary version (e.g. from `defra_version`).
     fn default() -> Self {
-        Self::new("defradb", env!("CARGO_PKG_VERSION"))
+        Self::new("DefraDB", env!("CARGO_PKG_VERSION"))
     }
 }

--- a/crates/telemetry/src/config.rs
+++ b/crates/telemetry/src/config.rs
@@ -1,0 +1,26 @@
+//! Telemetry configuration.
+//!
+//! Standard OTEL env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`,
+//! `OTEL_RESOURCE_ATTRIBUTES`) are honored automatically by `opentelemetry-otlp`
+//! 0.32, so this struct only carries the few DefraDB-specific defaults.
+
+#[derive(Debug, Clone)]
+pub struct TelemetryConfig {
+    pub service_name: String,
+    pub service_version: String,
+}
+
+impl TelemetryConfig {
+    pub fn new(service_name: impl Into<String>, service_version: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            service_version: service_version.into(),
+        }
+    }
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self::new("defradb", env!("CARGO_PKG_VERSION"))
+    }
+}

--- a/crates/telemetry/src/dedup.rs
+++ b/crates/telemetry/src/dedup.rs
@@ -32,10 +32,18 @@ use tracing_subscriber::registry::LookupSpan;
 
 const OTEL_TARGET_PREFIX: &str = "opentelemetry";
 
-/// Substrings that indicate the OTLP collector is unreachable.
-/// `"connection refused"` is the gRPC transport's wording; `"HTTP export
-/// failed"` / `"network error"` are what the HTTP+reqwest transport emits.
-const UNREACHABLE_NEEDLES: &[&str] = &["connection refused", "HTTP export failed", "network error"];
+/// Substrings that indicate the OTLP collector is *unreachable* (the only
+/// case Go special-cases). `"connection refused"` is the gRPC transport's
+/// wording; `"network error"` is what `opentelemetry-otlp`'s HTTP transport
+/// emits for connection/DNS failures (http/mod.rs:518).
+///
+/// Deliberately NOT `"HTTP export failed"`: that prefix also appears on
+/// status-code rejections from a *reachable* collector
+/// (`"HTTP export failed with status code: 401/429/503"`, http/mod.rs:540).
+/// Those are genuine server-side errors Go keeps visible (its `else` branch),
+/// so matching the prefix would wrongly suppress them behind the
+/// unreachable-collector hint and latch them off for the rest of the process.
+const UNREACHABLE_NEEDLES: &[&str] = &["connection refused", "network error"];
 
 /// Operator-facing hint, matching Go's `internal/telemetry/otel.go`.
 const UNREACHABLE_HINT: &str =
@@ -138,13 +146,32 @@ mod tests {
     }
 
     #[test]
-    fn http_exporter_failure_is_unreachable() {
-        // Real `opentelemetry_sdk` output captured by tools/otel-smoke/dedup.sh.
+    fn http_exporter_unreachable_is_unreachable() {
+        // Real `opentelemetry_sdk` output for an unreachable collector
+        // (http/mod.rs:518), captured by tools/otel-smoke/dedup.sh. Matches
+        // via the "network error" needle.
         let msg = r#"name="BatchSpanProcessor.ExportError" error="Operation failed: HTTP export failed: network error""#;
         assert!(OtelDedupFilter::is_collector_unreachable(
             "opentelemetry_sdk",
             msg
         ));
+    }
+
+    #[test]
+    fn http_status_code_error_is_not_unreachable() {
+        // A *reachable* collector rejecting the export (http/mod.rs:540) is a
+        // genuine server-side error Go keeps visible — it must NOT be treated
+        // as unreachable (else it gets suppressed behind the hint and latched
+        // off). Regression guard for the over-broad "HTTP export failed" needle.
+        for status in ["401", "413", "429", "503"] {
+            let msg = format!(
+                r#"name="BatchSpanProcessor.ExportError" error="Operation failed: HTTP export failed with status code: {status}""#
+            );
+            assert!(
+                !OtelDedupFilter::is_collector_unreachable("opentelemetry_sdk", &msg),
+                "status {status} should pass through, not be suppressed"
+            );
+        }
     }
 
     #[test]

--- a/crates/telemetry/src/dedup.rs
+++ b/crates/telemetry/src/dedup.rs
@@ -1,15 +1,23 @@
 //! Dedup filter for noisy OTEL exporter errors.
 //!
-//! When the OTLP collector is unreachable, `opentelemetry-otlp` emits a
-//! `"connection refused"` `tracing::error!` per failed batch — fast enough to
-//! flood logs. This filter suppresses all but the first such event per
-//! process, matching Go DefraDB's `otel.SetErrorHandler + sync.Once` dedup
-//! (PR #4639, commit `83af37a9`).
+//! Ports Go DefraDB's `sync.Once`-guarded `otel.SetErrorHandler` (PR #4639,
+//! commit `83af37a9`). Since `opentelemetry::global::set_error_handler` was
+//! removed in opentelemetry-rust v0.27, SDK diagnostics now flow through
+//! `tracing` at `target = "opentelemetry"*` and the natural hook is a
+//! `tracing_subscriber::layer::Filter`.
 //!
-//! `opentelemetry::global::set_error_handler` was removed in opentelemetry-rust
-//! v0.27; SDK diagnostics now flow through `tracing` at `target = "opentelemetry"`
-//! / `"opentelemetry_sdk"` / `"opentelemetry-otlp"`, so a
-//! `tracing_subscriber::layer::Filter` is the natural hook.
+//! **Per-needle latching.** A single shared `OnceLock` would let the first
+//! transient `"network error"` silence all subsequent `"connection refused"`
+//! hours later (or vice versa). Each known unreachable-collector pattern
+//! gets its own latch — one log per pattern per filter instance, then
+//! suppress.
+//!
+//! **Per-layer instances.** `tracing_subscriber::layer::Filter` is a
+//! per-layer hook. Each layer that ingests OTel events needs its own
+//! filter instance; trying to share state via `Arc` interleaves the
+//! per-event decisions (first layer wins the lock, second layer sees the
+//! event as already-suppressed). The right model is each layer logs the
+//! first occurrence and suppresses the rest, independently.
 
 use std::fmt;
 use std::sync::OnceLock;
@@ -20,17 +28,12 @@ use tracing_subscriber::layer::{Context, Filter};
 use tracing_subscriber::registry::LookupSpan;
 
 const OTEL_TARGET_PREFIX: &str = "opentelemetry";
-/// Substrings that indicate "OTLP collector unreachable". The Go port matches
-/// just `"connection refused"`, which is what the gRPC transport surfaces.
-/// With `opentelemetry-otlp`'s HTTP+reqwest transport, the SDK wraps the
-/// connection error as `"HTTP export failed: network error"`, so we match
-/// either pattern. `"connection refused"` is kept first for the gRPC path
-/// in case future builds switch transport.
-const UNREACHABLE_NEEDLES: &[&str] = &["connection refused", "HTTP export failed", "network error"];
 
 #[derive(Default)]
 pub struct OtelDedupFilter {
     refused_logged: OnceLock<()>,
+    http_export_failed_logged: OnceLock<()>,
+    network_error_logged: OnceLock<()>,
 }
 
 impl OtelDedupFilter {
@@ -38,20 +41,27 @@ impl OtelDedupFilter {
         Self::default()
     }
 
-    /// Decide whether to emit. Returns `true` to forward the event,
-    /// `false` to suppress it. Pure logic, separated from the `Filter`
-    /// impl so it can be unit-tested without spinning up a subscriber.
+    /// Decide whether to emit. Pure logic, unit-testable without a subscriber.
     fn decide(&self, target: &str, message: &str) -> bool {
         if !target.starts_with(OTEL_TARGET_PREFIX) {
             return true;
         }
-        if UNREACHABLE_NEEDLES.iter().any(|n| message.contains(n)) {
-            // `OnceLock::set` returns Ok only on the first call; subsequent
-            // calls return Err. That's exactly the "log once, then suppress"
-            // semantics of Go's `sync.Once.Do`.
-            return self.refused_logged.set(()).is_ok();
+        // First match wins. Order doesn't affect correctness — different
+        // needles have independent latches.
+        for (needle, lock) in self.needles() {
+            if message.contains(needle) {
+                return lock.set(()).is_ok();
+            }
         }
         true
+    }
+
+    fn needles(&self) -> [(&'static str, &OnceLock<()>); 3] {
+        [
+            ("connection refused", &self.refused_logged),
+            ("HTTP export failed", &self.http_export_failed_logged),
+            ("network error", &self.network_error_logged),
+        ]
     }
 }
 
@@ -74,11 +84,10 @@ where
     }
 }
 
-/// Concatenates every field of the event into a single string so that
-/// structured events (which the OTel SDK uses — e.g.
-/// `otel_error!(name: "BatchSpanProcessor.ExportError", error = ...)`) are
-/// matchable. An earlier "only the `message` field" version missed those
-/// because the SDK does not include a format-string message.
+/// Concatenates every field of the event into one string. The OTel SDK
+/// uses `otel_error!(name: "BatchSpanProcessor.ExportError", error = ...)`
+/// with no format-string `message` field, so a "message-only" visitor sees
+/// nothing.
 #[derive(Default)]
 struct MessageVisitor {
     message: String,
@@ -146,7 +155,6 @@ mod tests {
         let f = OtelDedupFilter::new();
         assert!(f.decide("opentelemetry-otlp", "connection refused"));
         assert!(!f.decide("opentelemetry-otlp", "connection refused"));
-        // Non-refused OTEL errors still flow through.
         assert!(f.decide("opentelemetry-otlp", "different error"));
         assert!(f.decide("opentelemetry_sdk", "another problem"));
     }
@@ -177,5 +185,21 @@ mod tests {
         assert!(!f1.decide("opentelemetry-otlp", "connection refused"));
         // Separate instance has its own state.
         assert!(f2.decide("opentelemetry-otlp", "connection refused"));
+    }
+
+    #[test]
+    fn needles_latch_independently() {
+        // Critical: a transient `"network error"` early in the process must
+        // NOT suppress later `"connection refused"` events from a different
+        // failure mode. Single shared OnceLock would conflate the two.
+        let f = OtelDedupFilter::new();
+        assert!(f.decide("opentelemetry-otlp", "transient network error"));
+        assert!(!f.decide("opentelemetry-otlp", "another network error"));
+        // Different needle → its own latch, still passes once.
+        assert!(f.decide("opentelemetry-otlp", "connection refused"));
+        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
+        // Third needle.
+        assert!(f.decide("opentelemetry-otlp", "HTTP export failed: 503"));
+        assert!(!f.decide("opentelemetry-otlp", "HTTP export failed: 502"));
     }
 }

--- a/crates/telemetry/src/dedup.rs
+++ b/crates/telemetry/src/dedup.rs
@@ -28,6 +28,12 @@ use tracing_subscriber::layer::{Context, Filter};
 use tracing_subscriber::registry::LookupSpan;
 
 const OTEL_TARGET_PREFIX: &str = "opentelemetry";
+const NEEDLES: &[&str] = &["connection refused", "HTTP export failed", "network error"];
+
+#[allow(non_snake_case)]
+fn UNREACHABLE_PATTERNS_MATCH_ANY(message: &str) -> bool {
+    NEEDLES.iter().any(|n| message.contains(n))
+}
 
 #[derive(Default)]
 pub struct OtelDedupFilter {
@@ -42,18 +48,25 @@ impl OtelDedupFilter {
     }
 
     /// Decide whether to emit. Pure logic, unit-testable without a subscriber.
+    ///
+    /// Iterates every needle: each one that matches the message claims its
+    /// own latch independently. The event is emitted only if at least one
+    /// matching needle was previously unclaimed. Marking ALL matching
+    /// needles (not just the first) means a real SDK message like
+    /// `"HTTP export failed: network error"` — which contains two needles
+    /// at once — consumes both latches, so a later "network error"-only
+    /// event can't slip through as a "first occurrence".
     fn decide(&self, target: &str, message: &str) -> bool {
         if !target.starts_with(OTEL_TARGET_PREFIX) {
             return true;
         }
-        // First match wins. Order doesn't affect correctness — different
-        // needles have independent latches.
+        let mut emit = false;
         for (needle, lock) in self.needles() {
-            if message.contains(needle) {
-                return lock.set(()).is_ok();
+            if message.contains(needle) && lock.set(()).is_ok() {
+                emit = true;
             }
         }
-        true
+        emit || !UNREACHABLE_PATTERNS_MATCH_ANY(message)
     }
 
     fn needles(&self) -> [(&'static str, &OnceLock<()>); 3] {
@@ -185,6 +198,29 @@ mod tests {
         assert!(!f1.decide("opentelemetry-otlp", "connection refused"));
         // Separate instance has its own state.
         assert!(f2.decide("opentelemetry-otlp", "connection refused"));
+    }
+
+    #[test]
+    fn combined_needles_in_single_message_claim_all_latches() {
+        // Real SDK output contains BOTH "HTTP export failed" AND
+        // "network error". Marking ALL matched needles (not just the
+        // first iterated) means a later "network error"-only event can't
+        // log as a "first occurrence" by riding a still-unclaimed latch.
+        // Regression for the prior first-match-wins bug.
+        let f = OtelDedupFilter::new();
+        let combined = r#"error="Operation failed: HTTP export failed: network error""#;
+        assert!(f.decide("opentelemetry_sdk", combined));
+        // Same combined message — both latches already claimed, suppressed.
+        assert!(!f.decide("opentelemetry_sdk", combined));
+        // A subsequent "network error"-only event must ALSO be suppressed,
+        // because its needle's latch was claimed by the combined message.
+        assert!(!f.decide("opentelemetry-otlp", "transient network error"));
+        // And a "HTTP export failed"-only event is also suppressed.
+        assert!(!f.decide("opentelemetry-otlp", "HTTP export failed: 502"));
+        // But a totally different needle (connection refused) still gets
+        // its one shot — its latch is still free.
+        assert!(f.decide("opentelemetry-otlp", "connection refused"));
+        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
     }
 
     #[test]

--- a/crates/telemetry/src/dedup.rs
+++ b/crates/telemetry/src/dedup.rs
@@ -1,23 +1,26 @@
-//! Dedup filter for noisy OTEL exporter errors.
+//! Quieting filter for noisy OTEL exporter errors.
 //!
 //! Ports Go DefraDB's `sync.Once`-guarded `otel.SetErrorHandler` (PR #4639,
-//! commit `83af37a9`). Since `opentelemetry::global::set_error_handler` was
-//! removed in opentelemetry-rust v0.27, SDK diagnostics now flow through
-//! `tracing` at `target = "opentelemetry"*` and the natural hook is a
-//! `tracing_subscriber::layer::Filter`.
+//! commit `83af37a9`). Go suppresses the SDK's repeated collector-unreachable
+//! export errors and emits a single actionable hint instead; other OTEL
+//! errors log normally (Go's `else` branch).
 //!
-//! **Per-needle latching.** A single shared `OnceLock` would let the first
-//! transient `"network error"` silence all subsequent `"connection refused"`
-//! hours later (or vice versa). Each known unreachable-collector pattern
-//! gets its own latch — one log per pattern per filter instance, then
-//! suppress.
+//! `opentelemetry::global::set_error_handler` was removed in opentelemetry-rust
+//! v0.27, so SDK diagnostics now flow through `tracing` at
+//! `target = "opentelemetry"*`. The hook is therefore a
+//! `tracing_subscriber::layer::Filter`:
 //!
-//! **Per-layer instances.** `tracing_subscriber::layer::Filter` is a
-//! per-layer hook. Each layer that ingests OTel events needs its own
-//! filter instance; trying to share state via `Arc` interleaves the
-//! per-event decisions (first layer wins the lock, second layer sees the
-//! event as already-suppressed). The right model is each layer logs the
-//! first occurrence and suppresses the rest, independently.
+//! - An event reporting an unreachable collector (matches a known needle) is
+//!   suppressed, and Go's hint is emitted **once per process** — via a global
+//!   `OnceLock` shared across every layer the filter is attached to, so the
+//!   hint appears exactly once regardless of layer count.
+//! - Any other `opentelemetry*` event passes through and logs normally
+//!   (matching Go's `else` branch — genuine errors stay visible).
+//!
+//! The hint is emitted with `eprintln!` rather than `tracing`: emitting a
+//! `tracing` event from inside a layer's event hook risks re-entering the
+//! subscriber mid-event. Plain stderr is re-entrancy-safe and matches the
+//! crate's existing operator-warning style (see `handle.rs`).
 
 use std::fmt;
 use std::sync::OnceLock;
@@ -29,50 +32,34 @@ use tracing_subscriber::registry::LookupSpan;
 
 const OTEL_TARGET_PREFIX: &str = "opentelemetry";
 
-/// Known "OTLP collector unreachable" substrings. `"connection refused"` is
-/// the gRPC transport's wording; `"HTTP export failed"` / `"network error"`
-/// are what `opentelemetry-otlp`'s HTTP+reqwest transport emits. Each gets
-/// its own latch (indexed positionally by [`OtelDedupFilter::latches`]).
-const NEEDLES: &[&str] = &["connection refused", "HTTP export failed", "network error"];
+/// Substrings that indicate the OTLP collector is unreachable.
+/// `"connection refused"` is the gRPC transport's wording; `"HTTP export
+/// failed"` / `"network error"` are what the HTTP+reqwest transport emits.
+const UNREACHABLE_NEEDLES: &[&str] = &["connection refused", "HTTP export failed", "network error"];
+
+/// Operator-facing hint, matching Go's `internal/telemetry/otel.go`.
+const UNREACHABLE_HINT: &str =
+    "OpenTelemetry export failed, ensure your OTLP collector is running and reachable";
+
+/// Guards the hint so it is emitted at most once per process, across every
+/// layer this filter is attached to. Go uses a single `sync.Once` for the
+/// same effect.
+static HINT_ONCE: OnceLock<()> = OnceLock::new();
 
 #[derive(Default)]
-pub struct OtelDedupFilter {
-    /// One latch per entry in [`NEEDLES`], positionally aligned. A single
-    /// shared latch would let the first transient `"network error"` silence
-    /// a later `"connection refused"` from a different failure mode.
-    latches: [OnceLock<()>; NEEDLES.len()],
-}
+pub struct OtelDedupFilter;
 
 impl OtelDedupFilter {
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 
-    /// Decide whether to emit. Pure logic, unit-testable without a subscriber.
-    ///
-    /// Every matching needle claims its own latch in one pass. The event is
-    /// emitted if at least one matching needle was previously unclaimed, OR
-    /// if no needle matched at all (non-unreachable-collector events always
-    /// pass through). Claiming ALL matching needles — not just the first —
-    /// means a real SDK message like `"HTTP export failed: network error"`
-    /// (two needles in one line) consumes both latches, so a later
-    /// `"network error"`-only event can't slip through as a "first
-    /// occurrence".
-    fn decide(&self, target: &str, message: &str) -> bool {
-        if !target.starts_with(OTEL_TARGET_PREFIX) {
-            return true;
-        }
-        let mut emit = false;
-        let mut any_match = false;
-        for (needle, lock) in NEEDLES.iter().zip(&self.latches) {
-            if message.contains(needle) {
-                any_match = true;
-                if lock.set(()).is_ok() {
-                    emit = true;
-                }
-            }
-        }
-        emit || !any_match
+    /// True if this is an `opentelemetry*`-target event reporting an
+    /// unreachable collector — the case Go suppresses. Pure and stateless,
+    /// so it's unit-testable without a subscriber.
+    fn is_collector_unreachable(target: &str, message: &str) -> bool {
+        target.starts_with(OTEL_TARGET_PREFIX)
+            && UNREACHABLE_NEEDLES.iter().any(|n| message.contains(n))
     }
 }
 
@@ -91,7 +78,17 @@ where
         }
         let mut visitor = MessageVisitor::default();
         event.record(&mut visitor);
-        self.decide(target, &visitor.message)
+        if Self::is_collector_unreachable(target, &visitor.message) {
+            // Suppress the raw, repeated export error; emit Go's hint once
+            // process-wide (including the underlying detail, as Go's
+            // `log.ErrorE(msg, err)` does).
+            if HINT_ONCE.set(()).is_ok() {
+                eprintln!("{UNREACHABLE_HINT}: {}", visitor.message);
+            }
+            return false;
+        }
+        // Genuine, non-unreachable OTEL error — log normally.
+        true
     }
 }
 
@@ -133,107 +130,60 @@ mod tests {
     use super::*;
 
     #[test]
-    fn first_connection_refused_passes() {
-        let f = OtelDedupFilter::new();
-        assert!(f.decide("opentelemetry-otlp", "transport error: connection refused"));
+    fn connection_refused_is_unreachable() {
+        assert!(OtelDedupFilter::is_collector_unreachable(
+            "opentelemetry-otlp",
+            "transport error: connection refused"
+        ));
     }
 
     #[test]
-    fn subsequent_connection_refused_suppressed() {
-        let f = OtelDedupFilter::new();
-        assert!(f.decide("opentelemetry-otlp", "connection refused"));
-        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
-        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
-    }
-
-    #[test]
-    fn other_otel_errors_pass_through() {
-        let f = OtelDedupFilter::new();
-        assert!(f.decide("opentelemetry-otlp", "invalid response from collector"));
-        assert!(f.decide("opentelemetry_sdk", "batch send took too long"));
-        assert!(f.decide("opentelemetry", "tls handshake failed"));
-    }
-
-    #[test]
-    fn non_otel_events_pass_through_even_with_refused_text() {
-        let f = OtelDedupFilter::new();
-        assert!(f.decide("hyper::client", "connection refused"));
-        assert!(f.decide("my_app::module", "hello"));
-    }
-
-    #[test]
-    fn other_otel_errors_unaffected_after_refused_suppression() {
-        let f = OtelDedupFilter::new();
-        assert!(f.decide("opentelemetry-otlp", "connection refused"));
-        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
-        assert!(f.decide("opentelemetry-otlp", "different error"));
-        assert!(f.decide("opentelemetry_sdk", "another problem"));
-    }
-
-    #[test]
-    fn http_exporter_unreachable_pattern_dedups() {
-        // Real-world output from `opentelemetry_sdk` when the HTTP exporter
-        // can't reach the collector (captured by `tools/otel-smoke/dedup.sh`):
-        //   name="BatchSpanProcessor.ExportError" error="Operation failed: HTTP export failed: network error"
-        let f = OtelDedupFilter::new();
+    fn http_exporter_failure_is_unreachable() {
+        // Real `opentelemetry_sdk` output captured by tools/otel-smoke/dedup.sh.
         let msg = r#"name="BatchSpanProcessor.ExportError" error="Operation failed: HTTP export failed: network error""#;
-        assert!(f.decide("opentelemetry_sdk", msg));
-        assert!(!f.decide("opentelemetry_sdk", msg));
+        assert!(OtelDedupFilter::is_collector_unreachable(
+            "opentelemetry_sdk",
+            msg
+        ));
     }
 
     #[test]
-    fn network_error_pattern_dedups() {
-        let f = OtelDedupFilter::new();
-        assert!(f.decide("opentelemetry-otlp", "transport network error"));
-        assert!(!f.decide("opentelemetry-otlp", "another network error case"));
+    fn network_error_is_unreachable() {
+        assert!(OtelDedupFilter::is_collector_unreachable(
+            "opentelemetry-otlp",
+            "transport network error"
+        ));
     }
 
     #[test]
-    fn dedup_state_is_per_instance() {
-        let f1 = OtelDedupFilter::new();
-        let f2 = OtelDedupFilter::new();
-        assert!(f1.decide("opentelemetry-otlp", "connection refused"));
-        assert!(!f1.decide("opentelemetry-otlp", "connection refused"));
-        // Separate instance has its own state.
-        assert!(f2.decide("opentelemetry-otlp", "connection refused"));
+    fn other_otel_errors_are_not_unreachable() {
+        // Genuine non-collector-unreachable OTEL errors must pass through
+        // (Go logs these via its `else` branch).
+        assert!(!OtelDedupFilter::is_collector_unreachable(
+            "opentelemetry-otlp",
+            "invalid response from collector"
+        ));
+        assert!(!OtelDedupFilter::is_collector_unreachable(
+            "opentelemetry_sdk",
+            "batch send took too long"
+        ));
+        assert!(!OtelDedupFilter::is_collector_unreachable(
+            "opentelemetry",
+            "tls handshake failed"
+        ));
     }
 
     #[test]
-    fn combined_needles_in_single_message_claim_all_latches() {
-        // Real SDK output contains BOTH "HTTP export failed" AND
-        // "network error". Marking ALL matched needles (not just the
-        // first iterated) means a later "network error"-only event can't
-        // log as a "first occurrence" by riding a still-unclaimed latch.
-        // Regression for the prior first-match-wins bug.
-        let f = OtelDedupFilter::new();
-        let combined = r#"error="Operation failed: HTTP export failed: network error""#;
-        assert!(f.decide("opentelemetry_sdk", combined));
-        // Same combined message — both latches already claimed, suppressed.
-        assert!(!f.decide("opentelemetry_sdk", combined));
-        // A subsequent "network error"-only event must ALSO be suppressed,
-        // because its needle's latch was claimed by the combined message.
-        assert!(!f.decide("opentelemetry-otlp", "transient network error"));
-        // And a "HTTP export failed"-only event is also suppressed.
-        assert!(!f.decide("opentelemetry-otlp", "HTTP export failed: 502"));
-        // But a totally different needle (connection refused) still gets
-        // its one shot — its latch is still free.
-        assert!(f.decide("opentelemetry-otlp", "connection refused"));
-        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
-    }
-
-    #[test]
-    fn needles_latch_independently() {
-        // Critical: a transient `"network error"` early in the process must
-        // NOT suppress later `"connection refused"` events from a different
-        // failure mode. Single shared OnceLock would conflate the two.
-        let f = OtelDedupFilter::new();
-        assert!(f.decide("opentelemetry-otlp", "transient network error"));
-        assert!(!f.decide("opentelemetry-otlp", "another network error"));
-        // Different needle → its own latch, still passes once.
-        assert!(f.decide("opentelemetry-otlp", "connection refused"));
-        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
-        // Third needle.
-        assert!(f.decide("opentelemetry-otlp", "HTTP export failed: 503"));
-        assert!(!f.decide("opentelemetry-otlp", "HTTP export failed: 502"));
+    fn non_otel_events_are_never_unreachable() {
+        // A non-OTEL target that happens to contain a needle must not be
+        // touched — only `opentelemetry*` targets are in scope.
+        assert!(!OtelDedupFilter::is_collector_unreachable(
+            "hyper::client",
+            "connection refused"
+        ));
+        assert!(!OtelDedupFilter::is_collector_unreachable(
+            "my_app::module",
+            "hello"
+        ));
     }
 }

--- a/crates/telemetry/src/dedup.rs
+++ b/crates/telemetry/src/dedup.rs
@@ -28,18 +28,19 @@ use tracing_subscriber::layer::{Context, Filter};
 use tracing_subscriber::registry::LookupSpan;
 
 const OTEL_TARGET_PREFIX: &str = "opentelemetry";
-const NEEDLES: &[&str] = &["connection refused", "HTTP export failed", "network error"];
 
-#[allow(non_snake_case)]
-fn UNREACHABLE_PATTERNS_MATCH_ANY(message: &str) -> bool {
-    NEEDLES.iter().any(|n| message.contains(n))
-}
+/// Known "OTLP collector unreachable" substrings. `"connection refused"` is
+/// the gRPC transport's wording; `"HTTP export failed"` / `"network error"`
+/// are what `opentelemetry-otlp`'s HTTP+reqwest transport emits. Each gets
+/// its own latch (indexed positionally by [`OtelDedupFilter::latches`]).
+const NEEDLES: &[&str] = &["connection refused", "HTTP export failed", "network error"];
 
 #[derive(Default)]
 pub struct OtelDedupFilter {
-    refused_logged: OnceLock<()>,
-    http_export_failed_logged: OnceLock<()>,
-    network_error_logged: OnceLock<()>,
+    /// One latch per entry in [`NEEDLES`], positionally aligned. A single
+    /// shared latch would let the first transient `"network error"` silence
+    /// a later `"connection refused"` from a different failure mode.
+    latches: [OnceLock<()>; NEEDLES.len()],
 }
 
 impl OtelDedupFilter {
@@ -49,32 +50,29 @@ impl OtelDedupFilter {
 
     /// Decide whether to emit. Pure logic, unit-testable without a subscriber.
     ///
-    /// Iterates every needle: each one that matches the message claims its
-    /// own latch independently. The event is emitted only if at least one
-    /// matching needle was previously unclaimed. Marking ALL matching
-    /// needles (not just the first) means a real SDK message like
-    /// `"HTTP export failed: network error"` — which contains two needles
-    /// at once — consumes both latches, so a later "network error"-only
-    /// event can't slip through as a "first occurrence".
+    /// Every matching needle claims its own latch in one pass. The event is
+    /// emitted if at least one matching needle was previously unclaimed, OR
+    /// if no needle matched at all (non-unreachable-collector events always
+    /// pass through). Claiming ALL matching needles — not just the first —
+    /// means a real SDK message like `"HTTP export failed: network error"`
+    /// (two needles in one line) consumes both latches, so a later
+    /// `"network error"`-only event can't slip through as a "first
+    /// occurrence".
     fn decide(&self, target: &str, message: &str) -> bool {
         if !target.starts_with(OTEL_TARGET_PREFIX) {
             return true;
         }
         let mut emit = false;
-        for (needle, lock) in self.needles() {
-            if message.contains(needle) && lock.set(()).is_ok() {
-                emit = true;
+        let mut any_match = false;
+        for (needle, lock) in NEEDLES.iter().zip(&self.latches) {
+            if message.contains(needle) {
+                any_match = true;
+                if lock.set(()).is_ok() {
+                    emit = true;
+                }
             }
         }
-        emit || !UNREACHABLE_PATTERNS_MATCH_ANY(message)
-    }
-
-    fn needles(&self) -> [(&'static str, &OnceLock<()>); 3] {
-        [
-            ("connection refused", &self.refused_logged),
-            ("HTTP export failed", &self.http_export_failed_logged),
-            ("network error", &self.network_error_logged),
-        ]
+        emit || !any_match
     }
 }
 

--- a/crates/telemetry/src/dedup.rs
+++ b/crates/telemetry/src/dedup.rs
@@ -20,7 +20,13 @@ use tracing_subscriber::layer::{Context, Filter};
 use tracing_subscriber::registry::LookupSpan;
 
 const OTEL_TARGET_PREFIX: &str = "opentelemetry";
-const REFUSED_NEEDLE: &str = "connection refused";
+/// Substrings that indicate "OTLP collector unreachable". The Go port matches
+/// just `"connection refused"`, which is what the gRPC transport surfaces.
+/// With `opentelemetry-otlp`'s HTTP+reqwest transport, the SDK wraps the
+/// connection error as `"HTTP export failed: network error"`, so we match
+/// either pattern. `"connection refused"` is kept first for the gRPC path
+/// in case future builds switch transport.
+const UNREACHABLE_NEEDLES: &[&str] = &["connection refused", "HTTP export failed", "network error"];
 
 #[derive(Default)]
 pub struct OtelDedupFilter {
@@ -39,7 +45,7 @@ impl OtelDedupFilter {
         if !target.starts_with(OTEL_TARGET_PREFIX) {
             return true;
         }
-        if message.contains(REFUSED_NEEDLE) {
+        if UNREACHABLE_NEEDLES.iter().any(|n| message.contains(n)) {
             // `OnceLock::set` returns Ok only on the first call; subsequent
             // calls return Err. That's exactly the "log once, then suppress"
             // semantics of Go's `sync.Once.Do`.
@@ -68,28 +74,37 @@ where
     }
 }
 
+/// Concatenates every field of the event into a single string so that
+/// structured events (which the OTel SDK uses — e.g.
+/// `otel_error!(name: "BatchSpanProcessor.ExportError", error = ...)`) are
+/// matchable. An earlier "only the `message` field" version missed those
+/// because the SDK does not include a format-string message.
 #[derive(Default)]
 struct MessageVisitor {
     message: String,
 }
 
+impl MessageVisitor {
+    fn push(&mut self, name: &str, value: impl fmt::Display) {
+        use std::fmt::Write;
+        if !self.message.is_empty() {
+            self.message.push(' ');
+        }
+        let _ = write!(self.message, "{name}={value}");
+    }
+}
+
 impl Visit for MessageVisitor {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        if field.name() == "message" {
-            use std::fmt::Write;
-            let _ = write!(self.message, "{:?}", value);
-        }
+        self.push(field.name(), format_args!("{value:?}"));
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == "message" {
-            self.message.push_str(value);
-        }
+        self.push(field.name(), value);
     }
 
-    fn record_error(&mut self, _field: &Field, value: &(dyn std::error::Error + 'static)) {
-        use std::fmt::Write;
-        let _ = write!(self.message, "{value}");
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.push(field.name(), value);
     }
 }
 
@@ -134,6 +149,24 @@ mod tests {
         // Non-refused OTEL errors still flow through.
         assert!(f.decide("opentelemetry-otlp", "different error"));
         assert!(f.decide("opentelemetry_sdk", "another problem"));
+    }
+
+    #[test]
+    fn http_exporter_unreachable_pattern_dedups() {
+        // Real-world output from `opentelemetry_sdk` when the HTTP exporter
+        // can't reach the collector (captured by `tools/otel-smoke/dedup.sh`):
+        //   name="BatchSpanProcessor.ExportError" error="Operation failed: HTTP export failed: network error"
+        let f = OtelDedupFilter::new();
+        let msg = r#"name="BatchSpanProcessor.ExportError" error="Operation failed: HTTP export failed: network error""#;
+        assert!(f.decide("opentelemetry_sdk", msg));
+        assert!(!f.decide("opentelemetry_sdk", msg));
+    }
+
+    #[test]
+    fn network_error_pattern_dedups() {
+        let f = OtelDedupFilter::new();
+        assert!(f.decide("opentelemetry-otlp", "transport network error"));
+        assert!(!f.decide("opentelemetry-otlp", "another network error case"));
     }
 
     #[test]

--- a/crates/telemetry/src/dedup.rs
+++ b/crates/telemetry/src/dedup.rs
@@ -1,0 +1,148 @@
+//! Dedup filter for noisy OTEL exporter errors.
+//!
+//! When the OTLP collector is unreachable, `opentelemetry-otlp` emits a
+//! `"connection refused"` `tracing::error!` per failed batch — fast enough to
+//! flood logs. This filter suppresses all but the first such event per
+//! process, matching Go DefraDB's `otel.SetErrorHandler + sync.Once` dedup
+//! (PR #4639, commit `83af37a9`).
+//!
+//! `opentelemetry::global::set_error_handler` was removed in opentelemetry-rust
+//! v0.27; SDK diagnostics now flow through `tracing` at `target = "opentelemetry"`
+//! / `"opentelemetry_sdk"` / `"opentelemetry-otlp"`, so a
+//! `tracing_subscriber::layer::Filter` is the natural hook.
+
+use std::fmt;
+use std::sync::OnceLock;
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Metadata, Subscriber};
+use tracing_subscriber::layer::{Context, Filter};
+use tracing_subscriber::registry::LookupSpan;
+
+const OTEL_TARGET_PREFIX: &str = "opentelemetry";
+const REFUSED_NEEDLE: &str = "connection refused";
+
+#[derive(Default)]
+pub struct OtelDedupFilter {
+    refused_logged: OnceLock<()>,
+}
+
+impl OtelDedupFilter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Decide whether to emit. Returns `true` to forward the event,
+    /// `false` to suppress it. Pure logic, separated from the `Filter`
+    /// impl so it can be unit-tested without spinning up a subscriber.
+    fn decide(&self, target: &str, message: &str) -> bool {
+        if !target.starts_with(OTEL_TARGET_PREFIX) {
+            return true;
+        }
+        if message.contains(REFUSED_NEEDLE) {
+            // `OnceLock::set` returns Ok only on the first call; subsequent
+            // calls return Err. That's exactly the "log once, then suppress"
+            // semantics of Go's `sync.Once.Do`.
+            return self.refused_logged.set(()).is_ok();
+        }
+        true
+    }
+}
+
+impl<S> Filter<S> for OtelDedupFilter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn enabled(&self, _meta: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+        true
+    }
+
+    fn event_enabled(&self, event: &Event<'_>, _cx: &Context<'_, S>) -> bool {
+        let target = event.metadata().target();
+        if !target.starts_with(OTEL_TARGET_PREFIX) {
+            return true;
+        }
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        self.decide(target, &visitor.message)
+    }
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+}
+
+impl Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if field.name() == "message" {
+            use std::fmt::Write;
+            let _ = write!(self.message, "{:?}", value);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        }
+    }
+
+    fn record_error(&mut self, _field: &Field, value: &(dyn std::error::Error + 'static)) {
+        use std::fmt::Write;
+        let _ = write!(self.message, "{value}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_connection_refused_passes() {
+        let f = OtelDedupFilter::new();
+        assert!(f.decide("opentelemetry-otlp", "transport error: connection refused"));
+    }
+
+    #[test]
+    fn subsequent_connection_refused_suppressed() {
+        let f = OtelDedupFilter::new();
+        assert!(f.decide("opentelemetry-otlp", "connection refused"));
+        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
+        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
+    }
+
+    #[test]
+    fn other_otel_errors_pass_through() {
+        let f = OtelDedupFilter::new();
+        assert!(f.decide("opentelemetry-otlp", "invalid response from collector"));
+        assert!(f.decide("opentelemetry_sdk", "batch send took too long"));
+        assert!(f.decide("opentelemetry", "tls handshake failed"));
+    }
+
+    #[test]
+    fn non_otel_events_pass_through_even_with_refused_text() {
+        let f = OtelDedupFilter::new();
+        assert!(f.decide("hyper::client", "connection refused"));
+        assert!(f.decide("my_app::module", "hello"));
+    }
+
+    #[test]
+    fn other_otel_errors_unaffected_after_refused_suppression() {
+        let f = OtelDedupFilter::new();
+        assert!(f.decide("opentelemetry-otlp", "connection refused"));
+        assert!(!f.decide("opentelemetry-otlp", "connection refused"));
+        // Non-refused OTEL errors still flow through.
+        assert!(f.decide("opentelemetry-otlp", "different error"));
+        assert!(f.decide("opentelemetry_sdk", "another problem"));
+    }
+
+    #[test]
+    fn dedup_state_is_per_instance() {
+        let f1 = OtelDedupFilter::new();
+        let f2 = OtelDedupFilter::new();
+        assert!(f1.decide("opentelemetry-otlp", "connection refused"));
+        assert!(!f1.decide("opentelemetry-otlp", "connection refused"));
+        // Separate instance has its own state.
+        assert!(f2.decide("opentelemetry-otlp", "connection refused"));
+    }
+}

--- a/crates/telemetry/src/handle.rs
+++ b/crates/telemetry/src/handle.rs
@@ -1,0 +1,41 @@
+//! Lifecycle handle returned by [`crate::init`]. Holds provider handles so
+//! the caller can flush buffered spans/metrics on shutdown.
+//!
+//! Go DefraDB never calls provider shutdown (`internal/telemetry/otel.go`
+//! has no Shutdown plumbing), so spans buffered at SIGTERM are lost. We
+//! fix that here: the CLI's main path takes ownership of this handle and
+//! calls [`TelemetryHandle::shutdown`] before exit.
+
+pub struct TelemetryHandle {
+    #[cfg(feature = "otlp")]
+    pub(crate) inner: Option<OtelProviders>,
+}
+
+#[cfg(feature = "otlp")]
+pub(crate) struct OtelProviders {
+    pub tracer_provider: opentelemetry_sdk::trace::SdkTracerProvider,
+    pub meter_provider: opentelemetry_sdk::metrics::SdkMeterProvider,
+}
+
+impl TelemetryHandle {
+    pub fn noop() -> Self {
+        Self {
+            #[cfg(feature = "otlp")]
+            inner: None,
+        }
+    }
+
+    pub fn shutdown(self) {
+        #[cfg(feature = "otlp")]
+        if let Some(p) = self.inner {
+            let _ = p.tracer_provider.shutdown();
+            let _ = p.meter_provider.shutdown();
+        }
+    }
+}
+
+impl Default for TelemetryHandle {
+    fn default() -> Self {
+        Self::noop()
+    }
+}

--- a/crates/telemetry/src/handle.rs
+++ b/crates/telemetry/src/handle.rs
@@ -44,25 +44,25 @@ impl TelemetryHandle {
     /// (e.g. shut down telemetry after the rest of the node stops emitting).
     /// Prefer this over relying on `Drop` — see the module docs for the
     /// blocking-thread + panic-safety reasons.
+    ///
+    /// Unlike the `Drop` path this does NOT swallow panics: a panic in the
+    /// SDK's shutdown (e.g. a poisoned batch-thread join) propagates to the
+    /// caller, who chose this explicit path and can react.
+    // `mut`/`self` are only touched on the otlp path; without it the body is
+    // empty and `self` just drops (a no-op).
+    #[cfg_attr(not(feature = "otlp"), allow(unused_mut, unused_variables))]
     pub fn shutdown(mut self) {
-        self.flush();
+        #[cfg(feature = "otlp")]
+        if let Some(p) = self.inner.take() {
+            Self::shutdown_providers(p);
+        }
     }
 
-    fn flush(&mut self) {
-        #[cfg(feature = "otlp")]
-        if let Some(_p) = self.inner.take() {
-            // `catch_unwind` keeps a panicked batch thread (which the SDK
-            // exposes via `handle.join().unwrap()` in shutdown) from
-            // turning a normal Drop into a double-panic → abort.
-            // `AssertUnwindSafe` is acceptable: the providers we move in
-            // are about to be dropped anyway, so post-panic logical state
-            // doesn't matter.
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-                let _ = _p.tracer_provider.shutdown();
-                #[cfg(feature = "metrics")]
-                let _ = _p.meter_provider.shutdown();
-            }));
-        }
+    #[cfg(feature = "otlp")]
+    fn shutdown_providers(p: OtelProviders) {
+        let _ = p.tracer_provider.shutdown();
+        #[cfg(feature = "metrics")]
+        let _ = p.meter_provider.shutdown();
     }
 }
 
@@ -73,7 +73,28 @@ impl TelemetryHandle {
 /// explicit `shutdown` is preferred.
 impl Drop for TelemetryHandle {
     fn drop(&mut self) {
-        self.flush();
+        #[cfg(feature = "otlp")]
+        if let Some(p) = self.inner.take() {
+            // `catch_unwind` keeps a panic inside the SDK shutdown (e.g. the
+            // `handle.join().unwrap()` the batch processor does) from
+            // becoming a panic-during-unwind → process abort when the handle
+            // is dropped while another panic is already unwinding.
+            // `AssertUnwindSafe` is fine: `p` is moved in and dropped here, so
+            // no post-panic logical state is observable. Unlike `shutdown`,
+            // the panic is swallowed — but we surface it so a dead batch
+            // thread isn't completely silent.
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                Self::shutdown_providers(p);
+            }));
+            if let Err(panic) = result {
+                let msg = panic
+                    .downcast_ref::<&str>()
+                    .copied()
+                    .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                    .unwrap_or("<non-string panic>");
+                eprintln!("warning: OpenTelemetry shutdown panicked during drop: {msg}");
+            }
+        }
     }
 }
 

--- a/crates/telemetry/src/handle.rs
+++ b/crates/telemetry/src/handle.rs
@@ -6,6 +6,16 @@
 //! flushes if the handle is dropped without one (panic, early return,
 //! caller forgot, etc.).
 //!
+//! **Prefer explicit `shutdown`.** Drop is a safety net, not a primary path.
+//! The opentelemetry-sdk 0.32 batch span processor + periodic metric reader
+//! each spawn dedicated OS threads; `shutdown` joins them synchronously
+//! with up to a 5 s timeout per signal (~10 s combined). Dropping a handle
+//! on a Tokio worker stalls that worker for the duration; dropping on a
+//! current-thread runtime stalls the whole reactor. The Drop impl also
+//! wraps the join in `catch_unwind` so a panicked batch thread can't
+//! propagate a second panic during stack unwinding (which would abort the
+//! process).
+//!
 //! [`shutdown`]: TelemetryHandle::shutdown
 
 pub struct TelemetryHandle {
@@ -16,6 +26,7 @@ pub struct TelemetryHandle {
 #[cfg(feature = "otlp")]
 pub(crate) struct OtelProviders {
     pub tracer_provider: opentelemetry_sdk::trace::SdkTracerProvider,
+    #[cfg(feature = "metrics")]
     pub meter_provider: opentelemetry_sdk::metrics::SdkMeterProvider,
 }
 
@@ -31,15 +42,26 @@ impl TelemetryHandle {
     /// Flush providers eagerly. Equivalent to letting the handle drop, but
     /// makes the flush point explicit and lets callers control ordering
     /// (e.g. shut down telemetry after the rest of the node stops emitting).
+    /// Prefer this over relying on `Drop` — see the module docs for the
+    /// blocking-thread + panic-safety reasons.
     pub fn shutdown(mut self) {
         self.flush();
     }
 
     fn flush(&mut self) {
         #[cfg(feature = "otlp")]
-        if let Some(p) = self.inner.take() {
-            let _ = p.tracer_provider.shutdown();
-            let _ = p.meter_provider.shutdown();
+        if let Some(_p) = self.inner.take() {
+            // `catch_unwind` keeps a panicked batch thread (which the SDK
+            // exposes via `handle.join().unwrap()` in shutdown) from
+            // turning a normal Drop into a double-panic → abort.
+            // `AssertUnwindSafe` is acceptable: the providers we move in
+            // are about to be dropped anyway, so post-panic logical state
+            // doesn't matter.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                let _ = _p.tracer_provider.shutdown();
+                #[cfg(feature = "metrics")]
+                let _ = _p.meter_provider.shutdown();
+            }));
         }
     }
 }
@@ -47,7 +69,8 @@ impl TelemetryHandle {
 /// Safety net: even if a caller forgets [`TelemetryHandle::shutdown`] or
 /// drops the handle on an error path, the providers get flushed. Without
 /// this, the fix for Go's "never calls shutdown" bug only worked on the
-/// happy path.
+/// happy path. See module-level docs for the blocking behavior and why
+/// explicit `shutdown` is preferred.
 impl Drop for TelemetryHandle {
     fn drop(&mut self) {
         self.flush();

--- a/crates/telemetry/src/handle.rs
+++ b/crates/telemetry/src/handle.rs
@@ -1,10 +1,12 @@
-//! Lifecycle handle returned by [`crate::init`]. Holds provider handles so
-//! the caller can flush buffered spans/metrics on shutdown.
+//! Lifecycle handle returned by [`crate::init`].
 //!
-//! Go DefraDB never calls provider shutdown (`internal/telemetry/otel.go`
-//! has no Shutdown plumbing), so spans buffered at SIGTERM are lost. We
-//! fix that here: the CLI's main path takes ownership of this handle and
-//! calls [`TelemetryHandle::shutdown`] before exit.
+//! Go DefraDB never flushes provider state — buffered spans at SIGTERM are
+//! lost. `TelemetryHandle` fixes that two ways: explicit [`shutdown`] for
+//! callers that want a deterministic flush point, and a `Drop` impl that
+//! flushes if the handle is dropped without one (panic, early return,
+//! caller forgot, etc.).
+//!
+//! [`shutdown`]: TelemetryHandle::shutdown
 
 pub struct TelemetryHandle {
     #[cfg(feature = "otlp")]
@@ -18,6 +20,7 @@ pub(crate) struct OtelProviders {
 }
 
 impl TelemetryHandle {
+    /// Returns a handle that owns no providers — `shutdown` and `Drop` are no-ops.
     pub fn noop() -> Self {
         Self {
             #[cfg(feature = "otlp")]
@@ -25,12 +28,29 @@ impl TelemetryHandle {
         }
     }
 
-    pub fn shutdown(self) {
+    /// Flush providers eagerly. Equivalent to letting the handle drop, but
+    /// makes the flush point explicit and lets callers control ordering
+    /// (e.g. shut down telemetry after the rest of the node stops emitting).
+    pub fn shutdown(mut self) {
+        self.flush();
+    }
+
+    fn flush(&mut self) {
         #[cfg(feature = "otlp")]
-        if let Some(p) = self.inner {
+        if let Some(p) = self.inner.take() {
             let _ = p.tracer_provider.shutdown();
             let _ = p.meter_provider.shutdown();
         }
+    }
+}
+
+/// Safety net: even if a caller forgets [`TelemetryHandle::shutdown`] or
+/// drops the handle on an error path, the providers get flushed. Without
+/// this, the fix for Go's "never calls shutdown" bug only worked on the
+/// happy path.
+impl Drop for TelemetryHandle {
+    fn drop(&mut self) {
+        self.flush();
     }
 }
 

--- a/crates/telemetry/src/init.rs
+++ b/crates/telemetry/src/init.rs
@@ -79,11 +79,10 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
         .with_http()
         .build()
         .map_err(|e| InitError::SpanExporter(Box::new(e)))?;
-    let tracer_provider = SdkTracerProvider::builder()
-        .with_batch_exporter(span_exporter)
-        .with_resource(resource.clone())
-        .build();
 
+    // Build the meter provider first (when enabled) so the trace provider can
+    // take `resource` by value — avoids a clone-then-discard dance on the
+    // metrics-off path.
     #[cfg(feature = "metrics")]
     let meter_provider = {
         let metric_exporter = MetricExporter::builder()
@@ -93,11 +92,14 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
         let reader = PeriodicReader::builder(metric_exporter).build();
         SdkMeterProvider::builder()
             .with_reader(reader)
-            .with_resource(resource)
+            .with_resource(resource.clone())
             .build()
     };
-    #[cfg(not(feature = "metrics"))]
-    let _ = resource; // moved into trace provider only; silence unused-binding
+
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(span_exporter)
+        .with_resource(resource)
+        .build();
 
     if config.install_global {
         global::set_tracer_provider(tracer_provider.clone());

--- a/crates/telemetry/src/init.rs
+++ b/crates/telemetry/src/init.rs
@@ -1,0 +1,90 @@
+//! OTLP exporter setup. Mirrors Go DefraDB's `internal/telemetry/otel.go`.
+//!
+//! - OTLP/gRPC transport (tonic), traces + metrics signals.
+//! - Standard OTEL env vars are honored automatically by `opentelemetry-otlp`
+//!   0.32: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
+//!   `OTEL_EXPORTER_OTLP_PROTOCOL`, signal-specific overrides, etc.
+//! - Resource attributes: `service.name`, `service.version`. `OS` /
+//!   `process` detectors from the sdk's defaults are not added here yet
+//!   (deferred — Go uses `resource.WithOS() / WithProcess()`).
+//!
+//! Requires a Tokio runtime: `grpc-tonic` builds at the call site assume one.
+
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::{MetricExporter, SpanExporter};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::trace::{SdkTracer, SdkTracerProvider};
+use opentelemetry_sdk::Resource;
+use thiserror::Error;
+use tracing::Subscriber;
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::registry::LookupSpan;
+
+use crate::config::TelemetryConfig;
+use crate::handle::{OtelProviders, TelemetryHandle};
+
+pub use opentelemetry_sdk::trace::SdkTracer as Tracer;
+
+#[derive(Debug, Error)]
+pub enum InitError {
+    #[error("failed to build OTLP span exporter: {0}")]
+    SpanExporter(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("failed to build OTLP metric exporter: {0}")]
+    MetricExporter(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// Returns the lifecycle handle and a configured [`SdkTracer`]. The caller
+/// wraps the tracer with `tracing_opentelemetry::layer().with_tracer(...)`
+/// at its subscriber-composition site so type inference can pick the right
+/// `S` parameter for `OpenTelemetryLayer<S, _>`.
+pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), InitError> {
+    let resource = Resource::builder()
+        .with_service_name(config.service_name.clone())
+        .with_attribute(KeyValue::new("service.version", config.service_version))
+        .build();
+
+    let span_exporter = SpanExporter::builder()
+        .with_tonic()
+        .build()
+        .map_err(|e| InitError::SpanExporter(Box::new(e)))?;
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(span_exporter)
+        .with_resource(resource.clone())
+        .build();
+
+    let metric_exporter = MetricExporter::builder()
+        .with_tonic()
+        .build()
+        .map_err(|e| InitError::MetricExporter(Box::new(e)))?;
+    let reader = PeriodicReader::builder(metric_exporter).build();
+    let meter_provider = SdkMeterProvider::builder()
+        .with_reader(reader)
+        .with_resource(resource)
+        .build();
+
+    global::set_tracer_provider(tracer_provider.clone());
+    global::set_meter_provider(meter_provider.clone());
+
+    let tracer = tracer_provider.tracer(config.service_name);
+
+    let handle = TelemetryHandle {
+        inner: Some(OtelProviders {
+            tracer_provider,
+            meter_provider,
+        }),
+    };
+
+    Ok((handle, tracer))
+}
+
+/// Build the `tracing` ↔ OTEL bridge layer for a given subscriber type.
+/// Call this at the subscriber-composition site so `S` is inferred from the
+/// inner subscriber at that point — the layer's `S` parameter must match.
+pub fn otel_layer<S>(tracer: SdkTracer) -> OpenTelemetryLayer<S, SdkTracer>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    tracing_opentelemetry::layer().with_tracer(tracer)
+}

--- a/crates/telemetry/src/init.rs
+++ b/crates/telemetry/src/init.rs
@@ -1,14 +1,18 @@
 //! OTLP exporter setup. Mirrors Go DefraDB's `internal/telemetry/otel.go`.
 //!
-//! - OTLP/gRPC transport (tonic), traces + metrics signals.
+//! - OTLP/HTTP transport (`reqwest`), traces + metrics signals. Same wire
+//!   protocol Go uses via `otlptracehttp` / `otlpmetrichttp`. Default
+//!   endpoint is `http://localhost:4318`.
 //! - Standard OTEL env vars are honored automatically by `opentelemetry-otlp`
 //!   0.32: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
 //!   `OTEL_EXPORTER_OTLP_PROTOCOL`, signal-specific overrides, etc.
-//! - Resource attributes: `service.name`, `service.version`. `OS` /
-//!   `process` detectors from the sdk's defaults are not added here yet
-//!   (deferred — Go uses `resource.WithOS() / WithProcess()`).
+//! - Resource attributes: `service.name`, `service.version`, `os.type`,
+//!   `host.arch`, `process.pid`, `process.executable.name`. Mirrors Go's
+//!   `resource.WithOS()` + `resource.WithProcess()` (which we approximate
+//!   with `std::env::consts` + `std::process` to avoid an extra dep).
 //!
-//! Requires a Tokio runtime: `grpc-tonic` builds at the call site assume one.
+//! Requires a Tokio runtime: `reqwest-client` needs one for the async
+//! HTTP exporter.
 
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider as _;
@@ -40,13 +44,26 @@ pub enum InitError {
 /// at its subscriber-composition site so type inference can pick the right
 /// `S` parameter for `OpenTelemetryLayer<S, _>`.
 pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), InitError> {
+    // Resource attributes mirror Go's `resource.WithSchemaURL + WithOS + WithProcess`.
+    // We use `std::env::consts` / `std::process` instead of pulling in
+    // `opentelemetry-resource-detectors`, which keeps the dep tree small —
+    // the attribute set matches what those detectors produce for the common
+    // fields (os.type, host.arch, process.pid, process.executable.name).
+    let executable_name = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_default();
     let resource = Resource::builder()
         .with_service_name(config.service_name.clone())
         .with_attribute(KeyValue::new("service.version", config.service_version))
+        .with_attribute(KeyValue::new("os.type", std::env::consts::OS))
+        .with_attribute(KeyValue::new("host.arch", std::env::consts::ARCH))
+        .with_attribute(KeyValue::new("process.pid", i64::from(std::process::id())))
+        .with_attribute(KeyValue::new("process.executable.name", executable_name))
         .build();
 
     let span_exporter = SpanExporter::builder()
-        .with_tonic()
+        .with_http()
         .build()
         .map_err(|e| InitError::SpanExporter(Box::new(e)))?;
     let tracer_provider = SdkTracerProvider::builder()
@@ -55,7 +72,7 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
         .build();
 
     let metric_exporter = MetricExporter::builder()
-        .with_tonic()
+        .with_http()
         .build()
         .map_err(|e| InitError::MetricExporter(Box::new(e)))?;
     let reader = PeriodicReader::builder(metric_exporter).build();

--- a/crates/telemetry/src/init.rs
+++ b/crates/telemetry/src/init.rs
@@ -1,8 +1,7 @@
 //! OTLP exporter setup. Mirrors Go DefraDB's `internal/telemetry/otel.go`.
 //!
-//! - OTLP/HTTP transport (`reqwest`), traces + metrics signals. Same wire
-//!   protocol Go uses via `otlptracehttp` / `otlpmetrichttp`. Default
-//!   endpoint is `http://localhost:4318`.
+//! - OTLP/HTTP transport (`reqwest-blocking-client`). Same wire protocol Go
+//!   uses via `otlptracehttp`. Default endpoint is `http://localhost:4318`.
 //! - Standard OTEL env vars are honored automatically by `opentelemetry-otlp`
 //!   0.32: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
 //!   `OTEL_EXPORTER_OTLP_PROTOCOL`, signal-specific overrides, etc.
@@ -11,20 +10,26 @@
 //!   `resource.WithOS()` + `resource.WithProcess()` (which we approximate
 //!   with `std::env::consts` + `std::process` to avoid an extra dep).
 //!
-//! Requires a Tokio runtime: `reqwest-client` needs one for the async
-//! HTTP exporter.
+//! Traces are always exported. Metrics export is off until the `metrics`
+//! feature is enabled — nothing in defradb.rs records metric instruments
+//! today, so leaving the metric pipeline running would burn an empty
+//! periodic export every 60 s.
 
 use opentelemetry::global;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::KeyValue;
-use opentelemetry_otlp::{MetricExporter, SpanExporter};
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_otlp::SpanExporter;
 use opentelemetry_sdk::trace::{SdkTracer, SdkTracerProvider};
 use opentelemetry_sdk::Resource;
 use thiserror::Error;
 use tracing::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::registry::LookupSpan;
+
+#[cfg(feature = "metrics")]
+use opentelemetry_otlp::MetricExporter;
+#[cfg(feature = "metrics")]
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 
 use crate::config::TelemetryConfig;
 use crate::handle::{OtelProviders, TelemetryHandle};
@@ -35,6 +40,7 @@ pub use opentelemetry_sdk::trace::SdkTracer as Tracer;
 pub enum InitError {
     #[error("failed to build OTLP span exporter: {0}")]
     SpanExporter(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[cfg(feature = "metrics")]
     #[error("failed to build OTLP metric exporter: {0}")]
     MetricExporter(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
@@ -44,26 +50,18 @@ pub enum InitError {
 /// at its subscriber-composition site so type inference can pick the right
 /// `S` parameter for `OpenTelemetryLayer<S, _>`.
 ///
-/// # Tokio runtime requirement
-///
-/// `opentelemetry_sdk`'s batch span processor and periodic metric reader
-/// (built with the `rt-tokio` feature here) require a Tokio runtime to be
-/// active at construction time — they call `tokio::runtime::Handle::current()`
-/// internally. Calling `init` outside a runtime panics with
-/// `there is no reactor running`. The CLI's `#[tokio::main]` covers this
-/// automatically; embedded library users must initialize within an async
-/// context or via `Runtime::block_on`.
+/// Safe to call from any context (no Tokio runtime required): with the
+/// `reqwest-blocking-client` transport selected in this crate's `Cargo.toml`,
+/// both `BatchSpanProcessor` and `PeriodicReader` (opentelemetry_sdk 0.32)
+/// spawn dedicated OS threads via `std::thread`. No `Handle::current()`
+/// call happens at init.
 ///
 /// By default `init` installs the providers in the process-wide
 /// `opentelemetry::global` slot. Set [`TelemetryConfig::install_global`] to
-/// `false` to skip that — useful when the host process already runs its own
-/// OTel stack and would otherwise see its globals silently replaced.
+/// `false` (or call [`TelemetryConfig::without_global`]) to skip that —
+/// useful when the host process already runs its own OTel stack and would
+/// otherwise see its globals silently replaced.
 pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), InitError> {
-    // Resource attributes mirror Go's `resource.WithSchemaURL + WithOS + WithProcess`.
-    // We use `std::env::consts` / `std::process` instead of pulling in
-    // `opentelemetry-resource-detectors`, which keeps the dep tree small —
-    // the attribute set matches what those detectors produce for the common
-    // fields (os.type, host.arch, process.pid, process.executable.name).
     let executable_name = std::env::current_exe()
         .ok()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
@@ -86,18 +84,24 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
         .with_resource(resource.clone())
         .build();
 
-    let metric_exporter = MetricExporter::builder()
-        .with_http()
-        .build()
-        .map_err(|e| InitError::MetricExporter(Box::new(e)))?;
-    let reader = PeriodicReader::builder(metric_exporter).build();
-    let meter_provider = SdkMeterProvider::builder()
-        .with_reader(reader)
-        .with_resource(resource)
-        .build();
+    #[cfg(feature = "metrics")]
+    let meter_provider = {
+        let metric_exporter = MetricExporter::builder()
+            .with_http()
+            .build()
+            .map_err(|e| InitError::MetricExporter(Box::new(e)))?;
+        let reader = PeriodicReader::builder(metric_exporter).build();
+        SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(resource)
+            .build()
+    };
+    #[cfg(not(feature = "metrics"))]
+    let _ = resource; // moved into trace provider only; silence unused-binding
 
     if config.install_global {
         global::set_tracer_provider(tracer_provider.clone());
+        #[cfg(feature = "metrics")]
         global::set_meter_provider(meter_provider.clone());
     }
 
@@ -106,6 +110,7 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
     let handle = TelemetryHandle {
         inner: Some(OtelProviders {
             tracer_provider,
+            #[cfg(feature = "metrics")]
             meter_provider,
         }),
     };

--- a/crates/telemetry/src/init.rs
+++ b/crates/telemetry/src/init.rs
@@ -29,6 +29,8 @@ use tracing_subscriber::registry::LookupSpan;
 #[cfg(feature = "metrics")]
 use opentelemetry_otlp::MetricExporter;
 #[cfg(feature = "metrics")]
+use opentelemetry_otlp::WithHttpConfig;
+#[cfg(feature = "metrics")]
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 
 use crate::config::TelemetryConfig;
@@ -83,10 +85,22 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
         .with_attribute(KeyValue::new("process.executable.name", executable_name))
         .build();
 
-    let span_exporter = SpanExporter::builder()
-        .with_http()
-        .build()
-        .map_err(|e| InitError::SpanExporter(Box::new(e)))?;
+    // When both signals export (metrics feature on) they share one HTTP
+    // client — one connection pool / TLS context / worker instead of two,
+    // since both target the same OTLP endpoint. Without metrics there's a
+    // single exporter, so the default build keeps the transitive client and
+    // takes no direct reqwest dependency.
+    #[cfg(feature = "metrics")]
+    let http_client = reqwest::blocking::Client::new();
+
+    let span_exporter = {
+        let builder = SpanExporter::builder().with_http();
+        #[cfg(feature = "metrics")]
+        let builder = builder.with_http_client(http_client.clone());
+        builder
+            .build()
+            .map_err(|e| InitError::SpanExporter(Box::new(e)))?
+    };
 
     // Build the meter provider first (when enabled) so the trace provider can
     // take `resource` by value — avoids a clone-then-discard dance on the
@@ -95,6 +109,7 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
     let meter_provider = {
         let metric_exporter = MetricExporter::builder()
             .with_http()
+            .with_http_client(http_client)
             .build()
             .map_err(|e| InitError::MetricExporter(Box::new(e)))?;
         let reader = PeriodicReader::builder(metric_exporter).build();

--- a/crates/telemetry/src/init.rs
+++ b/crates/telemetry/src/init.rs
@@ -43,6 +43,21 @@ pub enum InitError {
 /// wraps the tracer with `tracing_opentelemetry::layer().with_tracer(...)`
 /// at its subscriber-composition site so type inference can pick the right
 /// `S` parameter for `OpenTelemetryLayer<S, _>`.
+///
+/// # Tokio runtime requirement
+///
+/// `opentelemetry_sdk`'s batch span processor and periodic metric reader
+/// (built with the `rt-tokio` feature here) require a Tokio runtime to be
+/// active at construction time — they call `tokio::runtime::Handle::current()`
+/// internally. Calling `init` outside a runtime panics with
+/// `there is no reactor running`. The CLI's `#[tokio::main]` covers this
+/// automatically; embedded library users must initialize within an async
+/// context or via `Runtime::block_on`.
+///
+/// By default `init` installs the providers in the process-wide
+/// `opentelemetry::global` slot. Set [`TelemetryConfig::install_global`] to
+/// `false` to skip that — useful when the host process already runs its own
+/// OTel stack and would otherwise see its globals silently replaced.
 pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), InitError> {
     // Resource attributes mirror Go's `resource.WithSchemaURL + WithOS + WithProcess`.
     // We use `std::env::consts` / `std::process` instead of pulling in
@@ -81,8 +96,10 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
         .with_resource(resource)
         .build();
 
-    global::set_tracer_provider(tracer_provider.clone());
-    global::set_meter_provider(meter_provider.clone());
+    if config.install_global {
+        global::set_tracer_provider(tracer_provider.clone());
+        global::set_meter_provider(meter_provider.clone());
+    }
 
     let tracer = tracer_provider.tracer(config.service_name);
 

--- a/crates/telemetry/src/init.rs
+++ b/crates/telemetry/src/init.rs
@@ -67,6 +67,14 @@ pub fn init(config: TelemetryConfig) -> Result<(TelemetryHandle, SdkTracer), Ini
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
         .unwrap_or_default();
     let resource = Resource::builder()
+        .with_schema_url(
+            // Declare which semantic-conventions version these attributes
+            // follow, matching Go's `resource.WithSchemaURL(semconv.SchemaURL)`.
+            // The attributes themselves are passed via `.with_*` below, so the
+            // attribute iterator here is empty.
+            std::iter::empty::<KeyValue>(),
+            opentelemetry_semantic_conventions::SCHEMA_URL,
+        )
         .with_service_name(config.service_name.clone())
         .with_attribute(KeyValue::new("service.version", config.service_version))
         .with_attribute(KeyValue::new("os.type", std::env::consts::OS))

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -1,0 +1,26 @@
+//! OpenTelemetry exporter setup for DefraDB.
+//!
+//! Mirrors Go DefraDB's `internal/telemetry/otel.go`. The `otlp` feature
+//! compiles in OTLP/gRPC trace + metric exporters; without it the crate
+//! provides only a no-op [`TelemetryHandle`] and the [`OtelDedupFilter`]
+//! (always available, no-op when no `opentelemetry*` events exist).
+//!
+//! Connection-refused log spam from the OTEL SDK is deduped via
+//! [`OtelDedupFilter`] — the Rust equivalent of Go's `sync.Once`-guarded
+//! `otel.SetErrorHandler`. The global error handler API was removed from
+//! `opentelemetry::global` in v0.27; SDK diagnostics now flow through
+//! `tracing` at `target = "opentelemetry"*`, so a `tracing_subscriber`
+//! filter is the natural hook.
+
+mod config;
+mod dedup;
+mod handle;
+
+pub use config::TelemetryConfig;
+pub use dedup::OtelDedupFilter;
+pub use handle::TelemetryHandle;
+
+#[cfg(feature = "otlp")]
+mod init;
+#[cfg(feature = "otlp")]
+pub use init::{init, otel_layer, InitError, Tracer};

--- a/tools/otel-smoke/README.md
+++ b/tools/otel-smoke/README.md
@@ -1,0 +1,58 @@
+# OTel exporter smoke tests
+
+End-to-end verification for the OTLP exporter wired in issue #977.
+
+Two scripts:
+
+| Script | Purpose | Requires Docker |
+| --- | --- | --- |
+| `run.sh` | Positive path — starts otel-collector-contrib + Jaeger, runs `defra start --features otel` against them, asserts spans arrive with the expected resource attributes. | yes |
+| `dedup.sh` | Negative path — points `defra` at an unreachable port, asserts the "connection refused" message appears at most once (the Rust port of Go's `otel.SetErrorHandler + sync.Once` dedup). | no |
+
+## Quick start
+
+```bash
+# Positive — spans arrive at the collector
+./tools/otel-smoke/run.sh
+
+# Leave the stack up so you can browse spans in Jaeger
+./tools/otel-smoke/run.sh --keep
+# → Jaeger UI: http://localhost:16686 (service: DefraDB)
+# → Tear down: (cd tools/otel-smoke && docker compose down -v)
+
+# Negative — dedup catches connection-refused spam
+./tools/otel-smoke/dedup.sh
+```
+
+## What `run.sh` checks
+
+The collector's file exporter writes each received batch as one JSON line under `output/spans.jsonl`. `run.sh` asserts:
+
+- The file is non-empty (at least one batch landed).
+- `service.name = "DefraDB"` is present (matches Go DefraDB).
+- The Go-parity resource attributes (`service.version`, `os.type`, `host.arch`, `process.pid`, `process.executable.name`) are present.
+- The known span names (`request` from `tower_http::TraceLayer`, `query.execute_request` from `QueryRunner::execute`) are reported when the relevant endpoints are exercised.
+
+If `--keep` is passed, the stack stays up so you can:
+
+- Browse spans in the Jaeger UI at <http://localhost:16686> (search service "DefraDB").
+- Inspect `output/spans.jsonl` directly.
+- Inspect `output/defra.stderr` for OTel SDK diagnostics.
+
+## What `dedup.sh` checks
+
+Boots `defra start --features otel` with `OTEL_EXPORTER_OTLP_ENDPOINT` pointed at a port nobody is listening on. Lets the batch processor retry for a few seconds. Then SIGTERMs and `grep`s the stderr — `connection refused` must appear **at most once**.
+
+## Ports used
+
+| Port | Owner | Purpose |
+| --- | --- | --- |
+| 4317 | otelcol | OTLP/gRPC ingest (not used by defra, but exposed for parity) |
+| 4318 | otelcol | OTLP/HTTP ingest — defra exports here |
+| 9181 | defra (run.sh) | defra HTTP API |
+| 9182 | defra (dedup.sh) | defra HTTP API (different port to avoid collision) |
+| 14250 | jaeger | gRPC receiver from otelcol |
+| 16686 | jaeger | UI |
+| 14318 | (must be unbound) | dedup target — confirmed empty before the test runs |
+
+The scripts fail fast if a required port is already taken.

--- a/tools/otel-smoke/dedup.sh
+++ b/tools/otel-smoke/dedup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Negative-path verification: with no OTLP collector listening, the dedup
+# filter must squash "connection refused" log spam to a single occurrence
+# per process — the Rust port of Go DefraDB's `otel.SetErrorHandler +
+# sync.Once` (issue #977, Go commit 83af37a9).
+#
+# Does NOT use docker; it relies on the absence of a listener on the
+# chosen port.
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+STDERR_LOG="$SCRIPT_DIR/output/defra-dedup.stderr"
+STDOUT_LOG="$SCRIPT_DIR/output/defra-dedup.stdout"
+
+mkdir -p "$SCRIPT_DIR/output"
+rm -f "$STDERR_LOG" "$STDOUT_LOG"
+
+# Use a port that is almost certainly unbound.
+DEAD_PORT=14318
+if nc -z localhost "$DEAD_PORT" 2>/dev/null; then
+  echo "FAIL: port $DEAD_PORT is bound; pick another or stop the listener"
+  exit 1
+fi
+
+DEFRA_PID=""
+cleanup() {
+  if [ -n "$DEFRA_PID" ]; then
+    kill -TERM "$DEFRA_PID" 2>/dev/null || true
+    wait "$DEFRA_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+echo "=== building defra (cli --features otel) ==="
+(cd "$REPO_ROOT" && cargo build -p cli --features otel)
+
+echo "=== starting defra against unreachable collector ==="
+DEFRA_ROOT="$(mktemp -d)"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:$DEAD_PORT"
+export OTEL_BSP_SCHEDULE_DELAY="300"  # ms — provoke multiple retries quickly
+"$REPO_ROOT/target/debug/defra" start \
+  --rootdir "$DEFRA_ROOT" \
+  --no-keyring \
+  --store memory \
+  --url 127.0.0.1:9182 \
+  >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+DEFRA_PID=$!
+
+echo "=== waiting for defra HTTP :9182 ==="
+for _ in $(seq 1 30); do
+  if curl -sf -o /dev/null http://127.0.0.1:9182/ ; then
+    break
+  fi
+  if ! kill -0 "$DEFRA_PID" 2>/dev/null; then
+    echo "FAIL: defra exited; stderr below"
+    tail -50 "$STDERR_LOG"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "=== generating spans to provoke repeated batch-export attempts ==="
+# Each request creates a tower_http span; absent a collector, every batch
+# export attempt fails. Without dedup, every attempt would log.
+for _ in $(seq 1 30); do
+  curl -sf -o /dev/null http://127.0.0.1:9182/api/v0/schema || true
+  sleep 0.2
+done
+
+echo "=== letting any final batch processor retries fire ==="
+sleep 3
+
+echo "=== shutting down defra ==="
+kill -TERM "$DEFRA_PID"
+wait "$DEFRA_PID" 2>/dev/null || true
+DEFRA_PID=""
+
+echo "=== counting exporter-unreachable log lines in stderr ==="
+# These are the messages the dedup filter is responsible for squashing.
+# Counted as ERROR-level events from any `opentelemetry*` target, matching
+# the same needles the filter does (see crates/telemetry/src/dedup.rs).
+PATTERN='connection refused|HTTP export failed|network error'
+UNREACHABLE_LINES=$(grep -E "ERROR" "$STDERR_LOG" \
+    | grep -E "opentelemetry" \
+    | grep -Ec "$PATTERN" \
+    || true)
+echo "exporter-unreachable lines: $UNREACHABLE_LINES"
+
+if [ "$UNREACHABLE_LINES" -gt 1 ]; then
+  echo "FAIL: dedup let $UNREACHABLE_LINES exporter-unreachable lines through (expected at most 1)"
+  echo "--- offending lines ---"
+  grep -E "ERROR" "$STDERR_LOG" | grep -E "opentelemetry" | grep -E "$PATTERN" | head -20
+  exit 1
+fi
+
+if [ "$UNREACHABLE_LINES" -eq 0 ]; then
+  echo "WARN: zero exporter-unreachable lines logged."
+  echo "      Either the dedup is doing its job AND the test didn't provoke any pre-dedup logs"
+  echo "      (e.g. SDK self-throttled), or the exporter was reachable. Inspect $STDERR_LOG"
+  echo "      to confirm."
+fi
+
+echo "PASS: at most 1 exporter-unreachable log line (got $UNREACHABLE_LINES)"

--- a/tools/otel-smoke/dedup.sh
+++ b/tools/otel-smoke/dedup.sh
@@ -57,37 +57,19 @@ sleep 3
 echo "=== shutting down defra ==="
 stop_defra
 
-echo "=== counting exporter-unreachable log lines in stderr ==="
-# Each known needle (connection refused / HTTP export failed / network error)
-# has its own per-process latch — so the upper bound is one log line per
-# distinct pattern. In practice the SDK's unreachable-collector message
-# ("HTTP export failed: network error") matches two needles in one line and
-# claims both latches at once, so the realistic ceiling is 2, not 3. A
-# regression to first-match-wins would leak a 3rd line and trip this.
-# See crates/telemetry/src/dedup.rs.
-NEEDLE_MAX=2
-PATTERN='connection refused|HTTP export failed|network error'
-UNREACHABLE_LINES=$(grep -E "ERROR" "$STDERR_LOG" \
-    | grep -E "opentelemetry" \
-    | grep -Ec "$PATTERN" \
-    || true)
-echo "exporter-unreachable lines: $UNREACHABLE_LINES (per-needle ceiling: $NEEDLE_MAX)"
+echo "=== checking the operator hint was emitted exactly once ==="
+# Go-parity behavior (crates/telemetry/src/dedup.rs): the raw, repeated SDK
+# export errors are SUPPRESSED, and a single actionable hint is emitted once
+# per process via a global latch. So we assert:
+#   - the hint appears exactly once (proves: internal-logs on → SDK emitted →
+#     filter caught it → emitted once globally; matches Go's sync.Once), and
+#   - the raw needle text is gone from stderr (proves suppression).
+HINT='OpenTelemetry export failed, ensure your OTLP collector is running and reachable'
+HINT_LINES=$(grep -Fc "$HINT" "$STDERR_LOG" || true)
+echo "operator-hint lines: $HINT_LINES (expected exactly 1)"
 
-if [ "$UNREACHABLE_LINES" -gt "$NEEDLE_MAX" ]; then
-  echo "FAIL: dedup let $UNREACHABLE_LINES exporter-unreachable lines through (expected at most $NEEDLE_MAX, one per needle)"
-  echo "--- offending lines ---"
-  grep -E "ERROR" "$STDERR_LOG" | grep -E "opentelemetry" | grep -E "$PATTERN" | head -20
-  exit 1
-fi
-
-# Zero lines is a FAIL, not informational: with a guaranteed-unreachable
-# collector the SDK must emit at least one export-failure event. Zero means
-# either the dedup is over-suppressing OR — the regression this guards — the
-# SDK's `internal-logs` feature got disabled and the exporter went silent
-# (which would also make the dedup filter dead code). Either way it's a real
-# defect, so fail loudly.
-if [ "$UNREACHABLE_LINES" -eq 0 ]; then
-  echo "FAIL: zero exporter-unreachable lines despite an unreachable collector."
+if [ "$HINT_LINES" -eq 0 ]; then
+  echo "FAIL: the operator hint never appeared despite an unreachable collector."
   echo "      Likely the opentelemetry SDK's 'internal-logs' feature is off"
   echo "      (the otel_error! macros no-op without it), so export failures emit"
   echo "      nothing and the dedup filter is dead code. Check telemetry/Cargo.toml"
@@ -95,4 +77,21 @@ if [ "$UNREACHABLE_LINES" -eq 0 ]; then
   exit 1
 fi
 
-echo "PASS: $UNREACHABLE_LINES exporter-unreachable log line(s), within [1, $NEEDLE_MAX]"
+if [ "$HINT_LINES" -gt 1 ]; then
+  echo "FAIL: operator hint emitted $HINT_LINES times (expected exactly 1)."
+  echo "      The process-global once-latch is not deduping across layers."
+  grep -F "$HINT" "$STDERR_LOG" | head -10
+  exit 1
+fi
+
+# The raw, spammy SDK error lines should be fully suppressed (Go parity).
+RAW_LINES=$(grep -E "opentelemetry" "$STDERR_LOG" \
+    | grep -E "ERROR" \
+    | grep -Ec 'connection refused|HTTP export failed|network error' \
+    || true)
+if [ "$RAW_LINES" -ne 0 ]; then
+  echo "WARN: $RAW_LINES raw exporter-error line(s) leaked through (expected 0 — they should be suppressed in favor of the single hint)."
+  grep -E "opentelemetry" "$STDERR_LOG" | grep -E "ERROR" | head -5
+fi
+
+echo "PASS: operator hint emitted exactly once; raw exporter spam suppressed"

--- a/tools/otel-smoke/dedup.sh
+++ b/tools/otel-smoke/dedup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Negative-path verification: with no OTLP collector listening, the dedup
-# filter must squash "connection refused" log spam to a single occurrence
+# filter must squash exporter-unreachable log spam to one line per pattern
 # per process — the Rust port of Go DefraDB's `otel.SetErrorHandler +
 # sync.Once` (issue #977, Go commit 83af37a9).
 #
@@ -9,60 +9,33 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
-STDERR_LOG="$SCRIPT_DIR/output/defra-dedup.stderr"
-STDOUT_LOG="$SCRIPT_DIR/output/defra-dedup.stdout"
+# shellcheck source=tools/otel-smoke/lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib.sh"
 
-mkdir -p "$SCRIPT_DIR/output"
+STDERR_LOG="$OUTPUT_DIR/defra-dedup.stderr"
+STDOUT_LOG="$OUTPUT_DIR/defra-dedup.stdout"
+PORT=9182
+
+mkdir -p "$OUTPUT_DIR"
 rm -f "$STDERR_LOG" "$STDOUT_LOG"
 
-# Use a port that is almost certainly unbound.
+# Use a port that is almost certainly unbound. Pin to 127.0.0.1 so the
+# precondition check uses the same IP family as reqwest's resolver —
+# `localhost` would let a bound `[::1]:$DEAD_PORT` silently mask the test.
 DEAD_PORT=14318
-# Pin to 127.0.0.1 so the precondition check uses the same IP family as
-# reqwest's resolver — `localhost` would let a bound `[::1]:$DEAD_PORT`
-# silently mask the test.
 if nc -z 127.0.0.1 "$DEAD_PORT" 2>/dev/null; then
   echo "FAIL: port $DEAD_PORT is bound; pick another or stop the listener"
   exit 1
 fi
 
-DEFRA_PID=""
-cleanup() {
-  if [ -n "$DEFRA_PID" ]; then
-    kill -TERM "$DEFRA_PID" 2>/dev/null || true
-    wait "$DEFRA_PID" 2>/dev/null || true
-  fi
-}
-trap cleanup EXIT INT TERM
+trap stop_defra EXIT INT TERM
 
-echo "=== building defra (cli --features otel) ==="
-(cd "$REPO_ROOT" && cargo build -p cli --features otel)
+build_defra
 
-echo "=== starting defra against unreachable collector ==="
-DEFRA_ROOT="$(mktemp -d)"
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:$DEAD_PORT"
 export OTEL_BSP_SCHEDULE_DELAY="300"  # ms — provoke multiple retries quickly
-"$REPO_ROOT/target/debug/defra" start \
-  --rootdir "$DEFRA_ROOT" \
-  --no-keyring \
-  --store memory \
-  --url 127.0.0.1:9182 \
-  >"$STDOUT_LOG" 2>"$STDERR_LOG" &
-DEFRA_PID=$!
-
-echo "=== waiting for defra HTTP :9182 ==="
-for _ in $(seq 1 30); do
-  if curl -sf -o /dev/null http://127.0.0.1:9182/ ; then
-    break
-  fi
-  if ! kill -0 "$DEFRA_PID" 2>/dev/null; then
-    echo "FAIL: defra exited; stderr below"
-    tail -50 "$STDERR_LOG"
-    exit 1
-  fi
-  sleep 1
-done
+start_defra "$PORT" "$STDOUT_LOG" "$STDERR_LOG"
+wait_for_http "$PORT" "$STDERR_LOG"
 
 echo "=== generating spans to provoke repeated batch-export attempts ==="
 # Each GraphQL request creates a QueryRunner::execute span (info-level
@@ -72,7 +45,7 @@ echo "=== generating spans to provoke repeated batch-export attempts ==="
 # the BatchSpanProcessor to keep trying.
 for _ in $(seq 1 30); do
   curl -sf -o /dev/null \
-    -X POST http://127.0.0.1:9182/api/v0/graphql \
+    -X POST "http://127.0.0.1:$PORT/api/v0/graphql" \
     -H 'Content-Type: application/json' \
     -d '{"query": "query { __typename }"}' || true
   sleep 0.2
@@ -82,9 +55,7 @@ echo "=== letting any final batch processor retries fire ==="
 sleep 3
 
 echo "=== shutting down defra ==="
-kill -TERM "$DEFRA_PID"
-wait "$DEFRA_PID" 2>/dev/null || true
-DEFRA_PID=""
+stop_defra
 
 echo "=== counting exporter-unreachable log lines in stderr ==="
 # Each known needle (connection refused / HTTP export failed / network error)

--- a/tools/otel-smoke/dedup.sh
+++ b/tools/otel-smoke/dedup.sh
@@ -109,11 +109,19 @@ if [ "$UNREACHABLE_LINES" -gt "$NEEDLE_MAX" ]; then
   exit 1
 fi
 
+# Zero lines is a FAIL, not informational: with a guaranteed-unreachable
+# collector the SDK must emit at least one export-failure event. Zero means
+# either the dedup is over-suppressing OR — the regression this guards — the
+# SDK's `internal-logs` feature got disabled and the exporter went silent
+# (which would also make the dedup filter dead code). Either way it's a real
+# defect, so fail loudly.
 if [ "$UNREACHABLE_LINES" -eq 0 ]; then
-  echo "WARN: zero exporter-unreachable lines logged."
-  echo "      Either the dedup is doing its job AND the test didn't provoke any pre-dedup logs"
-  echo "      (e.g. SDK self-throttled), or the exporter was reachable. Inspect $STDERR_LOG"
-  echo "      to confirm."
+  echo "FAIL: zero exporter-unreachable lines despite an unreachable collector."
+  echo "      Likely the opentelemetry SDK's 'internal-logs' feature is off"
+  echo "      (the otel_error! macros no-op without it), so export failures emit"
+  echo "      nothing and the dedup filter is dead code. Check telemetry/Cargo.toml"
+  echo "      keeps internal-logs in the otlp feature. Server stderr: $STDERR_LOG"
+  exit 1
 fi
 
-echo "PASS: at most $NEEDLE_MAX exporter-unreachable log lines (got $UNREACHABLE_LINES)"
+echo "PASS: $UNREACHABLE_LINES exporter-unreachable log line(s), within [1, $NEEDLE_MAX]"

--- a/tools/otel-smoke/dedup.sh
+++ b/tools/otel-smoke/dedup.sh
@@ -19,7 +19,10 @@ rm -f "$STDERR_LOG" "$STDOUT_LOG"
 
 # Use a port that is almost certainly unbound.
 DEAD_PORT=14318
-if nc -z localhost "$DEAD_PORT" 2>/dev/null; then
+# Pin to 127.0.0.1 so the precondition check uses the same IP family as
+# reqwest's resolver — `localhost` would let a bound `[::1]:$DEAD_PORT`
+# silently mask the test.
+if nc -z 127.0.0.1 "$DEAD_PORT" 2>/dev/null; then
   echo "FAIL: port $DEAD_PORT is bound; pick another or stop the listener"
   exit 1
 fi
@@ -38,7 +41,7 @@ echo "=== building defra (cli --features otel) ==="
 
 echo "=== starting defra against unreachable collector ==="
 DEFRA_ROOT="$(mktemp -d)"
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:$DEAD_PORT"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:$DEAD_PORT"
 export OTEL_BSP_SCHEDULE_DELAY="300"  # ms — provoke multiple retries quickly
 "$REPO_ROOT/target/debug/defra" start \
   --rootdir "$DEFRA_ROOT" \
@@ -62,10 +65,16 @@ for _ in $(seq 1 30); do
 done
 
 echo "=== generating spans to provoke repeated batch-export attempts ==="
-# Each request creates a tower_http span; absent a collector, every batch
-# export attempt fails. Without dedup, every attempt would log.
+# Each GraphQL request creates a QueryRunner::execute span (info-level
+# `#[instrument]`); HTTP `tower_http::TraceLayer` spans are debug-level
+# (the default env filter is INFO). Without dedup, every failed batch
+# export logs an error to stderr — this loop generates enough spans for
+# the BatchSpanProcessor to keep trying.
 for _ in $(seq 1 30); do
-  curl -sf -o /dev/null http://127.0.0.1:9182/api/v0/schema || true
+  curl -sf -o /dev/null \
+    -X POST http://127.0.0.1:9182/api/v0/graphql \
+    -H 'Content-Type: application/json' \
+    -d '{"query": "query { __typename }"}' || true
   sleep 0.2
 done
 

--- a/tools/otel-smoke/dedup.sh
+++ b/tools/otel-smoke/dedup.sh
@@ -87,18 +87,19 @@ wait "$DEFRA_PID" 2>/dev/null || true
 DEFRA_PID=""
 
 echo "=== counting exporter-unreachable log lines in stderr ==="
-# These are the messages the dedup filter is responsible for squashing.
-# Counted as ERROR-level events from any `opentelemetry*` target, matching
-# the same needles the filter does (see crates/telemetry/src/dedup.rs).
+# Each known needle (connection refused / HTTP export failed / network error)
+# has its own per-process latch — so the upper bound is one log line per
+# needle, not one in total. See crates/telemetry/src/dedup.rs.
+NEEDLE_MAX=3
 PATTERN='connection refused|HTTP export failed|network error'
 UNREACHABLE_LINES=$(grep -E "ERROR" "$STDERR_LOG" \
     | grep -E "opentelemetry" \
     | grep -Ec "$PATTERN" \
     || true)
-echo "exporter-unreachable lines: $UNREACHABLE_LINES"
+echo "exporter-unreachable lines: $UNREACHABLE_LINES (per-needle ceiling: $NEEDLE_MAX)"
 
-if [ "$UNREACHABLE_LINES" -gt 1 ]; then
-  echo "FAIL: dedup let $UNREACHABLE_LINES exporter-unreachable lines through (expected at most 1)"
+if [ "$UNREACHABLE_LINES" -gt "$NEEDLE_MAX" ]; then
+  echo "FAIL: dedup let $UNREACHABLE_LINES exporter-unreachable lines through (expected at most $NEEDLE_MAX, one per needle)"
   echo "--- offending lines ---"
   grep -E "ERROR" "$STDERR_LOG" | grep -E "opentelemetry" | grep -E "$PATTERN" | head -20
   exit 1
@@ -111,4 +112,4 @@ if [ "$UNREACHABLE_LINES" -eq 0 ]; then
   echo "      to confirm."
 fi
 
-echo "PASS: at most 1 exporter-unreachable log line (got $UNREACHABLE_LINES)"
+echo "PASS: at most $NEEDLE_MAX exporter-unreachable log lines (got $UNREACHABLE_LINES)"

--- a/tools/otel-smoke/dedup.sh
+++ b/tools/otel-smoke/dedup.sh
@@ -89,8 +89,12 @@ DEFRA_PID=""
 echo "=== counting exporter-unreachable log lines in stderr ==="
 # Each known needle (connection refused / HTTP export failed / network error)
 # has its own per-process latch — so the upper bound is one log line per
-# needle, not one in total. See crates/telemetry/src/dedup.rs.
-NEEDLE_MAX=3
+# distinct pattern. In practice the SDK's unreachable-collector message
+# ("HTTP export failed: network error") matches two needles in one line and
+# claims both latches at once, so the realistic ceiling is 2, not 3. A
+# regression to first-match-wins would leak a 3rd line and trip this.
+# See crates/telemetry/src/dedup.rs.
+NEEDLE_MAX=2
 PATTERN='connection refused|HTTP export failed|network error'
 UNREACHABLE_LINES=$(grep -E "ERROR" "$STDERR_LOG" \
     | grep -E "opentelemetry" \

--- a/tools/otel-smoke/docker-compose.yml
+++ b/tools/otel-smoke/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  otelcol:
+    # Pinned to a recent contrib build. Bump as needed; this matches the
+    # `opentelemetry-otlp` 0.32 wire format.
+    image: otel/opentelemetry-collector-contrib:0.116.1
+    container_name: defra-otel-smoke-otelcol
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./otelcol.yaml:/etc/otelcol/config.yaml:ro
+      - ./output:/output
+    ports:
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+    depends_on:
+      - jaeger
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: defra-otel-smoke-jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686" # Jaeger UI
+      - "14250:14250" # Jaeger gRPC (from otelcol)

--- a/tools/otel-smoke/lib.sh
+++ b/tools/otel-smoke/lib.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared scaffolding for the OTel smoke scripts (run.sh, dedup.sh).
+# Source this; it does not run anything on its own.
+#
+# Exposes:
+#   SCRIPT_DIR / REPO_ROOT / OUTPUT_DIR  — resolved paths
+#   DEFRA_PID                            — set by start_defra, cleared by stop_defra
+#   build_defra                          — cargo build -p cli --features otel
+#   start_defra <port> <stdout> <stderr> — launch `defra start` (memory store, no keyring)
+#   wait_for_http <port> <stderr>        — poll until the HTTP API answers, or fail
+#   stop_defra                           — SIGTERM + wait, clears DEFRA_PID
+#
+# Callers pin the OTLP endpoint to 127.0.0.1 (not `localhost`) so reqwest's
+# resolver and any docker port binding agree on IPv4.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+OUTPUT_DIR="$SCRIPT_DIR/output"
+
+DEFRA_PID=""
+
+build_defra() {
+  echo "=== building defra (cli --features otel) ==="
+  (cd "$REPO_ROOT" && cargo build -p cli --features otel)
+}
+
+# start_defra <port> <stdout_log> <stderr_log>
+start_defra() {
+  local port="$1" stdout_log="$2" stderr_log="$3"
+  local rootdir
+  rootdir="$(mktemp -d)"
+  echo "=== starting defra on 127.0.0.1:$port ==="
+  "$REPO_ROOT/target/debug/defra" start \
+    --rootdir "$rootdir" \
+    --no-keyring \
+    --store memory \
+    --url "127.0.0.1:$port" \
+    >"$stdout_log" 2>"$stderr_log" &
+  DEFRA_PID=$!
+}
+
+# wait_for_http <port> <stderr_log>
+# Probes a real 200 route (`/api/v0/schema`); `/` returns 404, so `curl -sf`
+# against it never succeeds.
+wait_for_http() {
+  local port="$1" stderr_log="$2"
+  echo "=== waiting for defra HTTP :$port ==="
+  for _ in $(seq 1 30); do
+    if curl -sf -o /dev/null "http://127.0.0.1:$port/api/v0/schema"; then
+      return 0
+    fi
+    if ! kill -0 "$DEFRA_PID" 2>/dev/null; then
+      echo "FAIL: defra exited before serving; stderr below"
+      tail -100 "$stderr_log"
+      exit 1
+    fi
+    sleep 1
+  done
+  echo "FAIL: defra HTTP :$port did not come up"
+  exit 1
+}
+
+stop_defra() {
+  if [ -n "$DEFRA_PID" ]; then
+    kill -TERM "$DEFRA_PID" 2>/dev/null || true
+    wait "$DEFRA_PID" 2>/dev/null || true
+    DEFRA_PID=""
+  fi
+}

--- a/tools/otel-smoke/otelcol.yaml
+++ b/tools/otel-smoke/otelcol.yaml
@@ -1,0 +1,28 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  # Drives the assertions in run.sh — every batch is appended as JSON-Lines.
+  file:
+    path: /output/spans.jsonl
+  # Drives the Jaeger UI for human inspection at http://localhost:16686.
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [file, otlp/jaeger, debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [file, debug]

--- a/tools/otel-smoke/run.sh
+++ b/tools/otel-smoke/run.sh
@@ -14,6 +14,9 @@
 
 set -euo pipefail
 
+# shellcheck source=tools/otel-smoke/lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/lib.sh"
+
 KEEP=0
 for arg in "$@"; do
   case "$arg" in
@@ -22,21 +25,14 @@ for arg in "$@"; do
   esac
 done
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
-OUTPUT_DIR="$SCRIPT_DIR/output"
 SPANS_FILE="$OUTPUT_DIR/spans.jsonl"
 DEFRA_STDERR="$OUTPUT_DIR/defra.stderr"
 DEFRA_STDOUT="$OUTPUT_DIR/defra.stdout"
-
-DEFRA_PID=""
+PORT=9181
 
 cleanup() {
   local rc=$?
-  if [ -n "$DEFRA_PID" ]; then
-    kill -TERM "$DEFRA_PID" 2>/dev/null || true
-    wait "$DEFRA_PID" 2>/dev/null || true
-  fi
+  stop_defra
   if [ "$KEEP" -eq 0 ]; then
     (cd "$SCRIPT_DIR" && docker compose down -v >/dev/null 2>&1) || true
   else
@@ -67,45 +63,23 @@ for _ in $(seq 1 30); do
 done
 nc -z 127.0.0.1 4318 || { echo "FAIL: otelcol did not come up"; exit 1; }
 
-step "building defra (cli --features otel)"
-(cd "$REPO_ROOT" && cargo build -p cli --features otel)
+build_defra
 
-step "starting defra against http://127.0.0.1:4318"
-DEFRA_ROOT="$(mktemp -d)"
 # 127.0.0.1 (not `localhost`) so reqwest's resolver and the docker port
 # binding agree on IPv4 — `localhost` would otherwise prefer ::1 on some
 # Linux setups and miss the docker container that only listens on v4.
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"
 export OTEL_BSP_SCHEDULE_DELAY="500"  # ms — flush quickly so the test isn't slow
-# Memory store keeps the test hermetic.
-"$REPO_ROOT/target/debug/defra" start \
-  --rootdir "$DEFRA_ROOT" \
-  --no-keyring \
-  --store memory \
-  --url 127.0.0.1:9181 \
-  >"$DEFRA_STDOUT" 2>"$DEFRA_STDERR" &
-DEFRA_PID=$!
-
-step "waiting for defra HTTP :9181"
-for _ in $(seq 1 30); do
-  if curl -sf -o /dev/null http://127.0.0.1:9181/ ; then
-    break
-  fi
-  if ! kill -0 "$DEFRA_PID" 2>/dev/null; then
-    echo "FAIL: defra exited; stderr below"
-    cat "$DEFRA_STDERR"
-    exit 1
-  fi
-  sleep 1
-done
+start_defra "$PORT" "$DEFRA_STDOUT" "$DEFRA_STDERR"
+wait_for_http "$PORT" "$DEFRA_STDERR"
 
 step "exercising endpoints to emit spans"
 # Any HTTP request produces a tower_http TraceLayer span; GraphQL adds the
 # QueryRunner::execute span (already #[instrument]'d).
-curl -s -o /dev/null http://127.0.0.1:9181/ || true
-curl -s -o /dev/null http://127.0.0.1:9181/api/v0/schema || true
+curl -s -o /dev/null "http://127.0.0.1:$PORT/" || true
+curl -s -o /dev/null "http://127.0.0.1:$PORT/api/v0/schema" || true
 curl -s -o /dev/null \
-  -X POST http://127.0.0.1:9181/api/v0/graphql \
+  -X POST "http://127.0.0.1:$PORT/api/v0/graphql" \
   -H 'Content-Type: application/json' \
   -d '{"query": "query { __typename }"}' || true
 
@@ -113,9 +87,7 @@ step "waiting for batch flush"
 sleep 2
 
 step "shutting down defra (flushes provider)"
-kill -TERM "$DEFRA_PID"
-wait "$DEFRA_PID" 2>/dev/null || true
-DEFRA_PID=""
+stop_defra
 
 step "waiting for collector to flush file exporter"
 sleep 2

--- a/tools/otel-smoke/run.sh
+++ b/tools/otel-smoke/run.sh
@@ -60,19 +60,22 @@ step "starting otelcol + jaeger"
 
 step "waiting for otelcol :4318"
 for _ in $(seq 1 30); do
-  if nc -z localhost 4318 2>/dev/null; then
+  if nc -z 127.0.0.1 4318 2>/dev/null; then
     break
   fi
   sleep 1
 done
-nc -z localhost 4318 || { echo "FAIL: otelcol did not come up"; exit 1; }
+nc -z 127.0.0.1 4318 || { echo "FAIL: otelcol did not come up"; exit 1; }
 
 step "building defra (cli --features otel)"
 (cd "$REPO_ROOT" && cargo build -p cli --features otel)
 
-step "starting defra against http://localhost:4318"
+step "starting defra against http://127.0.0.1:4318"
 DEFRA_ROOT="$(mktemp -d)"
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+# 127.0.0.1 (not `localhost`) so reqwest's resolver and the docker port
+# binding agree on IPv4 — `localhost` would otherwise prefer ::1 on some
+# Linux setups and miss the docker container that only listens on v4.
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"
 export OTEL_BSP_SCHEDULE_DELAY="500"  # ms — flush quickly so the test isn't slow
 # Memory store keeps the test hermetic.
 "$REPO_ROOT/target/debug/defra" start \

--- a/tools/otel-smoke/run.sh
+++ b/tools/otel-smoke/run.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# End-to-end OTel exporter smoke test against a real OTLP collector + Jaeger.
+#
+# 1. Stands up otel-collector-contrib + Jaeger in docker compose.
+# 2. Builds and starts `defra start --features otel`, pointed at the collector.
+# 3. Makes a handful of HTTP / GraphQL requests so spans are emitted.
+# 4. SIGTERMs defra so the provider shutdown flushes the batch.
+# 5. Reads the collector's file exporter output and asserts that:
+#    - service.name=DefraDB resource attribute is present
+#    - At least one span batch landed
+#
+# Pass `--keep` to leave the stack up after the run (useful for inspecting
+# spans in the Jaeger UI at http://localhost:16686).
+
+set -euo pipefail
+
+KEEP=0
+for arg in "$@"; do
+  case "$arg" in
+    --keep) KEEP=1 ;;
+    *) echo "unknown flag: $arg" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+OUTPUT_DIR="$SCRIPT_DIR/output"
+SPANS_FILE="$OUTPUT_DIR/spans.jsonl"
+DEFRA_STDERR="$OUTPUT_DIR/defra.stderr"
+DEFRA_STDOUT="$OUTPUT_DIR/defra.stdout"
+
+DEFRA_PID=""
+
+cleanup() {
+  local rc=$?
+  if [ -n "$DEFRA_PID" ]; then
+    kill -TERM "$DEFRA_PID" 2>/dev/null || true
+    wait "$DEFRA_PID" 2>/dev/null || true
+  fi
+  if [ "$KEEP" -eq 0 ]; then
+    (cd "$SCRIPT_DIR" && docker compose down -v >/dev/null 2>&1) || true
+  else
+    echo "--- stack left running (--keep). Jaeger UI: http://localhost:16686 ---"
+    echo "--- tear down with:  (cd $SCRIPT_DIR && docker compose down -v) ---"
+  fi
+  exit $rc
+}
+trap cleanup EXIT INT TERM
+
+step() { printf '\n=== %s ===\n' "$1"; }
+
+step "preparing output dir"
+mkdir -p "$OUTPUT_DIR"
+rm -f "$SPANS_FILE" "$DEFRA_STDERR" "$DEFRA_STDOUT"
+# otelcol runs as non-root inside the container and needs write access.
+chmod 777 "$OUTPUT_DIR"
+
+step "starting otelcol + jaeger"
+(cd "$SCRIPT_DIR" && docker compose up -d)
+
+step "waiting for otelcol :4318"
+for _ in $(seq 1 30); do
+  if nc -z localhost 4318 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+nc -z localhost 4318 || { echo "FAIL: otelcol did not come up"; exit 1; }
+
+step "building defra (cli --features otel)"
+(cd "$REPO_ROOT" && cargo build -p cli --features otel)
+
+step "starting defra against http://localhost:4318"
+DEFRA_ROOT="$(mktemp -d)"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+export OTEL_BSP_SCHEDULE_DELAY="500"  # ms — flush quickly so the test isn't slow
+# Memory store keeps the test hermetic.
+"$REPO_ROOT/target/debug/defra" start \
+  --rootdir "$DEFRA_ROOT" \
+  --no-keyring \
+  --store memory \
+  --url 127.0.0.1:9181 \
+  >"$DEFRA_STDOUT" 2>"$DEFRA_STDERR" &
+DEFRA_PID=$!
+
+step "waiting for defra HTTP :9181"
+for _ in $(seq 1 30); do
+  if curl -sf -o /dev/null http://127.0.0.1:9181/ ; then
+    break
+  fi
+  if ! kill -0 "$DEFRA_PID" 2>/dev/null; then
+    echo "FAIL: defra exited; stderr below"
+    cat "$DEFRA_STDERR"
+    exit 1
+  fi
+  sleep 1
+done
+
+step "exercising endpoints to emit spans"
+# Any HTTP request produces a tower_http TraceLayer span; GraphQL adds the
+# QueryRunner::execute span (already #[instrument]'d).
+curl -s -o /dev/null http://127.0.0.1:9181/ || true
+curl -s -o /dev/null http://127.0.0.1:9181/api/v0/schema || true
+curl -s -o /dev/null \
+  -X POST http://127.0.0.1:9181/api/v0/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "query { __typename }"}' || true
+
+step "waiting for batch flush"
+sleep 2
+
+step "shutting down defra (flushes provider)"
+kill -TERM "$DEFRA_PID"
+wait "$DEFRA_PID" 2>/dev/null || true
+DEFRA_PID=""
+
+step "waiting for collector to flush file exporter"
+sleep 2
+
+step "asserting spans landed"
+if [ ! -s "$SPANS_FILE" ]; then
+  echo "FAIL: $SPANS_FILE is empty or missing"
+  echo "--- defra stderr ---"
+  tail -100 "$DEFRA_STDERR"
+  exit 1
+fi
+
+BATCH_COUNT=$(wc -l < "$SPANS_FILE" | tr -d '[:space:]')
+echo "spans.jsonl: $BATCH_COUNT batch(es)"
+
+if ! grep -q '"DefraDB"' "$SPANS_FILE"; then
+  echo "FAIL: service.name=DefraDB not found in exported batches"
+  echo "--- first batch (head) ---"
+  head -c 2000 "$SPANS_FILE"
+  exit 1
+fi
+echo "  service.name=DefraDB ............................. ok"
+
+for attr in "service.version" "os.type" "host.arch" "process.pid" "process.executable.name"; do
+  if grep -q "\"$attr\"" "$SPANS_FILE"; then
+    echo "  $attr ............................. ok"
+  else
+    echo "  $attr ............................. MISSING"
+  fi
+done
+
+# Look for the key span names we added or expect.
+for span in '"request"' '"query.execute_request"'; do
+  if grep -q "$span" "$SPANS_FILE"; then
+    echo "  span $span ........... ok"
+  else
+    echo "  span $span ........... not found (may need different endpoint)"
+  fi
+done
+
+step "PASS"
+echo "Jaeger UI:    http://localhost:16686  (search for service 'DefraDB')"
+echo "Spans file:   $SPANS_FILE"


### PR DESCRIPTION
## Summary

Wires OpenTelemetry into defradb.rs at functional parity with Go DefraDB's `internal/telemetry/otel.go`. Opt-in at compile time (`--features otel`, mirroring Go's `//go:build telemetry`); zero deps and zero cost when off. Resolves the design + implementation portion of #977.

- **OTLP/HTTP trace exporter** — same transport + default endpoint as Go (`http://localhost:4318`), honors the standard `OTEL_*` env vars.
- **Resource attributes** — `service.name=DefraDB`, a Go-style descriptive `service.version`, `os.type`/`host.arch`/`process.pid`/`process.executable.name`, and a semconv schema URL.
- **Connection-refused dedup** — ports Go's `otel.SetErrorHandler + sync.Once`: suppresses repeated exporter-unreachable errors and emits Go's exact hint once per process; genuine server-side errors still log.
- **Provider shutdown/flush** — which Go lacks (buffered spans survive SIGTERM). A strict superset.
- **Runtime control** — `--no-telemetry` / `DEFRA_NO_TELEMETRY`; telemetry initializes only for the `start` command (matching Go).
- **Embedded API** — `NodeBuilder::with_telemetry(handle)` for library consumers; node owns shutdown.
- **First-cut instrumentation** — HTTP request spans (tower-http), GraphQL `query.execute_request`, P2P push-log + gossip (debug level).
- **Metrics** — behind a separate, default-off `metrics` feature (no instruments recorded yet).

## Go parity

| | Go | This PR |
| --- | --- | --- |
| Transport / endpoint | OTLP/HTTP, `:4318` | same |
| service.name / version | `DefraDB` / descriptive string | same shape |
| dedup | suppress connection-refused, hint once via `sync.Once` | same behavior (substring match like Go; status-code errors pass through) |
| init scope | `start` only | `start` only |
| compile gate / runtime flag | build tag / `--no-telemetry` | `--features otel` / `--no-telemetry` |
| provider shutdown | none | added (superset) |

**Intentional, documented divergences:** dedup via a `tracing_subscriber` filter (the global error-handler API was removed in opentelemetry-rust 0.27); schema URL 1.36.0 (Rust semconv crate ceiling) vs Go's 1.40.0; OS/process attribute subset; no runtime metrics yet.

## Verification

- Unit tests across `telemetry` (otlp + metrics), `defra-version`, `cli`; workspace `cargo test` green.
- `clippy --all -- -D warnings` clean on default / otlp / metrics / otel / otel+profiling; `cargo fmt` clean.
- `tools/otel-smoke/run.sh` — spans land at a real collector (otel-collector-contrib + Jaeger) with all resource attributes.
- `tools/otel-smoke/dedup.sh` + `crates/cli/tests/telemetry_dedup.rs` — exporter-unreachable hint fires exactly once, raw suppressed. The Rust-native test is Docker-free and runs in CI; negative-control verified (fails if the SDK `internal-logs` feature regresses).

## Review history

11 commits. Went through four `/code-review` passes, a Go-parity audit, and a final review gate (multi-agent workflows). Each pass's findings were fixed or filed; the final gate returned fix-then-ship and those three fixes are included (notably narrowing the dedup needle so reachable-collector HTTP status errors aren't wrongly suppressed).

## Follow-up issues (out of scope)

- **#998** — dual opentelemetry 0.31/0.32 in the tree. Upstream-blocked: every `commonware-runtime` release pins otel `^0.31` (non-optional); no hub.rs/backbone/workspace bump changes it. Needs a commonware release on 0.32.
- **#1002** — metrics pipeline is gated but emits nothing (YAGNI); delete vs keep is an open call.

(#1000, #1001, #1003, #1004 closed — resolved in this PR or determined to already match Go.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)