### PR TITLE
Implement filtered replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,6 +3738,7 @@ dependencies = [
  "lens",
  "libp2p",
  "p2p",
+ "schema",
  "serde",
  "serde_bytes",
  "serde_ipld_dagcbor",

--- a/README.md
+++ b/README.md
@@ -144,6 +144,21 @@ ffi-test status                        # Show pass rates
 
 See `tools/ffi-test/README.md` for full usage.
 
+## P2P Replication
+
+### Filtered replication
+
+A replicator can carry an optional per-collection predicate so a source node only **pushes** documents whose field matches:
+
+```bash
+defradb client p2p replicator add -c MyCollection \
+  --filter-field agent_did --filter-value did:key:alice <peer-multiaddr>
+```
+
+The filter field must be a scalar, `@immutable` LWW field on the collection.
+
+**Filtered replication is a push-path selectivity optimization, not an access-control boundary.** A peer that also subscribes to the collection (`p2p collection add`) joins the collection's gossip topic and receives every document, bypassing the filter. Use ACP and encryption for confidentiality. The `--filter-value` is matched as a JSON string, so only string-valued fields can be filtered today.
+
 ## Documentation
 
 - [DefraDB (Go)](https://github.com/sourcenetwork/defradb) — concepts, architecture, specifications

--- a/crates/cli/src/commands/client/http_client/p2p.rs
+++ b/crates/cli/src/commands/client/http_client/p2p.rs
@@ -86,6 +86,15 @@ pub struct P2pReplicatorInfo {
         default
     )]
     pub last_status_change: Option<String>,
+
+    /// Optional per-collection filtered-replication predicates (Rust extension).
+    #[serde(
+        rename = "Filters",
+        alias = "filters",
+        default,
+        skip_serializing_if = "ReplicationFilters::is_empty"
+    )]
+    pub filters: ReplicationFilters,
 }
 
 /// P2P replicator request (Go-compatible format).
@@ -333,5 +342,19 @@ mod tests {
             info.last_status_change.as_deref(),
             Some("2026-04-26T10:00:00Z")
         );
+    }
+
+    #[test]
+    fn replicator_info_deserializes_filters() {
+        let json = r#"{"ID":"12D3KooWtest","CollectionIDs":["users"],"Addresses":[],"Status":0,"LastStatusChange":"0001-01-01T00:00:00Z","Filters":{"users":{"Field":"agent_did","Value":"did:key:alice"}}}"#;
+        let info: P2pReplicatorInfo = serde_json::from_str(json).unwrap();
+
+        let filter = info.filters.get("users").expect("users filter present");
+        assert_eq!(filter.field, "agent_did");
+        assert_eq!(filter.value, serde_json::json!("did:key:alice"));
+
+        let json_no_filters = r#"{"ID":"12D3KooWtest","CollectionIDs":["users"],"Addresses":[],"Status":0,"LastStatusChange":"0001-01-01T00:00:00Z"}"#;
+        let info_no_filters: P2pReplicatorInfo = serde_json::from_str(json_no_filters).unwrap();
+        assert!(info_no_filters.filters.is_empty());
     }
 }

--- a/crates/cli/src/commands/client/http_client/p2p.rs
+++ b/crates/cli/src/commands/client/http_client/p2p.rs
@@ -1,6 +1,8 @@
 //! P2P HTTP client methods
 
-use defra_http::router::{ExplicitReplayCapabilityInput, RemoteManageOp, RemoteManageQueryOp};
+use defra_http::router::{
+    ExplicitReplayCapabilityInput, RemoteManageOp, RemoteManageQueryOp, ReplicationFilters,
+};
 use serde::{Deserialize, Serialize};
 
 use super::HttpClient;
@@ -98,6 +100,11 @@ pub struct P2pReplicatorRequest {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
+    #[serde(
+        rename = "Filters",
+        skip_serializing_if = "ReplicationFilters::is_empty"
+    )]
+    pub filters: ReplicationFilters,
 }
 
 /// P2P collection request
@@ -140,6 +147,7 @@ impl HttpClient {
         &self,
         collections: &[String],
         address: Option<&str>,
+        filters: ReplicationFilters,
         explicit_replay_capabilities: &[ExplicitReplayCapabilityInput],
     ) -> Result<()> {
         let url = format!("{}/api/v0/p2p/replicator", self.base_url);
@@ -148,6 +156,7 @@ impl HttpClient {
             collections: collections.to_vec(),
             addresses,
             explicit_replay_capabilities: explicit_replay_capabilities.to_vec(),
+            filters,
         })?;
         self.request_void("POST", &url, Some(&body)).await
     }

--- a/crates/cli/src/commands/client/p2p/replicator.rs
+++ b/crates/cli/src/commands/client/p2p/replicator.rs
@@ -1,7 +1,7 @@
 //! P2P replicator command implementations
 
 use clap::{Args, Subcommand};
-use defra_http::router::ExplicitReplayCapabilityInput;
+use defra_http::router::{ExplicitReplayCapabilityInput, ReplicationFilter, ReplicationFilters};
 
 use crate::commands::client::http_client::HttpClient;
 use crate::commands::client::{raw_identity_from_key_bytes, validate_identifier, ClientContext};
@@ -40,6 +40,14 @@ pub struct P2pReplicatorAddArgs {
     /// Peer address(es) to replicate with
     #[arg(value_name = "addresses")]
     pub addresses: Vec<String>,
+
+    /// Field used for filtered replication, applied to every selected collection.
+    #[arg(long = "filter-field")]
+    pub filter_field: Option<String>,
+
+    /// Scalar value matched by --filter-field.
+    #[arg(long = "filter-value", requires = "filter_field")]
+    pub filter_value: Option<String>,
 }
 
 /// Arguments for replicator delete command
@@ -90,17 +98,58 @@ impl P2pReplicatorAddArgs {
             .with_verbose(ctx.verbose);
 
         let address = self.addresses.first().map(|s| s.as_str());
+        let filters = self.build_filters()?;
         let explicit_replay_capabilities =
             build_explicit_replay_capabilities(&client, ctx, &self.collection, address).await?;
 
         client
-            .p2p_replicator_add(&self.collection, address, &explicit_replay_capabilities)
+            .p2p_replicator_add(
+                &self.collection,
+                address,
+                filters,
+                &explicit_replay_capabilities,
+            )
             .await?;
         println!(
             "Set replicator for collections: {}",
             self.collection.join(", ")
         );
         Ok(())
+    }
+
+    fn build_filters(&self) -> Result<ReplicationFilters> {
+        let Some(field) = self.filter_field.as_deref() else {
+            if self.filter_value.is_some() {
+                return Err(Error::MissingInput(
+                    "--filter-value requires --filter-field".to_string(),
+                ));
+            }
+            return Ok(ReplicationFilters::new());
+        };
+        let Some(value) = self.filter_value.as_deref() else {
+            return Err(Error::MissingInput(
+                "--filter-field requires --filter-value".to_string(),
+            ));
+        };
+        if field.trim().is_empty() {
+            return Err(Error::InvalidConfig(
+                "--filter-field cannot be empty".to_string(),
+            ));
+        }
+
+        Ok(self
+            .collection
+            .iter()
+            .map(|collection| {
+                (
+                    collection.clone(),
+                    ReplicationFilter {
+                        field: field.to_string(),
+                        value: serde_json::Value::String(value.to_string()),
+                    },
+                )
+            })
+            .collect())
     }
 }
 

--- a/crates/cli/src/commands/client/p2p/tests.rs
+++ b/crates/cli/src/commands/client/p2p/tests.rs
@@ -8,6 +8,8 @@ fn test_p2p_replicator_add_args() {
     let args = P2pReplicatorAddArgs {
         collection: vec!["Users".to_string(), "Posts".to_string()],
         addresses: vec!["/ip4/127.0.0.1/tcp/9000".to_string()],
+        filter_field: None,
+        filter_value: None,
     };
     assert_eq!(args.collection.len(), 2);
     assert_eq!(args.addresses.len(), 1);
@@ -18,6 +20,8 @@ fn test_p2p_replicator_add_args_no_address() {
     let args = P2pReplicatorAddArgs {
         collection: vec!["Users".to_string()],
         addresses: vec![],
+        filter_field: None,
+        filter_value: None,
     };
     assert!(args.addresses.is_empty());
 }

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use blockstore::Blockstore;
 
-use defra_http::router::{P2PError, P2POperations, P2PResult, ReplicatorInfo};
+use defra_http::router::{P2PError, P2POperations, P2PResult, ReplicationFilters, ReplicatorInfo};
 use p2p::iroh::{
     best_shareable_public_addr, format_public_listen_addrs, parse_public_peer_addr, IrohTransport,
 };
@@ -52,7 +52,62 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
             address,
             status,
             last_status_change,
+            filters: info
+                .filters
+                .into_iter()
+                .map(|(collection, filter)| {
+                    (
+                        collection,
+                        defra_http::router::ReplicationFilter {
+                            field: filter.field,
+                            value: filter.value,
+                        },
+                    )
+                })
+                .collect(),
         }
+    }
+
+    fn resolve_replication_filters(
+        filters: ReplicationFilters,
+        effective_collections: &[String],
+        collection_cids: &[String],
+    ) -> P2PResult<p2p::ReplicationFilters> {
+        let mut resolved = p2p::ReplicationFilters::new();
+        for (key, filter) in filters {
+            if filter.field.trim().is_empty() {
+                return Err(P2PError::InvalidInput(
+                    "replication filter field cannot be empty".into(),
+                ));
+            }
+            if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
+                return Err(P2PError::InvalidInput(format!(
+                    "replication filter for collection '{key}' must use a scalar value"
+                )));
+            }
+
+            let collection_id = collection_cids
+                .iter()
+                .position(|collection_id| collection_id == &key)
+                .or_else(|| {
+                    effective_collections
+                        .iter()
+                        .position(|collection_name| collection_name == &key)
+                })
+                .and_then(|index| collection_cids.get(index))
+                .cloned()
+                .ok_or_else(|| {
+                    P2PError::InvalidInput(format!(
+                        "replication filter collection '{key}' was not requested"
+                    ))
+                })?;
+
+            resolved.insert(
+                collection_id,
+                p2p::ReplicationFilter::new(filter.field, filter.value),
+            );
+        }
+        Ok(resolved)
     }
 
     pub fn with_full_context(
@@ -236,6 +291,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
+        filters: ReplicationFilters,
         _explicit_replay_capabilities: Vec<defra_http::router::ExplicitReplayCapabilityInput>,
         _expected_authorizer_did: Option<&str>,
     ) -> P2PResult<()> {
@@ -273,11 +329,25 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         } else {
             collection_cids.clone_from(&effective_collections);
         }
+        let replication_filters =
+            Self::resolve_replication_filters(filters, &effective_collections, &collection_cids)?;
+        if !replication_filters.is_empty() {
+            self.doc_pusher
+                .as_ref()
+                .ok_or_else(|| {
+                    P2PError::Unsupported("no database context to validate filters".into())
+                })?
+                .validate_replication_filters(&replication_filters)
+                .map_err(P2PError::InvalidInput)?;
+        }
 
         // Check existing replicator state before creating/updating so we can
         // skip the expensive initial replay when the replicator already exists
         // with the same collections (idempotent reconnect path).
-        let existing_collection_ids: HashSet<String> = {
+        let (existing_collection_ids, existing_filters): (
+            HashSet<String>,
+            p2p::ReplicationFilters,
+        ) = {
             let result = if let Some(ref coordinator) = self.sync_coordinator {
                 coordinator
                     .get_replicator(&peer_id)
@@ -290,17 +360,22 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                     .map_err(|e| P2PError::Transport(e.to_string()))
             };
             match result {
-                Ok(Some(info)) => info.collections.into_iter().collect(),
-                Ok(None) => HashSet::new(),
+                Ok(Some(info)) => (info.collections.into_iter().collect(), info.filters),
+                Ok(None) => (HashSet::new(), p2p::ReplicationFilters::new()),
                 Err(e) => {
                     tracing::warn!(
                         peer_id = %peer_id,
                         error = %e,
                         "Failed to check existing replicator state; falling back to full replay"
                     );
-                    HashSet::new()
+                    (HashSet::new(), p2p::ReplicationFilters::new())
                 }
             }
+        };
+        let existing_collection_ids = if existing_filters == replication_filters {
+            existing_collection_ids
+        } else {
+            HashSet::new()
         };
 
         self.transport
@@ -315,22 +390,37 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         }
 
         if let Some(ref coordinator) = self.sync_coordinator {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
             coordinator
-                .create_replicator(&peer_id, collection_cids.clone(), true)
+                .create_replicator_info(&peer_id, info, true)
                 .await
                 .map_err(|e| P2PError::Transport(e.to_string()))?;
         } else {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
             self.transport
-                .create_replicator(&peer_id, collection_cids.clone())
+                .create_replicator_info(&peer_id, info)
                 .await
                 .map_err(|e| P2PError::Transport(e.to_string()))?;
         }
 
         if let Some(ref pusher) = self.doc_pusher {
-            if let Err(e) = pusher
-                .persist_replicator(&peer_id.to_string(), &collection_cids)
-                .await
-            {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
+            if let Err(e) = pusher.persist_replicator_info(&info).await {
                 tracing::warn!(peer_id = %peer_id, error = %e, "failed to persist replicator");
             }
         }
@@ -350,6 +440,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 let push_pusher = Arc::clone(pusher);
                 let push_event_bus = self.event_bus.clone();
                 let push_peer = peer_id;
+                let push_filters = replication_filters.clone();
 
                 tracing::info!(
                     peer_id = %push_peer,
@@ -359,7 +450,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
 
                 tokio::spawn(async move {
                     if let Err(e) = push_pusher
-                        .push_existing_docs(&push_peer, &new_collection_names, None)
+                        .push_existing_docs(&push_peer, &new_collection_names, &push_filters, None)
                         .await
                     {
                         tracing::error!(error = %e, "Failed to push existing docs to replicator");

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -8,7 +8,8 @@ use blockstore::Blockstore;
 use cid::Cid;
 
 use defra_http::router::{
-    ExplicitReplayCapabilityInput, P2PError, P2POperations, P2PResult, ReplicatorInfo,
+    ExplicitReplayCapabilityInput, P2PError, P2POperations, P2PResult, ReplicationFilters,
+    ReplicatorInfo,
 };
 use p2p::sync::Libp2pSyncCoordinator;
 use p2p::topics::DefraTopic;
@@ -37,6 +38,7 @@ pub trait DocPusher: Send + Sync {
         handle: &P2PHostHandle,
         peer_id: libp2p::PeerId,
         collections: &[String],
+        filters: &p2p::ReplicationFilters,
         se_key: Option<&[u8]>,
         se_identity_pubkey: Option<&[u8]>,
     ) -> Result<(), String>;
@@ -45,8 +47,20 @@ pub trait DocPusher: Send + Sync {
 
     fn list_collections(&self) -> Result<Vec<String>, String>;
 
+    fn validate_replication_filters(
+        &self,
+        _filters: &p2p::ReplicationFilters,
+    ) -> Result<(), String> {
+        Err("no database context to validate replication filters".to_string())
+    }
+
     async fn persist_replicator(&self, peer_id: &str, collections: &[String])
         -> Result<(), String>;
+
+    async fn persist_replicator_info(&self, info: &p2p::ReplicatorInfo) -> Result<(), String> {
+        self.persist_replicator(info.peer_id_str(), &info.collections)
+            .await
+    }
 
     async fn delete_persisted_replicator(&self, peer_id: &str) -> Result<(), String>;
 
@@ -130,7 +144,62 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
             address,
             status,
             last_status_change,
+            filters: info
+                .filters
+                .into_iter()
+                .map(|(collection, filter)| {
+                    (
+                        collection,
+                        defra_http::router::ReplicationFilter {
+                            field: filter.field,
+                            value: filter.value,
+                        },
+                    )
+                })
+                .collect(),
         }
+    }
+
+    fn resolve_replication_filters(
+        filters: ReplicationFilters,
+        effective_collections: &[String],
+        collection_cids: &[String],
+    ) -> P2PResult<p2p::ReplicationFilters> {
+        let mut resolved = p2p::ReplicationFilters::new();
+        for (key, filter) in filters {
+            if filter.field.trim().is_empty() {
+                return Err(P2PError::InvalidInput(
+                    "replication filter field cannot be empty".into(),
+                ));
+            }
+            if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
+                return Err(P2PError::InvalidInput(format!(
+                    "replication filter for collection '{key}' must use a scalar value"
+                )));
+            }
+
+            let collection_id = collection_cids
+                .iter()
+                .position(|collection_id| collection_id == &key)
+                .or_else(|| {
+                    effective_collections
+                        .iter()
+                        .position(|collection_name| collection_name == &key)
+                })
+                .and_then(|index| collection_cids.get(index))
+                .cloned()
+                .ok_or_else(|| {
+                    P2PError::InvalidInput(format!(
+                        "replication filter collection '{key}' was not requested"
+                    ))
+                })?;
+
+            resolved.insert(
+                collection_id,
+                p2p::ReplicationFilter::new(filter.field, filter.value),
+            );
+        }
+        Ok(resolved)
     }
 
     /// Pre-populate tracked documents from persisted state without re-subscribing.
@@ -263,6 +332,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
+        filters: ReplicationFilters,
         explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
         expected_authorizer_did: Option<&str>,
     ) -> P2PResult<()> {
@@ -301,6 +371,17 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
             }
         } else {
             collection_cids.clone_from(&effective_collections);
+        }
+        let replication_filters =
+            Self::resolve_replication_filters(filters, &effective_collections, &collection_cids)?;
+        if !replication_filters.is_empty() {
+            self.doc_pusher
+                .as_ref()
+                .ok_or_else(|| {
+                    P2PError::Unsupported("no database context to validate filters".into())
+                })?
+                .validate_replication_filters(&replication_filters)
+                .map_err(P2PError::InvalidInput)?;
         }
 
         let peer_id = parsed.peer_id;
@@ -377,7 +458,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         // Check existing replicator state before creating/updating so we can
         // skip the expensive initial replay when the replicator already exists
         // with the same collections and replay capability.
-        let existing_collection_ids: HashSet<String> = {
+        let (existing_collection_ids, existing_filters): (
+            HashSet<String>,
+            p2p::ReplicationFilters,
+        ) = {
             let result = if let Some(ref coordinator) = self.sync_coordinator {
                 let transport_pid = p2p::transport::PeerId::from(peer_id);
                 coordinator
@@ -391,17 +475,22 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                     .map_err(|e| P2PError::Transport(e.to_string()))
             };
             match result {
-                Ok(Some(info)) => info.collections.into_iter().collect(),
-                Ok(None) => HashSet::new(),
+                Ok(Some(info)) => (info.collections.into_iter().collect(), info.filters),
+                Ok(None) => (HashSet::new(), p2p::ReplicationFilters::new()),
                 Err(e) => {
                     tracing::warn!(
                         peer_id = %peer_id,
                         error = %e,
                         "Failed to check existing replicator state; falling back to full replay"
                     );
-                    HashSet::new()
+                    (HashSet::new(), p2p::ReplicationFilters::new())
                 }
             }
+        };
+        let existing_collection_ids = if existing_filters == replication_filters {
+            existing_collection_ids
+        } else {
+            HashSet::new()
         };
 
         // Dial peer
@@ -420,23 +509,38 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         // Register replicator (coordinator handles topic auto-subscribe)
         if let Some(ref coordinator) = self.sync_coordinator {
             let transport_pid = p2p::transport::PeerId::from(peer_id);
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
             coordinator
-                .create_replicator(&transport_pid, collection_cids.clone(), true)
+                .create_replicator_info(&transport_pid, info.clone(), true)
                 .await
                 .map_err(|e| P2PError::Transport(e.to_string()))?;
         } else {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
             self.handle
-                .create_replicator(peer_id, collection_cids.clone())
+                .create_replicator_info(peer_id, info.clone())
                 .await
                 .map_err(|e| P2PError::Transport(e.to_string()))?;
         }
 
         // Persist to peerstore (best-effort, log warning on failure)
         if let Some(ref pusher) = self.doc_pusher {
-            if let Err(e) = pusher
-                .persist_replicator(&peer_id.to_string(), &collection_cids)
-                .await
-            {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
+            if let Err(e) = pusher.persist_replicator_info(&info).await {
                 tracing::warn!(peer_id = %peer_id, error = %e, "failed to persist replicator");
             }
         }
@@ -457,6 +561,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 let push_handle = self.handle.clone();
                 let push_pusher = Arc::clone(pusher);
                 let push_event_bus = self.event_bus.clone();
+                let push_filters = replication_filters.clone();
 
                 tracing::info!(
                     peer_id = %peer_id,
@@ -470,6 +575,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                             &push_handle,
                             peer_id,
                             &collection_names_requiring_replay,
+                            &push_filters,
                             None,
                             None,
                         )

--- a/crates/cli/src/p2p_doc_pusher.rs
+++ b/crates/cli/src/p2p_doc_pusher.rs
@@ -116,6 +116,12 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
                     filter.field, collection_id
                 ));
             }
+            if !field.kind.accepts_filter_value(&filter.value) {
+                return Err(format!(
+                    "replication filter value for field '{}' in collection '{}' does not match the field type",
+                    filter.field, collection_id
+                ));
+            }
         }
         Ok(())
     }

--- a/crates/cli/src/p2p_doc_pusher.rs
+++ b/crates/cli/src/p2p_doc_pusher.rs
@@ -42,6 +42,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         handle: &P2PHostHandle,
         peer_id: libp2p::PeerId,
         collections: &[String],
+        filters: &p2p::ReplicationFilters,
         se_key: Option<&[u8]>,
         se_identity_pubkey: Option<&[u8]>,
     ) -> Result<(), String> {
@@ -51,6 +52,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             self.document_acp.get().map(|acp| acp.as_ref()),
             peer_id,
             collections,
+            filters,
             se_key,
             se_identity_pubkey,
         )
@@ -79,6 +81,43 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         self.db
             .list_collections()
             .map_err(|e| format!("failed to list collections: {}", e))
+    }
+
+    fn validate_replication_filters(
+        &self,
+        filters: &p2p::ReplicationFilters,
+    ) -> Result<(), String> {
+        for (collection_id, filter) in filters {
+            let collection = self
+                .db
+                .find_collection_by_id(collection_id)
+                .map_err(|e| format!("failed to load collection '{}': {}", collection_id, e))?
+                .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
+            let field = collection
+                .schema()
+                .fields
+                .iter()
+                .find(|field| field.name == filter.field)
+                .ok_or_else(|| {
+                    format!(
+                        "replication filter field '{}' not found in collection '{}'",
+                        filter.field, collection_id
+                    )
+                })?;
+            if !field.immutable {
+                return Err(format!(
+                    "replication filter field '{}' in collection '{}' must be marked @immutable",
+                    filter.field, collection_id
+                ));
+            }
+            if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
+                return Err(format!(
+                    "replication filter field '{}' in collection '{}' must be a scalar LWW field",
+                    filter.field, collection_id
+                ));
+            }
+        }
+        Ok(())
     }
 
     async fn persist_replicator(
@@ -112,6 +151,20 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         };
         info.id = peer_id.to_string();
         info.collections = collections.to_vec();
+        let bytes = info
+            .to_bytes()
+            .map_err(|e| format!("failed to serialize replicator info: {}", e))?;
+        peerstore
+            .create_replicator(peer_id, &bytes)
+            .await
+            .map_err(|e| format!("failed to persist replicator: {}", e))
+    }
+
+    async fn persist_replicator_info(&self, info: &p2p::ReplicatorInfo) -> Result<(), String> {
+        let peer_id = info.peer_id_str();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let mut info = info.clone();
+        info.id = peer_id.to_string();
         let bytes = info
             .to_bytes()
             .map_err(|e| format!("failed to serialize replicator info: {}", e))?;
@@ -204,6 +257,14 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         doc_id: &str,
         collection_id: &str,
     ) -> Result<(), String> {
+        let peer_id_str = peer_id.to_string();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let filters = match peerstore.get_replicator(&peer_id_str).await {
+            Ok(Some(bytes)) => p2p::ReplicatorInfo::from_bytes(&bytes)
+                .map(|info| info.filters)
+                .unwrap_or_default(),
+            _ => p2p::ReplicationFilters::new(),
+        };
         db_merge::retry_doc(
             handle,
             &self.db,
@@ -211,6 +272,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             peer_id,
             doc_id,
             collection_id,
+            &filters,
         )
         .await
     }

--- a/crates/cli/src/transport_doc_pusher.rs
+++ b/crates/cli/src/transport_doc_pusher.rs
@@ -18,6 +18,7 @@ pub trait TransportDocPusher: Send + Sync {
         &self,
         peer_id: &PeerId,
         collections: &[String],
+        filters: &p2p::ReplicationFilters,
         se_key: Option<&[u8]>,
     ) -> Result<(), String>;
 
@@ -40,8 +41,20 @@ pub trait TransportDocPusher: Send + Sync {
 
     fn list_collections(&self) -> Result<Vec<String>, String>;
 
+    fn validate_replication_filters(
+        &self,
+        _filters: &p2p::ReplicationFilters,
+    ) -> Result<(), String> {
+        Err("no database context to validate replication filters".to_string())
+    }
+
     async fn persist_replicator(&self, peer_id: &str, collections: &[String])
         -> Result<(), String>;
+
+    async fn persist_replicator_info(&self, info: &p2p::ReplicatorInfo) -> Result<(), String> {
+        self.persist_replicator(info.peer_id_str(), &info.collections)
+            .await
+    }
 
     async fn delete_persisted_replicator(&self, peer_id: &str) -> Result<(), String>;
 
@@ -93,6 +106,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         &self,
         peer_id: &PeerId,
         collections: &[String],
+        filters: &p2p::ReplicationFilters,
         se_key: Option<&[u8]>,
     ) -> Result<(), String> {
         db_merge::push_existing_docs_via_transport(
@@ -101,6 +115,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             self.document_acp.get().map(|acp| acp.as_ref()),
             peer_id,
             collections,
+            filters,
             se_key,
         )
         .await
@@ -112,6 +127,14 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         doc_id: &str,
         collection_id: &str,
     ) -> Result<(), String> {
+        let peer_id_str = peer_id.to_string();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let filters = match peerstore.get_replicator(&peer_id_str).await {
+            Ok(Some(bytes)) => p2p::ReplicatorInfo::from_bytes(&bytes)
+                .map(|info| info.filters)
+                .unwrap_or_default(),
+            _ => p2p::ReplicationFilters::new(),
+        };
         db_merge::retry_doc_via_transport(
             &self.transport,
             &self.db,
@@ -119,6 +142,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             peer_id,
             doc_id,
             collection_id,
+            &filters,
         )
         .await
     }
@@ -206,6 +230,43 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             .map_err(|e| format!("failed to list collections: {}", e))
     }
 
+    fn validate_replication_filters(
+        &self,
+        filters: &p2p::ReplicationFilters,
+    ) -> Result<(), String> {
+        for (collection_id, filter) in filters {
+            let collection = self
+                .db
+                .find_collection_by_id(collection_id)
+                .map_err(|e| format!("failed to load collection '{}': {}", collection_id, e))?
+                .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
+            let field = collection
+                .schema()
+                .fields
+                .iter()
+                .find(|field| field.name == filter.field)
+                .ok_or_else(|| {
+                    format!(
+                        "replication filter field '{}' not found in collection '{}'",
+                        filter.field, collection_id
+                    )
+                })?;
+            if !field.immutable {
+                return Err(format!(
+                    "replication filter field '{}' in collection '{}' must be marked @immutable",
+                    filter.field, collection_id
+                ));
+            }
+            if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
+                return Err(format!(
+                    "replication filter field '{}' in collection '{}' must be a scalar LWW field",
+                    filter.field, collection_id
+                ));
+            }
+        }
+        Ok(())
+    }
+
     async fn persist_replicator(
         &self,
         peer_id: &str,
@@ -226,6 +287,20 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         };
         info.id = peer_id.to_string();
         info.collections = collections.to_vec();
+        let bytes = info
+            .to_bytes()
+            .map_err(|e| format!("failed to serialize replicator info: {}", e))?;
+        peerstore
+            .create_replicator(peer_id, &bytes)
+            .await
+            .map_err(|e| format!("failed to persist replicator: {}", e))
+    }
+
+    async fn persist_replicator_info(&self, info: &p2p::ReplicatorInfo) -> Result<(), String> {
+        let peer_id = info.peer_id_str();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let mut info = info.clone();
+        info.id = peer_id.to_string();
         let bytes = info
             .to_bytes()
             .map_err(|e| format!("failed to serialize replicator info: {}", e))?;

--- a/crates/cli/src/transport_doc_pusher.rs
+++ b/crates/cli/src/transport_doc_pusher.rs
@@ -263,6 +263,12 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
                     filter.field, collection_id
                 ));
             }
+            if !field.kind.accepts_filter_value(&filter.value) {
+                return Err(format!(
+                    "replication filter value for field '{}' in collection '{}' does not match the field type",
+                    filter.field, collection_id
+                ));
+            }
         }
         Ok(())
     }

--- a/crates/db-merge/src/broadcast_mutator/batch.rs
+++ b/crates/db-merge/src/broadcast_mutator/batch.rs
@@ -23,6 +23,12 @@ enum BroadcastKind {
     SingleBlockPush,
 }
 
+fn document_json_value(doc: &Document) -> Option<serde_json::Value> {
+    Some(serde_json::Value::Object(
+        doc.to_map().ok()?.into_iter().collect(),
+    ))
+}
+
 struct PendingBroadcast {
     kind: BroadcastKind,
     cid: Cid,
@@ -30,6 +36,7 @@ struct PendingBroadcast {
     doc_id: String,
     collection_id: String,
     collection_name: String,
+    document_json: Option<serde_json::Value>,
     creator_did: Option<String>,
     broadcast_cid: Option<Cid>,
     broadcast_block: Option<Vec<u8>>,
@@ -41,6 +48,7 @@ struct BroadcastCapture<'a> {
     doc_id: &'a str,
     commit_cid: Option<Cid>,
     commit_block: Option<&'a Vec<u8>>,
+    document_json: Option<serde_json::Value>,
     broadcast_cid: Option<Cid>,
     broadcast_block: Option<&'a Vec<u8>>,
 }
@@ -89,6 +97,7 @@ impl<S: Store, B: Blockstore + 'static, T: P2PTransport + 'static> BroadcastBatc
             doc_id,
             commit_cid,
             commit_block,
+            document_json,
             broadcast_cid,
             broadcast_block,
         } = capture;
@@ -113,6 +122,7 @@ impl<S: Store, B: Blockstore + 'static, T: P2PTransport + 'static> BroadcastBatc
             doc_id: doc_id.to_string(),
             collection_id,
             collection_name: collection_name.to_string(),
+            document_json,
             creator_did: defra_core::signing::get_broadcast_creator_did(),
             broadcast_cid,
             broadcast_block: broadcast_block.cloned(),
@@ -129,6 +139,7 @@ impl<S: Store, B: Blockstore + 'static, T: P2PTransport + 'static> BroadcastBatc
             doc_id,
             collection_id,
             collection_name,
+            document_json,
             creator_did,
             broadcast_cid,
             broadcast_block,
@@ -136,18 +147,19 @@ impl<S: Store, B: Blockstore + 'static, T: P2PTransport + 'static> BroadcastBatc
 
         let creator_ref = creator_did.as_deref();
 
-        match kind {
-            BroadcastKind::DagPush => {
-                sync.push_to_replicators_with_creator(
+        match (kind, document_json.as_ref()) {
+            (_, Some(document_json)) => {
+                sync.push_document_to_replicators_with_creator(
                     &cid,
                     &block,
                     &doc_id,
                     &collection_id,
+                    document_json,
                     creator_ref,
                 )
                 .await;
             }
-            BroadcastKind::SingleBlockPush => {
+            (BroadcastKind::DagPush | BroadcastKind::SingleBlockPush, None) => {
                 sync.push_to_replicators_with_creator(
                     &cid,
                     &block,
@@ -232,12 +244,14 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
     ) -> query::error::Result<CreateResult> {
         let result = self.inner.create(collection_name, doc).await?;
         let doc_id = result.doc_id.to_string();
+        let document_json = document_json_value(&result.document);
         self.capture_broadcast(BroadcastCapture {
             kind: BroadcastKind::DagPush,
             collection_name,
             doc_id: &doc_id,
             commit_cid: result.commit_cid,
             commit_block: result.commit_block.as_ref(),
+            document_json,
             broadcast_cid: result.broadcast_cid,
             broadcast_block: result.broadcast_block.as_ref(),
         })
@@ -258,12 +272,14 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
 
         if let Some(doc_id) = result.document.id() {
             let doc_id = doc_id.to_string();
+            let document_json = document_json_value(&result.document);
             self.capture_broadcast(BroadcastCapture {
                 kind: BroadcastKind::DagPush,
                 collection_name,
                 doc_id: &doc_id,
                 commit_cid: result.commit_cid,
                 commit_block: result.commit_block.as_ref(),
+                document_json,
                 broadcast_cid: result.broadcast_cid,
                 broadcast_block: result.broadcast_block.as_ref(),
             })
@@ -283,6 +299,11 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
         collection_name: &str,
         doc_id: &DocID,
     ) -> query::error::Result<DeleteResult> {
+        let document_json = self
+            .inner
+            .get_for_update(collection_name, doc_id)
+            .await?
+            .and_then(|doc| document_json_value(&doc));
         let result = self.inner.delete(collection_name, doc_id).await?;
         let doc_id = result.doc_id.to_string();
         // Pass through the branchable collection block so it gets broadcast
@@ -294,6 +315,7 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
             doc_id: &doc_id,
             commit_cid: result.commit_cid,
             commit_block: result.commit_block.as_ref(),
+            document_json,
             broadcast_cid: result.broadcast_cid,
             broadcast_block: result.broadcast_block.as_ref(),
         })

--- a/crates/db-merge/src/broadcast_mutator/mod.rs
+++ b/crates/db-merge/src/broadcast_mutator/mod.rs
@@ -246,8 +246,10 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> SeArtifactRep
         if artifacts.is_empty() {
             return;
         }
+        let document_json =
+            serde_json::Value::Object(document.to_map().unwrap_or_default().into_iter().collect());
         self.sync
-            .push_se_artifacts_to_replicators(collection_id, artifacts)
+            .push_se_artifacts_to_replicators_for_document(collection_id, artifacts, &document_json)
             .await;
     }
 }
@@ -353,6 +355,14 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
             &result.document,
             &[],
         );
+        let document_json = serde_json::Value::Object(
+            result
+                .document
+                .to_map()
+                .unwrap_or_default()
+                .into_iter()
+                .collect(),
+        );
 
         // Capture everything for the spawned task by value.
         let sync = self.sync.clone();
@@ -367,16 +377,21 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
 
             // Match Go DefraDB's live replicator model: push the new head block
             // and let the receiver resolve any missing links via DAG sync.
-            sync.push_to_replicators_with_creator(
+            sync.push_document_to_replicators_with_creator(
                 &block_result.cid,
                 &block_result.block,
                 &block_result.doc_id,
                 &collection_id,
+                &document_json,
                 creator_ref,
             )
             .await;
-            sync.push_se_artifacts_to_replicators(&collection_id, se_artifacts)
-                .await;
+            sync.push_se_artifacts_to_replicators_for_document(
+                &collection_id,
+                se_artifacts,
+                &document_json,
+            )
+            .await;
 
             // Broadcast composite via GossipSub with retry for InsufficientPeers
             log_broadcast_failure(
@@ -444,8 +459,12 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
         // Build block results and collect broadcast work items.
         // Block building failures return Failed status immediately (not spawned).
         let mut broadcast_results = Vec::with_capacity(results.len());
-        let mut broadcast_work: Vec<(BlockResult, Option<BlockResult>, Vec<SEArtifact>)> =
-            Vec::with_capacity(results.len());
+        let mut broadcast_work: Vec<(
+            BlockResult,
+            Option<BlockResult>,
+            Vec<SEArtifact>,
+            serde_json::Value,
+        )> = Vec::with_capacity(results.len());
 
         for result in results {
             let (cid, block, doc_id_str) = if let (Some(cid), Some(block)) =
@@ -511,6 +530,14 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
                 &result.document,
                 &[],
             );
+            let document_json = serde_json::Value::Object(
+                result
+                    .document
+                    .to_map()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect(),
+            );
 
             broadcast_results.push(CreateResult::with_commit_and_broadcast(
                 result.doc_id,
@@ -520,7 +547,7 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
                 BroadcastStatus::Pending,
             ));
 
-            broadcast_work.push((block_result, branchable_data, se_artifacts));
+            broadcast_work.push((block_result, branchable_data, se_artifacts, document_json));
         }
 
         // Spawn a single detached task that processes all broadcast work items.
@@ -531,17 +558,23 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
             tokio::spawn(async move {
                 let creator_ref = creator_did.as_deref();
 
-                for (block_result, branchable_data, se_artifacts) in &broadcast_work {
-                    sync.push_to_replicators_with_creator(
+                for (block_result, branchable_data, se_artifacts, document_json) in &broadcast_work
+                {
+                    sync.push_document_to_replicators_with_creator(
                         &block_result.cid,
                         &block_result.block,
                         &block_result.doc_id,
                         &collection_id,
+                        document_json,
                         creator_ref,
                     )
                     .await;
-                    sync.push_se_artifacts_to_replicators(&collection_id, se_artifacts.clone())
-                        .await;
+                    sync.push_se_artifacts_to_replicators_for_document(
+                        &collection_id,
+                        se_artifacts.clone(),
+                        document_json,
+                    )
+                    .await;
 
                     log_broadcast_failure(
                         &broadcast_with_retry_with_creator(
@@ -661,6 +694,14 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
             &result.document,
             &se_fields,
         );
+        let document_json = serde_json::Value::Object(
+            result
+                .document
+                .to_map()
+                .unwrap_or_default()
+                .into_iter()
+                .collect(),
+        );
 
         // Capture everything for the spawned task by value.
         let sync = self.sync.clone();
@@ -673,16 +714,21 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
 
             // Match Go DefraDB's live replicator model: push the new head block
             // and let the receiver resolve any missing links via DAG sync.
-            sync.push_to_replicators_with_creator(
+            sync.push_document_to_replicators_with_creator(
                 &block_result.cid,
                 &block_result.block,
                 &block_result.doc_id,
                 &collection_id,
+                &document_json,
                 creator_ref,
             )
             .await;
-            sync.push_se_artifacts_to_replicators(&collection_id, se_artifacts)
-                .await;
+            sync.push_se_artifacts_to_replicators_for_document(
+                &collection_id,
+                se_artifacts,
+                &document_json,
+            )
+            .await;
 
             // Broadcast composite via GossipSub with retry for InsufficientPeers
             log_broadcast_failure(
@@ -738,6 +784,18 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
             .map_err(|e| query::error::QueryError::execution(e.to_string()))?
             .ok_or_else(|| query::error::QueryError::collection_not_found(collection_name))?;
         let collection_id = collection.collection_id().to_string();
+        let pre_delete_document_json = match db::block_reader::read_document_for_se(
+            &self.db,
+            &collection_id,
+            &doc_id.to_string(),
+        )
+        .await
+        {
+            Ok(Some(document)) => Some(serde_json::Value::Object(
+                document.to_map().unwrap_or_default().into_iter().collect(),
+            )),
+            _ => None,
+        };
 
         // Execute the delete mutation
         let result = self.inner.delete(collection_name, doc_id).await?;
@@ -810,14 +868,26 @@ impl<S: Store + 'static, B: Blockstore + 'static, T: P2PTransport> DocMutator
             let creator_ref = creator_did.as_deref();
 
             // Push to replicators (single block for delete, not full DAG).
-            sync.push_to_replicators_with_creator(
-                &block_result.cid,
-                &block_result.block,
-                &block_result.doc_id,
-                &collection_id,
-                creator_ref,
-            )
-            .await;
+            if let Some(document_json) = pre_delete_document_json.as_ref() {
+                sync.push_document_to_replicators_with_creator(
+                    &block_result.cid,
+                    &block_result.block,
+                    &block_result.doc_id,
+                    &collection_id,
+                    document_json,
+                    creator_ref,
+                )
+                .await;
+            } else {
+                sync.push_to_replicators_with_creator(
+                    &block_result.cid,
+                    &block_result.block,
+                    &block_result.doc_id,
+                    &collection_id,
+                    creator_ref,
+                )
+                .await;
+            }
 
             // Broadcast via GossipSub with retry for InsufficientPeers
             log_broadcast_failure(

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -263,11 +263,19 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 .await?
             {
                 Some(outcome) => Ok(Some(outcome)),
-                None => {
-                    self.persist_merged_document(&mut datastore, &context, &mut state)
-                        .await?;
-                    Ok(None)
-                }
+                None => match self
+                    .persist_merged_document(&mut datastore, &context, &mut state)
+                    .await
+                {
+                    Ok(()) => Ok(None),
+                    // A change to an @immutable field is a deterministic content
+                    // rejection: skip the block terminally so it is not retried
+                    // on every sync pass instead of failing transiently.
+                    Err(MergeError::ImmutableFieldChanged(reason)) => {
+                        Ok(Some(MergeOutcome::terminal_skip(reason)))
+                    }
+                    Err(e) => Err(e),
+                },
             }
         };
 
@@ -558,11 +566,19 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 .await?
             {
                 Some(outcome) => Ok(Some(outcome)),
-                None => {
-                    self.persist_merged_document(&mut datastore, &context, &mut state)
-                        .await?;
-                    Ok(None)
-                }
+                None => match self
+                    .persist_merged_document(&mut datastore, &context, &mut state)
+                    .await
+                {
+                    Ok(()) => Ok(None),
+                    // A change to an @immutable field is a deterministic content
+                    // rejection: skip the block terminally so it is not retried
+                    // on every sync pass instead of failing transiently.
+                    Err(MergeError::ImmutableFieldChanged(reason)) => {
+                        Ok(Some(MergeOutcome::terminal_skip(reason)))
+                    }
+                    Err(e) => Err(e),
+                },
             }
         };
 

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -258,21 +258,20 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 }
             };
 
-            // Validate @immutable fields BEFORE any field write so a rejected
-            // block leaves no partial CRDT write. A change is a deterministic
-            // content rejection: skip terminally (and roll back) rather than retry.
-            match self.validate_immutable_links(&datastore, &context).await {
-                Ok(()) => match self
-                    .process_linked_field_blocks(&mut datastore, &headstore, &context, &mut state)
-                    .await?
-                {
-                    Some(outcome) => Ok(Some(outcome)),
-                    None => {
-                        self.persist_merged_document(&mut datastore, &context, &mut state)
-                            .await?;
-                        Ok(None)
-                    }
-                },
+            // process_linked_field_blocks validates @immutable fields BEFORE
+            // persisting any field, so a rejected composite leaves no partial
+            // write. A change is a deterministic content rejection: skip terminally
+            // (and roll back) rather than retry.
+            match self
+                .process_linked_field_blocks(&mut datastore, &headstore, &context, &mut state)
+                .await
+            {
+                Ok(Some(outcome)) => Ok(Some(outcome)),
+                Ok(None) => {
+                    self.persist_merged_document(&mut datastore, &context, &mut state)
+                        .await?;
+                    Ok(None)
+                }
                 Err(MergeError::ImmutableFieldChanged(reason)) => {
                     Ok(Some(MergeOutcome::terminal_skip(reason)))
                 }
@@ -562,21 +561,20 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let process_result: std::result::Result<Option<MergeOutcome>, MergeError> = {
             let mut datastore = datastore.clone();
 
-            // Validate @immutable fields BEFORE any field write so a rejected
-            // block leaves no partial CRDT write in the shared batch txn. A change
-            // is a deterministic content rejection: skip terminally, not retry.
-            match self.validate_immutable_links(&datastore, &context).await {
-                Ok(()) => match self
-                    .process_linked_field_blocks(&mut datastore, headstore, &context, &mut state)
-                    .await?
-                {
-                    Some(outcome) => Ok(Some(outcome)),
-                    None => {
-                        self.persist_merged_document(&mut datastore, &context, &mut state)
-                            .await?;
-                        Ok(None)
-                    }
-                },
+            // process_linked_field_blocks validates @immutable fields BEFORE
+            // persisting any field, so a rejected composite leaves no partial write
+            // in the shared batch txn. A change is a deterministic content
+            // rejection: skip terminally, not retry.
+            match self
+                .process_linked_field_blocks(&mut datastore, headstore, &context, &mut state)
+                .await
+            {
+                Ok(Some(outcome)) => Ok(Some(outcome)),
+                Ok(None) => {
+                    self.persist_merged_document(&mut datastore, &context, &mut state)
+                        .await?;
+                    Ok(None)
+                }
                 Err(MergeError::ImmutableFieldChanged(reason)) => {
                     Ok(Some(MergeOutcome::terminal_skip(reason)))
                 }

--- a/crates/db-merge/src/merge_handler/composite.rs
+++ b/crates/db-merge/src/merge_handler/composite.rs
@@ -258,24 +258,25 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                 }
             };
 
-            match self
-                .process_linked_field_blocks(&mut datastore, &headstore, &context, &mut state)
-                .await?
-            {
-                Some(outcome) => Ok(Some(outcome)),
-                None => match self
-                    .persist_merged_document(&mut datastore, &context, &mut state)
-                    .await
+            // Validate @immutable fields BEFORE any field write so a rejected
+            // block leaves no partial CRDT write. A change is a deterministic
+            // content rejection: skip terminally (and roll back) rather than retry.
+            match self.validate_immutable_links(&datastore, &context).await {
+                Ok(()) => match self
+                    .process_linked_field_blocks(&mut datastore, &headstore, &context, &mut state)
+                    .await?
                 {
-                    Ok(()) => Ok(None),
-                    // A change to an @immutable field is a deterministic content
-                    // rejection: skip the block terminally so it is not retried
-                    // on every sync pass instead of failing transiently.
-                    Err(MergeError::ImmutableFieldChanged(reason)) => {
-                        Ok(Some(MergeOutcome::terminal_skip(reason)))
+                    Some(outcome) => Ok(Some(outcome)),
+                    None => {
+                        self.persist_merged_document(&mut datastore, &context, &mut state)
+                            .await?;
+                        Ok(None)
                     }
-                    Err(e) => Err(e),
                 },
+                Err(MergeError::ImmutableFieldChanged(reason)) => {
+                    Ok(Some(MergeOutcome::terminal_skip(reason)))
+                }
+                Err(e) => Err(e),
             }
         };
 
@@ -561,24 +562,25 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         let process_result: std::result::Result<Option<MergeOutcome>, MergeError> = {
             let mut datastore = datastore.clone();
 
-            match self
-                .process_linked_field_blocks(&mut datastore, headstore, &context, &mut state)
-                .await?
-            {
-                Some(outcome) => Ok(Some(outcome)),
-                None => match self
-                    .persist_merged_document(&mut datastore, &context, &mut state)
-                    .await
+            // Validate @immutable fields BEFORE any field write so a rejected
+            // block leaves no partial CRDT write in the shared batch txn. A change
+            // is a deterministic content rejection: skip terminally, not retry.
+            match self.validate_immutable_links(&datastore, &context).await {
+                Ok(()) => match self
+                    .process_linked_field_blocks(&mut datastore, headstore, &context, &mut state)
+                    .await?
                 {
-                    Ok(()) => Ok(None),
-                    // A change to an @immutable field is a deterministic content
-                    // rejection: skip the block terminally so it is not retried
-                    // on every sync pass instead of failing transiently.
-                    Err(MergeError::ImmutableFieldChanged(reason)) => {
-                        Ok(Some(MergeOutcome::terminal_skip(reason)))
+                    Some(outcome) => Ok(Some(outcome)),
+                    None => {
+                        self.persist_merged_document(&mut datastore, &context, &mut state)
+                            .await?;
+                        Ok(None)
                     }
-                    Err(e) => Err(e),
                 },
+                Err(MergeError::ImmutableFieldChanged(reason)) => {
+                    Ok(Some(MergeOutcome::terminal_skip(reason)))
+                }
+                Err(e) => Err(e),
             }
         };
 

--- a/crates/db-merge/src/merge_handler/composite_fields.rs
+++ b/crates/db-merge/src/merge_handler/composite_fields.rs
@@ -15,230 +15,173 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         context: &CompositeMergeContext<'_, '_>,
         state: &mut CompositeMergeState,
     ) -> std::result::Result<Option<MergeOutcome>, MergeError> {
-        if let Some(links) = &context.block.links {
-            if context.mode.is_standalone() {
-                tracing::info!(
-                    cid = %context.cid,
-                    links_count = links.len(),
-                    "Processing linked blocks from Composite delta"
-                );
-            }
-
-            for dag_link in links {
-                if let Some(outcome) = self
-                    .process_field_block(datastore, headstore, context, dag_link, state)
-                    .await?
-                {
-                    return Ok(Some(outcome));
-                }
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Reject a composite that changes an `@immutable` field BEFORE any field
-    /// block is persisted, so a rejected block never leaves a partial CRDT write
-    /// behind (which a shared batch transaction cannot roll back per-block).
-    ///
-    /// Only fields the composite actually links are checked, so a partial update
-    /// that does not touch an immutable field is not falsely rejected. The prior
-    /// value is read deleted-inclusively so a delete+recreate cannot change it.
-    pub(crate) async fn validate_immutable_links(
-        &self,
-        datastore: &NamespaceView,
-        context: &CompositeMergeContext<'_, '_>,
-    ) -> std::result::Result<(), MergeError> {
-        let Some(collection) = context.collection.as_ref() else {
-            return Ok(());
-        };
         let Some(links) = &context.block.links else {
-            return Ok(());
+            return Ok(None);
         };
-        let immutable: HashSet<&str> = collection
-            .schema()
-            .fields
-            .iter()
-            .filter(|field| field.immutable)
-            .map(|field| field.name.as_str())
-            .collect();
-        if immutable.is_empty() || !links.iter().any(|l| immutable.contains(l.name.as_str())) {
-            return Ok(());
-        }
-
-        let doc_id = DocID::from_string(context.doc_id_str)
-            .map_err(|e| MergeError::MergeFailed(format!("invalid doc_id: {e}")))?;
-        let Some((baseline, _)) = collection
-            .get_with_datastore_include_deleted(datastore, &doc_id, false)
-            .await
-            .map_err(MergeError::Database)?
-        else {
-            return Ok(());
-        };
-
-        for link in links {
-            if !immutable.contains(link.name.as_str()) {
-                continue;
-            }
-            let Some(prior) = baseline.get(&link.name) else {
-                continue;
-            };
-            let Ok(Some(block_data)) = self.blockstore.get(&link.link).await else {
-                continue;
-            };
-            let Ok(block) = Block::from_dag_cbor(&block_data) else {
-                continue;
-            };
-            // Decrypt with the policy hook already marked checked so this read-only
-            // validation does not trigger encryption side effects.
-            let mut hook_checked = true;
-            let effective = match self
-                .handle_encryption(context, &block, &mut hook_checked)
-                .await?
-            {
-                EffectiveLinkedDelta::Delta(delta) => delta,
-                _ => continue,
-            };
-            if let CrdtDelta::Lww(payload) = effective {
-                let Ok(incoming) = ciborium::from_reader::<NormalValue, _>(payload.data.as_slice())
-                else {
-                    continue;
-                };
-                if *prior != incoming {
-                    return Err(MergeError::ImmutableFieldChanged(format!(
-                        "immutable field '{}' cannot be changed",
-                        link.name
-                    )));
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn process_field_block(
-        &self,
-        datastore: &mut NamespaceView,
-        headstore: &NamespaceView,
-        context: &CompositeMergeContext<'_, '_>,
-        dag_link: &defra_core::block::DAGLink,
-        state: &mut CompositeMergeState,
-    ) -> std::result::Result<Option<MergeOutcome>, MergeError> {
-        let link_name = &dag_link.name;
-        let link_cid = &dag_link.link;
 
         if context.mode.is_standalone() {
-            tracing::debug!(
-                parent_cid = %context.cid,
-                link_cid = %link_cid,
-                link_name = %link_name,
-                "Processing linked block"
+            tracing::info!(
+                cid = %context.cid,
+                links_count = links.len(),
+                "Processing linked blocks from Composite delta"
             );
         }
 
-        let linked_block_data = match self.blockstore.get(link_cid).await {
-            Ok(Some(data)) => data,
-            Ok(None) => {
-                if context.mode.is_standalone() {
-                    tracing::error!(
-                        parent_cid = %context.cid,
-                        link_cid = %link_cid,
-                        "Linked block not found in blockstore"
-                    );
-                }
-                return Err(MergeError::Storage(format!(
-                    "Linked block {} not found in blockstore",
-                    link_cid
-                )));
-            }
-            Err(e) => {
-                if context.mode.is_standalone() {
-                    tracing::error!(
-                        parent_cid = %context.cid,
-                        link_cid = %link_cid,
-                        error = %e,
-                        "Failed to load linked block from blockstore"
-                    );
-                }
-                return Err(MergeError::Storage(e.to_string()));
-            }
+        // Load the prior value once (deleted-inclusive, so a delete+recreate cannot
+        // change an immutable field) when the composite links any @immutable field.
+        let immutable_fields: HashSet<&str> = context
+            .collection
+            .as_ref()
+            .map(|collection| {
+                collection
+                    .schema()
+                    .fields
+                    .iter()
+                    .filter(|field| field.immutable)
+                    .map(|field| field.name.as_str())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let immutable_baseline = if context.collection.as_ref().is_some_and(|_| {
+            links
+                .iter()
+                .any(|l| immutable_fields.contains(l.name.as_str()))
+        }) {
+            let doc_id = DocID::from_string(context.doc_id_str)
+                .map_err(|e| MergeError::MergeFailed(format!("invalid doc_id: {e}")))?;
+            context
+                .collection
+                .as_ref()
+                .unwrap()
+                .get_with_datastore_include_deleted(datastore, &doc_id, false)
+                .await
+                .map_err(MergeError::Database)?
+                .map(|(doc, _)| doc)
+        } else {
+            None
         };
 
-        let linked_block = Block::from_dag_cbor(&linked_block_data)
-            .map_err(|e| MergeError::BlockDecode(e.to_string()))?;
+        // Phase 1: decode/decrypt every linked field ONCE and validate @immutable
+        // BEFORE persisting anything, so a rejected composite leaves no partial write.
+        let mut pending: Vec<(Cid, CrdtDelta)> = Vec::with_capacity(links.len());
+        for dag_link in links {
+            let link_name = &dag_link.name;
+            let link_cid = &dag_link.link;
 
-        if let Some(heads) = &linked_block.heads {
-            state
-                .field_block_heads
-                .insert(link_name.clone(), heads.clone());
+            let linked_block_data = match self.blockstore.get(link_cid).await {
+                Ok(Some(data)) => data,
+                Ok(None) => {
+                    return Err(MergeError::Storage(format!(
+                        "Linked block {} not found in blockstore",
+                        link_cid
+                    )));
+                }
+                Err(e) => return Err(MergeError::Storage(e.to_string())),
+            };
+            let linked_block = Block::from_dag_cbor(&linked_block_data)
+                .map_err(|e| MergeError::BlockDecode(e.to_string()))?;
+
+            if let Some(heads) = &linked_block.heads {
+                state
+                    .field_block_heads
+                    .insert(link_name.clone(), heads.clone());
+            }
+
+            let effective = match self
+                .handle_encryption(context, &linked_block, &mut state.encrypted_policy_checked)
+                .await?
+            {
+                EffectiveLinkedDelta::Delta(delta) => delta,
+                EffectiveLinkedDelta::Skip(outcome) => return Ok(Some(outcome)),
+                EffectiveLinkedDelta::SkipField => continue,
+            };
+
+            if immutable_fields.contains(link_name.as_str()) {
+                if let Some(baseline) = immutable_baseline.as_ref() {
+                    Self::check_immutable_delta(baseline, link_name, &effective)?;
+                }
+            }
+
+            pending.push((*link_cid, effective));
         }
 
-        let effective_linked_delta = match self
-            .handle_encryption(context, &linked_block, &mut state.encrypted_policy_checked)
-            .await?
-        {
-            EffectiveLinkedDelta::Delta(delta) => delta,
-            EffectiveLinkedDelta::Skip(outcome) => return Ok(Some(outcome)),
-            EffectiveLinkedDelta::SkipField => return Ok(None),
-        };
-
-        match &effective_linked_delta {
-            CrdtDelta::Lww(lww_payload) => {
-                let result = self
-                    .process_lww_delta_in_txn(
-                        datastore,
-                        headstore,
-                        link_cid,
-                        lww_payload,
-                        context.metadata.collection_id,
-                    )
-                    .await?;
-                if result.applied {
-                    state.any_field_applied = true;
+        // Phase 2: persist the decoded deltas.
+        for (link_cid, effective) in pending {
+            match effective {
+                CrdtDelta::Lww(lww_payload) => {
+                    let result = self
+                        .process_lww_delta_in_txn(
+                            datastore,
+                            headstore,
+                            &link_cid,
+                            &lww_payload,
+                            context.metadata.collection_id,
+                        )
+                        .await?;
+                    if result.applied {
+                        state.any_field_applied = true;
+                    }
+                    if let Some(value) = result.value {
+                        state
+                            .field_values
+                            .insert(lww_payload.field_name.clone(), value);
+                    }
                 }
-                if let Some(value) = result.value {
-                    state
-                        .field_values
-                        .insert(lww_payload.field_name.clone(), value);
+                CrdtDelta::Counter(counter_payload) => {
+                    let result = self
+                        .process_counter_delta_in_txn(
+                            datastore,
+                            &link_cid,
+                            &counter_payload,
+                            context.metadata.collection_id,
+                        )
+                        .await?;
+                    if result.applied {
+                        state.any_field_applied = true;
+                    }
+                    if let Some(value) = result.value {
+                        state
+                            .field_values
+                            .insert(counter_payload.field_name.clone(), value);
+                    }
+                }
+                other => {
+                    return Err(MergeError::UnsupportedDelta(format!(
+                        "Unexpected delta type in linked block: {:?}",
+                        std::mem::discriminant(&other)
+                    )));
                 }
             }
-            CrdtDelta::Counter(counter_payload) => {
-                let result = self
-                    .process_counter_delta_in_txn(
-                        datastore,
-                        link_cid,
-                        counter_payload,
-                        context.metadata.collection_id,
-                    )
-                    .await?;
-                if result.applied {
-                    state.any_field_applied = true;
-                }
-                if let Some(value) = result.value {
-                    state
-                        .field_values
-                        .insert(counter_payload.field_name.clone(), value);
-                }
-            }
-            other => {
-                if context.mode.is_standalone() {
-                    tracing::error!(
-                        parent_cid = %context.cid,
-                        link_cid = %link_cid,
-                        delta_type = ?std::mem::discriminant(other),
-                        "Unexpected delta type in linked block - expected LWW or Counter"
-                    );
-                }
-                return Err(MergeError::UnsupportedDelta(format!(
-                    "Unexpected delta type in linked block: {:?}",
-                    std::mem::discriminant(other)
-                )));
-            }
+            state.linked_field_cids.push(link_cid);
         }
-
-        state.linked_field_cids.push(*link_cid);
 
         Ok(None)
+    }
+
+    /// Reject an incoming immutable-field delta that does not exactly preserve the
+    /// prior value — a different value, or a tombstone/clear (empty payload) — so a
+    /// crafted block cannot diverge the field store from the document store.
+    fn check_immutable_delta(
+        baseline: &Document,
+        field_name: &str,
+        effective: &CrdtDelta,
+    ) -> std::result::Result<(), MergeError> {
+        let Some(prior) = baseline.get(field_name) else {
+            return Ok(());
+        };
+        let CrdtDelta::Lww(payload) = effective else {
+            return Ok(());
+        };
+        let preserves_prior = !payload.data.is_empty()
+            && ciborium::from_reader::<NormalValue, _>(payload.data.as_slice())
+                .map(|incoming| incoming == *prior)
+                .unwrap_or(false);
+        if !preserves_prior {
+            return Err(MergeError::ImmutableFieldChanged(format!(
+                "immutable field '{field_name}' cannot be changed"
+            )));
+        }
+        Ok(())
     }
 
     async fn handle_encryption(

--- a/crates/db-merge/src/merge_handler/composite_fields.rs
+++ b/crates/db-merge/src/merge_handler/composite_fields.rs
@@ -37,6 +37,85 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         Ok(None)
     }
 
+    /// Reject a composite that changes an `@immutable` field BEFORE any field
+    /// block is persisted, so a rejected block never leaves a partial CRDT write
+    /// behind (which a shared batch transaction cannot roll back per-block).
+    ///
+    /// Only fields the composite actually links are checked, so a partial update
+    /// that does not touch an immutable field is not falsely rejected. The prior
+    /// value is read deleted-inclusively so a delete+recreate cannot change it.
+    pub(crate) async fn validate_immutable_links(
+        &self,
+        datastore: &NamespaceView,
+        context: &CompositeMergeContext<'_, '_>,
+    ) -> std::result::Result<(), MergeError> {
+        let Some(collection) = context.collection.as_ref() else {
+            return Ok(());
+        };
+        let Some(links) = &context.block.links else {
+            return Ok(());
+        };
+        let immutable: HashSet<&str> = collection
+            .schema()
+            .fields
+            .iter()
+            .filter(|field| field.immutable)
+            .map(|field| field.name.as_str())
+            .collect();
+        if immutable.is_empty() || !links.iter().any(|l| immutable.contains(l.name.as_str())) {
+            return Ok(());
+        }
+
+        let doc_id = DocID::from_string(context.doc_id_str)
+            .map_err(|e| MergeError::MergeFailed(format!("invalid doc_id: {e}")))?;
+        let Some((baseline, _)) = collection
+            .get_with_datastore_include_deleted(datastore, &doc_id, false)
+            .await
+            .map_err(MergeError::Database)?
+        else {
+            return Ok(());
+        };
+
+        for link in links {
+            if !immutable.contains(link.name.as_str()) {
+                continue;
+            }
+            let Some(prior) = baseline.get(&link.name) else {
+                continue;
+            };
+            let Ok(Some(block_data)) = self.blockstore.get(&link.link).await else {
+                continue;
+            };
+            let Ok(block) = Block::from_dag_cbor(&block_data) else {
+                continue;
+            };
+            // Decrypt with the policy hook already marked checked so this read-only
+            // validation does not trigger encryption side effects.
+            let mut hook_checked = true;
+            let effective = match self
+                .handle_encryption(context, &block, &mut hook_checked)
+                .await?
+            {
+                EffectiveLinkedDelta::Delta(delta) => delta,
+                _ => continue,
+            };
+            if let CrdtDelta::Lww(payload) = effective {
+                let Ok(incoming) = ciborium::from_reader::<NormalValue, _>(payload.data.as_slice())
+                else {
+                    continue;
+                };
+                if *prior != incoming {
+                    return Err(MergeError::ImmutableFieldChanged(format!(
+                        "immutable field '{}' cannot be changed",
+                        link.name
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     async fn process_field_block(
         &self,
         datastore: &mut NamespaceView,

--- a/crates/db-merge/src/merge_handler/composite_fields.rs
+++ b/crates/db-merge/src/merge_handler/composite_fields.rs
@@ -158,9 +158,14 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         Ok(None)
     }
 
-    /// Reject an incoming immutable-field delta that does not exactly preserve the
+    /// Reject an incoming immutable-field delta that does not exactly preserve a
     /// prior value — a different value, or a tombstone/clear (empty payload) — so a
     /// crafted block cannot diverge the field store from the document store.
+    ///
+    /// A field with no prior value is allowed to be set: out-of-order sync can
+    /// materialize a partial document before the create-composite carrying the
+    /// immutable field merges, so rejecting first-set would false-reject the
+    /// legitimate block.
     fn check_immutable_delta(
         baseline: &Document,
         field_name: &str,

--- a/crates/db-merge/src/merge_handler/composite_fields.rs
+++ b/crates/db-merge/src/merge_handler/composite_fields.rs
@@ -37,7 +37,15 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
                     .schema()
                     .fields
                     .iter()
-                    .filter(|field| field.immutable)
+                    // JSON fields encode numbers differently in the document store
+                    // (json_to_cbor_value) than in the field block (ciborium), so a
+                    // cross-encoding merge comparison would false-reject. The local
+                    // write path compares same-representation values and still
+                    // enforces immutability for JSON fields.
+                    .filter(|field| {
+                        field.immutable
+                            && !matches!(field.kind, FieldKind::Scalar(ScalarKind::Json))
+                    })
                     .map(|field| field.name.as_str())
                     .collect()
             })

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -73,6 +73,22 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             }
         }
 
+        if let Some(old_doc) = old_doc.as_ref() {
+            for field in collection
+                .schema()
+                .fields
+                .iter()
+                .filter(|field| field.immutable)
+            {
+                if old_doc.get(&field.name) != doc.get(&field.name) {
+                    return Err(MergeError::MergeFailed(format!(
+                        "immutable field '{}' cannot be changed",
+                        field.name
+                    )));
+                }
+            }
+        }
+
         collection
             .save_with_datastore(datastore, &doc)
             .await

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -76,7 +76,7 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         if let Some(old_doc) = old_doc.as_ref() {
             collection
                 .validate_immutable_fields_unchanged(old_doc, &doc)
-                .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
+                .map_err(|e| MergeError::ImmutableFieldChanged(e.to_string()))?;
         }
 
         collection

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -74,19 +74,9 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
         }
 
         if let Some(old_doc) = old_doc.as_ref() {
-            for field in collection
-                .schema()
-                .fields
-                .iter()
-                .filter(|field| field.immutable)
-            {
-                if old_doc.get(&field.name) != doc.get(&field.name) {
-                    return Err(MergeError::MergeFailed(format!(
-                        "immutable field '{}' cannot be changed",
-                        field.name
-                    )));
-                }
-            }
+            collection
+                .validate_immutable_fields_unchanged(old_doc, &doc)
+                .map_err(|e| MergeError::MergeFailed(e.to_string()))?;
         }
 
         collection

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -73,9 +73,22 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             }
         }
 
-        if let Some(old_doc) = old_doc.as_ref() {
+        // Enforce @immutable even when the prior version is logically deleted:
+        // get_with_datastore returns None for a deleted doc, so a delete+recreate
+        // would otherwise bypass the check and re-materialize with a changed
+        // immutable field. Recover the prior value via the deleted-inclusive read.
+        let immutable_baseline = match old_doc.as_ref() {
+            Some(old_doc) => Some(old_doc.clone()),
+            None => collection
+                .get_with_datastore_include_deleted(datastore, &doc_id, false)
+                .await
+                .ok()
+                .flatten()
+                .map(|(prior, _)| prior),
+        };
+        if let Some(baseline) = immutable_baseline.as_ref() {
             collection
-                .validate_immutable_fields_unchanged(old_doc, &doc)
+                .validate_immutable_fields_unchanged(baseline, &doc)
                 .map_err(|e| MergeError::ImmutableFieldChanged(e.to_string()))?;
         }
 

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -73,24 +73,8 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             }
         }
 
-        // Enforce @immutable even when the prior version is logically deleted:
-        // get_with_datastore returns None for a deleted doc, so a delete+recreate
-        // would otherwise bypass the check and re-materialize with a changed
-        // immutable field. Recover the prior value via the deleted-inclusive read.
-        let immutable_baseline = match old_doc.as_ref() {
-            Some(old_doc) => Some(old_doc.clone()),
-            None => collection
-                .get_with_datastore_include_deleted(datastore, &doc_id, false)
-                .await
-                .ok()
-                .flatten()
-                .map(|(prior, _)| prior),
-        };
-        if let Some(baseline) = immutable_baseline.as_ref() {
-            collection
-                .validate_immutable_fields_unchanged(baseline, &doc)
-                .map_err(|e| MergeError::ImmutableFieldChanged(e.to_string()))?;
-        }
+        // @immutable enforcement happens in validate_immutable_links, BEFORE any
+        // field block is persisted, so a rejected block leaves no partial write.
 
         collection
             .save_with_datastore(datastore, &doc)

--- a/crates/db-merge/src/merge_handler/composite_persist.rs
+++ b/crates/db-merge/src/merge_handler/composite_persist.rs
@@ -73,8 +73,9 @@ impl<S: Store, B: blockstore::Blockstore + Send + Sync> DbMergeHandler<S, B> {
             }
         }
 
-        // @immutable enforcement happens in validate_immutable_links, BEFORE any
-        // field block is persisted, so a rejected block leaves no partial write.
+        // @immutable enforcement happens in process_linked_field_blocks (phase 1),
+        // BEFORE any field block is persisted, so a rejected block leaves no
+        // partial write.
 
         collection
             .save_with_datastore(datastore, &doc)

--- a/crates/db-merge/src/merge_handler/error.rs
+++ b/crates/db-merge/src/merge_handler/error.rs
@@ -22,6 +22,12 @@ pub enum MergeError {
     #[error("merge failed: {0}")]
     MergeFailed(String),
 
+    /// A merge would change an `@immutable` field. This is a deterministic
+    /// rejection of the block's content, not a transient failure: the offending
+    /// block must be marked terminal (skipped) so it is not retried forever.
+    #[error("immutable field rejected: {0}")]
+    ImmutableFieldChanged(String),
+
     /// Database error.
     #[error("database error: {0}")]
     Database(#[from] db::error::Error),

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1593,6 +1593,184 @@ mod tests {
         assert_eq!(stored.get("score"), Some(&NormalValue::Int(20)));
     }
 
+    async fn make_handler_with_immutable_schema() -> (
+        DbMergeHandler<MemoryStore, DefraBlockstore<MemoryStore>>,
+        Arc<DefraBlockstore<MemoryStore>>,
+    ) {
+        let store = Arc::new(MemoryStore::new());
+        let db = Arc::new(DB::from_arc(store.clone()).unwrap());
+
+        db.create_collection(CollectionVersion::new(
+            "AgentDocs",
+            "v1",
+            "col-agentdocs",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "agent_did", FieldKind::string()).as_immutable(),
+                FieldDescription::new("3", "body", FieldKind::string()),
+            ],
+        ))
+        .await
+        .unwrap();
+
+        let blockstore = Arc::new(DefraBlockstore::new(store, false));
+        let handler = DbMergeHandler::new(db, blockstore.clone());
+        (handler, blockstore)
+    }
+
+    /// Remote-merge enforcement of `@immutable` (filtered-replication B3 hazard).
+    ///
+    /// A higher-priority remote composite delta that flips an immutable field
+    /// must be rejected by the merge handler, leaving the local value intact.
+    /// This guards the `composite_persist.rs` path, which re-implements the
+    /// check independently of the local-write validator — so it needs its own
+    /// coverage. Honest two-node e2e cannot reach this: local validation blocks
+    /// the originating update and content-addressed doc IDs prevent honest
+    /// divergence, so the conflicting delta is crafted directly here.
+    #[tokio::test]
+    async fn remote_composite_merge_rejects_immutable_field_change() {
+        let (handler, blockstore) = make_handler_with_immutable_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-agentdocs")
+            .unwrap()
+            .expect("agentdocs collection should exist");
+
+        let mut doc = Document::new();
+        doc.set(
+            "agent_did",
+            NormalValue::String("did:key:alice".to_string()),
+        );
+        doc.set("body", NormalValue::String("v1".to_string()));
+        doc.generate_and_set_doc_id().unwrap();
+        doc.set_schema_version_id("v1");
+        let doc_id = doc.id().unwrap().clone();
+        let doc_id_str = doc_id.to_string();
+
+        // Persist the initial document locally (agent_did = alice).
+        let create_blocks = {
+            let txn = handler.db.new_txn(false).await.unwrap();
+            let blocks = {
+                let datastore = txn.datastore().unwrap();
+                let headstore = txn.headstore().unwrap();
+                let raw_blockstore = txn.blockstore().unwrap();
+                collection
+                    .save_with_datastore(&datastore, &doc)
+                    .await
+                    .unwrap();
+                db_blocks::write_document_blocks(
+                    &raw_blockstore,
+                    &headstore,
+                    &doc,
+                    "v1",
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+            };
+            txn.force_commit().await.unwrap();
+            blocks
+        };
+
+        // Craft a higher-priority remote update that flips the immutable field.
+        let mut update_data = Vec::new();
+        ciborium::into_writer(
+            &NormalValue::String("did:key:bob".to_string()),
+            &mut update_data,
+        )
+        .unwrap();
+        let update_field_payload = LwwDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            field_name: "agent_did".to_string(),
+            schema_version_id: "v1".to_string(),
+            priority: 2,
+            data: update_data,
+        };
+        let update_field_block = Block::new(
+            CrdtDelta::Lww(update_field_payload),
+            create_blocks.field_cids.clone(),
+            vec![],
+        );
+        let update_field_cid = update_field_block.generate_cid().unwrap();
+        blockstore
+            .put(
+                &update_field_cid,
+                &update_field_block.to_dag_cbor().unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let update_payload = CompositeDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 2,
+            status: 1,
+        };
+        let update_composite_block = Block::new(
+            CrdtDelta::Composite(update_payload.clone()),
+            vec![create_blocks.cid],
+            vec![DAGLink::new("agent_did", update_field_cid)],
+        );
+        let update_composite_cid = update_composite_block.generate_cid().unwrap();
+        blockstore
+            .put(
+                &update_composite_cid,
+                &update_composite_block.to_dag_cbor().unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let metadata = BlockMetadata::normal(
+            &doc_id_str,
+            "col-agentdocs",
+            "did:key:z6MkrRemoteImmutableMerge",
+            None,
+            false,
+        );
+        let result = handler
+            .process_composite_delta(
+                &update_composite_cid,
+                &update_composite_block,
+                &update_payload,
+                &metadata,
+                false,
+                0,
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "remote merge changing an immutable field must be rejected, got {result:?}"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains("immutable"),
+            "rejection should cite the immutable field"
+        );
+
+        // The locally-stored immutable value must be unchanged.
+        let stored = {
+            let txn = handler.db.new_txn(true).await.unwrap();
+            let stored = {
+                let datastore = txn.datastore().unwrap();
+                collection
+                    .get_with_datastore(&datastore, &doc_id)
+                    .await
+                    .unwrap()
+                    .expect("document should still exist")
+            };
+            txn.force_discard().unwrap();
+            stored
+        };
+        assert_eq!(
+            stored.get("agent_did"),
+            Some(&NormalValue::String("did:key:alice".to_string())),
+            "immutable field must survive a rejected remote merge"
+        );
+    }
+
     #[tokio::test]
     async fn composite_lww_reseeds_from_local_doc_when_crdt_store_is_stale() {
         let (handler, blockstore, _bus) = make_handler_with_schema_and_bus().await;

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1770,6 +1770,163 @@ mod tests {
         );
     }
 
+    /// A remotely-deleted document still retains its bytes (handle_deletion only
+    /// sets the marker), so a later merge that re-materializes it must NOT be able
+    /// to change an immutable field via delete+recreate. Without the
+    /// deleted-inclusive baseline read, get_with_datastore returns None and the
+    /// check is skipped.
+    #[tokio::test]
+    async fn remote_merge_rejects_immutable_change_after_delete() {
+        let (handler, blockstore) = make_handler_with_immutable_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-agentdocs")
+            .unwrap()
+            .expect("agentdocs collection should exist");
+
+        let mut doc = Document::new();
+        doc.set(
+            "agent_did",
+            NormalValue::String("did:key:alice".to_string()),
+        );
+        doc.set("body", NormalValue::String("v1".to_string()));
+        doc.generate_and_set_doc_id().unwrap();
+        doc.set_schema_version_id("v1");
+        let doc_id = doc.id().unwrap().clone();
+        let doc_id_str = doc_id.to_string();
+
+        let create_blocks = {
+            let txn = handler.db.new_txn(false).await.unwrap();
+            let blocks = {
+                let datastore = txn.datastore().unwrap();
+                let headstore = txn.headstore().unwrap();
+                let raw_blockstore = txn.blockstore().unwrap();
+                collection
+                    .save_with_datastore(&datastore, &doc)
+                    .await
+                    .unwrap();
+                db_blocks::write_document_blocks(
+                    &raw_blockstore,
+                    &headstore,
+                    &doc,
+                    "v1",
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+            };
+            txn.force_commit().await.unwrap();
+            blocks
+        };
+
+        // Remote deletion (status = 2): sets the deleted marker, retains bytes.
+        let delete_payload = CompositeDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 2,
+            status: 2,
+        };
+        let delete_block = Block::new(
+            CrdtDelta::Composite(delete_payload.clone()),
+            vec![create_blocks.cid],
+            vec![],
+        );
+        let delete_cid = delete_block.generate_cid().unwrap();
+        blockstore
+            .put(&delete_cid, &delete_block.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let delete_meta = BlockMetadata::normal(
+            &doc_id_str,
+            "col-agentdocs",
+            "did:key:z6MkrDeleter",
+            None,
+            false,
+        );
+        let delete_outcome = handler
+            .process_composite_delta(
+                &delete_cid,
+                &delete_block,
+                &delete_payload,
+                &delete_meta,
+                false,
+                0,
+            )
+            .await
+            .expect("delete merge");
+        assert_eq!(delete_outcome, MergeOutcome::Merged);
+
+        // Remote re-materialize with a CHANGED immutable field (priority 3).
+        let mut update_data = Vec::new();
+        ciborium::into_writer(
+            &NormalValue::String("did:key:bob".to_string()),
+            &mut update_data,
+        )
+        .unwrap();
+        let recreate_field_payload = LwwDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            field_name: "agent_did".to_string(),
+            schema_version_id: "v1".to_string(),
+            priority: 3,
+            data: update_data,
+        };
+        let recreate_field_block = Block::new(
+            CrdtDelta::Lww(recreate_field_payload),
+            create_blocks.field_cids.clone(),
+            vec![],
+        );
+        let recreate_field_cid = recreate_field_block.generate_cid().unwrap();
+        blockstore
+            .put(
+                &recreate_field_cid,
+                &recreate_field_block.to_dag_cbor().unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let recreate_payload = CompositeDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 3,
+            status: 1,
+        };
+        let recreate_block = Block::new(
+            CrdtDelta::Composite(recreate_payload.clone()),
+            vec![delete_cid],
+            vec![DAGLink::new("agent_did", recreate_field_cid)],
+        );
+        let recreate_cid = recreate_block.generate_cid().unwrap();
+        blockstore
+            .put(&recreate_cid, &recreate_block.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let recreate_meta = BlockMetadata::normal(
+            &doc_id_str,
+            "col-agentdocs",
+            "did:key:z6MkrRecreator",
+            None,
+            false,
+        );
+        let outcome = handler
+            .process_composite_delta(
+                &recreate_cid,
+                &recreate_block,
+                &recreate_payload,
+                &recreate_meta,
+                false,
+                0,
+            )
+            .await
+            .expect("an immutable rejection is a terminal skip, not a hard error");
+        assert!(
+            outcome.is_terminal_skip(),
+            "re-materializing a deleted doc with a changed immutable field must be rejected, got {outcome:?}"
+        );
+    }
+
     #[tokio::test]
     async fn composite_lww_reseeds_from_local_doc_when_crdt_store_is_stale() {
         let (handler, blockstore, _bus) = make_handler_with_schema_and_bus().await;

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1927,6 +1927,339 @@ mod tests {
         );
     }
 
+    /// A composite that does NOT touch an immutable field must not be rejected,
+    /// even against a deleted prior version. Only linked immutable fields are
+    /// validated, so a partial update is not falsely flagged.
+    #[tokio::test]
+    async fn remote_merge_allows_partial_update_to_deleted_doc() {
+        let (handler, blockstore) = make_handler_with_immutable_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-agentdocs")
+            .unwrap()
+            .expect("agentdocs collection should exist");
+
+        let mut doc = Document::new();
+        doc.set(
+            "agent_did",
+            NormalValue::String("did:key:alice".to_string()),
+        );
+        doc.set("body", NormalValue::String("v1".to_string()));
+        doc.generate_and_set_doc_id().unwrap();
+        doc.set_schema_version_id("v1");
+        let doc_id = doc.id().unwrap().clone();
+        let doc_id_str = doc_id.to_string();
+
+        let create_blocks = {
+            let txn = handler.db.new_txn(false).await.unwrap();
+            let blocks = {
+                let datastore = txn.datastore().unwrap();
+                let headstore = txn.headstore().unwrap();
+                let raw_blockstore = txn.blockstore().unwrap();
+                collection
+                    .save_with_datastore(&datastore, &doc)
+                    .await
+                    .unwrap();
+                db_blocks::write_document_blocks(
+                    &raw_blockstore,
+                    &headstore,
+                    &doc,
+                    "v1",
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+            };
+            txn.force_commit().await.unwrap();
+            blocks
+        };
+
+        // Delete (status 2).
+        let delete_payload = CompositeDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 2,
+            status: 2,
+        };
+        let delete_block = Block::new(
+            CrdtDelta::Composite(delete_payload.clone()),
+            vec![create_blocks.cid],
+            vec![],
+        );
+        let delete_cid = delete_block.generate_cid().unwrap();
+        blockstore
+            .put(&delete_cid, &delete_block.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        handler
+            .process_composite_delta(
+                &delete_cid,
+                &delete_block,
+                &delete_payload,
+                &BlockMetadata::normal(
+                    &doc_id_str,
+                    "col-agentdocs",
+                    "did:key:z6MkrDel",
+                    None,
+                    false,
+                ),
+                false,
+                0,
+            )
+            .await
+            .expect("delete merge");
+
+        // Re-materialize touching only the (mutable) body field — must be allowed.
+        let mut body_data = Vec::new();
+        ciborium::into_writer(&NormalValue::String("v2".to_string()), &mut body_data).unwrap();
+        let body_payload = LwwDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            field_name: "body".to_string(),
+            schema_version_id: "v1".to_string(),
+            priority: 3,
+            data: body_data,
+        };
+        let body_block = Block::new(
+            CrdtDelta::Lww(body_payload),
+            create_blocks.field_cids.clone(),
+            vec![],
+        );
+        let body_cid = body_block.generate_cid().unwrap();
+        blockstore
+            .put(&body_cid, &body_block.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let recreate_payload = CompositeDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 3,
+            status: 1,
+        };
+        let recreate_block = Block::new(
+            CrdtDelta::Composite(recreate_payload.clone()),
+            vec![delete_cid],
+            vec![DAGLink::new("body", body_cid)],
+        );
+        let recreate_cid = recreate_block.generate_cid().unwrap();
+        blockstore
+            .put(&recreate_cid, &recreate_block.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let outcome = handler
+            .process_composite_delta(
+                &recreate_cid,
+                &recreate_block,
+                &recreate_payload,
+                &BlockMetadata::normal(
+                    &doc_id_str,
+                    "col-agentdocs",
+                    "did:key:z6MkrRe",
+                    None,
+                    false,
+                ),
+                false,
+                0,
+            )
+            .await
+            .expect("partial update merge");
+        assert!(
+            !outcome.is_terminal_skip(),
+            "a partial update that does not touch an immutable field must be allowed, got {outcome:?}"
+        );
+    }
+
+    /// Batch path: a composite that changes an @immutable field is terminally
+    /// skipped and leaves NO partial write (not even of its sibling mutable
+    /// field), while a valid block in the same batch still commits.
+    #[tokio::test]
+    async fn batch_merge_rejects_immutable_change_without_partial_write() {
+        let (handler, blockstore) = make_handler_with_immutable_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-agentdocs")
+            .unwrap()
+            .expect("agentdocs collection should exist");
+
+        let mut doc = Document::new();
+        doc.set(
+            "agent_did",
+            NormalValue::String("did:key:alice".to_string()),
+        );
+        doc.set("body", NormalValue::String("v1".to_string()));
+        doc.generate_and_set_doc_id().unwrap();
+        doc.set_schema_version_id("v1");
+        let doc_id = doc.id().unwrap().clone();
+        let doc_id_str = doc_id.to_string();
+
+        let create_blocks = {
+            let txn = handler.db.new_txn(false).await.unwrap();
+            let blocks = {
+                let datastore = txn.datastore().unwrap();
+                let headstore = txn.headstore().unwrap();
+                let raw_blockstore = txn.blockstore().unwrap();
+                collection
+                    .save_with_datastore(&datastore, &doc)
+                    .await
+                    .unwrap();
+                db_blocks::write_document_blocks(
+                    &raw_blockstore,
+                    &headstore,
+                    &doc,
+                    "v1",
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+            };
+            txn.force_commit().await.unwrap();
+            blocks
+        };
+
+        // Violating composite: changes the immutable agent_did AND a benign body.
+        let encode = |s: &str| {
+            let mut b = Vec::new();
+            ciborium::into_writer(&NormalValue::String(s.to_string()), &mut b).unwrap();
+            b
+        };
+        let did_block = Block::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: doc_id_str.as_bytes().to_vec(),
+                field_name: "agent_did".to_string(),
+                schema_version_id: "v1".to_string(),
+                priority: 2,
+                data: encode("did:key:bob"),
+            }),
+            create_blocks.field_cids.clone(),
+            vec![],
+        );
+        let did_cid = did_block.generate_cid().unwrap();
+        blockstore
+            .put(&did_cid, &did_block.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let body_block = Block::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: doc_id_str.as_bytes().to_vec(),
+                field_name: "body".to_string(),
+                schema_version_id: "v1".to_string(),
+                priority: 2,
+                data: encode("hijacked"),
+            }),
+            create_blocks.field_cids.clone(),
+            vec![],
+        );
+        let body_cid = body_block.generate_cid().unwrap();
+        blockstore
+            .put(&body_cid, &body_block.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let bad_payload = CompositeDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 2,
+            status: 1,
+        };
+        let bad_block = Block::new(
+            CrdtDelta::Composite(bad_payload),
+            vec![create_blocks.cid],
+            vec![
+                DAGLink::new("agent_did", did_cid),
+                DAGLink::new("body", body_cid),
+            ],
+        );
+        let bad_cid = bad_block.generate_cid().unwrap();
+        blockstore
+            .put(&bad_cid, &bad_block.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let bad_merge = MergeBlock {
+            cid: bad_cid,
+            block_data: bytes::Bytes::from(bad_block.to_dag_cbor().unwrap()),
+            doc_id: doc_id_str.clone(),
+            collection_id: "col-agentdocs".to_string(),
+            creator: "did:key:z6MkrBad".to_string(),
+            sender_peer: Some("peer1".to_string()),
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+            verified_creator: None,
+        };
+
+        // Valid sibling: a fresh document in the same batch.
+        let mut sibling = Document::new();
+        sibling.set(
+            "agent_did",
+            NormalValue::String("did:key:carol".to_string()),
+        );
+        sibling.set("body", NormalValue::String("sibling".to_string()));
+        sibling.generate_and_set_doc_id().unwrap();
+        let sibling_id = sibling.id().unwrap().to_string();
+        let sibling_result = db_blocks::build_blocks_from_document(&sibling, "v1", &blockstore)
+            .await
+            .unwrap();
+        let sibling_merge = MergeBlock {
+            cid: sibling_result.cid,
+            block_data: bytes::Bytes::from(sibling_result.block),
+            doc_id: sibling_result.doc_id,
+            collection_id: "col-agentdocs".to_string(),
+            creator: "did:key:z6MkrSib".to_string(),
+            sender_peer: Some("peer1".to_string()),
+            is_explicit_replicator: false,
+            explicit_replay_authorization: None,
+            verified_creator: None,
+        };
+
+        let results = handler
+            .handle_block_batch(&[bad_merge, sibling_merge])
+            .await;
+        assert!(
+            matches!(results[0], Ok(ref o) if o.is_terminal_skip()),
+            "immutable-violating batch block must be terminally skipped, got {:?}",
+            results[0]
+        );
+        assert!(
+            matches!(results[1], Ok(MergeOutcome::Merged)),
+            "valid sibling block must commit, got {:?}",
+            results[1]
+        );
+
+        // No partial write: neither the immutable field NOR the benign body of the
+        // rejected composite persisted; the sibling did.
+        let txn = handler.db.new_txn(true).await.unwrap();
+        let (doc1, sibling_present) = {
+            let datastore = txn.datastore().unwrap();
+            let doc1 = collection
+                .get_with_datastore(&datastore, &doc_id)
+                .await
+                .unwrap()
+                .expect("doc1 exists");
+            let sibling_present = collection
+                .get_with_datastore(&datastore, &DocID::from_string(&sibling_id).unwrap())
+                .await
+                .unwrap()
+                .is_some();
+            (doc1, sibling_present)
+        };
+        txn.force_discard().unwrap();
+
+        assert_eq!(
+            doc1.get("agent_did"),
+            Some(&NormalValue::String("did:key:alice".to_string())),
+            "immutable field must be unchanged"
+        );
+        assert_eq!(
+            doc1.get("body"),
+            Some(&NormalValue::String("v1".to_string())),
+            "rejected composite must not have written its sibling field (no partial write)"
+        );
+        assert!(sibling_present, "valid sibling document must be committed");
+    }
+
     #[tokio::test]
     async fn composite_lww_reseeds_from_local_doc_when_crdt_store_is_stale() {
         let (handler, blockstore, _bus) = make_handler_with_schema_and_bus().await;

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1770,6 +1770,111 @@ mod tests {
         );
     }
 
+    /// Clearing an @immutable field (an empty/tombstone LWW delta) is also a
+    /// change and must be rejected — not silently applied to the field store.
+    #[tokio::test]
+    async fn remote_composite_merge_rejects_immutable_field_clear() {
+        let (handler, blockstore) = make_handler_with_immutable_schema().await;
+        let collection = handler
+            .db
+            .find_collection_by_id("col-agentdocs")
+            .unwrap()
+            .expect("agentdocs collection should exist");
+
+        let mut doc = Document::new();
+        doc.set(
+            "agent_did",
+            NormalValue::String("did:key:alice".to_string()),
+        );
+        doc.set("body", NormalValue::String("v1".to_string()));
+        doc.generate_and_set_doc_id().unwrap();
+        doc.set_schema_version_id("v1");
+        let doc_id = doc.id().unwrap().clone();
+        let doc_id_str = doc_id.to_string();
+
+        let create_blocks = {
+            let txn = handler.db.new_txn(false).await.unwrap();
+            let blocks = {
+                let datastore = txn.datastore().unwrap();
+                let headstore = txn.headstore().unwrap();
+                let raw_blockstore = txn.blockstore().unwrap();
+                collection
+                    .save_with_datastore(&datastore, &doc)
+                    .await
+                    .unwrap();
+                db_blocks::write_document_blocks(
+                    &raw_blockstore,
+                    &headstore,
+                    &doc,
+                    "v1",
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+            };
+            txn.force_commit().await.unwrap();
+            blocks
+        };
+
+        // Tombstone: an LWW delta with empty data clears the field.
+        let clear_field = Block::new(
+            CrdtDelta::Lww(LwwDeltaPayload {
+                doc_id: doc_id_str.as_bytes().to_vec(),
+                field_name: "agent_did".to_string(),
+                schema_version_id: "v1".to_string(),
+                priority: 2,
+                data: Vec::new(),
+            }),
+            create_blocks.field_cids.clone(),
+            vec![],
+        );
+        let clear_field_cid = clear_field.generate_cid().unwrap();
+        blockstore
+            .put(&clear_field_cid, &clear_field.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let clear_payload = CompositeDeltaPayload {
+            doc_id: doc_id_str.as_bytes().to_vec(),
+            schema_version_id: "v1".to_string(),
+            priority: 2,
+            status: 1,
+        };
+        let clear_composite = Block::new(
+            CrdtDelta::Composite(clear_payload.clone()),
+            vec![create_blocks.cid],
+            vec![DAGLink::new("agent_did", clear_field_cid)],
+        );
+        let clear_cid = clear_composite.generate_cid().unwrap();
+        blockstore
+            .put(&clear_cid, &clear_composite.to_dag_cbor().unwrap())
+            .await
+            .unwrap();
+        let outcome = handler
+            .process_composite_delta(
+                &clear_cid,
+                &clear_composite,
+                &clear_payload,
+                &BlockMetadata::normal(
+                    &doc_id_str,
+                    "col-agentdocs",
+                    "did:key:z6MkrClr",
+                    None,
+                    false,
+                ),
+                false,
+                0,
+            )
+            .await
+            .expect("immutable clear rejection is a terminal skip, not a hard error");
+        assert!(
+            outcome.is_terminal_skip(),
+            "clearing an immutable field must be terminally skipped, got {outcome:?}"
+        );
+    }
+
     /// A remotely-deleted document still retains its bytes (handle_deletion only
     /// sets the marker), so a later merge that re-materializes it must NOT be able
     /// to change an immutable field via delete+recreate. Without the

--- a/crates/db-merge/src/merge_handler/mod.rs
+++ b/crates/db-merge/src/merge_handler/mod.rs
@@ -1730,7 +1730,7 @@ mod tests {
             None,
             false,
         );
-        let result = handler
+        let outcome = handler
             .process_composite_delta(
                 &update_composite_cid,
                 &update_composite_block,
@@ -1739,15 +1739,14 @@ mod tests {
                 false,
                 0,
             )
-            .await;
+            .await
+            .expect("an immutable-field rejection is a terminal skip, not a hard error");
 
+        // The rejection must be TERMINAL (skipped), not a transient Err — a hard
+        // error would leave the CID unmarked and re-fetched on every sync pass.
         assert!(
-            result.is_err(),
-            "remote merge changing an immutable field must be rejected, got {result:?}"
-        );
-        assert!(
-            result.unwrap_err().to_string().contains("immutable"),
-            "rejection should cite the immutable field"
+            outcome.is_terminal_skip(),
+            "remote merge changing an immutable field must be terminally skipped, got {outcome:?}"
         );
 
         // The locally-stored immutable value must be unchanged.

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -49,6 +49,7 @@ async fn document_matches_filter<R: Reader + ?Sized>(
 /// If an SE encryption key is provided, also generates and pushes SE artifacts
 /// for collections with encrypted indexes. The identity pubkey is threaded
 /// through SE artifact generation to ensure per-identity tag isolation.
+#[allow(clippy::too_many_arguments)]
 pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
     handle: &p2p::P2PHostHandle,
     db: &DB<S>,
@@ -76,6 +77,7 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
 }
 
 /// Push existing documents to a replicator peer with explicit replay limits.
+#[allow(clippy::too_many_arguments)]
 pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>(
     handle: &p2p::P2PHostHandle,
     db: &DB<S>,

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -16,6 +16,32 @@ pub struct PushExistingDocsSeOptions<'a> {
     pub identity_pubkey: Option<&'a [u8]>,
 }
 
+async fn document_matches_filter<R: Reader + ?Sized>(
+    datastore: &R,
+    collection_id: &str,
+    doc_id: &str,
+    filter: &p2p::ReplicationFilter,
+) -> Result<bool, String> {
+    let doc_key = format!("/d/{}/{}", collection_id, doc_id).into_bytes();
+    let Some(doc_data) = datastore
+        .get(&doc_key)
+        .await
+        .map_err(|e| format!("failed to read document for replication filter: {}", e))?
+    else {
+        return Ok(false);
+    };
+
+    let doc = document::Document::from_cbor(&doc_data)
+        .map_err(|e| format!("failed to decode document for replication filter: {}", e))?;
+    let document_json = serde_json::Value::Object(
+        doc.to_map()
+            .map_err(|e| format!("failed to encode document for replication filter: {}", e))?
+            .into_iter()
+            .collect(),
+    );
+    Ok(filter.matches_json_object(&document_json))
+}
+
 /// Push existing documents to a replicator peer.
 ///
 /// Matches Go's `pushHeadsForAllDocs`: for each collection, iterate all docs,
@@ -29,6 +55,7 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
     document_acp: Option<&dyn DocumentACP>,
     peer_id: libp2p::PeerId,
     collections: &[String],
+    filters: &p2p::ReplicationFilters,
     se_encryption_key: Option<&[u8]>,
     se_identity_pubkey: Option<&[u8]>,
 ) -> Result<(), String> {
@@ -38,6 +65,7 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
         document_acp,
         peer_id,
         collections,
+        filters,
         PushExistingDocsSeOptions {
             encryption_key: se_encryption_key,
             identity_pubkey: se_identity_pubkey,
@@ -54,6 +82,7 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
     document_acp: Option<&dyn DocumentACP>,
     peer_id: libp2p::PeerId,
     collections: &[String],
+    filters: &p2p::ReplicationFilters,
     se_options: PushExistingDocsSeOptions<'_>,
     replay_config: ReplayPushConfig,
 ) -> Result<(), String> {
@@ -147,6 +176,14 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
         // processes the composite block, otherwise it tries Bitswap which
         // doesn't work reliably cross-platform.
         for doc_id in &doc_ids {
+            if let Some(filter) = filters.get(collection.collection_id()) {
+                if !document_matches_filter(&datastore, collection.collection_id(), doc_id, filter)
+                    .await?
+                {
+                    continue;
+                }
+            }
+
             let creator = match resolve_push_creator(
                 document_acp,
                 &collection,
@@ -331,6 +368,19 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
             // For each document, load field values and generate artifacts.
             let mut all_artifacts = Vec::new();
             for doc_id in &se_doc_ids {
+                if let Some(filter) = filters.get(collection.collection_id()) {
+                    if !document_matches_filter(
+                        &datastore,
+                        collection.collection_id(),
+                        doc_id,
+                        filter,
+                    )
+                    .await?
+                    {
+                        continue;
+                    }
+                }
+
                 // Read document CBOR from datastore: /d/{collection_id}/{doc_id}
                 let doc_key = format!("/d/{}/{}", collection.collection_id(), doc_id).into_bytes();
                 let doc_data = match datastore.get(&doc_key).await {
@@ -410,6 +460,7 @@ pub async fn retry_doc<S: Store + 'static>(
     peer_id: libp2p::PeerId,
     doc_id: &str,
     collection_id: &str,
+    filters: &p2p::ReplicationFilters,
 ) -> Result<(), String> {
     let local_peer_id = handle
         .local_peer_id()
@@ -420,6 +471,18 @@ pub async fn retry_doc<S: Store + 'static>(
         .find_collection_by_id(collection_id)
         .map_err(|e| format!("failed to get collection: {}", e))?
         .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
+    if let Some(filter) = filters.get(collection_id) {
+        let txn = db
+            .new_txn(true)
+            .await
+            .map_err(|e| format!("failed to create filter transaction: {}", e))?;
+        let datastore = txn
+            .datastore()
+            .map_err(|e| format!("failed to get datastore: {}", e))?;
+        if !document_matches_filter(&datastore, collection_id, doc_id, filter).await? {
+            return Ok(());
+        }
+    }
     let creator = resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id_str)
         .await
         .map_err(|e| e.to_string())?;

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -12,6 +12,32 @@ use crate::push_docs_creator::resolve_push_creator;
 use crate::push_docs_replay::{ReplayPushConfig, ReplayPushGate};
 use db::database::DB;
 
+async fn document_matches_filter<R: Reader + ?Sized>(
+    datastore: &R,
+    collection_id: &str,
+    doc_id: &str,
+    filter: &p2p::ReplicationFilter,
+) -> Result<bool, String> {
+    let doc_key = format!("/d/{}/{}", collection_id, doc_id).into_bytes();
+    let Some(doc_data) = datastore
+        .get(&doc_key)
+        .await
+        .map_err(|e| format!("failed to read document for replication filter: {}", e))?
+    else {
+        return Ok(false);
+    };
+
+    let doc = document::Document::from_cbor(&doc_data)
+        .map_err(|e| format!("failed to decode document for replication filter: {}", e))?;
+    let document_json = serde_json::Value::Object(
+        doc.to_map()
+            .map_err(|e| format!("failed to encode document for replication filter: {}", e))?
+            .into_iter()
+            .collect(),
+    );
+    Ok(filter.matches_json_object(&document_json))
+}
+
 /// Push existing documents to a replicator peer via a generic transport.
 ///
 /// Transport-agnostic equivalent of `push_existing_docs`. Uses `P2PTransport`
@@ -22,6 +48,7 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
     document_acp: Option<&dyn DocumentACP>,
     peer_id: &PeerId,
     collections: &[String],
+    filters: &p2p::ReplicationFilters,
     se_encryption_key: Option<&[u8]>,
 ) -> Result<(), String> {
     push_existing_docs_via_transport_with_config(
@@ -30,6 +57,7 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
         document_acp,
         peer_id,
         collections,
+        filters,
         se_encryption_key,
         ReplayPushConfig::default(),
     )
@@ -43,6 +71,7 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
     document_acp: Option<&dyn DocumentACP>,
     peer_id: &PeerId,
     collections: &[String],
+    filters: &p2p::ReplicationFilters,
     se_encryption_key: Option<&[u8]>,
     replay_config: ReplayPushConfig,
 ) -> Result<(), String> {
@@ -133,6 +162,14 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
             .map_err(|e| format!("datastore close error: {}", e))?;
 
         for doc_id in &doc_ids {
+            if let Some(filter) = filters.get(collection.collection_id()) {
+                if !document_matches_filter(&datastore, collection.collection_id(), doc_id, filter)
+                    .await?
+                {
+                    continue;
+                }
+            }
+
             let creator = match resolve_push_creator(
                 document_acp,
                 &collection,
@@ -306,6 +343,19 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
 
             let mut all_artifacts = Vec::new();
             for doc_id in &se_doc_ids {
+                if let Some(filter) = filters.get(collection.collection_id()) {
+                    if !document_matches_filter(
+                        &datastore,
+                        collection.collection_id(),
+                        doc_id,
+                        filter,
+                    )
+                    .await?
+                    {
+                        continue;
+                    }
+                }
+
                 let doc_key = format!("/d/{}/{}", collection.collection_id(), doc_id).into_bytes();
                 let doc_data = match datastore.get(&doc_key).await {
                     Ok(Some(data)) => data,
@@ -382,12 +432,25 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
     peer_id: &PeerId,
     doc_id: &str,
     collection_id: &str,
+    filters: &p2p::ReplicationFilters,
 ) -> Result<(), String> {
     let local_peer_id = transport.local_peer_id().to_string();
     let collection = db
         .find_collection_by_id(collection_id)
         .map_err(|e| format!("failed to get collection: {}", e))?
         .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
+    if let Some(filter) = filters.get(collection_id) {
+        let txn = db
+            .new_txn(true)
+            .await
+            .map_err(|e| format!("failed to create filter transaction: {}", e))?;
+        let datastore = txn
+            .datastore()
+            .map_err(|e| format!("failed to get datastore: {}", e))?;
+        if !document_matches_filter(&datastore, collection_id, doc_id, filter).await? {
+            return Ok(());
+        }
+    }
     let creator = resolve_push_creator(document_acp, &collection, doc_id, &local_peer_id)
         .await
         .map_err(|e| e.to_string())?;

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -65,6 +65,7 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
 }
 
 /// Push existing documents to a replicator peer via a generic transport with explicit replay limits.
+#[allow(clippy::too_many_arguments)]
 pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T: P2PTransport>(
     transport: &T,
     db: &DB<S>,

--- a/crates/db-merge/src/txn_broadcaster.rs
+++ b/crates/db-merge/src/txn_broadcaster.rs
@@ -43,6 +43,7 @@ where
             doc_id,
             doc_cid,
             doc_block,
+            document_json,
             collection_block,
             creator_did,
         } = event;
@@ -55,14 +56,26 @@ where
         tokio::spawn(async move {
             let creator_ref = creator_did.as_deref();
 
-            sync.push_to_replicators_with_creator(
-                &doc_cid,
-                &doc_block,
-                &doc_id,
-                &collection_id,
-                creator_ref,
-            )
-            .await;
+            if let Some(document_json) = document_json.as_ref() {
+                sync.push_document_to_replicators_with_creator(
+                    &doc_cid,
+                    &doc_block,
+                    &doc_id,
+                    &collection_id,
+                    document_json,
+                    creator_ref,
+                )
+                .await;
+            } else {
+                sync.push_to_replicators_with_creator(
+                    &doc_cid,
+                    &doc_block,
+                    &doc_id,
+                    &collection_id,
+                    creator_ref,
+                )
+                .await;
+            }
 
             let doc_block_result = BlockResult {
                 cid: doc_cid,

--- a/crates/db/src/auto_commit_mutator/batch.rs
+++ b/crates/db/src/auto_commit_mutator/batch.rs
@@ -78,6 +78,7 @@ impl<S: Store + 'static> BatchMutator<S> {
             doc_id,
             doc_cid,
             doc_block,
+            None,
             collection_block,
             None,
         )

--- a/crates/db/src/collection/crud.rs
+++ b/crates/db/src/collection/crud.rs
@@ -77,15 +77,21 @@ impl Collection {
 
         let key = self.doc_key(doc_id);
 
-        // Check document exists
-        if !txn.datastore()?.has(&key).await.map_err(Error::Storage)? {
-            return Err(Error::DocumentNotFound(doc_id.to_string()));
-        }
+        let datastore = txn.datastore()?;
+        let old_doc = match datastore.get(&key).await.map_err(Error::Storage)? {
+            Some(bytes) => {
+                let mut d = Document::from_cbor(&bytes)?;
+                d.set_id(doc_id.clone());
+                d
+            }
+            None => return Err(Error::DocumentNotFound(doc_id.to_string())),
+        };
+
+        self.validate_immutable_fields_unchanged(&old_doc, doc)?;
 
         // Serialize and store
         let data = doc.to_cbor()?;
 
-        let datastore = txn.datastore()?;
         datastore.set(&key, &data).await.map_err(Error::Storage)?;
 
         // Update schema version to current collection version

--- a/crates/db/src/collection/crud_datastore.rs
+++ b/crates/db/src/collection/crud_datastore.rs
@@ -185,10 +185,16 @@ impl Collection {
 
         let key = self.doc_key(doc_id);
 
-        // Check document exists
-        if !datastore.has(&key).await.map_err(Error::Storage)? {
-            return Err(Error::DocumentNotFound(doc_id.to_string()));
-        }
+        let old_doc = match datastore.get(&key).await.map_err(Error::Storage)? {
+            Some(bytes) => {
+                let mut d = Document::from_cbor(&bytes)?;
+                d.set_id(doc_id.clone());
+                d
+            }
+            None => return Err(Error::DocumentNotFound(doc_id.to_string())),
+        };
+
+        self.validate_immutable_fields_unchanged(&old_doc, doc)?;
 
         // Serialize and store
         let data = doc.to_cbor()?;

--- a/crates/db/src/collection/index_ops.rs
+++ b/crates/db/src/collection/index_ops.rs
@@ -82,6 +82,8 @@ impl Collection {
             None => return Err(Error::DocumentNotFound(doc_id.to_string())),
         };
 
+        self.validate_immutable_fields_unchanged(&old_doc, doc)?;
+
         // Serialize and store
         let data = doc.to_cbor()?;
 

--- a/crates/db/src/collection/validation.rs
+++ b/crates/db/src/collection/validation.rs
@@ -26,6 +26,24 @@ impl Collection {
         }
         Ok(())
     }
+
+    pub(crate) fn validate_immutable_fields_unchanged(
+        &self,
+        old_doc: &Document,
+        new_doc: &Document,
+    ) -> Result<()> {
+        for field_def in self.def.fields.iter().filter(|field| field.immutable) {
+            let old_value = old_doc.get(&field_def.name);
+            let new_value = new_doc.get(&field_def.name);
+            if old_value != new_value {
+                return Err(Error::InvalidDocument(format!(
+                    "immutable field '{}' cannot be changed",
+                    field_def.name
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Check if a NormalValue is compatible with a FieldKind.
@@ -216,5 +234,51 @@ fn is_empty_array(value: &NormalValue) -> bool {
         NormalValue::NillableFloat64ElementArray(arr) => arr.is_empty(),
         NormalValue::NillableStringElementArray(arr) => arr.is_empty(),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use schema::{CollectionVersion, FieldDescription, FieldKind};
+
+    fn filtered_collection() -> Collection {
+        Collection::new(CollectionVersion::new(
+            "AgentDoc",
+            "agent_doc_version",
+            "agent_doc_collection",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "agent_did", FieldKind::string()).as_immutable(),
+                FieldDescription::new("3", "body", FieldKind::string()),
+            ],
+        ))
+    }
+
+    #[test]
+    fn immutable_field_validation_allows_other_field_changes() {
+        let collection = filtered_collection();
+        let old_doc =
+            Document::from_json_str(r#"{"agent_did":"did:key:z6M","body":"before"}"#).unwrap();
+        let new_doc =
+            Document::from_json_str(r#"{"agent_did":"did:key:z6M","body":"after"}"#).unwrap();
+
+        collection
+            .validate_immutable_fields_unchanged(&old_doc, &new_doc)
+            .unwrap();
+    }
+
+    #[test]
+    fn immutable_field_validation_rejects_key_changes() {
+        let collection = filtered_collection();
+        let old_doc =
+            Document::from_json_str(r#"{"agent_did":"did:key:z6M","body":"before"}"#).unwrap();
+        let new_doc =
+            Document::from_json_str(r#"{"agent_did":"did:key:other","body":"before"}"#).unwrap();
+
+        let result = collection.validate_immutable_fields_unchanged(&old_doc, &new_doc);
+        assert!(
+            matches!(result, Err(Error::InvalidDocument(message)) if message.contains("agent_did"))
+        );
     }
 }

--- a/crates/db/src/collection/validation.rs
+++ b/crates/db/src/collection/validation.rs
@@ -27,7 +27,7 @@ impl Collection {
         Ok(())
     }
 
-    pub(crate) fn validate_immutable_fields_unchanged(
+    pub fn validate_immutable_fields_unchanged(
         &self,
         old_doc: &Document,
         new_doc: &Document,

--- a/crates/db/src/doc_mutator.rs
+++ b/crates/db/src/doc_mutator.rs
@@ -18,6 +18,12 @@ use crate::txn::DbTxn;
 use defra_core::encryption::{get_doc_encryption, get_encryption_config, store_doc_encryption};
 use defra_core::signing::get_signing_config;
 
+fn document_json_value(doc: &Document) -> Option<serde_json::Value> {
+    Some(serde_json::Value::Object(
+        doc.to_map().ok()?.into_iter().collect(),
+    ))
+}
+
 /// Document mutator that uses a database transaction.
 ///
 /// This mutator holds a reference to an active transaction and uses the
@@ -137,6 +143,7 @@ impl<S: Store + 'static> DbDocMutator<S> {
         doc_id: String,
         doc_cid: Cid,
         doc_block: Vec<u8>,
+        document_json: Option<serde_json::Value>,
         collection_block: Option<(Cid, Vec<u8>)>,
     ) -> query::error::Result<()> {
         let mut txn_guard = self.txn.lock().await;
@@ -153,6 +160,7 @@ impl<S: Store + 'static> DbDocMutator<S> {
             doc_id,
             doc_cid,
             doc_block,
+            document_json,
             collection_block,
             creator_did,
         )
@@ -283,6 +291,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             doc_id.to_string(),
             doc_cid,
             doc_block,
+            document_json_value(&doc),
             col_block_data,
         )
         .await?;
@@ -399,6 +408,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
                 doc_id.to_string(),
                 doc_cid,
                 doc_block,
+                document_json_value(&doc),
                 col_block_data,
             )
             .await?;
@@ -422,6 +432,12 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             get_collection_with_index_manager(&self.txn, collection_name).await?;
         self.ensure_collection_can_write(collection_name, &collection)
             .await?;
+        let pre_delete_document_json = collection
+            .get_with_datastore(&datastore, doc_id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|doc| document_json_value(&doc));
 
         let existed = collection
             .delete_with_indexes(&datastore, doc_id, &index_manager)
@@ -498,6 +514,7 @@ impl<S: Store + 'static> DocMutator for DbDocMutator<S> {
             doc_id.to_string(),
             doc_cid,
             doc_block,
+            pre_delete_document_json,
             col_block_data,
         )
         .await?;
@@ -717,6 +734,11 @@ mod tests {
         assert_eq!(event.collection_name, "TestDoc");
         assert_ne!(event.doc_cid, cid::Cid::default(), "doc_cid populated");
         assert!(!event.doc_block.is_empty(), "doc_block populated");
+        assert_eq!(
+            event.document_json.as_ref().and_then(|json| json.get("x")),
+            Some(&serde_json::json!(1)),
+            "document_json populated for filtered transaction replication"
+        );
     }
 
     #[tokio::test]

--- a/crates/db/src/event_emission.rs
+++ b/crates/db/src/event_emission.rs
@@ -21,6 +21,7 @@ pub struct TxnBroadcastEvent {
     pub doc_id: String,
     pub doc_cid: Cid,
     pub doc_block: Vec<u8>,
+    pub document_json: Option<serde_json::Value>,
     pub collection_block: Option<(Cid, Vec<u8>)>,
     pub creator_did: Option<String>,
 }
@@ -59,6 +60,7 @@ pub(crate) fn register_update_event_callback<S: Store + 'static>(
     doc_id: String,
     doc_cid: Cid,
     doc_block: Vec<u8>,
+    document_json: Option<serde_json::Value>,
     collection_block: Option<(Cid, Vec<u8>)>,
     creator_did: Option<String>,
 ) -> Result<()> {
@@ -102,6 +104,7 @@ pub(crate) fn register_update_event_callback<S: Store + 'static>(
                     doc_id,
                     doc_cid,
                     doc_block,
+                    document_json,
                     collection_block,
                     creator_did,
                 };

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1577,6 +1577,12 @@ fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
                     continue;
                 }
 
+                let retry_filters = match peerstore.get_replicator(&peer_id_str).await {
+                    Ok(Some(bytes)) => p2p::ReplicatorInfo::from_bytes(&bytes)
+                        .map(|info| info.filters)
+                        .unwrap_or_default(),
+                    _ => p2p::ReplicationFilters::new(),
+                };
                 let mut all_succeeded = true;
                 for (doc_id, collection_id) in &docs {
                     match db_merge::retry_doc_via_transport(
@@ -1586,6 +1592,7 @@ fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
                         &peer_id,
                         doc_id,
                         collection_id,
+                        &retry_filters,
                     )
                     .await
                     {

--- a/crates/defra-node/src/p2p_tests.rs
+++ b/crates/defra-node/src/p2p_tests.rs
@@ -346,13 +346,20 @@ async fn install_one_way_replicator(
         .add_replicator(
             collection_names.clone(),
             Some(&sender_addr),
+            Default::default(),
             Vec::new(),
             None,
         )
         .await
         .expect("authorize sender as receiver-side replicator");
     sender_p2p
-        .add_replicator(collection_names, Some(&receiver_addr), Vec::new(), None)
+        .add_replicator(
+            collection_names,
+            Some(&receiver_addr),
+            Default::default(),
+            Vec::new(),
+            None,
+        )
         .await
         .expect("set sender -> receiver replicator");
 }
@@ -1135,12 +1142,24 @@ async fn live_replicator_pushes_post_config_writes() {
         .await
         .expect("subscribe node1 User");
 
-    p2p1.add_replicator(vec!["User".to_string()], Some(&addr0), Vec::new(), None)
-        .await
-        .expect("authorize node0 on node1");
-    p2p0.add_replicator(vec!["User".to_string()], Some(&addr1), Vec::new(), None)
-        .await
-        .expect("set replicator node0 -> node1");
+    p2p1.add_replicator(
+        vec!["User".to_string()],
+        Some(&addr0),
+        Default::default(),
+        Vec::new(),
+        None,
+    )
+    .await
+    .expect("authorize node0 on node1");
+    p2p0.add_replicator(
+        vec!["User".to_string()],
+        Some(&addr1),
+        Default::default(),
+        Vec::new(),
+        None,
+    )
+    .await
+    .expect("set replicator node0 -> node1");
 
     let response = node0
         .execute(r#"mutation { add_User(input: {name: "Alice", age: 30}) { _docID name age } }"#)

--- a/crates/embedded/src/node_recovery.rs
+++ b/crates/embedded/src/node_recovery.rs
@@ -10,15 +10,17 @@ pub(crate) async fn restore_libp2p_replicators<S: storage::corekv::Store + 'stat
                 match p2p::ReplicatorInfo::from_bytes(&data) {
                     Ok(info) => {
                         if let Some(peer_id) = info.peer_id() {
-                            if let Err(error) = handle
-                                .create_replicator(peer_id, info.collections.clone())
-                                .await
+                            if let Err(error) =
+                                handle.create_replicator_info(peer_id, info.clone()).await
                             {
                                 tracing::warn!(peer_id = %peer_id, error = %error, "failed to restore replicator");
                                 continue;
                             }
 
                             for collection_id in &info.collections {
+                                if info.is_filtered_for_collection(collection_id) {
+                                    continue;
+                                }
                                 let topic = DefraTopic::collection(collection_id);
                                 if let Err(error) = handle.subscribe(topic).await {
                                     tracing::warn!(collection_id = %collection_id, error = %error, "failed to restore collection topic");
@@ -64,7 +66,7 @@ pub(crate) async fn restore_iroh_replicators<S, B>(
                 if let Ok(rep_info) = p2p::ReplicatorInfo::from_bytes(&data) {
                     let peer_id = p2p::transport::PeerId::new(rep_info.peer_id_str().to_string());
                     let _ = coordinator
-                        .create_replicator(&peer_id, rep_info.collections.clone(), false)
+                        .create_replicator_info(&peer_id, rep_info, false)
                         .await;
                 }
             }

--- a/crates/embedded/tests/se_owner.rs
+++ b/crates/embedded/tests/se_owner.rs
@@ -85,6 +85,7 @@ async fn embedded_libp2p_se_owner_queries_replicator() -> Result<()> {
         .add_replicator(
             vec!["User".to_string()],
             Some(&replicator_addr),
+            Default::default(),
             Vec::new(),
             None,
         )
@@ -188,6 +189,7 @@ async fn embedded_iroh_se_owner_queries_replicator() -> Result<()> {
         .add_replicator(
             vec!["User".to_string()],
             Some(&replicator_addr),
+            Default::default(),
             Vec::new(),
             None,
         )

--- a/crates/ffi/src/p2p/replicator.rs
+++ b/crates/ffi/src/p2p/replicator.rs
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn p2p_add_replicator(
                 rt.block_on(async move {
                     p2p.system
                         .ops()
-                        .add_replicator(collections, Some(&addr), Vec::new(), None)
+                        .add_replicator(collections, Some(&addr), Default::default(), Vec::new(), None)
                         .await
                         .map_err(FfiP2PError::from)
                 })

--- a/crates/http/src/handlers/p2p/replicators.rs
+++ b/crates/http/src/handlers/p2p/replicators.rs
@@ -230,6 +230,7 @@ mod tests {
             collection_ids: vec!["Users".to_string(), "Posts".to_string()],
             status: 0,
             last_status_change: "0001-01-01T00:00:00Z".to_string(),
+            filters: Default::default(),
         };
         let json = serde_json::to_string(&response).unwrap();
         // Verify PascalCase field names

--- a/crates/http/src/handlers/p2p/replicators.rs
+++ b/crates/http/src/handlers/p2p/replicators.rs
@@ -7,7 +7,7 @@ use super::{map_p2p_bad_request, map_p2p_internal};
 use crate::error::HttpError;
 use crate::identity_extractor::ExtractIdentity;
 use crate::nac_guard::require_permission;
-use crate::router::{AppState, ExplicitReplayCapabilityInput, NodePermission};
+use crate::router::{AppState, ExplicitReplayCapabilityInput, NodePermission, ReplicationFilters};
 use crate::validation::{validate_collection_name, validate_multiaddr};
 
 /// Response for replicator info (Go-compatible format with PascalCase).
@@ -29,6 +29,12 @@ pub struct ReplicatorInfoResponse {
     /// Last time the status changed, formatted like Go's time.Time JSON.
     #[serde(rename = "LastStatusChange")]
     pub last_status_change: String,
+    /// Optional Rust extension for filtered replication.
+    #[serde(
+        rename = "Filters",
+        skip_serializing_if = "ReplicationFilters::is_empty"
+    )]
+    pub filters: ReplicationFilters,
 }
 
 /// Request to add a replicator (Go-compatible format).
@@ -42,6 +48,9 @@ pub struct ReplicatorRequest {
     pub addresses: Vec<String>,
     #[serde(rename = "ExplicitReplayCapabilities", default)]
     pub explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
+    /// Optional per-collection filtered replication predicates.
+    #[serde(rename = "Filters", default)]
+    pub filters: ReplicationFilters,
 }
 
 /// Request body for replicator removal (Go-compatible).
@@ -86,6 +95,7 @@ pub async fn list_replicators(
             last_status_change: r
                 .last_status_change
                 .unwrap_or_else(|| "0001-01-01T00:00:00Z".to_string()),
+            filters: r.filters,
         })
         .collect();
 
@@ -131,6 +141,7 @@ pub async fn add_replicator(
     p2p.add_replicator(
         request.collections,
         addr,
+        request.filters,
         request.explicit_replay_capabilities,
         expected_authorizer_did.as_deref(),
     )

--- a/crates/http/src/mock/p2p.rs
+++ b/crates/http/src/mock/p2p.rs
@@ -61,6 +61,7 @@ impl MockP2POperations {
             address,
             status: Some(0),
             last_status_change: Some("0001-01-01T00:00:00Z".to_string()),
+            filters: Default::default(),
         });
         self
     }
@@ -113,6 +114,7 @@ impl P2POperations for MockP2POperations {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
+        filters: crate::router::ReplicationFilters,
         _explicit_replay_capabilities: Vec<crate::router::ExplicitReplayCapabilityInput>,
         _expected_authorizer_did: Option<&str>,
     ) -> P2PResult<()> {
@@ -122,6 +124,7 @@ impl P2POperations for MockP2POperations {
             address: addr.map(|s| s.to_string()),
             status: Some(0),
             last_status_change: Some("0001-01-01T00:00:00Z".to_string()),
+            filters,
         });
         Ok(())
     }
@@ -230,6 +233,7 @@ impl P2POperations for FailingMockP2POperations {
         &self,
         _collections: Vec<String>,
         _addr: Option<&str>,
+        _filters: crate::router::ReplicationFilters,
         _explicit_replay_capabilities: Vec<crate::router::ExplicitReplayCapabilityInput>,
         _expected_authorizer_did: Option<&str>,
     ) -> P2PResult<()> {

--- a/crates/http/src/router/mod.rs
+++ b/crates/http/src/router/mod.rs
@@ -13,7 +13,7 @@ pub use traits::{
     IndexInfo, IndexOperations, LensOperations, ManageRequester, NacStatus, NacStatusInfo,
     NodeAcpOperations, NodePermission, P2PError, P2POperations, P2PResult, P2pDocumentInfo,
     P2pDocumentRequest, PolicyInfo, RemoteManageDocRef, RemoteManageOp, RemoteManageQueryOp,
-    RemoteManageQueryResult, ReplicatorInfo, SchemaOperations, SyncBranchableRequest,
-    SyncDocumentsRequest, SyncVersionsRequest, TransactionOperations, ViewOperations,
-    MANAGE_UNAUTHORIZED,
+    RemoteManageQueryResult, ReplicationFilter, ReplicationFilters, ReplicatorInfo,
+    SchemaOperations, SyncBranchableRequest, SyncDocumentsRequest, SyncVersionsRequest,
+    TransactionOperations, ViewOperations, MANAGE_UNAUTHORIZED,
 };

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -328,6 +328,7 @@ mod tests {
             &self,
             _collections: Vec<String>,
             _addr: Option<&str>,
+            _filters: crate::router::ReplicationFilters,
             _explicit_replay_capabilities: Vec<crate::router::ExplicitReplayCapabilityInput>,
             _expected_authorizer_did: Option<&str>,
         ) -> P2PResult<()> {

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -2,6 +2,18 @@
 
 use thiserror::Error;
 
+pub type ReplicationFilters = std::collections::BTreeMap<String, ReplicationFilter>;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ReplicationFilter {
+    #[serde(rename = "Field")]
+    pub field: String,
+    #[serde(rename = "Value")]
+    pub value: serde_json::Value,
+}
+
+impl Eq for ReplicationFilter {}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExplicitReplayCapabilityInput {
     #[serde(rename = "CollectionID")]
@@ -90,6 +102,7 @@ pub trait P2POperations: Send + Sync {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
+        filters: ReplicationFilters,
         explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
         expected_authorizer_did: Option<&str>,
     ) -> P2PResult<()>;
@@ -137,6 +150,7 @@ pub struct ReplicatorInfo {
     pub address: Option<String>,
     pub status: Option<u8>,
     pub last_status_change: Option<String>,
+    pub filters: ReplicationFilters,
 }
 
 /// P2P document information for HTTP responses.

--- a/crates/p2p-adapter/Cargo.toml
+++ b/crates/p2p-adapter/Cargo.toml
@@ -20,6 +20,7 @@ events = { path = "../events" }
 identity = { path = "../identity" }
 lens = { path = "../lens" }
 p2p = { path = "../p2p", default-features = false }
+schema = { path = "../schema" }
 storage = { path = "../storage" }
 
 async-trait.workspace = true

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -8,7 +8,7 @@ use crate::transport_doc_pusher::TransportDocPusher;
 use crate::transport_version_syncer::TransportVersionSyncer;
 use crate::{
     ExplicitReplayCapabilityInput, P2PError, P2PErrorExt as _, P2POperations, P2PResult,
-    P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo, ReplicatorPushOptions,
+    P2pDocumentInfo, P2pDocumentRequest, ReplicationFilters, ReplicatorInfo, ReplicatorPushOptions,
     ReplicatorPushOptionsState,
 };
 
@@ -88,6 +88,48 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
     pub fn with_replicator_push_options(mut self, options: ReplicatorPushOptions) -> Self {
         self.replicator_push_options = ReplicatorPushOptionsState::new(options);
         self
+    }
+
+    fn resolve_replication_filters(
+        filters: ReplicationFilters,
+        effective_collections: &[String],
+        collection_cids: &[String],
+    ) -> P2PResult<p2p::ReplicationFilters> {
+        let mut resolved = p2p::ReplicationFilters::new();
+        for (key, filter) in filters {
+            if filter.field.trim().is_empty() {
+                return Err(P2PError::invalid_input(
+                    "replication filter field cannot be empty",
+                ));
+            }
+            if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
+                return Err(P2PError::invalid_input(format!(
+                    "replication filter for collection '{key}' must use a scalar value"
+                )));
+            }
+
+            let collection_id = collection_cids
+                .iter()
+                .position(|collection_id| collection_id == &key)
+                .or_else(|| {
+                    effective_collections
+                        .iter()
+                        .position(|collection_name| collection_name == &key)
+                })
+                .and_then(|index| collection_cids.get(index))
+                .cloned()
+                .ok_or_else(|| {
+                    P2PError::invalid_input(format!(
+                        "replication filter collection '{key}' was not requested"
+                    ))
+                })?;
+
+            resolved.insert(
+                collection_id,
+                p2p::ReplicationFilter::new(filter.field, filter.value),
+            );
+        }
+        Ok(resolved)
     }
 
     pub fn with_replicator_push_options_state(
@@ -281,6 +323,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
+        filters: ReplicationFilters,
         _explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
         _expected_authorizer_did: Option<&str>,
     ) -> P2PResult<()> {
@@ -317,11 +360,22 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         } else {
             collection_cids.clone_from(&effective_collections);
         }
+        let replication_filters =
+            Self::resolve_replication_filters(filters, &effective_collections, &collection_cids)?;
+        if !replication_filters.is_empty() {
+            self.doc_pusher
+                .as_ref()
+                .ok_or_else(|| P2PError::unsupported("no database context to validate filters"))?
+                .validate_replication_filters(&replication_filters)?;
+        }
 
         // Check existing replicator state before creating/updating so we can
         // skip the expensive initial replay when the replicator already exists
         // with the same collections (idempotent reconnect path).
-        let existing_collection_ids: HashSet<String> = {
+        let (existing_collection_ids, existing_filters): (
+            HashSet<String>,
+            p2p::ReplicationFilters,
+        ) = {
             let result = if let Some(ref coordinator) = self.sync_coordinator {
                 coordinator
                     .get_replicator(&peer_id)
@@ -334,17 +388,22 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                     .map_err(|error| P2PError::transport(error.to_string()))
             };
             match result {
-                Ok(Some(info)) => info.collections.into_iter().collect(),
-                Ok(None) => HashSet::new(),
+                Ok(Some(info)) => (info.collections.into_iter().collect(), info.filters),
+                Ok(None) => (HashSet::new(), p2p::ReplicationFilters::new()),
                 Err(e) => {
                     tracing::warn!(
                         peer_id = %peer_id,
                         error = %e,
                         "Failed to check existing replicator state; falling back to full replay"
                     );
-                    HashSet::new()
+                    (HashSet::new(), p2p::ReplicationFilters::new())
                 }
             }
+        };
+        let existing_collection_ids = if existing_filters == replication_filters {
+            existing_collection_ids
+        } else {
+            HashSet::new()
         };
 
         self.transport
@@ -359,22 +418,37 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         }
 
         if let Some(ref coordinator) = self.sync_coordinator {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
             coordinator
-                .create_replicator(&peer_id, collection_cids.clone(), true)
+                .create_replicator_info(&peer_id, info, true)
                 .await
                 .map_err(|error| P2PError::transport(error.to_string()))?;
         } else {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
             self.transport
-                .create_replicator(&peer_id, collection_cids.clone())
+                .create_replicator_info(&peer_id, info)
                 .await
                 .map_err(|error| P2PError::transport(error.to_string()))?;
         }
 
         if let Some(ref pusher) = self.doc_pusher {
-            if let Err(error) = pusher
-                .persist_replicator(&peer_id.to_string(), &collection_cids)
-                .await
-            {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
+            if let Err(error) = pusher.persist_replicator_info(&info).await {
                 tracing::warn!(peer_id = %peer_id, error = %error, "failed to persist replicator");
             }
         }
@@ -394,6 +468,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                 let push_peer = peer_id;
                 let push_options = self.replicator_push_options.load();
                 let push_se_key = push_options.se_encryption_key;
+                let push_filters = replication_filters.clone();
 
                 tracing::info!(
                     peer_id = %push_peer,
@@ -406,6 +481,7 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
                         .push_existing_docs(
                             &push_peer,
                             &new_collection_names,
+                            &push_filters,
                             push_se_key.as_ref().map(|key| key.as_slice()),
                         )
                         .await

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -35,7 +35,7 @@ pub use version_syncer::DbVersionSyncer;
 
 pub use defra_http::router::{
     ExplicitReplayCapabilityInput, P2PError, P2POperations, P2PResult, P2pDocumentInfo,
-    P2pDocumentRequest, ReplicatorInfo,
+    P2pDocumentRequest, ReplicationFilter, ReplicationFilters, ReplicatorInfo,
 };
 
 /// Convert a p2p `ReplicatorInfo` into the HTTP-facing `ReplicatorInfo`.
@@ -49,6 +49,19 @@ pub(crate) fn to_http_replicator_info(info: p2p::ReplicatorInfo) -> ReplicatorIn
         address,
         status,
         last_status_change,
+        filters: info
+            .filters
+            .into_iter()
+            .map(|(collection, filter)| {
+                (
+                    collection,
+                    defra_http::router::ReplicationFilter {
+                        field: filter.field,
+                        value: filter.value,
+                    },
+                )
+            })
+            .collect(),
     }
 }
 

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -7,7 +7,7 @@ use blockstore::Blockstore;
 use crate::libp2p_doc_pusher::DocPusher;
 use crate::{
     ExplicitReplayCapabilityInput, P2PError, P2PErrorExt as _, P2POperations, P2PResult,
-    P2pDocumentInfo, P2pDocumentRequest, ReplicatorInfo, ReplicatorPushOptions,
+    P2pDocumentInfo, P2pDocumentRequest, ReplicationFilters, ReplicatorInfo, ReplicatorPushOptions,
     ReplicatorPushOptionsState,
 };
 
@@ -127,6 +127,48 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
             tracked_documents: Arc::new(std::sync::RwLock::new(HashSet::new())),
             nac_checker: Some(nac_checker),
         }
+    }
+
+    fn resolve_replication_filters(
+        filters: ReplicationFilters,
+        effective_collections: &[String],
+        collection_cids: &[String],
+    ) -> P2PResult<p2p::ReplicationFilters> {
+        let mut resolved = p2p::ReplicationFilters::new();
+        for (key, filter) in filters {
+            if filter.field.trim().is_empty() {
+                return Err(P2PError::invalid_input(
+                    "replication filter field cannot be empty",
+                ));
+            }
+            if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
+                return Err(P2PError::invalid_input(format!(
+                    "replication filter for collection '{key}' must use a scalar value"
+                )));
+            }
+
+            let collection_id = collection_cids
+                .iter()
+                .position(|collection_id| collection_id == &key)
+                .or_else(|| {
+                    effective_collections
+                        .iter()
+                        .position(|collection_name| collection_name == &key)
+                })
+                .and_then(|index| collection_cids.get(index))
+                .cloned()
+                .ok_or_else(|| {
+                    P2PError::invalid_input(format!(
+                        "replication filter collection '{key}' was not requested"
+                    ))
+                })?;
+
+            resolved.insert(
+                collection_id,
+                p2p::ReplicationFilter::new(filter.field, filter.value),
+            );
+        }
+        Ok(resolved)
     }
 
     pub fn with_replicator_push_options(mut self, options: ReplicatorPushOptions) -> Self {
@@ -269,6 +311,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         &self,
         collections: Vec<String>,
         addr: Option<&str>,
+        filters: ReplicationFilters,
         explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
         expected_authorizer_did: Option<&str>,
     ) -> P2PResult<()> {
@@ -305,6 +348,14 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         } else {
             collection_cids.clone_from(&effective_collections);
         }
+        let replication_filters =
+            Self::resolve_replication_filters(filters, &effective_collections, &collection_cids)?;
+        if !replication_filters.is_empty() {
+            self.doc_pusher
+                .as_ref()
+                .ok_or_else(|| P2PError::unsupported("no database context to validate filters"))?
+                .validate_replication_filters(&replication_filters)?;
+        }
 
         let peer_id = parsed.peer_id;
         for explicit in explicit_replay_capabilities {
@@ -333,7 +384,10 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         // Check existing replicator state before creating/updating so we can
         // skip the expensive initial replay when the replicator already exists
         // with the same collections (idempotent reconnect path).
-        let existing_collection_ids: HashSet<String> = {
+        let (existing_collection_ids, existing_filters): (
+            HashSet<String>,
+            p2p::ReplicationFilters,
+        ) = {
             let result = if let Some(ref coordinator) = self.sync_coordinator {
                 let transport_peer_id = p2p::transport::PeerId::from(peer_id);
                 coordinator
@@ -347,17 +401,22 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                     .map_err(|error| P2PError::transport(error.to_string()))
             };
             match result {
-                Ok(Some(info)) => info.collections.into_iter().collect(),
-                Ok(None) => HashSet::new(),
+                Ok(Some(info)) => (info.collections.into_iter().collect(), info.filters),
+                Ok(None) => (HashSet::new(), p2p::ReplicationFilters::new()),
                 Err(e) => {
                     tracing::warn!(
                         peer_id = %peer_id,
                         error = %e,
                         "Failed to check existing replicator state; falling back to full replay"
                     );
-                    HashSet::new()
+                    (HashSet::new(), p2p::ReplicationFilters::new())
                 }
             }
+        };
+        let existing_collection_ids = if existing_filters == replication_filters {
+            existing_collection_ids
+        } else {
+            HashSet::new()
         };
 
         self.handle
@@ -372,22 +431,37 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
 
         if let Some(ref coordinator) = self.sync_coordinator {
             let transport_peer_id = p2p::transport::PeerId::from(peer_id);
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
             coordinator
-                .create_replicator(&transport_peer_id, collection_cids.clone(), true)
+                .create_replicator_info(&transport_peer_id, info, true)
                 .await
                 .map_err(|error| P2PError::transport(error.to_string()))?;
         } else {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
             self.handle
-                .create_replicator(peer_id, collection_cids.clone())
+                .create_replicator_info(peer_id, info)
                 .await
                 .map_err(|error| P2PError::transport(error.to_string()))?;
         }
 
         if let Some(ref pusher) = self.doc_pusher {
-            if let Err(error) = pusher
-                .persist_replicator(&peer_id.to_string(), &collection_cids)
-                .await
-            {
+            let info = p2p::ReplicatorInfo::from_raw_with_filters(
+                peer_id.to_string(),
+                collection_cids.clone(),
+                vec![addr_str.to_string()],
+                replication_filters.clone(),
+            );
+            if let Err(error) = pusher.persist_replicator_info(&info).await {
                 tracing::warn!(peer_id = %peer_id, error = %error, "failed to persist replicator");
             }
         }
@@ -408,6 +482,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                 let push_options = self.replicator_push_options.load();
                 let push_se_key = push_options.se_encryption_key;
                 let push_identity = push_options.se_identity_pubkey;
+                let push_filters = replication_filters.clone();
 
                 tracing::info!(
                     peer_id = %peer_id,
@@ -421,6 +496,7 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
                             &push_handle,
                             peer_id,
                             &new_collection_names,
+                            &push_filters,
                             push_se_key.as_ref().map(|key| key.as_slice()),
                             push_identity.as_deref(),
                         )

--- a/crates/p2p-adapter/src/libp2p_doc_pusher.rs
+++ b/crates/p2p-adapter/src/libp2p_doc_pusher.rs
@@ -177,6 +177,12 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
                     filter.field, collection_id
                 )));
             }
+            if !field.kind.accepts_filter_value(&filter.value) {
+                return Err(P2PError::invalid_input(format!(
+                    "replication filter value for field '{}' in collection '{}' does not match the field type",
+                    filter.field, collection_id
+                )));
+            }
         }
         Ok(())
     }

--- a/crates/p2p-adapter/src/libp2p_doc_pusher.rs
+++ b/crates/p2p-adapter/src/libp2p_doc_pusher.rs
@@ -14,6 +14,7 @@ pub trait DocPusher: Send + Sync {
         handle: &P2PHostHandle,
         peer_id: libp2p::PeerId,
         collections: &[String],
+        filters: &p2p::ReplicationFilters,
         se_key: Option<&[u8]>,
         se_identity_pubkey: Option<&[u8]>,
     ) -> P2PResult<()>;
@@ -22,7 +23,18 @@ pub trait DocPusher: Send + Sync {
 
     fn list_collections(&self) -> P2PResult<Vec<String>>;
 
+    fn validate_replication_filters(&self, _filters: &p2p::ReplicationFilters) -> P2PResult<()> {
+        Err(P2PError::invalid_input(
+            "no database context to validate replication filters",
+        ))
+    }
+
     async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()>;
+
+    async fn persist_replicator_info(&self, info: &p2p::ReplicatorInfo) -> P2PResult<()> {
+        self.persist_replicator(info.peer_id_str(), &info.collections)
+            .await
+    }
 
     async fn delete_persisted_replicator(&self, peer_id: &str) -> P2PResult<()>;
 
@@ -87,6 +99,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         handle: &P2PHostHandle,
         peer_id: libp2p::PeerId,
         collections: &[String],
+        filters: &p2p::ReplicationFilters,
         se_key: Option<&[u8]>,
         se_identity_pubkey: Option<&[u8]>,
     ) -> P2PResult<()> {
@@ -96,6 +109,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             self.document_acp.get().map(|acp| acp.as_ref()),
             peer_id,
             collections,
+            filters,
             se_key,
             se_identity_pubkey,
         )
@@ -125,6 +139,46 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         self.db
             .list_collections()
             .map_err(|error| P2PError::internal(format!("failed to list collections: {error}")))
+    }
+
+    fn validate_replication_filters(&self, filters: &p2p::ReplicationFilters) -> P2PResult<()> {
+        for (collection_id, filter) in filters {
+            let collection = self
+                .db
+                .find_collection_by_id(collection_id)
+                .map_err(|error| {
+                    P2PError::internal(format!(
+                        "failed to load collection '{collection_id}': {error}"
+                    ))
+                })?
+                .ok_or_else(|| {
+                    P2PError::not_found(format!("collection '{collection_id}' not found"))
+                })?;
+            let field = collection
+                .schema()
+                .fields
+                .iter()
+                .find(|field| field.name == filter.field)
+                .ok_or_else(|| {
+                    P2PError::invalid_input(format!(
+                        "replication filter field '{}' not found in collection '{}'",
+                        filter.field, collection_id
+                    ))
+                })?;
+            if !field.immutable {
+                return Err(P2PError::invalid_input(format!(
+                    "replication filter field '{}' in collection '{}' must be marked @immutable",
+                    filter.field, collection_id
+                )));
+            }
+            if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
+                return Err(P2PError::invalid_input(format!(
+                    "replication filter field '{}' in collection '{}' must be a scalar LWW field",
+                    filter.field, collection_id
+                )));
+            }
+        }
+        Ok(())
     }
 
     async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()> {
@@ -157,6 +211,22 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             };
         info.id = peer_id.to_string();
         info.collections = collections.to_vec();
+        let bytes = info.to_bytes().map_err(|error| {
+            P2PError::internal(format!("failed to serialize replicator info: {error}"))
+        })?;
+        peerstore
+            .create_replicator(peer_id, &bytes)
+            .await
+            .map_err(|error| {
+                P2PError::persistence(format!("failed to persist replicator: {error}"))
+            })
+    }
+
+    async fn persist_replicator_info(&self, info: &p2p::ReplicatorInfo) -> P2PResult<()> {
+        let peer_id = info.peer_id_str();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let mut info = info.clone();
+        info.id = peer_id.to_string();
         let bytes = info.to_bytes().map_err(|error| {
             P2PError::internal(format!("failed to serialize replicator info: {error}"))
         })?;
@@ -238,6 +308,14 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
         doc_id: &str,
         collection_id: &str,
     ) -> P2PResult<()> {
+        let peer_id_str = peer_id.to_string();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let filters = match peerstore.get_replicator(&peer_id_str).await {
+            Ok(Some(bytes)) => p2p::ReplicatorInfo::from_bytes(&bytes)
+                .map(|info| info.filters)
+                .unwrap_or_default(),
+            _ => p2p::ReplicationFilters::new(),
+        };
         db_merge::retry_doc(
             handle,
             &self.db,
@@ -245,6 +323,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             peer_id,
             doc_id,
             collection_id,
+            &filters,
         )
         .await
         .map_err(P2PError::from)

--- a/crates/p2p-adapter/src/manage/serve.rs
+++ b/crates/p2p-adapter/src/manage/serve.rs
@@ -99,6 +99,7 @@ async fn authorize_and_apply(
                 ops.add_replicator(
                     collection_ids.clone(),
                     addresses.first().map(|s| s.as_str()),
+                    Default::default(),
                     vec![],
                     Some(did_str.as_str()),
                 )
@@ -216,6 +217,16 @@ fn to_p2p_replicator_info(info: defra_http::router::ReplicatorInfo) -> p2p::Repl
         info.collections,
         info.address.into_iter().collect(),
     );
+    out.filters = info
+        .filters
+        .into_iter()
+        .map(|(collection, filter)| {
+            (
+                collection,
+                p2p::ReplicationFilter::new(filter.field, filter.value),
+            )
+        })
+        .collect();
     out.status = info
         .status
         .map(|s| p2p::ReplicatorStatus::try_from(s).unwrap_or_default())
@@ -288,6 +299,7 @@ mod tests {
             &self,
             collections: Vec<String>,
             addr: Option<&str>,
+            _filters: defra_http::router::ReplicationFilters,
             _explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
             _expected_authorizer_did: Option<&str>,
         ) -> P2PResult<()> {
@@ -420,6 +432,7 @@ mod tests {
             address: Some("/ip4/1.2.3.4/tcp/9000".into()),
             status: Some(1),
             last_status_change: Some("2024-03-14T15:09:26.535Z".into()),
+            filters: Default::default(),
         };
         let out = to_p2p_replicator_info(http);
         assert_eq!(

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -13,6 +13,7 @@ pub trait TransportDocPusher: Send + Sync {
         &self,
         peer_id: &PeerId,
         collections: &[String],
+        filters: &p2p::ReplicationFilters,
         se_key: Option<&[u8]>,
     ) -> P2PResult<()>;
 
@@ -31,7 +32,18 @@ pub trait TransportDocPusher: Send + Sync {
 
     fn list_collections(&self) -> P2PResult<Vec<String>>;
 
+    fn validate_replication_filters(&self, _filters: &p2p::ReplicationFilters) -> P2PResult<()> {
+        Err(P2PError::invalid_input(
+            "no database context to validate replication filters",
+        ))
+    }
+
     async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()>;
+
+    async fn persist_replicator_info(&self, info: &p2p::ReplicatorInfo) -> P2PResult<()> {
+        self.persist_replicator(info.peer_id_str(), &info.collections)
+            .await
+    }
 
     async fn delete_persisted_replicator(&self, peer_id: &str) -> P2PResult<()>;
 
@@ -83,6 +95,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         &self,
         peer_id: &PeerId,
         collections: &[String],
+        filters: &p2p::ReplicationFilters,
         se_key: Option<&[u8]>,
     ) -> P2PResult<()> {
         db_merge::push_existing_docs_via_transport(
@@ -91,6 +104,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             self.document_acp.get().map(|acp| acp.as_ref()),
             peer_id,
             collections,
+            filters,
             se_key,
         )
         .await
@@ -103,6 +117,14 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         doc_id: &str,
         collection_id: &str,
     ) -> P2PResult<()> {
+        let peer_id_str = peer_id.to_string();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let filters = match peerstore.get_replicator(&peer_id_str).await {
+            Ok(Some(bytes)) => p2p::ReplicatorInfo::from_bytes(&bytes)
+                .map(|info| info.filters)
+                .unwrap_or_default(),
+            _ => p2p::ReplicationFilters::new(),
+        };
         db_merge::retry_doc_via_transport(
             &self.transport,
             &self.db,
@@ -110,6 +132,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             peer_id,
             doc_id,
             collection_id,
+            &filters,
         )
         .await
         .map_err(P2PError::from)
@@ -176,6 +199,46 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             .map_err(|error| P2PError::internal(format!("failed to list collections: {error}")))
     }
 
+    fn validate_replication_filters(&self, filters: &p2p::ReplicationFilters) -> P2PResult<()> {
+        for (collection_id, filter) in filters {
+            let collection = self
+                .db
+                .find_collection_by_id(collection_id)
+                .map_err(|error| {
+                    P2PError::internal(format!(
+                        "failed to load collection '{collection_id}': {error}"
+                    ))
+                })?
+                .ok_or_else(|| {
+                    P2PError::not_found(format!("collection '{collection_id}' not found"))
+                })?;
+            let field = collection
+                .schema()
+                .fields
+                .iter()
+                .find(|field| field.name == filter.field)
+                .ok_or_else(|| {
+                    P2PError::invalid_input(format!(
+                        "replication filter field '{}' not found in collection '{}'",
+                        filter.field, collection_id
+                    ))
+                })?;
+            if !field.immutable {
+                return Err(P2PError::invalid_input(format!(
+                    "replication filter field '{}' in collection '{}' must be marked @immutable",
+                    filter.field, collection_id
+                )));
+            }
+            if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
+                return Err(P2PError::invalid_input(format!(
+                    "replication filter field '{}' in collection '{}' must be a scalar LWW field",
+                    filter.field, collection_id
+                )));
+            }
+        }
+        Ok(())
+    }
+
     async fn persist_replicator(&self, peer_id: &str, collections: &[String]) -> P2PResult<()> {
         let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
         let mut info = match peerstore.get_replicator(peer_id).await.map_err(|error| {
@@ -190,6 +253,22 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
         };
         info.id = peer_id.to_string();
         info.collections = collections.to_vec();
+        let bytes = info.to_bytes().map_err(|error| {
+            P2PError::internal(format!("failed to serialize replicator info: {error}"))
+        })?;
+        peerstore
+            .create_replicator(peer_id, &bytes)
+            .await
+            .map_err(|error| {
+                P2PError::persistence(format!("failed to persist replicator: {error}"))
+            })
+    }
+
+    async fn persist_replicator_info(&self, info: &p2p::ReplicatorInfo) -> P2PResult<()> {
+        let peer_id = info.peer_id_str();
+        let peerstore = storage::stores::Peerstore::new(self.db.store().clone());
+        let mut info = info.clone();
+        info.id = peer_id.to_string();
         let bytes = info.to_bytes().map_err(|error| {
             P2PError::internal(format!("failed to serialize replicator info: {error}"))
         })?;

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -235,6 +235,12 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
                     filter.field, collection_id
                 )));
             }
+            if !field.kind.accepts_filter_value(&filter.value) {
+                return Err(P2PError::invalid_input(format!(
+                    "replication filter value for field '{}' in collection '{}' does not match the field type",
+                    filter.field, collection_id
+                )));
+            }
         }
         Ok(())
     }

--- a/crates/p2p/src/bitswap/filter.rs
+++ b/crates/p2p/src/bitswap/filter.rs
@@ -107,6 +107,15 @@ async fn check_access<S: Store>(
                 return false;
             };
             let peer_str = peer_id.to_string();
+            if registry.is_filtered_replicator(collection_id, &peer_str) {
+                debug!(
+                    cid = %cid,
+                    peer = %peer_id,
+                    collection = %collection_id,
+                    "bitswap request denied: filtered replicator data-block access uses direct push"
+                );
+                return false;
+            }
             if registry.is_replicator(collection_id, &peer_str) {
                 return true;
             }
@@ -138,6 +147,7 @@ async fn check_access<S: Store>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::replicator::{ReplicationFilter, ReplicationFilters, ReplicatorInfo};
     use async_trait::async_trait;
     use iroh_bitswap::{Block, Store};
     use std::collections::HashMap;
@@ -237,6 +247,33 @@ mod tests {
 
         let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
         assert!(allowed, "registered replicator must be served");
+    }
+
+    #[tokio::test]
+    async fn controlled_mode_denies_filtered_replicator_data_block_requests() {
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        let (cid, bytes) = make_data_block("users");
+        store.put(cid, bytes);
+
+        let peer = PeerId::random();
+        let mut filters = ReplicationFilters::new();
+        filters.insert(
+            "users".to_string(),
+            ReplicationFilter::new("agent_did", serde_json::json!("did:key:z6M")),
+        );
+        registry.set_replicator_info(ReplicatorInfo::from_raw_with_filters(
+            peer.to_string(),
+            vec!["users".to_string()],
+            vec![],
+            filters,
+        ));
+
+        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        assert!(
+            !allowed,
+            "filtered replicators receive matching full DAGs by direct push, not collection-wide Bitswap"
+        );
     }
 
     #[tokio::test]

--- a/crates/p2p/src/bitswap/registry.rs
+++ b/crates/p2p/src/bitswap/registry.rs
@@ -2,8 +2,6 @@
 //!
 //! Uses string-based peer IDs so the registry works with both libp2p and iroh transports.
 
-use std::collections::{HashMap, HashSet};
-
 use parking_lot::RwLock;
 
 use crate::replicator::ReplicatorInfo;
@@ -17,134 +15,139 @@ use crate::replicator::ReplicatorInfo;
 /// iroh EndpointIds without coupling to either transport.
 #[derive(Debug, Default)]
 pub struct ReplicatorRegistry {
-    /// Map of collection_id -> set of authorized peer ID strings
-    replicators: RwLock<HashMap<String, HashSet<String>>>,
+    /// Map of peer ID string -> persisted replicator metadata.
+    replicators: RwLock<std::collections::BTreeMap<String, ReplicatorInfo>>,
 }
 
 impl ReplicatorRegistry {
     /// Create a new empty registry.
     pub fn new() -> Self {
         Self {
-            replicators: RwLock::new(HashMap::new()),
+            replicators: RwLock::new(std::collections::BTreeMap::new()),
         }
     }
 
     /// Register a peer as a replicator for a collection.
     pub fn add_replicator(&self, collection_id: &str, peer_id: &str) {
         let mut replicators = self.replicators.write();
-        replicators
-            .entry(collection_id.to_string())
-            .or_default()
-            .insert(peer_id.to_string());
+        let info = replicators.entry(peer_id.to_string()).or_insert_with(|| {
+            ReplicatorInfo::from_raw(peer_id.to_string(), Vec::new(), Vec::new())
+        });
+        if !info.collections.iter().any(|id| id == collection_id) {
+            info.collections.push(collection_id.to_string());
+        }
     }
 
     /// Replace the full set of collections replicated by a peer.
     pub fn set_peer_collections(&self, peer_id: &str, collections: &[String]) {
-        let mut replicators = self.replicators.write();
-        for peers in replicators.values_mut() {
-            peers.remove(peer_id);
+        let mut info =
+            ReplicatorInfo::from_raw(peer_id.to_string(), collections.to_vec(), Vec::new());
+        if let Some(existing) = self.replicators.read().get(peer_id) {
+            info.addresses = existing.addresses.clone();
+            info.status = existing.status;
+            info.last_status_change = existing.last_status_change;
         }
-        replicators.retain(|_, peers| !peers.is_empty());
+        self.set_replicator_info(info);
+    }
 
-        for collection_id in collections {
-            replicators
-                .entry(collection_id.clone())
-                .or_default()
-                .insert(peer_id.to_string());
+    /// Replace the full metadata record for a peer.
+    pub fn set_replicator_info(&self, info: ReplicatorInfo) {
+        let peer_id = info.peer_id_str().to_string();
+        if peer_id.is_empty() {
+            return;
         }
+        if info.collections.is_empty() {
+            self.replicators.write().remove(&peer_id);
+            return;
+        }
+        self.replicators.write().insert(peer_id, info);
     }
 
     /// Remove a peer as a replicator for a collection.
     pub fn remove_replicator(&self, collection_id: &str, peer_id: &str) {
         let mut replicators = self.replicators.write();
-        if let Some(peers) = replicators.get_mut(collection_id) {
-            peers.remove(peer_id);
-            if peers.is_empty() {
-                replicators.remove(collection_id);
+        if let Some(info) = replicators.get_mut(peer_id) {
+            info.collections.retain(|id| id != collection_id);
+            info.filters
+                .retain(|collection, _| collection != collection_id);
+            if info.collections.is_empty() {
+                replicators.remove(peer_id);
             }
         }
     }
 
     /// Remove a peer from all collections.
     pub fn remove_peer(&self, peer_id: &str) {
-        let mut replicators = self.replicators.write();
-        for peers in replicators.values_mut() {
-            peers.remove(peer_id);
-        }
-        replicators.retain(|_, peers| !peers.is_empty());
+        self.replicators.write().remove(peer_id);
     }
 
     /// Remove a peer from specific collections. Returns true if the peer no
     /// longer replicates any collections afterwards.
     pub fn remove_peer_collections(&self, peer_id: &str, collections: &[String]) -> bool {
         let mut replicators = self.replicators.write();
+        let Some(info) = replicators.get_mut(peer_id) else {
+            return true;
+        };
+
         for collection_id in collections {
-            if let Some(peers) = replicators.get_mut(collection_id) {
-                peers.remove(peer_id);
-                if peers.is_empty() {
-                    replicators.remove(collection_id);
-                }
-            }
+            info.collections.retain(|id| id != collection_id);
+            info.filters
+                .retain(|collection, _| collection != collection_id);
         }
 
-        !replicators.values().any(|peers| peers.contains(peer_id))
+        if info.collections.is_empty() {
+            replicators.remove(peer_id);
+            true
+        } else {
+            false
+        }
     }
 
     /// Check if a peer is a replicator for a collection.
     pub fn is_replicator(&self, collection_id: &str, peer_id: &str) -> bool {
-        let replicators = self.replicators.read();
-        replicators
-            .get(collection_id)
-            .map(|peers| peers.contains(peer_id))
+        self.replicators
+            .read()
+            .get(peer_id)
+            .map(|info| info.collections.iter().any(|id| id == collection_id))
+            .unwrap_or(false)
+    }
+
+    /// Check if a peer has a filter for a collection it replicates.
+    pub fn is_filtered_replicator(&self, collection_id: &str, peer_id: &str) -> bool {
+        self.replicators
+            .read()
+            .get(peer_id)
+            .map(|info| info.is_filtered_for_collection(collection_id))
             .unwrap_or(false)
     }
 
     /// Check if a peer is a replicator for any collection.
     pub fn is_any_replicator(&self, peer_id: &str) -> bool {
-        let replicators = self.replicators.read();
-        replicators.values().any(|peers| peers.contains(peer_id))
+        self.replicators.read().contains_key(peer_id)
     }
 
     /// Get all replicator peer ID strings for a collection.
     pub fn get_replicators(&self, collection_id: &str) -> Vec<String> {
-        let replicators = self.replicators.read();
-        replicators
-            .get(collection_id)
-            .map(|peers| peers.iter().cloned().collect())
-            .unwrap_or_default()
+        self.replicators
+            .read()
+            .iter()
+            .filter(|(_, info)| info.collections.iter().any(|id| id == collection_id))
+            .map(|(peer_id, _)| peer_id.clone())
+            .collect()
     }
 
     /// Get all collections a peer is replicating.
     pub fn get_collections(&self, peer_id: &str) -> Vec<String> {
-        let replicators = self.replicators.read();
-        replicators
-            .iter()
-            .filter(|(_, peers)| peers.contains(peer_id))
-            .map(|(col_id, _)| col_id.clone())
-            .collect()
+        self.replicators
+            .read()
+            .get(peer_id)
+            .map(|info| info.collections.clone())
+            .unwrap_or_default()
     }
 
     /// Get all registered replicators as ReplicatorInfo.
     pub fn list_replicator_info(&self) -> Vec<ReplicatorInfo> {
-        let replicators = self.replicators.read();
-
-        let mut peer_collections: HashMap<String, Vec<String>> = HashMap::new();
-
-        for (collection_id, peers) in replicators.iter() {
-            for peer in peers {
-                peer_collections
-                    .entry(peer.clone())
-                    .or_default()
-                    .push(collection_id.clone());
-            }
-        }
-
-        peer_collections
-            .into_iter()
-            .map(|(peer_id, collections)| {
-                ReplicatorInfo::from_raw(peer_id, collections, Vec::new())
-            })
-            .collect()
+        self.replicators.read().values().cloned().collect()
     }
 
     /// Load replicators from ReplicatorInfo records.
@@ -169,11 +172,8 @@ impl ReplicatorRegistry {
                 continue;
             }
 
-            for collection_id in &info.collections {
-                replicators
-                    .entry(collection_id.clone())
-                    .or_default()
-                    .insert(peer_id_str.to_string());
+            if !info.collections.is_empty() {
+                replicators.insert(peer_id_str.to_string(), info.clone());
             }
             loaded += 1;
         }
@@ -183,34 +183,19 @@ impl ReplicatorRegistry {
 
     /// Get replicator info for a specific peer.
     pub fn get_replicator_info(&self, peer_id: &str) -> Option<ReplicatorInfo> {
-        let collections = self.get_collections(peer_id);
-        if collections.is_empty() {
-            None
-        } else {
-            Some(ReplicatorInfo::from_raw(
-                peer_id.to_string(),
-                collections,
-                Vec::new(),
-            ))
-        }
+        self.replicators.read().get(peer_id).cloned()
     }
 
     /// Get all unique peer ID strings that are replicators.
     pub fn get_all_peer_ids(&self) -> Vec<String> {
-        let replicators = self.replicators.read();
-        let mut peers: HashSet<String> = HashSet::new();
-
-        for peer_set in replicators.values() {
-            peers.extend(peer_set.iter().cloned());
-        }
-
-        peers.into_iter().collect()
+        self.replicators.read().keys().cloned().collect()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::replicator::{ReplicationFilter, ReplicationFilters};
 
     fn random_peer_id() -> String {
         libp2p::PeerId::random().to_string()
@@ -402,6 +387,36 @@ mod tests {
         assert_eq!(info.collections.len(), 2);
         assert!(info.collections.contains(&"users".to_string()));
         assert!(info.collections.contains(&"posts".to_string()));
+    }
+
+    #[test]
+    fn test_replicator_registry_preserves_filters() {
+        let registry = ReplicatorRegistry::new();
+        let peer = random_peer_id();
+        let mut filters = ReplicationFilters::new();
+        filters.insert(
+            "users".to_string(),
+            ReplicationFilter::new("agent_did", serde_json::json!("did:key:z6M")),
+        );
+
+        registry.set_replicator_info(ReplicatorInfo::from_raw_with_filters(
+            peer.clone(),
+            vec!["users".to_string(), "posts".to_string()],
+            vec![],
+            filters.clone(),
+        ));
+
+        assert!(registry.is_replicator("users", &peer));
+        assert!(registry.is_filtered_replicator("users", &peer));
+        assert!(!registry.is_filtered_replicator("posts", &peer));
+
+        let info = registry.get_replicator_info(&peer).unwrap();
+        assert_eq!(info.filters, filters);
+
+        registry.remove_replicator("users", &peer);
+        let info = registry.get_replicator_info(&peer).unwrap();
+        assert!(info.filters.is_empty());
+        assert!(registry.is_replicator("posts", &peer));
     }
 
     #[test]

--- a/crates/p2p/src/host/command.rs
+++ b/crates/p2p/src/host/command.rs
@@ -138,7 +138,7 @@ pub enum HostCommand {
     /// If the peer is already a replicator, updates their collections.
     CreateReplicator {
         peer_id: PeerId,
-        collections: Vec<String>,
+        info: ReplicatorInfo,
         response: oneshot::Sender<Result<()>>,
     },
 

--- a/crates/p2p/src/host/command_handler/messaging.rs
+++ b/crates/p2p/src/host/command_handler/messaging.rs
@@ -12,6 +12,7 @@ use crate::message::{
     ManageQueryReply, ManageQueryRequest, ManageReply, ManageRequest, PushLogReply, PushLogRequest,
     PushSEArtifactsReply, PushSEArtifactsRequest, QuerySEArtifactsReply, QuerySEArtifactsRequest,
 };
+use crate::replicator::ReplicatorInfo;
 
 use super::super::p2p_host::P2PHost;
 
@@ -399,13 +400,13 @@ impl<S: Store> P2PHost<S> {
     pub(super) fn handle_create_replicator(
         &mut self,
         peer_id: PeerId,
-        collections: Vec<String>,
+        mut info: ReplicatorInfo,
         response: tokio::sync::oneshot::Sender<Result<()>>,
     ) {
-        debug!(peer_id = %peer_id, collections = ?collections, "Creating replicator");
+        debug!(peer_id = %peer_id, collections = ?info.collections, filters = ?info.filters, "Creating replicator");
         let peer_str = peer_id.to_string();
-        self.replicators
-            .set_peer_collections(&peer_str, &collections);
+        info.id = peer_str;
+        self.replicators.set_replicator_info(info);
         if response.send(Ok(())).is_err() {
             debug!(peer_id = %peer_id, "CreateReplicator command response dropped - caller cancelled");
         }

--- a/crates/p2p/src/host/command_handler/mod.rs
+++ b/crates/p2p/src/host/command_handler/mod.rs
@@ -193,10 +193,10 @@ impl<S: Store> P2PHost<S> {
             }
             HostCommand::CreateReplicator {
                 peer_id,
-                collections,
+                info,
                 response,
             } => {
-                self.handle_create_replicator(peer_id, collections, response);
+                self.handle_create_replicator(peer_id, info, response);
             }
             HostCommand::DeleteReplicator { peer_id, response } => {
                 self.handle_delete_replicator(peer_id, response);

--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -424,11 +424,21 @@ impl P2PHostHandle {
     /// Adds the peer as a replicator for the specified collections.
     /// If the peer is already a replicator, updates their collections.
     pub async fn create_replicator(&self, peer_id: PeerId, collections: Vec<String>) -> Result<()> {
+        let info = ReplicatorInfo::from_raw(peer_id.to_string(), collections, Vec::new());
+        self.create_replicator_info(peer_id, info).await
+    }
+
+    /// Set (add/update) a replicator using the full persisted metadata record.
+    pub async fn create_replicator_info(
+        &self,
+        peer_id: PeerId,
+        info: ReplicatorInfo,
+    ) -> Result<()> {
         let (response_tx, response_rx) = oneshot::channel();
         self.command_tx
             .send(HostCommand::CreateReplicator {
                 peer_id,
-                collections,
+                info,
                 response: response_tx,
             })
             .await

--- a/crates/p2p/src/host/libp2p_transport.rs
+++ b/crates/p2p/src/host/libp2p_transport.rs
@@ -322,6 +322,11 @@ impl P2PTransport for Libp2pTransport {
         self.handle.create_replicator(pid, collections).await
     }
 
+    async fn create_replicator_info(&self, peer_id: &PeerId, info: ReplicatorInfo) -> Result<()> {
+        let pid = parse_libp2p_peer_id(peer_id)?;
+        self.handle.create_replicator_info(pid, info).await
+    }
+
     async fn delete_replicator(&self, peer_id: &PeerId) -> Result<()> {
         let pid = parse_libp2p_peer_id(peer_id)?;
         self.handle.delete_replicator(pid).await

--- a/crates/p2p/src/iroh/command.rs
+++ b/crates/p2p/src/iroh/command.rs
@@ -187,7 +187,7 @@ pub enum IrohCommand {
     // Replicators
     CreateReplicator {
         peer_id: PeerId,
-        collections: Vec<String>,
+        info: ReplicatorInfo,
         reply: oneshot::Sender<crate::error::Result<()>>,
     },
     DeleteReplicator {

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -632,10 +632,11 @@ pub(super) async fn handle_command(
         }
         IrohCommand::CreateReplicator {
             peer_id,
-            collections,
+            mut info,
             reply,
         } => {
-            replicators.set_peer_collections(peer_id.as_str(), &collections);
+            info.id = peer_id.to_string();
+            replicators.set_replicator_info(info);
             let _ = reply.send(Ok(()));
         }
         IrohCommand::DeleteReplicator { peer_id, reply } => {

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -420,9 +420,14 @@ impl P2PTransport for IrohTransport {
     }
 
     async fn create_replicator(&self, peer_id: &PeerId, collections: Vec<String>) -> Result<()> {
+        let info = ReplicatorInfo::from_raw(peer_id.to_string(), collections, Vec::new());
+        self.create_replicator_info(peer_id, info).await
+    }
+
+    async fn create_replicator_info(&self, peer_id: &PeerId, info: ReplicatorInfo) -> Result<()> {
         self.send_command(|reply| IrohCommand::CreateReplicator {
             peer_id: peer_id.clone(),
-            collections,
+            info,
             reply,
         })
         .await

--- a/crates/p2p/src/kms/pubsub_transport.rs
+++ b/crates/p2p/src/kms/pubsub_transport.rs
@@ -388,6 +388,7 @@ mod tests {
     /// Mock transport that records raw publishes and mimics the gossipsub
     /// subscription-propagation race for `topic_peers`/`publish_raw`.
     #[derive(Clone)]
+    #[allow(clippy::type_complexity)]
     struct RacyTransport {
         local_peer_id: PeerId,
         peer: PeerId,

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -152,7 +152,7 @@ pub use iroh_bitswap::Store as BitswapStore;
 pub struct QueryId(pub u64);
 
 // Re-export replicator types
-pub use replicator::{ReplicatorInfo, ReplicatorStatus};
+pub use replicator::{ReplicationFilter, ReplicationFilters, ReplicatorInfo, ReplicatorStatus};
 
 // Re-export management correlators
 pub use manage_correlator::{

--- a/crates/p2p/src/replicator.rs
+++ b/crates/p2p/src/replicator.rs
@@ -87,10 +87,16 @@ impl ReplicationFilter {
 /// equality treats as unequal.
 fn json_scalar_eq(a: &JsonValue, b: &JsonValue) -> bool {
     match (a, b) {
-        (JsonValue::Number(x), JsonValue::Number(y)) => match (x.as_f64(), y.as_f64()) {
-            (Some(xf), Some(yf)) => xf == yf,
-            _ => x == y,
-        },
+        (JsonValue::Number(x), JsonValue::Number(y)) => {
+            // A whole-number float (2.0) materializes as an integer, so a float
+            // filter value must match an integer field value. But compare two
+            // integers exactly to avoid f64 precision loss above 2^53.
+            if x.is_f64() || y.is_f64() {
+                x.as_f64() == y.as_f64()
+            } else {
+                x == y
+            }
+        }
         _ => a == b,
     }
 }

--- a/crates/p2p/src/replicator.rs
+++ b/crates/p2p/src/replicator.rs
@@ -77,7 +77,21 @@ impl ReplicationFilter {
         document
             .as_object()
             .and_then(|object| object.get(&self.field))
-            .is_some_and(|value| value == &self.value)
+            .is_some_and(|value| json_scalar_eq(value, &self.value))
+    }
+}
+
+/// Equality for filter matching. Numbers are compared numerically so a filter
+/// value of `2.0` matches a field materialized as the integer `2` (Go-compatible
+/// JSON encodes whole-number floats as integers), which raw `serde_json::Value`
+/// equality treats as unequal.
+fn json_scalar_eq(a: &JsonValue, b: &JsonValue) -> bool {
+    match (a, b) {
+        (JsonValue::Number(x), JsonValue::Number(y)) => match (x.as_f64(), y.as_f64()) {
+            (Some(xf), Some(yf)) => xf == yf,
+            _ => x == y,
+        },
+        _ => a == b,
     }
 }
 

--- a/crates/p2p/src/replicator.rs
+++ b/crates/p2p/src/replicator.rs
@@ -15,6 +15,8 @@ use chrono::{DateTime, NaiveDate, SecondsFormat, Utc};
 #[cfg(feature = "libp2p-transport")]
 use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value as JsonValue;
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 /// Error type for replicator operations.
@@ -44,6 +46,45 @@ pub enum ReplicatorStatus {
     #[default]
     Active = 0,
     Inactive = 1,
+}
+
+/// Per-collection equality predicate for filtered replication.
+///
+/// This is intentionally narrow for the first filtered-replication release:
+/// a document is selected when its materialized JSON contains `Field` with
+/// exactly `Value`. The full within-document DAG is still replicated for
+/// selected documents.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReplicationFilter {
+    #[serde(rename = "Field")]
+    pub field: String,
+
+    #[serde(rename = "Value")]
+    pub value: JsonValue,
+}
+
+impl Eq for ReplicationFilter {}
+
+impl ReplicationFilter {
+    pub fn new(field: impl Into<String>, value: JsonValue) -> Self {
+        Self {
+            field: field.into(),
+            value,
+        }
+    }
+
+    pub fn matches_json_object(&self, document: &JsonValue) -> bool {
+        document
+            .as_object()
+            .and_then(|object| object.get(&self.field))
+            .is_some_and(|value| value == &self.value)
+    }
+}
+
+pub type ReplicationFilters = BTreeMap<String, ReplicationFilter>;
+
+fn no_replication_filters(filters: &ReplicationFilters) -> bool {
+    filters.is_empty()
 }
 
 impl From<ReplicatorStatus> for u8 {
@@ -131,7 +172,7 @@ fn format_go_time(t: &DateTime<Utc>) -> String {
 /// Persisted to the peerstore as JSON, matching Go's `client.Replicator`
 /// wire format exactly so a shared datastore can be read by either
 /// implementation. See `defradb/client/replicator.go:18-24`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReplicatorInfo {
     #[serde(rename = "ID")]
     pub id: String,
@@ -155,7 +196,20 @@ pub struct ReplicatorInfo {
         with = "go_time_serde"
     )]
     pub last_status_change: DateTime<Utc>,
+
+    /// Optional Rust extension for filtered replication.
+    ///
+    /// Omitted when empty so unfiltered records remain byte-identical to Go's
+    /// `client.Replicator` JSON. Go decoders ignore this field when present.
+    #[serde(
+        rename = "Filters",
+        default,
+        skip_serializing_if = "no_replication_filters"
+    )]
+    pub filters: ReplicationFilters,
 }
+
+impl Eq for ReplicatorInfo {}
 
 impl ReplicatorInfo {
     /// Create a new replicator info.
@@ -174,7 +228,19 @@ impl ReplicatorInfo {
             collections,
             status: ReplicatorStatus::Active,
             last_status_change: go_time_zero(),
+            filters: ReplicationFilters::new(),
         })
+    }
+
+    /// Create a new replicator info with per-collection filters.
+    pub fn new_with_filters(
+        peer_id: impl ToString,
+        collections: Vec<String>,
+        filters: ReplicationFilters,
+    ) -> Result<Self, ReplicatorError> {
+        let mut info = Self::new(peer_id, collections)?;
+        info.filters = filters;
+        Ok(info)
     }
 
     /// Unchecked constructor for test fixtures and raw peerstore reads.
@@ -191,7 +257,39 @@ impl ReplicatorInfo {
             collections,
             status: ReplicatorStatus::Active,
             last_status_change: go_time_zero(),
+            filters: ReplicationFilters::new(),
         }
+    }
+
+    /// Unchecked constructor that preserves filter metadata.
+    pub fn from_raw_with_filters(
+        peer_id: String,
+        collections: Vec<String>,
+        addresses: Vec<String>,
+        filters: ReplicationFilters,
+    ) -> Self {
+        Self {
+            id: peer_id,
+            addresses,
+            collections,
+            status: ReplicatorStatus::Active,
+            last_status_change: go_time_zero(),
+            filters,
+        }
+    }
+
+    pub fn is_filtered_for_collection(&self, collection_id: &str) -> bool {
+        self.filters.contains_key(collection_id)
+    }
+
+    pub fn filter_for_collection(&self, collection_id: &str) -> Option<&ReplicationFilter> {
+        self.filters.get(collection_id)
+    }
+
+    pub fn matches_filter(&self, collection_id: &str, document: &JsonValue) -> bool {
+        self.filter_for_collection(collection_id)
+            .map(|filter| filter.matches_json_object(document))
+            .unwrap_or(true)
     }
 
     /// Get the peer ID. Returns `None` if the stored ID is not a valid libp2p PeerId.

--- a/crates/p2p/src/sync/coordinator/authorizer.rs
+++ b/crates/p2p/src/sync/coordinator/authorizer.rs
@@ -64,9 +64,9 @@ impl<T: P2PTransport> RuntimeAuthorizer<T> {
         let peer_id = PeerId::new(peer_id_str.to_string());
         match self.transport.get_replicator(&peer_id).await {
             Ok(Some(info)) if !info.collections.is_empty() => {
-                self.replicators
-                    .set_peer_collections(peer_id_str, &info.collections);
-                Some(info.collections)
+                let collections = info.collections.clone();
+                self.replicators.set_replicator_info(info);
+                Some(collections)
             }
             Ok(_) => None,
             Err(error) => {

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use blockstore::Blockstore;
 use bytes::Bytes;
 use cid::Cid;
+use serde_json::Value as JsonValue;
 
 use super::SyncCoordinator;
 use crate::error::{is_rate_limited_message, Result};
@@ -77,6 +78,22 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 doc_id,
                 collection_id,
             });
+        }
+    }
+
+    fn replicator_in_collection(
+        rep: &crate::replicator::ReplicatorInfo,
+        collection_id: &str,
+    ) -> bool {
+        rep.collections.is_empty() || rep.collections.iter().any(|id| id == collection_id)
+    }
+
+    fn peer_id_for_replicator(rep: &crate::replicator::ReplicatorInfo) -> Option<PeerId> {
+        let peer_id_str = rep.peer_id_str();
+        if peer_id_str.is_empty() {
+            None
+        } else {
+            Some(PeerId::new(peer_id_str.to_string()))
         }
     }
 
@@ -155,16 +172,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         );
 
         for rep in &replicators {
-            if !rep.collections.is_empty() && !rep.collections.contains(&collection_id.to_string())
-            {
+            if !Self::replicator_in_collection(rep, collection_id) {
+                continue;
+            }
+            if rep.is_filtered_for_collection(collection_id) {
                 continue;
             }
 
-            let peer_id_str = rep.peer_id_str().to_string();
-            if peer_id_str.is_empty() {
+            let Some(peer_id) = Self::peer_id_for_replicator(rep) else {
                 continue;
-            }
-            let peer_id = PeerId::new(peer_id_str);
+            };
 
             let mut requests: Vec<(Cid, PushLogRequest)> = Vec::new();
 
@@ -239,16 +256,16 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         };
 
         for rep in &replicators {
-            if !rep.collections.is_empty() && !rep.collections.contains(&collection_id.to_string())
-            {
+            if !Self::replicator_in_collection(rep, collection_id) {
+                continue;
+            }
+            if rep.is_filtered_for_collection(collection_id) {
                 continue;
             }
 
-            let peer_id_str = rep.peer_id_str().to_string();
-            if peer_id_str.is_empty() {
+            let Some(peer_id) = Self::peer_id_for_replicator(rep) else {
                 continue;
-            }
-            let peer_id = PeerId::new(peer_id_str);
+            };
 
             let mut request = PushLogRequest::new(
                 doc_id.to_string(),
@@ -294,6 +311,117 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         }
     }
 
+    /// Push a committed document update to replicators using document JSON to
+    /// evaluate filtered peers. Filtered peers receive the full document DAG so
+    /// merge completeness does not depend on generic Bitswap access.
+    pub async fn push_document_to_replicators_with_creator(
+        &self,
+        cid: &Cid,
+        block: &[u8],
+        doc_id: &str,
+        collection_id: &str,
+        document: &JsonValue,
+        creator_override: Option<&str>,
+    ) {
+        let creator = creator_override.unwrap_or(&self.access.local_peer_id);
+        let Some(replicators) = self.list_replicators_for_push().await else {
+            return;
+        };
+
+        if replicators.is_empty() {
+            return;
+        }
+
+        let mut dag_blocks: Option<Vec<(Cid, Bytes)>> = None;
+        for rep in &replicators {
+            if !Self::replicator_in_collection(rep, collection_id) {
+                continue;
+            }
+
+            let Some(peer_id) = Self::peer_id_for_replicator(rep) else {
+                continue;
+            };
+
+            let use_full_dag = if rep.is_filtered_for_collection(collection_id) {
+                if !rep.matches_filter(collection_id, document) {
+                    continue;
+                }
+                true
+            } else {
+                false
+            };
+
+            let requests: Vec<(Cid, PushLogRequest)> = if use_full_dag {
+                if dag_blocks.is_none() {
+                    dag_blocks = Some(
+                        self.load_dag_blocks(*cid, Bytes::copy_from_slice(block))
+                            .await,
+                    );
+                }
+                let dag_blocks = dag_blocks.as_ref().expect("dag blocks loaded");
+                let mut requests = Vec::new();
+                for (block_cid, block_data) in dag_blocks.iter() {
+                    let mut req = PushLogRequest::new(
+                        doc_id.to_string(),
+                        Bytes::from(block_cid.to_bytes()),
+                        collection_id.to_string(),
+                        creator.to_string(),
+                        block_data.clone(),
+                    );
+                    if sign_with_transport(&self.runtime.transport, &mut req).is_ok() {
+                        requests.push((*block_cid, req));
+                    }
+                }
+                requests
+            } else {
+                let mut request = PushLogRequest::new(
+                    doc_id.to_string(),
+                    Bytes::from(cid.to_bytes()),
+                    collection_id.to_string(),
+                    creator.to_string(),
+                    Bytes::copy_from_slice(block),
+                );
+                if let Err(e) = sign_with_transport(&self.runtime.transport, &mut request) {
+                    tracing::debug!(error = %e, "Failed to sign PushLog request");
+                    continue;
+                }
+                vec![(*cid, request)]
+            };
+
+            if requests.is_empty() {
+                continue;
+            }
+
+            let transport = self.runtime.transport.clone();
+            let failure_tx = self.runtime.failure_tx.clone();
+            let doc_id_owned = doc_id.to_string();
+            let collection_id_owned = collection_id.to_string();
+            let semaphore = self.runtime.push_semaphore.clone();
+            let peer_id_clone = peer_id.clone();
+            let send_timeout = self.runtime.push_send_timeout;
+            self.spawn_background_task("push_document_to_replicators", async move {
+                let Ok(_permit) = semaphore.acquire().await else {
+                    return;
+                };
+                let any_failed = Self::send_ordered_pushlogs_via_transport(
+                    &transport,
+                    &peer_id_clone,
+                    requests,
+                    send_timeout,
+                )
+                .await;
+                if any_failed {
+                    Self::report_push_failure(
+                        &failure_tx,
+                        &peer_id_clone,
+                        doc_id_owned,
+                        collection_id_owned,
+                    );
+                }
+            });
+        }
+    }
+
     /// Push searchable-encryption artifacts for a committed document to
     /// replicators of the collection. This mirrors Go's SE coordinator, which
     /// listens to committed update events independently of document access.
@@ -312,6 +440,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         for rep in replicators {
             if !rep.collections.iter().any(|id| id == collection_id) {
+                continue;
+            }
+            if rep.is_filtered_for_collection(collection_id) {
                 continue;
             }
 
@@ -334,6 +465,61 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 // reconnects. Mirrors Go's independent `seRetryInfo`; the doc
                 // block push failure is racy and may not fire when the SE push
                 // does, so SE pushes must record their own retries.
+                for doc_id in artifacts
+                    .iter()
+                    .map(|artifact| artifact.doc_id.clone())
+                    .collect::<std::collections::HashSet<_>>()
+                {
+                    Self::report_push_failure(
+                        &self.runtime.failure_tx,
+                        &peer_id,
+                        doc_id,
+                        collection_id.to_string(),
+                    );
+                }
+            }
+        }
+    }
+
+    /// Push SE artifacts with document-filter evaluation for filtered peers.
+    pub async fn push_se_artifacts_to_replicators_for_document(
+        &self,
+        collection_id: &str,
+        artifacts: Vec<SEArtifact>,
+        document: &JsonValue,
+    ) {
+        if artifacts.is_empty() {
+            return;
+        }
+
+        let Some(replicators) = self.list_replicators_for_push().await else {
+            return;
+        };
+
+        for rep in replicators {
+            if !rep.collections.iter().any(|id| id == collection_id) {
+                continue;
+            }
+            if !rep.matches_filter(collection_id, document) {
+                continue;
+            }
+
+            let Some(peer_id) = Self::peer_id_for_replicator(&rep) else {
+                continue;
+            };
+            let request = PushSEArtifactsRequest::new(collection_id.to_string(), artifacts.clone());
+            if let Err(error) = self
+                .runtime
+                .transport
+                .send_se_artifacts(&peer_id, request)
+                .await
+            {
+                tracing::warn!(
+                    peer_id = %peer_id,
+                    collection_id,
+                    error = %error,
+                    "Failed to push SE artifacts to replicator"
+                );
                 for doc_id in artifacts
                     .iter()
                     .map(|artifact| artifact.doc_id.clone())

--- a/crates/p2p/src/sync/coordinator/replicators.rs
+++ b/crates/p2p/src/sync/coordinator/replicators.rs
@@ -53,7 +53,26 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             .create_replicator_info(peer_id, info.clone())
             .await?;
 
+        let filtered_collections: Vec<String> = info.filters.keys().cloned().collect();
         self.register_replicator_access(info);
+
+        if !filtered_collections.is_empty() {
+            if let Ok(subscribed) = self.get_subscribed_collections().await {
+                let bypassed: Vec<&String> = filtered_collections
+                    .iter()
+                    .filter(|collection_id| subscribed.contains(collection_id))
+                    .collect();
+                if !bypassed.is_empty() {
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        collections = ?bypassed,
+                        "filtered replicator added for collection(s) this node also gossip-subscribes; \
+                         filtered replication is push-path selectivity, not an access boundary \
+                         (subscribed peers receive all documents) — use ACP/encryption for confidentiality"
+                    );
+                }
+            }
+        }
 
         let mut result = CreateReplicatorResult {
             subscribed: Vec::new(),

--- a/crates/p2p/src/sync/coordinator/replicators.rs
+++ b/crates/p2p/src/sync/coordinator/replicators.rs
@@ -5,7 +5,7 @@ use blockstore::Blockstore;
 use super::result_types::{CreateReplicatorResult, LoadReplicatorsResult};
 use super::SyncCoordinator;
 use crate::error::Result;
-use crate::replicator::ReplicatorInfo;
+use crate::replicator::{ReplicationFilters, ReplicatorInfo};
 use crate::transport::{P2PTransport, PeerId};
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
@@ -16,12 +16,44 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collections: Vec<String>,
         auto_subscribe: bool,
     ) -> Result<CreateReplicatorResult> {
+        let info = ReplicatorInfo::from_raw(peer_id.to_string(), collections, Vec::new());
+        self.create_replicator_info(peer_id, info, auto_subscribe)
+            .await
+    }
+
+    /// Set (add/update) a replicator with per-collection filters.
+    pub async fn create_replicator_with_filters(
+        &self,
+        peer_id: &PeerId,
+        collections: Vec<String>,
+        filters: ReplicationFilters,
+        auto_subscribe: bool,
+    ) -> Result<CreateReplicatorResult> {
+        let info = ReplicatorInfo::from_raw_with_filters(
+            peer_id.to_string(),
+            collections,
+            Vec::new(),
+            filters,
+        );
+        self.create_replicator_info(peer_id, info, auto_subscribe)
+            .await
+    }
+
+    /// Set (add/update) a replicator from a full metadata record.
+    pub async fn create_replicator_info(
+        &self,
+        peer_id: &PeerId,
+        mut info: ReplicatorInfo,
+        auto_subscribe: bool,
+    ) -> Result<CreateReplicatorResult> {
+        info.id = peer_id.to_string();
+        let collections = info.collections.clone();
         self.runtime
             .transport
-            .create_replicator(peer_id, collections.clone())
+            .create_replicator_info(peer_id, info.clone())
             .await?;
 
-        self.register_replicator_access(peer_id, &collections);
+        self.register_replicator_access(info);
 
         let mut result = CreateReplicatorResult {
             subscribed: Vec::new(),
@@ -30,6 +62,13 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
         if auto_subscribe {
             for collection_id in &collections {
+                if self
+                    .access
+                    .replicators
+                    .is_filtered_replicator(collection_id, peer_id.as_str())
+                {
+                    continue;
+                }
                 match self.subscribe_collection(collection_id).await {
                     Ok(_) => {
                         result.subscribed.push(collection_id.clone());
@@ -191,7 +230,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
 
             let peer_id = PeerId::new(peer_id_str.to_string());
             match self
-                .create_replicator(&peer_id, info.collections.clone(), auto_subscribe)
+                .create_replicator_info(&peer_id, info.clone(), auto_subscribe)
                 .await
             {
                 Ok(set_result) => {
@@ -231,9 +270,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         result
     }
 
-    fn register_replicator_access(&self, peer_id: &PeerId, collections: &[String]) {
-        self.access
-            .replicators
-            .set_peer_collections(peer_id.as_str(), collections);
+    fn register_replicator_access(&self, info: ReplicatorInfo) {
+        self.access.replicators.set_replicator_info(info);
     }
 }

--- a/crates/p2p/src/transport.rs
+++ b/crates/p2p/src/transport.rs
@@ -466,6 +466,10 @@ pub trait P2PTransport: Clone + Send + Sync + 'static {
 
     async fn create_replicator(&self, peer_id: &PeerId, collections: Vec<String>) -> Result<()>;
 
+    async fn create_replicator_info(&self, peer_id: &PeerId, info: ReplicatorInfo) -> Result<()> {
+        self.create_replicator(peer_id, info.collections).await
+    }
+
     async fn delete_replicator(&self, peer_id: &PeerId) -> Result<()>;
 
     async fn list_replicators(&self) -> Result<Vec<ReplicatorInfo>>;

--- a/crates/p2p/tests/replicator_tests.rs
+++ b/crates/p2p/tests/replicator_tests.rs
@@ -157,6 +157,13 @@ fn filter_matches_numbers_numerically() {
     // A string filter value never matches a numeric field (type mismatch).
     let str_filter = ReplicationFilter::new("score", serde_json::json!("2"));
     assert!(!str_filter.matches_json_object(&serde_json::json!({"score": 2})));
+
+    // Two distinct large integers must NOT match: comparing them as f64 would
+    // lose precision above 2^53 and falsely match.
+    let big = 9_007_199_254_740_993_i64; // 2^53 + 1
+    let big_filter = ReplicationFilter::new("id", serde_json::json!(big));
+    assert!(big_filter.matches_json_object(&serde_json::json!({ "id": big })));
+    assert!(!big_filter.matches_json_object(&serde_json::json!({ "id": big + 1 })));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/p2p/tests/replicator_tests.rs
+++ b/crates/p2p/tests/replicator_tests.rs
@@ -141,6 +141,24 @@ fn filtered_replicator_round_trips_rust_extension() {
     assert!(!restored.matches_filter("users", &serde_json::json!({"agent_did": "did:key:other"})));
 }
 
+#[test]
+fn filter_matches_numbers_numerically() {
+    // A whole-number Float field materializes as an integer in Go-compatible
+    // JSON, so a 2.0 filter value must still match a stored 2.
+    let float_filter = ReplicationFilter::new("score", serde_json::json!(2.0));
+    assert!(float_filter.matches_json_object(&serde_json::json!({"score": 2})));
+    assert!(float_filter.matches_json_object(&serde_json::json!({"score": 2.0})));
+    assert!(!float_filter.matches_json_object(&serde_json::json!({"score": 3})));
+
+    // Non-whole floats and integers still match their own form.
+    let frac_filter = ReplicationFilter::new("ratio", serde_json::json!(2.5));
+    assert!(frac_filter.matches_json_object(&serde_json::json!({"ratio": 2.5})));
+
+    // A string filter value never matches a numeric field (type mismatch).
+    let str_filter = ReplicationFilter::new("score", serde_json::json!("2"));
+    assert!(!str_filter.matches_json_object(&serde_json::json!({"score": 2})));
+}
+
 // ---------------------------------------------------------------------------
 // Round-trip
 // ---------------------------------------------------------------------------

--- a/crates/p2p/tests/replicator_tests.rs
+++ b/crates/p2p/tests/replicator_tests.rs
@@ -3,6 +3,7 @@
 use chrono::{TimeZone, Utc};
 use p2p::replicator::{ReplicatorError, ReplicatorInfo, ReplicatorStatus};
 use p2p::{Multiaddr, PeerId};
+use p2p::{ReplicationFilter, ReplicationFilters};
 
 // ---------------------------------------------------------------------------
 // Go-produced fixtures (generated via `encoding/json` on the real
@@ -91,6 +92,53 @@ fn encodes_byte_exact_to_go_zero_time() {
 
     let bytes = info.to_bytes().unwrap();
     assert_eq!(std::str::from_utf8(&bytes).unwrap(), GO_ZERO_STATUS_CHANGE);
+}
+
+#[test]
+fn unfiltered_rust_extension_does_not_change_go_bytes() {
+    let info = ReplicatorInfo::from_raw(
+        GO_FIXTURE_PEER_ID.to_string(),
+        vec!["users".to_string()],
+        vec![],
+    );
+
+    let json = std::str::from_utf8(&info.to_bytes().unwrap())
+        .unwrap()
+        .to_string();
+    assert_eq!(json, GO_ZERO_STATUS_CHANGE);
+    assert!(
+        !json.contains("Filters"),
+        "empty Rust-only filter metadata must not drift from Go peerstore JSON"
+    );
+}
+
+#[test]
+fn filtered_replicator_round_trips_rust_extension() {
+    let mut filters = ReplicationFilters::new();
+    filters.insert(
+        "users".to_string(),
+        ReplicationFilter::new("agent_did", serde_json::json!("did:key:z6M")),
+    );
+    let info = ReplicatorInfo::from_raw_with_filters(
+        GO_FIXTURE_PEER_ID.to_string(),
+        vec!["users".to_string()],
+        vec![],
+        filters,
+    );
+
+    let bytes = info.to_bytes().unwrap();
+    assert_eq!(
+        std::str::from_utf8(&bytes).unwrap(),
+        r#"{"ID":"12D3KooWGjMkcMy5PM9iSbgWWgUnH5dQhvzhNu7w3Gk4kHZBsxnJ","Addresses":[],"CollectionIDs":["users"],"Status":0,"LastStatusChange":"0001-01-01T00:00:00Z","Filters":{"users":{"Field":"agent_did","Value":"did:key:z6M"}}}"#
+    );
+
+    let restored = ReplicatorInfo::from_bytes(&bytes).unwrap();
+    assert_eq!(restored, info);
+    assert!(restored.matches_filter(
+        "users",
+        &serde_json::json!({"agent_did": "did:key:z6M", "body": "selected"})
+    ));
+    assert!(!restored.matches_filter("users", &serde_json::json!({"agent_did": "did:key:other"})));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/query-parse/src/sdl_parse/builder.rs
+++ b/crates/query-parse/src/sdl_parse/builder.rs
@@ -467,6 +467,9 @@ impl<'a> SdlParser<'a> {
             if let Some(size) = parsed_field.directives.size_constraint {
                 field = field.with_size(size);
             }
+            if parsed_field.directives.immutable {
+                field = field.as_immutable();
+            }
 
             // Set relation name - use explicit @relation(name:) if provided, otherwise auto-generate
             if kind.is_relation() {

--- a/crates/query-parse/src/sdl_parse/directives.rs
+++ b/crates/query-parse/src/sdl_parse/directives.rs
@@ -18,6 +18,7 @@ pub const KNOWN_FIELD_DIRECTIVES: &[&str] = &[
     "embedding",
     "encryptedIndex",
     "fulltext",
+    "immutable",
     "policy", // Go allows @policy on fields in some contexts
 ];
 
@@ -49,6 +50,7 @@ pub fn known_directive_arguments(directive_name: &str) -> &'static [&'static str
         "embedding" => &["provider", "model", "url", "fields", "template"],
         "encryptedIndex" => &["type"],
         "fulltext" => &["language", "k1", "b"],
+        "immutable" => &[],
         _ => &[],
     }
 }
@@ -146,6 +148,8 @@ pub struct ParsedDirectives {
     pub embedding: Option<EmbeddingConfig>,
     /// Full-text search configuration from @fulltext directive
     pub fulltext: Option<FullTextConfig>,
+    /// Whether this field is immutable after document creation
+    pub immutable: bool,
 }
 
 /// Full-text search configuration from @fulltext directive

--- a/crates/query-parse/src/sdl_parse/fields.rs
+++ b/crates/query-parse/src/sdl_parse/fields.rs
@@ -92,6 +92,7 @@ impl<'a> SdlParser<'a> {
                         self.get_float_with_warning(directive, "b", &type_name, Some(field_name));
                     result.fulltext = Some(super::directives::FullTextConfig { language, k1, b });
                 }
+                "immutable" => result.immutable = true,
                 "embedding" => {
                     let provider = get_directive_string(directive, "provider").unwrap_or_default();
                     let model = get_directive_string(directive, "model").unwrap_or_default();

--- a/crates/query-parse/src/sdl_parse/parser_tests.rs
+++ b/crates/query-parse/src/sdl_parse/parser_tests.rs
@@ -146,9 +146,9 @@ fn test_parse_relation() {
 
     assert!(
         post.indexes.iter().all(|idx| {
-            !idx.fields
+            idx.fields
                 .first()
-                .is_some_and(|field| field.name == "_authorID")
+                .is_none_or(|field| field.name != "_authorID")
         }),
         "one-to-many relation FK indexes require an explicit @index"
     );

--- a/crates/query-parse/src/sdl_parse/parser_tests.rs
+++ b/crates/query-parse/src/sdl_parse/parser_tests.rs
@@ -82,6 +82,25 @@ fn test_parse_crdt_directive() {
 }
 
 #[test]
+fn test_parse_immutable_directive() {
+    let sdl = r#"
+        type AgentDoc {
+            agent_did: String @immutable
+            body: String
+        }
+    "#;
+
+    let collections = parse_sdl(sdl).unwrap();
+    let agent_doc = &collections[0];
+
+    let agent_did = agent_doc.field_by_name("agent_did").unwrap();
+    assert!(agent_did.immutable);
+
+    let body = agent_doc.field_by_name("body").unwrap();
+    assert!(!body.immutable);
+}
+
+#[test]
 fn test_parse_primary_directive() {
     let sdl = r#"
         type Post {
@@ -1122,6 +1141,7 @@ fn test_known_directives_no_warnings() {
             name: String @index(unique: true)
             age: Int @crdt(type: "pncounter")
             role: String @default(string: "user")
+            agent_did: String @immutable
         }
     "#;
 

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -62,6 +62,9 @@ pub enum SchemaError {
 
     #[error("invalid downsample configuration: {0}")]
     InvalidDownsample(String),
+
+    #[error("invalid immutable field {field_name}: {reason}")]
+    InvalidImmutableField { field_name: String, reason: String },
 }
 
 impl From<serde_json::Error> for SchemaError {

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -8,6 +8,10 @@ fn default_ctype_none() -> CType {
     CType::None
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 /// Describes a field within a collection schema.
 ///
 /// This matches Go's CollectionFieldDescription struct.
@@ -52,6 +56,10 @@ pub struct FieldDescription {
     /// Go uses int with 0 meaning no constraint.
     #[serde(rename = "Size", default)]
     pub size: usize,
+
+    /// Whether the field is write-once after document creation.
+    #[serde(rename = "Immutable", default, skip_serializing_if = "is_false")]
+    pub immutable: bool,
 }
 
 impl FieldDescription {
@@ -66,6 +74,7 @@ impl FieldDescription {
             is_primary: false,
             default_value: None,
             size: 0, // 0 means no constraint (matches Go)
+            immutable: false,
         }
     }
 
@@ -99,6 +108,12 @@ impl FieldDescription {
         self
     }
 
+    /// Mark the field as immutable after document creation.
+    pub fn as_immutable(mut self) -> Self {
+        self.immutable = true;
+        self
+    }
+
     /// Returns true if this is a secondary (non-primary) relation field.
     ///
     /// Secondary relation fields are local-only and do not get saved in the blockstore.
@@ -120,6 +135,21 @@ impl FieldDescription {
                 crdt_type: self.crdt_type.to_string().to_lowercase(),
                 field_kind: self.kind.graphql_type_name().to_string(),
             });
+        }
+
+        if self.immutable {
+            if self.crdt_type != CType::LwwRegister {
+                return Err(SchemaError::InvalidImmutableField {
+                    field_name: self.name.clone(),
+                    reason: "only LWW register fields can be immutable".to_string(),
+                });
+            }
+            if !self.kind.is_scalar() {
+                return Err(SchemaError::InvalidImmutableField {
+                    field_name: self.name.clone(),
+                    reason: "only scalar fields can be immutable".to_string(),
+                });
+            }
         }
 
         // Float counter merge is not order-independent: IEEE-754 addition is not
@@ -230,6 +260,55 @@ mod tests {
         let json = serde_json::to_string(&field).unwrap();
         let parsed: FieldDescription = serde_json::from_str(&json).unwrap();
         assert_eq!(field, parsed);
+    }
+
+    #[test]
+    fn test_immutable_scalar_lww_field_validates_and_serializes() {
+        let field = FieldDescription::new("1", "agent_did", FieldKind::string()).as_immutable();
+
+        field.validate().unwrap();
+        let json = serde_json::to_string(&field).unwrap();
+        assert!(
+            json.contains(r#""Immutable":true"#),
+            "immutable fields must persist the Rust extension metadata"
+        );
+        let parsed: FieldDescription = serde_json::from_str(&json).unwrap();
+        assert!(parsed.immutable);
+    }
+
+    #[test]
+    fn test_non_immutable_field_omits_rust_extension() {
+        let field = FieldDescription::new("1", "agent_did", FieldKind::string());
+
+        let json = serde_json::to_string(&field).unwrap();
+        assert!(
+            !json.contains("Immutable"),
+            "false immutable metadata must be omitted for Go-compatible schema JSON"
+        );
+    }
+
+    #[test]
+    fn test_immutable_counter_field_fails_validation() {
+        let field = FieldDescription::new("1", "score", FieldKind::int())
+            .with_crdt_type(CType::PnCounter)
+            .as_immutable();
+
+        let result = field.validate();
+        assert!(matches!(
+            result,
+            Err(SchemaError::InvalidImmutableField { .. })
+        ));
+    }
+
+    #[test]
+    fn test_immutable_array_field_fails_validation() {
+        let field = FieldDescription::new("1", "tags", FieldKind::string_array()).as_immutable();
+
+        let result = field.validate();
+        assert!(matches!(
+            result,
+            Err(SchemaError::InvalidImmutableField { .. })
+        ));
     }
 
     #[test]

--- a/crates/schema/src/field_kind.rs
+++ b/crates/schema/src/field_kind.rs
@@ -296,6 +296,27 @@ impl FieldKind {
         matches!(self, FieldKind::Scalar(_))
     }
 
+    /// Returns true if `value` has a JSON shape that could equal a materialized
+    /// document field of this kind. Used by filtered replication to reject a
+    /// filter predicate whose value type can never match the field (e.g. a
+    /// string `"30"` against an `Int` field), which would otherwise silently
+    /// select zero documents.
+    pub fn accepts_filter_value(&self, value: &serde_json::Value) -> bool {
+        match self {
+            FieldKind::Scalar(ScalarKind::String)
+            | FieldKind::Scalar(ScalarKind::DateTime)
+            | FieldKind::Scalar(ScalarKind::Blob)
+            | FieldKind::Scalar(ScalarKind::DocID) => value.is_string(),
+            FieldKind::Scalar(ScalarKind::Bool) => value.is_boolean(),
+            FieldKind::Scalar(ScalarKind::Int) => value.is_i64() || value.is_u64(),
+            FieldKind::Scalar(ScalarKind::Float64) | FieldKind::Scalar(ScalarKind::Float32) => {
+                value.is_number()
+            }
+            FieldKind::Scalar(ScalarKind::Json) => true,
+            _ => false,
+        }
+    }
+
     /// Returns true if values of this kind can be nil/null.
     /// In Go DefraDB, ALL types return true for IsNillable().
     pub fn is_nillable(&self) -> bool {
@@ -601,5 +622,44 @@ fn parse_string_kind(s: &str) -> Result<FieldKind, String> {
             };
             Ok(FieldKind::Named { name, is_array })
         }
+    }
+}
+
+#[cfg(test)]
+mod accepts_filter_value_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn string_field_accepts_only_strings() {
+        let k = FieldKind::string();
+        assert!(k.accepts_filter_value(&json!("did:key:alice")));
+        assert!(!k.accepts_filter_value(&json!(30)));
+        assert!(!k.accepts_filter_value(&json!(true)));
+    }
+
+    #[test]
+    fn int_field_rejects_stringified_numbers() {
+        let k = FieldKind::int();
+        assert!(k.accepts_filter_value(&json!(30)));
+        assert!(!k.accepts_filter_value(&json!("30")));
+        assert!(!k.accepts_filter_value(&json!(1.5)));
+    }
+
+    #[test]
+    fn bool_and_float_fields() {
+        assert!(FieldKind::bool().accepts_filter_value(&json!(true)));
+        assert!(!FieldKind::bool().accepts_filter_value(&json!("true")));
+        assert!(FieldKind::float64().accepts_filter_value(&json!(1.5)));
+        assert!(FieldKind::float64().accepts_filter_value(&json!(2)));
+    }
+
+    #[test]
+    fn relations_never_accept() {
+        let k = FieldKind::Relation {
+            collection_id: "Other".to_string(),
+            is_array: false,
+        };
+        assert!(!k.accepts_filter_value(&json!("x")));
     }
 }

--- a/crates/schema/tests/relation_id_fields_tests.rs
+++ b/crates/schema/tests/relation_id_fields_tests.rs
@@ -172,9 +172,9 @@ fn test_finalize_relations_adds_id_fields() {
 
     assert!(
         posts.indexes.iter().all(|idx| {
-            !idx.fields
+            idx.fields
                 .first()
-                .is_some_and(|field| field.name == "_authorID")
+                .is_none_or(|field| field.name != "_authorID")
         }),
         "one-to-many relation FK indexes require an explicit @index"
     );
@@ -261,9 +261,9 @@ fn test_finalize_relations_hashmap() {
 
     assert!(
         posts.indexes.iter().all(|idx| {
-            !idx.fields
+            idx.fields
                 .first()
-                .is_some_and(|field| field.name == "_authorID")
+                .is_none_or(|field| field.name != "_authorID")
         }),
         "one-to-many relation FK indexes require an explicit @index"
     );

--- a/crates/storage/src/backends/lark/tests/mod.rs
+++ b/crates/storage/src/backends/lark/tests/mod.rs
@@ -341,7 +341,7 @@ async fn low_level_crash_writer_helper() {
 
     for op_idx in 0..max_ops {
         let key = random_crash_key(&mut rng, 10_000);
-        let delete = rng.next_u64() % 10 == 0;
+        let delete = rng.next_u64().is_multiple_of(10);
         let line = if delete {
             let mut txn = store.new_txn(false).await.unwrap();
             txn.delete(&key).await.unwrap();
@@ -388,6 +388,7 @@ async fn verify_synced_shadow_log(db_path: &Path, shadow_path: &Path, synced_ops
     store.close().await.unwrap();
 }
 
+#[allow(clippy::type_complexity)]
 fn replay_synced_shadow_log(
     shadow_path: &Path,
     synced_ops: usize,

--- a/proofs/tests/behavioral/bughunt.rs
+++ b/proofs/tests/behavioral/bughunt.rs
@@ -603,12 +603,12 @@ async fn bughunt_counter_3node() {
     }
     // Full mesh: every node replicates to the other two.
     for i in 0..3 {
-        for j in 0..3 {
+        for (j, peer_addr) in addr.iter().enumerate() {
             if i != j {
-                cluster.client(i).p2p_connect(&[addr[j].as_str()]).ok();
+                cluster.client(i).p2p_connect(&[peer_addr.as_str()]).ok();
                 cluster
                     .client(i)
-                    .p2p_replicator_set(&["Tally"], &addr[j])
+                    .p2p_replicator_set(&["Tally"], peer_addr)
                     .ok();
             }
         }

--- a/proofs/tests/behavioral/parity.rs
+++ b/proofs/tests/behavioral/parity.rs
@@ -218,7 +218,7 @@ async fn parity_samedoc_rust_rust() {
 /// replication first silently dropped its own increment. This reports the
 /// Go-only and mixed cases to confirm Go converges (the parity target) and that
 /// Rust<->Go interop accumulates correctly.
-async fn run_counter_parity(mut cluster: TestCluster, label: &str) {
+async fn run_counter_parity(cluster: TestCluster, label: &str) {
     let schema = "type Tally { name: String  hits: Int @crdt(type: pcounter) }";
     cluster.client(0).schema_add(schema).expect("schema node0");
     cluster.client(1).schema_add(schema).expect("schema node1");
@@ -273,7 +273,7 @@ async fn run_counter_parity(mut cluster: TestCluster, label: &str) {
 /// classic semantic divergence point (does delete win, or does the concurrent
 /// update revive the doc?). The property that matters is that BOTH agree AND that
 /// Go and Rust agree with EACH OTHER.
-async fn run_delete_update_parity(mut cluster: TestCluster, label: &str) {
+async fn run_delete_update_parity(cluster: TestCluster, label: &str) {
     let schema = "type User { name: String  age: Int }";
     cluster.client(0).schema_add(schema).expect("schema node0");
     cluster.client(1).schema_add(schema).expect("schema node1");

--- a/proofs/tests/behavioral/partition.rs
+++ b/proofs/tests/behavioral/partition.rs
@@ -366,7 +366,7 @@ async fn poll_hits(node: &DefraClient, want: i64, timeout: Duration) -> bool {
 /// rust<->rust, go<->go, and rust<->go all converge to 90.
 #[tokio::test]
 async fn convergence_concurrent_counter_increments_sum() {
-    let mut cluster = TestCluster::builder()
+    let cluster = TestCluster::builder()
         .rust_nodes(2)
         .with_p2p()
         .with_store("redb")

--- a/tools/integration-test/tests/p2p.rs
+++ b/tools/integration-test/tests/p2p.rs
@@ -2,6 +2,8 @@
 mod connection_manager;
 #[path = "p2p/document.rs"]
 mod document;
+#[path = "p2p/filtered_replication.rs"]
+mod filtered_replication;
 #[path = "p2p/idempotent_replay.rs"]
 mod idempotent_replay;
 #[path = "p2p/manage_relay.rs"]

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -500,6 +500,35 @@ async fn rust_filtered_replicator_rejects_non_immutable_field() {
     );
 }
 
+/// G8/F1: filtering on a non-String scalar field with a value whose type cannot
+/// match it is rejected at add time. The CLI wraps `--filter-value` as a JSON
+/// string, so a filter on an `@immutable` Int field would otherwise pass
+/// validation yet silently match zero documents.
+#[tokio::test]
+async fn rust_filtered_replicator_rejects_type_mismatch() {
+    const INT_SCHEMA: &str = "type IntDoc { count: Int @immutable  body: String }";
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 1).await;
+    cluster.client(0).schema_add(INT_SCHEMA).expect("schema");
+
+    // `count` is a scalar @immutable Int, but the CLI sends "30" as a string.
+    let output = run_replicator_add(&cluster, 0, &["IntDoc"], DUMMY_PEER_ADDR, "count", "30");
+    assert!(
+        !output.status.success(),
+        "string filter value against an Int field must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not match the field type"),
+        "error should explain the value/field type mismatch, got: {stderr}"
+    );
+}
+
 // #3 (remote-merge enforcement of `@immutable`) is intentionally NOT an
 // integration-suite test. The guard in `composite_persist.rs` is defense-in-depth
 // against a malicious or divergent peer and is unreachable through two honest

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -581,6 +581,29 @@ async fn rust_filtered_replicator_rejects_type_mismatch() {
     );
 }
 
+/// G8/F6: the "must be a scalar LWW field" branch of filter validation is
+/// belt-and-suspenders — the schema layer already forbids `@immutable` on any
+/// non-LWW field, so a filter field that passes the `@immutable` check is
+/// necessarily a scalar LWW field. There is therefore no way to construct an
+/// `@immutable` non-LWW field to reach that branch; verify the underlying schema
+/// invariant directly instead.
+#[tokio::test]
+async fn rust_schema_rejects_immutable_non_lww_field() {
+    const COUNTER_SCHEMA: &str =
+        r#"type CounterDoc { hits: Int @crdt(type: "pncounter") @immutable  body: String }"#;
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+
+    let err = cluster
+        .client(0)
+        .schema_add(COUNTER_SCHEMA)
+        .expect_err("@immutable on a non-LWW (counter) field must be rejected by the schema");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("only LWW register fields can be immutable"),
+        "schema rejection should explain @immutable requires an LWW field, got: {msg}"
+    );
+}
+
 // #3 (remote-merge enforcement of `@immutable`) is intentionally NOT an
 // integration-suite test. The guard in `composite_persist.rs` is defense-in-depth
 // against a malicious or divergent peer and is unreachable through two honest

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -215,9 +215,10 @@ async fn filtered_excludes_nonmatching(cluster: TestCluster) {
         ))
         .expect("create non-matching doc");
 
-    // A SECOND matching doc, created AFTER the non-matching one. Replicator pushes
-    // are ordered, so once this arrives we know the non-matching doc's push slot was
-    // already processed-and-skipped — making its absence conclusive without a sleep.
+    // The non-matching doc is filtered at the SENDER and never pushed, so its
+    // absence is guaranteed by the filter — not by timing. Create a second
+    // matching doc and wait for it so the assertion runs only after the push
+    // pipeline has demonstrably delivered, replacing the earlier wall-clock sleep.
     let matching2 = node0
         .query(&format!(
             r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "selected-2"}}) {{ _docID }} }}"#
@@ -349,6 +350,9 @@ async fn rust_filtered_replication_backfill_respects_filter() {
     )
     .await;
 
+    // The non-matching doc is excluded by the sender-side backfill filter, not by
+    // this window. Backfill is unordered (no "after" anchor like the live-push
+    // tests), so a short settle window remains before asserting absence.
     tokio::time::sleep(ABSENCE_GRACE).await;
     let dids = agent_did_values(&cluster, 1);
     assert_eq!(
@@ -492,8 +496,8 @@ async fn rust_filtered_replication_encrypted_respects_filter() {
         ))
         .expect("create non-matching encrypted doc");
 
-    // Second matching doc created AFTER the non-matching one anchors the
-    // exclusion to ordered delivery rather than a wall-clock window.
+    // The non-matching doc is filtered at the sender and never pushed; the
+    // second matching doc just ensures delivery happened before asserting absence.
     let matching2 = node0
         .query(&format!(
             r#"mutation {{ add_SecretDoc(input: {{agent_did: "{ALICE}", secret: "s2"}}, encryptFields: [secret]) {{ _docID }} }}"#
@@ -715,7 +719,8 @@ async fn rust_filtered_replication_excludes_nonmatching_controlled_mode() {
     node0
         .query_with_identity(&mk(BOB, "b"), &alice.private_key_hex)
         .expect("create non-matching");
-    // Second matching doc after the non-matching one anchors exclusion to ordered delivery.
+    // BOB is filtered at the sender and never pushed; the second matching doc
+    // just ensures the push pipeline has delivered before we assert absence.
     let matching2 = node0
         .query_with_identity(&mk(ALICE, "a2"), &alice.private_key_hex)
         .expect("create second matching");

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -40,17 +40,17 @@ fn socket_addr(cluster: &TestCluster, node: usize) -> String {
 /// Add a filtered replicator from `node` to `addr` over the CLI, exercising the
 /// `--filter-field` / `--filter-value` flags the PR introduced. The CLI wraps
 /// `--filter-value` as a JSON string, matching string scalar fields.
-fn add_filtered_replicator(
+fn run_replicator_add(
     cluster: &TestCluster,
     node: usize,
     collections: &[&str],
     addr: &str,
     field: &str,
     value: &str,
-) {
+) -> std::process::Output {
     let client = cluster.client(node);
     let cols = collections.join(",");
-    let output = Command::new(client.binary_path())
+    Command::new(client.binary_path())
         .arg("--url")
         .arg(socket_addr(cluster, node))
         .args([
@@ -67,7 +67,18 @@ fn add_filtered_replicator(
             addr,
         ])
         .output()
-        .expect("exec filtered replicator add");
+        .expect("exec filtered replicator add")
+}
+
+fn add_filtered_replicator(
+    cluster: &TestCluster,
+    node: usize,
+    collections: &[&str],
+    addr: &str,
+    field: &str,
+    value: &str,
+) {
+    let output = run_replicator_add(cluster, node, collections, addr, field, value);
     assert!(
         output.status.success(),
         "filtered replicator add failed: status={} stderr={}",
@@ -424,6 +435,68 @@ async fn rust_filtered_replication_encrypted_respects_filter() {
     assert_eq!(
         count, 1,
         "filtered peer must hold only the matching encrypted document"
+    );
+}
+
+const DUMMY_PEER_ADDR: &str =
+    "/ip4/127.0.0.1/tcp/1/p2p/12D3KooWGjMkcMy5PM9iSbgWWgUnH5dQhvzhNu7w3Gk4kHZBsxnJ";
+
+/// G8: a filter on a field absent from the collection schema is rejected at
+/// add time (prevents a typo silently producing zero replication). Validation
+/// runs before any dial, so an unreachable dummy peer address is fine.
+#[tokio::test]
+async fn rust_filtered_replicator_rejects_unknown_field() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 1).await;
+    cluster.client(0).schema_add(AGENT_SCHEMA).expect("schema");
+
+    let output = run_replicator_add(
+        &cluster,
+        0,
+        &["AgentDoc"],
+        DUMMY_PEER_ADDR,
+        "nonexistent_field",
+        ALICE,
+    );
+    assert!(
+        !output.status.success(),
+        "filtering on a non-existent field must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "error should explain the field is not in the schema, got: {stderr}"
+    );
+}
+
+/// G8: a filter on an existing-but-mutable field is rejected — the filter key
+/// must be `@immutable` (the B3 split-ownership guard).
+#[tokio::test]
+async fn rust_filtered_replicator_rejects_non_immutable_field() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 1).await;
+    cluster.client(0).schema_add(AGENT_SCHEMA).expect("schema");
+
+    // `body` exists but is not @immutable.
+    let output = run_replicator_add(&cluster, 0, &["AgentDoc"], DUMMY_PEER_ADDR, "body", "x");
+    assert!(
+        !output.status.success(),
+        "filtering on a mutable field must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("immutable"),
+        "error should require the filter field be @immutable, got: {stderr}"
     );
 }
 

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -1,0 +1,436 @@
+//! End-to-end coverage for filtered replication (PR #1033).
+//!
+//! Filtered replication is a Rust-only extension: a replicator may carry a
+//! per-collection `{Field, Value}` predicate so a source node only pushes
+//! documents whose field matches. The feature spans live push, backfill, SE
+//! artifacts, and `@immutable` enforcement. These tests exercise that behavior
+//! across two running nodes via the real CLI/HTTP surface — the layer where the
+//! emergent "non-matching document must NOT arrive" property is observable.
+//!
+//! Because the predicate has no Go equivalent, these are explicit `rust_nodes`
+//! tests rather than `for_each_p2p_topology!` (which would generate Go variants).
+
+use std::process::Command;
+use std::time::Duration;
+
+use integration_test::{
+    extract_doc_id, extract_p2p_addr, poll_until, TestCluster, P2P_POLL_INTERVAL, P2P_TIMEOUT,
+};
+
+const AGENT_SCHEMA: &str = "type AgentDoc { agent_did: String @immutable  body: String }";
+const ALICE: &str = "did:key:alice";
+const BOB: &str = "did:key:bob";
+
+/// Grace window used to confirm a non-matching document stays absent *after*
+/// a matching document has already replicated. Once the matching doc arrives we
+/// know the push pipeline ran, so continued absence of the non-matching doc is
+/// meaningful rather than merely "not yet replicated".
+const ABSENCE_GRACE: Duration = Duration::from_secs(3);
+
+/// The CLI `--url` flag expects a bare `host:port`, while `api_url` carries the
+/// `http://` scheme. The harness's own client uses the node's bare address.
+fn socket_addr(cluster: &TestCluster, node: usize) -> String {
+    let url = cluster.api_url(node);
+    url.strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .unwrap_or(url)
+        .to_string()
+}
+
+/// Add a filtered replicator from `node` to `addr` over the CLI, exercising the
+/// `--filter-field` / `--filter-value` flags the PR introduced. The CLI wraps
+/// `--filter-value` as a JSON string, matching string scalar fields.
+fn add_filtered_replicator(
+    cluster: &TestCluster,
+    node: usize,
+    collections: &[&str],
+    addr: &str,
+    field: &str,
+    value: &str,
+) {
+    let client = cluster.client(node);
+    let cols = collections.join(",");
+    let output = Command::new(client.binary_path())
+        .arg("--url")
+        .arg(socket_addr(cluster, node))
+        .args([
+            "client",
+            "p2p",
+            "replicator",
+            "add",
+            "-c",
+            &cols,
+            "--filter-field",
+            field,
+            "--filter-value",
+            value,
+            addr,
+        ])
+        .output()
+        .expect("exec filtered replicator add");
+    assert!(
+        output.status.success(),
+        "filtered replicator add failed: status={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn agent_did_values(cluster: &TestCluster, node: usize) -> Vec<String> {
+    let result = cluster
+        .client(node)
+        .query("query { AgentDoc { _docID agent_did body } }")
+        .expect("query AgentDoc");
+    result["AgentDoc"]
+        .as_array()
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|r| r["agent_did"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+async fn wait_for_log_ready(cluster: &TestCluster, count: usize) {
+    for i in 0..count {
+        cluster
+            .wait_for_log(i, "p2p_listening", P2P_TIMEOUT)
+            .await
+            .unwrap_or_else(|_| panic!("node{i} P2P listener did not start"));
+    }
+}
+
+/// Core of tests #1 (negative match) and #2 (positive match + full-DAG
+/// completeness): a matching document replicates with ALL fields populated,
+/// while a non-matching document is excluded. Parameterized over transport.
+async fn filtered_excludes_nonmatching(cluster: TestCluster) {
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AGENT_SCHEMA).expect("schema node0");
+    node1.schema_add(AGENT_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0");
+    // The receiver does NOT subscribe to the collection: it must receive
+    // documents only via the filtered replicator push. Subscribing it would
+    // pull all docs over collection pubsub and bypass the filter.
+    add_filtered_replicator(&cluster, 0, &["AgentDoc"], &addr1, "agent_did", ALICE);
+
+    // Confirm the predicate landed in the persisted replicator record, read via
+    // the HTTP API (wire-format coverage for the Rust-only `Filters` extension).
+    // NOTE: the CLI `replicator list` deserializer (`P2pReplicatorInfo`) does not
+    // carry a `filters` field, so this must be asserted over HTTP, not the CLI.
+    let listed: serde_json::Value =
+        reqwest::get(format!("{}/api/v0/p2p/replicators", cluster.api_url(0)))
+            .await
+            .expect("GET replicators")
+            .json()
+            .await
+            .expect("parse replicators json");
+    let listed_str = serde_json::to_string(&listed).unwrap();
+    assert!(
+        listed_str.contains("Filters") && listed_str.contains("agent_did"),
+        "HTTP replicator list should expose the Filters predicate: {listed_str}"
+    );
+
+    let matching = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "selected"}}) {{ _docID }} }}"#
+        ))
+        .expect("create matching doc");
+    let matching_id = extract_doc_id(&matching, "add_AgentDoc");
+
+    node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{BOB}", body: "excluded"}}) {{ _docID }} }}"#
+        ))
+        .expect("create non-matching doc");
+
+    // The matching document must arrive AND be fully materialized — body
+    // populated proves the full document DAG was delivered (filtered peers
+    // bypass generic Bitswap, so partial delivery would surface here).
+    let node1_for_poll = cluster.client(1);
+    let matching_id_poll = matching_id.clone();
+    poll_until(
+        || {
+            let result = node1_for_poll
+                .query("query { AgentDoc { _docID agent_did body } }")
+                .unwrap_or_default();
+            result["AgentDoc"].as_array().is_some_and(|rows| {
+                rows.iter().any(|r| {
+                    r["_docID"].as_str() == Some(matching_id_poll.as_str())
+                        && r["agent_did"].as_str() == Some(ALICE)
+                        && r["body"].as_str() == Some("selected")
+                })
+            })
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "matching document did not replicate to filtered peer",
+    )
+    .await;
+
+    // After the matching doc has replicated, the non-matching doc must remain
+    // absent through a grace window.
+    tokio::time::sleep(ABSENCE_GRACE).await;
+    let dids = agent_did_values(&cluster, 1);
+    assert_eq!(
+        dids,
+        vec![ALICE.to_string()],
+        "filtered peer must hold only the matching document, found: {dids:?}"
+    );
+}
+
+/// #1 + #2 over libp2p.
+#[tokio::test]
+async fn rust_filtered_replication_excludes_nonmatching() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    filtered_excludes_nonmatching(cluster).await;
+}
+
+/// #7: identical guarantee must hold over the iroh transport (defra-agent's
+/// production transport).
+#[tokio::test]
+async fn rust_filtered_replication_excludes_nonmatching_iroh() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_iroh_transport()
+        .build()
+        .await
+        .unwrap();
+    filtered_excludes_nonmatching(cluster).await;
+}
+
+/// #5: a replicator added AFTER documents already exist must backfill only the
+/// documents matching its predicate.
+#[tokio::test]
+async fn rust_filtered_replication_backfill_respects_filter() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AGENT_SCHEMA).expect("schema node0");
+    node1.schema_add(AGENT_SCHEMA).expect("schema node1");
+
+    // Create documents BEFORE wiring replication so delivery comes from
+    // backfill, not live push.
+    let matching = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "backfilled"}}) {{ _docID }} }}"#
+        ))
+        .expect("create matching doc");
+    let matching_id = extract_doc_id(&matching, "add_AgentDoc");
+    node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{BOB}", body: "excluded"}}) {{ _docID }} }}"#
+        ))
+        .expect("create non-matching doc");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0");
+    // Receiver relies on the filtered replicator push only (see note above).
+    add_filtered_replicator(&cluster, 0, &["AgentDoc"], &addr1, "agent_did", ALICE);
+
+    let node1_for_poll = cluster.client(1);
+    let matching_id_poll = matching_id.clone();
+    poll_until(
+        || {
+            let result = node1_for_poll
+                .query("query { AgentDoc { _docID } }")
+                .unwrap_or_default();
+            result["AgentDoc"].as_array().is_some_and(|rows| {
+                rows.iter()
+                    .any(|r| r["_docID"].as_str() == Some(matching_id_poll.as_str()))
+            })
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "matching document did not backfill to filtered peer",
+    )
+    .await;
+
+    tokio::time::sleep(ABSENCE_GRACE).await;
+    let dids = agent_did_values(&cluster, 1);
+    assert_eq!(
+        dids,
+        vec![ALICE.to_string()],
+        "backfill must respect the filter, found: {dids:?}"
+    );
+}
+
+/// #4: `@immutable` enforcement on the LOCAL write path. Updating the immutable
+/// field must be rejected; updating other fields must succeed.
+#[tokio::test]
+async fn rust_immutable_field_rejects_local_update() {
+    let cluster = TestCluster::builder().rust_nodes(1).build().await.unwrap();
+    let node = cluster.client(0);
+    node.schema_add(AGENT_SCHEMA).expect("schema");
+
+    let created = node
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "v1"}}) {{ _docID }} }}"#
+        ))
+        .expect("create doc");
+    let doc_id = extract_doc_id(&created, "add_AgentDoc");
+
+    // Allowed: mutate a non-immutable field.
+    node.query(&format!(
+        r#"mutation {{ update_AgentDoc(docID: "{doc_id}", input: {{body: "v2"}}) {{ _docID body }} }}"#
+    ))
+    .expect("update body should succeed");
+
+    // Rejected: mutate the immutable field. The CLI may surface this as a
+    // non-zero exit or a GraphQL error payload — either way the stored value
+    // must be unchanged, which is the invariant we assert.
+    let _ = node.query(&format!(
+        r#"mutation {{ update_AgentDoc(docID: "{doc_id}", input: {{agent_did: "{BOB}"}}) {{ _docID }} }}"#
+    ));
+
+    let after = node
+        .query("query { AgentDoc { agent_did body } }")
+        .expect("query after update");
+    let row = &after["AgentDoc"][0];
+    assert_eq!(
+        row["agent_did"].as_str(),
+        Some(ALICE),
+        "immutable field must not change"
+    );
+    assert_eq!(
+        row["body"].as_str(),
+        Some("v2"),
+        "non-immutable field update should have persisted"
+    );
+}
+
+/// #6: the CLI contract — `--filter-value` without `--filter-field` is rejected
+/// before any network call (clap `requires`).
+#[tokio::test]
+async fn rust_filtered_replicator_cli_requires_filter_field() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    let client = cluster.client(0);
+    let output = Command::new(client.binary_path())
+        .arg("--url")
+        .arg(socket_addr(&cluster, 0))
+        .args([
+            "client",
+            "p2p",
+            "replicator",
+            "add",
+            "-c",
+            "AgentDoc",
+            "--filter-value",
+            ALICE,
+            "/ip4/127.0.0.1/tcp/1/p2p/12D3KooWGjMkcMy5PM9iSbgWWgUnH5dQhvzhNu7w3Gk4kHZBsxnJ",
+        ])
+        .output()
+        .expect("exec replicator add");
+    assert!(
+        !output.status.success(),
+        "--filter-value without --filter-field must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("filter-field"),
+        "error should mention the missing --filter-field, got: {stderr}"
+    );
+}
+
+/// #8: the filter must gate the encrypted (SE-artifact) push path too. A
+/// non-matching encrypted document must not reach the filtered peer; a matching
+/// one must (its `_docID` is observable even without the decryption key).
+#[tokio::test]
+async fn rust_filtered_replication_encrypted_respects_filter() {
+    const SECRET_SCHEMA: &str = "type SecretDoc { agent_did: String @immutable  secret: String }";
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(SECRET_SCHEMA).expect("schema node0");
+    node1.schema_add(SECRET_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["SecretDoc"])
+        .expect("subscribe 0");
+    // Receiver relies on the filtered replicator push only (see note above).
+    add_filtered_replicator(&cluster, 0, &["SecretDoc"], &addr1, "agent_did", ALICE);
+
+    let matching = node0
+        .query(&format!(
+            r#"mutation {{ add_SecretDoc(input: {{agent_did: "{ALICE}", secret: "s"}}, encryptFields: [secret]) {{ _docID }} }}"#
+        ))
+        .expect("create matching encrypted doc");
+    let matching_id = extract_doc_id(&matching, "add_SecretDoc");
+    node0
+        .query(&format!(
+            r#"mutation {{ add_SecretDoc(input: {{agent_did: "{BOB}", secret: "s"}}, encryptFields: [secret]) {{ _docID }} }}"#
+        ))
+        .expect("create non-matching encrypted doc");
+
+    let node1_for_poll = cluster.client(1);
+    let matching_id_poll = matching_id.clone();
+    poll_until(
+        || {
+            let result = node1_for_poll
+                .query("query { SecretDoc { _docID } }")
+                .unwrap_or_default();
+            result["SecretDoc"].as_array().is_some_and(|rows| {
+                rows.iter()
+                    .any(|r| r["_docID"].as_str() == Some(matching_id_poll.as_str()))
+            })
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "matching encrypted document did not replicate to filtered peer",
+    )
+    .await;
+
+    tokio::time::sleep(ABSENCE_GRACE).await;
+    let result = node1
+        .query("query { SecretDoc { _docID } }")
+        .expect("query SecretDoc on node1");
+    let count = result["SecretDoc"].as_array().map(Vec::len).unwrap_or(0);
+    assert_eq!(
+        count, 1,
+        "filtered peer must hold only the matching encrypted document"
+    );
+}
+
+// #3 (remote-merge enforcement of `@immutable`) is intentionally NOT an
+// integration-suite test. The guard in `composite_persist.rs` is defense-in-depth
+// against a malicious or divergent peer and is unreachable through two honest
+// nodes: local validation blocks the originating update, and content-addressed
+// doc IDs prevent two honest nodes from forging the same docID with differing
+// immutable values. It is covered directly at the merge layer by
+// `db-merge`'s `remote_composite_merge_rejects_immutable_field_change`.

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -14,7 +14,8 @@ use std::process::Command;
 use std::time::Duration;
 
 use integration_test::{
-    extract_doc_id, extract_p2p_addr, poll_until, TestCluster, P2P_POLL_INTERVAL, P2P_TIMEOUT,
+    extract_doc_id, extract_p2p_addr, generate_identity, poll_until, TestCluster,
+    P2P_POLL_INTERVAL, P2P_TIMEOUT, USER_ACP_POLICY,
 };
 
 const AGENT_SCHEMA: &str = "type AgentDoc { agent_did: String @immutable  body: String }";
@@ -82,6 +83,46 @@ fn add_filtered_replicator(
     assert!(
         output.status.success(),
         "filtered replicator add failed: status={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Add a filtered replicator authenticated as `identity_hex` (for Controlled/ACP mode).
+fn add_filtered_replicator_with_identity(
+    cluster: &TestCluster,
+    node: usize,
+    collections: &[&str],
+    addr: &str,
+    field: &str,
+    value: &str,
+    identity_hex: &str,
+) {
+    let client = cluster.client(node);
+    let cols = collections.join(",");
+    let output = Command::new(client.binary_path())
+        .arg("--url")
+        .arg(socket_addr(cluster, node))
+        .args([
+            "client",
+            "-i",
+            identity_hex,
+            "p2p",
+            "replicator",
+            "add",
+            "-c",
+            &cols,
+            "--filter-field",
+            field,
+            "--filter-value",
+            value,
+            addr,
+        ])
+        .output()
+        .expect("exec filtered replicator add (with identity)");
+    assert!(
+        output.status.success(),
+        "filtered replicator add (identity) failed: status={} stderr={}",
         output.status,
         String::from_utf8_lossy(&output.stderr)
     );
@@ -601,6 +642,118 @@ async fn rust_schema_rejects_immutable_non_lww_field() {
     assert!(
         msg.contains("only LWW register fields can be immutable"),
         "schema rejection should explain @immutable requires an LWW field, got: {msg}"
+    );
+}
+
+/// #1-test / F7: filtered replication under ACP (Controlled access mode). Every
+/// other filtered test runs in Open mode, where `bitswap/filter.rs` short-circuits
+/// (`mode.is_open() -> true`) before the filtered-replicator gating. Running under
+/// `with_acp_local()` keeps `check_access` in Controlled mode so its
+/// filtered-replicator logic is active. (The deny branch itself fires only on a
+/// Bitswap WANT for a known non-matching CID, which the harness cannot issue; that
+/// branch stays covered by the in-process unit test
+/// `controlled_mode_denies_filtered_replicator_data_block_requests`.)
+#[tokio::test]
+async fn rust_filtered_replication_excludes_nonmatching_controlled_mode() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_acp_local()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    let alice = generate_identity(node0.binary_path()).expect("generate identity");
+
+    let policy = node0
+        .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+        .expect("policy node0");
+    let policy_id = policy["PolicyID"]
+        .as_str()
+        .or_else(|| policy["policyID"].as_str())
+        .expect("policy id")
+        .to_string();
+    node1
+        .acp_policy_add(USER_ACP_POLICY, &alice.private_key_hex)
+        .expect("policy node1");
+
+    let schema = format!(
+        r#"type User @policy(id: "{policy_id}", resource: "users") {{ agent_did: String @immutable  name: String }}"#
+    );
+    node0
+        .schema_add_with_identity(&schema, &alice.private_key_hex)
+        .expect("schema node0");
+    node1
+        .schema_add_with_identity(&schema, &alice.private_key_hex)
+        .expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0.p2p_collection_add(&["User"]).expect("subscribe 0");
+    add_filtered_replicator_with_identity(
+        &cluster,
+        0,
+        &["User"],
+        &addr1,
+        "agent_did",
+        ALICE,
+        &alice.private_key_hex,
+    );
+
+    let mk = |did: &str, name: &str| {
+        format!(
+            r#"mutation {{ add_User(input: {{agent_did: "{did}", name: "{name}"}}) {{ _docID }} }}"#
+        )
+    };
+    let matching = node0
+        .query_with_identity(&mk(ALICE, "a"), &alice.private_key_hex)
+        .expect("create matching");
+    let matching_id = extract_doc_id(&matching, "add_User");
+    node0
+        .query_with_identity(&mk(BOB, "b"), &alice.private_key_hex)
+        .expect("create non-matching");
+    // Second matching doc after the non-matching one anchors exclusion to ordered delivery.
+    let matching2 = node0
+        .query_with_identity(&mk(ALICE, "a2"), &alice.private_key_hex)
+        .expect("create second matching");
+    let matching2_id = extract_doc_id(&matching2, "add_User");
+
+    // Replicated docs are unregistered on node1, so they are public there.
+    let node1_for_poll = cluster.client(1);
+    let m1 = matching_id.clone();
+    let m2 = matching2_id.clone();
+    poll_until(
+        || {
+            let result = node1_for_poll
+                .query("query { User { _docID agent_did } }")
+                .unwrap_or_default();
+            let Some(rows) = result["User"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&m1.as_str()) && ids.contains(&m2.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "matching docs did not replicate to filtered peer under ACP",
+    )
+    .await;
+
+    let result = node1
+        .query("query { User { agent_did } }")
+        .expect("query node1");
+    let rows = result["User"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        rows.len(),
+        2,
+        "filtered peer must hold only the two matching docs under ACP, found: {rows:?}"
+    );
+    assert!(
+        rows.iter().all(|r| r["agent_did"].as_str() == Some(ALICE)),
+        "filtered peer must hold only matching documents under ACP, found: {rows:?}"
     );
 }
 

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -87,6 +87,18 @@ fn add_filtered_replicator(
     );
 }
 
+/// Run a GraphQL query/mutation over the CLI and return the raw process output,
+/// so a test can observe error payloads the typed `query()` helper discards.
+fn run_query(cluster: &TestCluster, node: usize, gql: &str) -> std::process::Output {
+    let client = cluster.client(node);
+    Command::new(client.binary_path())
+        .arg("--url")
+        .arg(socket_addr(cluster, node))
+        .args(["client", "query", gql])
+        .output()
+        .expect("exec query")
+}
+
 fn agent_did_values(cluster: &TestCluster, node: usize) -> Vec<String> {
     let result = cluster
         .client(node)
@@ -309,12 +321,25 @@ async fn rust_immutable_field_rejects_local_update() {
     ))
     .expect("update body should succeed");
 
-    // Rejected: mutate the immutable field. The CLI may surface this as a
-    // non-zero exit or a GraphQL error payload — either way the stored value
-    // must be unchanged, which is the invariant we assert.
-    let _ = node.query(&format!(
-        r#"mutation {{ update_AgentDoc(docID: "{doc_id}", input: {{agent_did: "{BOB}"}}) {{ _docID }} }}"#
-    ));
+    // Rejected: mutate the immutable field. Observe the rejection directly from
+    // the raw CLI output so a regression into silently DROPPING the field (a
+    // no-op that also leaves the value unchanged) cannot pass this test.
+    let rejected = run_query(
+        &cluster,
+        0,
+        &format!(
+            r#"mutation {{ update_AgentDoc(docID: "{doc_id}", input: {{agent_did: "{BOB}"}}) {{ _docID }} }}"#
+        ),
+    );
+    let output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&rejected.stdout),
+        String::from_utf8_lossy(&rejected.stderr)
+    );
+    assert!(
+        output.contains("immutable"),
+        "immutable update must surface an error mentioning the immutable field, got: {output}"
+    );
 
     let after = node
         .query("query { AgentDoc { agent_did body } }")

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -174,38 +174,55 @@ async fn filtered_excludes_nonmatching(cluster: TestCluster) {
         ))
         .expect("create non-matching doc");
 
-    // The matching document must arrive AND be fully materialized — body
-    // populated proves the full document DAG was delivered (filtered peers
-    // bypass generic Bitswap, so partial delivery would surface here).
+    // A SECOND matching doc, created AFTER the non-matching one. Replicator pushes
+    // are ordered, so once this arrives we know the non-matching doc's push slot was
+    // already processed-and-skipped — making its absence conclusive without a sleep.
+    let matching2 = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "selected-2"}}) {{ _docID }} }}"#
+        ))
+        .expect("create second matching doc");
+    let matching2_id = extract_doc_id(&matching2, "add_AgentDoc");
+
+    // Both matching docs must arrive; the first fully materialized (body present)
+    // proves the full document DAG was delivered (filtered peers bypass Bitswap).
     let node1_for_poll = cluster.client(1);
     let matching_id_poll = matching_id.clone();
+    let matching2_id_poll = matching2_id.clone();
     poll_until(
         || {
             let result = node1_for_poll
                 .query("query { AgentDoc { _docID agent_did body } }")
                 .unwrap_or_default();
-            result["AgentDoc"].as_array().is_some_and(|rows| {
-                rows.iter().any(|r| {
-                    r["_docID"].as_str() == Some(matching_id_poll.as_str())
-                        && r["agent_did"].as_str() == Some(ALICE)
-                        && r["body"].as_str() == Some("selected")
-                })
-            })
+            let Some(rows) = result["AgentDoc"].as_array() else {
+                return false;
+            };
+            let first_full = rows.iter().any(|r| {
+                r["_docID"].as_str() == Some(matching_id_poll.as_str())
+                    && r["agent_did"].as_str() == Some(ALICE)
+                    && r["body"].as_str() == Some("selected")
+            });
+            let second = rows
+                .iter()
+                .any(|r| r["_docID"].as_str() == Some(matching2_id_poll.as_str()));
+            first_full && second
         },
         P2P_TIMEOUT,
         P2P_POLL_INTERVAL,
-        "matching document did not replicate to filtered peer",
+        "both matching documents did not replicate to filtered peer",
     )
     .await;
 
-    // After the matching doc has replicated, the non-matching doc must remain
-    // absent through a grace window.
-    tokio::time::sleep(ABSENCE_GRACE).await;
+    // The non-matching doc must be absent: the peer holds only the two matching docs.
     let dids = agent_did_values(&cluster, 1);
     assert_eq!(
-        dids,
-        vec![ALICE.to_string()],
-        "filtered peer must hold only the matching document, found: {dids:?}"
+        dids.len(),
+        2,
+        "filtered peer must hold exactly the two matching docs, found: {dids:?}"
+    );
+    assert!(
+        dids.iter().all(|d| d == ALICE),
+        "filtered peer must hold only matching documents, found: {dids:?}"
     );
 }
 
@@ -434,32 +451,42 @@ async fn rust_filtered_replication_encrypted_respects_filter() {
         ))
         .expect("create non-matching encrypted doc");
 
+    // Second matching doc created AFTER the non-matching one anchors the
+    // exclusion to ordered delivery rather than a wall-clock window.
+    let matching2 = node0
+        .query(&format!(
+            r#"mutation {{ add_SecretDoc(input: {{agent_did: "{ALICE}", secret: "s2"}}, encryptFields: [secret]) {{ _docID }} }}"#
+        ))
+        .expect("create second matching encrypted doc");
+    let matching2_id = extract_doc_id(&matching2, "add_SecretDoc");
+
     let node1_for_poll = cluster.client(1);
     let matching_id_poll = matching_id.clone();
+    let matching2_id_poll = matching2_id.clone();
     poll_until(
         || {
             let result = node1_for_poll
                 .query("query { SecretDoc { _docID } }")
                 .unwrap_or_default();
-            result["SecretDoc"].as_array().is_some_and(|rows| {
-                rows.iter()
-                    .any(|r| r["_docID"].as_str() == Some(matching_id_poll.as_str()))
-            })
+            let Some(rows) = result["SecretDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&matching_id_poll.as_str()) && ids.contains(&matching2_id_poll.as_str())
         },
         P2P_TIMEOUT,
         P2P_POLL_INTERVAL,
-        "matching encrypted document did not replicate to filtered peer",
+        "matching encrypted documents did not replicate to filtered peer",
     )
     .await;
 
-    tokio::time::sleep(ABSENCE_GRACE).await;
     let result = node1
         .query("query { SecretDoc { _docID } }")
         .expect("query SecretDoc on node1");
     let count = result["SecretDoc"].as_array().map(Vec::len).unwrap_or(0);
     assert_eq!(
-        count, 1,
-        "filtered peer must hold only the matching encrypted document"
+        count, 2,
+        "filtered peer must hold only the two matching encrypted documents"
     );
 }
 

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -762,6 +762,89 @@ async fn rust_filtered_replication_excludes_nonmatching_controlled_mode() {
     );
 }
 
+/// A typed Float filter value (2.0) — set via HTTP, since the CLI only sends
+/// string values — matches a whole-number Float field that materializes as an
+/// integer JSON number, exercising numeric-aware filter matching end to end.
+#[tokio::test]
+async fn rust_filtered_replication_float_filter_matches_numerically() {
+    const SCORE_SCHEMA: &str = "type ScoreDoc { score: Float @immutable  body: String }";
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+    node0.schema_add(SCORE_SCHEMA).expect("schema node0");
+    node1.schema_add(SCORE_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["ScoreDoc"])
+        .expect("subscribe 0");
+
+    // Typed Float filter value (2.0) — must go via HTTP; the CLI wraps as a string.
+    let resp = reqwest::Client::new()
+        .post(format!("{}/api/v0/p2p/replicators", cluster.api_url(0)))
+        .json(&serde_json::json!({
+            "Collections": ["ScoreDoc"],
+            "Addresses": [addr1],
+            "Filters": {"ScoreDoc": {"Field": "score", "Value": 2.0}}
+        }))
+        .send()
+        .await
+        .expect("add filtered replicator");
+    assert!(
+        resp.status().is_success(),
+        "HTTP filtered replicator add failed: {}",
+        resp.status()
+    );
+
+    let matching = node0
+        .query(r#"mutation { add_ScoreDoc(input: {score: 2.0, body: "a"}) { _docID } }"#)
+        .expect("matching");
+    let matching_id = extract_doc_id(&matching, "add_ScoreDoc");
+    node0
+        .query(r#"mutation { add_ScoreDoc(input: {score: 3.0, body: "b"}) { _docID } }"#)
+        .expect("non-matching");
+    let matching2 = node0
+        .query(r#"mutation { add_ScoreDoc(input: {score: 2.0, body: "a2"}) { _docID } }"#)
+        .expect("matching2");
+    let matching2_id = extract_doc_id(&matching2, "add_ScoreDoc");
+
+    let node1_poll = cluster.client(1);
+    let m1 = matching_id.clone();
+    let m2 = matching2_id.clone();
+    poll_until(
+        || {
+            let r = node1_poll
+                .query("query { ScoreDoc { _docID } }")
+                .unwrap_or_default();
+            let Some(rows) = r["ScoreDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|x| x["_docID"].as_str()).collect();
+            ids.contains(&m1.as_str()) && ids.contains(&m2.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "Float-matching docs did not replicate to filtered peer",
+    )
+    .await;
+
+    let result = node1
+        .query("query { ScoreDoc { _docID } }")
+        .expect("query node1");
+    let count = result["ScoreDoc"].as_array().map(Vec::len).unwrap_or(0);
+    assert_eq!(
+        count, 2,
+        "filtered peer must hold only the two score=2.0 docs, not score=3.0"
+    );
+}
+
 // #3 (remote-merge enforcement of `@immutable`) is intentionally NOT an
 // integration-suite test. The guard in `composite_persist.rs` is defense-in-depth
 // against a malicious or divergent peer and is unreachable through two honest


### PR DESCRIPTION
Closes #1013.

## Summary
- Add optional per-collection `ReplicatorInfo.Filters` equality predicates while preserving byte-identical Go peerstore JSON for unfiltered records.
- Add `@immutable` scalar LWW filter keys and enforce them on local writes and remote P2P merge.
- Make live push, transaction/batch broadcast, backfill, retry, SE artifacts, recovery, registry, and Bitswap access filter-aware. Filtered peers receive matching full document DAGs by direct push and are not subscribed to collection-wide data gossip.
- Expose filtered replicators through HTTP/CLI/adapters with validation and persisted recovery for libp2p and iroh.

## Verification
- `cargo test -p p2p`
- `cargo test -p schema immutable`
- `cargo test -p query-parse immutable`
- `cargo test -p query-parse test_known_directives_no_warnings`
- `cargo test -p db create_in_tx_forwards_to_broadcaster_on_commit`
- `cargo test -p db immutable_field_validation`
- `cargo test -p db-merge`
- `cargo test -p defra-p2p-adapter`
- `cargo check -p p2p -p db -p db-merge -p defra-http -p defra-p2p-adapter -p cli -p defra-node -p embedded`
- `git diff --check`