### PR TITLE
ci: run conformance in a dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,6 @@ jobs:
 
       - run: cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance
 
-      # The conformance crate (proofs/) drives real `defra` subprocesses. Run it
-      # SERIALLY (not in the parallel --workspace job above) so concurrent node
-      # startup doesn't contend on ports/CPU and flake ("failed to start
-      # rust-0"). It uses the default-feature `target/debug/defra` built above
-      # (proofs/tests/support.rs::release_binary); the Lean drift-check skips when
-      # `lake` is absent.
-      - run: cargo test -p conformance -- --test-threads=1
-
       # Cache binaries BEFORE any feature-on rebuild. `cargo test --workspace`
       # above left a default-feature `defra` at target/debug/defra; the otel
       # steps below recompile it with `--features otel`, so caching must happen
@@ -144,6 +136,48 @@ jobs:
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
+          pkill -f "target/debug/defra" || true
+
+  conformance:
+    name: Conformance
+    needs: build
+    runs-on: [self-hosted, macOS, ARM64, studio]
+    env:
+      DEFRA_CONFORMANCE_BINARY: ${{ github.workspace }}/target/release/defra
+      DEFRA_WORKSPACE_ROOT: ${{ github.workspace }}
+      # The conformance harness waits on INFO-level node readiness/P2P log lines.
+      # Pin the child-node filter so an inherited runner-level RUST_LOG=warn
+      # cannot make healthy nodes look unready.
+      RUST_LOG: info
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Configure private repo access
+        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binary under test
+        run: |
+          cargo build --release -p cli
+          "$DEFRA_CONFORMANCE_BINARY" version --format json
+
+      # The conformance crate (proofs/) drives real `defra` subprocesses. Run it
+      # serially so concurrent node startup doesn't contend on ports/CPU and
+      # flake ("failed to start rust-0"). The Lean drift-check still skips when
+      # `lake` is absent; a Lean-equipped job can make that mandatory later.
+      - name: Run conformance tests
+        run: cargo test -p conformance -- --test-threads=1
+
+      - name: Cleanup
+        if: always()
+        run: |
+          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git checkout -- .
+          git clean -fd
+          pkill -f "target/release/defra" || true
           pkill -f "target/debug/defra" || true
 
   integration:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,16 @@ jobs:
 
   conformance:
     name: Conformance
-    needs: build
+    # Serialized after `integration` (not just `build`) so it never co-runs
+    # with the integration matrix on the single studio host. Both jobs spawn
+    # real `defra` nodes and the studio harness port allocator has a TOCTOU
+    # bind race ("failed to start rust-0") when node-spawning jobs run
+    # concurrently — the same reason the integration matrix pins
+    # `max-parallel: 1`. The dependency edge is the strict-ordering fix; it
+    # does not affect correctness, only scheduling.
+    needs: [build, integration]
     runs-on: [self-hosted, macOS, ARM64, studio]
+    timeout-minutes: 45
     env:
       DEFRA_CONFORMANCE_BINARY: ${{ github.workspace }}/target/release/defra
       DEFRA_WORKSPACE_ROOT: ${{ github.workspace }}


### PR DESCRIPTION
## What

Splits the `proofs/` conformance harness out of the general `Build & Test` job into a dedicated CI job.

The new `Conformance` job:

- builds the release `defra` binary under test
- runs `cargo test -p conformance -- --test-threads=1`
- points the harness at `target/release/defra` via `DEFRA_CONFORMANCE_BINARY`
- pins `DEFRA_WORKSPACE_ROOT` and `RUST_LOG=info` for deterministic node startup/readiness logs
- keeps node-process cleanup local to the conformance job

## Why

#1022 calls out that conformance should run like integration tests: isolated from regular unit tests, serial where it spawns real nodes, and against an optimized binary.

This is the first CI-focused slice. It keeps Go-parity and Lean-equipped mandatory checks as future follow-ups, while making the existing Rust conformance coverage less coupled to the unit-test job.

## Testing

- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'`
- [x] `git diff --check`

Note: I did not run the local release conformance job end-to-end because this change is CI workflow wiring; the new job itself performs the release build and conformance run.