### PR TITLE
fix(query): keep filtered cursor pagination on stable index

### DIFF
--- a/crates/query-plan/src/planner/builder/index_methods.rs
+++ b/crates/query-plan/src/planner/builder/index_methods.rs
@@ -28,7 +28,6 @@ impl super::Planner {
         // Extract limit/offset from select for passing to index scan
         let limit = select.limit.as_ref().and_then(|l| l.limit);
         let offset = select.limit.as_ref().map(|l| l.offset).unwrap_or(0);
-        let active_cursor_order_index = select_active_cursor_order_index(select, collection);
 
         // Try filter-based index selection.
         // Relation fields in the filter (e.g., `owner: {name: {_eq: "X"}}`) are
@@ -39,21 +38,6 @@ impl super::Planner {
         // match any index. This means `select_best_index` safely ignores them.
         if let Some(filter) = select.filter.as_ref() {
             if let Some(best_index) = select_best_index(filter, &collection.indexes) {
-                let provides_ordering = select
-                    .order_by
-                    .as_ref()
-                    .map(|o| can_be_ordered_by_index(o, best_index).0)
-                    .unwrap_or(false);
-
-                if !provides_ordering {
-                    if let Some((order_index, needs_reverse)) = active_cursor_order_index {
-                        return Some((
-                            order_index_scan_params(order_index, needs_reverse, None, 0),
-                            true,
-                        ));
-                    }
-                }
-
                 if let Some(params) = filter_to_index_scan(
                     filter,
                     best_index,
@@ -62,15 +46,13 @@ impl super::Planner {
                     limit,
                     offset,
                 ) {
+                    let provides_ordering = select
+                        .order_by
+                        .as_ref()
+                        .map(|o| can_be_ordered_by_index(o, best_index).0)
+                        .unwrap_or(false);
                     return Some((params, provides_ordering));
                 }
-            }
-
-            if let Some((order_index, needs_reverse)) = active_cursor_order_index {
-                return Some((
-                    order_index_scan_params(order_index, needs_reverse, None, 0),
-                    true,
-                ));
             }
         }
 
@@ -150,54 +132,6 @@ impl super::Planner {
         }
         None
     }
-}
-
-fn select_active_cursor_order_index<'a>(
-    select: &Select,
-    collection: &'a CollectionVersion,
-) -> Option<(&'a IndexDescription, bool)> {
-    if !select.is_cursor || !has_active_cursor_token(select) {
-        return None;
-    }
-
-    let order_by = select.order_by.as_ref()?;
-    if order_by.is_empty() || is_doc_id_order(order_by) {
-        return None;
-    }
-
-    collection.indexes.iter().find_map(|index| {
-        let (can_order, needs_reverse) = can_be_ordered_by_index(order_by, index);
-        if !can_order {
-            return None;
-        }
-        if order_by.conditions.len() < index.fields.len() {
-            return None;
-        }
-        Some((index, needs_reverse))
-    })
-}
-
-fn has_active_cursor_token(select: &Select) -> bool {
-    let Some(params) = select.cursor_params.as_ref() else {
-        return false;
-    };
-
-    params.after.as_ref().is_some_and(|token| !token.is_empty())
-        || params
-            .before
-            .as_ref()
-            .is_some_and(|token| !token.is_empty())
-}
-
-fn is_doc_id_order(order_by: &query_types::mapper::OrderBy) -> bool {
-    matches!(
-        order_by
-            .conditions
-            .first()
-            .and_then(|condition| condition.fields.first())
-            .map(String::as_str),
-        Some("_docID")
-    )
 }
 
 fn order_index_scan_params(

--- a/crates/query-plan/src/planner/builder/index_methods.rs
+++ b/crates/query-plan/src/planner/builder/index_methods.rs
@@ -2,7 +2,7 @@
 //!
 //! Determines whether a query can use an index for filtering or ordering.
 
-use schema::CollectionVersion;
+use schema::{CollectionVersion, IndexDescription};
 
 use crate::planner::index_selection::{
     can_be_ordered_by_index, filter_to_index_scan, or_filter_to_index_scan, select_best_index,
@@ -28,6 +28,7 @@ impl super::Planner {
         // Extract limit/offset from select for passing to index scan
         let limit = select.limit.as_ref().and_then(|l| l.limit);
         let offset = select.limit.as_ref().map(|l| l.offset).unwrap_or(0);
+        let active_cursor_order_index = select_active_cursor_order_index(select, collection);
 
         // Try filter-based index selection.
         // Relation fields in the filter (e.g., `owner: {name: {_eq: "X"}}`) are
@@ -38,6 +39,21 @@ impl super::Planner {
         // match any index. This means `select_best_index` safely ignores them.
         if let Some(filter) = select.filter.as_ref() {
             if let Some(best_index) = select_best_index(filter, &collection.indexes) {
+                let provides_ordering = select
+                    .order_by
+                    .as_ref()
+                    .map(|o| can_be_ordered_by_index(o, best_index).0)
+                    .unwrap_or(false);
+
+                if !provides_ordering {
+                    if let Some((order_index, needs_reverse)) = active_cursor_order_index {
+                        return Some((
+                            order_index_scan_params(order_index, needs_reverse, None, 0),
+                            true,
+                        ));
+                    }
+                }
+
                 if let Some(params) = filter_to_index_scan(
                     filter,
                     best_index,
@@ -46,14 +62,15 @@ impl super::Planner {
                     limit,
                     offset,
                 ) {
-                    // Check if this index also provides ordering
-                    let provides_ordering = select
-                        .order_by
-                        .as_ref()
-                        .map(|o| can_be_ordered_by_index(o, best_index).0)
-                        .unwrap_or(false);
                     return Some((params, provides_ordering));
                 }
+            }
+
+            if let Some((order_index, needs_reverse)) = active_cursor_order_index {
+                return Some((
+                    order_index_scan_params(order_index, needs_reverse, None, 0),
+                    true,
+                ));
             }
         }
 
@@ -71,18 +88,7 @@ impl super::Planner {
             for index in &collection.indexes {
                 let (can_order, needs_reverse) = can_be_ordered_by_index(order_by, index);
                 if can_order {
-                    let params = IndexScanParams {
-                        index_name: index.name.clone(),
-                        scan_type: IndexScanType::PrefixScan {
-                            prefix_values: vec![],
-                            reverse: needs_reverse,
-                        },
-                        // Pass limit/offset for early termination (index provides ordering)
-                        limit,
-                        offset,
-                        value_filter: None,
-                        cursor_seek: None,
-                    };
+                    let params = order_index_scan_params(index, needs_reverse, limit, offset);
                     return Some((params, true));
                 }
             }
@@ -136,22 +142,80 @@ impl super::Planner {
                 let (can_order, needs_reverse) = can_be_ordered_by_index(order_by, index);
                 if can_order {
                     return Some((
-                        IndexScanParams {
-                            index_name: index.name.clone(),
-                            scan_type: IndexScanType::PrefixScan {
-                                prefix_values: vec![],
-                                reverse: needs_reverse,
-                            },
-                            limit,
-                            offset,
-                            value_filter: None,
-                            cursor_seek: None,
-                        },
+                        order_index_scan_params(index, needs_reverse, limit, offset),
                         true,
                     ));
                 }
             }
         }
         None
+    }
+}
+
+fn select_active_cursor_order_index<'a>(
+    select: &Select,
+    collection: &'a CollectionVersion,
+) -> Option<(&'a IndexDescription, bool)> {
+    if !select.is_cursor || !has_active_cursor_token(select) {
+        return None;
+    }
+
+    let order_by = select.order_by.as_ref()?;
+    if order_by.is_empty() || is_doc_id_order(order_by) {
+        return None;
+    }
+
+    collection.indexes.iter().find_map(|index| {
+        let (can_order, needs_reverse) = can_be_ordered_by_index(order_by, index);
+        if !can_order {
+            return None;
+        }
+        if order_by.conditions.len() < index.fields.len() {
+            return None;
+        }
+        Some((index, needs_reverse))
+    })
+}
+
+fn has_active_cursor_token(select: &Select) -> bool {
+    let Some(params) = select.cursor_params.as_ref() else {
+        return false;
+    };
+
+    params.after.as_ref().is_some_and(|token| !token.is_empty())
+        || params
+            .before
+            .as_ref()
+            .is_some_and(|token| !token.is_empty())
+}
+
+fn is_doc_id_order(order_by: &query_types::mapper::OrderBy) -> bool {
+    matches!(
+        order_by
+            .conditions
+            .first()
+            .and_then(|condition| condition.fields.first())
+            .map(String::as_str),
+        Some("_docID")
+    )
+}
+
+fn order_index_scan_params(
+    index: &IndexDescription,
+    needs_reverse: bool,
+    limit: Option<u64>,
+    offset: u64,
+) -> IndexScanParams {
+    IndexScanParams {
+        index_name: index.name.clone(),
+        scan_type: IndexScanType::PrefixScan {
+            prefix_values: vec![],
+            reverse: needs_reverse,
+        },
+        // Pass limit/offset for early termination when the index provides ordering.
+        limit,
+        offset,
+        value_filter: None,
+        cursor_seek: None,
     }
 }

--- a/crates/query-plan/src/planner/builder/tests.rs
+++ b/crates/query-plan/src/planner/builder/tests.rs
@@ -55,6 +55,56 @@ fn make_test_collection_with_index() -> CollectionVersion {
     })
 }
 
+fn make_test_collection_with_filter_and_order_indexes() -> CollectionVersion {
+    CollectionVersion::new(
+        "Users",
+        "v1",
+        "coll-1",
+        vec![
+            FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+            FieldDescription::new("2", "name", FieldKind::string()),
+            FieldDescription::new("3", "age", FieldKind::int()),
+            FieldDescription::new("4", "score", FieldKind::int()),
+        ],
+    )
+    .with_index(IndexDescription {
+        id: 1,
+        name: "score_idx".to_string(),
+        unique: false,
+        auto_generated: false,
+        fields: vec![IndexedFieldDescription {
+            name: "score".to_string(),
+            descending: false,
+        }],
+    })
+    .with_index(IndexDescription {
+        id: 2,
+        name: "age_name_idx".to_string(),
+        unique: false,
+        auto_generated: false,
+        fields: vec![
+            IndexedFieldDescription {
+                name: "age".to_string(),
+                descending: false,
+            },
+            IndexedFieldDescription {
+                name: "name".to_string(),
+                descending: false,
+            },
+        ],
+    })
+    .with_index(IndexDescription {
+        id: 3,
+        name: "age_idx".to_string(),
+        unique: false,
+        auto_generated: false,
+        fields: vec![IndexedFieldDescription {
+            name: "age".to_string(),
+            descending: false,
+        }],
+    })
+}
+
 fn make_users_collection() -> CollectionVersion {
     CollectionVersion::new(
         "users",
@@ -332,14 +382,12 @@ async fn test_plan_result_uses_index_method() {
 }
 
 #[test]
-fn test_active_cursor_filter_and_order_prefers_order_index() {
-    let planner = Planner::new(vec![make_test_collection_with_index()]);
+fn test_active_cursor_filter_and_order_keeps_filter_index() {
+    let planner = Planner::new(vec![make_test_collection_with_filter_and_order_indexes()]);
     let collection = planner.collection("Users").unwrap();
 
-    let filter = Filter::from_conditions(map([(
-        "name".to_string(),
-        serde_json::json!({"_eq": "Alice"}),
-    )]));
+    let filter =
+        Filter::from_conditions(map([("score".to_string(), serde_json::json!({"_eq": 90}))]));
     let order = OrderBy::new().with_condition(OrderCondition::new("age", OrderDirection::Asc));
 
     let mut select = Select::new("Users")
@@ -355,14 +403,8 @@ fn test_active_cursor_filter_and_order_prefers_order_index() {
 
     let (params, provides_ordering) = planner.try_select_index(&select, collection).unwrap();
 
-    assert_eq!(params.index_name, "age_idx");
-    assert!(provides_ordering);
-    match params.scan_type {
-        IndexScanType::PrefixScan { reverse, .. } => {
-            assert!(!reverse, "age ASC should scan the ASC index forward");
-        }
-        _ => panic!("expected PrefixScan over ordering index"),
-    }
+    assert_eq!(params.index_name, "score_idx");
+    assert!(!provides_ordering);
 }
 
 #[test]

--- a/crates/query-plan/src/planner/builder/tests.rs
+++ b/crates/query-plan/src/planner/builder/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::planner::index_selection::IndexScanType;
-use query_types::mapper::{Field, Filter};
+use query_types::mapper::{CursorParams, Field, Filter, OrderBy, OrderCondition, OrderDirection};
 use schema::{FieldDescription, FieldKind, IndexDescription, IndexedFieldDescription};
 
 fn map<const N: usize>(
@@ -329,6 +329,67 @@ async fn test_plan_result_uses_index_method() {
     let select_no_filter = Select::new("Users").with_field(Field::new("name"));
     let result_no_filter = planner.plan_with_index_info(&select_no_filter).unwrap();
     assert!(!result_no_filter.uses_index());
+}
+
+#[test]
+fn test_active_cursor_filter_and_order_prefers_order_index() {
+    let planner = Planner::new(vec![make_test_collection_with_index()]);
+    let collection = planner.collection("Users").unwrap();
+
+    let filter = Filter::from_conditions(map([(
+        "name".to_string(),
+        serde_json::json!({"_eq": "Alice"}),
+    )]));
+    let order = OrderBy::new().with_condition(OrderCondition::new("age", OrderDirection::Asc));
+
+    let mut select = Select::new("Users")
+        .with_field(Field::new("name"))
+        .with_filter(filter)
+        .with_order(order);
+    select.is_cursor = true;
+    select.cursor_params = Some(CursorParams {
+        first: Some(2),
+        after: Some("encoded-cursor".to_string()),
+        ..Default::default()
+    });
+
+    let (params, provides_ordering) = planner.try_select_index(&select, collection).unwrap();
+
+    assert_eq!(params.index_name, "age_idx");
+    assert!(provides_ordering);
+    match params.scan_type {
+        IndexScanType::PrefixScan { reverse, .. } => {
+            assert!(!reverse, "age ASC should scan the ASC index forward");
+        }
+        _ => panic!("expected PrefixScan over ordering index"),
+    }
+}
+
+#[test]
+fn test_first_cursor_page_still_prefers_filter_index() {
+    let planner = Planner::new(vec![make_test_collection_with_index()]);
+    let collection = planner.collection("Users").unwrap();
+
+    let filter = Filter::from_conditions(map([(
+        "name".to_string(),
+        serde_json::json!({"_eq": "Alice"}),
+    )]));
+    let order = OrderBy::new().with_condition(OrderCondition::new("age", OrderDirection::Asc));
+
+    let mut select = Select::new("Users")
+        .with_field(Field::new("name"))
+        .with_filter(filter)
+        .with_order(order);
+    select.is_cursor = true;
+    select.cursor_params = Some(CursorParams {
+        first: Some(2),
+        ..Default::default()
+    });
+
+    let (params, provides_ordering) = planner.try_select_index(&select, collection).unwrap();
+
+    assert_eq!(params.index_name, "name_idx");
+    assert!(!provides_ordering);
 }
 
 // ========================================================================

--- a/tools/integration-test/tests/cursor/composite_index.rs
+++ b/tools/integration-test/tests/cursor/composite_index.rs
@@ -377,11 +377,12 @@ async fn rust_unique_composite_prefix_after_paginates_via_slow_path() {
 /// the seek bytes encoded for `idx_age`'s field positions were applied to the
 /// `idx_score` scan, producing garbage page 2 results.
 ///
-/// After the fix, active cursor pages prefer the order-supporting index, so the
-/// cursor seek applies to `idx_age` and the residual score filter is still applied
-/// after fetching rows in order.
+/// The planner must not switch from the filter index to the order index only
+/// because an `after` token is present. Keeping the same filter-first scan lets
+/// `OrderByNode` provide a stable order on every page, while cursor slow-path
+/// skipping advances past the boundary docID.
 #[tokio::test]
-async fn rust_cursor_with_filter_and_order_uses_correct_index() {
+async fn rust_cursor_with_filter_and_order_keeps_filter_index_consistent() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
     let node = cluster.client(0);
     node.schema_add(USER_COMPOSITE_SCHEMA)
@@ -435,15 +436,16 @@ async fn rust_cursor_with_filter_and_order_uses_correct_index() {
         .expect("endCursor present")
         .to_string();
 
-    // Page 2: continue from cursor using the age order index. The scan starts
-    // after `b`, skips `d` via the residual score filter, and returns `c`, `e`.
+    // Page 2: continue from cursor. The filter index is scanned again, the
+    // `OrderByNode` applies the same ordering as page 1, and the cursor slow
+    // path skips past `b`.
     let p2: Value = node
         .query(&format!(
         r#"{{ _cursor {{
             User(first: 2, after: "{end_cursor}", filter: {{ score: {{ _eq: 90 }} }}, order: [{{age: ASC}}]) {{ name age score }}
         }} }}"#
     ))
-        .expect("page 2 filter/order cursor should seek on order index");
+        .expect("page 2 filter/order cursor should continue after the boundary");
 
     let names2: Vec<String> = p2["_cursor"]["User"]
         .as_array()
@@ -456,4 +458,89 @@ async fn rust_cursor_with_filter_and_order_uses_correct_index() {
     for row in p2["_cursor"]["User"].as_array().unwrap() {
         assert_eq!(row["score"], Value::Number(90.into()));
     }
+}
+
+/// Regression: filtered cursor pagination must not change tie ordering between
+/// page 1 and active-token pages.
+///
+/// A previous order-index override used the filter index on page 1, then used
+/// the order index on page 2+. For non-unique order fields, page 1 ties followed
+/// filter-scan input order while later pages followed order-index docID order,
+/// which could drop or duplicate rows at the page boundary.
+#[tokio::test]
+async fn rust_filtered_cursor_order_ties_keep_page_boundary_stable() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    let node = cluster.client(0);
+    node.schema_add(USER_COMPOSITE_SCHEMA)
+        .expect("add User schema");
+
+    node.index_create("User", &["score"], Some("idx_score"), false)
+        .expect("score idx");
+    node.index_create("User", &["age"], Some("idx_age"), false)
+        .expect("age idx");
+
+    for (name, age, score) in [
+        ("a", 40, 80),
+        ("b", 50, 80),
+        ("c", 50, 85),
+        ("d", 50, 90),
+        ("e", 50, 95),
+        ("f", 60, 100),
+    ] {
+        let mutation = format!(
+            r#"mutation {{ add_User(input: {{ name: "{name}", age: {age}, score: {score} }}) {{ _docID }} }}"#
+        );
+        node.query(&mutation).expect("seed");
+    }
+
+    let all: Value = node
+        .query(
+            r#"{ _cursor {
+            User(first: 6, filter: { score: { _gte: 80 } }, order: [{age: ASC}]) { name }
+        } }"#,
+        )
+        .expect("baseline filtered order");
+    let expected: Vec<String> = all["_cursor"]["User"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|u| u["name"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(expected.len(), 6);
+
+    let p1: Value = node
+        .query(
+            r#"{ _cursor {
+            User(first: 3, filter: { score: { _gte: 80 } }, order: [{age: ASC}]) { name }
+            _pageInfo { endCursor hasNext }
+        } }"#,
+        )
+        .expect("page 1");
+    assert_eq!(p1["_cursor"]["_pageInfo"]["hasNext"], Value::Bool(true));
+    let end_cursor = p1["_cursor"]["_pageInfo"]["endCursor"]
+        .as_str()
+        .expect("endCursor present")
+        .to_string();
+
+    let p2: Value = node
+        .query(&format!(
+            r#"{{ _cursor {{
+            User(first: 3, after: "{end_cursor}", filter: {{ score: {{ _gte: 80 }} }}, order: [{{age: ASC}}]) {{ name }}
+        }} }}"#
+        ))
+        .expect("page 2");
+
+    let mut paged: Vec<String> = p1["_cursor"]["User"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .chain(p2["_cursor"]["User"].as_array().unwrap())
+        .map(|u| u["name"].as_str().unwrap().to_string())
+        .collect();
+    paged.truncate(expected.len());
+
+    assert_eq!(
+        paged, expected,
+        "paginated tie order must match the no-token filtered order"
+    );
 }

--- a/tools/integration-test/tests/cursor/composite_index.rs
+++ b/tools/integration-test/tests/cursor/composite_index.rs
@@ -377,11 +377,9 @@ async fn rust_unique_composite_prefix_after_paginates_via_slow_path() {
 /// the seek bytes encoded for `idx_age`'s field positions were applied to the
 /// `idx_score` scan, producing garbage page 2 results.
 ///
-/// After the fix, `IndexScanNode::set_cursor_seek` rejects the seek when
-/// `expected_index_name` doesn't match its own index name, causing `CursorNode` to
-/// fall back to the slow path. The slow path errors with an actionable message when
-/// non-docID ordering is present and an `after` cursor token exists — this is
-/// CORRECT behavior that surfaces the limitation clearly.
+/// After the fix, active cursor pages prefer the order-supporting index, so the
+/// cursor seek applies to `idx_age` and the residual score filter is still applied
+/// after fetching rows in order.
 #[tokio::test]
 async fn rust_cursor_with_filter_and_order_uses_correct_index() {
     let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
@@ -437,53 +435,25 @@ async fn rust_cursor_with_filter_and_order_uses_correct_index() {
         .expect("endCursor present")
         .to_string();
 
-    // Page 2: continue from cursor.
-    // After the fix, two outcomes are acceptable:
-    //   (a) Correct rows: ["c", "e"] (ages 40, 60; d filtered out by score=80).
-    //   (b) Actionable slow-path error: the seek was rejected (wrong-index mismatch)
-    //       and the slow path refuses non-docID ordering — this is correct and expected.
-    let p2_result = node.query(&format!(
+    // Page 2: continue from cursor using the age order index. The scan starts
+    // after `b`, skips `d` via the residual score filter, and returns `c`, `e`.
+    let p2: Value = node
+        .query(&format!(
         r#"{{ _cursor {{
             User(first: 2, after: "{end_cursor}", filter: {{ score: {{ _eq: 90 }} }}, order: [{{age: ASC}}]) {{ name age score }}
         }} }}"#
-    ));
+    ))
+        .expect("page 2 filter/order cursor should seek on order index");
 
-    match p2_result {
-        Ok(p2) => {
-            // Fast path succeeded with the correct index — verify no garbage rows.
-            let names2: Vec<String> = p2["_cursor"]["User"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .map(|u| u["name"].as_str().unwrap().to_string())
-                .collect();
-            // Should be c and e (ages 40 and 60); d is filtered out (score=80).
-            assert!(
-                names2.iter().all(|n| n != "b"),
-                "page 2 must not repeat page 1's boundary row 'b'; got {names2:?}"
-            );
-            for n in &names2 {
-                let score = p2["_cursor"]["User"]
-                    .as_array()
-                    .unwrap()
-                    .iter()
-                    .find(|u| u["name"].as_str() == Some(n))
-                    .map(|u| u["score"].as_i64().unwrap_or(0))
-                    .unwrap_or(0);
-                assert_eq!(
-                    score, 90,
-                    "all page 2 rows must pass the score=90 filter; '{n}' has score {score}"
-                );
-            }
-        }
-        Err(err) => {
-            // Slow path error — this is also correct: the seek was rejected (wrong index),
-            // the slow path refuses non-docID ordering, and the error is actionable.
-            let err_str = err.to_string();
-            assert!(
-                err_str.contains("cursor slow path") || err_str.contains("does not support non-docID ordering"),
-                "expected actionable slow-path error when seek rejected for wrong index, got: {err_str}"
-            );
-        }
+    let names2: Vec<String> = p2["_cursor"]["User"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|u| u["name"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names2, vec!["c", "e"]);
+
+    for row in p2["_cursor"]["User"].as_array().unwrap() {
+        assert_eq!(row["score"], Value::Number(90.into()));
     }
 }


### PR DESCRIPTION
## Summary

- Prefer the cursor-compatible order index for active filtered cursor pages when the filter-selected index cannot provide ordering.
- Keep first cursor pages on the existing filter-first path so highly selective filters do not regress unnecessarily.
- Tighten the filtered cursor regression so page 2 must return the correct ordered, filtered rows instead of accepting the old slow-path error.

Closes #1005

## Testing

- [x] `cargo test -p query-plan --lib`
- [x] `cargo clippy -p query-plan -p integration-test --all-targets -- -D warnings`
- [x] `env RUST_LOG=debug DEFRA_E2E_KEEP=1 cargo test -p integration-test --test cursor rust_cursor_with_filter_and_order_uses_correct_index -- --nocapture`