### PR TITLE
Fix Rust FFI parity for issue 1023

### DIFF
--- a/crates/db-merge/src/merge_handler/batch.rs
+++ b/crates/db-merge/src/merge_handler/batch.rs
@@ -41,9 +41,6 @@ impl<S: Store + 'static, B: blockstore::Blockstore + Send + Sync + 'static> DbMe
                 continue;
             }
 
-            // Serialize merges for the same document
-            let _guard = self.merge_queue.acquire(&block.doc_id).await;
-
             let metadata = BlockMetadata::normal(
                 &block.doc_id,
                 &block.collection_id,

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -78,16 +78,8 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
         let _guard = self.merge_queue.acquire(&doc_id_str).await;
 
-        self.process_composite_delta_locked(
-            cid,
-            block,
-            payload,
-            metadata,
-            from_collection,
-            depth,
-            &doc_id_str,
-        )
-        .await
+        self.process_composite_delta_locked(cid, block, payload, metadata, from_collection, depth)
+            .await
     }
 
     async fn process_composite_delta_locked(
@@ -98,7 +90,6 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         metadata: &BlockMetadata<'_>,
         from_collection: bool,
         depth: usize,
-        doc_id_str: &str,
     ) -> std::result::Result<MergeOutcome, MergeError> {
         if depth >= super::MAX_MERGE_DEPTH {
             return Err(MergeError::depth_exceeded(cid, depth));
@@ -114,6 +105,8 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 return Ok(MergeOutcome::terminal_skip("already merged"));
             }
         }
+
+        let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
 
         tracing::info!(
             cid = %cid,
@@ -218,7 +211,6 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                         child_cid = %cid,
                         "Recursively merging parent composite before current"
                     );
-                    let head_doc_id_str = String::from_utf8_lossy(&head_payload.doc_id).to_string();
                     match Box::pin(self.process_composite_delta_locked(
                         head_cid,
                         &head_block,
@@ -226,7 +218,6 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                         metadata,
                         from_collection,
                         depth + 1,
-                        &head_doc_id_str,
                     ))
                     .await
                     {

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -75,6 +75,31 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         from_collection: bool,
         depth: usize,
     ) -> std::result::Result<MergeOutcome, MergeError> {
+        let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
+        let _guard = self.merge_queue.acquire(&doc_id_str).await;
+
+        self.process_composite_delta_locked(
+            cid,
+            block,
+            payload,
+            metadata,
+            from_collection,
+            depth,
+            &doc_id_str,
+        )
+        .await
+    }
+
+    async fn process_composite_delta_locked(
+        &self,
+        cid: &Cid,
+        block: &Block,
+        payload: &defra_core::block::CompositeDeltaPayload,
+        metadata: &BlockMetadata<'_>,
+        from_collection: bool,
+        depth: usize,
+        doc_id_str: &str,
+    ) -> std::result::Result<MergeOutcome, MergeError> {
         if depth >= super::MAX_MERGE_DEPTH {
             return Err(MergeError::depth_exceeded(cid, depth));
         }
@@ -89,8 +114,6 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 return Ok(MergeOutcome::terminal_skip("already merged"));
             }
         }
-
-        let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
 
         tracing::info!(
             cid = %cid,
@@ -195,13 +218,15 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                         child_cid = %cid,
                         "Recursively merging parent composite before current"
                     );
-                    match Box::pin(self.process_composite_delta(
+                    let head_doc_id_str = String::from_utf8_lossy(&head_payload.doc_id).to_string();
+                    match Box::pin(self.process_composite_delta_locked(
                         head_cid,
                         &head_block,
                         head_payload,
                         metadata,
                         from_collection,
                         depth + 1,
+                        &head_doc_id_str,
                     ))
                     .await
                     {
@@ -261,7 +286,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 if outcome.is_terminal_skip() && !from_collection {
                     if let Some(bus) = self.db.event_bus() {
                         let merge_complete = MergeCompleteData {
-                            doc_id: doc_id_str.clone(),
+                            doc_id: doc_id_str.to_string(),
                             subject_doc_id: None,
                             cid: *cid,
                             collection_id: metadata
@@ -319,7 +344,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
 
                 if let Some(bus) = self.db.event_bus() {
                     let update = Update::new(
-                        doc_id_str.clone(),
+                        doc_id_str.to_string(),
                         *cid,
                         payload.schema_version_id.clone(),
                         vec![],
@@ -330,7 +355,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
 
                     if !from_collection {
                         let merge_complete = MergeCompleteData {
-                            doc_id: doc_id_str.clone(),
+                            doc_id: doc_id_str.to_string(),
                             subject_doc_id: None,
                             cid: *cid,
                             collection_id: metadata
@@ -345,7 +370,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     if state.is_branchable {
                         let merge_complete = MergeCompleteData {
                             doc_id: String::new(),
-                            subject_doc_id: Some(doc_id_str.clone()),
+                            subject_doc_id: Some(doc_id_str.to_string()),
                             cid: *cid,
                             collection_id: metadata
                                 .collection_id

--- a/crates/db-merge/src/merge_handler/counter.rs
+++ b/crates/db-merge/src/merge_handler/counter.rs
@@ -9,6 +9,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         metadata: &BlockMetadata<'_>,
     ) -> std::result::Result<MergeOutcome, MergeError> {
         let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
+        let _guard = self.merge_queue.acquire(&doc_id_str).await;
 
         tracing::debug!(
             cid = %cid,

--- a/crates/db-merge/src/merge_handler/lww.rs
+++ b/crates/db-merge/src/merge_handler/lww.rs
@@ -139,6 +139,9 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         payload: &defra_core::block::LwwDeltaPayload,
         metadata: &BlockMetadata<'_>,
     ) -> std::result::Result<MergeOutcome, MergeError> {
+        let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
+        let _guard = self.merge_queue.acquire(&doc_id_str).await;
+
         tracing::debug!(
             cid = %cid,
             field_name = %payload.field_name,
@@ -166,8 +169,6 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             payload.data.clone(),
         )
         .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
-
-        let doc_id_str = String::from_utf8_lossy(&payload.doc_id).to_string();
 
         // Perform the merge in a scoped block to ensure datastore reference is dropped
         // before we try to commit/discard the transaction.

--- a/crates/db-merge/src/merge_handler/lww.rs
+++ b/crates/db-merge/src/merge_handler/lww.rs
@@ -62,14 +62,14 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let hs_priority = self
             .current_field_priority(headstore, doc_id_str, &payload.field_name)
             .await?;
-        let ds_priority = crdt::traits::PriorityReader::priority(lww, datastore)
+        let stored_priority = crdt::traits::PriorityReader::priority(lww, datastore)
             .await
             .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
 
-        // Fast path: the datastore LWW already reflects (or exceeds) the
-        // headstore priority — nothing to seed. A non-zero datastore priority
-        // also implies the document exists.
-        if ds_priority != 0 && ds_priority >= hs_priority {
+        // Fast path: the datastore LWW is strictly ahead of the headstore, so
+        // nothing in the materialized doc can improve it. Equal priority still
+        // needs the value tie-break below to preserve Go LWW behavior.
+        if stored_priority != 0 && stored_priority > hs_priority {
             return Ok(true);
         }
 
@@ -95,6 +95,21 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         ciborium::into_writer(field_value, &mut value_bytes)
             .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
 
+        let should_seed = match priority.cmp(&stored_priority) {
+            std::cmp::Ordering::Greater => true,
+            std::cmp::Ordering::Less => false,
+            std::cmp::Ordering::Equal => {
+                match crdt::traits::ValueReader::value(lww, datastore).await {
+                    Ok(stored_value) => value_bytes > stored_value,
+                    Err(_) => true,
+                }
+            }
+        };
+
+        if !should_seed {
+            return Ok(true);
+        }
+
         let seed_delta = LwwDelta::new(
             payload.doc_id.clone(),
             payload.field_name.clone(),
@@ -107,7 +122,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let seed_ctx = Context {
             doc_id: DocId::new(doc_id_str).map_err(|e| MergeError::MergeFailed(e.to_string()))?,
             schema_version: payload.schema_version_id.clone(),
-            is_create: true,
+            is_create: false,
         };
 
         lww.merge(datastore, &seed_ctx, &seed_delta)

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1536,6 +1536,181 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn composite_lww_reseeds_from_local_doc_when_crdt_store_is_stale() {
+        let (handler, blockstore, _bus) = make_handler_with_schema_and_bus().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-users")
+            .unwrap()
+            .expect("users collection should exist");
+
+        let mut doc = Document::new();
+        doc.set("age", NormalValue::Int(21));
+        doc.generate_and_set_doc_id().unwrap();
+        doc.set_schema_version_id("v1");
+        let doc_id = doc.id().unwrap().clone();
+        let doc_id_str = doc_id.to_string();
+
+        let create_blocks = {
+            let txn = handler.db.new_txn(false).await.unwrap();
+            let blocks = {
+                let datastore = txn.datastore().unwrap();
+                let headstore = txn.headstore().unwrap();
+                let raw_blockstore = txn.blockstore().unwrap();
+                collection
+                    .save_with_datastore(&datastore, &doc)
+                    .await
+                    .unwrap();
+                db_blocks::write_document_blocks(
+                    &raw_blockstore,
+                    &headstore,
+                    &doc,
+                    "v1",
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+            };
+            txn.force_commit().await.unwrap();
+            blocks
+        };
+
+        doc.set("age", NormalValue::Int(60));
+        let mut modified_fields = HashSet::new();
+        modified_fields.insert("age".to_string());
+        {
+            let txn = handler.db.new_txn(false).await.unwrap();
+            {
+                let datastore = txn.datastore().unwrap();
+                let headstore = txn.headstore().unwrap();
+                let raw_blockstore = txn.blockstore().unwrap();
+                collection
+                    .save_with_datastore(&datastore, &doc)
+                    .await
+                    .unwrap();
+                db_blocks::write_document_blocks(
+                    &raw_blockstore,
+                    &headstore,
+                    &doc,
+                    "v1",
+                    Some(&modified_fields),
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            }
+            txn.force_commit().await.unwrap();
+        }
+
+        let lww = Lww::new("v1", doc_id_str.as_bytes(), "age").unwrap();
+        let mut stale_value = Vec::new();
+        ciborium::into_writer(&NormalValue::Int(30), &mut stale_value).unwrap();
+        let stale_delta = LwwDelta::new(
+            doc_id_str.as_bytes().to_vec(),
+            "age".to_string(),
+            2,
+            "v1".to_string(),
+            stale_value.clone(),
+        )
+        .unwrap();
+        {
+            let txn = handler.db.new_txn(false).await.unwrap();
+            {
+                let mut datastore = txn.datastore().unwrap();
+                lww.merge(
+                    &mut datastore,
+                    &Context {
+                        doc_id: DocId::new(&doc_id_str).unwrap(),
+                        schema_version: "v1".to_string(),
+                        is_create: false,
+                    },
+                    &stale_delta,
+                )
+                .await
+                .unwrap();
+            }
+            txn.force_commit().await.unwrap();
+        }
+
+        let incoming_field_payload = LwwDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            field_name: "age".to_string(),
+            schema_version_id: "v1".to_string(),
+            priority: 2,
+            data: stale_value,
+        };
+        let incoming_field_block = Block::new(
+            CrdtDelta::Lww(incoming_field_payload),
+            create_blocks.field_cids.clone(),
+            vec![],
+        );
+        let incoming_field_cid = incoming_field_block.generate_cid().unwrap();
+        let incoming_field_data = incoming_field_block.to_dag_cbor().unwrap();
+        blockstore
+            .put(&incoming_field_cid, &incoming_field_data)
+            .await
+            .unwrap();
+
+        let incoming_composite_payload = CompositeDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 2,
+            status: 1,
+        };
+        let incoming_composite_block = Block::new(
+            CrdtDelta::Composite(incoming_composite_payload.clone()),
+            vec![create_blocks.cid],
+            vec![DAGLink::new("age", incoming_field_cid)],
+        );
+        let incoming_composite_cid = incoming_composite_block.generate_cid().unwrap();
+        let incoming_composite_data = incoming_composite_block.to_dag_cbor().unwrap();
+        blockstore
+            .put(&incoming_composite_cid, &incoming_composite_data)
+            .await
+            .unwrap();
+
+        let metadata = BlockMetadata::normal(
+            &doc_id_str,
+            "col-users",
+            "did:key:z6MkrCompositeStaleLww",
+            None,
+            false,
+        );
+        let outcome = handler
+            .process_composite_delta(
+                &incoming_composite_cid,
+                &incoming_composite_block,
+                &incoming_composite_payload,
+                &metadata,
+                false,
+                0,
+            )
+            .await
+            .unwrap();
+        assert_eq!(outcome, MergeOutcome::Merged);
+
+        let stored = {
+            let txn = handler.db.new_txn(true).await.unwrap();
+            let stored = {
+                let datastore = txn.datastore().unwrap();
+                collection
+                    .get_with_datastore(&datastore, &doc_id)
+                    .await
+                    .unwrap()
+                    .expect("document should exist")
+            };
+            txn.force_discard().unwrap();
+            stored
+        };
+        assert_eq!(stored.get("age"), Some(&NormalValue::Int(60)));
+    }
+
+    #[tokio::test]
     async fn composite_parent_replay_updates_headstore_for_merged_parent() {
         let (handler, blockstore, _bus) = make_handler_with_schema_and_bus().await;
         let collection = handler

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1348,6 +1348,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_block_serializes_standalone_counter_by_doc_id() {
+        let (handler, blockstore) = make_handler_with_counter_schema().await;
+        let mut doc = Document::new();
+        doc.generate_and_set_doc_id().unwrap();
+        let doc_id = doc.id().unwrap().clone();
+        let doc_id_str = doc_id.to_string();
+
+        let mut delta_data = Vec::new();
+        ciborium::into_writer(&5_i64, &mut delta_data).unwrap();
+
+        let payload = CounterDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            field_name: "score".to_string(),
+            schema_version_id: "v1".to_string(),
+            priority: 1,
+            data: delta_data,
+            nonce: 4243,
+        };
+        let block = Block {
+            delta: CrdtDelta::Counter(payload),
+            heads: None,
+            links: None,
+            encryption: None,
+            signature: None,
+        };
+        let cid = block.generate_cid().unwrap();
+        let block_data = block.to_dag_cbor().unwrap();
+        blockstore.put(&cid, &block_data).await.unwrap();
+
+        let metadata = BlockMetadata::normal(
+            &doc_id_str,
+            "col-counters",
+            "did:key:z6MkrCounterMergeQueueTest",
+            None,
+            false,
+        );
+
+        let guard = handler.merge_queue.acquire(&doc_id_str).await;
+        let merge = handler.handle_block(&cid, &block_data, metadata);
+        tokio::pin!(merge);
+
+        assert!(
+            timeout(Duration::from_millis(50), merge.as_mut())
+                .await
+                .is_err(),
+            "standalone counter merge should wait on the per-document queue"
+        );
+
+        drop(guard);
+        let outcome = timeout(Duration::from_secs(1), merge)
+            .await
+            .expect("counter merge should complete after releasing the queue")
+            .unwrap();
+        assert_eq!(outcome, MergeOutcome::Merged);
+        assert!(blockstore.is_merged(&cid).await.unwrap());
+    }
+
+    #[tokio::test]
     async fn counter_standalone_skips_already_merged_block() {
         let (handler, blockstore) = make_handler_with_counter_schema().await;
         let collection = handler

--- a/crates/db/src/commits_fetcher/conversion.rs
+++ b/crates/db/src/commits_fetcher/conversion.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use cid::Cid;
 use defra_core::block::{Block, Signature};
 use document::Document;
@@ -195,7 +196,7 @@ impl<S: Store> CommitsFetcher<S> {
                     let sig_json = json!({
                         "type": sig_type,
                         "identity": String::from_utf8_lossy(&sig.header.identity).to_string(),
-                        "value": hex::encode(&sig.value),
+                        "value": BASE64_STANDARD.encode(&sig.value),
                     });
                     tracing::debug!(sig_type, "Signature loaded successfully");
                     sig_json

--- a/crates/ffi/src/collection/write.rs
+++ b/crates/ffi/src/collection/write.rs
@@ -31,6 +31,10 @@ pub unsafe extern "C" fn delete_collection(
         permission = NodePermission::CollectionPatch,
         name => name_str: "name";
         {
+        if name_str.is_empty() {
+            return Err("collection name can't be empty".to_string());
+        }
+
         database
             .delete_collection(&name_str)
             .await
@@ -215,6 +219,25 @@ mod tests {
         let value = unsafe { std::ffi::CStr::from_ptr(result.value).to_string_lossy() };
         assert_eq!(value, "false");
         unsafe { crate::types::defra_free_string(result.value) };
+
+        node_close(node);
+    }
+
+    #[test]
+    fn test_delete_collection_empty_name_returns_validation_error() {
+        assert!(crate::runtime::init_runtime());
+
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        let name = CString::new("").unwrap();
+        let result = unsafe { delete_collection(node, std::ptr::null(), name.as_ptr()) };
+        assert_eq!(result.status, 1);
+        let error = unsafe { std::ffi::CStr::from_ptr(result.error).to_string_lossy() };
+        assert_eq!(error, "collection name can't be empty");
+        unsafe { crate::types::defra_free_string(result.error) };
 
         node_close(node);
     }

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -69,6 +69,7 @@ use std::ffi::{c_char, CString};
 pub const ERR_INVALID_NODE_HANDLE: &str = "invalid node handle";
 
 const DETERMINISTIC_TEST_CRYPTO_ENV: &str = "DEFRA_ALLOW_DETERMINISTIC_TEST_CRYPTO";
+const RUST_FFI_CLIENT_ENV: &str = "DEFRA_CLIENT_RUST_FFI";
 
 fn deterministic_test_crypto_env_enabled() -> bool {
     matches!(
@@ -77,8 +78,27 @@ fn deterministic_test_crypto_env_enabled() -> bool {
     )
 }
 
-fn should_use_deterministic_test_crypto_for_arg(arg0: &str) -> bool {
-    should_use_deterministic_test_crypto(deterministic_test_crypto_env_enabled(), arg0)
+fn rust_ffi_client_env_enabled() -> bool {
+    matches!(std::env::var(RUST_FFI_CLIENT_ENV).as_deref(), Ok("true"))
+}
+
+fn should_use_deterministic_test_crypto_for_process() -> bool {
+    let arg0 = std::env::args().next();
+    should_use_deterministic_test_crypto_for_process_state(
+        deterministic_test_crypto_env_enabled(),
+        rust_ffi_client_env_enabled(),
+        arg0.as_deref(),
+    )
+}
+
+fn should_use_deterministic_test_crypto_for_process_state(
+    env_enabled: bool,
+    rust_ffi_client_enabled: bool,
+    arg0: Option<&str>,
+) -> bool {
+    env_enabled
+        && (rust_ffi_client_enabled
+            || arg0.is_some_and(|arg0| should_use_deterministic_test_crypto(env_enabled, arg0)))
 }
 
 fn should_use_deterministic_test_crypto(env_enabled: bool, arg0: &str) -> bool {
@@ -263,11 +283,7 @@ pub use types::defra_free_string;
 #[no_mangle]
 pub extern "C" fn defra_init() {
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        if std::env::args()
-            .next()
-            .as_deref()
-            .is_some_and(should_use_deterministic_test_crypto_for_arg)
-        {
+        if should_use_deterministic_test_crypto_for_process() {
             crypto::encryption::nonce::set_deterministic_nonce(true);
             defra_core::encryption::set_deterministic_encryption_key(true);
         }
@@ -345,6 +361,30 @@ mod tests {
         assert!(!should_use_deterministic_test_crypto(
             true,
             "/usr/local/bin/defradb"
+        ));
+    }
+
+    #[test]
+    fn test_ffi_test_env_detection_for_deterministic_test_crypto() {
+        assert!(!should_use_deterministic_test_crypto_for_process_state(
+            false,
+            true,
+            Some("/usr/local/bin/defradb")
+        ));
+        assert!(should_use_deterministic_test_crypto_for_process_state(
+            true,
+            true,
+            Some("/usr/local/bin/defradb")
+        ));
+        assert!(!should_use_deterministic_test_crypto_for_process_state(
+            true,
+            false,
+            Some("/usr/local/bin/defradb")
+        ));
+        assert!(should_use_deterministic_test_crypto_for_process_state(
+            true,
+            false,
+            Some("/tmp/go-build123/tests.test")
         ));
     }
 

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -345,4 +345,45 @@ mod tests {
         }
         node_close(node);
     }
+
+    #[test]
+    fn test_add_schema_duplicate_implicit_relation_name_errors() {
+        assert!(crate::runtime::init_runtime());
+
+        let options = NodeInitOptions::default();
+        let result = new_node(options);
+        assert_eq!(result.status, 0);
+        let node = result.node_ptr;
+
+        let sdl = CString::new(
+            r#"
+            type Book {
+                title: String
+                author: Person
+                reviewer: Person
+            }
+
+            type Person {
+                name: String
+                authoredBooks: [Book]
+                reviewedBooks: [Book]
+            }
+            "#,
+        )
+        .unwrap();
+        let result = unsafe { add_schema(node, std::ptr::null(), sdl.as_ptr()) };
+        assert_eq!(result.status, 1);
+        let error = unsafe { std::ffi::CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(
+            error.contains(
+                "relation name is not unique within collection. Field: author, RelationName: book_person"
+            ),
+            "unexpected error: {error}"
+        );
+        unsafe {
+            crate::types::defra_free_string(result.error);
+        }
+
+        node_close(node);
+    }
 }

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -44,6 +44,40 @@ pub struct P2PAdapter<B: Blockstore + 'static> {
     nac_checker: Option<Arc<dyn db::NodeAccessChecker>>,
 }
 
+async fn wait_for_branchable_merges(
+    sub: &mut events::Subscription,
+    collection_id: &str,
+    start: std::time::Instant,
+    overall_timeout: std::time::Duration,
+    idle_timeout: std::time::Duration,
+) {
+    let mut saw_merge = false;
+    let mut last_activity = std::time::Instant::now();
+
+    while start.elapsed() < overall_timeout {
+        if last_activity.elapsed() > idle_timeout {
+            break;
+        }
+
+        match tokio::time::timeout(std::time::Duration::from_millis(100), sub.recv()).await {
+            Ok(Some(msg)) => {
+                if let Some(data) = msg.as_merge_complete() {
+                    if data.collection_id == collection_id {
+                        saw_merge = true;
+                        last_activity = std::time::Instant::now();
+                    }
+                }
+            }
+            Ok(None) => break,
+            Err(_) => {
+                if !saw_merge && start.elapsed() > idle_timeout {
+                    break;
+                }
+            }
+        }
+    }
+}
+
 impl<B: Blockstore + 'static> P2PAdapter<B> {
     async fn check_nac(&self, permission: acp::nac::NodePermission) -> P2PResult<()> {
         if let Some(ref checker) = self.nac_checker {
@@ -787,6 +821,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             .as_ref()
             .ok_or_else(|| P2PError::unsupported("no database context for sync"))?;
         pusher.validate_branchable_collection(collection_id)?;
+        let event_bus = self
+            .event_bus
+            .as_ref()
+            .ok_or_else(|| P2PError::unsupported("no event bus for sync"))?;
 
         let connected_peers = self.handle.connected_peers().await.map_err(|error| {
             P2PError::transport(format!("failed to get connected peers: {error}"))
@@ -795,24 +833,53 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             return Ok(());
         }
 
+        let mut sub = event_bus.subscribe(&[events::EventName::MergeComplete]);
+        let overall_timeout = std::time::Duration::from_secs(30);
+        let idle_timeout = std::time::Duration::from_secs(3);
+        let start = std::time::Instant::now();
+        let collection_id_string = collection_id.to_string();
+
         // Go-compatible pubsub_rpc path when coordinator is wired (#828).
         // Falls back to two-stream per-peer requests otherwise.
         if let Some(coord) = self.sync_coordinator.as_ref() {
+            let expected_responses = match self.handle.topic_peers(DefraTopic::SyncBranchable).await
+            {
+                Ok(peers) if !peers.is_empty() => peers.len(),
+                Ok(_) => connected_peers.len(),
+                Err(error) => {
+                    tracing::debug!(
+                        error = %error,
+                        "failed to get sync-branchable topic peers; using connected peer count"
+                    );
+                    connected_peers.len()
+                }
+            };
             coord
                 .pubsub_sync_branchable_collection(
                     collection_id.to_string(),
                     Some(std::time::Duration::from_secs(8)),
-                    Some(connected_peers.len()),
+                    Some(expected_responses),
                 )
                 .await
                 .map_err(|error| {
+                    event_bus.unsubscribe(sub.id());
                     P2PError::transport(format!("pubsub_rpc branchable-sync failed: {error}"))
                 })?;
+            wait_for_branchable_merges(
+                &mut sub,
+                &collection_id_string,
+                start,
+                overall_timeout,
+                idle_timeout,
+            )
+            .await;
+            event_bus.unsubscribe(sub.id());
             return Ok(());
         }
 
         let mut request = p2p::message::BranchableSyncRequest::new(collection_id.to_string());
         p2p::signing::sign_message(self.handle.keypair(), &mut request).map_err(|error| {
+            event_bus.unsubscribe(sub.id());
             P2PError::internal(format!("failed to sign BranchableSync request: {error}"))
         })?;
 
@@ -830,6 +897,15 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             });
         }
 
+        wait_for_branchable_merges(
+            &mut sub,
+            &collection_id_string,
+            start,
+            overall_timeout,
+            idle_timeout,
+        )
+        .await;
+        event_bus.unsubscribe(sub.id());
         Ok(())
     }
 

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -407,11 +407,24 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
         )
         .await?;
 
-        // Enable TCP port reuse to match Go-libp2p behavior.
-        // Go-libp2p reuses the listen port for outgoing connections, so the
-        // remote side sees the listen address (not an ephemeral port).
-        // This is critical for ActivePeers to return correct addresses.
-        let tcp_config = tcp::Config::default().port_reuse(true);
+        // Outgoing dials use an ephemeral source port (no TCP port reuse).
+        //
+        // `port_reuse(true)` makes libp2p bind each outgoing dial to the listen
+        // port. rust-libp2p 0.53 has no fallback when that bind fails (unlike
+        // go-libp2p's reuseport dialer), so on any host where a connecting
+        // socket cannot share the listener's local port (macOS, or a node
+        // dialing several peers on one IP) the dial fails permanently with
+        // `EADDRINUSE`, the peer never connects, and replicated DAGs never sync.
+        //
+        // Disabling it does NOT affect Rust<->Go interop. Port reuse exists only
+        // to make a node's *observed* source port dialable for DCUtR hole
+        // punching, and DefraDB performs no hole punching: there is no dcutr or
+        // autonat behaviour (see `DefraBehaviour`), and NAT traversal goes
+        // through the circuit relay, which is independent of the dial source
+        // port. The TCP/Noise/Yamux wire protocol is identical either way, and
+        // peers learn each other's dialable listen address from Identify (see
+        // `handle_identify_event`), not from the observed source port.
+        let tcp_config = tcp::Config::default().port_reuse(false);
 
         // Two builder paths required: libp2p's SwarmBuilder uses a typestate
         // pattern where `.with_relay_client()` transitions to a different builder

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -16,8 +16,8 @@ use tokio::time::timeout;
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Error;
 use crate::message::{
-    BranchableSyncRequest, CarFetchRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
-    PushLogRequest,
+    BranchableSyncReply, BranchableSyncRequest, CarFetchRequest, DocSyncReply, DocSyncRequest,
+    PushLogBroadcast, PushLogRequest,
 };
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::NoOpCollectionStorage;
@@ -541,6 +541,21 @@ fn branchable_sync_event(peer_id: PeerId, collection_id: &str) -> TransportEvent
     }
 }
 
+fn branchable_sync_reply_event(
+    peer_id: PeerId,
+    collection_id: &str,
+    heads: Vec<Cid>,
+) -> TransportEvent<()> {
+    TransportEvent::BranchableSyncReply {
+        peer_id,
+        reply: BranchableSyncReply::success(
+            "branchable-sync-request",
+            collection_id,
+            heads.iter().map(|cid| cid.to_bytes()).collect(),
+        ),
+    }
+}
+
 fn random_peer_id() -> PeerId {
     let libp2p_peer = libp2p::PeerId::random();
     PeerId::from(libp2p_peer)
@@ -978,6 +993,76 @@ async fn branchable_sync_controlled_mode_allows_connected_peer() {
         "Connected peer should be allowed for Go-compatible BranchableSync, got {:?}",
         result
     );
+}
+
+#[tokio::test]
+async fn branchable_sync_reply_remerges_locally_complete_unmerged_head() {
+    use defra_core::{Block, CompositeDeltaPayload, CrdtDelta};
+
+    let replicators = Arc::new(ReplicatorRegistry::new());
+    let peer_state = Arc::new(PeerStateTracker::new());
+    let peer = random_peer_id();
+
+    let transport = NoopTransport::new();
+    let local_peer_id = transport.local_peer_id().to_string();
+    let broadcaster = Broadcaster::new(transport.clone());
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+
+    let block = Block::new(
+        CrdtDelta::Composite(CompositeDeltaPayload {
+            doc_id: b"doc1".to_vec(),
+            schema_version_id: "collection1".to_string(),
+            priority: 1,
+            status: 1,
+        }),
+        vec![],
+        vec![],
+    );
+    let block_data = block.to_dag_cbor().unwrap();
+    let cid = block.generate_cid().unwrap();
+    blockstore.put(&cid, &block_data).await.unwrap();
+    assert!(
+        !blockstore.is_merged(&cid).await.unwrap(),
+        "test setup requires an unmerged local root"
+    );
+
+    let (coordinator, mut events) =
+        create_test_coordinator_with_blockstore(TestCoordinatorParams {
+            access_mode: AccessMode::Open,
+            replicators,
+            peer_state,
+            transport,
+            local_peer_id,
+            broadcaster,
+            blockstore,
+            rate_limiter: Arc::new(PeerRateLimiter::default()),
+        });
+
+    coordinator
+        .handle_transport_event(branchable_sync_reply_event(
+            peer.clone(),
+            "collection1",
+            vec![cid],
+        ))
+        .await
+        .unwrap();
+
+    match recv_block_received(&mut events).await {
+        SyncEvent::BlockReceived {
+            cid: event_cid,
+            doc_id,
+            collection_id,
+            sender_peer,
+            ..
+        } => {
+            assert_eq!(event_cid, cid);
+            assert_eq!(doc_id, "doc1");
+            assert_eq!(collection_id, "collection1");
+            assert_eq!(sender_peer.as_deref(), Some(peer.as_str()));
+        }
+        other => panic!("expected BlockReceived for unmerged BranchableSync head, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/branchable_sync.rs
@@ -123,6 +123,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
 
         let mut cids_to_fetch: Vec<Cid> = Vec::new();
+        let mut cids_to_remerge: Vec<Cid> = Vec::new();
         for head_bytes in &reply.heads {
             match Cid::try_from(head_bytes.as_slice()) {
                 Ok(cid) => {
@@ -141,7 +142,32 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                                 )
                                 .await
                                 {
-                                    Ok(missing) => !missing.is_empty(),
+                                    Ok(missing) => {
+                                        if missing.is_empty() {
+                                            match self.manager.blockstore().is_merged(&cid).await {
+                                                Ok(true) => false,
+                                                Ok(false) => {
+                                                    tracing::info!(
+                                                        cid = %cid,
+                                                        collection_id = %reply.collection_id,
+                                                        "Collection head exists with complete DAG but is unmerged, scheduling re-merge"
+                                                    );
+                                                    cids_to_remerge.push(cid);
+                                                    false
+                                                }
+                                                Err(e) => {
+                                                    tracing::debug!(
+                                                        cid = %cid,
+                                                        error = %e,
+                                                        "Failed to check merge status; falling back to fetch"
+                                                    );
+                                                    true
+                                                }
+                                            }
+                                        } else {
+                                            true
+                                        }
+                                    }
                                     Err(e) => {
                                         tracing::debug!(
                                             cid = %cid,
@@ -169,6 +195,52 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "Failed to parse CID from BranchableSync reply");
+                }
+            }
+        }
+
+        if !cids_to_remerge.is_empty() {
+            let event_tx = self.manager.event_sender();
+            for cid in cids_to_remerge {
+                match self.manager.blockstore().get(&cid).await {
+                    Ok(Some(data)) => {
+                        let mut context = DagFetchContext::new(
+                            String::new(),
+                            reply.collection_id.clone(),
+                            String::new(),
+                            peer_id.clone(),
+                        )
+                        .with_explicit_replicator(
+                            self.is_registered_replicator(peer_id.as_str(), &reply.collection_id),
+                        );
+                        context.fill_missing_from_block(&data);
+                        tracing::info!(
+                            cid = %cid,
+                            collection_id = %context.collection_id,
+                            "DAG complete locally, emitting BlockReceived for BranchableSync re-merge"
+                        );
+                        if event_tx
+                            .send(crate::sync::manager::SyncEvent::BlockReceived {
+                                cid,
+                                doc_id: context.doc_id,
+                                collection_id: context.collection_id,
+                                creator: context.creator,
+                                sender_peer: Some(context.source_peer.to_string()),
+                                is_explicit_replicator: context.is_explicit_replicator,
+                                explicit_replay_authorization: None,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            tracing::error!(
+                                cid = %cid,
+                                collection_id = %reply.collection_id,
+                                "Failed to emit BlockReceived for locally complete BranchableSync DAG"
+                            );
+                            return Err(crate::error::Error::ChannelSend);
+                        }
+                    }
+                    _ => cids_to_fetch.push(cid),
                 }
             }
         }

--- a/crates/schema/src/definition_validation/global_validators.rs
+++ b/crates/schema/src/definition_validation/global_validators.rs
@@ -2,7 +2,7 @@
 
 use super::helpers::*;
 use super::DefinitionState;
-use crate::ORPHAN_COLLECTION_ID;
+use crate::{FieldKind, ScalarKind, ORPHAN_COLLECTION_ID};
 
 /// Matches Go's validateCollectionNameUnique.
 pub(super) fn validate_collection_name_unique(
@@ -93,6 +93,50 @@ pub(super) fn validate_field_not_duplicated(
             if !seen.insert(&field.name) {
                 errs.push(format!("duplicate field. Name: {}", field.name));
             }
+        }
+    }
+    errs
+}
+
+/// Matches Go's validateRelationNameUnique.
+pub(super) fn validate_relation_name_unique(
+    new_state: &DefinitionState,
+    _old_state: &DefinitionState,
+) -> Vec<String> {
+    let mut errs = Vec::new();
+    for col in &new_state.collections {
+        let mut relation_fields: std::collections::HashMap<&str, Vec<(&str, bool)>> =
+            std::collections::HashMap::new();
+
+        for field in &col.fields {
+            let Some(relation_name) = field.relation_name.as_deref() else {
+                continue;
+            };
+
+            if matches!(field.kind, FieldKind::Scalar(ScalarKind::DocID)) {
+                continue;
+            }
+
+            relation_fields
+                .entry(relation_name)
+                .or_default()
+                .push((field.name.as_str(), field.is_primary));
+        }
+
+        for (relation_name, fields) in relation_fields {
+            if fields.len() <= 1 {
+                continue;
+            }
+
+            let primary_count = fields.iter().filter(|(_, is_primary)| *is_primary).count();
+            if primary_count == 1 && fields.len() == 2 {
+                continue;
+            }
+
+            errs.push(format!(
+                "relation name is not unique within collection. Field: {}, RelationName: {}",
+                fields[0].0, relation_name
+            ));
         }
     }
     errs

--- a/crates/schema/src/definition_validation/mod.rs
+++ b/crates/schema/src/definition_validation/mod.rs
@@ -71,6 +71,7 @@ const GLOBAL_VALIDATORS: &[Validator] = &[
     validate_type_supported,
     validate_type_and_kind_compatible,
     validate_field_not_duplicated,
+    validate_relation_name_unique,
     validate_collection_materialized,
     validate_materialized_has_no_policy,
     validate_embedding_and_kind_compatible,
@@ -80,8 +81,8 @@ const GLOBAL_VALIDATORS: &[Validator] = &[
 
 /// Validates embedding definitions on newly created collections.
 ///
-/// Only runs embedding-specific validators (type and fields).
-/// Other global validators are not appropriate at create time.
+/// Only runs validators that are safe before collection IDs and persisted metadata
+/// are assigned.
 pub fn validate_new_collections(new_collections: &[CollectionVersion]) -> Result<(), String> {
     let new_state = DefinitionState::new(new_collections);
     let old_state = DefinitionState::new(&[]);
@@ -91,6 +92,7 @@ pub fn validate_new_collections(new_collections: &[CollectionVersion]) -> Result
         validate_embedding_fields_for_generation,
         validate_embedding_provider_and_model,
         validate_index_fields_not_counter,
+        validate_relation_name_unique,
     ];
 
     let mut errors = Vec::new();


### PR DESCRIPTION
## Summary
- align Rust FFI schema validation and commit signature encoding with Go expectations
- fix branchable sync completion and LWW merge seeding regressions found by ffi-test
- make deterministic test crypto robust for Rust FFI test runs via the test-client env gate

## Verification
- cargo fmt --check
- cargo test -p ffi deterministic_test_crypto
- cargo test -p ffi test_defra_init
- cargo test -p p2p branchable_sync
- cargo test -p db-merge
- ffi-test run node -v
- cargo run -p ffi-test -- run encryption --skip-build -v: 32 passed, 0 failed, 12 skipped
- ffi-test status: 2798 passed, 32 failed, 373 skipped

## Notes
The paired Go worktree is left clean on develop. The remaining 32 query failures are signed-doc hardcoded CID/version-CID expectation failures; representative cases reproduce directly on clean Go develop with DEFRA_MULTIPLIERS=signed-docs, so they are not Rust FFI-only regressions.