### PR TITLE
fix(query): build cursor seek keys from schema types

### DIFF
--- a/crates/query-plan/src/planner/builder/cursor.rs
+++ b/crates/query-plan/src/planner/builder/cursor.rs
@@ -542,6 +542,52 @@ mod tests {
         );
     }
 
+    // Converse of the date-like-String case: a real DateTime field must seek
+    // with Time (DateTime) bytes, not String bytes, so cursor pagination lands
+    // on the right index entry. Guards the schema-typed seek path for #1026.
+    #[test]
+    fn seek_key_uses_time_bytes_for_datetime_field() {
+        use document::NormalValue;
+        use schema::{FieldDescription, FieldKind};
+        use storage::field_value::encode_field_value;
+        use storage::keys::IndexDataStoreKey;
+
+        let idx = make_index("idx_stamp", vec![("stamp", false)], true);
+
+        let stamp_field = FieldDescription::new("1", "stamp", FieldKind::datetime());
+        let mut coll = CollectionVersion::new("test", "v1", "coll_test_001", vec![stamp_field]);
+        coll.indexes = vec![idx.clone()];
+
+        let stamp = "2026-05-29T13:06:28Z";
+        let mut keys = std::collections::BTreeMap::new();
+        keys.insert("stamp".to_string(), serde_json::json!(stamp));
+        let cursor = Cursor {
+            keys,
+            doc_id: "bae-test".to_string(),
+            direction: String::new(),
+        };
+        let order = order_asc("stamp");
+
+        let key = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
+
+        let prefix = IndexDataStoreKey::index_prefix(coll.resolved_root_id(), idx.id);
+        let parsed_time = chrono::DateTime::parse_from_rfc3339(stamp).unwrap();
+        let expected = encode_field_value(prefix.clone(), &NormalValue::Time(parsed_time), false)
+            .expect("time value should encode");
+        let string_encoded =
+            encode_field_value(prefix, &NormalValue::String(stamp.to_string()), false)
+                .expect("string value should encode");
+
+        assert_eq!(
+            key, expected,
+            "seek key must use DateTime (Time) bytes for a DateTime field"
+        );
+        assert_ne!(
+            key, string_encoded,
+            "seek key must not use String bytes for a DateTime field"
+        );
+    }
+
     #[test]
     fn seek_key_preserves_null_for_schema_typed_field() {
         use document::NormalValue;

--- a/crates/query-plan/src/planner/builder/cursor.rs
+++ b/crates/query-plan/src/planner/builder/cursor.rs
@@ -13,7 +13,7 @@ use schema::{CollectionVersion, IndexDescription};
 use storage::field_value::encode_field_value;
 use storage::keys::IndexDataStoreKey;
 
-use crate::planner::index_selection::{json_to_normal_value, normalize_for_index_field};
+use crate::planner::index_selection::json_to_normal_value_for_index_field;
 
 /// Wrap a plan tree with `CursorNode`, configure any scan in the tree
 /// with `cursor_seek`, and validate that ordering is supported by an
@@ -304,10 +304,8 @@ fn build_cursor_seek_key(
         let Some(json_val) = cursor.keys.get(field_name) else {
             return Err(QueryError::cursor_invalid());
         };
-        let raw = json_to_normal_value(json_val).ok_or_else(QueryError::cursor_invalid)?;
-        // Normalize to the schema field's encoding type so the seek key bytes
-        // match what the index actually stores (e.g., Float64 JSON → Float32).
-        let normal = normalize_for_index_field(raw, field_name, &collection.fields);
+        let normal = json_to_normal_value_for_index_field(json_val, field_name, &collection.fields)
+            .ok_or_else(QueryError::cursor_invalid)?;
 
         // Use the index's descending flag for this field position, if available.
         let descending = idx.fields.get(i).map(|f| f.descending).unwrap_or(false);
@@ -495,6 +493,87 @@ mod tests {
         assert_eq!(
             key, expected,
             "seek key must use Float32 encoding to match index bytes"
+        );
+    }
+
+    #[test]
+    fn seek_key_keeps_date_like_json_string_as_string_for_string_field() {
+        use document::NormalValue;
+        use schema::{FieldDescription, FieldKind};
+        use storage::field_value::encode_field_value;
+        use storage::keys::IndexDataStoreKey;
+
+        let idx = make_index("idx_stamp", vec![("stamp", false)], true);
+
+        let stamp_field = FieldDescription::new("1", "stamp", FieldKind::string());
+        let mut coll = CollectionVersion::new("test", "v1", "coll_test_001", vec![stamp_field]);
+        coll.indexes = vec![idx.clone()];
+
+        let stamp = "2026-05-29T13:06:28Z";
+        let mut keys = std::collections::BTreeMap::new();
+        keys.insert("stamp".to_string(), serde_json::json!(stamp));
+        let cursor = Cursor {
+            keys,
+            doc_id: "bae-test".to_string(),
+            direction: String::new(),
+        };
+        let order = order_asc("stamp");
+
+        let key = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
+
+        let prefix = IndexDataStoreKey::index_prefix(coll.resolved_root_id(), idx.id);
+        let expected = encode_field_value(
+            prefix.clone(),
+            &NormalValue::String(stamp.to_string()),
+            false,
+        )
+        .unwrap();
+        let parsed_time = chrono::DateTime::parse_from_rfc3339(stamp).unwrap();
+        let time_encoded = encode_field_value(prefix, &NormalValue::Time(parsed_time), false)
+            .expect("time value should encode");
+
+        assert_eq!(
+            key, expected,
+            "seek key must preserve date-like text as String for String fields"
+        );
+        assert_ne!(
+            key, time_encoded,
+            "seek key must not use DateTime bytes for a String field"
+        );
+    }
+
+    #[test]
+    fn seek_key_preserves_null_for_schema_typed_field() {
+        use document::NormalValue;
+        use schema::{FieldDescription, FieldKind};
+        use storage::field_value::encode_field_value;
+        use storage::keys::IndexDataStoreKey;
+
+        let idx = make_index("idx_stamp", vec![("stamp", false)], true);
+
+        let stamp_field = FieldDescription::new("1", "stamp", FieldKind::string());
+        let mut coll = CollectionVersion::new("test", "v1", "coll_test_001", vec![stamp_field]);
+        coll.indexes = vec![idx.clone()];
+
+        let doc_id = "bae-test";
+        let mut keys = std::collections::BTreeMap::new();
+        keys.insert("stamp".to_string(), serde_json::Value::Null);
+        let cursor = Cursor {
+            keys,
+            doc_id: doc_id.to_string(),
+            direction: String::new(),
+        };
+        let order = order_asc("stamp");
+
+        let key = build_cursor_seek_key(&cursor, &order, &coll, &idx).unwrap();
+
+        let prefix = IndexDataStoreKey::index_prefix(coll.resolved_root_id(), idx.id);
+        let mut expected = encode_field_value(prefix, &NormalValue::Null, false).unwrap();
+        expected.extend_from_slice(doc_id.as_bytes());
+
+        assert_eq!(
+            key, expected,
+            "null cursor keys remain valid and include doc_id for unique null entries"
         );
     }
 }

--- a/crates/query-plan/src/planner/index_selection/mod.rs
+++ b/crates/query-plan/src/planner/index_selection/mod.rs
@@ -18,4 +18,4 @@ pub use filter_to_scan::{can_or_filter_use_index, filter_to_index_scan, or_filte
 pub use types::{
     ConditionValue, CursorSeek, FieldCondition, IndexScanParams, IndexScanType, ScanValueFilter,
 };
-pub(crate) use values::{json_to_normal_value, normalize_for_index_field};
+pub(crate) use values::json_to_normal_value_for_index_field;

--- a/crates/query-plan/src/planner/index_selection/values.rs
+++ b/crates/query-plan/src/planner/index_selection/values.rs
@@ -1,7 +1,7 @@
 //! Value conversion and normalization for index selection.
 
 use document::{JsonLeafValue, JsonPath, JsonScalarValue, NormalValue};
-use schema::{FieldKind, ScalarKind};
+use schema::{FieldDescription, FieldKind, ScalarKind};
 use serde_json::Value as JsonValue;
 
 /// Convert JSON value to NormalValue.
@@ -21,6 +21,40 @@ pub(crate) fn json_to_normal_value(value: &JsonValue) -> Option<NormalValue> {
             Some(NormalValue::String(s.clone()))
         }
         _ => None,
+    }
+}
+
+/// Convert a cursor/index JSON value using the declared schema kind when known.
+///
+/// Cursor tokens are JSON, so shape-based inference is ambiguous: the same JSON
+/// string can be either a `String` or a `DateTime`. Use schema metadata before
+/// falling back to legacy inference so seek-key bytes match index write bytes.
+pub(crate) fn json_to_normal_value_for_index_field(
+    value: &JsonValue,
+    field_name: &str,
+    collection_fields: &[FieldDescription],
+) -> Option<NormalValue> {
+    if value.is_null() {
+        return Some(NormalValue::Null);
+    }
+
+    match collection_fields
+        .iter()
+        .find(|field| field.name == field_name)
+        .map(|field| &field.kind)
+    {
+        Some(FieldKind::Scalar(kind)) => match kind {
+            ScalarKind::Json | ScalarKind::None => json_to_normal_value(value),
+            _ => document::encoding::json_to_normal_value_for_kind(value, kind),
+        },
+        _ => {
+            let raw = json_to_normal_value(value)?;
+            Some(normalize_for_index_field(
+                raw,
+                field_name,
+                collection_fields,
+            ))
+        }
     }
 }
 

--- a/tools/integration-test/tests/cursor/smoke.rs
+++ b/tools/integration-test/tests/cursor/smoke.rs
@@ -158,6 +158,78 @@ async fn rust_pagination_round_trip() {
 }
 
 #[tokio::test]
+async fn rust_cursor_after_date_like_string_uses_string_seek_key() {
+    let cluster = integration_test::TestCluster::builder()
+        .rust_nodes(1)
+        .build()
+        .await
+        .unwrap();
+    let node = cluster.client(0);
+    node.schema_add("type Event { name: String  stamp: String }")
+        .expect("add Event schema");
+    node.index_create("Event", &["stamp"], Some("idx_stamp"), false)
+        .expect("create stamp index");
+
+    let events = [
+        ("jan", "2026-01-05T18:05:40Z"),
+        ("feb", "2026-02-10T09:00:00Z"),
+        ("mar", "2026-03-15T12:30:00Z"),
+        ("apr", "2026-04-20T08:15:00Z"),
+    ];
+    for (name, stamp) in events {
+        node.query(&format!(
+            r#"mutation {{ add_Event(input: {{ name: "{name}", stamp: "{stamp}" }}) {{ _docID }} }}"#
+        ))
+        .expect("seed event");
+    }
+
+    let page1: Value = node
+        .query(
+            r#"{ _cursor {
+            Event(first: 2, order: [{stamp: ASC}]) { name stamp }
+            _pageInfo { endCursor hasNext }
+        } }"#,
+        )
+        .expect("page 1");
+
+    let first_page_names: Vec<&str> = page1["_cursor"]["Event"]
+        .as_array()
+        .expect("page 1 events")
+        .iter()
+        .map(|event| event["name"].as_str().expect("event name"))
+        .collect();
+    assert_eq!(first_page_names, vec!["jan", "feb"]);
+    assert_eq!(
+        page1["_cursor"]["_pageInfo"]["hasNext"],
+        Value::Bool(true),
+        "hasNext should be true on page 1"
+    );
+
+    let end_cursor = page1["_cursor"]["_pageInfo"]["endCursor"]
+        .as_str()
+        .expect("endCursor present");
+    let page2: Value = node
+        .query(&format!(
+            r#"{{ _cursor {{
+            Event(first: 2, after: "{end_cursor}", order: [{{stamp: ASC}}]) {{ name stamp }}
+        }} }}"#
+        ))
+        .expect("page 2");
+
+    let second_page_names: Vec<&str> = page2["_cursor"]["Event"]
+        .as_array()
+        .expect("page 2 events")
+        .iter()
+        .map(|event| event["name"].as_str().expect("event name"))
+        .collect();
+    assert_eq!(
+        second_page_names,
+        vec!["mar", "apr"],
+        "cursor seek must use String bytes, not DateTime bytes, for String fields"
+    );
+}
+
+#[tokio::test]
 async fn rust_forward_first_after_doc_id_desc() {
     // Regression: forward slow path with _docID DESC used `row > after` (ASC comparison).
     // For DESC order, smaller doc_ids come next, so the correct comparison is `row < after`.

--- a/tools/integration-test/tests/cursor/smoke.rs
+++ b/tools/integration-test/tests/cursor/smoke.rs
@@ -229,6 +229,90 @@ async fn rust_cursor_after_date_like_string_uses_string_seek_key() {
     );
 }
 
+// Converse of `rust_cursor_after_date_like_string_uses_string_seek_key`: a real
+// DateTime field must paginate correctly across pages via the schema-typed seek
+// path (Time bytes), with no rows dropped or duplicated at the page boundary.
+#[tokio::test]
+async fn rust_cursor_after_datetime_paginates_across_pages() {
+    let cluster = integration_test::TestCluster::builder()
+        .rust_nodes(1)
+        .build()
+        .await
+        .unwrap();
+    let node = cluster.client(0);
+    node.schema_add("type Reading { name: String  stamp: DateTime }")
+        .expect("add Reading schema");
+    node.index_create("Reading", &["stamp"], Some("idx_stamp"), false)
+        .expect("create stamp index");
+
+    let readings = [
+        ("jan", "2026-01-05T18:05:40Z"),
+        ("feb", "2026-02-10T09:00:00Z"),
+        ("mar", "2026-03-15T12:30:00Z"),
+        ("apr", "2026-04-20T08:15:00Z"),
+    ];
+    for (name, stamp) in readings {
+        node.query(&format!(
+            r#"mutation {{ add_Reading(input: {{ name: "{name}", stamp: "{stamp}" }}) {{ _docID }} }}"#
+        ))
+        .expect("seed reading");
+    }
+
+    let page1: Value = node
+        .query(
+            r#"{ _cursor {
+            Reading(first: 2, order: [{stamp: ASC}]) { name stamp }
+            _pageInfo { endCursor hasNext }
+        } }"#,
+        )
+        .expect("page 1");
+
+    let first_page_names: Vec<&str> = page1["_cursor"]["Reading"]
+        .as_array()
+        .expect("page 1 readings")
+        .iter()
+        .map(|reading| reading["name"].as_str().expect("reading name"))
+        .collect();
+    assert_eq!(first_page_names, vec!["jan", "feb"]);
+    assert_eq!(
+        page1["_cursor"]["_pageInfo"]["hasNext"],
+        Value::Bool(true),
+        "hasNext should be true on page 1"
+    );
+
+    let end_cursor = page1["_cursor"]["_pageInfo"]["endCursor"]
+        .as_str()
+        .expect("endCursor present");
+    let page2: Value = node
+        .query(&format!(
+            r#"{{ _cursor {{
+            Reading(first: 2, after: "{end_cursor}", order: [{{stamp: ASC}}]) {{ name stamp }}
+        }} }}"#
+        ))
+        .expect("page 2");
+
+    let second_page_names: Vec<&str> = page2["_cursor"]["Reading"]
+        .as_array()
+        .expect("page 2 readings")
+        .iter()
+        .map(|reading| reading["name"].as_str().expect("reading name"))
+        .collect();
+    assert_eq!(
+        second_page_names,
+        vec!["mar", "apr"],
+        "DateTime cursor seek must use Time bytes and continue past the boundary"
+    );
+
+    // No rows dropped or duplicated across the page boundary.
+    let mut all_names = first_page_names;
+    all_names.extend(second_page_names);
+    assert_eq!(
+        all_names,
+        vec!["jan", "feb", "mar", "apr"],
+        "every seeded reading must appear exactly once, in stamp order, across both pages"
+    );
+}
+
 #[tokio::test]
 async fn rust_forward_first_after_doc_id_desc() {
     // Regression: forward slow path with _docID DESC used `row > after` (ASC comparison).


### PR DESCRIPTION
## Summary

Closes #1006.

This PR makes cursor seek-key construction schema-aware. Cursor tokens are JSON, so shape-based inference can misclassify date-like `String` values as `DateTime`; seek keys now use the ordered field's declared schema kind so cursor pagination lands in the same byte range as the stored index entries.

## Details

- Adds schema-aware JSON-to-`NormalValue` conversion for cursor/index seek values.
- Preserves date-like text as `String` when the ordered field is declared as `String`.
- Keeps `DateTime`, numeric width, and fallback behavior aligned with existing index encoding.
- Preserves `null` cursor boundary handling, including docID suffix behavior for unique null index entries.
- Adds unit coverage for date-like `String` seek bytes, Float32 normalization, and null cursor keys.
- Adds an integration regression covering forward cursor pagination over an indexed `String` field containing RFC3339-looking text.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p query-plan --lib`
- `cargo clippy -p query-plan --tests -- -D warnings`
- `cargo clippy -p integration-test --test cursor -- -D warnings`
- `RUST_LOG=debug cargo test -p integration-test --test cursor rust_cursor_after_date_like_string_uses_string_seek_key -- --nocapture`

## Notes

A local full-file `cargo test -p integration-test --test cursor` run hit harness node-readiness timeouts before exercising assertions across existing cursor tests. The focused regression passes end-to-end with the harness ready log visible.
