### PR TITLE
perf(storage): fast-path Lark readonly reads

### DIFF
--- a/crates/storage/src/backends/lark/tests/mod.rs
+++ b/crates/storage/src/backends/lark/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::corekv::{Dropable, Store, Txn};
+use crate::corekv::{Dropable, IterOptions, Store, Txn};
 
 mod shared_tests {
     use super::*;
@@ -48,4 +48,44 @@ mod shared_tests {
     generate_backend_tests!(create_store);
     generate_backend_concurrency_tests!(create_arc_store);
     generate_backend_dropable_tests!(create_store);
+}
+
+#[tokio::test]
+async fn readonly_reads_preserve_snapshot_after_later_writes() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let store = LarkStore::open(temp_dir.path()).unwrap();
+
+    let mut setup = store.new_txn(false).await.unwrap();
+    setup.set(b"a", b"old").await.unwrap();
+    setup.set(b"b", b"keep").await.unwrap();
+    setup.commit().await.unwrap();
+
+    let readonly = store.new_txn(true).await.unwrap();
+
+    let mut writer = store.new_txn(false).await.unwrap();
+    writer.set(b"a", b"new").await.unwrap();
+    writer.delete(b"b").await.unwrap();
+    writer.set(b"c", b"later").await.unwrap();
+    writer.commit().await.unwrap();
+
+    assert_eq!(readonly.get(b"a").await.unwrap(), Some(b"old".to_vec()));
+    assert!(readonly.has(b"b").await.unwrap());
+    assert_eq!(readonly.get_size(b"b").await.unwrap(), Some(4));
+    assert_eq!(readonly.get(b"c").await.unwrap(), None);
+
+    let mut iter = readonly.iterator(IterOptions::new()).await.unwrap();
+    let mut items = Vec::new();
+    while let Some(pair) = iter.next().await.unwrap() {
+        items.push((pair.key, pair.value));
+    }
+    assert_eq!(
+        items,
+        vec![
+            (b"a".to_vec(), b"old".to_vec()),
+            (b"b".to_vec(), b"keep".to_vec())
+        ]
+    );
+
+    readonly.discard();
+    store.close().await.unwrap();
 }

--- a/crates/storage/src/backends/lark/transaction.rs
+++ b/crates/storage/src/backends/lark/transaction.rs
@@ -98,6 +98,12 @@ impl LarkTxn {
             .map_err(|e| Error::Backend(e.to_string()))
     }
 
+    fn snapshot_get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.snapshot
+            .get(key)
+            .map_err(|e| Error::Backend(e.to_string()))
+    }
+
     fn has_internal(&self, key: &[u8]) -> Result<bool> {
         let pending = self.pending.lock();
         if let Some(pending_value) = pending.get(key) {
@@ -105,6 +111,13 @@ impl LarkTxn {
         }
         drop(pending);
 
+        self.snapshot
+            .get(key)
+            .map(|v| v.is_some())
+            .map_err(|e| Error::Backend(e.to_string()))
+    }
+
+    fn snapshot_has(&self, key: &[u8]) -> Result<bool> {
         self.snapshot
             .get(key)
             .map(|v| v.is_some())
@@ -123,6 +136,9 @@ impl Reader for LarkTxn {
         if key.is_empty() {
             return Err(Error::EmptyKey);
         }
+        if self.readonly {
+            return self.snapshot_get(key);
+        }
         self.read_set.lock().record_key(key);
         self.get_internal(key)
     }
@@ -133,6 +149,9 @@ impl Reader for LarkTxn {
         }
         if key.is_empty() {
             return Err(Error::EmptyKey);
+        }
+        if self.readonly {
+            return self.snapshot_has(key);
         }
         self.read_set.lock().record_key(key);
         self.has_internal(key)
@@ -145,6 +164,9 @@ impl Reader for LarkTxn {
         if key.is_empty() {
             return Err(Error::EmptyKey);
         }
+        if self.readonly {
+            return Ok(self.snapshot_get(key)?.map(|v| v.len()));
+        }
         self.read_set.lock().record_key(key);
         Ok(self.get_internal(key)?.map(|v| v.len()))
     }
@@ -154,7 +176,9 @@ impl Reader for LarkTxn {
             return Err(Error::DiscardedTxn);
         }
 
-        self.read_set.lock().record_iter_options(&opts);
+        if !self.readonly {
+            self.read_set.lock().record_iter_options(&opts);
+        }
         let keys_only = opts.keys_only();
         let matches_prefix =
             |key: &[u8]| -> bool { opts.prefix().is_none_or(|p| key.starts_with(p)) };
@@ -162,19 +186,22 @@ impl Reader for LarkTxn {
         let (start_bound, end_bound) = compute_range_bounds(&opts);
         let snapshot_iter = self.snapshot.owned_iter();
 
-        // Extract pending items in range
-        let pending = self.pending.lock();
-        let pending_items: Vec<(Vec<u8>, Option<Vec<u8>>)> = pending
-            .range((start_bound.clone(), end_bound.clone()))
-            .filter(|(k, _)| matches_prefix(k))
-            .map(|(k, v)| {
-                (
-                    k.clone(),
-                    v.as_ref()
-                        .map(|value| if keys_only { Vec::new() } else { value.clone() }),
-                )
-            })
-            .collect();
+        let pending_items = if self.readonly {
+            Vec::new()
+        } else {
+            let pending = self.pending.lock();
+            pending
+                .range((start_bound.clone(), end_bound.clone()))
+                .filter(|(k, _)| matches_prefix(k))
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        v.as_ref()
+                            .map(|value| if keys_only { Vec::new() } else { value.clone() }),
+                    )
+                })
+                .collect()
+        };
 
         Ok(Box::new(MergingIterator::new(
             snapshot_iter,


### PR DESCRIPTION
## Summary

Closes #1016.

This PR trims DefraDB-side overhead from Lark readonly transactions. Readonly transactions cannot write and do not need commit conflict tracking, so their read operations can read directly from the captured Lark snapshot instead of going through writable-transaction bookkeeping.

## Details

- Fast-paths readonly `get`, `has`, and `get_size` to the Lark snapshot.
- Skips read-set tracking for readonly point reads and iterators.
- Skips pending-write range collection for readonly iterators.
- Leaves writable transaction read-your-writes and conflict-tracking behavior unchanged.
- Adds a Lark backend test covering readonly snapshot reads after later writes.

## Benchmark Context

The DefraDB storage benchmark profile showed:

- raw `lark_kv::Db::get`: about `0.75-0.81 us/op`
- DefraDB wrapper `Txn::get`: about `0.98 us/op`

This change targets that integration-layer overhead without changing Lark engine semantics.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p storage --features lark --no-default-features readonly_reads_preserve_snapshot_after_later_writes`
- `cargo test -p storage --features lark --no-default-features`
- `cargo clippy -p storage --features lark --no-default-features --all-targets -- -D warnings`
