### PR TITLE
Filtered replication: rich filter predicates (IN-set, composite, typed) via query-filter reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,6 +3703,7 @@ dependencies = [
  "lens",
  "p2p",
  "query",
+ "replication-filter",
  "reqwest 0.12.28",
  "schema",
  "serde",
@@ -3739,6 +3740,7 @@ dependencies = [
  "lens",
  "libp2p",
  "p2p",
+ "replication-filter",
  "schema",
  "serde",
  "serde_bytes",
@@ -10478,6 +10480,7 @@ version = "0.5.0"
 dependencies = [
  "p2p",
  "query",
+ "schema",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,6 +2121,7 @@ dependencies = [
  "portpicker",
  "query",
  "rand 0.9.2",
+ "replication-filter",
  "reqwest 0.12.28",
  "schema",
  "serde",
@@ -4236,6 +4237,7 @@ dependencies = [
  "libp2p",
  "p2p",
  "query",
+ "replication-filter",
  "schema",
  "serde",
  "serde_bytes",
@@ -10468,6 +10470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "replication-filter"
+version = "0.5.0"
+dependencies = [
+ "p2p",
+ "query",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "crates/wasm",
     "crates/pg-compat",
     "crates/defra-node",
+    "crates/replication-filter",
     "crates/telemetry",
     "tools/lens-host",
     "tools/ffi-test",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,6 +29,7 @@ p2p = { path = "../p2p", features = ["libp2p-transport"] }
 defra-p2p-adapter = { path = "../p2p-adapter", default-features = false, features = ["libp2p"] }
 defra-http = { path = "../http" }
 query = { path = "../query" }
+replication-filter = { path = "../replication-filter" }
 db = { path = "../db" }
 db-backup = { path = "../db-backup" }
 db-merge = { path = "../db-merge" }

--- a/crates/cli/src/commands/client/p2p/manage.rs
+++ b/crates/cli/src/commands/client/p2p/manage.rs
@@ -6,7 +6,9 @@
 //! operation via NAC.
 
 use clap::{Args, Subcommand};
-use defra_http::router::{RemoteManageDocRef, RemoteManageOp, RemoteManageQueryOp};
+use defra_http::router::{
+    RemoteManageDocRef, RemoteManageOp, RemoteManageQueryOp, ReplicationFilter, ReplicationFilters,
+};
 
 use crate::commands::client::http_client::HttpClient;
 use crate::commands::client::http_client::{mint_manage_token, ManageQueryResultResponse};
@@ -267,6 +269,10 @@ pub struct ManageReplicatorMutateArgs {
     /// Collection ID(s) to replicate
     #[arg(value_name = "COLLECTION_IDS", required = true)]
     pub collection_ids: Vec<String>,
+
+    /// Optional rich replication filter (JSON conditions object), applied to all listed collections.
+    #[arg(long, value_name = "json")]
+    pub filter: Option<String>,
 }
 
 impl P2pManageReplicatorArgs {
@@ -304,6 +310,7 @@ impl ManageReplicatorMutateArgs {
             RemoteManageOp::ReplicatorAdd {
                 addresses,
                 collection_ids: self.collection_ids.clone(),
+                filters: self.build_filters()?,
             }
         } else {
             RemoteManageOp::ReplicatorDelete {
@@ -321,6 +328,25 @@ impl ManageReplicatorMutateArgs {
             self.collection_ids.join(", ")
         );
         Ok(())
+    }
+
+    fn build_filters(&self) -> Result<ReplicationFilters> {
+        let Some(raw) = self.filter.as_deref() else {
+            return Ok(ReplicationFilters::new());
+        };
+        let value: serde_json::Value = serde_json::from_str(raw)
+            .map_err(|e| Error::InvalidConfig(format!("--filter is not valid JSON: {e}")))?;
+        let conds = value
+            .as_object()
+            .ok_or_else(|| {
+                Error::InvalidConfig("--filter must be a JSON object of conditions".to_string())
+            })?
+            .clone();
+        Ok(self
+            .collection_ids
+            .iter()
+            .map(|c| (c.clone(), ReplicationFilter::predicate(conds.clone())))
+            .collect())
     }
 }
 

--- a/crates/cli/src/commands/client/p2p/replicator.rs
+++ b/crates/cli/src/commands/client/p2p/replicator.rs
@@ -48,6 +48,11 @@ pub struct P2pReplicatorAddArgs {
     /// Scalar value matched by --filter-field.
     #[arg(long = "filter-value", requires = "filter_field")]
     pub filter_value: Option<String>,
+
+    /// Full query-filter conditions JSON applied to every selected collection,
+    /// e.g. --filter '{"agent_did": {"_in": ["did:a","did:b"]}}'. Mutually exclusive with --filter-field.
+    #[arg(long = "filter", conflicts_with = "filter_field")]
+    pub filter: Option<String>,
 }
 
 /// Arguments for replicator delete command
@@ -118,6 +123,22 @@ impl P2pReplicatorAddArgs {
     }
 
     fn build_filters(&self) -> Result<ReplicationFilters> {
+        if let Some(raw) = self.filter.as_deref() {
+            let value: serde_json::Value = serde_json::from_str(raw)
+                .map_err(|e| Error::InvalidConfig(format!("--filter is not valid JSON: {e}")))?;
+            let conds = value
+                .as_object()
+                .ok_or_else(|| {
+                    Error::InvalidConfig("--filter must be a JSON object of conditions".to_string())
+                })?
+                .clone();
+            return Ok(self
+                .collection
+                .iter()
+                .map(|c| (c.clone(), ReplicationFilter::predicate(conds.clone())))
+                .collect());
+        }
+
         let Some(field) = self.filter_field.as_deref() else {
             if self.filter_value.is_some() {
                 return Err(Error::MissingInput(
@@ -143,10 +164,10 @@ impl P2pReplicatorAddArgs {
             .map(|collection| {
                 (
                     collection.clone(),
-                    ReplicationFilter {
-                        field: field.to_string(),
-                        value: serde_json::Value::String(value.to_string()),
-                    },
+                    ReplicationFilter::eq(
+                        field.to_string(),
+                        serde_json::Value::String(value.to_string()),
+                    ),
                 )
             })
             .collect())
@@ -251,7 +272,7 @@ impl P2pReplicatorDeleteArgs {
 
 #[cfg(test)]
 mod tests {
-    use super::extract_public_peer_id;
+    use super::{extract_public_peer_id, P2pReplicatorAddArgs};
 
     #[test]
     fn extract_public_peer_id_accepts_libp2p_multiaddr() {
@@ -271,5 +292,39 @@ mod tests {
         let addr = format!("127.0.0.1:9000/p2p/{peer_id}");
 
         assert_eq!(extract_public_peer_id(&addr).unwrap(), peer_id);
+    }
+
+    #[test]
+    fn build_filters_with_filter_flag_produces_predicate() {
+        let args = P2pReplicatorAddArgs {
+            collection: vec!["users".to_string()],
+            addresses: vec![],
+            filter_field: None,
+            filter_value: None,
+            filter: Some(r#"{"agent_did":{"_in":["did:a","did:b"]}}"#.to_string()),
+        };
+
+        let filters = args.build_filters().expect("build_filters should succeed");
+        let filter = filters.get("users").expect("users filter present");
+
+        let conds = filter.conditions.as_ref().expect("conditions set");
+        let in_vals = conds["agent_did"]["_in"].as_array().expect("_in is array");
+        assert_eq!(in_vals.len(), 2);
+        assert_eq!(in_vals[0], "did:a");
+        assert_eq!(in_vals[1], "did:b");
+        assert!(filter.field.is_empty());
+    }
+
+    #[test]
+    fn build_filters_with_filter_flag_rejects_non_object() {
+        let args = P2pReplicatorAddArgs {
+            collection: vec!["users".to_string()],
+            addresses: vec![],
+            filter_field: None,
+            filter_value: None,
+            filter: Some(r#"["not","an","object"]"#.to_string()),
+        };
+
+        assert!(args.build_filters().is_err());
     }
 }

--- a/crates/cli/src/commands/client/p2p/tests.rs
+++ b/crates/cli/src/commands/client/p2p/tests.rs
@@ -10,6 +10,7 @@ fn test_p2p_replicator_add_args() {
         addresses: vec!["/ip4/127.0.0.1/tcp/9000".to_string()],
         filter_field: None,
         filter_value: None,
+        filter: None,
     };
     assert_eq!(args.collection.len(), 2);
     assert_eq!(args.addresses.len(), 1);
@@ -22,6 +23,7 @@ fn test_p2p_replicator_add_args_no_address() {
         addresses: vec![],
         filter_field: None,
         filter_value: None,
+        filter: None,
     };
     assert!(args.addresses.is_empty());
 }

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -208,6 +208,7 @@ impl Node {
             replicator_registry,
             collection_store,
             head_provider,
+            std::sync::Arc::new(p2p::EqOnlyFilterMatcher),
         )
         .await
         .map_err(Error::P2P)?;
@@ -778,6 +779,7 @@ impl Node {
             replicator_registry,
             collection_store,
             head_provider,
+            std::sync::Arc::new(p2p::EqOnlyFilterMatcher),
         )
         .await
         .map_err(Error::P2P)?;

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -208,7 +208,7 @@ impl Node {
             replicator_registry,
             collection_store,
             head_provider,
-            std::sync::Arc::new(p2p::EqOnlyFilterMatcher),
+            std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
         )
         .await
         .map_err(Error::P2P)?;
@@ -779,7 +779,7 @@ impl Node {
             replicator_registry,
             collection_store,
             head_provider,
-            std::sync::Arc::new(p2p::EqOnlyFilterMatcher),
+            std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
         )
         .await
         .map_err(Error::P2P)?;

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -40,7 +40,12 @@ fn p2p_filter_to_http(
                 conds.clone(),
             ))
         }
-        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => None,
+        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => {
+            tracing::warn!(
+                "replication filter variant not representable over HTTP yet; omitted from replicator listing"
+            );
+            None
+        }
     }
 }
 

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -55,14 +55,25 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
             filters: info
                 .filters
                 .into_iter()
-                .map(|(collection, filter)| {
-                    (
-                        collection,
-                        defra_http::router::ReplicationFilter {
-                            field: filter.field,
-                            value: filter.value,
-                        },
-                    )
+                .filter_map(|(collection, filter)| {
+                    if let p2p::ReplicationFilter::Predicate(ref conds) = filter {
+                        if conds.len() == 1 {
+                            if let Some((field, condition)) = conds.iter().next() {
+                                if let Some(value) =
+                                    condition.as_object().and_then(|op| op.get("_eq")).cloned()
+                                {
+                                    return Some((
+                                        collection,
+                                        defra_http::router::ReplicationFilter {
+                                            field: field.clone(),
+                                            value,
+                                        },
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    None
                 })
                 .collect(),
         }

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -22,6 +22,28 @@ use crate::transport_version_syncer::TransportVersionSyncer;
 
 const DOC_SYNC_DISPATCH_PARALLELISM: usize = 16;
 
+fn p2p_filter_to_http(
+    filter: &p2p::ReplicationFilter,
+) -> Option<defra_http::router::ReplicationFilter> {
+    match filter {
+        p2p::ReplicationFilter::Predicate(conds) => {
+            if conds.len() == 1 {
+                let (field, condition) = conds.iter().next()?;
+                if let Some(value) = condition.as_object().and_then(|op| op.get("_eq")).cloned() {
+                    return Some(defra_http::router::ReplicationFilter::eq(
+                        field.clone(),
+                        value,
+                    ));
+                }
+            }
+            Some(defra_http::router::ReplicationFilter::predicate(
+                conds.clone(),
+            ))
+        }
+        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => None,
+    }
+}
+
 /// P2POperations implementation for iroh transport.
 pub struct IrohP2PAdapter<B: Blockstore + 'static> {
     transport: IrohTransport,
@@ -55,26 +77,7 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
             filters: info
                 .filters
                 .into_iter()
-                .filter_map(|(collection, filter)| {
-                    if let p2p::ReplicationFilter::Predicate(ref conds) = filter {
-                        if conds.len() == 1 {
-                            if let Some((field, condition)) = conds.iter().next() {
-                                if let Some(value) =
-                                    condition.as_object().and_then(|op| op.get("_eq")).cloned()
-                                {
-                                    return Some((
-                                        collection,
-                                        defra_http::router::ReplicationFilter {
-                                            field: field.clone(),
-                                            value,
-                                        },
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                    None
-                })
+                .filter_map(|(collection, filter)| Some((collection, p2p_filter_to_http(&filter)?)))
                 .collect(),
         }
     }
@@ -86,16 +89,21 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
     ) -> P2PResult<p2p::ReplicationFilters> {
         let mut resolved = p2p::ReplicationFilters::new();
         for (key, filter) in filters {
-            if filter.field.trim().is_empty() {
-                return Err(P2PError::InvalidInput(
-                    "replication filter field cannot be empty".into(),
-                ));
-            }
-            if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
-                return Err(P2PError::InvalidInput(format!(
-                    "replication filter for collection '{key}' must use a scalar value"
-                )));
-            }
+            let p2p_filter = if let Some(conds) = filter.conditions {
+                p2p::ReplicationFilter::predicate(conds)
+            } else {
+                if filter.field.trim().is_empty() {
+                    return Err(P2PError::InvalidInput(
+                        "replication filter field cannot be empty".into(),
+                    ));
+                }
+                if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
+                    return Err(P2PError::InvalidInput(format!(
+                        "replication filter for collection '{key}' must use a scalar value"
+                    )));
+                }
+                p2p::ReplicationFilter::new(filter.field, filter.value)
+            };
 
             let collection_id = collection_cids
                 .iter()
@@ -113,10 +121,7 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
                     ))
                 })?;
 
-            resolved.insert(
-                collection_id,
-                p2p::ReplicationFilter::new(filter.field, filter.value),
-            );
+            resolved.insert(collection_id, p2p_filter);
         }
         Ok(resolved)
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -29,7 +29,6 @@ pub(crate) mod p2p_adapter_helpers;
 pub(crate) mod p2p_collection_lookup;
 #[allow(dead_code)]
 pub(crate) mod p2p_doc_pusher;
-pub mod replication_filter_matcher;
 pub(crate) mod schema_adapter;
 pub(crate) mod sourcehub_acp_adapter;
 #[allow(dead_code)]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -29,6 +29,7 @@ pub(crate) mod p2p_adapter_helpers;
 pub(crate) mod p2p_collection_lookup;
 #[allow(dead_code)]
 pub(crate) mod p2p_doc_pusher;
+pub mod replication_filter_matcher;
 pub(crate) mod schema_adapter;
 pub(crate) mod sourcehub_acp_adapter;
 #[allow(dead_code)]

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -19,6 +19,33 @@ use p2p::P2PHostHandle;
 pub(crate) use crate::p2p_adapter_helpers::collections_requiring_replay;
 pub use crate::p2p_doc_pusher::DbDocPusher;
 
+/// Convert a `p2p::ReplicationFilter` to its HTTP wire representation.
+///
+/// Simple single-field `_eq` predicates use the legacy `Field`/`Value` shape so
+/// older clients can still read them. All other predicates (multi-field, `_in`,
+/// `_gt`, etc.) are encoded via the `Conditions` field.
+fn p2p_filter_to_http(
+    filter: &p2p::ReplicationFilter,
+) -> Option<defra_http::router::ReplicationFilter> {
+    match filter {
+        p2p::ReplicationFilter::Predicate(conds) => {
+            if conds.len() == 1 {
+                let (field, condition) = conds.iter().next()?;
+                if let Some(value) = condition.as_object().and_then(|op| op.get("_eq")).cloned() {
+                    return Some(defra_http::router::ReplicationFilter::eq(
+                        field.clone(),
+                        value,
+                    ));
+                }
+            }
+            Some(defra_http::router::ReplicationFilter::predicate(
+                conds.clone(),
+            ))
+        }
+        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => None,
+    }
+}
+
 /// Trait for looking up collection IDs by name.
 ///
 /// This is used by the P2P adapter to resolve collection names to their
@@ -147,26 +174,7 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
             filters: info
                 .filters
                 .into_iter()
-                .filter_map(|(collection, filter)| {
-                    if let p2p::ReplicationFilter::Predicate(ref conds) = filter {
-                        if conds.len() == 1 {
-                            if let Some((field, condition)) = conds.iter().next() {
-                                if let Some(value) =
-                                    condition.as_object().and_then(|op| op.get("_eq")).cloned()
-                                {
-                                    return Some((
-                                        collection,
-                                        defra_http::router::ReplicationFilter {
-                                            field: field.clone(),
-                                            value,
-                                        },
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                    None
-                })
+                .filter_map(|(collection, filter)| Some((collection, p2p_filter_to_http(&filter)?)))
                 .collect(),
         }
     }
@@ -178,16 +186,21 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
     ) -> P2PResult<p2p::ReplicationFilters> {
         let mut resolved = p2p::ReplicationFilters::new();
         for (key, filter) in filters {
-            if filter.field.trim().is_empty() {
-                return Err(P2PError::InvalidInput(
-                    "replication filter field cannot be empty".into(),
-                ));
-            }
-            if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
-                return Err(P2PError::InvalidInput(format!(
-                    "replication filter for collection '{key}' must use a scalar value"
-                )));
-            }
+            let p2p_filter = if let Some(conds) = filter.conditions {
+                p2p::ReplicationFilter::predicate(conds)
+            } else {
+                if filter.field.trim().is_empty() {
+                    return Err(P2PError::InvalidInput(
+                        "replication filter field cannot be empty".into(),
+                    ));
+                }
+                if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
+                    return Err(P2PError::InvalidInput(format!(
+                        "replication filter for collection '{key}' must use a scalar value"
+                    )));
+                }
+                p2p::ReplicationFilter::new(filter.field, filter.value)
+            };
 
             let collection_id = collection_cids
                 .iter()
@@ -205,10 +218,7 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
                     ))
                 })?;
 
-            resolved.insert(
-                collection_id,
-                p2p::ReplicationFilter::new(filter.field, filter.value),
-            );
+            resolved.insert(collection_id, p2p_filter);
         }
         Ok(resolved)
     }

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -42,7 +42,12 @@ fn p2p_filter_to_http(
                 conds.clone(),
             ))
         }
-        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => None,
+        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => {
+            tracing::warn!(
+                "replication filter variant not representable over HTTP yet; omitted from replicator listing"
+            );
+            None
+        }
     }
 }
 

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -147,14 +147,25 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
             filters: info
                 .filters
                 .into_iter()
-                .map(|(collection, filter)| {
-                    (
-                        collection,
-                        defra_http::router::ReplicationFilter {
-                            field: filter.field,
-                            value: filter.value,
-                        },
-                    )
+                .filter_map(|(collection, filter)| {
+                    if let p2p::ReplicationFilter::Predicate(ref conds) = filter {
+                        if conds.len() == 1 {
+                            if let Some((field, condition)) = conds.iter().next() {
+                                if let Some(value) =
+                                    condition.as_object().and_then(|op| op.get("_eq")).cloned()
+                                {
+                                    return Some((
+                                        collection,
+                                        defra_http::router::ReplicationFilter {
+                                            field: field.clone(),
+                                            value,
+                                        },
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    None
                 })
                 .collect(),
         }

--- a/crates/cli/src/p2p_doc_pusher.rs
+++ b/crates/cli/src/p2p_doc_pusher.rs
@@ -55,6 +55,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             filters,
             se_key,
             se_identity_pubkey,
+            &replication_filter::QueryReplicationFilterMatcher::new(),
         )
         .await
     }
@@ -255,6 +256,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             doc_id,
             collection_id,
             &filters,
+            &replication_filter::QueryReplicationFilterMatcher::new(),
         )
         .await
     }

--- a/crates/cli/src/p2p_doc_pusher.rs
+++ b/crates/cli/src/p2p_doc_pusher.rs
@@ -93,34 +93,44 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
                 .find_collection_by_id(collection_id)
                 .map_err(|e| format!("failed to load collection '{}': {}", collection_id, e))?
                 .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
-            let field = collection
-                .schema()
-                .fields
-                .iter()
-                .find(|field| field.name == filter.field)
-                .ok_or_else(|| {
-                    format!(
-                        "replication filter field '{}' not found in collection '{}'",
-                        filter.field, collection_id
-                    )
-                })?;
-            if !field.immutable {
-                return Err(format!(
-                    "replication filter field '{}' in collection '{}' must be marked @immutable",
-                    filter.field, collection_id
-                ));
-            }
-            if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
-                return Err(format!(
-                    "replication filter field '{}' in collection '{}' must be a scalar LWW field",
-                    filter.field, collection_id
-                ));
-            }
-            if !field.kind.accepts_filter_value(&filter.value) {
-                return Err(format!(
-                    "replication filter value for field '{}' in collection '{}' does not match the field type",
-                    filter.field, collection_id
-                ));
+            let p2p::ReplicationFilter::Predicate(conds) = filter else {
+                continue;
+            };
+            for (field_name, condition) in conds {
+                let value = condition
+                    .as_object()
+                    .and_then(|op| op.get("_eq"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let field = collection
+                    .schema()
+                    .fields
+                    .iter()
+                    .find(|field| field.name == *field_name)
+                    .ok_or_else(|| {
+                        format!(
+                            "replication filter field '{}' not found in collection '{}'",
+                            field_name, collection_id
+                        )
+                    })?;
+                if !field.immutable {
+                    return Err(format!(
+                        "replication filter field '{}' in collection '{}' must be marked @immutable",
+                        field_name, collection_id
+                    ));
+                }
+                if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
+                    return Err(format!(
+                        "replication filter field '{}' in collection '{}' must be a scalar LWW field",
+                        field_name, collection_id
+                    ));
+                }
+                if !field.kind.accepts_filter_value(&value) {
+                    return Err(format!(
+                        "replication filter value for field '{}' in collection '{}' does not match the field type",
+                        field_name, collection_id
+                    ));
+                }
             }
         }
         Ok(())

--- a/crates/cli/src/p2p_doc_pusher.rs
+++ b/crates/cli/src/p2p_doc_pusher.rs
@@ -93,45 +93,11 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
                 .find_collection_by_id(collection_id)
                 .map_err(|e| format!("failed to load collection '{}': {}", collection_id, e))?
                 .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
-            let p2p::ReplicationFilter::Predicate(conds) = filter else {
-                continue;
-            };
-            for (field_name, condition) in conds {
-                let value = condition
-                    .as_object()
-                    .and_then(|op| op.get("_eq"))
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                let field = collection
-                    .schema()
-                    .fields
-                    .iter()
-                    .find(|field| field.name == *field_name)
-                    .ok_or_else(|| {
-                        format!(
-                            "replication filter field '{}' not found in collection '{}'",
-                            field_name, collection_id
-                        )
-                    })?;
-                if !field.immutable {
-                    return Err(format!(
-                        "replication filter field '{}' in collection '{}' must be marked @immutable",
-                        field_name, collection_id
-                    ));
-                }
-                if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
-                    return Err(format!(
-                        "replication filter field '{}' in collection '{}' must be a scalar LWW field",
-                        field_name, collection_id
-                    ));
-                }
-                if !field.kind.accepts_filter_value(&value) {
-                    return Err(format!(
-                        "replication filter value for field '{}' in collection '{}' does not match the field type",
-                        field_name, collection_id
-                    ));
-                }
-            }
+            replication_filter::validate_replication_filter(
+                &collection.schema().fields,
+                collection_id,
+                filter,
+            )?;
         }
         Ok(())
     }

--- a/crates/cli/src/replication_filter_matcher.rs
+++ b/crates/cli/src/replication_filter_matcher.rs
@@ -1,0 +1,152 @@
+//! Query-filter-backed replication filter matcher.
+//!
+//! Evaluates [`p2p::ReplicationFilter`] predicates by delegating to the
+//! DefraDB query filter engine (`query::Filter`), enabling the full
+//! operator set (`_in`, `_eq`, `_gt`, `_and`, `_or`, `_not`, …).
+
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::sync::Mutex;
+
+use p2p::{ReplicationFilter, ReplicationFilterMatcher};
+use query::Filter;
+
+/// Evaluates replication filters using the DefraDB query filter engine.
+///
+/// Parsed [`Filter`] objects are cached by a hash of the conditions JSON so
+/// re-parsing is avoided when the same predicate is applied to many documents.
+pub struct QueryReplicationFilterMatcher {
+    cache: Mutex<HashMap<u64, Filter>>,
+}
+
+impl QueryReplicationFilterMatcher {
+    pub fn new() -> Self {
+        Self {
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn eval(&self, filter: &ReplicationFilter, document: &serde_json::Value) -> bool {
+        match filter {
+            ReplicationFilter::Predicate(conds) => {
+                let key = hash_conditions(conds);
+                let parsed = {
+                    let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
+                    cache
+                        .entry(key)
+                        .or_insert_with(|| Filter::from_conditions(conds.clone()))
+                        .clone()
+                };
+                parsed.matches_json_object(document).unwrap_or(false)
+            }
+            ReplicationFilter::All(subs) => subs.iter().all(|s| self.eval(s, document)),
+            ReplicationFilter::Acp { .. } => false,
+        }
+    }
+}
+
+impl Default for QueryReplicationFilterMatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReplicationFilterMatcher for QueryReplicationFilterMatcher {
+    fn matches(
+        &self,
+        _collection_id: &str,
+        filter: &ReplicationFilter,
+        document: &serde_json::Value,
+    ) -> bool {
+        self.eval(filter, document)
+    }
+}
+
+fn hash_conditions(conds: &serde_json::Map<String, serde_json::Value>) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    serde_json::to_string(conds)
+        .unwrap_or_default()
+        .hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn matcher() -> QueryReplicationFilterMatcher {
+        QueryReplicationFilterMatcher::new()
+    }
+
+    fn predicate(conds: serde_json::Value) -> ReplicationFilter {
+        ReplicationFilter::Predicate(conds.as_object().unwrap().clone())
+    }
+
+    #[test]
+    fn predicate_in_matches_and_excludes() {
+        let m = matcher();
+        let f = predicate(json!({"agent_did": {"_in": ["did:a", "did:b"]}}));
+
+        assert!(m.matches("col", &f, &json!({"agent_did": "did:a", "x": 1})));
+        assert!(m.matches("col", &f, &json!({"agent_did": "did:b"})));
+        assert!(!m.matches("col", &f, &json!({"agent_did": "did:c"})));
+    }
+
+    #[test]
+    fn predicate_composite_and() {
+        let m = matcher();
+        let f = predicate(json!({"agent_did": {"_eq": "did:a"}, "kind": {"_eq": "x"}}));
+
+        assert!(m.matches("col", &f, &json!({"agent_did": "did:a", "kind": "x"})));
+        assert!(!m.matches("col", &f, &json!({"agent_did": "did:a", "kind": "y"})));
+        assert!(!m.matches("col", &f, &json!({"agent_did": "did:b", "kind": "x"})));
+    }
+
+    #[test]
+    fn predicate_typed_values() {
+        let m = matcher();
+
+        let score_f = predicate(json!({"score": {"_eq": 2}}));
+        assert!(m.matches("col", &score_f, &json!({"score": 2})));
+        assert!(!m.matches("col", &score_f, &json!({"score": 3})));
+
+        let bool_f = predicate(json!({"active": {"_eq": true}}));
+        assert!(m.matches("col", &bool_f, &json!({"active": true})));
+        assert!(!m.matches("col", &bool_f, &json!({"active": false})));
+    }
+
+    #[test]
+    fn all_requires_all() {
+        let m = matcher();
+        let f = ReplicationFilter::All(vec![
+            predicate(json!({"agent_did": {"_eq": "did:a"}})),
+            predicate(json!({"kind": {"_eq": "x"}})),
+        ]);
+
+        assert!(m.matches("col", &f, &json!({"agent_did": "did:a", "kind": "x"})));
+        assert!(!m.matches("col", &f, &json!({"agent_did": "did:a", "kind": "y"})));
+        assert!(!m.matches("col", &f, &json!({"agent_did": "did:b", "kind": "x"})));
+    }
+
+    #[test]
+    fn acp_never_matches() {
+        let m = matcher();
+        let f = ReplicationFilter::Acp {
+            relation: "owner".to_string(),
+        };
+        assert!(!m.matches("col", &f, &json!({"agent_did": "did:a"})));
+        assert!(!m.matches("col", &f, &json!({})));
+    }
+
+    #[test]
+    fn caching_is_consistent() {
+        let m = matcher();
+        let f = predicate(json!({"agent_did": {"_in": ["did:a", "did:b"]}}));
+
+        assert!(m.matches("col", &f, &json!({"agent_did": "did:a"})));
+        assert!(!m.matches("col", &f, &json!({"agent_did": "did:c"})));
+        assert!(m.matches("col", &f, &json!({"agent_did": "did:b"})));
+        assert!(!m.matches("col", &f, &json!({"agent_did": "did:z"})));
+    }
+}

--- a/crates/cli/src/transport_doc_pusher.rs
+++ b/crates/cli/src/transport_doc_pusher.rs
@@ -117,6 +117,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             collections,
             filters,
             se_key,
+            &replication_filter::QueryReplicationFilterMatcher::new(),
         )
         .await
     }
@@ -143,6 +144,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             doc_id,
             collection_id,
             &filters,
+            &replication_filter::QueryReplicationFilterMatcher::new(),
         )
         .await
     }

--- a/crates/cli/src/transport_doc_pusher.rs
+++ b/crates/cli/src/transport_doc_pusher.rs
@@ -240,34 +240,44 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
                 .find_collection_by_id(collection_id)
                 .map_err(|e| format!("failed to load collection '{}': {}", collection_id, e))?
                 .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
-            let field = collection
-                .schema()
-                .fields
-                .iter()
-                .find(|field| field.name == filter.field)
-                .ok_or_else(|| {
-                    format!(
-                        "replication filter field '{}' not found in collection '{}'",
-                        filter.field, collection_id
-                    )
-                })?;
-            if !field.immutable {
-                return Err(format!(
-                    "replication filter field '{}' in collection '{}' must be marked @immutable",
-                    filter.field, collection_id
-                ));
-            }
-            if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
-                return Err(format!(
-                    "replication filter field '{}' in collection '{}' must be a scalar LWW field",
-                    filter.field, collection_id
-                ));
-            }
-            if !field.kind.accepts_filter_value(&filter.value) {
-                return Err(format!(
-                    "replication filter value for field '{}' in collection '{}' does not match the field type",
-                    filter.field, collection_id
-                ));
+            let p2p::ReplicationFilter::Predicate(conds) = filter else {
+                continue;
+            };
+            for (field_name, condition) in conds {
+                let value = condition
+                    .as_object()
+                    .and_then(|op| op.get("_eq"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let field = collection
+                    .schema()
+                    .fields
+                    .iter()
+                    .find(|field| field.name == *field_name)
+                    .ok_or_else(|| {
+                        format!(
+                            "replication filter field '{}' not found in collection '{}'",
+                            field_name, collection_id
+                        )
+                    })?;
+                if !field.immutable {
+                    return Err(format!(
+                        "replication filter field '{}' in collection '{}' must be marked @immutable",
+                        field_name, collection_id
+                    ));
+                }
+                if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
+                    return Err(format!(
+                        "replication filter field '{}' in collection '{}' must be a scalar LWW field",
+                        field_name, collection_id
+                    ));
+                }
+                if !field.kind.accepts_filter_value(&value) {
+                    return Err(format!(
+                        "replication filter value for field '{}' in collection '{}' does not match the field type",
+                        field_name, collection_id
+                    ));
+                }
             }
         }
         Ok(())

--- a/crates/cli/src/transport_doc_pusher.rs
+++ b/crates/cli/src/transport_doc_pusher.rs
@@ -240,45 +240,11 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
                 .find_collection_by_id(collection_id)
                 .map_err(|e| format!("failed to load collection '{}': {}", collection_id, e))?
                 .ok_or_else(|| format!("collection '{}' not found", collection_id))?;
-            let p2p::ReplicationFilter::Predicate(conds) = filter else {
-                continue;
-            };
-            for (field_name, condition) in conds {
-                let value = condition
-                    .as_object()
-                    .and_then(|op| op.get("_eq"))
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                let field = collection
-                    .schema()
-                    .fields
-                    .iter()
-                    .find(|field| field.name == *field_name)
-                    .ok_or_else(|| {
-                        format!(
-                            "replication filter field '{}' not found in collection '{}'",
-                            field_name, collection_id
-                        )
-                    })?;
-                if !field.immutable {
-                    return Err(format!(
-                        "replication filter field '{}' in collection '{}' must be marked @immutable",
-                        field_name, collection_id
-                    ));
-                }
-                if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
-                    return Err(format!(
-                        "replication filter field '{}' in collection '{}' must be a scalar LWW field",
-                        field_name, collection_id
-                    ));
-                }
-                if !field.kind.accepts_filter_value(&value) {
-                    return Err(format!(
-                        "replication filter value for field '{}' in collection '{}' does not match the field type",
-                        field_name, collection_id
-                    ));
-                }
-            }
+            replication_filter::validate_replication_filter(
+                &collection.schema().fields,
+                collection_id,
+                filter,
+            )?;
         }
         Ok(())
     }

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use acp::DocumentACP;
 use bytes::Bytes;
 use p2p::message::PushLogRequest;
+use p2p::replicator::ReplicationFilterMatcher as _;
 use storage::corekv::{IterOptions, Reader, Store};
 
 use crate::push_docs_common::{load_latest_composite_head_cids, load_push_dag_blocks};
@@ -39,7 +40,7 @@ async fn document_matches_filter<R: Reader + ?Sized>(
             .into_iter()
             .collect(),
     );
-    Ok(filter.matches_json_object(&document_json))
+    Ok(p2p::replicator::EqOnlyFilterMatcher.matches("", filter, &document_json))
 }
 
 /// Push existing documents to a replicator peer.

--- a/crates/db-merge/src/push_docs.rs
+++ b/crates/db-merge/src/push_docs.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use acp::DocumentACP;
 use bytes::Bytes;
 use p2p::message::PushLogRequest;
-use p2p::replicator::ReplicationFilterMatcher as _;
 use storage::corekv::{IterOptions, Reader, Store};
 
 use crate::push_docs_common::{load_latest_composite_head_cids, load_push_dag_blocks};
@@ -22,6 +21,7 @@ async fn document_matches_filter<R: Reader + ?Sized>(
     collection_id: &str,
     doc_id: &str,
     filter: &p2p::ReplicationFilter,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
 ) -> Result<bool, String> {
     let doc_key = format!("/d/{}/{}", collection_id, doc_id).into_bytes();
     let Some(doc_data) = datastore
@@ -40,7 +40,7 @@ async fn document_matches_filter<R: Reader + ?Sized>(
             .into_iter()
             .collect(),
     );
-    Ok(p2p::replicator::EqOnlyFilterMatcher.matches("", filter, &document_json))
+    Ok(matcher.matches("", filter, &document_json))
 }
 
 /// Push existing documents to a replicator peer.
@@ -60,6 +60,7 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
     filters: &p2p::ReplicationFilters,
     se_encryption_key: Option<&[u8]>,
     se_identity_pubkey: Option<&[u8]>,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
 ) -> Result<(), String> {
     push_existing_docs_with_config(
         handle,
@@ -73,6 +74,7 @@ pub async fn push_existing_docs<S: storage::corekv::Store + 'static>(
             identity_pubkey: se_identity_pubkey,
         },
         ReplayPushConfig::default(),
+        matcher,
     )
     .await
 }
@@ -88,6 +90,7 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
     filters: &p2p::ReplicationFilters,
     se_options: PushExistingDocsSeOptions<'_>,
     replay_config: ReplayPushConfig,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
 ) -> Result<(), String> {
     // Wait for the connection to be fully established (dial is non-blocking).
     // After a node restart, re-establishing connectivity can take longer than
@@ -180,8 +183,14 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
         // doesn't work reliably cross-platform.
         for doc_id in &doc_ids {
             if let Some(filter) = filters.get(collection.collection_id()) {
-                if !document_matches_filter(&datastore, collection.collection_id(), doc_id, filter)
-                    .await?
+                if !document_matches_filter(
+                    &datastore,
+                    collection.collection_id(),
+                    doc_id,
+                    filter,
+                    matcher,
+                )
+                .await?
                 {
                     continue;
                 }
@@ -377,6 +386,7 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
                         collection.collection_id(),
                         doc_id,
                         filter,
+                        matcher,
                     )
                     .await?
                     {
@@ -456,6 +466,7 @@ pub async fn push_existing_docs_with_config<S: storage::corekv::Store + 'static>
 /// Reads composite head CIDs from the headstore, loads block data
 /// (field blocks + composite block) from the blockstore, and sends
 /// signed PushLogRequests to the target peer.
+#[allow(clippy::too_many_arguments)]
 pub async fn retry_doc<S: Store + 'static>(
     handle: &p2p::P2PHostHandle,
     db: &DB<S>,
@@ -464,6 +475,7 @@ pub async fn retry_doc<S: Store + 'static>(
     doc_id: &str,
     collection_id: &str,
     filters: &p2p::ReplicationFilters,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
 ) -> Result<(), String> {
     let local_peer_id = handle
         .local_peer_id()
@@ -482,7 +494,7 @@ pub async fn retry_doc<S: Store + 'static>(
         let datastore = txn
             .datastore()
             .map_err(|e| format!("failed to get datastore: {}", e))?;
-        if !document_matches_filter(&datastore, collection_id, doc_id, filter).await? {
+        if !document_matches_filter(&datastore, collection_id, doc_id, filter, matcher).await? {
             return Ok(());
         }
     }

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use acp::DocumentACP;
 use bytes::Bytes;
 use p2p::message::PushLogRequest;
-use p2p::replicator::ReplicationFilterMatcher as _;
 use p2p::transport::PeerId;
 use p2p::P2PTransport;
 use storage::corekv::{IterOptions, Reader, Store};
@@ -18,6 +17,7 @@ async fn document_matches_filter<R: Reader + ?Sized>(
     collection_id: &str,
     doc_id: &str,
     filter: &p2p::ReplicationFilter,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
 ) -> Result<bool, String> {
     let doc_key = format!("/d/{}/{}", collection_id, doc_id).into_bytes();
     let Some(doc_data) = datastore
@@ -36,13 +36,14 @@ async fn document_matches_filter<R: Reader + ?Sized>(
             .into_iter()
             .collect(),
     );
-    Ok(p2p::replicator::EqOnlyFilterMatcher.matches("", filter, &document_json))
+    Ok(matcher.matches("", filter, &document_json))
 }
 
 /// Push existing documents to a replicator peer via a generic transport.
 ///
 /// Transport-agnostic equivalent of `push_existing_docs`. Uses `P2PTransport`
 /// methods instead of `P2PHostHandle`.
+#[allow(clippy::too_many_arguments)]
 pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTransport>(
     transport: &T,
     db: &DB<S>,
@@ -51,6 +52,7 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
     collections: &[String],
     filters: &p2p::ReplicationFilters,
     se_encryption_key: Option<&[u8]>,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
 ) -> Result<(), String> {
     push_existing_docs_via_transport_with_config(
         transport,
@@ -61,6 +63,7 @@ pub async fn push_existing_docs_via_transport<S: Store + 'static, T: P2PTranspor
         filters,
         se_encryption_key,
         ReplayPushConfig::default(),
+        matcher,
     )
     .await
 }
@@ -76,6 +79,7 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
     filters: &p2p::ReplicationFilters,
     se_encryption_key: Option<&[u8]>,
     replay_config: ReplayPushConfig,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
 ) -> Result<(), String> {
     let conn_timeout = std::time::Duration::from_secs(15);
     let conn_start = std::time::Instant::now();
@@ -165,8 +169,14 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
 
         for doc_id in &doc_ids {
             if let Some(filter) = filters.get(collection.collection_id()) {
-                if !document_matches_filter(&datastore, collection.collection_id(), doc_id, filter)
-                    .await?
+                if !document_matches_filter(
+                    &datastore,
+                    collection.collection_id(),
+                    doc_id,
+                    filter,
+                    matcher,
+                )
+                .await?
                 {
                     continue;
                 }
@@ -351,6 +361,7 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
                         collection.collection_id(),
                         doc_id,
                         filter,
+                        matcher,
                     )
                     .await?
                     {
@@ -427,6 +438,7 @@ pub async fn push_existing_docs_via_transport_with_config<S: Store + 'static, T:
 /// via a generic transport.
 ///
 /// Transport-agnostic equivalent of `retry_doc`.
+#[allow(clippy::too_many_arguments)]
 pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
     transport: &T,
     db: &DB<S>,
@@ -435,6 +447,7 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
     doc_id: &str,
     collection_id: &str,
     filters: &p2p::ReplicationFilters,
+    matcher: &dyn p2p::replicator::ReplicationFilterMatcher,
 ) -> Result<(), String> {
     let local_peer_id = transport.local_peer_id().to_string();
     let collection = db
@@ -449,7 +462,7 @@ pub async fn retry_doc_via_transport<S: Store + 'static, T: P2PTransport>(
         let datastore = txn
             .datastore()
             .map_err(|e| format!("failed to get datastore: {}", e))?;
-        if !document_matches_filter(&datastore, collection_id, doc_id, filter).await? {
+        if !document_matches_filter(&datastore, collection_id, doc_id, filter, matcher).await? {
             return Ok(());
         }
     }

--- a/crates/db-merge/src/push_docs_transport.rs
+++ b/crates/db-merge/src/push_docs_transport.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use acp::DocumentACP;
 use bytes::Bytes;
 use p2p::message::PushLogRequest;
+use p2p::replicator::ReplicationFilterMatcher as _;
 use p2p::transport::PeerId;
 use p2p::P2PTransport;
 use storage::corekv::{IterOptions, Reader, Store};
@@ -35,7 +36,7 @@ async fn document_matches_filter<R: Reader + ?Sized>(
             .into_iter()
             .collect(),
     );
-    Ok(filter.matches_json_object(&document_json))
+    Ok(p2p::replicator::EqOnlyFilterMatcher.matches("", filter, &document_json))
 }
 
 /// Push existing documents to a replicator peer via a generic transport.

--- a/crates/defra-node/Cargo.toml
+++ b/crates/defra-node/Cargo.toml
@@ -25,6 +25,7 @@ otel = ["dep:telemetry", "telemetry/otlp"]
 [dependencies]
 db = { path = "../db" }
 db-merge = { path = "../db-merge" }
+replication-filter = { path = "../replication-filter" }
 storage = { path = "../storage" }
 query = { path = "../query" }
 events = { path = "../events" }

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1265,6 +1265,7 @@ impl NodeBuilder {
             p2p::AccessMode::Controlled,
             replicator_registry,
             collection_store,
+            Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
         )
         .await
         .map_err(|e| anyhow::anyhow!("SyncCoordinator creation failed: {}", e))?;

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1593,6 +1593,7 @@ fn spawn_iroh_retry_loop<S: storage::corekv::Store + 'static>(
                         doc_id,
                         collection_id,
                         &retry_filters,
+                        &replication_filter::QueryReplicationFilterMatcher::new(),
                     )
                     .await
                     {

--- a/crates/defra-node/src/p2p_tests.rs
+++ b/crates/defra-node/src/p2p_tests.rs
@@ -364,6 +364,118 @@ async fn install_one_way_replicator(
         .expect("set sender -> receiver replicator");
 }
 
+const AGENT_SCHEMA: &str = "type AgentDoc { agent_did: String @immutable  body: String }";
+
+async fn install_filtered_one_way_replicator(
+    sender: &EmbeddedNode,
+    receiver: &EmbeddedNode,
+    collections: &[&str],
+    filters: defra_http::router::ReplicationFilters,
+) {
+    let sender_addr = wait_for_listen_addr(sender).await;
+    let receiver_addr = wait_for_listen_addr(receiver).await;
+    let sender_p2p = sender.p2p().expect("sender p2p");
+    let receiver_p2p = receiver.p2p().expect("receiver p2p");
+
+    sender_p2p
+        .connect_peer(&receiver_addr)
+        .await
+        .expect("connect sender -> receiver");
+    wait_for_connected_peer(sender).await;
+    wait_for_connected_peer(receiver).await;
+
+    let collection_names = collections
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<Vec<_>>();
+    sender_p2p
+        .add_collections(collection_names.clone())
+        .await
+        .expect("add collections to sender p2p");
+    receiver_p2p
+        .add_collections(collection_names.clone())
+        .await
+        .expect("add collections to receiver p2p");
+    receiver_p2p
+        .add_replicator(
+            collection_names.clone(),
+            Some(&sender_addr),
+            Default::default(),
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("authorize sender as receiver-side replicator");
+    sender_p2p
+        .add_replicator(
+            collection_names,
+            Some(&receiver_addr),
+            filters,
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("set sender -> receiver filtered replicator");
+}
+
+async fn query_agent_doc_dids(node: &EmbeddedNode) -> Vec<String> {
+    let response = node.execute("query { AgentDoc { agent_did } }").await;
+    assert!(
+        response.errors.is_empty(),
+        "AgentDoc query returned errors: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentDoc"))
+        .and_then(|v| v.as_array())
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|row| {
+                    row.get("agent_did")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+async fn wait_for_agent_doc_dids(node: &EmbeddedNode, expected_dids: &[&str]) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        let present = query_agent_doc_dids(node).await;
+        if expected_dids
+            .iter()
+            .all(|did| present.contains(&did.to_string()))
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "receiver never got expected dids {:?}; last seen: {:?}",
+            expected_dids,
+            present
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+fn agent_did_in_filter(dids: &[&str]) -> defra_http::router::ReplicationFilters {
+    let conds = serde_json::json!({"agent_did": {"_in": dids}});
+    let conditions = conds
+        .as_object()
+        .expect("conditions must be an object")
+        .clone();
+    let mut filters = defra_http::router::ReplicationFilters::new();
+    filters.insert(
+        "AgentDoc".to_string(),
+        defra_http::router::ReplicationFilter::predicate(conditions),
+    );
+    filters
+}
+
 async fn fetch_turn_snapshot(
     node: &EmbeddedNode,
     session_id: &str,
@@ -1468,4 +1580,140 @@ async fn live_replicator_same_session_followup_turn_converges() {
         expected_receiver,
         "same-session followup turn failed to converge without explicit sync nudge; receiver={receiver:?} expected={second_expected:?} sender_diag={sender_diag:?} receiver_diag={receiver_diag:?}",
     );
+}
+
+#[tokio::test]
+async fn live_replicator_filtered_push_respects_predicate() {
+    init_tracing();
+
+    let sender = EmbeddedNode::builder()
+        .with_p2p(test_p2p_config())
+        .build()
+        .await
+        .expect("build sender");
+    let receiver = EmbeddedNode::builder()
+        .with_p2p(test_p2p_config())
+        .build()
+        .await
+        .expect("build receiver");
+
+    sender
+        .add_schema(AGENT_SCHEMA)
+        .await
+        .expect("schema on sender");
+    receiver
+        .add_schema(AGENT_SCHEMA)
+        .await
+        .expect("schema on receiver");
+
+    install_filtered_one_way_replicator(
+        &sender,
+        &receiver,
+        &["AgentDoc"],
+        agent_did_in_filter(&["did:key:alice", "did:key:carol"]),
+    )
+    .await;
+
+    for (agent_did, body) in [
+        ("did:key:alice", "alice body"),
+        ("did:key:bob", "bob body"),
+        ("did:key:carol", "carol body"),
+    ] {
+        let response = sender
+            .execute(&format!(
+                r#"mutation {{ add_AgentDoc(input: {{agent_did: "{agent_did}", body: "{body}"}}) {{ _docID }} }}"#
+            ))
+            .await;
+        assert!(
+            response.errors.is_empty(),
+            "add_AgentDoc({agent_did}) returned errors: {:?}",
+            response.errors
+        );
+    }
+
+    wait_for_agent_doc_dids(&receiver, &["did:key:alice", "did:key:carol"]).await;
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let present = query_agent_doc_dids(&receiver).await;
+    assert!(
+        !present.contains(&"did:key:bob".to_string()),
+        "bob's doc must NOT have replicated; receiver has: {present:?}"
+    );
+    assert_eq!(
+        present.len(),
+        2,
+        "receiver must have exactly 2 docs; got: {present:?}"
+    );
+
+    sender.shutdown().await;
+    receiver.shutdown().await;
+}
+
+#[tokio::test]
+async fn filtered_backfill_via_transport_pusher_respects_predicate() {
+    init_tracing();
+
+    let sender = EmbeddedNode::builder()
+        .with_p2p(test_p2p_config())
+        .build()
+        .await
+        .expect("build sender");
+    let receiver = EmbeddedNode::builder()
+        .with_p2p(test_p2p_config())
+        .build()
+        .await
+        .expect("build receiver");
+
+    sender
+        .add_schema(AGENT_SCHEMA)
+        .await
+        .expect("schema on sender");
+    receiver
+        .add_schema(AGENT_SCHEMA)
+        .await
+        .expect("schema on receiver");
+
+    for (agent_did, body) in [
+        ("did:key:alice", "alice body"),
+        ("did:key:bob", "bob body"),
+        ("did:key:carol", "carol body"),
+    ] {
+        let response = sender
+            .execute(&format!(
+                r#"mutation {{ add_AgentDoc(input: {{agent_did: "{agent_did}", body: "{body}"}}) {{ _docID }} }}"#
+            ))
+            .await;
+        assert!(
+            response.errors.is_empty(),
+            "pre-replicator add_AgentDoc({agent_did}) returned errors: {:?}",
+            response.errors
+        );
+    }
+
+    install_filtered_one_way_replicator(
+        &sender,
+        &receiver,
+        &["AgentDoc"],
+        agent_did_in_filter(&["did:key:alice", "did:key:carol"]),
+    )
+    .await;
+
+    wait_for_agent_doc_dids(&receiver, &["did:key:alice", "did:key:carol"]).await;
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let present = query_agent_doc_dids(&receiver).await;
+    assert!(
+        !present.contains(&"did:key:bob".to_string()),
+        "bob's doc must NOT have backfilled; receiver has: {present:?}"
+    );
+    assert_eq!(
+        present.len(),
+        2,
+        "receiver must have exactly 2 docs after backfill; got: {present:?}"
+    );
+
+    sender.shutdown().await;
+    receiver.shutdown().await;
 }

--- a/crates/embedded/Cargo.toml
+++ b/crates/embedded/Cargo.toml
@@ -24,6 +24,7 @@ kms = { path = "../kms" }
 lens = { path = "../lens" }
 p2p = { path = "../p2p", features = ["libp2p-transport"] }
 query = { path = "../query" }
+replication-filter = { path = "../replication-filter" }
 schema = { path = "../schema" }
 sourcehub = { path = "../sourcehub" }
 storage = { path = "../storage" }

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -142,7 +142,7 @@ where
         replicator_registry,
         collection_store,
         head_provider,
-        std::sync::Arc::new(p2p::EqOnlyFilterMatcher),
+        std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
     )
     .await
     .map_err(|error| anyhow!("failed to create sync coordinator: {error}"))?;
@@ -401,7 +401,7 @@ where
         replicator_registry,
         collection_store,
         head_provider,
-        std::sync::Arc::new(p2p::EqOnlyFilterMatcher),
+        std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
     )
     .await
     .map_err(|error| anyhow!("failed to create iroh sync coordinator: {error}"))?;

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -142,6 +142,7 @@ where
         replicator_registry,
         collection_store,
         head_provider,
+        std::sync::Arc::new(p2p::EqOnlyFilterMatcher),
     )
     .await
     .map_err(|error| anyhow!("failed to create sync coordinator: {error}"))?;
@@ -400,6 +401,7 @@ where
         replicator_registry,
         collection_store,
         head_provider,
+        std::sync::Arc::new(p2p::EqOnlyFilterMatcher),
     )
     .await
     .map_err(|error| anyhow!("failed to create iroh sync coordinator: {error}"))?;

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -4,15 +4,50 @@ use thiserror::Error;
 
 pub type ReplicationFilters = std::collections::BTreeMap<String, ReplicationFilter>;
 
+/// HTTP wire shape for a per-collection replication filter.
+///
+/// Supports two forms:
+/// - Legacy scalar equality: `{"Field": "f", "Value": <scalar>}`
+/// - Rich predicate (any DefraDB query-filter conditions object): `{"Conditions": {"f": {"_in": [...]}}}`
+///
+/// When `conditions` is present it takes precedence over `field`/`value`.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ReplicationFilter {
-    #[serde(rename = "Field")]
+    #[serde(rename = "Field", default)]
     pub field: String,
-    #[serde(rename = "Value")]
+    #[serde(rename = "Value", default)]
     pub value: serde_json::Value,
+    /// Full query-filter conditions object for rich predicates (IN, composite, etc.).
+    /// When present, `field`/`value` are ignored during conversion.
+    #[serde(
+        rename = "Conditions",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub conditions: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 impl Eq for ReplicationFilter {}
+
+impl ReplicationFilter {
+    /// Construct a simple scalar equality filter.
+    pub fn eq(field: impl Into<String>, value: serde_json::Value) -> Self {
+        Self {
+            field: field.into(),
+            value,
+            conditions: None,
+        }
+    }
+
+    /// Construct a rich predicate filter from a conditions map.
+    pub fn predicate(conditions: serde_json::Map<String, serde_json::Value>) -> Self {
+        Self {
+            field: String::new(),
+            value: serde_json::Value::Null,
+            conditions: Some(conditions),
+        }
+    }
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExplicitReplayCapabilityInput {

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -245,6 +245,8 @@ pub enum RemoteManageOp {
     ReplicatorAdd {
         addresses: Vec<String>,
         collection_ids: Vec<String>,
+        #[serde(default)]
+        filters: ReplicationFilters,
     },
     ReplicatorDelete {
         addresses: Vec<String>,

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -13,9 +13,13 @@ pub type ReplicationFilters = std::collections::BTreeMap<String, ReplicationFilt
 /// When `conditions` is present it takes precedence over `field`/`value`.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ReplicationFilter {
-    #[serde(rename = "Field", default)]
+    #[serde(rename = "Field", default, skip_serializing_if = "String::is_empty")]
     pub field: String,
-    #[serde(rename = "Value", default)]
+    #[serde(
+        rename = "Value",
+        default,
+        skip_serializing_if = "serde_json::Value::is_null"
+    )]
     pub value: serde_json::Value,
     /// Full query-filter conditions object for rich predicates (IN, composite, etc.).
     /// When present, `field`/`value` are ignored during conversion.

--- a/crates/p2p-adapter/Cargo.toml
+++ b/crates/p2p-adapter/Cargo.toml
@@ -20,6 +20,7 @@ events = { path = "../events" }
 identity = { path = "../identity" }
 lens = { path = "../lens" }
 p2p = { path = "../p2p", default-features = false }
+replication-filter = { path = "../replication-filter" }
 schema = { path = "../schema" }
 storage = { path = "../storage" }
 

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -97,16 +97,21 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
     ) -> P2PResult<p2p::ReplicationFilters> {
         let mut resolved = p2p::ReplicationFilters::new();
         for (key, filter) in filters {
-            if filter.field.trim().is_empty() {
-                return Err(P2PError::invalid_input(
-                    "replication filter field cannot be empty",
-                ));
-            }
-            if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
-                return Err(P2PError::invalid_input(format!(
-                    "replication filter for collection '{key}' must use a scalar value"
-                )));
-            }
+            let p2p_filter = if let Some(conds) = filter.conditions {
+                p2p::ReplicationFilter::predicate(conds)
+            } else {
+                if filter.field.trim().is_empty() {
+                    return Err(P2PError::invalid_input(
+                        "replication filter field cannot be empty",
+                    ));
+                }
+                if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
+                    return Err(P2PError::invalid_input(format!(
+                        "replication filter for collection '{key}' must use a scalar value"
+                    )));
+                }
+                p2p::ReplicationFilter::new(filter.field, filter.value)
+            };
 
             let collection_id = collection_cids
                 .iter()
@@ -124,10 +129,7 @@ impl<B: Blockstore + 'static> IrohP2PAdapter<B> {
                     ))
                 })?;
 
-            resolved.insert(
-                collection_id,
-                p2p::ReplicationFilter::new(filter.field, filter.value),
-            );
+            resolved.insert(collection_id, p2p_filter);
         }
         Ok(resolved)
     }

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -52,30 +52,36 @@ pub(crate) fn to_http_replicator_info(info: p2p::ReplicatorInfo) -> ReplicatorIn
         filters: info
             .filters
             .into_iter()
-            .filter_map(|(collection, filter)| {
-                let (field, value) = filter_to_field_value(&filter)?;
-                Some((
-                    collection,
-                    defra_http::router::ReplicationFilter { field, value },
-                ))
-            })
+            .filter_map(|(collection, filter)| Some((collection, p2p_filter_to_http(&filter)?)))
             .collect(),
     }
 }
 
-/// Extract a (field, value) pair from a `Predicate` filter with a single `_eq` condition.
+/// Convert a `p2p::ReplicationFilter` to the HTTP wire representation.
 ///
-/// Returns `None` for non-Predicate variants or multi-field predicates (those
-/// are newer filter shapes that the legacy HTTP response format cannot represent).
-fn filter_to_field_value(filter: &p2p::ReplicationFilter) -> Option<(String, serde_json::Value)> {
-    if let p2p::ReplicationFilter::Predicate(conds) = filter {
-        if conds.len() == 1 {
-            let (field, condition) = conds.iter().next()?;
-            let value = condition.as_object()?.get("_eq")?.clone();
-            return Some((field.clone(), value));
+/// Simple single-field `_eq` predicates use the legacy `Field`/`Value` shape so
+/// older clients can still read them. All other predicates (multi-field, `_in`,
+/// `_gt`, etc.) are encoded via the `Conditions` field.
+pub(crate) fn p2p_filter_to_http(
+    filter: &p2p::ReplicationFilter,
+) -> Option<defra_http::router::ReplicationFilter> {
+    match filter {
+        p2p::ReplicationFilter::Predicate(conds) => {
+            if conds.len() == 1 {
+                let (field, condition) = conds.iter().next()?;
+                if let Some(value) = condition.as_object().and_then(|op| op.get("_eq")).cloned() {
+                    return Some(defra_http::router::ReplicationFilter::eq(
+                        field.clone(),
+                        value,
+                    ));
+                }
+            }
+            Some(defra_http::router::ReplicationFilter::predicate(
+                conds.clone(),
+            ))
         }
+        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => None,
     }
-    None
 }
 
 /// Optional inputs used when pushing existing documents to replicators.

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -52,17 +52,30 @@ pub(crate) fn to_http_replicator_info(info: p2p::ReplicatorInfo) -> ReplicatorIn
         filters: info
             .filters
             .into_iter()
-            .map(|(collection, filter)| {
-                (
+            .filter_map(|(collection, filter)| {
+                let (field, value) = filter_to_field_value(&filter)?;
+                Some((
                     collection,
-                    defra_http::router::ReplicationFilter {
-                        field: filter.field,
-                        value: filter.value,
-                    },
-                )
+                    defra_http::router::ReplicationFilter { field, value },
+                ))
             })
             .collect(),
     }
+}
+
+/// Extract a (field, value) pair from a `Predicate` filter with a single `_eq` condition.
+///
+/// Returns `None` for non-Predicate variants or multi-field predicates (those
+/// are newer filter shapes that the legacy HTTP response format cannot represent).
+fn filter_to_field_value(filter: &p2p::ReplicationFilter) -> Option<(String, serde_json::Value)> {
+    if let p2p::ReplicationFilter::Predicate(conds) = filter {
+        if conds.len() == 1 {
+            let (field, condition) = conds.iter().next()?;
+            let value = condition.as_object()?.get("_eq")?.clone();
+            return Some((field.clone(), value));
+        }
+    }
+    None
 }
 
 /// Optional inputs used when pushing existing documents to replicators.

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -80,7 +80,12 @@ pub(crate) fn p2p_filter_to_http(
                 conds.clone(),
             ))
         }
-        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => None,
+        p2p::ReplicationFilter::Acp { .. } | p2p::ReplicationFilter::All(_) => {
+            tracing::warn!(
+                "replication filter variant not representable over HTTP yet; omitted from replicator listing"
+            );
+            None
+        }
     }
 }
 

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -136,16 +136,21 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
     ) -> P2PResult<p2p::ReplicationFilters> {
         let mut resolved = p2p::ReplicationFilters::new();
         for (key, filter) in filters {
-            if filter.field.trim().is_empty() {
-                return Err(P2PError::invalid_input(
-                    "replication filter field cannot be empty",
-                ));
-            }
-            if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
-                return Err(P2PError::invalid_input(format!(
-                    "replication filter for collection '{key}' must use a scalar value"
-                )));
-            }
+            let p2p_filter = if let Some(conds) = filter.conditions {
+                p2p::ReplicationFilter::predicate(conds)
+            } else {
+                if filter.field.trim().is_empty() {
+                    return Err(P2PError::invalid_input(
+                        "replication filter field cannot be empty",
+                    ));
+                }
+                if filter.value.is_null() || filter.value.is_array() || filter.value.is_object() {
+                    return Err(P2PError::invalid_input(format!(
+                        "replication filter for collection '{key}' must use a scalar value"
+                    )));
+                }
+                p2p::ReplicationFilter::new(filter.field, filter.value)
+            };
 
             let collection_id = collection_cids
                 .iter()
@@ -163,10 +168,7 @@ impl<B: Blockstore + 'static> P2PAdapter<B> {
                     ))
                 })?;
 
-            resolved.insert(
-                collection_id,
-                p2p::ReplicationFilter::new(filter.field, filter.value),
-            );
+            resolved.insert(collection_id, p2p_filter);
         }
         Ok(resolved)
     }

--- a/crates/p2p-adapter/src/libp2p_doc_pusher.rs
+++ b/crates/p2p-adapter/src/libp2p_doc_pusher.rs
@@ -154,34 +154,40 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
                 .ok_or_else(|| {
                     P2PError::not_found(format!("collection '{collection_id}' not found"))
                 })?;
-            let field = collection
-                .schema()
-                .fields
-                .iter()
-                .find(|field| field.name == filter.field)
-                .ok_or_else(|| {
-                    P2PError::invalid_input(format!(
-                        "replication filter field '{}' not found in collection '{}'",
-                        filter.field, collection_id
-                    ))
-                })?;
-            if !field.immutable {
-                return Err(P2PError::invalid_input(format!(
-                    "replication filter field '{}' in collection '{}' must be marked @immutable",
-                    filter.field, collection_id
-                )));
-            }
-            if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
-                return Err(P2PError::invalid_input(format!(
-                    "replication filter field '{}' in collection '{}' must be a scalar LWW field",
-                    filter.field, collection_id
-                )));
-            }
-            if !field.kind.accepts_filter_value(&filter.value) {
-                return Err(P2PError::invalid_input(format!(
-                    "replication filter value for field '{}' in collection '{}' does not match the field type",
-                    filter.field, collection_id
-                )));
+            let p2p::ReplicationFilter::Predicate(conds) = filter else {
+                continue;
+            };
+            for (field_name, condition) in conds {
+                let value = condition
+                    .as_object()
+                    .and_then(|op| op.get("_eq"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let field = collection
+                    .schema()
+                    .fields
+                    .iter()
+                    .find(|field| field.name == *field_name)
+                    .ok_or_else(|| {
+                        P2PError::invalid_input(format!(
+                            "replication filter field '{field_name}' not found in collection '{collection_id}'"
+                        ))
+                    })?;
+                if !field.immutable {
+                    return Err(P2PError::invalid_input(format!(
+                        "replication filter field '{field_name}' in collection '{collection_id}' must be marked @immutable"
+                    )));
+                }
+                if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
+                    return Err(P2PError::invalid_input(format!(
+                        "replication filter field '{field_name}' in collection '{collection_id}' must be a scalar LWW field"
+                    )));
+                }
+                if !field.kind.accepts_filter_value(&value) {
+                    return Err(P2PError::invalid_input(format!(
+                        "replication filter value for field '{field_name}' in collection '{collection_id}' does not match the field type"
+                    )));
+                }
             }
         }
         Ok(())

--- a/crates/p2p-adapter/src/libp2p_doc_pusher.rs
+++ b/crates/p2p-adapter/src/libp2p_doc_pusher.rs
@@ -154,41 +154,12 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
                 .ok_or_else(|| {
                     P2PError::not_found(format!("collection '{collection_id}' not found"))
                 })?;
-            let p2p::ReplicationFilter::Predicate(conds) = filter else {
-                continue;
-            };
-            for (field_name, condition) in conds {
-                let value = condition
-                    .as_object()
-                    .and_then(|op| op.get("_eq"))
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                let field = collection
-                    .schema()
-                    .fields
-                    .iter()
-                    .find(|field| field.name == *field_name)
-                    .ok_or_else(|| {
-                        P2PError::invalid_input(format!(
-                            "replication filter field '{field_name}' not found in collection '{collection_id}'"
-                        ))
-                    })?;
-                if !field.immutable {
-                    return Err(P2PError::invalid_input(format!(
-                        "replication filter field '{field_name}' in collection '{collection_id}' must be marked @immutable"
-                    )));
-                }
-                if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
-                    return Err(P2PError::invalid_input(format!(
-                        "replication filter field '{field_name}' in collection '{collection_id}' must be a scalar LWW field"
-                    )));
-                }
-                if !field.kind.accepts_filter_value(&value) {
-                    return Err(P2PError::invalid_input(format!(
-                        "replication filter value for field '{field_name}' in collection '{collection_id}' does not match the field type"
-                    )));
-                }
-            }
+            replication_filter::validate_replication_filter(
+                &collection.schema().fields,
+                collection_id,
+                filter,
+            )
+            .map_err(P2PError::invalid_input)?;
         }
         Ok(())
     }

--- a/crates/p2p-adapter/src/libp2p_doc_pusher.rs
+++ b/crates/p2p-adapter/src/libp2p_doc_pusher.rs
@@ -112,6 +112,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             filters,
             se_key,
             se_identity_pubkey,
+            &replication_filter::QueryReplicationFilterMatcher::new(),
         )
         .await
         .map_err(P2PError::from)
@@ -307,6 +308,7 @@ impl<S: storage::corekv::Store + 'static> DocPusher for DbDocPusher<S> {
             doc_id,
             collection_id,
             &filters,
+            &replication_filter::QueryReplicationFilterMatcher::new(),
         )
         .await
         .map_err(P2PError::from)

--- a/crates/p2p-adapter/src/manage/requester_impl.rs
+++ b/crates/p2p-adapter/src/manage/requester_impl.rs
@@ -82,9 +82,11 @@ fn to_mutate_op(op: RemoteManageOp) -> ManageMutateOp {
         RemoteManageOp::ReplicatorAdd {
             addresses,
             collection_ids,
+            filters,
         } => ManageMutateOp::ReplicatorAdd {
             addresses,
             collection_ids,
+            filters: http_filters_to_p2p(filters),
         },
         RemoteManageOp::ReplicatorDelete {
             addresses,
@@ -107,6 +109,19 @@ fn to_mutate_op(op: RemoteManageOp) -> ManageMutateOp {
         },
         RemoteManageOp::PeerConnect { address } => ManageMutateOp::PeerConnect { address },
     }
+}
+
+fn http_filters_to_p2p(filters: defra_http::router::ReplicationFilters) -> p2p::ReplicationFilters {
+    filters
+        .into_iter()
+        .map(|(key, f)| {
+            let pf = match f.conditions {
+                Some(conds) => p2p::ReplicationFilter::predicate(conds),
+                None => p2p::ReplicationFilter::new(f.field, f.value),
+            };
+            (key, pf)
+        })
+        .collect()
 }
 
 fn to_doc_ref(doc: RemoteManageDocRef) -> ManageDocRef {

--- a/crates/p2p-adapter/src/manage/serve.rs
+++ b/crates/p2p-adapter/src/manage/serve.rs
@@ -92,14 +92,16 @@ async fn authorize_and_apply(
             ManageMutateOp::ReplicatorAdd {
                 addresses,
                 collection_ids,
+                filters,
             } => {
                 if addresses.len() > 1 {
                     return Err("replicator add supports at most one address".to_string());
                 }
+                let http_filters = p2p_filters_to_http(filters)?;
                 ops.add_replicator(
                     collection_ids.clone(),
                     addresses.first().map(|s| s.as_str()),
-                    Default::default(),
+                    http_filters,
                     vec![],
                     Some(did_str.as_str()),
                 )
@@ -142,6 +144,28 @@ async fn authorize_and_apply(
         }
     })
     .await
+}
+
+fn p2p_filters_to_http(
+    filters: &p2p::ReplicationFilters,
+) -> Result<defra_http::router::ReplicationFilters, String> {
+    let mut out = defra_http::router::ReplicationFilters::new();
+    for (key, f) in filters {
+        match f {
+            p2p::ReplicationFilter::Predicate(map) => {
+                out.insert(
+                    key.clone(),
+                    defra_http::router::ReplicationFilter::predicate(map.clone()),
+                );
+            }
+            _ => {
+                return Err(format!(
+                    "replication filter for collection '{key}' uses a form unsupported over the manage relay"
+                ));
+            }
+        }
+    }
+    Ok(out)
 }
 
 fn to_doc_reqs(docs: &[ManageDocRef]) -> Vec<P2pDocumentRequest> {
@@ -253,11 +277,17 @@ mod tests {
     use p2p::message::Message;
     use std::sync::Mutex;
 
+    type RecordedReplicator = (
+        Vec<String>,
+        Option<String>,
+        defra_http::router::ReplicationFilters,
+    );
+
     /// Records mutating calls so tests can prove no side effect occurred.
     struct MockOps {
         peer_id: String,
         added_collections: Mutex<Vec<String>>,
-        added_replicators: Mutex<Vec<(Vec<String>, Option<String>)>>,
+        added_replicators: Mutex<Vec<RecordedReplicator>>,
     }
 
     impl MockOps {
@@ -273,7 +303,7 @@ mod tests {
             self.added_collections.lock().unwrap().clone()
         }
 
-        fn added_replicators(&self) -> Vec<(Vec<String>, Option<String>)> {
+        fn added_replicators(&self) -> Vec<RecordedReplicator> {
             self.added_replicators.lock().unwrap().clone()
         }
     }
@@ -299,14 +329,15 @@ mod tests {
             &self,
             collections: Vec<String>,
             addr: Option<&str>,
-            _filters: defra_http::router::ReplicationFilters,
+            filters: defra_http::router::ReplicationFilters,
             _explicit_replay_capabilities: Vec<ExplicitReplayCapabilityInput>,
             _expected_authorizer_did: Option<&str>,
         ) -> P2PResult<()> {
-            self.added_replicators
-                .lock()
-                .unwrap()
-                .push((collections, addr.map(|s| s.to_string())));
+            self.added_replicators.lock().unwrap().push((
+                collections,
+                addr.map(|s| s.to_string()),
+                filters,
+            ));
             Ok(())
         }
         async fn remove_replicator(
@@ -507,6 +538,7 @@ mod tests {
                     "/ip4/2.2.2.2/tcp/9000".into(),
                 ],
                 collection_ids: vec!["c1".into()],
+                filters: Default::default(),
             },
             token,
         );
@@ -531,6 +563,7 @@ mod tests {
             ManageMutateOp::ReplicatorAdd {
                 addresses: vec!["/ip4/1.1.1.1/tcp/9000".into()],
                 collection_ids: vec!["c1".into()],
+                filters: Default::default(),
             },
             token,
         );
@@ -540,8 +573,43 @@ mod tests {
             ops.added_replicators(),
             vec![(
                 vec!["c1".to_string()],
-                Some("/ip4/1.1.1.1/tcp/9000".to_string())
+                Some("/ip4/1.1.1.1/tcp/9000".to_string()),
+                defra_http::router::ReplicationFilters::new()
             )]
+        );
+    }
+
+    #[tokio::test]
+    async fn replicator_add_forwards_filters() {
+        let ops = MockOps::new("12D3KooW-THIS");
+        let token = crate::manage::auth::mint_token_for("12D3KooW-THIS").0;
+        let mut conds = serde_json::Map::new();
+        conds.insert(
+            "agent_did".to_string(),
+            serde_json::json!({ "_eq": "did:key:alice" }),
+        );
+        let mut filters = p2p::ReplicationFilters::new();
+        filters.insert("User".to_string(), p2p::ReplicationFilter::predicate(conds));
+        let req = ManageRequest::new(
+            ManageMutateOp::ReplicatorAdd {
+                addresses: vec!["/ip4/1.1.1.1/tcp/9000".into()],
+                collection_ids: vec!["User".into()],
+                filters,
+            },
+            token,
+        );
+        let reply = build_manage_reply(&ops, &BoolNac(true), req).await;
+        assert_eq!(reply.err_message(), None);
+        let recorded = ops.added_replicators();
+        assert_eq!(recorded.len(), 1);
+        let (_collections, _addr, http_filters) = &recorded[0];
+        assert!(
+            !http_filters.is_empty(),
+            "relayed filters must reach add_replicator non-empty"
+        );
+        assert!(
+            http_filters.contains_key("User"),
+            "the User collection filter must survive the relay"
         );
     }
 }

--- a/crates/p2p-adapter/src/manage/serve.rs
+++ b/crates/p2p-adapter/src/manage/serve.rs
@@ -245,10 +245,11 @@ fn to_p2p_replicator_info(info: defra_http::router::ReplicatorInfo) -> p2p::Repl
         .filters
         .into_iter()
         .map(|(collection, filter)| {
-            (
-                collection,
-                p2p::ReplicationFilter::new(filter.field, filter.value),
-            )
+            let p2p_filter = match filter.conditions {
+                Some(conds) => p2p::ReplicationFilter::predicate(conds),
+                None => p2p::ReplicationFilter::new(filter.field, filter.value),
+            };
+            (collection, p2p_filter)
         })
         .collect();
     out.status = info
@@ -472,6 +473,34 @@ mod tests {
         );
         assert_eq!(out.status, p2p::ReplicatorStatus::Inactive);
         assert_eq!(out.addresses_str(), &["/ip4/1.2.3.4/tcp/9000".to_string()]);
+    }
+
+    /// A rich (non-`_eq`) predicate must survive the reply-path http->p2p
+    /// conversion intact. Reconstructing via `new(field, value)` would ignore
+    /// `conditions` and corrupt it into `Predicate({"": {"_eq": null}})`.
+    #[test]
+    fn replicator_rich_filter_survives_round_trip() {
+        let conds: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_value(serde_json::json!({ "name": { "_in": ["keep", "also"] } }))
+                .unwrap();
+        let mut filters = defra_http::router::ReplicationFilters::new();
+        filters.insert(
+            "User".into(),
+            defra_http::router::ReplicationFilter::predicate(conds.clone()),
+        );
+        let http = ReplicatorInfo {
+            id: Some("12D3KooW-PEER".into()),
+            collections: vec!["User".into()],
+            address: Some("/ip4/1.2.3.4/tcp/9000".into()),
+            status: Some(0),
+            last_status_change: None,
+            filters,
+        };
+        let out = to_p2p_replicator_info(http);
+        match out.filters.get("User").expect("filter present for User") {
+            p2p::ReplicationFilter::Predicate(m) => assert_eq!(m, &conds),
+            other => panic!("expected predicate filter to round-trip, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -212,34 +212,40 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
                 .ok_or_else(|| {
                     P2PError::not_found(format!("collection '{collection_id}' not found"))
                 })?;
-            let field = collection
-                .schema()
-                .fields
-                .iter()
-                .find(|field| field.name == filter.field)
-                .ok_or_else(|| {
-                    P2PError::invalid_input(format!(
-                        "replication filter field '{}' not found in collection '{}'",
-                        filter.field, collection_id
-                    ))
-                })?;
-            if !field.immutable {
-                return Err(P2PError::invalid_input(format!(
-                    "replication filter field '{}' in collection '{}' must be marked @immutable",
-                    filter.field, collection_id
-                )));
-            }
-            if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
-                return Err(P2PError::invalid_input(format!(
-                    "replication filter field '{}' in collection '{}' must be a scalar LWW field",
-                    filter.field, collection_id
-                )));
-            }
-            if !field.kind.accepts_filter_value(&filter.value) {
-                return Err(P2PError::invalid_input(format!(
-                    "replication filter value for field '{}' in collection '{}' does not match the field type",
-                    filter.field, collection_id
-                )));
+            let p2p::ReplicationFilter::Predicate(conds) = filter else {
+                continue;
+            };
+            for (field_name, condition) in conds {
+                let value = condition
+                    .as_object()
+                    .and_then(|op| op.get("_eq"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let field = collection
+                    .schema()
+                    .fields
+                    .iter()
+                    .find(|field| field.name == *field_name)
+                    .ok_or_else(|| {
+                        P2PError::invalid_input(format!(
+                            "replication filter field '{field_name}' not found in collection '{collection_id}'"
+                        ))
+                    })?;
+                if !field.immutable {
+                    return Err(P2PError::invalid_input(format!(
+                        "replication filter field '{field_name}' in collection '{collection_id}' must be marked @immutable"
+                    )));
+                }
+                if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
+                    return Err(P2PError::invalid_input(format!(
+                        "replication filter field '{field_name}' in collection '{collection_id}' must be a scalar LWW field"
+                    )));
+                }
+                if !field.kind.accepts_filter_value(&value) {
+                    return Err(P2PError::invalid_input(format!(
+                        "replication filter value for field '{field_name}' in collection '{collection_id}' does not match the field type"
+                    )));
+                }
             }
         }
         Ok(())

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -212,41 +212,12 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
                 .ok_or_else(|| {
                     P2PError::not_found(format!("collection '{collection_id}' not found"))
                 })?;
-            let p2p::ReplicationFilter::Predicate(conds) = filter else {
-                continue;
-            };
-            for (field_name, condition) in conds {
-                let value = condition
-                    .as_object()
-                    .and_then(|op| op.get("_eq"))
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                let field = collection
-                    .schema()
-                    .fields
-                    .iter()
-                    .find(|field| field.name == *field_name)
-                    .ok_or_else(|| {
-                        P2PError::invalid_input(format!(
-                            "replication filter field '{field_name}' not found in collection '{collection_id}'"
-                        ))
-                    })?;
-                if !field.immutable {
-                    return Err(P2PError::invalid_input(format!(
-                        "replication filter field '{field_name}' in collection '{collection_id}' must be marked @immutable"
-                    )));
-                }
-                if field.crdt_type != schema::CType::LwwRegister || !field.kind.is_scalar() {
-                    return Err(P2PError::invalid_input(format!(
-                        "replication filter field '{field_name}' in collection '{collection_id}' must be a scalar LWW field"
-                    )));
-                }
-                if !field.kind.accepts_filter_value(&value) {
-                    return Err(P2PError::invalid_input(format!(
-                        "replication filter value for field '{field_name}' in collection '{collection_id}' does not match the field type"
-                    )));
-                }
-            }
+            replication_filter::validate_replication_filter(
+                &collection.schema().fields,
+                collection_id,
+                filter,
+            )
+            .map_err(P2PError::invalid_input)?;
         }
         Ok(())
     }

--- a/crates/p2p-adapter/src/transport_doc_pusher.rs
+++ b/crates/p2p-adapter/src/transport_doc_pusher.rs
@@ -106,6 +106,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             collections,
             filters,
             se_key,
+            &replication_filter::QueryReplicationFilterMatcher::new(),
         )
         .await
         .map_err(P2PError::from)
@@ -133,6 +134,7 @@ impl<S: storage::corekv::Store + 'static, T: P2PTransport> TransportDocPusher
             doc_id,
             collection_id,
             &filters,
+            &replication_filter::QueryReplicationFilterMatcher::new(),
         )
         .await
         .map_err(P2PError::from)

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -152,7 +152,10 @@ pub use iroh_bitswap::Store as BitswapStore;
 pub struct QueryId(pub u64);
 
 // Re-export replicator types
-pub use replicator::{ReplicationFilter, ReplicationFilters, ReplicatorInfo, ReplicatorStatus};
+pub use replicator::{
+    EqOnlyFilterMatcher, ReplicationFilter, ReplicationFilterMatcher, ReplicationFilters,
+    ReplicatorInfo, ReplicatorStatus,
+};
 
 // Re-export management correlators
 pub use manage_correlator::{

--- a/crates/p2p/src/message/manage.rs
+++ b/crates/p2p/src/message/manage.rs
@@ -30,6 +30,12 @@ pub enum ManageMutateOp {
         addresses: Vec<String>,
         #[serde(rename = "CollectionIDs", default)]
         collection_ids: Vec<String>,
+        #[serde(
+            rename = "Filters",
+            default,
+            skip_serializing_if = "crate::replicator::no_replication_filters"
+        )]
+        filters: crate::replicator::ReplicationFilters,
     },
     ReplicatorDelete {
         #[serde(rename = "Addresses", default)]
@@ -612,6 +618,7 @@ mod tests {
             ManageMutateOp::ReplicatorAdd {
                 addresses: vec![],
                 collection_ids: vec![],
+                filters: Default::default(),
             }
             .permission(),
             P::P2pReplicatorAdd

--- a/crates/p2p/src/replicator.rs
+++ b/crates/p2p/src/replicator.rs
@@ -209,7 +209,7 @@ fn json_scalar_eq(a: &JsonValue, b: &JsonValue) -> bool {
 
 pub type ReplicationFilters = BTreeMap<String, ReplicationFilter>;
 
-fn no_replication_filters(filters: &ReplicationFilters) -> bool {
+pub(crate) fn no_replication_filters(filters: &ReplicationFilters) -> bool {
     filters.is_empty()
 }
 

--- a/crates/p2p/src/replicator.rs
+++ b/crates/p2p/src/replicator.rs
@@ -48,43 +48,149 @@ pub enum ReplicatorStatus {
     Inactive = 1,
 }
 
-/// Per-collection equality predicate for filtered replication.
-///
-/// This is intentionally narrow for the first filtered-replication release:
-/// a document is selected when its materialized JSON contains `Field` with
-/// exactly `Value`. The full within-document DAG is still replicated for
-/// selected documents.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ReplicationFilter {
-    #[serde(rename = "Field")]
-    pub field: String,
-
-    #[serde(rename = "Value")]
-    pub value: JsonValue,
+/// Per-collection filter for filtered replication.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReplicationFilter {
+    /// A DefraDB query-filter conditions map, e.g. `{"agent_did": {"_eq": "did:a"}}`.
+    Predicate(serde_json::Map<String, JsonValue>),
+    /// Deferred ACP-based filter (not evaluated in p2p; reserved for future use).
+    Acp { relation: String },
+    /// AND-composition of sub-filters.
+    All(Vec<ReplicationFilter>),
 }
 
 impl Eq for ReplicationFilter {}
 
-impl ReplicationFilter {
-    pub fn new(field: impl Into<String>, value: JsonValue) -> Self {
-        Self {
-            field: field.into(),
-            value,
-        }
-    }
+/// Tagged serde representation for new-format filters.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ReplicationFilterTagged {
+    Predicate(serde_json::Map<String, JsonValue>),
+    Acp { relation: String },
+    All(Vec<ReplicationFilter>),
+}
 
-    pub fn matches_json_object(&self, document: &JsonValue) -> bool {
-        document
-            .as_object()
-            .and_then(|object| object.get(&self.field))
-            .is_some_and(|value| json_scalar_eq(value, &self.value))
+/// Legacy wire shape: `{"Field": "...", "Value": ...}`.
+#[derive(Deserialize)]
+struct LegacyFilter {
+    #[serde(rename = "Field")]
+    field: String,
+    #[serde(rename = "Value")]
+    value: JsonValue,
+}
+
+impl From<&ReplicationFilter> for ReplicationFilterTagged {
+    fn from(f: &ReplicationFilter) -> Self {
+        match f {
+            ReplicationFilter::Predicate(m) => ReplicationFilterTagged::Predicate(m.clone()),
+            ReplicationFilter::Acp { relation } => ReplicationFilterTagged::Acp {
+                relation: relation.clone(),
+            },
+            ReplicationFilter::All(v) => ReplicationFilterTagged::All(v.clone()),
+        }
     }
 }
 
-/// Equality for filter matching. Numbers are compared numerically so a filter
-/// value of `2.0` matches a field materialized as the integer `2` (Go-compatible
-/// JSON encodes whole-number floats as integers), which raw `serde_json::Value`
-/// equality treats as unequal.
+impl Serialize for ReplicationFilter {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        ReplicationFilterTagged::from(self).serialize(s)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReplicationFilter {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let v = JsonValue::deserialize(d)?;
+        if v.as_object()
+            .map(|o| o.contains_key("Field"))
+            .unwrap_or(false)
+        {
+            let legacy: LegacyFilter =
+                serde_json::from_value(v).map_err(serde::de::Error::custom)?;
+            Ok(ReplicationFilter::eq(legacy.field, legacy.value))
+        } else {
+            let tagged: ReplicationFilterTagged =
+                serde_json::from_value(v).map_err(serde::de::Error::custom)?;
+            Ok(match tagged {
+                ReplicationFilterTagged::Predicate(m) => ReplicationFilter::Predicate(m),
+                ReplicationFilterTagged::Acp { relation } => ReplicationFilter::Acp { relation },
+                ReplicationFilterTagged::All(v) => ReplicationFilter::All(v),
+            })
+        }
+    }
+}
+
+impl ReplicationFilter {
+    /// Create a legacy-compatible equality filter. Normalizes to `Predicate({field: {_eq: value}})`.
+    pub fn new(field: impl Into<String>, value: JsonValue) -> Self {
+        Self::eq(field, value)
+    }
+
+    /// Create a simple equality predicate filter.
+    pub fn eq(field: impl Into<String>, value: JsonValue) -> Self {
+        let mut conds = serde_json::Map::new();
+        let mut op = serde_json::Map::new();
+        op.insert("_eq".to_string(), value);
+        conds.insert(field.into(), JsonValue::Object(op));
+        Self::Predicate(conds)
+    }
+
+    /// Create a predicate filter directly from a conditions map.
+    pub fn predicate(conditions: serde_json::Map<String, JsonValue>) -> Self {
+        Self::Predicate(conditions)
+    }
+}
+
+/// Evaluates a [`ReplicationFilter`] against a materialized document JSON object.
+pub trait ReplicationFilterMatcher: Send + Sync {
+    fn matches(
+        &self,
+        collection_id: &str,
+        filter: &ReplicationFilter,
+        document: &JsonValue,
+    ) -> bool;
+}
+
+/// Default matcher that handles only the simple `{field: {"_eq": value}}` predicate shape.
+///
+/// Handles `Predicate` (single `_eq` per field), `All` (all sub-filters must match),
+/// `Acp` → always false (not evaluated in p2p).
+pub struct EqOnlyFilterMatcher;
+
+impl ReplicationFilterMatcher for EqOnlyFilterMatcher {
+    fn matches(
+        &self,
+        _collection_id: &str,
+        filter: &ReplicationFilter,
+        document: &JsonValue,
+    ) -> bool {
+        match filter {
+            ReplicationFilter::Predicate(conds) => {
+                let Some(obj) = document.as_object() else {
+                    return false;
+                };
+                conds.iter().all(|(field, condition)| {
+                    let Some(op_map) = condition.as_object() else {
+                        return false;
+                    };
+                    let Some(field_val) = obj.get(field) else {
+                        return false;
+                    };
+                    op_map
+                        .get("_eq")
+                        .is_some_and(|expected| json_scalar_eq(field_val, expected))
+                })
+            }
+            ReplicationFilter::All(filters) => filters
+                .iter()
+                .all(|f| self.matches(_collection_id, f, document)),
+            ReplicationFilter::Acp { .. } => false,
+        }
+    }
+}
+
+/// Numbers are compared numerically so a filter value of `2.0` matches a field
+/// materialized as the integer `2` (Go-compatible JSON encodes whole-number
+/// floats as integers), which raw `serde_json::Value` equality treats as unequal.
 fn json_scalar_eq(a: &JsonValue, b: &JsonValue) -> bool {
     match (a, b) {
         (JsonValue::Number(x), JsonValue::Number(y)) => {
@@ -306,10 +412,16 @@ impl ReplicatorInfo {
         self.filters.get(collection_id)
     }
 
-    pub fn matches_filter(&self, collection_id: &str, document: &JsonValue) -> bool {
-        self.filter_for_collection(collection_id)
-            .map(|filter| filter.matches_json_object(document))
-            .unwrap_or(true)
+    pub fn matches_filter(
+        &self,
+        matcher: &dyn ReplicationFilterMatcher,
+        collection_id: &str,
+        document: &JsonValue,
+    ) -> bool {
+        match self.filters.get(collection_id) {
+            Some(filter) => matcher.matches(collection_id, filter, document),
+            None => true,
+        }
     }
 
     /// Get the peer ID. Returns `None` if the stored ID is not a valid libp2p PeerId.

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -146,6 +146,7 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
             rate_limiter,
             push_send_timeout: DEFAULT_PUSH_SEND_TIMEOUT,
             shutdown: SyncShutdownHandle::new(),
+            filter_matcher: Arc::new(crate::replicator::EqOnlyFilterMatcher),
         },
         manager,
         access: SyncAccessState {

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -343,7 +343,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             };
 
             let use_full_dag = if rep.is_filtered_for_collection(collection_id) {
-                if !rep.matches_filter(collection_id, document) {
+                if !rep.matches_filter(
+                    self.runtime.filter_matcher.as_ref(),
+                    collection_id,
+                    document,
+                ) {
                     continue;
                 }
                 true
@@ -500,7 +504,11 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             if !rep.collections.iter().any(|id| id == collection_id) {
                 continue;
             }
-            if !rep.matches_filter(collection_id, document) {
+            if !rep.matches_filter(
+                self.runtime.filter_matcher.as_ref(),
+                collection_id,
+                document,
+            ) {
                 continue;
             }
 

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
 use crate::error::Result;
+use crate::replicator::{EqOnlyFilterMatcher, ReplicationFilterMatcher};
 use crate::sync::broadcaster::Broadcaster;
 use crate::sync::collection_store::{NoOpCollectionStorage, P2PCollectionStorage};
 use crate::sync::head_provider::{DocumentHeadProvider, NoOpHeadProvider};
@@ -82,6 +83,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             replicators,
             collection_store,
             Arc::new(NoOpHeadProvider),
+            Arc::new(EqOnlyFilterMatcher),
         )
         .await
     }
@@ -89,6 +91,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Create a new sync coordinator with a document head provider for DocSync.
     ///
     /// Returns the coordinator and a receiver for sync events.
+    #[allow(clippy::too_many_arguments)]
     pub async fn with_head_provider(
         transport: T,
         blockstore: Arc<B>,
@@ -97,6 +100,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         replicators: Arc<ReplicatorRegistry>,
         collection_store: Arc<dyn P2PCollectionStorage>,
         head_provider: Arc<dyn DocumentHeadProvider>,
+        filter_matcher: Arc<dyn ReplicationFilterMatcher>,
     ) -> Result<(Self, mpsc::Receiver<SyncEvent>)> {
         let local_peer_id = transport.local_peer_id().to_string();
         let broadcaster = Broadcaster::new(transport.clone());
@@ -143,6 +147,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     )),
                     push_send_timeout,
                     shutdown: super::SyncShutdownHandle::new(),
+                    filter_matcher,
                 },
                 manager,
                 access: SyncAccessState {

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -39,6 +39,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             AccessMode::Open,
             Arc::new(ReplicatorRegistry::new()),
             Arc::new(NoOpCollectionStorage),
+            Arc::new(EqOnlyFilterMatcher),
         )
         .await
     }
@@ -60,6 +61,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             access_mode,
             Arc::new(ReplicatorRegistry::new()),
             collection_store,
+            Arc::new(EqOnlyFilterMatcher),
         )
         .await
     }
@@ -67,6 +69,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
     /// Create a new sync coordinator with access control.
     ///
     /// Returns the coordinator and a receiver for sync events.
+    #[allow(clippy::too_many_arguments)]
     pub async fn with_access_control(
         transport: T,
         blockstore: Arc<B>,
@@ -74,6 +77,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         access_mode: AccessMode,
         replicators: Arc<ReplicatorRegistry>,
         collection_store: Arc<dyn P2PCollectionStorage>,
+        filter_matcher: Arc<dyn ReplicationFilterMatcher>,
     ) -> Result<(Self, mpsc::Receiver<SyncEvent>)> {
         Self::with_head_provider(
             transport,
@@ -83,7 +87,7 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             replicators,
             collection_store,
             Arc::new(NoOpHeadProvider),
-            Arc::new(EqOnlyFilterMatcher),
+            filter_matcher,
         )
         .await
     }

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -71,6 +71,7 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
 use crate::bitswap::{AccessMode, ReplicatorRegistry};
+use crate::replicator::ReplicationFilterMatcher;
 use crate::transport::{P2PTransport, PeerId};
 
 use super::broadcaster::Broadcaster;
@@ -261,6 +262,9 @@ pub(super) struct SyncRuntime<T: P2PTransport> {
 
     /// Shutdown state for coordinator-owned background tasks.
     pub(super) shutdown: SyncShutdownHandle,
+
+    /// Filter matcher used to evaluate replication filters during push.
+    pub(super) filter_matcher: Arc<dyn ReplicationFilterMatcher>,
 }
 
 /// Access control and peer identity state for the coordinator.

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -39,6 +39,7 @@ mod tests {
         BranchableSyncReply, BranchableSyncRequest, DocSyncReply, DocSyncRequest, PushLogBroadcast,
         PushLogReply, PushLogRequest, PushSEArtifactsRequest,
     };
+    use crate::replicator::EqOnlyFilterMatcher;
     use crate::sync::manager::SyncEvent;
     use crate::sync::merge::{
         BlockMetadata, MergeBlock, MergeHandler, MergeOutcome, RecoveredBlockMetadata,
@@ -989,6 +990,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1057,6 +1059,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1102,6 +1105,7 @@ mod tests {
                 AccessMode::Controlled,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1149,6 +1153,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1214,6 +1219,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1359,6 +1365,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1422,6 +1429,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1508,6 +1516,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1564,6 +1573,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();
@@ -1612,6 +1622,7 @@ mod tests {
                 AccessMode::Open,
                 Arc::new(crate::ReplicatorRegistry::new()),
                 Arc::new(crate::sync::collection_store::NoOpCollectionStorage),
+                Arc::new(EqOnlyFilterMatcher),
             )
             .await
             .unwrap();

--- a/crates/p2p/tests/replicator_tests.rs
+++ b/crates/p2p/tests/replicator_tests.rs
@@ -1,7 +1,10 @@
 //! Tests for replicator types, including Go wire-format parity.
 
 use chrono::{TimeZone, Utc};
-use p2p::replicator::{ReplicatorError, ReplicatorInfo, ReplicatorStatus};
+use p2p::replicator::{
+    EqOnlyFilterMatcher, ReplicationFilterMatcher as _, ReplicatorError, ReplicatorInfo,
+    ReplicatorStatus,
+};
 use p2p::{Multiaddr, PeerId};
 use p2p::{ReplicationFilter, ReplicationFilters};
 
@@ -114,6 +117,7 @@ fn unfiltered_rust_extension_does_not_change_go_bytes() {
 
 #[test]
 fn filtered_replicator_round_trips_rust_extension() {
+    let matcher = EqOnlyFilterMatcher;
     let mut filters = ReplicationFilters::new();
     filters.insert(
         "users".to_string(),
@@ -129,41 +133,56 @@ fn filtered_replicator_round_trips_rust_extension() {
     let bytes = info.to_bytes().unwrap();
     assert_eq!(
         std::str::from_utf8(&bytes).unwrap(),
-        r#"{"ID":"12D3KooWGjMkcMy5PM9iSbgWWgUnH5dQhvzhNu7w3Gk4kHZBsxnJ","Addresses":[],"CollectionIDs":["users"],"Status":0,"LastStatusChange":"0001-01-01T00:00:00Z","Filters":{"users":{"Field":"agent_did","Value":"did:key:z6M"}}}"#
+        r#"{"ID":"12D3KooWGjMkcMy5PM9iSbgWWgUnH5dQhvzhNu7w3Gk4kHZBsxnJ","Addresses":[],"CollectionIDs":["users"],"Status":0,"LastStatusChange":"0001-01-01T00:00:00Z","Filters":{"users":{"predicate":{"agent_did":{"_eq":"did:key:z6M"}}}}}"#
     );
 
     let restored = ReplicatorInfo::from_bytes(&bytes).unwrap();
     assert_eq!(restored, info);
     assert!(restored.matches_filter(
+        &matcher,
         "users",
         &serde_json::json!({"agent_did": "did:key:z6M", "body": "selected"})
     ));
-    assert!(!restored.matches_filter("users", &serde_json::json!({"agent_did": "did:key:other"})));
+    assert!(!restored.matches_filter(
+        &matcher,
+        "users",
+        &serde_json::json!({"agent_did": "did:key:other"})
+    ));
+
+    // Legacy wire format deserializes into the same Predicate variant.
+    let legacy_json = r#"{"Field":"agent_did","Value":"did:key:z6M"}"#;
+    let from_legacy: ReplicationFilter = serde_json::from_str(legacy_json).unwrap();
+    assert_eq!(
+        from_legacy,
+        ReplicationFilter::new("agent_did", serde_json::json!("did:key:z6M"))
+    );
 }
 
 #[test]
 fn filter_matches_numbers_numerically() {
+    let matcher = EqOnlyFilterMatcher;
+
     // A whole-number Float field materializes as an integer in Go-compatible
     // JSON, so a 2.0 filter value must still match a stored 2.
     let float_filter = ReplicationFilter::new("score", serde_json::json!(2.0));
-    assert!(float_filter.matches_json_object(&serde_json::json!({"score": 2})));
-    assert!(float_filter.matches_json_object(&serde_json::json!({"score": 2.0})));
-    assert!(!float_filter.matches_json_object(&serde_json::json!({"score": 3})));
+    assert!(matcher.matches("", &float_filter, &serde_json::json!({"score": 2})));
+    assert!(matcher.matches("", &float_filter, &serde_json::json!({"score": 2.0})));
+    assert!(!matcher.matches("", &float_filter, &serde_json::json!({"score": 3})));
 
     // Non-whole floats and integers still match their own form.
     let frac_filter = ReplicationFilter::new("ratio", serde_json::json!(2.5));
-    assert!(frac_filter.matches_json_object(&serde_json::json!({"ratio": 2.5})));
+    assert!(matcher.matches("", &frac_filter, &serde_json::json!({"ratio": 2.5})));
 
     // A string filter value never matches a numeric field (type mismatch).
     let str_filter = ReplicationFilter::new("score", serde_json::json!("2"));
-    assert!(!str_filter.matches_json_object(&serde_json::json!({"score": 2})));
+    assert!(!matcher.matches("", &str_filter, &serde_json::json!({"score": 2})));
 
     // Two distinct large integers must NOT match: comparing them as f64 would
     // lose precision above 2^53 and falsely match.
     let big = 9_007_199_254_740_993_i64; // 2^53 + 1
     let big_filter = ReplicationFilter::new("id", serde_json::json!(big));
-    assert!(big_filter.matches_json_object(&serde_json::json!({ "id": big })));
-    assert!(!big_filter.matches_json_object(&serde_json::json!({ "id": big + 1 })));
+    assert!(matcher.matches("", &big_filter, &serde_json::json!({ "id": big })));
+    assert!(!matcher.matches("", &big_filter, &serde_json::json!({ "id": big + 1 })));
 }
 
 // ---------------------------------------------------------------------------
@@ -347,4 +366,69 @@ fn from_bytes_rejects_truncated_json() {
 fn from_bytes_rejects_unknown_status() {
     let bad = r#"{"ID":"peer","Addresses":[],"CollectionIDs":["users"],"Status":42,"LastStatusChange":"0001-01-01T00:00:00Z"}"#;
     assert!(ReplicatorInfo::from_bytes(bad.as_bytes()).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// ReplicationFilter enum and EqOnlyFilterMatcher
+// ---------------------------------------------------------------------------
+
+#[test]
+fn legacy_wire_deserializes_to_predicate() {
+    let json = r#"{"Field":"agent_did","Value":"x"}"#;
+    let filter: ReplicationFilter = serde_json::from_str(json).unwrap();
+    let mut expected_conds = serde_json::Map::new();
+    let mut op = serde_json::Map::new();
+    op.insert("_eq".to_string(), serde_json::json!("x"));
+    expected_conds.insert("agent_did".to_string(), serde_json::Value::Object(op));
+    assert_eq!(filter, ReplicationFilter::Predicate(expected_conds));
+}
+
+#[test]
+fn predicate_with_in_round_trips() {
+    let mut conds = serde_json::Map::new();
+    conds.insert(
+        "agent_did".to_string(),
+        serde_json::json!({"_in": ["did:a", "did:b"]}),
+    );
+    let filter = ReplicationFilter::Predicate(conds);
+    let json = serde_json::to_string(&filter).unwrap();
+    assert!(
+        json.contains("predicate"),
+        "predicate variant serializes as tagged"
+    );
+    let restored: ReplicationFilter = serde_json::from_str(&json).unwrap();
+    assert_eq!(filter, restored);
+}
+
+#[test]
+fn eq_only_matcher_evaluates_filters() {
+    use p2p::replicator::EqOnlyFilterMatcher;
+    let matcher = EqOnlyFilterMatcher;
+
+    // No filter for collection → true
+    let info = ReplicatorInfo::from_raw("peer".to_string(), vec!["users".to_string()], vec![]);
+    assert!(info.matches_filter(&matcher, "users", &serde_json::json!({"x": 1})));
+
+    // Matching _eq → true
+    let mut filters = ReplicationFilters::new();
+    filters.insert(
+        "users".to_string(),
+        ReplicationFilter::eq("agent_did", serde_json::json!("did:x")),
+    );
+    let info_filtered = ReplicatorInfo::from_raw_with_filters(
+        "peer".to_string(),
+        vec!["users".to_string()],
+        vec![],
+        filters,
+    );
+    assert!(info_filtered.matches_filter(
+        &matcher,
+        "users",
+        &serde_json::json!({"agent_did": "did:x"})
+    ));
+    assert!(!info_filtered.matches_filter(
+        &matcher,
+        "users",
+        &serde_json::json!({"agent_did": "did:y"})
+    ));
 }

--- a/crates/replication-filter/Cargo.toml
+++ b/crates/replication-filter/Cargo.toml
@@ -11,6 +11,7 @@ description = "Query-filter-backed replication filter matcher shared between cli
 [dependencies]
 p2p = { path = "../p2p" }
 query = { path = "../query" }
+schema = { path = "../schema" }
 
 serde_json.workspace = true
 

--- a/crates/replication-filter/Cargo.toml
+++ b/crates/replication-filter/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "replication-filter"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Query-filter-backed replication filter matcher shared between cli and embedded"
+
+[dependencies]
+p2p = { path = "../p2p" }
+query = { path = "../query" }
+
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/replication-filter/src/lib.rs
+++ b/crates/replication-filter/src/lib.rs
@@ -1,9 +1,3 @@
-//! Query-filter-backed replication filter matcher.
-//!
-//! Evaluates [`p2p::ReplicationFilter`] predicates by delegating to the
-//! DefraDB query filter engine (`query::Filter`), enabling the full
-//! operator set (`_in`, `_eq`, `_gt`, `_and`, `_or`, `_not`, …).
-
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Mutex;

--- a/crates/replication-filter/src/lib.rs
+++ b/crates/replication-filter/src/lib.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Mutex;
 
 use p2p::{ReplicationFilter, ReplicationFilterMatcher};
@@ -125,10 +124,10 @@ fn validate_op(
 
 /// Evaluates replication filters using the DefraDB query filter engine.
 ///
-/// Parsed [`Filter`] objects are cached by a hash of the conditions JSON so
-/// re-parsing is avoided when the same predicate is applied to many documents.
+/// Parsed [`Filter`] objects are cached by the canonical JSON of the conditions
+/// so re-parsing is avoided when the same predicate is applied to many documents.
 pub struct QueryReplicationFilterMatcher {
-    cache: Mutex<HashMap<u64, Filter>>,
+    cache: Mutex<HashMap<String, Filter>>,
 }
 
 impl QueryReplicationFilterMatcher {
@@ -141,9 +140,12 @@ impl QueryReplicationFilterMatcher {
     fn eval(&self, filter: &ReplicationFilter, document: &serde_json::Value) -> bool {
         match filter {
             ReplicationFilter::Predicate(conds) => {
-                let key = hash_conditions(conds);
+                let key = serde_json::to_string(conds).unwrap_or_default();
                 let parsed = {
                     let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
+                    if cache.len() >= 256 {
+                        cache.clear();
+                    }
                     cache
                         .entry(key)
                         .or_insert_with(|| Filter::from_conditions(conds.clone()))
@@ -172,14 +174,6 @@ impl ReplicationFilterMatcher for QueryReplicationFilterMatcher {
     ) -> bool {
         self.eval(filter, document)
     }
-}
-
-fn hash_conditions(conds: &serde_json::Map<String, serde_json::Value>) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    serde_json::to_string(conds)
-        .unwrap_or_default()
-        .hash(&mut hasher);
-    hasher.finish()
 }
 
 #[cfg(test)]
@@ -281,6 +275,19 @@ mod tests {
             relation: "owner".to_string(),
         };
         let err = validate_replication_filter(&fields, "col", &filter).unwrap_err();
+        assert!(
+            err.contains("not yet implemented"),
+            "expected not yet implemented error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn acp_filter_rejected_for_agent_doc_collection() {
+        let fields = test_fields();
+        let filter = ReplicationFilter::Acp {
+            relation: "reader".to_string(),
+        };
+        let err = validate_replication_filter(&fields, "AgentDoc", &filter).unwrap_err();
         assert!(
             err.contains("not yet implemented"),
             "expected not yet implemented error, got: {err}"

--- a/crates/replication-filter/src/lib.rs
+++ b/crates/replication-filter/src/lib.rs
@@ -4,6 +4,124 @@ use std::sync::Mutex;
 
 use p2p::{ReplicationFilter, ReplicationFilterMatcher};
 use query::Filter;
+use schema::{CType, FieldDescription, FieldKind};
+use serde_json::Value as JsonValue;
+
+/// Validate a replication filter against a collection's schema fields.
+///
+/// Every field referenced anywhere in the predicate must be @immutable scalar-LWW,
+/// and every operator/value must be supported and type-compatible.
+pub fn validate_replication_filter(
+    fields: &[FieldDescription],
+    collection_id: &str,
+    filter: &ReplicationFilter,
+) -> Result<(), String> {
+    match filter {
+        ReplicationFilter::Acp { .. } => {
+            Err("acp-scoped replication filters are not yet implemented (see #1036)".to_string())
+        }
+        ReplicationFilter::All(subs) => subs
+            .iter()
+            .try_for_each(|f| validate_replication_filter(fields, collection_id, f)),
+        ReplicationFilter::Predicate(conds) => validate_conditions(conds, fields, collection_id),
+    }
+}
+
+fn validate_conditions(
+    conds: &serde_json::Map<String, JsonValue>,
+    fields: &[FieldDescription],
+    collection_id: &str,
+) -> Result<(), String> {
+    for (key, val) in conds {
+        match key.as_str() {
+            "_and" | "_or" => {
+                let arr = val.as_array().ok_or_else(|| {
+                    format!(
+                        "'{key}' in replication filter for collection '{collection_id}' must be an array"
+                    )
+                })?;
+                for elem in arr {
+                    let obj = elem.as_object().ok_or_else(|| {
+                        format!(
+                            "each element of '{key}' in replication filter for collection '{collection_id}' must be an object"
+                        )
+                    })?;
+                    validate_conditions(obj, fields, collection_id)?;
+                }
+            }
+            k if k.starts_with('_') => {
+                return Err(format!(
+                    "unsupported top-level operator '{key}' in replication filter for collection '{collection_id}'"
+                ));
+            }
+            _ => {
+                let field = fields
+                    .iter()
+                    .find(|f| f.name == *key)
+                    .ok_or_else(|| {
+                        format!(
+                            "replication filter field '{key}' not found in collection '{collection_id}'"
+                        )
+                    })?;
+                if !field.immutable {
+                    return Err(format!(
+                        "replication filter field '{key}' in collection '{collection_id}' must be marked @immutable"
+                    ));
+                }
+                if field.crdt_type != CType::LwwRegister || !field.kind.is_scalar() {
+                    return Err(format!(
+                        "replication filter field '{key}' in collection '{collection_id}' must be a scalar LWW field"
+                    ));
+                }
+                let op_obj = val.as_object().ok_or_else(|| {
+                    format!("replication filter field '{key}' must map to an operator object")
+                })?;
+                for (op, opval) in op_obj {
+                    validate_op(op, opval, &field.kind, key, collection_id)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_op(
+    op: &str,
+    opval: &JsonValue,
+    kind: &FieldKind,
+    field_name: &str,
+    collection_id: &str,
+) -> Result<(), String> {
+    match op {
+        "_eq" | "_ne" | "_gt" | "_gte" | "_lt" | "_lte" => {
+            if !kind.accepts_filter_value(opval) {
+                return Err(format!(
+                    "replication filter value for field '{field_name}' in collection '{collection_id}' does not match the field type"
+                ));
+            }
+        }
+        "_in" | "_nin" => {
+            let arr = opval.as_array().ok_or_else(|| {
+                format!(
+                    "operator '{op}' for field '{field_name}' in collection '{collection_id}' must be an array"
+                )
+            })?;
+            for v in arr {
+                if !kind.accepts_filter_value(v) {
+                    return Err(format!(
+                        "replication filter value for field '{field_name}' in collection '{collection_id}' does not match the field type"
+                    ));
+                }
+            }
+        }
+        _ => {
+            return Err(format!(
+                "operator '{op}' is not supported in replication filters (collection '{collection_id}')"
+            ));
+        }
+    }
+    Ok(())
+}
 
 /// Evaluates replication filters using the DefraDB query filter engine.
 ///
@@ -67,7 +185,125 @@ fn hash_conditions(conds: &serde_json::Map<String, serde_json::Value>) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use schema::{FieldDescription, FieldKind};
     use serde_json::json;
+
+    fn test_fields() -> Vec<FieldDescription> {
+        vec![
+            FieldDescription::new("1", "agent_did", FieldKind::string()).as_immutable(),
+            FieldDescription::new("2", "kind", FieldKind::string()).as_immutable(),
+            FieldDescription::new("3", "body", FieldKind::string()),
+        ]
+    }
+
+    #[test]
+    fn valid_in_on_immutable_field() {
+        let fields = test_fields();
+        let filter = ReplicationFilter::Predicate(
+            json!({"agent_did": {"_in": ["did:a", "did:b"]}})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        assert!(validate_replication_filter(&fields, "col", &filter).is_ok());
+    }
+
+    #[test]
+    fn valid_and_of_immutable_field_eqs() {
+        let fields = test_fields();
+        let filter = ReplicationFilter::Predicate(
+            json!({"_and": [
+                {"agent_did": {"_eq": "did:a"}},
+                {"kind": {"_eq": "post"}}
+            ]})
+            .as_object()
+            .unwrap()
+            .clone(),
+        );
+        assert!(validate_replication_filter(&fields, "col", &filter).is_ok());
+    }
+
+    #[test]
+    fn or_containing_mutable_field_errors() {
+        let fields = test_fields();
+        let filter = ReplicationFilter::Predicate(
+            json!({"_or": [
+                {"agent_did": {"_eq": "did:a"}},
+                {"body": {"_eq": "hello"}}
+            ]})
+            .as_object()
+            .unwrap()
+            .clone(),
+        );
+        let err = validate_replication_filter(&fields, "col", &filter).unwrap_err();
+        assert!(
+            err.contains("immutable"),
+            "expected immutable error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_field_errors() {
+        let fields = test_fields();
+        let filter = ReplicationFilter::Predicate(
+            json!({"nosuchfield": {"_eq": "x"}})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        let err = validate_replication_filter(&fields, "col", &filter).unwrap_err();
+        assert!(
+            err.contains("not found"),
+            "expected not found error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unsupported_operator_errors() {
+        let fields = test_fields();
+        let filter = ReplicationFilter::Predicate(
+            json!({"agent_did": {"_like": "%did%"}})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        let err = validate_replication_filter(&fields, "col", &filter).unwrap_err();
+        assert!(
+            err.contains("not supported"),
+            "expected not supported error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn acp_filter_errors() {
+        let fields = test_fields();
+        let filter = ReplicationFilter::Acp {
+            relation: "owner".to_string(),
+        };
+        let err = validate_replication_filter(&fields, "col", &filter).unwrap_err();
+        assert!(
+            err.contains("not yet implemented"),
+            "expected not yet implemented error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn type_mismatch_in_array_errors() {
+        let fields = test_fields();
+        let filter = ReplicationFilter::Predicate(
+            json!({"agent_did": {"_in": ["did:a", 42]}})
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
+        let err = validate_replication_filter(&fields, "col", &filter).unwrap_err();
+        assert!(
+            err.contains("does not match the field type"),
+            "expected type mismatch error, got: {err}"
+        );
+    }
+
+    // ---- QueryReplicationFilterMatcher tests (kept from original) ----
 
     fn matcher() -> QueryReplicationFilterMatcher {
         QueryReplicationFilterMatcher::new()

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -21,6 +21,7 @@ use integration_test::{
 const AGENT_SCHEMA: &str = "type AgentDoc { agent_did: String @immutable  body: String }";
 const ALICE: &str = "did:key:alice";
 const BOB: &str = "did:key:bob";
+const CAROL: &str = "did:key:carol";
 
 /// Grace window used to confirm a non-matching document stays absent *after*
 /// a matching document has already replicated. Once the matching doc arrives we
@@ -852,3 +853,498 @@ async fn rust_filtered_replication_float_filter_matches_numerically() {
 // doc IDs prevent two honest nodes from forging the same docID with differing
 // immutable values. It is covered directly at the merge layer by
 // `db-merge`'s `remote_composite_merge_rejects_immutable_field_change`.
+
+/// Add a replicator with a raw query-filter conditions JSON via the CLI --filter flag.
+fn run_replicator_add_filter(
+    cluster: &TestCluster,
+    node: usize,
+    collections: &[&str],
+    addr: &str,
+    filter_json: &str,
+) -> std::process::Output {
+    let client = cluster.client(node);
+    let cols = collections.join(",");
+    Command::new(client.binary_path())
+        .arg("--url")
+        .arg(socket_addr(cluster, node))
+        .args([
+            "client",
+            "p2p",
+            "replicator",
+            "add",
+            "-c",
+            &cols,
+            "--filter",
+            filter_json,
+            addr,
+        ])
+        .output()
+        .expect("exec replicator add --filter")
+}
+
+/// IN-set predicate: only docs whose `agent_did` is in `[alice, carol]` replicate.
+///
+/// The ordering-anchor is the carol doc created after the non-matching bob doc.
+/// Once carol arrives on node1 the push pipeline has provably run; bob's absence
+/// is then attributable to the filter, not to a not-yet-delivered race.
+#[tokio::test]
+async fn rust_filtered_replication_in_set() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AGENT_SCHEMA).expect("schema node0");
+    node1.schema_add(AGENT_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0");
+
+    let filter_json = format!(r#"{{"agent_did":{{"_in":["{ALICE}","{CAROL}"]}}}}"#);
+    let out = run_replicator_add_filter(&cluster, 0, &["AgentDoc"], &addr1, &filter_json);
+    assert!(
+        out.status.success(),
+        "IN-set replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let alice_doc = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "alice-1"}}) {{ _docID }} }}"#
+        ))
+        .expect("create alice doc");
+    let alice_id = extract_doc_id(&alice_doc, "add_AgentDoc");
+
+    node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{BOB}", body: "bob-1"}}) {{ _docID }} }}"#
+        ))
+        .expect("create bob doc");
+
+    let carol_doc = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{CAROL}", body: "carol-1"}}) {{ _docID }} }}"#
+        ))
+        .expect("create carol doc (ordering anchor)");
+    let carol_id = extract_doc_id(&carol_doc, "add_AgentDoc");
+
+    let node1_poll = cluster.client(1);
+    let alice_id_poll = alice_id.clone();
+    let carol_id_poll = carol_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { AgentDoc { _docID agent_did } }")
+                .unwrap_or_default();
+            let Some(rows) = result["AgentDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&alice_id_poll.as_str()) && ids.contains(&carol_id_poll.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "alice and carol docs did not replicate to IN-set filtered peer",
+    )
+    .await;
+
+    let dids = agent_did_values(&cluster, 1);
+    assert_eq!(
+        dids.len(),
+        2,
+        "IN-set filtered peer must hold exactly 2 docs (alice + carol), found: {dids:?}"
+    );
+    assert!(
+        dids.iter().all(|d| d == ALICE || d == CAROL),
+        "IN-set filtered peer must hold only alice and carol, found: {dids:?}"
+    );
+    assert!(
+        !dids.iter().any(|d| d == BOB),
+        "bob must be excluded by IN-set filter, found: {dids:?}"
+    );
+}
+
+/// Composite AND predicate: only docs where `agent_did = alice` AND `kind = keep` replicate.
+#[tokio::test]
+async fn rust_filtered_replication_composite_and() {
+    const AND_SCHEMA: &str =
+        "type AndDoc { agent_did: String @immutable  kind: String @immutable  seq: Int }";
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AND_SCHEMA).expect("schema node0");
+    node1.schema_add(AND_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0.p2p_collection_add(&["AndDoc"]).expect("subscribe 0");
+
+    let filter_json = format!(r#"{{"agent_did":{{"_eq":"{ALICE}"}},"kind":{{"_eq":"keep"}}}}"#);
+    let out = run_replicator_add_filter(&cluster, 0, &["AndDoc"], &addr1, &filter_json);
+    assert!(
+        out.status.success(),
+        "composite AND replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let mk = |did: &str, kind: &str, seq: i32| {
+        format!(
+            r#"mutation {{ add_AndDoc(input: {{agent_did: "{did}", kind: "{kind}", seq: {seq}}}) {{ _docID }} }}"#
+        )
+    };
+
+    let match1 = node0
+        .query(&mk(ALICE, "keep", 1))
+        .expect("create (alice, keep, 1) doc");
+    let match1_id = extract_doc_id(&match1, "add_AndDoc");
+
+    node0
+        .query(&mk(ALICE, "drop", 2))
+        .expect("create (alice, drop) doc");
+    node0
+        .query(&mk(BOB, "keep", 3))
+        .expect("create (bob, keep) doc");
+
+    let match2 = node0
+        .query(&mk(ALICE, "keep", 4))
+        .expect("create second (alice, keep, 4) anchor");
+    let match2_id = extract_doc_id(&match2, "add_AndDoc");
+
+    let node1_poll = cluster.client(1);
+    let m1 = match1_id.clone();
+    let m2 = match2_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { AndDoc { _docID agent_did kind } }")
+                .unwrap_or_default();
+            let Some(rows) = result["AndDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&m1.as_str()) && ids.contains(&m2.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "composite AND matching docs did not replicate",
+    )
+    .await;
+
+    let result = node1
+        .query("query { AndDoc { agent_did kind } }")
+        .expect("query AndDoc on node1");
+    let rows = result["AndDoc"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        rows.len(),
+        2,
+        "composite AND filtered peer must hold exactly 2 (alice,keep) docs, found: {rows:?}"
+    );
+    assert!(
+        rows.iter()
+            .all(|r| r["agent_did"].as_str() == Some(ALICE) && r["kind"].as_str() == Some("keep")),
+        "composite AND filtered peer must hold only (alice,keep) docs, found: {rows:?}"
+    );
+}
+
+/// A predicate on a mutable field (`body`) must be rejected at add time.
+#[tokio::test]
+async fn rust_filtered_replicator_rejects_predicate_non_immutable_field() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 1).await;
+    cluster.client(0).schema_add(AGENT_SCHEMA).expect("schema");
+
+    let out = run_replicator_add_filter(
+        &cluster,
+        0,
+        &["AgentDoc"],
+        DUMMY_PEER_ADDR,
+        r#"{"body":{"_eq":"x"}}"#,
+    );
+    assert!(
+        !out.status.success(),
+        "filtering on a mutable field via --filter must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("immutable"),
+        "error should require the filter field be @immutable, got: {stderr}"
+    );
+}
+
+/// The HTTP wire format cannot express the internal `Acp` variant of
+/// `p2p::ReplicationFilter` — `ReplicationFilter` carries only `Field`, `Value`,
+/// and `Conditions`. Sending an unknown key produces a filter where `Field` is
+/// empty and `Conditions` is None, which the adapter rejects with 4xx.
+#[tokio::test]
+async fn rust_filtered_replicator_rejects_acp_variant() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 1).await;
+    cluster.client(0).schema_add(AGENT_SCHEMA).expect("schema");
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/api/v0/p2p/replicators", cluster.api_url(0)))
+        .json(&serde_json::json!({
+            "Collections": ["AgentDoc"],
+            "Addresses": [DUMMY_PEER_ADDR],
+            "Filters": {"AgentDoc": {"Field": "", "Value": null}}
+        }))
+        .send()
+        .await
+        .expect("POST replicators");
+
+    assert!(
+        resp.status().is_client_error(),
+        "empty-field filter must be rejected with a 4xx, got: {}",
+        resp.status()
+    );
+}
+
+/// The legacy `{Field, Value}` HTTP shape still routes correctly through the new
+/// filter resolution path — back-compat for clients that have not migrated to
+/// the `Conditions` shape.
+#[tokio::test]
+async fn rust_filtered_replication_legacy_format_back_compat() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AGENT_SCHEMA).expect("schema node0");
+    node1.schema_add(AGENT_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0");
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/api/v0/p2p/replicators", cluster.api_url(0)))
+        .json(&serde_json::json!({
+            "Collections": ["AgentDoc"],
+            "Addresses": [addr1],
+            "Filters": {"AgentDoc": {"Field": "agent_did", "Value": ALICE}}
+        }))
+        .send()
+        .await
+        .expect("POST replicators legacy");
+    assert!(
+        resp.status().is_success(),
+        "legacy {{Field, Value}} replicator add failed: {}",
+        resp.status()
+    );
+
+    let alice1 = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "a1"}}) {{ _docID }} }}"#
+        ))
+        .expect("alice1");
+    let alice1_id = extract_doc_id(&alice1, "add_AgentDoc");
+
+    node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{BOB}", body: "b1"}}) {{ _docID }} }}"#
+        ))
+        .expect("bob1");
+
+    let alice2 = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "a2"}}) {{ _docID }} }}"#
+        ))
+        .expect("alice2 anchor");
+    let alice2_id = extract_doc_id(&alice2, "add_AgentDoc");
+
+    let node1_poll = cluster.client(1);
+    let a1 = alice1_id.clone();
+    let a2 = alice2_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { AgentDoc { _docID } }")
+                .unwrap_or_default();
+            let Some(rows) = result["AgentDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&a1.as_str()) && ids.contains(&a2.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "legacy-format alice docs did not replicate",
+    )
+    .await;
+
+    let dids = agent_did_values(&cluster, 1);
+    assert_eq!(
+        dids.len(),
+        2,
+        "legacy back-compat: only alice docs must replicate, found: {dids:?}"
+    );
+    assert!(
+        dids.iter().all(|d| d == ALICE),
+        "legacy back-compat: bob must be excluded, found: {dids:?}"
+    );
+}
+
+/// A replicator's filter can be updated in-place (upsert) by re-adding with the
+/// same peer+collection but a new predicate. Documents that match the updated
+/// filter but not the original must begin replicating after the upsert without
+/// requiring a remove/re-add cycle.
+#[tokio::test]
+async fn rust_filtered_replication_mutable_filter_upsert() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AGENT_SCHEMA).expect("schema node0");
+    node1.schema_add(AGENT_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0");
+
+    let narrow_filter = format!(r#"{{"agent_did":{{"_in":["{ALICE}"]}}}}"#);
+    let out = run_replicator_add_filter(&cluster, 0, &["AgentDoc"], &addr1, &narrow_filter);
+    assert!(
+        out.status.success(),
+        "initial narrow filter add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let alice1 = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "alice-before-upsert"}}) {{ _docID }} }}"#
+        ))
+        .expect("alice1");
+    let alice1_id = extract_doc_id(&alice1, "add_AgentDoc");
+
+    node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{CAROL}", body: "carol-before-upsert"}}) {{ _docID }} }}"#
+        ))
+        .expect("carol before upsert");
+
+    let node1_poll = cluster.client(1);
+    let a1 = alice1_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { AgentDoc { _docID } }")
+                .unwrap_or_default();
+            result["AgentDoc"].as_array().is_some_and(|rows| {
+                rows.iter()
+                    .any(|r| r["_docID"].as_str() == Some(a1.as_str()))
+            })
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "alice1 did not replicate before upsert",
+    )
+    .await;
+
+    // Carol arrived on node0 first but must still be absent on node1 at this
+    // point (the narrow filter excludes her). A brief settle window confirms
+    // absence before the upsert changes the filter.
+    tokio::time::sleep(ABSENCE_GRACE).await;
+    let before_upsert = agent_did_values(&cluster, 1);
+    assert!(
+        !before_upsert.iter().any(|d| d == CAROL),
+        "carol must not be present before filter upsert, found: {before_upsert:?}"
+    );
+
+    // Upsert the replicator with a wider filter that now includes carol.
+    let wide_filter = format!(r#"{{"agent_did":{{"_in":["{ALICE}","{CAROL}"]}}}}"#);
+    let out = run_replicator_add_filter(&cluster, 0, &["AgentDoc"], &addr1, &wide_filter);
+    assert!(
+        out.status.success(),
+        "filter upsert failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Create new docs after the upsert so delivery comes from live push under
+    // the updated filter (not backfill, which is separate behavior).
+    let carol2 = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{CAROL}", body: "carol-after-upsert"}}) {{ _docID }} }}"#
+        ))
+        .expect("carol2 after upsert");
+    let carol2_id = extract_doc_id(&carol2, "add_AgentDoc");
+
+    let alice2 = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "alice-anchor"}}) {{ _docID }} }}"#
+        ))
+        .expect("alice2 ordering anchor");
+    let alice2_id = extract_doc_id(&alice2, "add_AgentDoc");
+
+    let node1_poll2 = cluster.client(1);
+    let c2 = carol2_id.clone();
+    let a2 = alice2_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll2
+                .query("query { AgentDoc { _docID agent_did } }")
+                .unwrap_or_default();
+            let Some(rows) = result["AgentDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&c2.as_str()) && ids.contains(&a2.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "carol2 or alice2 did not replicate after filter upsert",
+    )
+    .await;
+
+    let dids_after = agent_did_values(&cluster, 1);
+    assert!(
+        dids_after.iter().any(|d| d == CAROL),
+        "carol must replicate after filter upsert, found: {dids_after:?}"
+    );
+    assert!(
+        !dids_after.iter().any(|d| d == BOB),
+        "bob must remain excluded after filter upsert, found: {dids_after:?}"
+    );
+}

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -1094,12 +1094,13 @@ async fn rust_filtered_replicator_rejects_predicate_non_immutable_field() {
     );
 }
 
-/// The HTTP wire format cannot express the internal `Acp` variant of
-/// `p2p::ReplicationFilter` — `ReplicationFilter` carries only `Field`, `Value`,
-/// and `Conditions`. Sending an unknown key produces a filter where `Field` is
-/// empty and `Conditions` is None, which the adapter rejects with 4xx.
+/// A filter with an empty `Field` and no `Conditions` is structurally invalid
+/// over HTTP. The adapter rejects it with a 4xx before any P2P dial is attempted.
+/// (The internal `Acp` variant of `p2p::ReplicationFilter` cannot be expressed
+/// over the HTTP wire format at all; see the `replication-filter` unit tests for
+/// that coverage.)
 #[tokio::test]
-async fn rust_filtered_replicator_rejects_acp_variant() {
+async fn rust_filtered_replicator_rejects_empty_field_over_http() {
     let cluster = TestCluster::builder()
         .rust_nodes(1)
         .with_p2p()

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -1348,3 +1348,99 @@ async fn rust_filtered_replication_mutable_filter_upsert() {
         "bob must remain excluded after filter upsert, found: {dids_after:?}"
     );
 }
+
+/// Backfill with `_in` set filter: docs created BEFORE replicator is added must
+/// be backfilled only if they appear in the IN set.
+///
+/// This test would fail if the backfill path used `EqOnlyFilterMatcher` because
+/// `_in` has no `_eq` key — EqOnly would match nothing and silently drop ALL docs.
+#[tokio::test]
+async fn rust_filtered_replication_in_set_backfill() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AGENT_SCHEMA).expect("schema node0");
+    node1.schema_add(AGENT_SCHEMA).expect("schema node1");
+
+    // Create all docs BEFORE wiring replication so delivery comes from backfill.
+    let alice_doc = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "alice-backfill"}}) {{ _docID }} }}"#
+        ))
+        .expect("create alice doc");
+    let alice_id = extract_doc_id(&alice_doc, "add_AgentDoc");
+
+    node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{BOB}", body: "bob-backfill"}}) {{ _docID }} }}"#
+        ))
+        .expect("create bob doc");
+
+    let carol_doc = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{CAROL}", body: "carol-backfill"}}) {{ _docID }} }}"#
+        ))
+        .expect("create carol doc");
+    let carol_id = extract_doc_id(&carol_doc, "add_AgentDoc");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0");
+
+    let filter_json = format!(r#"{{"agent_did":{{"_in":["{ALICE}","{CAROL}"]}}}}"#);
+    let out = run_replicator_add_filter(&cluster, 0, &["AgentDoc"], &addr1, &filter_json);
+    assert!(
+        out.status.success(),
+        "IN-set backfill replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Both alice and carol must arrive via backfill.
+    let node1_poll = cluster.client(1);
+    let alice_id_poll = alice_id.clone();
+    let carol_id_poll = carol_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { AgentDoc { _docID agent_did } }")
+                .unwrap_or_default();
+            let Some(rows) = result["AgentDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&alice_id_poll.as_str()) && ids.contains(&carol_id_poll.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "alice and carol did not backfill to IN-set filtered peer",
+    )
+    .await;
+
+    // Bob must be absent. After both matching docs arrived the push pipeline has
+    // provably run, so bob's absence is attributable to the filter.
+    tokio::time::sleep(ABSENCE_GRACE).await;
+    let dids = agent_did_values(&cluster, 1);
+    assert_eq!(
+        dids.len(),
+        2,
+        "IN-set backfill filtered peer must hold exactly 2 docs (alice + carol), found: {dids:?}"
+    );
+    assert!(
+        dids.iter().all(|d| d == ALICE || d == CAROL),
+        "IN-set backfill filtered peer must hold only alice and carol, found: {dids:?}"
+    );
+    assert!(
+        !dids.iter().any(|d| d == BOB),
+        "bob must be excluded by IN-set backfill filter, found: {dids:?}"
+    );
+}

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -1445,3 +1445,606 @@ async fn rust_filtered_replication_in_set_backfill() {
         "bob must be excluded by IN-set backfill filter, found: {dids:?}"
     );
 }
+
+/// OR predicate: docs where `agent_did = alice` OR `kind = keep` replicate;
+/// (bob, drop) satisfies neither arm and must be excluded.
+#[tokio::test]
+async fn rust_filtered_replication_or() {
+    const OR_SCHEMA: &str = "type OrDoc { agent_did: String @immutable  kind: String @immutable }";
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(OR_SCHEMA).expect("schema node0");
+    node1.schema_add(OR_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0.p2p_collection_add(&["OrDoc"]).expect("subscribe 0");
+
+    let filter_json =
+        format!(r#"{{"_or":[{{"agent_did":{{"_eq":"{ALICE}"}}}},{{"kind":{{"_eq":"keep"}}}}]}}"#);
+    let out = run_replicator_add_filter(&cluster, 0, &["OrDoc"], &addr1, &filter_json);
+    assert!(
+        out.status.success(),
+        "OR replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let mk = |did: &str, kind: &str| {
+        format!(
+            r#"mutation {{ add_OrDoc(input: {{agent_did: "{did}", kind: "{kind}"}}) {{ _docID }} }}"#
+        )
+    };
+
+    let match_alice = node0
+        .query(&mk(ALICE, "x"))
+        .expect("create (alice, x) — matches via agent_did arm");
+    let match_alice_id = extract_doc_id(&match_alice, "add_OrDoc");
+
+    node0
+        .query(&mk(BOB, "drop"))
+        .expect("create (bob, drop) — matches neither arm");
+
+    let match_keep = node0
+        .query(&mk(BOB, "keep"))
+        .expect("create (bob, keep) — matches via kind arm (ordering anchor)");
+    let match_keep_id = extract_doc_id(&match_keep, "add_OrDoc");
+
+    let node1_poll = cluster.client(1);
+    let m_alice = match_alice_id.clone();
+    let m_keep = match_keep_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { OrDoc { _docID } }")
+                .unwrap_or_default();
+            let Some(rows) = result["OrDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&m_alice.as_str()) && ids.contains(&m_keep.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "OR-matching docs did not replicate to filtered peer",
+    )
+    .await;
+
+    let result = node1
+        .query("query { OrDoc { agent_did kind } }")
+        .expect("query OrDoc on node1");
+    let rows = result["OrDoc"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        rows.len(),
+        2,
+        "OR filtered peer must hold exactly 2 matching docs, found: {rows:?}"
+    );
+    let has_drop = rows.iter().any(|r| r["kind"].as_str() == Some("drop"));
+    assert!(
+        !has_drop,
+        "(bob, drop) must be excluded by OR filter, found: {rows:?}"
+    );
+}
+
+/// NE predicate: docs where `agent_did != bob` replicate; bob is excluded.
+#[tokio::test]
+async fn rust_filtered_replication_ne_excludes() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AGENT_SCHEMA).expect("schema node0");
+    node1.schema_add(AGENT_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0");
+
+    let filter_json = format!(r#"{{"agent_did":{{"_ne":"{BOB}"}}}}"#);
+    let out = run_replicator_add_filter(&cluster, 0, &["AgentDoc"], &addr1, &filter_json);
+    assert!(
+        out.status.success(),
+        "NE replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let alice_doc = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "alice-ne"}}) {{ _docID }} }}"#
+        ))
+        .expect("alice doc");
+    let alice_id = extract_doc_id(&alice_doc, "add_AgentDoc");
+
+    node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{BOB}", body: "bob-ne"}}) {{ _docID }} }}"#
+        ))
+        .expect("bob doc");
+
+    let carol_doc = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{CAROL}", body: "carol-ne"}}) {{ _docID }} }}"#
+        ))
+        .expect("carol doc (ordering anchor)");
+    let carol_id = extract_doc_id(&carol_doc, "add_AgentDoc");
+
+    let node1_poll = cluster.client(1);
+    let a_id = alice_id.clone();
+    let c_id = carol_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { AgentDoc { _docID } }")
+                .unwrap_or_default();
+            let Some(rows) = result["AgentDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&a_id.as_str()) && ids.contains(&c_id.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "alice and carol did not replicate under NE filter",
+    )
+    .await;
+
+    let dids = agent_did_values(&cluster, 1);
+    assert_eq!(
+        dids.len(),
+        2,
+        "NE filter must admit exactly alice + carol (not bob), found: {dids:?}"
+    );
+    assert!(
+        !dids.iter().any(|d| d == BOB),
+        "bob must be excluded by NE filter, found: {dids:?}"
+    );
+    assert!(
+        dids.iter().any(|d| d == ALICE) && dids.iter().any(|d| d == CAROL),
+        "alice and carol must be present, found: {dids:?}"
+    );
+}
+
+/// Range predicate (GTE): docs with `tier >= 2` replicate; tier=1 is excluded.
+#[tokio::test]
+async fn rust_filtered_replication_range() {
+    const TIER_SCHEMA: &str = "type TierDoc { tier: Int @immutable  body: String }";
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(TIER_SCHEMA).expect("schema node0");
+    node1.schema_add(TIER_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0.p2p_collection_add(&["TierDoc"]).expect("subscribe 0");
+
+    let filter_json = r#"{"tier":{"_gte":2}}"#;
+    let out = run_replicator_add_filter(&cluster, 0, &["TierDoc"], &addr1, filter_json);
+    assert!(
+        out.status.success(),
+        "range (GTE) replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let mk = |tier: i32, body: &str| {
+        format!(
+            r#"mutation {{ add_TierDoc(input: {{tier: {tier}, body: "{body}"}}) {{ _docID }} }}"#
+        )
+    };
+
+    node0.query(&mk(1, "tier1")).expect("tier=1 doc");
+
+    let tier2 = node0.query(&mk(2, "tier2")).expect("tier=2 doc");
+    let tier2_id = extract_doc_id(&tier2, "add_TierDoc");
+
+    let tier3 = node0
+        .query(&mk(3, "tier3"))
+        .expect("tier=3 doc (ordering anchor)");
+    let tier3_id = extract_doc_id(&tier3, "add_TierDoc");
+
+    let node1_poll = cluster.client(1);
+    let t2 = tier2_id.clone();
+    let t3 = tier3_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { TierDoc { _docID } }")
+                .unwrap_or_default();
+            let Some(rows) = result["TierDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&t2.as_str()) && ids.contains(&t3.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "tier>=2 docs did not replicate to range-filtered peer",
+    )
+    .await;
+
+    let result = node1
+        .query("query { TierDoc { tier } }")
+        .expect("query TierDoc on node1");
+    let rows = result["TierDoc"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        rows.len(),
+        2,
+        "range filter must admit exactly tier=2 and tier=3, found: {rows:?}"
+    );
+    assert!(
+        rows.iter().all(|r| r["tier"].as_i64().unwrap_or(0) >= 2),
+        "all replicated docs must have tier >= 2, found: {rows:?}"
+    );
+    let has_tier1 = rows.iter().any(|r| r["tier"].as_i64() == Some(1));
+    assert!(
+        !has_tier1,
+        "tier=1 doc must be excluded by range filter, found: {rows:?}"
+    );
+}
+
+/// Typed Int equality filter: only docs with `code = 7` replicate.
+/// Proves Int materialization + matching e2e (the silent-zero-match guard for Int).
+#[tokio::test]
+async fn rust_filtered_replication_int_match() {
+    const INT_SCHEMA: &str = "type IntDoc { code: Int @immutable  body: String }";
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(INT_SCHEMA).expect("schema node0");
+    node1.schema_add(INT_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0.p2p_collection_add(&["IntDoc"]).expect("subscribe 0");
+
+    let filter_json = r#"{"code":{"_eq":7}}"#;
+    let out = run_replicator_add_filter(&cluster, 0, &["IntDoc"], &addr1, filter_json);
+    assert!(
+        out.status.success(),
+        "Int _eq replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let match1 = node0
+        .query(r#"mutation { add_IntDoc(input: {code: 7, body: "seven-1"}) { _docID } }"#)
+        .expect("code=7 doc");
+    let match1_id = extract_doc_id(&match1, "add_IntDoc");
+
+    node0
+        .query(r#"mutation { add_IntDoc(input: {code: 9, body: "nine"}) { _docID } }"#)
+        .expect("code=9 doc");
+
+    let match2 = node0
+        .query(r#"mutation { add_IntDoc(input: {code: 7, body: "seven-2"}) { _docID } }"#)
+        .expect("code=7 anchor");
+    let match2_id = extract_doc_id(&match2, "add_IntDoc");
+
+    let node1_poll = cluster.client(1);
+    let m1 = match1_id.clone();
+    let m2 = match2_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { IntDoc { _docID } }")
+                .unwrap_or_default();
+            let Some(rows) = result["IntDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&m1.as_str()) && ids.contains(&m2.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "Int code=7 docs did not replicate to Int-filtered peer",
+    )
+    .await;
+
+    let result = node1
+        .query("query { IntDoc { code } }")
+        .expect("query IntDoc on node1");
+    let rows = result["IntDoc"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        rows.len(),
+        2,
+        "Int filter must admit exactly the two code=7 docs, found: {rows:?}"
+    );
+    assert!(
+        rows.iter().all(|r| r["code"].as_i64() == Some(7)),
+        "all replicated IntDoc must have code=7, found: {rows:?}"
+    );
+}
+
+/// Bool equality filter: only docs with `active = true` replicate.
+/// Proves Bool materialization + matching e2e.
+#[tokio::test]
+async fn rust_filtered_replication_bool_match() {
+    const FLAG_SCHEMA: &str = "type FlagDoc { active: Boolean @immutable  body: String }";
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(FLAG_SCHEMA).expect("schema node0");
+    node1.schema_add(FLAG_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0.p2p_collection_add(&["FlagDoc"]).expect("subscribe 0");
+
+    let filter_json = r#"{"active":{"_eq":true}}"#;
+    let out = run_replicator_add_filter(&cluster, 0, &["FlagDoc"], &addr1, filter_json);
+    assert!(
+        out.status.success(),
+        "Bool _eq replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let match1 = node0
+        .query(r#"mutation { add_FlagDoc(input: {active: true, body: "on-1"}) { _docID } }"#)
+        .expect("active=true doc");
+    let match1_id = extract_doc_id(&match1, "add_FlagDoc");
+
+    node0
+        .query(r#"mutation { add_FlagDoc(input: {active: false, body: "off"}) { _docID } }"#)
+        .expect("active=false doc");
+
+    let match2 = node0
+        .query(r#"mutation { add_FlagDoc(input: {active: true, body: "on-2"}) { _docID } }"#)
+        .expect("active=true anchor");
+    let match2_id = extract_doc_id(&match2, "add_FlagDoc");
+
+    let node1_poll = cluster.client(1);
+    let m1 = match1_id.clone();
+    let m2 = match2_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { FlagDoc { _docID } }")
+                .unwrap_or_default();
+            let Some(rows) = result["FlagDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&m1.as_str()) && ids.contains(&m2.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "Bool active=true docs did not replicate to Bool-filtered peer",
+    )
+    .await;
+
+    let result = node1
+        .query("query { FlagDoc { active } }")
+        .expect("query FlagDoc on node1");
+    let rows = result["FlagDoc"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        rows.len(),
+        2,
+        "Bool filter must admit exactly the two active=true docs, found: {rows:?}"
+    );
+    assert!(
+        rows.iter().all(|r| r["active"].as_bool() == Some(true)),
+        "all replicated FlagDoc must have active=true, found: {rows:?}"
+    );
+}
+
+/// DateTime range filter: docs with `at >= 2026-01-01T00:00:00Z` replicate;
+/// earlier dates are excluded. Proves DateTime materialization + comparison e2e.
+#[tokio::test]
+async fn rust_filtered_replication_datetime() {
+    const EVENT_SCHEMA: &str = "type EventDoc { at: DateTime @immutable  body: String }";
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(EVENT_SCHEMA).expect("schema node0");
+    node1.schema_add(EVENT_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["EventDoc"])
+        .expect("subscribe 0");
+
+    let filter_json = r#"{"at":{"_gte":"2026-01-01T00:00:00Z"}}"#;
+    let out = run_replicator_add_filter(&cluster, 0, &["EventDoc"], &addr1, filter_json);
+    assert!(
+        out.status.success(),
+        "DateTime GTE replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    node0
+        .query(
+            r#"mutation { add_EventDoc(input: {at: "2025-06-01T00:00:00Z", body: "old"}) { _docID } }"#,
+        )
+        .expect("old datetime doc");
+
+    let match1 = node0
+        .query(
+            r#"mutation { add_EventDoc(input: {at: "2026-01-01T00:00:00Z", body: "new-1"}) { _docID } }"#,
+        )
+        .expect("matching datetime doc");
+    let match1_id = extract_doc_id(&match1, "add_EventDoc");
+
+    let match2 = node0
+        .query(
+            r#"mutation { add_EventDoc(input: {at: "2026-06-01T00:00:00Z", body: "new-2"}) { _docID } }"#,
+        )
+        .expect("matching datetime anchor");
+    let match2_id = extract_doc_id(&match2, "add_EventDoc");
+
+    let node1_poll = cluster.client(1);
+    let m1 = match1_id.clone();
+    let m2 = match2_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { EventDoc { _docID } }")
+                .unwrap_or_default();
+            let Some(rows) = result["EventDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&m1.as_str()) && ids.contains(&m2.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "DateTime >= 2026 docs did not replicate to DateTime-filtered peer",
+    )
+    .await;
+
+    let result = node1
+        .query("query { EventDoc { body } }")
+        .expect("query EventDoc on node1");
+    let rows = result["EventDoc"].as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        rows.len(),
+        2,
+        "DateTime filter must admit exactly the two >= 2026 docs, found: {rows:?}"
+    );
+    let has_old = rows.iter().any(|r| r["body"].as_str() == Some("old"));
+    assert!(
+        !has_old,
+        "old (2025) EventDoc must be excluded by DateTime filter, found: {rows:?}"
+    );
+}
+
+/// Iroh transport variant of `rust_filtered_replication_in_set`: verifies the
+/// rich `_in` filter works over Iroh (previously broken in the iroh adapter).
+#[tokio::test]
+async fn rust_filtered_replication_in_set_iroh() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_iroh_transport()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0.schema_add(AGENT_SCHEMA).expect("schema node0");
+    node1.schema_add(AGENT_SCHEMA).expect("schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0");
+
+    let filter_json = format!(r#"{{"agent_did":{{"_in":["{ALICE}","{CAROL}"]}}}}"#);
+    let out = run_replicator_add_filter(&cluster, 0, &["AgentDoc"], &addr1, &filter_json);
+    assert!(
+        out.status.success(),
+        "IN-set iroh replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let alice_doc = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{ALICE}", body: "alice-iroh"}}) {{ _docID }} }}"#
+        ))
+        .expect("alice doc");
+    let alice_id = extract_doc_id(&alice_doc, "add_AgentDoc");
+
+    node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{BOB}", body: "bob-iroh"}}) {{ _docID }} }}"#
+        ))
+        .expect("bob doc");
+
+    let carol_doc = node0
+        .query(&format!(
+            r#"mutation {{ add_AgentDoc(input: {{agent_did: "{CAROL}", body: "carol-iroh"}}) {{ _docID }} }}"#
+        ))
+        .expect("carol doc (ordering anchor)");
+    let carol_id = extract_doc_id(&carol_doc, "add_AgentDoc");
+
+    let node1_poll = cluster.client(1);
+    let a_id = alice_id.clone();
+    let c_id = carol_id.clone();
+    poll_until(
+        || {
+            let result = node1_poll
+                .query("query { AgentDoc { _docID agent_did } }")
+                .unwrap_or_default();
+            let Some(rows) = result["AgentDoc"].as_array() else {
+                return false;
+            };
+            let ids: Vec<&str> = rows.iter().filter_map(|r| r["_docID"].as_str()).collect();
+            ids.contains(&a_id.as_str()) && ids.contains(&c_id.as_str())
+        },
+        P2P_TIMEOUT,
+        P2P_POLL_INTERVAL,
+        "alice and carol did not replicate over iroh IN-set filter",
+    )
+    .await;
+
+    let dids = agent_did_values(&cluster, 1);
+    assert_eq!(
+        dids.len(),
+        2,
+        "iroh IN-set filtered peer must hold exactly 2 docs (alice + carol), found: {dids:?}"
+    );
+    assert!(
+        dids.iter().all(|d| d == ALICE || d == CAROL),
+        "iroh IN-set filtered peer must hold only alice and carol, found: {dids:?}"
+    );
+    assert!(
+        !dids.iter().any(|d| d == BOB),
+        "bob must be excluded by iroh IN-set filter, found: {dids:?}"
+    );
+}

--- a/tools/integration-test/tests/p2p/manage_relay.rs
+++ b/tools/integration-test/tests/p2p/manage_relay.rs
@@ -18,7 +18,7 @@ use serial_test::serial;
 
 use crate::manage_relay_common::{peer_id_of, post_manage, post_manage_query};
 
-const SCHEMA: &str = "type User { name: String  age: Int }";
+const SCHEMA: &str = "type User { name: String @immutable  age: Int }";
 
 /// Bring up a NAC-enabled 2-node libp2p cluster, deploy the `User` schema on
 /// node B, and return the admin key plus node B's peer-id and dial address.
@@ -424,6 +424,79 @@ async fn manage_replicator_add_and_list_over_p2p() {
         assert!(
             Instant::now() < deadline,
             "node B did not report the added replicator over the relay"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// A relayed `ReplicatorAdd` that carries a rich filter must PRESERVE the filter
+/// end-to-end: the `ReplicatorList` reply over the same relay shows the replicator
+/// WITH a non-empty `filters`. Guards the manage-channel filter-drop regression.
+#[tokio::test]
+#[serial]
+async fn manage_replicator_add_preserves_filter() {
+    let (cluster, admin_key, addr_b, peer_id_b) = setup().await;
+    let api_a = cluster.api_url(0).to_string();
+
+    // Node A's listen address: B will replicate the User collection back to A.
+    let node_a = cluster.client(0);
+    let info_a = node_a
+        .p2p_info_with_identity(&admin_key)
+        .expect("p2p_info node A");
+    let addr_a = info_a
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("node A has no P2P address")
+        .to_string();
+
+    let token = crate::manage_relay_common::mint_manage_token(&admin_key, &peer_id_b);
+
+    let status = post_manage(
+        &api_a,
+        &admin_key,
+        &addr_b,
+        &token,
+        json!({
+            "Kind": "ReplicatorAdd",
+            "addresses": [addr_a],
+            "collection_ids": ["User"],
+            "filters": { "User": { "Conditions": { "name": { "_eq": "keep" } } } },
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "authorized filtered ReplicatorAdd relay should return 200"
+    );
+
+    // ReplicatorList over the relay must reflect the replicator WITH its filter.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let (status, body) = post_manage_query(
+            &api_a,
+            &admin_key,
+            &addr_b,
+            &token,
+            json!({ "Kind": "ReplicatorList" }),
+        )
+        .await;
+        if status == StatusCode::OK && replicator_list_nonempty(&body) {
+            assert_eq!(
+                body["Kind"], "Replicators",
+                "ReplicatorList must return a typed Replicators result, got {body}"
+            );
+            let filters = &body["replicators"][0]["filters"];
+            assert!(
+                filters.as_object().map(|m| !m.is_empty()).unwrap_or(false),
+                "relayed replicator must retain a non-empty filter, got {body}"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "node B did not report the filtered replicator over the relay"
         );
         tokio::time::sleep(Duration::from_millis(200)).await;
     }

--- a/tools/integration-test/tests/p2p/manage_relay.rs
+++ b/tools/integration-test/tests/p2p/manage_relay.rs
@@ -502,6 +502,82 @@ async fn manage_replicator_add_preserves_filter() {
     }
 }
 
+/// A RICH predicate (`_in`, not a single `_eq`) must round-trip through the
+/// relay's ReplicatorList reply with its `Conditions` intact. The reply path
+/// reconstructs the filter on the target (`to_p2p_replicator_info`); a
+/// field/value-only reconstruction silently corrupts any non-`_eq` predicate
+/// into `{"": {"_eq": null}}`, which a presence-only assertion would miss.
+#[tokio::test]
+#[serial]
+async fn manage_replicator_add_preserves_rich_filter() {
+    let (cluster, admin_key, addr_b, peer_id_b) = setup().await;
+    let api_a = cluster.api_url(0).to_string();
+
+    let node_a = cluster.client(0);
+    let info_a = node_a
+        .p2p_info_with_identity(&admin_key)
+        .expect("p2p_info node A");
+    let addr_a = info_a
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("node A has no P2P address")
+        .to_string();
+
+    let token = crate::manage_relay_common::mint_manage_token(&admin_key, &peer_id_b);
+    let expected = json!({ "name": { "_in": ["keep", "also"] } });
+
+    let status = post_manage(
+        &api_a,
+        &admin_key,
+        &addr_b,
+        &token,
+        json!({
+            "Kind": "ReplicatorAdd",
+            "addresses": [addr_a],
+            "collection_ids": ["User"],
+            "filters": { "User": { "Conditions": expected } },
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "authorized rich-filtered ReplicatorAdd relay should return 200"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let (status, body) = post_manage_query(
+            &api_a,
+            &admin_key,
+            &addr_b,
+            &token,
+            json!({ "Kind": "ReplicatorList" }),
+        )
+        .await;
+        if status == StatusCode::OK && replicator_list_nonempty(&body) {
+            let filters = body["replicators"][0]["filters"]
+                .as_object()
+                .expect("replicator must carry a filters object");
+            let (_collection, filter) = filters
+                .iter()
+                .next()
+                .expect("filters object must have one entry");
+            assert_eq!(
+                filter["Conditions"], expected,
+                "rich predicate must round-trip through the relay reply intact, got {body}"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "node B did not report the rich-filtered replicator over the relay"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
 /// Admin token (`aud` = B peer-id) relays a `DocumentAdd`. Document subscribe is a
 /// broadcaster delegation that succeeds even for a not-yet-existing doc id (the
 /// p2p document tests treat doc ids the same way), so a 200 proves the dispatch


### PR DESCRIPTION
Implements the **Predicate increment** of #1034 — generalizes replication filters from a single `{Field == Value}` equality to a rich DefraDB query-filter expression (IN-set, composite `_and`/`_or`, `_ne`/range operators, typed values), behind an extensible filter-source abstraction.

Filtered replication is **push-path selectivity, not confidentiality**: a filter narrows what a *source* node chooses to push to a replicator. Confidentiality remains ACP + encryption.

## What landed

- **Extensible filter enum** (`crates/p2p`): `ReplicationFilter = Predicate(conditions) | Acp{relation} | All([...])`. The MVP `{Field,Value}` shape deserializes back-compatibly to `Predicate({field:{_eq:value}})`; empty filters stay byte-identical to Go (parity fixtures unchanged).
- **Decoupled matcher injection**: p2p owns the filter opaquely + a `ReplicationFilterMatcher` trait injected into the sync coordinator; p2p stays engine-agnostic. `with_access_control` now requires an explicit matcher (the old hardcoded `_eq`-only default was a footgun — see fixes below).
- **Rich matcher via query-engine reuse** (new `crates/replication-filter` bridge crate): `Predicate` → `query::Filter::from_conditions(..).matches_json_object(doc)`. Deletes p2p's hand-rolled scalar matcher. Wired into the CLI server, the embedded node, **and** the in-process iroh node (defra-node).
- **Recursive validation**: every field referenced anywhere in a predicate must be `@immutable` scalar-LWW; supported operators/types enforced; unsupported ops and the `Acp` variant rejected at add-time.
- **Manage-channel parity**: the P2P management relay (`ReplicatorAdd` / `ReplicatorList`) now carries filters end-to-end through the http↔p2p conversions, so a replicator added via a relayed, NAC-authorized request is filtered identically to a direct add.
- **Surface**: CLI `--filter '<json conditions>'` (alongside the `--filter-field/--filter-value` sugar) and a manage `--filter`; HTTP carries a `Conditions` field for rich predicates.
- **Mutable filter falls out free**: re-POSTing a replicator upserts the filter; the hash-keyed matcher cache treats the new predicate as a miss, so changes take effect without remove/re-add.

## Bugs found & fixed during review

Several real defects surfaced via adversarial (ultracode) review of component seams:

- **Backfill/live-push used the `_eq`-only matcher** — rich `_in`/composite filters silently dropped all matches on the backfill and defra-node live-push paths. Threaded the real matcher through `db-merge` and made the coordinator matcher explicit.
- **Iroh adapter ignored `conditions`** — `resolve_replication_filters` was missing the rich-predicate branch, so rich filters over the iroh transport were rejected. (The whole integration suite spawns the CLI server, so the production iroh node had been structurally untested; defra-node now has in-process iroh guards.)
- **Manage `ReplicatorList` reply corrupted rich predicates** — `to_p2p_replicator_info` reconstructed filters via `new(field,value)`, ignoring `conditions`, turning any non-`_eq` predicate into `{"": {"_eq": null}}` in the listing. Fixed (failing-test-first) to mirror the requester-side conversion.

## Deferred (designed, not built)
- `AcpScoped` (authorization-driven push) — the enum variant exists but is rejected at add-time; design tracked in #1036.
- Long-tail e2e coverage gaps (retry-filter, delete-path, encryption-rich, ACP-rich, HTTP `Conditions` round-trip, GET /replicators shape, CLI list rendering) tracked in #1038. None are known bugs — untested seams.

## Tests
- **Unit**: 24 p2p + 14 `replication-filter` (enum serde/back-compat, matcher dispatch incl. IN/composite/typed/caching, recursive validation) + manage serve round-trip/forwarding tests.
- **Integration**: 26 `filtered_replication` tests — IN-set (live + backfill), composite AND, the operator matrix (`_or`/`_ne`/range/Int/Bool/DateTime — the silent-zero-match class), an iroh `_in` variant, validation rejections (non-immutable field, unsupported op, acp variant), legacy `{Field,Value}` back-compat, mutable-filter upsert, ACP-controlled mode.
- **defra-node in-process**: 2 (rich live-push + transport backfill, exercising the production iroh path).
- **Manage relay**: 3 (`_eq` preserve, rich `_in` content round-trip, list).
- `clippy --all --all-targets -- -D warnings` clean.

Refs #1034, #1036, #1038.

🤖 Generated with [Claude Code](https://claude.com/claude-code)