### PR TITLE
Close out #1012: DocumentList + PeerDisconnect manage-channel verbs

### DIFF
--- a/crates/cli/src/commands/client/http_client/p2p.rs
+++ b/crates/cli/src/commands/client/http_client/p2p.rs
@@ -285,8 +285,22 @@ impl HttpClient {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "Kind")]
 pub enum ManageQueryResultResponse {
-    Replicators { replicators: Vec<P2pReplicatorInfo> },
-    Strings { values: Vec<String> },
+    Replicators {
+        replicators: Vec<P2pReplicatorInfo>,
+    },
+    Strings {
+        values: Vec<String>,
+    },
+    Documents {
+        documents: Vec<ManageDocRefResponse>,
+    },
+}
+
+/// Deserializable mirror of `RemoteManageDocRef` for `Documents` query responses.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ManageDocRefResponse {
+    pub collection: String,
+    pub doc_id: String,
 }
 
 /// Mint an actor JWT for a P2P management request.

--- a/crates/cli/src/commands/client/p2p/manage.rs
+++ b/crates/cli/src/commands/client/p2p/manage.rs
@@ -368,6 +368,8 @@ pub enum P2pManageDocumentCommand {
     Add(ManageDocumentMutateArgs),
     /// Remove document(s) from the target peer's P2P sync
     Remove(ManageDocumentMutateArgs),
+    /// List the target peer's P2P documents
+    List(ManageTarget),
 }
 
 #[derive(Args, Debug)]
@@ -389,6 +391,18 @@ impl P2pManageDocumentArgs {
         match &self.command {
             P2pManageDocumentCommand::Add(args) => args.execute(ctx, /* add = */ true).await,
             P2pManageDocumentCommand::Remove(args) => args.execute(ctx, /* add = */ false).await,
+            P2pManageDocumentCommand::List(target) => {
+                let auth = target.resolve(ctx)?;
+                let client = client(ctx, auth.bearer)?;
+                let result = client
+                    .p2p_manage_query(
+                        &target.target,
+                        &auth.actor_token,
+                        RemoteManageQueryOp::DocumentList,
+                    )
+                    .await?;
+                print_query_result(&result)
+            }
         }
     }
 }

--- a/crates/cli/src/commands/client/p2p/manage.rs
+++ b/crates/cli/src/commands/client/p2p/manage.rs
@@ -454,6 +454,8 @@ pub struct P2pManagePeerArgs {
 pub enum P2pManagePeerCommand {
     /// Instruct the target peer to connect to another peer
     Connect(ManagePeerConnectArgs),
+    /// Instruct the target peer to disconnect from another peer
+    Disconnect(ManagePeerDisconnectArgs),
 }
 
 #[derive(Args, Debug)]
@@ -466,10 +468,21 @@ pub struct ManagePeerConnectArgs {
     pub address: String,
 }
 
+#[derive(Args, Debug)]
+pub struct ManagePeerDisconnectArgs {
+    #[command(flatten)]
+    pub target: ManageTarget,
+
+    /// Address of the peer the target should disconnect from
+    #[arg(long, value_name = "multiaddr")]
+    pub address: String,
+}
+
 impl P2pManagePeerArgs {
     pub async fn execute(&self, ctx: &ClientContext) -> Result<()> {
         match &self.command {
             P2pManagePeerCommand::Connect(args) => args.execute(ctx).await,
+            P2pManagePeerCommand::Disconnect(args) => args.execute(ctx).await,
         }
     }
 }
@@ -485,6 +498,21 @@ impl ManagePeerConnectArgs {
             .p2p_manage(&self.target.target, &auth.actor_token, op)
             .await?;
         println!("Instructed target peer to connect to {}", self.address);
+        Ok(())
+    }
+}
+
+impl ManagePeerDisconnectArgs {
+    async fn execute(&self, ctx: &ClientContext) -> Result<()> {
+        let auth = self.target.resolve(ctx)?;
+        let op = RemoteManageOp::PeerDisconnect {
+            address: self.address.clone(),
+        };
+        let client = client(ctx, auth.bearer)?;
+        client
+            .p2p_manage(&self.target.target, &auth.actor_token, op)
+            .await?;
+        println!("Disconnected target peer from {}", self.address);
         Ok(())
     }
 }

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -272,6 +272,25 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
+    async fn disconnect_peer(&self, addr: &str) -> P2PResult<()> {
+        self.check_nac(acp::nac::NodePermission::P2pPeerConnect)
+            .await?;
+
+        let (peer_id, _direct_addrs) =
+            parse_public_peer_addr(addr).map_err(|e| P2PError::InvalidInput(e.to_string()))?;
+
+        self.transport
+            .disconnect(&peer_id)
+            .await
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
+
+        if let Ok(mut addrs) = self.peer_addresses.write() {
+            addrs.remove(&peer_id.to_string());
+        }
+
+        Ok(())
+    }
+
     async fn notify_network_change(&self) -> P2PResult<()> {
         self.transport
             .network_change()

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -321,6 +321,25 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
+    async fn disconnect_peer(&self, addr: &str) -> P2PResult<()> {
+        self.check_nac(acp::nac::NodePermission::P2pPeerConnect)
+            .await?;
+
+        let parsed = p2p::parse_multiaddr_with_peer_id(addr)
+            .map_err(|e| P2PError::InvalidInput(e.to_string()))?;
+
+        self.handle
+            .disconnect(parsed.peer_id)
+            .await
+            .map_err(|e| P2PError::Transport(e.to_string()))?;
+
+        if let Ok(mut addrs) = self.peer_addresses.write() {
+            addrs.remove(&parsed.peer_id.to_string());
+        }
+
+        Ok(())
+    }
+
     async fn notify_network_change(&self) -> P2PResult<()> {
         Ok(())
     }

--- a/crates/http/src/mock/p2p.rs
+++ b/crates/http/src/mock/p2p.rs
@@ -102,6 +102,16 @@ impl P2POperations for MockP2POperations {
         Ok(())
     }
 
+    async fn disconnect_peer(&self, addr: &str) -> P2PResult<()> {
+        let peer_id = if addr.contains("/p2p/") {
+            addr.split("/p2p/").last().unwrap_or("unknown").to_string()
+        } else {
+            format!("peer-{}", addr.len())
+        };
+        self.peers.write().unwrap().retain(|p| p != &peer_id);
+        Ok(())
+    }
+
     async fn notify_network_change(&self) -> P2PResult<()> {
         Ok(())
     }
@@ -218,6 +228,10 @@ impl P2POperations for FailingMockP2POperations {
     }
 
     async fn connect_peer(&self, _addr: &str) -> P2PResult<()> {
+        Err(P2PError::Internal(self.error.clone()))
+    }
+
+    async fn disconnect_peer(&self, _addr: &str) -> P2PResult<()> {
         Err(P2PError::Internal(self.error.clone()))
     }
 

--- a/crates/http/src/router/routes.rs
+++ b/crates/http/src/router/routes.rs
@@ -320,6 +320,10 @@ mod tests {
             Ok(())
         }
 
+        async fn disconnect_peer(&self, _addr: &str) -> P2PResult<()> {
+            Ok(())
+        }
+
         async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
             Ok(vec![])
         }

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -282,6 +282,7 @@ pub struct RemoteManageDocRef {
 pub enum RemoteManageQueryOp {
     ReplicatorList,
     CollectionList,
+    DocumentList,
 }
 
 /// Typed result of a [`RemoteManageQueryOp`].
@@ -293,6 +294,7 @@ pub enum RemoteManageQueryOp {
 pub enum RemoteManageQueryResult {
     Replicators { replicators: Vec<ReplicatorInfo> },
     Strings { values: Vec<String> },
+    Documents { documents: Vec<RemoteManageDocRef> },
 }
 
 /// Wire sentinel for a remote NAC denial on the management channel.

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -124,6 +124,9 @@ pub trait P2POperations: Send + Sync {
     /// Connect to a peer at the given address.
     async fn connect_peer(&self, addr: &str) -> P2PResult<()>;
 
+    /// Disconnect the live connection to the peer at the given address.
+    async fn disconnect_peer(&self, addr: &str) -> P2PResult<()>;
+
     /// Notify the transport that local network conditions may have changed.
     ///
     /// Some transports, such as iroh, use this to refresh relay/direct
@@ -265,6 +268,9 @@ pub enum RemoteManageOp {
         docs: Vec<RemoteManageDocRef>,
     },
     PeerConnect {
+        address: String,
+    },
+    PeerDisconnect {
         address: String,
     },
 }

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -288,6 +288,22 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         Ok(())
     }
 
+    async fn disconnect_peer(&self, addr: &str) -> P2PResult<()> {
+        self.check_nac(acp::nac::NodePermission::P2pPeerConnect)
+            .await?;
+
+        let (peer_id, _direct_addrs) = parse_public_peer_addr(addr)
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
+        self.transport
+            .disconnect(&peer_id)
+            .await
+            .map_err(|error| P2PError::transport(error.to_string()))?;
+        if let Ok(mut addrs) = self.peer_addresses.write() {
+            addrs.remove(&peer_id.to_string());
+        }
+        Ok(())
+    }
+
     async fn notify_network_change(&self) -> P2PResult<()> {
         self.transport
             .network_change()

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -279,6 +279,22 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         Ok(())
     }
 
+    async fn disconnect_peer(&self, addr: &str) -> P2PResult<()> {
+        self.check_nac(acp::nac::NodePermission::P2pPeerConnect)
+            .await?;
+
+        let parsed = p2p::parse_multiaddr_with_peer_id(addr)
+            .map_err(|error| P2PError::invalid_input(error.to_string()))?;
+        self.handle
+            .disconnect(parsed.peer_id)
+            .await
+            .map_err(|error| P2PError::transport(error.to_string()))?;
+        if let Ok(mut addrs) = self.peer_addresses.write() {
+            addrs.remove(&parsed.peer_id.to_string());
+        }
+        Ok(())
+    }
+
     async fn notify_network_change(&self) -> P2PResult<()> {
         Ok(())
     }

--- a/crates/p2p-adapter/src/manage/requester_impl.rs
+++ b/crates/p2p-adapter/src/manage/requester_impl.rs
@@ -131,10 +131,18 @@ fn to_doc_ref(doc: RemoteManageDocRef) -> ManageDocRef {
     }
 }
 
+fn to_remote_doc_ref(doc: ManageDocRef) -> RemoteManageDocRef {
+    RemoteManageDocRef {
+        collection: doc.collection,
+        doc_id: doc.doc_id,
+    }
+}
+
 fn to_query_op(op: RemoteManageQueryOp) -> ManageQueryOp {
     match op {
         RemoteManageQueryOp::ReplicatorList => ManageQueryOp::ReplicatorList,
         RemoteManageQueryOp::CollectionList => ManageQueryOp::CollectionList,
+        RemoteManageQueryOp::DocumentList => ManageQueryOp::DocumentList,
     }
 }
 
@@ -147,5 +155,8 @@ fn to_http_query_result(result: ManageQueryResult) -> RemoteManageQueryResult {
                 .collect(),
         },
         ManageQueryResult::Strings { values } => RemoteManageQueryResult::Strings { values },
+        ManageQueryResult::Documents { documents } => RemoteManageQueryResult::Documents {
+            documents: documents.into_iter().map(to_remote_doc_ref).collect(),
+        },
     }
 }

--- a/crates/p2p-adapter/src/manage/requester_impl.rs
+++ b/crates/p2p-adapter/src/manage/requester_impl.rs
@@ -108,6 +108,7 @@ fn to_mutate_op(op: RemoteManageOp) -> ManageMutateOp {
             docs: docs.into_iter().map(to_doc_ref).collect(),
         },
         RemoteManageOp::PeerConnect { address } => ManageMutateOp::PeerConnect { address },
+        RemoteManageOp::PeerDisconnect { address } => ManageMutateOp::PeerDisconnect { address },
     }
 }
 

--- a/crates/p2p-adapter/src/manage/serve.rs
+++ b/crates/p2p-adapter/src/manage/serve.rs
@@ -212,6 +212,18 @@ pub async fn build_manage_query_reply(
                 ManageQueryOp::CollectionList => ManageQueryResult::Strings {
                     values: ops.get_collections().await.map_err(|e| e.to_string())?,
                 },
+                ManageQueryOp::DocumentList => ManageQueryResult::Documents {
+                    documents: ops
+                        .get_documents()
+                        .await
+                        .map_err(|e| e.to_string())?
+                        .into_iter()
+                        .map(|d| ManageDocRef {
+                            collection: d.collection,
+                            doc_id: d.doc_id,
+                        })
+                        .collect(),
+                },
             })
         })
         .await
@@ -289,6 +301,7 @@ mod tests {
         peer_id: String,
         added_collections: Mutex<Vec<String>>,
         added_replicators: Mutex<Vec<RecordedReplicator>>,
+        documents: Vec<P2pDocumentInfo>,
     }
 
     impl MockOps {
@@ -297,6 +310,16 @@ mod tests {
                 peer_id: peer_id.to_string(),
                 added_collections: Mutex::new(Vec::new()),
                 added_replicators: Mutex::new(Vec::new()),
+                documents: Vec::new(),
+            }
+        }
+
+        fn with_documents(peer_id: &str, documents: Vec<P2pDocumentInfo>) -> Self {
+            Self {
+                peer_id: peer_id.to_string(),
+                added_collections: Mutex::new(Vec::new()),
+                added_replicators: Mutex::new(Vec::new()),
+                documents,
             }
         }
 
@@ -359,7 +382,7 @@ mod tests {
             unimplemented!()
         }
         async fn get_documents(&self) -> P2PResult<Vec<P2pDocumentInfo>> {
-            unimplemented!()
+            Ok(self.documents.clone())
         }
         async fn add_documents(&self, _docs: Vec<P2pDocumentRequest>) -> P2PResult<()> {
             unimplemented!()
@@ -640,5 +663,44 @@ mod tests {
             http_filters.contains_key("User"),
             "the User collection filter must survive the relay"
         );
+    }
+
+    #[tokio::test]
+    async fn document_list_returns_documents() {
+        let ops = MockOps::with_documents(
+            "12D3KooW-THIS",
+            vec![
+                P2pDocumentInfo {
+                    collection: "User".into(),
+                    doc_id: "bae-doc-1".into(),
+                },
+                P2pDocumentInfo {
+                    collection: "User".into(),
+                    doc_id: "bae-doc-2".into(),
+                },
+            ],
+        );
+        let token = crate::manage::auth::mint_token_for("12D3KooW-THIS").0;
+        let req = ManageQueryRequest::new(ManageQueryOp::DocumentList, token);
+        let reply = build_manage_query_reply(&ops, &BoolNac(true), req).await;
+        assert_eq!(reply.err_message(), None);
+        match reply.result {
+            Some(ManageQueryResult::Documents { documents }) => {
+                assert_eq!(
+                    documents,
+                    vec![
+                        ManageDocRef {
+                            collection: "User".into(),
+                            doc_id: "bae-doc-1".into(),
+                        },
+                        ManageDocRef {
+                            collection: "User".into(),
+                            doc_id: "bae-doc-2".into(),
+                        },
+                    ]
+                );
+            }
+            other => panic!("expected a Documents result, got {other:?}"),
+        }
     }
 }

--- a/crates/p2p-adapter/src/manage/serve.rs
+++ b/crates/p2p-adapter/src/manage/serve.rs
@@ -141,6 +141,10 @@ async fn authorize_and_apply(
             ManageMutateOp::PeerConnect { address } => {
                 ops.connect_peer(address).await.map_err(|e| e.to_string())
             }
+            ManageMutateOp::PeerDisconnect { address } => ops
+                .disconnect_peer(address)
+                .await
+                .map_err(|e| e.to_string()),
         }
     })
     .await
@@ -301,6 +305,7 @@ mod tests {
         peer_id: String,
         added_collections: Mutex<Vec<String>>,
         added_replicators: Mutex<Vec<RecordedReplicator>>,
+        disconnected_peers: Mutex<Vec<String>>,
         documents: Vec<P2pDocumentInfo>,
     }
 
@@ -310,6 +315,7 @@ mod tests {
                 peer_id: peer_id.to_string(),
                 added_collections: Mutex::new(Vec::new()),
                 added_replicators: Mutex::new(Vec::new()),
+                disconnected_peers: Mutex::new(Vec::new()),
                 documents: Vec::new(),
             }
         }
@@ -319,6 +325,7 @@ mod tests {
                 peer_id: peer_id.to_string(),
                 added_collections: Mutex::new(Vec::new()),
                 added_replicators: Mutex::new(Vec::new()),
+                disconnected_peers: Mutex::new(Vec::new()),
                 documents,
             }
         }
@@ -329,6 +336,10 @@ mod tests {
 
         fn added_replicators(&self) -> Vec<RecordedReplicator> {
             self.added_replicators.lock().unwrap().clone()
+        }
+
+        fn disconnected_peers(&self) -> Vec<String> {
+            self.disconnected_peers.lock().unwrap().clone()
         }
     }
 
@@ -345,6 +356,13 @@ mod tests {
         }
         async fn connect_peer(&self, _addr: &str) -> P2PResult<()> {
             unimplemented!()
+        }
+        async fn disconnect_peer(&self, addr: &str) -> P2PResult<()> {
+            self.disconnected_peers
+                .lock()
+                .unwrap()
+                .push(addr.to_string());
+            Ok(())
         }
         async fn get_replicators(&self) -> P2PResult<Vec<ReplicatorInfo>> {
             unimplemented!()
@@ -702,5 +720,41 @@ mod tests {
             }
             other => panic!("expected a Documents result, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn peer_disconnect_dispatches() {
+        let ops = MockOps::new("12D3KooW-THIS");
+        let token = crate::manage::auth::mint_token_for("12D3KooW-THIS").0;
+        let req = ManageRequest::new(
+            ManageMutateOp::PeerDisconnect {
+                address: "/ip4/1.2.3.4/tcp/9000".into(),
+            },
+            token,
+        );
+        let reply = build_manage_reply(&ops, &BoolNac(true), req).await;
+        assert_eq!(reply.err_message(), None);
+        assert_eq!(
+            ops.disconnected_peers(),
+            vec!["/ip4/1.2.3.4/tcp/9000".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_disconnect_unauthorized_rejected_before_side_effects() {
+        let ops = MockOps::new("12D3KooW-THIS");
+        let token = crate::manage::auth::mint_token_for("12D3KooW-THIS").0;
+        let req = ManageRequest::new(
+            ManageMutateOp::PeerDisconnect {
+                address: "/ip4/1.2.3.4/tcp/9000".into(),
+            },
+            token,
+        );
+        let reply = build_manage_reply(&ops, &BoolNac(false), req).await;
+        assert_eq!(reply.err_message(), Some("unauthorized"));
+        assert!(
+            ops.disconnected_peers().is_empty(),
+            "no side effect on denial"
+        );
     }
 }

--- a/crates/p2p/src/host/command.rs
+++ b/crates/p2p/src/host/command.rs
@@ -29,6 +29,12 @@ pub enum HostCommand {
         response: oneshot::Sender<Result<()>>,
     },
 
+    /// Disconnect from a peer, hanging up any live connection.
+    Disconnect {
+        peer_id: PeerId,
+        response: oneshot::Sender<Result<()>>,
+    },
+
     /// Send a PushLog request to a peer.
     SendPushLog {
         peer_id: PeerId,

--- a/crates/p2p/src/host/command_handler/mod.rs
+++ b/crates/p2p/src/host/command_handler/mod.rs
@@ -27,6 +27,9 @@ impl<S: Store> P2PHost<S> {
             } => {
                 self.handle_dial(peer_id, addrs, response);
             }
+            HostCommand::Disconnect { peer_id, response } => {
+                self.handle_disconnect(peer_id, response);
+            }
             HostCommand::Shutdown => {
                 return self.handle_shutdown().await;
             }

--- a/crates/p2p/src/host/command_handler/network.rs
+++ b/crates/p2p/src/host/command_handler/network.rs
@@ -38,6 +38,19 @@ impl<S: Store> P2PHost<S> {
         }
     }
 
+    pub(super) fn handle_disconnect(
+        &mut self,
+        peer_id: PeerId,
+        response: tokio::sync::oneshot::Sender<Result<()>>,
+    ) {
+        // `disconnect_peer_id` returns `Err(())` when the peer is not connected.
+        // Disconnect is idempotent: hanging up on an absent peer is success.
+        let _ = self.swarm.disconnect_peer_id(peer_id);
+        if response.send(Ok(())).is_err() {
+            debug!(peer_id = %peer_id, "Disconnect command response dropped - caller cancelled");
+        }
+    }
+
     pub(super) fn handle_peer_addresses(
         &self,
         response: tokio::sync::oneshot::Sender<Vec<String>>,

--- a/crates/p2p/src/host/handle.rs
+++ b/crates/p2p/src/host/handle.rs
@@ -138,6 +138,21 @@ impl P2PHostHandle {
         response_rx.await.map_err(|_| Error::ChannelReceive)?
     }
 
+    /// Disconnect from a peer, hanging up any live connection.
+    ///
+    /// Idempotent: disconnecting an already-absent peer returns `Ok(())`.
+    pub async fn disconnect(&self, peer_id: PeerId) -> Result<()> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(HostCommand::Disconnect {
+                peer_id,
+                response: response_tx,
+            })
+            .await
+            .map_err(|_| Error::ChannelSend)?;
+        response_rx.await.map_err(|_| Error::ChannelReceive)?
+    }
+
     /// Send a PushLog request to a peer and wait for the response.
     pub async fn send_pushlog(
         &self,

--- a/crates/p2p/src/host/libp2p_transport.rs
+++ b/crates/p2p/src/host/libp2p_transport.rs
@@ -91,6 +91,11 @@ impl P2PTransport for Libp2pTransport {
         self.handle.dial(pid, multiaddrs).await
     }
 
+    async fn disconnect(&self, peer_id: &PeerId) -> Result<()> {
+        let pid = parse_libp2p_peer_id(peer_id)?;
+        self.handle.disconnect(pid).await
+    }
+
     fn parse_dial_addr(&self, addr: &str) -> Result<(PeerId, Vec<PeerAddr>)> {
         let parsed = crate::address::parse_multiaddr_with_peer_id(addr)?;
         Ok((

--- a/crates/p2p/src/iroh/command.rs
+++ b/crates/p2p/src/iroh/command.rs
@@ -21,6 +21,10 @@ pub enum IrohCommand {
         addrs: Vec<PeerAddr>,
         reply: oneshot::Sender<crate::error::Result<()>>,
     },
+    Disconnect {
+        peer_id: PeerId,
+        reply: oneshot::Sender<crate::error::Result<()>>,
+    },
     Listen {
         addr: PeerAddr,
         reply: oneshot::Sender<crate::error::Result<()>>,

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -23,8 +23,9 @@ use super::endpoint::{
     TopicSubscription,
 };
 use super::endpoint_rpc::{
-    handle_block_sync, handle_car_request_response, handle_fire_and_forget,
-    handle_request_response, handle_send_only, BlockSyncResources, ConnectionCache,
+    close_cached_connections, handle_block_sync, handle_car_request_response,
+    handle_fire_and_forget, handle_request_response, handle_send_only, BlockSyncResources,
+    ConnectionCache,
 };
 use super::peer_map::{endpoint_id_to_peer_id, parse_endpoint_id, PeerMap};
 use super::protocols;
@@ -67,6 +68,10 @@ pub(super) async fn handle_command(
                 event_tx,
             };
             let result = handle_dial(ctx, &peer_id, addrs).await;
+            let _ = reply.send(result);
+        }
+        IrohCommand::Disconnect { peer_id, reply } => {
+            let result = handle_disconnect(peer_id, peer_map, connection_cache);
             let _ = reply.send(result);
         }
         IrohCommand::Listen { addr: _, reply } => {
@@ -706,10 +711,11 @@ async fn handle_dial(
 
     let conn_alpn = connection.alpn().to_vec();
 
-    let is_new = ctx
-        .peer_map
-        .lock()
-        .increment_connections(endpoint_id, direct_addresses.first().copied());
+    let is_new = ctx.peer_map.lock().increment_connections(
+        endpoint_id,
+        direct_addresses.first().copied(),
+        connection.clone(),
+    );
 
     if is_new
         && ctx
@@ -744,6 +750,28 @@ async fn handle_dial(
     });
     track_task(ctx.spawned_tasks, task);
 
+    Ok(())
+}
+
+/// Hang up the live connection to a peer.
+///
+/// Closes both the connection handle retained in `peer_map` (covering dial- and
+/// accept-initiated connections) and any cached outbound-send connections.
+/// iroh `Connection` clones share the underlying QUIC connection, so closing
+/// any handle tears down the connection; the stream task then observes the
+/// `accept_bi` error, decrements the count, and emits `PeerDisconnected`.
+///
+/// Idempotent: disconnecting an already-absent peer returns `Ok(())`.
+fn handle_disconnect(
+    peer_id: PeerId,
+    peer_map: &Arc<parking_lot::Mutex<PeerMap>>,
+    connection_cache: &ConnectionCache,
+) -> crate::error::Result<()> {
+    let endpoint_id = parse_endpoint_id(&peer_id)?;
+    if let Some(connection) = peer_map.lock().take_connection(&endpoint_id) {
+        connection.close(0u32.into(), b"disconnect");
+    }
+    close_cached_connections(connection_cache, &endpoint_id);
     Ok(())
 }
 

--- a/crates/p2p/src/iroh/endpoint_rpc.rs
+++ b/crates/p2p/src/iroh/endpoint_rpc.rs
@@ -202,6 +202,28 @@ fn evict_connection(cache: &ConnectionCache, peer_id: &PeerId, alpn: &[u8]) {
     }
 }
 
+/// QUIC application error code used when locally closing a connection in
+/// response to a `disconnect` request.
+const DISCONNECT_ERROR_CODE: u32 = 0;
+
+/// Close and remove every cached connection to `endpoint_id`.
+///
+/// Used by `disconnect` to tear down the outbound-send connection cache for a
+/// peer. Closing is idempotent — a peer with no cached connections is a no-op.
+pub(super) fn close_cached_connections(cache: &ConnectionCache, endpoint_id: &iroh::EndpointId) {
+    let mut guard = cache.lock();
+    let keys: Vec<ConnectionCacheKey> = guard
+        .keys()
+        .filter(|key| &key.endpoint_id == endpoint_id)
+        .cloned()
+        .collect();
+    for key in keys {
+        if let Some(connection) = guard.remove(&key) {
+            connection.close(DISCONNECT_ERROR_CODE.into(), b"disconnect");
+        }
+    }
+}
+
 async fn connect_with_cache(
     endpoint: &Endpoint,
     peer_id: &PeerId,

--- a/crates/p2p/src/iroh/endpoint_streams.rs
+++ b/crates/p2p/src/iroh/endpoint_streams.rs
@@ -79,7 +79,7 @@ pub(super) async fn handle_incoming(
 
     let is_new = peer_map
         .lock()
-        .increment_connections(remote_id, remote_addr);
+        .increment_connections(remote_id, remote_addr, connection.clone());
 
     if is_new
         && event_tx

--- a/crates/p2p/src/iroh/peer_map.rs
+++ b/crates/p2p/src/iroh/peer_map.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 
+use iroh::endpoint::Connection;
 use iroh::EndpointId;
 
 use crate::transport::PeerId;
@@ -25,6 +26,10 @@ pub fn endpoint_id_to_peer_id(id: &EndpointId) -> PeerId {
 pub struct ConnectionInfo {
     pub remote_addr: Option<SocketAddr>,
     pub active_connections: u32,
+    /// A handle to the underlying QUIC connection, used to hang up on
+    /// `disconnect`. iroh `Connection` clones share the same QUIC connection,
+    /// so closing this handle closes the connection for the peer.
+    connection: Option<Connection>,
 }
 
 /// Tracks connected peers and their connection info.
@@ -40,16 +45,21 @@ impl PeerMap {
 
     /// Increment connection count for a peer. Returns `true` if this is the
     /// first connection (0 -> 1), meaning PeerConnected should be emitted.
+    ///
+    /// `connection` is a handle to the underlying QUIC connection, retained so
+    /// `disconnect` can hang up on the peer.
     pub fn increment_connections(
         &mut self,
         id: EndpointId,
         remote_addr: Option<SocketAddr>,
+        connection: Connection,
     ) -> bool {
         if let Some(info) = self.connections.get_mut(&id) {
             info.active_connections += 1;
             if let Some(addr) = remote_addr {
                 info.remote_addr = Some(addr);
             }
+            info.connection = Some(connection);
             false
         } else {
             self.connections.insert(
@@ -57,10 +67,21 @@ impl PeerMap {
                 ConnectionInfo {
                     remote_addr,
                     active_connections: 1,
+                    connection: Some(connection),
                 },
             );
             true
         }
+    }
+
+    /// Take the retained connection handle for a peer without removing the
+    /// connection-count entry. Returns `None` if the peer is unknown or no
+    /// handle was retained. Used by `disconnect` to close the live connection;
+    /// the count entry is then cleared by the stream task on `accept_bi` error.
+    pub fn take_connection(&mut self, id: &EndpointId) -> Option<Connection> {
+        self.connections
+            .get_mut(id)
+            .and_then(|info| info.connection.take())
     }
 
     /// Decrement connection count for a peer. Returns `true` if the count

--- a/crates/p2p/src/iroh/transport.rs
+++ b/crates/p2p/src/iroh/transport.rs
@@ -98,6 +98,14 @@ impl P2PTransport for IrohTransport {
         .await
     }
 
+    async fn disconnect(&self, peer_id: &PeerId) -> Result<()> {
+        self.send_command(|reply| IrohCommand::Disconnect {
+            peer_id: peer_id.clone(),
+            reply,
+        })
+        .await
+    }
+
     fn parse_dial_addr(&self, addr: &str) -> Result<(PeerId, Vec<PeerAddr>)> {
         super::addr::parse_public_peer_addr(addr)
     }
@@ -598,6 +606,80 @@ mod tests {
         transport1.shutdown().await.unwrap();
         task0.await.unwrap();
         task1.await.unwrap();
+    }
+
+    async fn poll_until_disconnected(transport: &IrohTransport, peer_id: &PeerId) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let peers = transport.connected_peers().await.unwrap_or_default();
+            if !peers.iter().any(|p| p.as_str() == peer_id.as_str()) {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for disconnection from {}",
+                peer_id
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn disconnect_drops_connected_peer() {
+        let key0 = SecretKey::generate();
+        let key1 = SecretKey::generate();
+        let (command_tx0, _events0, _replicators0, task0) =
+            spawn_endpoint(test_config(key0.clone())).await.unwrap();
+        let (command_tx1, _events1, _replicators1, task1) =
+            spawn_endpoint(test_config(key1.clone())).await.unwrap();
+        let transport0 = IrohTransport::new(command_tx0, key0);
+        let transport1 = IrohTransport::new(command_tx1, key1);
+
+        transport0
+            .dial(
+                transport1.local_peer_id(),
+                transport1.listen_addresses().await.unwrap(),
+            )
+            .await
+            .unwrap();
+        transport0
+            .poll_until_connected(transport1.local_peer_id(), Duration::from_secs(5))
+            .await
+            .unwrap();
+
+        let connected = transport0.connected_peers().await.unwrap();
+        assert!(connected
+            .iter()
+            .any(|p| p.as_str() == transport1.local_peer_id().as_str()));
+
+        transport0
+            .disconnect(transport1.local_peer_id())
+            .await
+            .unwrap();
+        poll_until_disconnected(&transport0, transport1.local_peer_id()).await;
+
+        transport0.shutdown().await.unwrap();
+        transport1.shutdown().await.unwrap();
+        task0.await.unwrap();
+        task1.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn disconnect_absent_peer_is_ok() {
+        let key0 = SecretKey::generate();
+        let key1 = SecretKey::generate();
+        let (command_tx0, _events0, _replicators0, task0) =
+            spawn_endpoint(test_config(key0.clone())).await.unwrap();
+        let transport0 = IrohTransport::new(command_tx0, key0);
+        let never_connected = PeerId::new(key1.public().to_string());
+
+        transport0
+            .disconnect(&never_connected)
+            .await
+            .expect("disconnecting a never-connected peer must be Ok");
+
+        transport0.shutdown().await.unwrap();
+        task0.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/p2p/src/kms/pubsub_transport.rs
+++ b/crates/p2p/src/kms/pubsub_transport.rs
@@ -432,6 +432,9 @@ mod tests {
         async fn dial(&self, _p: &PeerId, _a: Vec<PeerAddr>) -> Result<()> {
             Ok(())
         }
+        async fn disconnect(&self, _p: &PeerId) -> Result<()> {
+            Ok(())
+        }
         async fn listen(&self, _a: PeerAddr) -> Result<()> {
             Ok(())
         }

--- a/crates/p2p/src/message/manage.rs
+++ b/crates/p2p/src/message/manage.rs
@@ -72,6 +72,7 @@ pub enum ManageMutateOp {
 pub enum ManageQueryOp {
     ReplicatorList,
     CollectionList,
+    DocumentList,
 }
 
 /// Typed payload for a `manage_query` reply.
@@ -85,6 +86,10 @@ pub enum ManageQueryResult {
     Strings {
         #[serde(rename = "Values")]
         values: Vec<String>,
+    },
+    Documents {
+        #[serde(rename = "Documents")]
+        documents: Vec<ManageDocRef>,
     },
 }
 
@@ -109,6 +114,7 @@ impl ManageQueryOp {
         match self {
             ManageQueryOp::ReplicatorList => P::P2pReplicatorList,
             ManageQueryOp::CollectionList => P::P2pCollectionList,
+            ManageQueryOp::DocumentList => P::P2pDocumentList,
         }
     }
 }

--- a/crates/p2p/src/message/manage.rs
+++ b/crates/p2p/src/message/manage.rs
@@ -63,6 +63,10 @@ pub enum ManageMutateOp {
         #[serde(rename = "Address")]
         address: String,
     },
+    PeerDisconnect {
+        #[serde(rename = "Address")]
+        address: String,
+    },
 }
 
 /// Read-only management operations (typed reply).
@@ -104,6 +108,7 @@ impl ManageMutateOp {
             ManageMutateOp::DocumentAdd { .. } => P::P2pDocumentAdd,
             ManageMutateOp::DocumentRemove { .. } => P::P2pDocumentDelete,
             ManageMutateOp::PeerConnect { .. } => P::P2pPeerConnect,
+            ManageMutateOp::PeerDisconnect { .. } => P::P2pPeerConnect,
         }
     }
 }

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -309,6 +309,10 @@ impl P2PTransport for NoopTransport {
         Ok(())
     }
 
+    async fn disconnect(&self, _peer_id: &PeerId) -> crate::Result<()> {
+        Ok(())
+    }
+
     async fn listen(&self, _addr: PeerAddr) -> crate::Result<()> {
         Ok(())
     }

--- a/crates/p2p/src/sync/coordinator/broadcast.rs
+++ b/crates/p2p/src/sync/coordinator/broadcast.rs
@@ -756,6 +756,10 @@ mod tests {
             Ok(())
         }
 
+        async fn disconnect(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
         async fn listen(&self, _addr: PeerAddr) -> P2PResult<()> {
             Ok(())
         }

--- a/crates/p2p/src/sync/coordinator/dag_fetcher.rs
+++ b/crates/p2p/src/sync/coordinator/dag_fetcher.rs
@@ -389,6 +389,10 @@ mod tests {
             Ok(())
         }
 
+        async fn disconnect(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
         async fn listen(&self, _addr: PeerAddr) -> P2PResult<()> {
             Ok(())
         }

--- a/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/bitswap.rs
@@ -266,6 +266,10 @@ mod tests {
             Ok(())
         }
 
+        async fn disconnect(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
         async fn listen(&self, _addr: PeerAddr) -> P2PResult<()> {
             Ok(())
         }

--- a/crates/p2p/src/sync/coordinator/pubsub_client.rs
+++ b/crates/p2p/src/sync/coordinator/pubsub_client.rs
@@ -346,6 +346,10 @@ mod tests {
             Ok(())
         }
 
+        async fn disconnect(&self, _peer_id: &PeerId) -> Result<()> {
+            Ok(())
+        }
+
         async fn listen(&self, _addr: PeerAddr) -> Result<()> {
             Ok(())
         }

--- a/crates/p2p/src/sync/coordinator/subscriptions.rs
+++ b/crates/p2p/src/sync/coordinator/subscriptions.rs
@@ -265,6 +265,10 @@ mod tests {
             Ok(())
         }
 
+        async fn disconnect(&self, _peer_id: &PeerId) -> crate::Result<()> {
+            Ok(())
+        }
+
         async fn listen(&self, _addr: PeerAddr) -> crate::Result<()> {
             Ok(())
         }

--- a/crates/p2p/src/sync/replication/mod.rs
+++ b/crates/p2p/src/sync/replication/mod.rs
@@ -213,6 +213,10 @@ mod tests {
             Ok(())
         }
 
+        async fn disconnect(&self, _peer_id: &PeerId) -> P2PResult<()> {
+            Ok(())
+        }
+
         async fn listen(&self, _addr: PeerAddr) -> P2PResult<()> {
             Ok(())
         }
@@ -421,6 +425,10 @@ mod tests {
         }
 
         async fn dial(&self, _peer_id: &PeerId, _addrs: Vec<PeerAddr>) -> P2PResult<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&self, _peer_id: &PeerId) -> P2PResult<()> {
             Ok(())
         }
 

--- a/crates/p2p/src/transport.rs
+++ b/crates/p2p/src/transport.rs
@@ -270,6 +270,13 @@ pub trait P2PTransport: Clone + Send + Sync + 'static {
 
     async fn dial(&self, peer_id: &PeerId, addrs: Vec<PeerAddr>) -> Result<()>;
 
+    /// Disconnect from a peer, hanging up any live connection.
+    ///
+    /// Disconnect-only: this hangs up the current connection but does not
+    /// prevent the peer from reconnecting (no persistent allow/deny list).
+    /// Idempotent: disconnecting an already-absent peer returns `Ok(())`.
+    async fn disconnect(&self, peer_id: &PeerId) -> Result<()>;
+
     /// Parse a peer address string into a transport-agnostic peer id and dial
     /// hints. The accepted string format is transport-specific (libp2p
     /// multiaddrs vs iroh tickets/endpoint ids), which is why this lives on the

--- a/crates/p2p/tests/host_tests.rs
+++ b/crates/p2p/tests/host_tests.rs
@@ -865,3 +865,68 @@ async fn regression_834_gossipsub_message_id_distinguishes_senders() {
     handle0.shutdown().await.unwrap();
     handle1.shutdown().await.unwrap();
 }
+
+async fn wait_until_disconnected(handle: &p2p::P2PHostHandle, peer_id: PeerId) {
+    let start = std::time::Instant::now();
+    loop {
+        if !handle
+            .connected_peers()
+            .await
+            .unwrap_or_default()
+            .contains(&peer_id)
+        {
+            return;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "timed out waiting for disconnection from {peer_id}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test]
+async fn test_disconnect_drops_connected_peer() {
+    let (host0, handle0, _events0, _replicators0) =
+        P2PHost::new(MockBitswapStore::new()).await.unwrap();
+    let (host1, handle1, _events1, _replicators1) =
+        P2PHost::new(MockBitswapStore::new()).await.unwrap();
+
+    tokio::spawn(host0.run());
+    tokio::spawn(host1.run());
+
+    handle1
+        .listen("/ip4/127.0.0.1/tcp/0".parse().unwrap())
+        .await
+        .unwrap();
+    let addr1 = handle1.listen_addresses().await.unwrap().remove(0);
+    let peer1 = handle1.local_peer_id_cached();
+
+    handle0.dial(peer1, vec![addr1]).await.unwrap();
+    wait_until_connected(&handle0, peer1).await;
+    assert!(handle0.connected_peers().await.unwrap().contains(&peer1));
+
+    handle0.disconnect(peer1).await.unwrap();
+    wait_until_disconnected(&handle0, peer1).await;
+
+    handle0.shutdown().await.unwrap();
+    handle1.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_disconnect_absent_peer_is_ok() {
+    let (host0, handle0, _events0, _replicators0) =
+        P2PHost::new(MockBitswapStore::new()).await.unwrap();
+    tokio::spawn(host0.run());
+
+    let (_host1, handle1, _events1, _replicators1) =
+        P2PHost::new(MockBitswapStore::new()).await.unwrap();
+    let never_connected = handle1.local_peer_id_cached();
+
+    handle0
+        .disconnect(never_connected)
+        .await
+        .expect("disconnecting a never-connected peer must be Ok");
+
+    handle0.shutdown().await.unwrap();
+}

--- a/tools/integration-test/tests/p2p/manage_relay.rs
+++ b/tools/integration-test/tests/p2p/manage_relay.rs
@@ -664,6 +664,142 @@ async fn manage_document_list_over_p2p() {
     }
 }
 
+/// Bring up a NAC-enabled 3-node libp2p cluster (A=relay controller, B=manage
+/// target, C=the peer B will be told to disconnect from), deploy the `User`
+/// schema on node B, and return the admin key plus B's and C's dial addresses.
+async fn setup_3() -> (TestCluster, String, String, String) {
+    let cluster = TestCluster::builder()
+        .rust_nodes(3)
+        .with_acp_local()
+        .with_nac()
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+
+    let timeout = Duration::from_secs(15);
+    for node in 0..3 {
+        cluster
+            .wait_for_log(node, "p2p_listening", timeout)
+            .await
+            .unwrap_or_else(|_| panic!("node{node} P2P listener did not start"));
+    }
+
+    let admin_key = cluster
+        .startup_identity()
+        .expect("NAC cluster must have startup identity")
+        .to_string();
+
+    let node_b = cluster.client(1);
+    node_b
+        .schema_add_with_identity(SCHEMA, &admin_key)
+        .expect("deploy schema on node B");
+
+    let addr_b = first_addr(&cluster.client(1), &admin_key);
+    let addr_c = first_addr(&cluster.client(2), &admin_key);
+
+    (cluster, admin_key, addr_b, addr_c)
+}
+
+/// First P2P dial address of `client`, fetched with the admin identity.
+fn first_addr(client: &integration_test::DefraClient, admin_key: &str) -> String {
+    client
+        .p2p_info_with_identity(admin_key)
+        .expect("p2p_info")
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .expect("node has no P2P address")
+        .to_string()
+}
+
+/// True when `peer_id` appears (as the `/p2p/<id>` suffix) in node `idx`'s
+/// active-peers list, fetched with the admin identity.
+fn active_peers_contains(
+    cluster: &TestCluster,
+    idx: usize,
+    admin_key: &str,
+    peer_id: &str,
+) -> bool {
+    cluster
+        .client(idx)
+        .p2p_active_peers_with_identity(admin_key)
+        .expect("p2p_active_peers")
+        .as_array()
+        .map(|peers| {
+            peers
+                .iter()
+                .filter_map(|v| v.as_str())
+                .any(|addr| peer_id_of(addr) == peer_id)
+        })
+        .unwrap_or(false)
+}
+
+/// 3-node e2e: a relayed `PeerDisconnect` must SEVER a live connection, not just
+/// return 200. Node A (HTTP relay) tells node B to disconnect from node C, while
+/// a live B<->C connection (established directly, not over the relay) exists.
+/// The disconnect is proven by C disappearing from B's active peers. The third
+/// node is essential: the A<->B relay link is a different connection, so the
+/// relay reply still returns even after C is dropped.
+#[tokio::test]
+#[serial]
+async fn manage_peer_disconnect_severs_live_connection() {
+    let (cluster, admin_key, addr_b, addr_c) = setup_3().await;
+    let api_a = cluster.api_url(0).to_string();
+    let peer_id_b = peer_id_of(&addr_b).to_string();
+    let peer_id_c = peer_id_of(&addr_c).to_string();
+
+    // Establish a LIVE B<->C connection directly (not over the relay).
+    cluster
+        .client(1)
+        .p2p_connect_with_identity(&[addr_c.as_str()], &admin_key)
+        .expect("node B connect to node C");
+
+    // Poll until C is present in B's active peers (connect is eventually-consistent).
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if active_peers_contains(&cluster, 1, &admin_key, &peer_id_c) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "node C never appeared in node B's active peers; cannot test disconnect"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Relay a PeerDisconnect to B targeting C's address.
+    let token = crate::manage_relay_common::mint_manage_token(&admin_key, &peer_id_b);
+    let status = post_manage(
+        &api_a,
+        &admin_key,
+        &addr_b,
+        &token,
+        json!({ "Kind": "PeerDisconnect", "address": addr_c }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "authorized PeerDisconnect relay should return 200"
+    );
+
+    // The real assertion: C must vanish from B's active peers — the relayed verb
+    // severed a live connection.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if !active_peers_contains(&cluster, 1, &admin_key, &peer_id_c) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "relayed PeerDisconnect did not sever the live B<->C connection: \
+             node C is still in node B's active peers"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
 /// Admin token (`aud` = B peer-id) relays a `PeerDisconnect`. The disconnect
 /// primitive is idempotent-Ok, so a 200 proves the dispatch path is wired
 /// (mirrors `manage_document_add_over_p2p`). The target address is a third,

--- a/tools/integration-test/tests/p2p/manage_relay.rs
+++ b/tools/integration-test/tests/p2p/manage_relay.rs
@@ -664,6 +664,37 @@ async fn manage_document_list_over_p2p() {
     }
 }
 
+/// Admin token (`aud` = B peer-id) relays a `PeerDisconnect`. The disconnect
+/// primitive is idempotent-Ok, so a 200 proves the dispatch path is wired
+/// (mirrors `manage_document_add_over_p2p`). The target address is a third,
+/// unconnected peer so the relay's own A<->B connection is never torn down.
+#[tokio::test]
+#[serial]
+async fn manage_peer_disconnect_over_p2p() {
+    let (cluster, admin_key, addr_b, peer_id_b) = setup().await;
+    let api_a = cluster.api_url(0).to_string();
+
+    let token = crate::manage_relay_common::mint_manage_token(&admin_key, &peer_id_b);
+
+    // A syntactically-valid multiaddr for a peer node B is not connected to.
+    // Disconnect is idempotent, so hanging up an absent peer succeeds.
+    let absent_peer =
+        "/ip4/127.0.0.1/tcp/65535/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X";
+    let status = post_manage(
+        &api_a,
+        &admin_key,
+        &addr_b,
+        &token,
+        json!({ "Kind": "PeerDisconnect", "address": absent_peer }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "authorized PeerDisconnect relay should return 200"
+    );
+}
+
 /// True when a `RemoteManageQueryResult::Strings` body carries at least one value.
 fn collection_list_nonempty(body: &Value) -> bool {
     body["Kind"] == "Strings"

--- a/tools/integration-test/tests/p2p/manage_relay.rs
+++ b/tools/integration-test/tests/p2p/manage_relay.rs
@@ -610,6 +610,60 @@ async fn manage_document_add_over_p2p() {
     );
 }
 
+/// Admin token (`aud` = B peer-id) relays a `DocumentAdd` for a doc id, then a
+/// `DocumentList` query over the same relay reflects it. Proves the DocumentList
+/// dispatch path AND the structured `Documents` reply round-trip.
+#[tokio::test]
+#[serial]
+async fn manage_document_list_over_p2p() {
+    let (cluster, admin_key, addr_b, peer_id_b) = setup().await;
+    let api_a = cluster.api_url(0).to_string();
+
+    let token = crate::manage_relay_common::mint_manage_token(&admin_key, &peer_id_b);
+
+    let doc_id = "bae-0e7c3bb5-4917-46e2-b36e-3f8d0c4b3f5d";
+    let status = post_manage(
+        &api_a,
+        &admin_key,
+        &addr_b,
+        &token,
+        json!({
+            "Kind": "DocumentAdd",
+            "docs": [{ "collection": "User", "doc_id": doc_id }],
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "authorized DocumentAdd relay should return 200"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let (status, body) = post_manage_query(
+            &api_a,
+            &admin_key,
+            &addr_b,
+            &token,
+            json!({ "Kind": "DocumentList" }),
+        )
+        .await;
+        if status == StatusCode::OK && documents_list_contains(&body, doc_id) {
+            assert_eq!(
+                body["Kind"], "Documents",
+                "DocumentList must return a typed Documents result, got {body}"
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "node B did not report the subscribed document over the relay"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
 /// True when a `RemoteManageQueryResult::Strings` body carries at least one value.
 fn collection_list_nonempty(body: &Value) -> bool {
     body["Kind"] == "Strings"
@@ -626,5 +680,14 @@ fn replicator_list_nonempty(body: &Value) -> bool {
         && body["replicators"]
             .as_array()
             .map(|a| !a.is_empty())
+            .unwrap_or(false)
+}
+
+/// True when a `RemoteManageQueryResult::Documents` body contains the given doc id.
+fn documents_list_contains(body: &Value, doc_id: &str) -> bool {
+    body["Kind"] == "Documents"
+        && body["documents"]
+            .as_array()
+            .map(|docs| docs.iter().any(|d| d["doc_id"] == doc_id))
             .unwrap_or(false)
 }


### PR DESCRIPTION
Closes #1012.

The authenticated P2P management/admin channel (A1 channel + A2 actor-DID auth + NAC) landed via PR #1020, and PR #1037 added rich-filter threading to `ReplicatorAdd`. This PR fills the two remaining gaps in the documented verb set, completing #1012.

## What was missing
Auditing #1012's verb set against the implementation, everything was present **except**:
- **DocumentList** — the channel had `ReplicatorList` and `CollectionList` but not the "P2P document … list" query verb.
- **PeerRemove/Disconnect** (A3) — only `PeerConnect` existed; there was no way to hang up a peer, and **no `disconnect` primitive existed on either transport**.

The issue's hardening notes were already satisfied: `read_cbor_message` bounds bytes via `.take(max_msg_size)` + a read timeout (#4718), and `sign_with_transport` clears the signature before signing (#4719).

## What this PR adds

**1. `DocumentList` query verb** (commit 1) — wires `ManageQueryOp::DocumentList` → the existing `get_documents()` op, returning structured `(collection, doc_id)` pairs via a new `Documents` result variant. Gated by the existing `P2pDocumentList` NAC permission. Mirrors the `CollectionList` path across p2p/http/requester/serve/CLI.

**2. Transport `disconnect(peer_id)` primitive** (commit 2) — the foundational piece. Adds `P2PHostHandle::disconnect` (libp2p `Swarm::disconnect_peer_id`) and `P2PTransport::disconnect` (iroh — retains the `Connection` handle in `peer_map` and closes it; clones share the QUIC connection). Disconnect-only, **idempotent-Ok** when the peer isn't connected. Implemented for all 10 `P2PTransport` impls.

**3. `PeerDisconnect` verb** (commit 3) — `disconnect_peer` on `P2POperations` (parse addr → `transport/handle.disconnect` → evict the address cache), wired as `ManageMutateOp::PeerDisconnect` across the stack + CLI `p2p manage peer disconnect`. Gated by `P2pPeerConnect` (no separate disconnect permission — parity-safe peer-connection management).

## Go parity
Go has `client.Host.Disconnect(ctx, peerID)` at the host level, but it is **not exposed** on Go's high-level `P2P` client interface, HTTP API, or CLI (`grep disconnect` in Go's `http/`+`cli/` is empty). Our disconnect-only semantics mirror `Host.Disconnect`; surfacing it over the authenticated manage channel is exactly the P2P-first control gap #1012 is about — we're ahead of Go here, not over-building. A persistent allowlist/denylist was deliberately **not** built (that's #515's domain).

## Tests
- **Transport primitive**: libp2p `test_disconnect_drops_connected_peer` + `_absent_peer_is_ok` (host_tests); iroh `disconnect_drops_connected_peer` + `_absent_peer_is_ok`.
- **Manage dispatch**: serve unit tests `document_list_returns_documents`, `peer_disconnect_dispatches`, `peer_disconnect_unauthorized_rejected_before_side_effects`.
- **E2e** (manage_relay): `manage_document_list_over_p2p`, `manage_peer_disconnect_over_p2p` (idempotent-Ok dispatch — a 2-node real disconnect would tear down the relay link itself; the primitive's real-disconnect behavior is covered by the transport unit tests).
- All CI clippy gates (incl. `--features iroh-transport`, cli/defra-node `--features otel --all-targets`) + fmt clean; full manage_relay module 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)