### PR TITLE
test(conformance): assert PN-counter and mixed-field convergence

### DIFF
--- a/proofs/tests/behavioral/bughunt.rs
+++ b/proofs/tests/behavioral/bughunt.rs
@@ -603,12 +603,12 @@ async fn bughunt_counter_3node() {
     }
     // Full mesh: every node replicates to the other two.
     for i in 0..3 {
-        for j in 0..3 {
+        for (j, peer_addr) in addr.iter().enumerate() {
             if i != j {
-                cluster.client(i).p2p_connect(&[addr[j].as_str()]).ok();
+                cluster.client(i).p2p_connect(&[peer_addr.as_str()]).ok();
                 cluster
                     .client(i)
-                    .p2p_replicator_set(&["Tally"], &addr[j])
+                    .p2p_replicator_set(&["Tally"], peer_addr)
                     .ok();
             }
         }

--- a/proofs/tests/behavioral/parity.rs
+++ b/proofs/tests/behavioral/parity.rs
@@ -218,7 +218,7 @@ async fn parity_samedoc_rust_rust() {
 /// replication first silently dropped its own increment. This reports the
 /// Go-only and mixed cases to confirm Go converges (the parity target) and that
 /// Rust<->Go interop accumulates correctly.
-async fn run_counter_parity(mut cluster: TestCluster, label: &str) {
+async fn run_counter_parity(cluster: TestCluster, label: &str) {
     let schema = "type Tally { name: String  hits: Int @crdt(type: pcounter) }";
     cluster.client(0).schema_add(schema).expect("schema node0");
     cluster.client(1).schema_add(schema).expect("schema node1");
@@ -273,7 +273,7 @@ async fn run_counter_parity(mut cluster: TestCluster, label: &str) {
 /// classic semantic divergence point (does delete win, or does the concurrent
 /// update revive the doc?). The property that matters is that BOTH agree AND that
 /// Go and Rust agree with EACH OTHER.
-async fn run_delete_update_parity(mut cluster: TestCluster, label: &str) {
+async fn run_delete_update_parity(cluster: TestCluster, label: &str) {
     let schema = "type User { name: String  age: Int }";
     cluster.client(0).schema_add(schema).expect("schema node0");
     cluster.client(1).schema_add(schema).expect("schema node1");

--- a/proofs/tests/behavioral/partition.rs
+++ b/proofs/tests/behavioral/partition.rs
@@ -350,6 +350,63 @@ async fn poll_hits(node: &DefraClient, want: i64, timeout: Duration) -> bool {
     }
 }
 
+fn wire_bidirectional(cluster: &TestCluster, collection: &str) {
+    let (a0, a1) = (node_addr(cluster, 0), node_addr(cluster, 1));
+    cluster
+        .client(0)
+        .p2p_connect(&[a1.as_str()])
+        .expect("connect 0->1");
+    cluster
+        .client(1)
+        .p2p_connect(&[a0.as_str()])
+        .expect("connect 1->0");
+    cluster
+        .client(0)
+        .p2p_collection_add(&[collection])
+        .expect("subscribe node0");
+    cluster
+        .client(1)
+        .p2p_collection_add(&[collection])
+        .expect("subscribe node1");
+    cluster
+        .client(0)
+        .p2p_replicator_set(&[collection], &a1)
+        .expect("replicator 0->1");
+    cluster
+        .client(1)
+        .p2p_replicator_set(&[collection], &a0)
+        .expect("replicator 1->0");
+}
+
+fn mixed_state(node: &DefraClient) -> (String, i64) {
+    let r = node
+        .query("query { Mixed { name views } }")
+        .expect("query Mixed");
+    r["Mixed"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .map(|doc| {
+            (
+                doc["name"].as_str().unwrap_or("<none>").to_string(),
+                doc["views"].as_i64().unwrap_or(-1),
+            )
+        })
+        .unwrap_or_else(|| ("<missing>".to_string(), -1))
+}
+
+async fn poll_mixed_state(node: &DefraClient, name: &str, views: i64, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if mixed_state(node) == (name.to_string(), views) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
 /// Concurrent PCounter increments must converge to the SUM. Two nodes share a
 /// `hits=0` document over a live bidirectional connection; each increments by 45,
 /// concurrently; both must converge to 90.
@@ -366,7 +423,7 @@ async fn poll_hits(node: &DefraClient, want: i64, timeout: Duration) -> bool {
 /// rust<->rust, go<->go, and rust<->go all converge to 90.
 #[tokio::test]
 async fn convergence_concurrent_counter_increments_sum() {
-    let mut cluster = TestCluster::builder()
+    let cluster = TestCluster::builder()
         .rust_nodes(2)
         .with_p2p()
         .with_store("redb")
@@ -443,4 +500,133 @@ async fn convergence_concurrent_counter_increments_sum() {
             tally_hits(&cluster.client(1))
         );
     }
+}
+
+/// Concurrent PNCounter updates must accumulate signed deltas, not just positive
+/// increments. node0 contributes `+50` while node1 contributes `-30`; after
+/// merging, both materialized documents must show `20`.
+///
+/// This extends the PCounter two-store regression guard above to the
+/// decrement-capable counter variant. A merge path that clamps, drops, or
+/// re-materializes from a stale accumulation store would converge to the wrong
+/// value even if both replicas agree.
+#[tokio::test]
+async fn convergence_concurrent_pncounter_signed_deltas_sum() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_store("redb")
+        .with_rust_binary(support::release_binary())
+        .build()
+        .await
+        .expect("build 2-node p2p cluster");
+
+    let schema = "type Tally { name: String  hits: Int @crdt(type: pncounter) }";
+    cluster.client(0).schema_add(schema).expect("schema node0");
+    cluster.client(1).schema_add(schema).expect("schema node1");
+    wire_bidirectional(&cluster, "Tally");
+
+    let created = cluster
+        .client(0)
+        .query(r#"mutation { add_Tally(input: {name: "t", hits: 0}) { _docID } }"#)
+        .expect("create");
+    let id = created["add_Tally"][0]["_docID"]
+        .as_str()
+        .expect("_docID")
+        .to_string();
+    assert!(
+        poll_hits(&cluster.client(1), 0, Duration::from_secs(20)).await,
+        "seed document must replicate to node1 before the signed counter updates"
+    );
+
+    cluster
+        .client(0)
+        .query(&format!(
+            r#"mutation {{ update_Tally(docID: "{id}", input: {{hits: 50}}) {{ _docID }} }}"#
+        ))
+        .expect("node0 increment");
+    cluster
+        .client(1)
+        .query(&format!(
+            r#"mutation {{ update_Tally(docID: "{id}", input: {{hits: -30}}) {{ _docID }} }}"#
+        ))
+        .expect("node1 decrement");
+
+    if !poll_hits(&cluster.client(0), 20, Duration::from_secs(30)).await {
+        panic!(
+            "node0 did not converge to 20; hits = {}",
+            tally_hits(&cluster.client(0))
+        );
+    }
+    if !poll_hits(&cluster.client(1), 20, Duration::from_secs(30)).await {
+        panic!(
+            "node1 did not converge to 20; hits = {}",
+            tally_hits(&cluster.client(1))
+        );
+    }
+}
+
+/// Mixed-field convergence: the same document carries an LWW field and a
+/// counter field, and different nodes update different CRDT families
+/// concurrently. Persisting one linked field must not re-materialize the
+/// document from stale state and clobber the other field's local write.
+#[tokio::test]
+async fn convergence_concurrent_mixed_lww_and_counter_fields_merge() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_store("redb")
+        .with_rust_binary(support::release_binary())
+        .build()
+        .await
+        .expect("build 2-node p2p cluster");
+
+    let schema = "type Mixed { name: String  views: Int @crdt(type: pcounter) }";
+    cluster.client(0).schema_add(schema).expect("schema node0");
+    cluster.client(1).schema_add(schema).expect("schema node1");
+    wire_bidirectional(&cluster, "Mixed");
+
+    let created = cluster
+        .client(0)
+        .query(r#"mutation { add_Mixed(input: {name: "seed", views: 0}) { _docID } }"#)
+        .expect("create");
+    let id = created["add_Mixed"][0]["_docID"]
+        .as_str()
+        .expect("_docID")
+        .to_string();
+    assert!(
+        poll_mixed_state(&cluster.client(1), "seed", 0, Duration::from_secs(20)).await,
+        "seed document must replicate to node1 before mixed-field updates"
+    );
+
+    cluster
+        .client(0)
+        .query(&format!(
+            r#"mutation {{ update_Mixed(docID: "{id}", input: {{name: "alice"}}) {{ _docID }} }}"#
+        ))
+        .expect("node0 name update");
+    cluster
+        .client(1)
+        .query(&format!(
+            r#"mutation {{ update_Mixed(docID: "{id}", input: {{views: 10}}) {{ _docID }} }}"#
+        ))
+        .expect("node1 views increment");
+
+    if !poll_mixed_state(&cluster.client(0), "alice", 10, Duration::from_secs(30)).await {
+        panic!(
+            "node0 did not converge to name=alice views=10; state = {:?}",
+            mixed_state(&cluster.client(0))
+        );
+    }
+    if !poll_mixed_state(&cluster.client(1), "alice", 10, Duration::from_secs(30)).await {
+        panic!(
+            "node1 did not converge to name=alice views=10; state = {:?}",
+            mixed_state(&cluster.client(1))
+        );
+    }
+    assert_eq!(
+        mixed_state(&cluster.client(0)),
+        mixed_state(&cluster.client(1)),
+        "replicas must materialize identical mixed-field state"
+    );
 }

--- a/proofs/tests/support.rs
+++ b/proofs/tests/support.rs
@@ -4,6 +4,8 @@
 use defra_harness::BinarySource;
 use std::path::PathBuf;
 
+const CONFORMANCE_RUST_LOG: &str = "info";
+
 /// The artifact under test.
 ///
 /// Defaults to `target/debug/defra` — the binary that `cargo test --workspace`
@@ -17,10 +19,14 @@ use std::path::PathBuf;
 /// artifact (e.g. a downloaded tagged release, or a local release build from
 /// `proofs/verify-all.sh`).
 pub fn release_binary() -> BinarySource {
+    let root = workspace_root();
+    ensure_harness_uses_workspace(&root);
+    ensure_harness_logs_are_visible();
+
     if let Some(path) = std::env::var_os("DEFRA_CONFORMANCE_BINARY") {
         return BinarySource::Path(PathBuf::from(path));
     }
-    BinarySource::Path(workspace_root().join("target/debug/defra"))
+    BinarySource::Path(root.join("target/debug/defra"))
 }
 
 pub fn workspace_root() -> PathBuf {
@@ -28,4 +34,49 @@ pub fn workspace_root() -> PathBuf {
         .parent()
         .expect("proofs/ has a parent (the workspace root)")
         .to_path_buf()
+}
+
+fn ensure_harness_logs_are_visible() {
+    let should_set = std::env::var("RUST_LOG")
+        .map(|value| !global_filter_allows_info(&value))
+        .unwrap_or(true);
+
+    if should_set {
+        std::env::set_var("RUST_LOG", CONFORMANCE_RUST_LOG);
+    }
+}
+
+fn ensure_harness_uses_workspace(root: &std::path::Path) {
+    std::env::set_var("DEFRA_WORKSPACE_ROOT", root);
+}
+
+fn global_filter_allows_info(value: &str) -> bool {
+    value.split(',').any(|directive| {
+        let directive = directive.trim();
+        if directive.is_empty() || directive.contains('=') {
+            return false;
+        }
+
+        matches!(
+            directive.to_ascii_lowercase().as_str(),
+            "info" | "debug" | "trace"
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::global_filter_allows_info;
+
+    #[test]
+    fn global_rust_log_filter_must_include_info_for_harness_readiness() {
+        assert!(global_filter_allows_info("info"));
+        assert!(global_filter_allows_info("warn,info"));
+        assert!(global_filter_allows_info("debug,cranelift=warn"));
+
+        assert!(!global_filter_allows_info(""));
+        assert!(!global_filter_allows_info("warn"));
+        assert!(!global_filter_allows_info("error"));
+        assert!(!global_filter_allows_info("defra_http::server=info"));
+    }
 }

--- a/proofs/tests/support.rs
+++ b/proofs/tests/support.rs
@@ -3,6 +3,7 @@
 
 use defra_harness::BinarySource;
 use std::path::PathBuf;
+use std::sync::Once;
 
 const CONFORMANCE_RUST_LOG: &str = "info";
 
@@ -20,8 +21,7 @@ const CONFORMANCE_RUST_LOG: &str = "info";
 /// `proofs/verify-all.sh`).
 pub fn release_binary() -> BinarySource {
     let root = workspace_root();
-    ensure_harness_uses_workspace(&root);
-    ensure_harness_logs_are_visible();
+    init_harness_env(&root);
 
     if let Some(path) = std::env::var_os("DEFRA_CONFORMANCE_BINARY") {
         return BinarySource::Path(PathBuf::from(path));
@@ -34,6 +34,17 @@ pub fn workspace_root() -> PathBuf {
         .parent()
         .expect("proofs/ has a parent (the workspace root)")
         .to_path_buf()
+}
+
+/// Mutate process env exactly once. `release_binary()` is called from every
+/// `#[tokio::test]`, which run in parallel; `set_var` from multiple threads is
+/// unsound, so the env setup is gated behind a `Once`.
+fn init_harness_env(root: &std::path::Path) {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        ensure_harness_uses_workspace(root);
+        ensure_harness_logs_are_visible();
+    });
 }
 
 fn ensure_harness_logs_are_visible() {


### PR DESCRIPTION
## What

Promotes two #1021 bug-hunt cases into asserting conformance coverage:

- PN-counter signed deltas: concurrent `+50` and `-30` updates must converge to `20`
- Mixed-field documents: concurrent LWW and counter updates on the same document must both survive materialization

Also hardens the conformance harness against inherited `RUST_LOG=warn`/`error`, which was hiding the INFO readiness log the node harness waits on, and keeps retained conformance run dirs under the current workspace via `DEFRA_WORKSPACE_ROOT`.

## Why

#1021 tracks the remaining two-store convergence audit after the LWW and PCounter fixes. The latest bug-hunt probes showed these cases converging, but they were still reporting-only and would not fail CI on regression.

This turns the highest-signal passing probes into real behavioral assertions so future CRDT/materialization regressions are caught automatically.

## Testing

- [x] `cargo test -p conformance --test tla_conformance global_rust_log_filter_must_include_info_for_harness_readiness`
- [x] `cargo clippy -p conformance --test tla_conformance -- -D warnings`
- [x] `DEFRA_E2E_KEEP=1 cargo test -p conformance --test tla_conformance convergence_concurrent_ -- --test-threads=1 --nocapture`