### PR TITLE
feat(p2p): make DocSync request limit configurable

### DIFF
--- a/crates/cli/src/commands/start/mod.rs
+++ b/crates/cli/src/commands/start/mod.rs
@@ -213,6 +213,10 @@ pub struct StartArgs {
     #[arg(long)]
     pub p2p_rate_limit_rate: Option<f64>,
 
+    /// Max document IDs accepted in one DocSync request. Default: 1000.
+    #[arg(long)]
+    pub p2p_max_doc_sync_request_doc_ids: Option<usize>,
+
     /// P2P transport backend: "libp2p" (default) or "iroh"
     #[arg(long)]
     pub p2p_transport: Option<String>,
@@ -435,6 +439,9 @@ impl StartArgs {
         }
         if let Some(rate) = self.p2p_rate_limit_rate {
             config.net.p2p_rate_limit_rate = rate;
+        }
+        if let Some(max) = self.p2p_max_doc_sync_request_doc_ids {
+            config.net.p2p_max_doc_sync_request_doc_ids = max;
         }
         if let Some(ref transport) = self.p2p_transport {
             config.net.transport = transport.parse()?;

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -1240,6 +1240,7 @@ impl Node {
         p2p::sync::SyncConfig {
             rate_limit_burst: config.net.p2p_rate_limit_burst,
             rate_limit_rate: config.net.p2p_rate_limit_rate,
+            max_doc_sync_request_doc_ids: config.net.p2p_max_doc_sync_request_doc_ids,
             ..Default::default()
         }
     }

--- a/crates/cli/src/config/sections.rs
+++ b/crates/cli/src/config/sections.rs
@@ -318,6 +318,9 @@ pub struct NetConfig {
     /// Per-peer rate limit refill rate (tokens per second). Default: 50.
     #[serde(default = "default_rate_limit_rate")]
     pub p2p_rate_limit_rate: f64,
+    /// Max document IDs accepted in one DocSync request. Default: 1000.
+    #[serde(default = "default_max_doc_sync_request_doc_ids")]
+    pub p2p_max_doc_sync_request_doc_ids: usize,
 }
 
 fn default_max_msg_size() -> u64 {
@@ -350,6 +353,9 @@ fn default_rate_limit_burst() -> u32 {
 fn default_rate_limit_rate() -> f64 {
     50.0
 }
+fn default_max_doc_sync_request_doc_ids() -> usize {
+    p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS
+}
 fn default_true() -> bool {
     true
 }
@@ -381,6 +387,7 @@ impl Default for NetConfig {
             iroh_bind_addr: None,
             p2p_rate_limit_burst: default_rate_limit_burst(),
             p2p_rate_limit_rate: default_rate_limit_rate(),
+            p2p_max_doc_sync_request_doc_ids: default_max_doc_sync_request_doc_ids(),
         }
     }
 }

--- a/crates/cli/tests/start_tests.rs
+++ b/crates/cli/tests/start_tests.rs
@@ -43,6 +43,7 @@ fn default_start_args() -> StartArgs {
         max_connections_per_peer: None,
         p2p_rate_limit_burst: None,
         p2p_rate_limit_rate: None,
+        p2p_max_doc_sync_request_doc_ids: None,
         max_merge_depth: None,
         query_timeout: None,
         transaction_idle_timeout: None,
@@ -150,6 +151,7 @@ fn test_apply_to_config_all_flags() {
         max_connections_per_peer: Some(8),
         p2p_rate_limit_burst: Some(32),
         p2p_rate_limit_rate: Some(4.5),
+        p2p_max_doc_sync_request_doc_ids: Some(64),
         max_merge_depth: Some(2048),
         query_timeout: Some(45),
         transaction_idle_timeout: Some(900),
@@ -182,6 +184,7 @@ fn test_apply_to_config_all_flags() {
     assert_eq!(config.net.max_connections_per_peer, 8);
     assert_eq!(config.net.p2p_rate_limit_burst, 32);
     assert_eq!(config.net.p2p_rate_limit_rate, 4.5);
+    assert_eq!(config.net.p2p_max_doc_sync_request_doc_ids, 64);
     assert_eq!(config.datastore.max_merge_depth, 2048);
     assert_eq!(config.api.max_body_size, 1024);
     assert_eq!(config.api.max_schema_size, 2048);

--- a/crates/defra-node/src/config.rs
+++ b/crates/defra-node/src/config.rs
@@ -107,6 +107,8 @@ pub struct P2PConfig {
     /// Maximum concurrent push tasks for sending blocks to replicators.
     /// Default: 8.
     pub max_concurrent_push_tasks: usize,
+    /// Maximum document IDs accepted in a single DocSync request. Default: 1000.
+    pub max_doc_sync_request_doc_ids: usize,
     /// Per-peer rate limit burst capacity (max tokens in bucket). Default: 500.
     pub rate_limit_burst: u32,
     /// Per-peer rate limit refill rate (tokens per second). Default: 50.

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1254,6 +1254,7 @@ impl NodeBuilder {
         let sync_config = p2p::sync::SyncConfig {
             max_concurrent_dag_fetches: config.max_concurrent_dag_fetches,
             max_concurrent_push_tasks: config.max_concurrent_push_tasks,
+            max_doc_sync_request_doc_ids: config.max_doc_sync_request_doc_ids,
             rate_limit_burst: config.rate_limit_burst,
             rate_limit_rate: config.rate_limit_rate,
             ..Default::default()

--- a/crates/defra-node/src/p2p_tests.rs
+++ b/crates/defra-node/src/p2p_tests.rs
@@ -40,6 +40,7 @@ fn test_p2p_config() -> P2PConfig {
         load_persisted_collections: false,
         max_concurrent_dag_fetches: p2p::sync::DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
         max_concurrent_push_tasks: p2p::sync::DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+        max_doc_sync_request_doc_ids: p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
         rate_limit_burst: p2p::sync::DEFAULT_RATE_LIMIT_BURST,
         rate_limit_rate: p2p::sync::DEFAULT_RATE_LIMIT_RATE,
     }
@@ -701,16 +702,27 @@ async fn fetch_turn_diagnostics(
     })
 }
 
-async fn create_turn(
-    node: &EmbeddedNode,
-    session_id: &str,
-    request_id: &str,
-    prompt: &str,
+struct TurnSpec<'a> {
+    session_id: &'a str,
+    request_id: &'a str,
+    prompt: &'a str,
     user_sequence: usize,
     assistant_sequence: usize,
     chunk_count: usize,
     tool_call_every: usize,
-) {
+}
+
+async fn create_turn(node: &EmbeddedNode, spec: TurnSpec<'_>) {
+    let TurnSpec {
+        session_id,
+        request_id,
+        prompt,
+        user_sequence,
+        assistant_sequence,
+        chunk_count,
+        tool_call_every,
+    } = spec;
+
     let now = synthetic_timestamp();
     let upsert_conversation = node
         .execute(&format!(
@@ -1374,13 +1386,15 @@ async fn live_replicator_same_session_followup_turn_converges() {
     let session_id = "sess-followup";
     create_turn(
         &node0,
-        session_id,
-        "req-1",
-        "Hey amy can you tell me about the p2p communcation between the agent and the desktop in this app and the docuemnt based request model?",
-        1,
-        2,
-        64,
-        3,
+        TurnSpec {
+            session_id,
+            request_id: "req-1",
+            prompt: "Hey amy can you tell me about the p2p communcation between the agent and the desktop in this app and the docuemnt based request model?",
+            user_sequence: 1,
+            assistant_sequence: 2,
+            chunk_count: 64,
+            tool_call_every: 3,
+        },
     )
     .await;
 
@@ -1407,13 +1421,15 @@ async fn live_replicator_same_session_followup_turn_converges() {
 
     create_turn(
         &node0,
-        session_id,
-        "req-2",
-        "Awesome breakdown, can you please tell me what you like about the architecture and point to files?",
-        3,
-        4,
-        128,
-        2,
+        TurnSpec {
+            session_id,
+            request_id: "req-2",
+            prompt: "Awesome breakdown, can you please tell me what you like about the architecture and point to files?",
+            user_sequence: 3,
+            assistant_sequence: 4,
+            chunk_count: 128,
+            tool_call_every: 2,
+        },
     )
     .await;
 

--- a/crates/embedded/src/lib.rs
+++ b/crates/embedded/src/lib.rs
@@ -110,6 +110,7 @@ pub struct EmbeddedNodeConfig {
     pub query_limits: query::QueryLimits,
     pub max_concurrent_dag_fetches: Option<usize>,
     pub max_concurrent_push_tasks: Option<usize>,
+    pub max_doc_sync_request_doc_ids: Option<usize>,
     pub rate_limit_burst: Option<u32>,
     pub rate_limit_rate: Option<f64>,
 }

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -482,6 +482,9 @@ where
         max_concurrent_push_tasks: config
             .max_concurrent_push_tasks
             .unwrap_or(p2p::sync::DEFAULT_MAX_CONCURRENT_PUSH_TASKS),
+        max_doc_sync_request_doc_ids: config
+            .max_doc_sync_request_doc_ids
+            .unwrap_or(p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS),
         rate_limit_burst: config
             .rate_limit_burst
             .unwrap_or(p2p::sync::DEFAULT_RATE_LIMIT_BURST),

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -284,6 +284,11 @@ pub extern "C" fn defra_mobile_open_node(config_json: *const c_char) -> NewNodeR
                 .as_ref()
                 .and_then(|p2p| p2p.max_concurrent_push_tasks)
                 .unwrap_or(0),
+            max_doc_sync_request_doc_ids: config
+                .p2p
+                .as_ref()
+                .and_then(|p2p| p2p.max_doc_sync_request_doc_ids)
+                .unwrap_or(0),
             rate_limit_burst: config
                 .p2p
                 .as_ref()

--- a/crates/ffi/src/mobile_config.rs
+++ b/crates/ffi/src/mobile_config.rs
@@ -42,6 +42,7 @@ pub(crate) struct MobileP2pConfig {
     pub iroh: Option<MobileIrohConfig>,
     pub max_concurrent_dag_fetches: Option<usize>,
     pub max_concurrent_push_tasks: Option<usize>,
+    pub max_doc_sync_request_doc_ids: Option<usize>,
     pub rate_limit_burst: Option<u32>,
     pub rate_limit_rate: Option<f64>,
 }

--- a/crates/ffi/src/node.rs
+++ b/crates/ffi/src/node.rs
@@ -244,6 +244,11 @@ fn resolve_embedded_config(
         } else {
             None
         },
+        max_doc_sync_request_doc_ids: if options.max_doc_sync_request_doc_ids > 0 {
+            Some(options.max_doc_sync_request_doc_ids)
+        } else {
+            None
+        },
         rate_limit_burst: if options.rate_limit_burst > 0 {
             Some(options.rate_limit_burst)
         } else {

--- a/crates/ffi/src/types.rs
+++ b/crates/ffi/src/types.rs
@@ -218,6 +218,8 @@ pub struct NodeInitOptions {
     pub max_concurrent_dag_fetches: usize,
     /// Maximum concurrent push tasks. 0 means use default.
     pub max_concurrent_push_tasks: usize,
+    /// Maximum DocSync request document IDs. 0 means use default (1000).
+    pub max_doc_sync_request_doc_ids: usize,
     /// Per-peer rate limit burst capacity. 0 means use default (500).
     pub rate_limit_burst: u32,
     /// Per-peer rate limit refill rate (tokens/sec). 0 means use default (50).
@@ -251,6 +253,7 @@ impl Default for NodeInitOptions {
             iroh_key_path: ptr::null(),
             max_concurrent_dag_fetches: 0,
             max_concurrent_push_tasks: 0,
+            max_doc_sync_request_doc_ids: 0,
             rate_limit_burst: 0,
             rate_limit_rate: 0.0,
         }

--- a/crates/p2p/src/kms/pubsub_transport.rs
+++ b/crates/p2p/src/kms/pubsub_transport.rs
@@ -381,6 +381,8 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    type PublishedRawMessages = Arc<Mutex<Vec<(String, Vec<u8>)>>>;
+
     fn a_libp2p_peer() -> libp2p::PeerId {
         libp2p::PeerId::from_public_key(&libp2p::identity::Keypair::generate_ed25519().public())
     }
@@ -394,7 +396,7 @@ mod tests {
         topic_peers_calls: Arc<AtomicUsize>,
         subscriber_visible_after: usize,
         publish_attempts: Arc<AtomicUsize>,
-        published: Arc<Mutex<Vec<(String, Vec<u8>)>>>,
+        published: PublishedRawMessages,
     }
 
     impl RacyTransport {

--- a/crates/p2p/src/message/docsync.rs
+++ b/crates/p2p/src/message/docsync.rs
@@ -5,10 +5,10 @@ use serde::{Deserialize, Serialize};
 use super::cbor::{nullable_bytes, optional_bytes, vec_of_bytes};
 use super::traits::Message;
 
-/// Maximum number of document IDs allowed in a single DocSyncRequest.
+/// Default maximum number of document IDs allowed in a single DocSyncRequest.
 ///
-/// Enforces an upper bound to prevent memory exhaustion from malicious peers
-/// sending oversized arrays.
+/// Coordinators may lower or raise this runtime limit through
+/// `SyncConfig::max_doc_sync_request_doc_ids`.
 pub const MAX_DOC_IDS: usize = 1000;
 
 /// DocSync request message for pulling specific documents from peers.

--- a/crates/p2p/src/message/pubsub.rs
+++ b/crates/p2p/src/message/pubsub.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 
 /// Upper bound on document IDs per DocSync request / items per reply.
 /// Prevents memory exhaustion from malicious peers; matches the
-/// `MAX_DOC_IDS` constant used on the two-stream path.
+/// default `MAX_DOC_IDS` constant used on the two-stream path.
 pub const MAX_DOC_IDS: usize = 1000;
 
 /// Upper bound on the number of head CIDs per document in a DocSync reply.

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -37,6 +37,7 @@ use super::authorizer::RuntimeAuthorizer;
 use super::{
     DagFetchLimiter, SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState,
     DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+    DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
 };
 
 type TestBlockstore = DefraBlockstore<MemoryStore>;
@@ -145,6 +146,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
             )),
             rate_limiter,
             push_send_timeout: DEFAULT_PUSH_SEND_TIMEOUT,
+            max_doc_sync_request_doc_ids: DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
             shutdown: SyncShutdownHandle::new(),
         },
         manager,
@@ -526,9 +528,13 @@ impl P2PTransport for NoopTransport {
 }
 
 fn doc_sync_event(peer_id: PeerId) -> TransportEvent<()> {
+    doc_sync_event_with_ids(peer_id, vec!["doc1".to_string()])
+}
+
+fn doc_sync_event_with_ids(peer_id: PeerId, doc_ids: Vec<String>) -> TransportEvent<()> {
     TransportEvent::DocSyncRequest {
         peer_id,
-        request: DocSyncRequest::new(vec!["doc1".to_string()]),
+        request: DocSyncRequest::new(doc_ids),
         token: None,
     }
 }
@@ -903,6 +909,33 @@ async fn doc_sync_open_mode_allows_any_peer() {
         "Open mode should not deny access, got {:?}",
         result
     );
+}
+
+#[tokio::test]
+async fn doc_sync_rejects_requests_above_configured_doc_id_limit() {
+    let transport = NoopTransport::new();
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let config = SyncConfig {
+        max_doc_sync_request_doc_ids: 2,
+        ..Default::default()
+    };
+    let (coordinator, _events) = SyncCoordinator::new(transport, blockstore, config)
+        .await
+        .unwrap();
+
+    let result = coordinator
+        .handle_transport_event(doc_sync_event_with_ids(
+            random_peer_id(),
+            vec!["doc1".into(), "doc2".into(), "doc3".into()],
+        ))
+        .await;
+
+    let Err(Error::InvalidConfig(message)) = result else {
+        panic!("expected InvalidConfig, got {:?}", result);
+    };
+    assert!(message.contains("3 doc IDs"));
+    assert!(message.contains("limit of 2"));
 }
 
 // --- BranchableSync access check tests ---

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -938,6 +938,71 @@ async fn doc_sync_rejects_requests_above_configured_doc_id_limit() {
     assert!(message.contains("limit of 2"));
 }
 
+#[tokio::test]
+async fn doc_sync_accepts_requests_at_exactly_configured_doc_id_limit() {
+    let transport = NoopTransport::new();
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let config = SyncConfig {
+        max_doc_sync_request_doc_ids: 2,
+        ..Default::default()
+    };
+    let (coordinator, _events) = SyncCoordinator::new(transport, blockstore, config)
+        .await
+        .unwrap();
+
+    let result = coordinator
+        .handle_transport_event(doc_sync_event_with_ids(
+            random_peer_id(),
+            vec!["doc1".into(), "doc2".into()],
+        ))
+        .await;
+
+    assert!(
+        !matches!(&result, Err(Error::InvalidConfig(_))),
+        "a request with exactly the configured limit of doc IDs must be accepted, got {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn doc_sync_zero_config_resolves_to_default_limit() {
+    let transport = NoopTransport::new();
+    let store = Arc::new(MemoryStore::new());
+    let blockstore = Arc::new(DefraBlockstore::new(store, true));
+    let config = SyncConfig {
+        max_doc_sync_request_doc_ids: 0,
+        ..Default::default()
+    };
+    let (coordinator, _events) = SyncCoordinator::new(transport, blockstore, config)
+        .await
+        .unwrap();
+
+    let at_default = (0..DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS)
+        .map(|i| format!("doc{i}"))
+        .collect::<Vec<_>>();
+    let result = coordinator
+        .handle_transport_event(doc_sync_event_with_ids(random_peer_id(), at_default))
+        .await;
+    assert!(
+        !matches!(&result, Err(Error::InvalidConfig(_))),
+        "config 0 should resolve to the default limit, accepting a default-sized request, got {:?}",
+        result
+    );
+
+    let over_default = (0..=DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS)
+        .map(|i| format!("doc{i}"))
+        .collect::<Vec<_>>();
+    let result = coordinator
+        .handle_transport_event(doc_sync_event_with_ids(random_peer_id(), over_default))
+        .await;
+    assert!(
+        matches!(&result, Err(Error::InvalidConfig(_))),
+        "config 0 should resolve to the default limit, rejecting an over-default request, got {:?}",
+        result
+    );
+}
+
 // --- BranchableSync access check tests ---
 
 #[tokio::test]

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -17,7 +17,10 @@ use crate::error::Result;
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::{NoOpCollectionStorage, P2PCollectionStorage};
 use crate::sync::head_provider::{DocumentHeadProvider, NoOpHeadProvider};
-use crate::sync::manager::{SyncConfig, SyncEvent, SyncManager, DEFAULT_PUSH_SEND_TIMEOUT};
+use crate::sync::manager::{
+    SyncConfig, SyncEvent, SyncManager, DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
+    DEFAULT_PUSH_SEND_TIMEOUT,
+};
 use crate::sync::peer_state::PeerStateTracker;
 use crate::sync::rate_limiter::PeerRateLimiter;
 use crate::transport::P2PTransport;
@@ -106,7 +109,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let rate_limit_burst = config.rate_limit_burst;
         let rate_limit_rate = config.rate_limit_rate;
         let rate_limit_backoff = config.rate_limit_backoff.clone();
-        let max_doc_sync_request_doc_ids = config.max_doc_sync_request_doc_ids.max(1);
+        let max_doc_sync_request_doc_ids =
+            resolve_max_doc_sync_request_doc_ids(config.max_doc_sync_request_doc_ids);
         let push_send_timeout = if config.push_send_timeout.is_zero() {
             DEFAULT_PUSH_SEND_TIMEOUT
         } else {
@@ -173,4 +177,21 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     pub fn set_failure_channel(&mut self, tx: tokio::sync::mpsc::Sender<super::PushFailure>) {
         self.runtime.failure_tx = Some(tx);
     }
+}
+
+/// Resolve the effective DocSync request doc-ID limit from a configured value.
+///
+/// A configured `0` means "use the default" across every entry point
+/// (CLI/config, FFI, embedded, mobile), matching the documented default
+/// behavior. Any other value is used as-is.
+fn resolve_max_doc_sync_request_doc_ids(configured: usize) -> usize {
+    if configured == 0 {
+        tracing::warn!(
+            configured = 0,
+            effective = DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
+            "max_doc_sync_request_doc_ids of 0 is invalid, using default"
+        );
+        return DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS;
+    }
+    configured
 }

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -106,6 +106,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         let rate_limit_burst = config.rate_limit_burst;
         let rate_limit_rate = config.rate_limit_rate;
         let rate_limit_backoff = config.rate_limit_backoff.clone();
+        let max_doc_sync_request_doc_ids = config.max_doc_sync_request_doc_ids.max(1);
         let push_send_timeout = if config.push_send_timeout.is_zero() {
             DEFAULT_PUSH_SEND_TIMEOUT
         } else {
@@ -142,6 +143,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                         rate_limit_backoff,
                     )),
                     push_send_timeout,
+                    max_doc_sync_request_doc_ids,
                     shutdown: super::SyncShutdownHandle::new(),
                 },
                 manager,

--- a/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/doc_sync.rs
@@ -8,7 +8,7 @@ use super::super::authorizer::AccessAuthorizer;
 use super::super::dag_context::{block_context_from_data, DagFetchContext};
 use super::super::SyncCoordinator;
 use crate::error::{Error, Result};
-use crate::message::{DocSyncItem, DocSyncReply, MAX_DOC_IDS};
+use crate::message::{DocSyncItem, DocSyncReply};
 use crate::signing::sign_with_transport;
 use crate::transport::{P2PTransport, PeerId};
 
@@ -128,17 +128,18 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     ) -> Result<()> {
         self.check_peer_is_replicator(&peer_id).await?;
 
-        if request.doc_ids.len() > MAX_DOC_IDS {
+        let max_doc_ids = self.runtime.max_doc_sync_request_doc_ids;
+        if request.doc_ids.len() > max_doc_ids {
             tracing::warn!(
                 peer_id = %peer_id,
                 doc_ids_count = request.doc_ids.len(),
-                max = MAX_DOC_IDS,
-                "DocSyncRequest exceeds MAX_DOC_IDS limit, rejecting"
+                max = max_doc_ids,
+                "DocSyncRequest exceeds configured doc ID limit, rejecting"
             );
             return Err(Error::InvalidConfig(format!(
                 "DocSyncRequest contains {} doc IDs, exceeding the limit of {}",
                 request.doc_ids.len(),
-                MAX_DOC_IDS,
+                max_doc_ids,
             )));
         }
 

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -83,6 +83,7 @@ use super::rate_limiter::PeerRateLimiter;
 #[cfg(test)]
 pub(crate) use super::manager::{
     DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+    DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
 };
 
 /// A push failure notification sent when a PushLog to a replicator peer fails.
@@ -258,6 +259,9 @@ pub(super) struct SyncRuntime<T: P2PTransport> {
 
     /// Timeout for one outbound PushLog send to a replicator peer.
     pub(super) push_send_timeout: Duration,
+
+    /// Maximum document IDs accepted in a single DocSync request.
+    pub(super) max_doc_sync_request_doc_ids: usize,
 
     /// Shutdown state for coordinator-owned background tasks.
     pub(super) shutdown: SyncShutdownHandle,

--- a/crates/p2p/src/sync/manager/config.rs
+++ b/crates/p2p/src/sync/manager/config.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use crate::message::MAX_DOC_IDS;
+
 /// Default maximum number of concurrent DAG fetch tasks.
 ///
 /// Lowered from 16 to 4 for mobile client compatibility — 16 concurrent
@@ -10,6 +12,9 @@ pub const DEFAULT_MAX_CONCURRENT_DAG_FETCHES: usize = 4;
 
 /// Default maximum number of concurrent push tasks.
 pub const DEFAULT_MAX_CONCURRENT_PUSH_TASKS: usize = 8;
+
+/// Default maximum document IDs accepted in one DocSync request.
+pub const DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS: usize = MAX_DOC_IDS;
 
 /// Default per-peer rate limit burst capacity.
 pub const DEFAULT_RATE_LIMIT_BURST: u32 = 500;
@@ -54,6 +59,12 @@ pub struct SyncConfig {
     /// prevent resource exhaustion when many documents are created in a burst.
     pub max_concurrent_push_tasks: usize,
 
+    /// Maximum document IDs accepted in a single DocSync request.
+    ///
+    /// Keeps pull-based document sync bounded while allowing deployments to tune
+    /// static document-ID batch sizes for filtered-replication workflows.
+    pub max_doc_sync_request_doc_ids: usize,
+
     /// Per-peer rate limit burst capacity (max tokens in bucket).
     pub rate_limit_burst: u32,
 
@@ -73,6 +84,7 @@ impl Default for SyncConfig {
             event_buffer_size: 256,
             max_concurrent_dag_fetches: DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
             max_concurrent_push_tasks: DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+            max_doc_sync_request_doc_ids: DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
             rate_limit_burst: DEFAULT_RATE_LIMIT_BURST,
             rate_limit_rate: DEFAULT_RATE_LIMIT_RATE,
             rate_limit_backoff: default_rate_limit_backoff(),

--- a/crates/p2p/src/sync/manager/mod.rs
+++ b/crates/p2p/src/sync/manager/mod.rs
@@ -21,8 +21,9 @@ mod process;
 
 pub use config::{
     default_rate_limit_backoff, SyncConfig, DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
-    DEFAULT_MAX_CONCURRENT_PUSH_TASKS, DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS,
-    DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
+    DEFAULT_MAX_CONCURRENT_PUSH_TASKS, DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
+    DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS, DEFAULT_RATE_LIMIT_BURST,
+    DEFAULT_RATE_LIMIT_RATE,
 };
 #[cfg(any(feature = "libp2p-transport", feature = "iroh-transport"))]
 pub(crate) use diagnostics::record_gossip_decode_failure_sample;

--- a/crates/p2p/src/sync/mod.rs
+++ b/crates/p2p/src/sync/mod.rs
@@ -37,8 +37,8 @@ pub use manager::{
     default_rate_limit_backoff, GossipDecodeFailureSample, GossipTransport, SyncConfig,
     SyncDiagnostics, SyncDiagnosticsSnapshot, SyncEvent, SyncManager,
     DEFAULT_MAX_CONCURRENT_DAG_FETCHES, DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
-    DEFAULT_PUSH_SEND_TIMEOUT, DEFAULT_RATE_LIMIT_BACKOFF_SECS, DEFAULT_RATE_LIMIT_BURST,
-    DEFAULT_RATE_LIMIT_RATE,
+    DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS, DEFAULT_PUSH_SEND_TIMEOUT,
+    DEFAULT_RATE_LIMIT_BACKOFF_SECS, DEFAULT_RATE_LIMIT_BURST, DEFAULT_RATE_LIMIT_RATE,
 };
 pub use merge::{BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata};
 pub use peer_state::{PeerStateTracker, PeerStats};


### PR DESCRIPTION
## Summary

Refs #1013.

This PR implements the safe B5 slice from filtered-replication prep work by replacing the hard-coded signed DocSync request document-ID limit with a runtime `SyncConfig` knob.

The default remains `1000`, so existing behavior is unchanged unless a deployment explicitly tunes the limit. This gives static document-ID-set / filtered-replication workflows a configurable batch size without changing the wire format or adding predicate semantics yet.

## Details

- Adds `SyncConfig::max_doc_sync_request_doc_ids`.
- Defaults the new knob to the existing `MAX_DOC_IDS` value.
- Stores the sanitized limit in `SyncCoordinator` runtime state.
- Uses the configured limit when rejecting oversized two-stream `DocSyncRequest`s.
- Exposes the knob through CLI config/start args, embedded config, FFI/mobile config, and `defra-node` P2P config.
- Keeps the pubsub DocSync CBOR decode cap unchanged.
- Adds a focused P2P regression test for configured-limit rejection.
- Cleans two test-helper clippy issues encountered while validating the touched feature paths.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p p2p doc_sync_rejects_requests_above_configured_doc_id_limit`
- `cargo test -p cli test_apply_to_config_all_flags`
- `cargo clippy -p p2p -p embedded -p cli -p ffi -p defra-node --all-targets -- -D warnings`
- `cargo clippy -p defra-node --features p2p --all-targets -- -D warnings`

## Notes

This does not implement predicate-filtered replication or immutable filter-key enforcement. It only parameterizes the DocSync request size limit called out as B5 in #1013, preserving Go/Rust wire compatibility while making the static doc-ID-set path tunable.