### PR TITLE
fix(storage): stream Lark iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "lark-kv"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/lark.git?rev=5ddc43dbb08f21bd4078ff89b06fb57bde9398f3#5ddc43dbb08f21bd4078ff89b06fb57bde9398f3"
+source = "git+https://github.com/sourcenetwork/lark.git?rev=ab924471c2e376591c1e3b3cd419655f9c7c6dc4#ab924471c2e376591c1e3b3cd419655f9c7c6dc4"
 dependencies = [
  "crossbeam-skiplist",
  "lru 0.16.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ postcard = { version = "1.0", features = ["alloc"] }
 redb = "2.4"
 fjall = "3.1.4"
 rocksdb = "0.24.0"
-lark-kv = { git = "https://github.com/sourcenetwork/lark.git", rev = "5ddc43dbb08f21bd4078ff89b06fb57bde9398f3" }
+lark-kv = { git = "https://github.com/sourcenetwork/lark.git", rev = "ab924471c2e376591c1e3b3cd419655f9c7c6dc4" }
 
 # Cryptography
 ed25519-dalek = { version = "2.1", features = ["serde", "zeroize"] }

--- a/crates/storage/src/backends/lark/iterator.rs
+++ b/crates/storage/src/backends/lark/iterator.rs
@@ -1,15 +1,18 @@
 use async_trait::async_trait;
+use std::cmp::Ordering;
+use std::ops::Bound;
 
 use crate::corekv::{Error, IterOptions, Iterator, KvPair, Result};
 
-/// Merging iterator that combines pre-materialized snapshot and pending changes.
-///
-/// Same pattern as rocksdb and fjall backends.
+/// Merging iterator that combines a streaming Lark snapshot cursor and pending changes.
 pub(crate) struct MergingIterator {
-    snapshot_items: Vec<(Vec<u8>, Vec<u8>)>,
-    snapshot_pos: usize,
+    snapshot_iter: lark_kv::OwnedSnapshotIter,
+    snapshot_item: Option<(Vec<u8>, Vec<u8>)>,
     pending_items: Vec<(Vec<u8>, Option<Vec<u8>>)>,
     pending_pos: usize,
+    start_bound: Bound<Vec<u8>>,
+    end_bound: Bound<Vec<u8>>,
+    prefix: Option<Vec<u8>>,
     reverse: bool,
     keys_only: bool,
     closed: bool,
@@ -17,46 +20,52 @@ pub(crate) struct MergingIterator {
 
 impl MergingIterator {
     pub(crate) fn new(
-        mut snapshot_items: Vec<(Vec<u8>, Vec<u8>)>,
+        snapshot_iter: lark_kv::OwnedSnapshotIter,
         mut pending_items: Vec<(Vec<u8>, Option<Vec<u8>>)>,
         opts: IterOptions,
-    ) -> Self {
+        start_bound: Bound<Vec<u8>>,
+        end_bound: Bound<Vec<u8>>,
+    ) -> Result<Self> {
         let reverse = opts.reverse();
         if reverse {
-            snapshot_items.reverse();
             pending_items.reverse();
         }
 
-        Self {
-            snapshot_items,
-            snapshot_pos: 0,
+        let mut iter = Self {
+            snapshot_iter,
+            snapshot_item: None,
             pending_items,
             pending_pos: 0,
+            start_bound,
+            end_bound,
+            prefix: opts.prefix().map(Vec::from),
             reverse,
             keys_only: opts.keys_only(),
             closed: false,
-        }
+        };
+        iter.reset_positions()?;
+        Ok(iter)
     }
 
-    fn next_merged(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+    fn next_merged(&mut self) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
         loop {
-            let snap_key = self.snapshot_items.get(self.snapshot_pos).map(|(k, _)| k);
+            let snap_key = self.snapshot_item.as_ref().map(|(k, _)| k);
             let pend_key = self.pending_items.get(self.pending_pos).map(|(k, _)| k);
 
             match (snap_key, pend_key) {
-                (None, None) => return None,
+                (None, None) => return Ok(None),
 
                 (Some(_), None) => {
-                    let (key, value) = self.snapshot_items[self.snapshot_pos].clone();
-                    self.snapshot_pos += 1;
-                    return Some((key, value));
+                    let item = self.snapshot_item.take();
+                    self.advance_snapshot()?;
+                    return Ok(item);
                 }
 
                 (None, Some(_)) => {
                     let (key, value_opt) = self.pending_items[self.pending_pos].clone();
                     self.pending_pos += 1;
                     match value_opt {
-                        Some(value) => return Some((key, value)),
+                        Some(value) => return Ok(Some((key, value))),
                         None => continue,
                     }
                 }
@@ -65,25 +74,26 @@ impl MergingIterator {
                     let cmp = if self.reverse { pk.cmp(sk) } else { sk.cmp(pk) };
 
                     match cmp {
-                        std::cmp::Ordering::Less => {
-                            let (key, value) = self.snapshot_items[self.snapshot_pos].clone();
-                            self.snapshot_pos += 1;
-                            return Some((key, value));
+                        Ordering::Less => {
+                            let item = self.snapshot_item.take();
+                            self.advance_snapshot()?;
+                            return Ok(item);
                         }
-                        std::cmp::Ordering::Greater => {
+                        Ordering::Greater => {
                             let (key, value_opt) = self.pending_items[self.pending_pos].clone();
                             self.pending_pos += 1;
                             match value_opt {
-                                Some(value) => return Some((key, value)),
+                                Some(value) => return Ok(Some((key, value))),
                                 None => continue,
                             }
                         }
-                        std::cmp::Ordering::Equal => {
+                        Ordering::Equal => {
                             let (key, value_opt) = self.pending_items[self.pending_pos].clone();
-                            self.snapshot_pos += 1;
                             self.pending_pos += 1;
+                            self.snapshot_item = None;
+                            self.advance_snapshot()?;
                             match value_opt {
-                                Some(value) => return Some((key, value)),
+                                Some(value) => return Ok(Some((key, value))),
                                 None => continue,
                             }
                         }
@@ -100,6 +110,131 @@ impl MergingIterator {
             items.partition_point(|(k, _)| k.as_slice() < key)
         }
     }
+
+    fn reset_positions(&mut self) -> Result<()> {
+        self.pending_pos = 0;
+        if self.reverse {
+            match &self.end_bound {
+                Bound::Included(end) | Bound::Excluded(end) => {
+                    self.snapshot_iter.seek_for_prev(end)
+                }
+                Bound::Unbounded => self.snapshot_iter.seek_to_last(),
+            }
+        } else {
+            match &self.start_bound {
+                Bound::Included(start) | Bound::Excluded(start) => self.snapshot_iter.seek(start),
+                Bound::Unbounded => self.snapshot_iter.seek_to_first(),
+            }
+        }
+        self.refresh_snapshot_item()
+    }
+
+    fn seek_positions(&mut self, key: &[u8]) -> Result<()> {
+        let snapshot_target = self.snapshot_seek_target(key);
+        if self.reverse {
+            self.snapshot_iter.seek_for_prev(&snapshot_target);
+        } else {
+            self.snapshot_iter.seek(&snapshot_target);
+        }
+        self.refresh_snapshot_item()?;
+        self.pending_pos = Self::binary_search_position(&self.pending_items, key, self.reverse);
+        Ok(())
+    }
+
+    fn snapshot_seek_target(&self, key: &[u8]) -> Vec<u8> {
+        if self.reverse {
+            match &self.end_bound {
+                Bound::Included(end) | Bound::Excluded(end) if key >= end.as_slice() => end.clone(),
+                _ => key.to_vec(),
+            }
+        } else {
+            match &self.start_bound {
+                Bound::Included(start) | Bound::Excluded(start) if key < start.as_slice() => {
+                    start.clone()
+                }
+                _ => key.to_vec(),
+            }
+        }
+    }
+
+    fn advance_snapshot(&mut self) -> Result<()> {
+        if self.reverse {
+            self.snapshot_iter.prev();
+        } else {
+            self.snapshot_iter.next();
+        }
+        self.refresh_snapshot_item()
+    }
+
+    fn refresh_snapshot_item(&mut self) -> Result<()> {
+        self.snapshot_item = None;
+        loop {
+            self.snapshot_iter
+                .status()
+                .map_err(|e| Error::Backend(format!("lark iterator error: {}", e)))?;
+            if !self.snapshot_iter.valid() {
+                return Ok(());
+            }
+
+            let key = self
+                .snapshot_iter
+                .key()
+                .ok_or_else(|| Error::Backend("lark iterator returned no key".into()))?
+                .to_vec();
+
+            if self.in_bounds(&key) {
+                let value = if self.keys_only {
+                    Vec::new()
+                } else {
+                    self.snapshot_iter
+                        .value()
+                        .ok_or_else(|| Error::Backend("lark iterator returned no value".into()))?
+                        .to_vec()
+                };
+                self.snapshot_item = Some((key, value));
+                return Ok(());
+            }
+
+            if self.reverse {
+                if self.below_start(&key) {
+                    return Ok(());
+                }
+                self.snapshot_iter.prev();
+            } else {
+                if self.at_or_after_end(&key) {
+                    return Ok(());
+                }
+                self.snapshot_iter.next();
+            }
+        }
+    }
+
+    fn in_bounds(&self, key: &[u8]) -> bool {
+        if self
+            .prefix
+            .as_deref()
+            .is_some_and(|prefix| !key.starts_with(prefix))
+        {
+            return false;
+        }
+        !self.below_start(key) && !self.at_or_after_end(key)
+    }
+
+    fn below_start(&self, key: &[u8]) -> bool {
+        match &self.start_bound {
+            Bound::Included(start) => key < start.as_slice(),
+            Bound::Excluded(start) => key <= start.as_slice(),
+            Bound::Unbounded => false,
+        }
+    }
+
+    fn at_or_after_end(&self, key: &[u8]) -> bool {
+        match &self.end_bound {
+            Bound::Included(end) => key > end.as_slice(),
+            Bound::Excluded(end) => key >= end.as_slice(),
+            Bound::Unbounded => false,
+        }
+    }
 }
 
 impl crate::corekv::private::Sealed for MergingIterator {}
@@ -111,7 +246,7 @@ impl Iterator for MergingIterator {
             return Err(Error::Iterator("Iterator has been closed".into()));
         }
 
-        match self.next_merged() {
+        match self.next_merged()? {
             Some((key, value)) => {
                 if self.keys_only {
                     Ok(Some(KvPair::key_only(key)))
@@ -133,14 +268,9 @@ impl Iterator for MergingIterator {
             return Err(Error::Iterator("Iterator has been closed".into()));
         }
 
-        self.snapshot_pos = Self::binary_search_position(&self.snapshot_items, key, self.reverse);
-        self.pending_pos = Self::binary_search_position(&self.pending_items, key, self.reverse);
-
-        let saved_snapshot_pos = self.snapshot_pos;
-        let saved_pending_pos = self.pending_pos;
-        let has_data = self.next_merged().is_some();
-        self.snapshot_pos = saved_snapshot_pos;
-        self.pending_pos = saved_pending_pos;
+        self.seek_positions(key)?;
+        let has_data = self.next_merged()?.is_some();
+        self.seek_positions(key)?;
 
         Ok(has_data)
     }
@@ -150,9 +280,7 @@ impl Iterator for MergingIterator {
             return Err(Error::Iterator("Iterator has been closed".into()));
         }
 
-        self.snapshot_pos = 0;
-        self.pending_pos = 0;
-        Ok(())
+        self.reset_positions()
     }
 
     fn is_valid(&self) -> bool {

--- a/crates/storage/src/backends/lark/transaction.rs
+++ b/crates/storage/src/backends/lark/transaction.rs
@@ -160,33 +160,12 @@ impl Reader for LarkTxn {
             |key: &[u8]| -> bool { opts.prefix().is_none_or(|p| key.starts_with(p)) };
 
         let (start_bound, end_bound) = compute_range_bounds(&opts);
-
-        // Compute scan bounds for lark
-        let scan_start = match &start_bound {
-            Bound::Included(v) => Some(v.as_slice()),
-            Bound::Excluded(v) => Some(v.as_slice()),
-            Bound::Unbounded => None,
-        };
-        let scan_end = match &end_bound {
-            Bound::Included(v) => Some(v.as_slice()),
-            Bound::Excluded(v) => Some(v.as_slice()),
-            Bound::Unbounded => None,
-        };
-
-        // Read matching items from snapshot
-        let snapshot_items: Vec<(Vec<u8>, Vec<u8>)> = self
-            .snapshot
-            .scan(scan_start, scan_end)
-            .map_err(|e| Error::Backend(e.to_string()))?
-            .into_iter()
-            .filter(|(k, _)| matches_prefix(k))
-            .map(|(k, v)| if keys_only { (k, Vec::new()) } else { (k, v) })
-            .collect();
+        let snapshot_iter = self.snapshot.owned_iter();
 
         // Extract pending items in range
         let pending = self.pending.lock();
         let pending_items: Vec<(Vec<u8>, Option<Vec<u8>>)> = pending
-            .range((start_bound, end_bound))
+            .range((start_bound.clone(), end_bound.clone()))
             .filter(|(k, _)| matches_prefix(k))
             .map(|(k, v)| {
                 (
@@ -198,10 +177,12 @@ impl Reader for LarkTxn {
             .collect();
 
         Ok(Box::new(MergingIterator::new(
-            snapshot_items,
+            snapshot_iter,
             pending_items,
             opts,
-        )))
+            start_bound,
+            end_bound,
+        )?))
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #1008.

This PR changes the DefraDB Lark backend iterator from a fully materialized snapshot scan into a streaming merge cursor.

The snapshot side now uses Lark owned snapshot iteration and keeps only one current snapshot item in memory while merging against transaction-local pending writes. Pending writes remain materialized because they are already held in the transaction overlay.

## Details

- Replaces `Snapshot::scan(...).collect()` in `LarkTxn::iterator` with `self.snapshot.owned_iter()`.
- Reworks the Lark backend `MergingIterator` to merge:
  - one streaming snapshot cursor item
  - the existing pending write/delete overlay
- Preserves iterator semantics for:
  - forward and reverse scans
  - prefix scans
  - start/end bounds
  - seek and reset
  - keys-only mode
  - pending writes and deletes shadowing snapshot data
- Avoids snapshot value cloning in keys-only mode.
- Updates the Lark dependency to sourcenetwork/lark@ab924471 for `OwnedSnapshotIter` support.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p storage --features lark lark::tests::shared_tests::shared_test_iterator_basic --no-default-features`
- `cargo test -p storage --features lark --no-default-features`
- `cargo clippy -p storage --features lark --no-default-features --all-targets -- -D warnings`

## Dependencies

- Depends on sourcenetwork/lark#158 for `Snapshot::owned_iter()` / `OwnedSnapshotIter`.

## Notes

This removes the O(range-size) snapshot vector allocation from Lark-backed DefraDB iterators. The iterator still allocates returned key/value pairs as required by the storage trait, but construction no longer reads or copies the whole snapshot range up front.