### PR TITLE
fix(p2p/iroh): reliable direct-only reverse-edge connect (#511)

### DIFF
--- a/crates/p2p/src/iroh/addr.rs
+++ b/crates/p2p/src/iroh/addr.rs
@@ -125,9 +125,24 @@ pub fn best_shareable_public_addr(peer_id: &PeerId, raw_addrs: &[PeerAddr]) -> O
     let formatted = format_public_listen_addrs(peer_id, raw_addrs);
     formatted
         .iter()
-        .find(|addr| is_ticket_string(addr))
+        .find(|addr| ticket_has_dialable_addr(addr))
         .cloned()
         .or_else(|| formatted.into_iter().find(|addr| addr.contains("/p2p/")))
+}
+
+/// True if `value` is an iroh endpoint ticket that embeds at least one
+/// transport address. An identity-only ticket (no embedded addrs — e.g. emitted
+/// before direct-address discovery has populated `endpoint.addr()`) is NOT a
+/// shareable address: a peer that dials it resolves to zero direct addrs and
+/// falls back to relay/discovery, which is off in trusted-fleet/loopback
+/// deployments, failing with "Address Lookup failed". Such a ticket is
+/// functionally equivalent to the bare endpoint-id fallback, so it must be
+/// skipped exactly like it — otherwise `shareable_address()` advertises an
+/// undialable address and reverse mesh edges never converge (#511).
+fn ticket_has_dialable_addr(value: &str) -> bool {
+    EndpointTicket::from_str(value.trim())
+        .map(|ticket| ticket.endpoint_addr().addrs.iter().next().is_some())
+        .unwrap_or(false)
 }
 
 /// Build an [`EndpointAddr`] from a peer id and a list of dial hints.
@@ -297,6 +312,20 @@ mod tests {
 
         let selected =
             best_shareable_public_addr(&peer_id, &[PeerAddr::new(format!("iroh://{}", peer_id))]);
+
+        assert_eq!(selected, None);
+    }
+
+    #[test]
+    fn best_shareable_public_addr_skips_identity_only_ticket() {
+        // A ticket carrying NO embedded transport addrs (e.g. emitted before
+        // direct-address discovery populated `endpoint.addr()`) resolves to zero
+        // dial hints, so it must be skipped just like the bare endpoint-id
+        // fallback rather than advertised as a shareable address (#511).
+        let peer_id = PeerId::new(endpoint_id().to_string());
+        let addrless_ticket = EndpointTicket::from(EndpointAddr::new(endpoint_id())).to_string();
+
+        let selected = best_shareable_public_addr(&peer_id, &[PeerAddr::new(addrless_ticket)]);
 
         assert_eq!(selected, None);
     }

--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -278,19 +278,6 @@ async fn run_event_loop(
     );
 }
 
-/// Join a newly connected peer into all active gossip topic subscriptions.
-///
-/// iroh-gossip subscriptions are created with an explicit neighbor list.
-/// When a new peer connects after subscription, we add them as a neighbor
-/// so they can receive (and send us) gossip messages on all subscribed topics.
-pub(super) async fn join_peer_to_subscriptions(
-    subscriptions: &HashMap<String, TopicSubscription>,
-    endpoint_id: EndpointId,
-) {
-    let subscription_senders = snapshot_subscription_senders(subscriptions);
-    join_peer_to_subscription_senders(&subscription_senders, endpoint_id).await;
-}
-
 pub(super) fn snapshot_subscription_senders(
     subscriptions: &HashMap<String, TopicSubscription>,
 ) -> SubscriptionSenders {
@@ -300,6 +287,11 @@ pub(super) fn snapshot_subscription_senders(
         .collect()
 }
 
+/// Join a newly connected peer into all active gossip topic subscriptions.
+///
+/// iroh-gossip subscriptions are created with an explicit neighbor list.
+/// When a new peer connects after subscription, we add them as a neighbor
+/// so they can receive (and send us) gossip messages on all subscribed topics.
 pub(super) async fn join_peer_to_subscription_senders(
     subscriptions: &[(String, iroh_gossip::api::GossipSender)],
     endpoint_id: EndpointId,

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -696,12 +696,24 @@ async fn handle_dial(
     addrs: Vec<PeerAddr>,
 ) -> crate::error::Result<()> {
     let endpoint_id = parse_endpoint_id(peer_id)?;
-    let endpoint_addr = endpoint_addr_from_parts(peer_id, &addrs)?;
+    let mut endpoint_addr = endpoint_addr_from_parts(peer_id, &addrs)?;
 
-    let direct_addresses: Vec<std::net::SocketAddr> = addrs
-        .iter()
-        .filter_map(|a| a.as_str().parse().ok())
-        .collect();
+    // Fix B (#511 reverse-edge dial): the advertised address may be
+    // identity-only — an iroh ticket published before direct-addr discovery
+    // completed carries no dialable direct addr. iroh rc.0 `connect()` requires
+    // the addr to be present in the EndpointAddr (there is no persistent
+    // address book to seed), so when no direct addr was supplied, reuse the
+    // observed address learned from an existing inbound connection (e.g. a peer
+    // that already dialed us during its network join). This lets a reverse mesh
+    // edge dial back over the path the peer opened to us, instead of failing
+    // "Address Lookup failed" under no-relay/no-discovery.
+    if endpoint_addr.ip_addrs().next().is_none() {
+        if let Some(observed) = peer_direct_addr(ctx.peer_map, peer_id) {
+            endpoint_addr = endpoint_addr.with_ip_addr(observed);
+        }
+    }
+
+    let direct_addresses: Vec<std::net::SocketAddr> = endpoint_addr.ip_addrs().copied().collect();
 
     let connection = ctx
         .endpoint

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -693,7 +693,8 @@ pub(super) async fn handle_command(
 struct DialContext {
     endpoint: Endpoint,
     peer_map: Arc<parking_lot::Mutex<PeerMap>>,
-    pending_pushlog_replies: Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    pending_pushlog_replies:
+        Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
     subscription_senders: SubscriptionSenders,
     spawned_tasks: SpawnedTasks,
     event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,

--- a/crates/p2p/src/iroh/endpoint_commands.rs
+++ b/crates/p2p/src/iroh/endpoint_commands.rs
@@ -19,8 +19,8 @@ use crate::QueryId;
 use super::addr::{endpoint_addr_from_parts, endpoint_ticket_string};
 use super::command::IrohCommand;
 use super::endpoint::{
-    join_peer_to_subscriptions, peer_direct_addr, track_task, ActiveSync, SpawnedTasks,
-    TopicSubscription,
+    join_peer_to_subscription_senders, peer_direct_addr, snapshot_subscription_senders, track_task,
+    ActiveSync, SpawnedTasks, SubscriptionSenders, TopicSubscription,
 };
 use super::endpoint_rpc::{
     close_cached_connections, handle_block_sync, handle_car_request_response,
@@ -59,16 +59,26 @@ pub(super) async fn handle_command(
             addrs,
             reply,
         } => {
+            // SPAWN the dial off the command loop. `handle_dial` blocks on
+            // `endpoint.connect()` (up to the dial timeout); awaiting it inline
+            // here would park the endpoint `select!` in this branch and stop it
+            // polling `accept()`, so two peers dialing each other in-window can
+            // never accept each other's inbound connection — a mutual-dial
+            // deadlock. The reply is delivered from the spawned task, so callers
+            // still get their result.
             let ctx = DialContext {
-                endpoint,
-                peer_map,
-                pending_pushlog_replies,
-                subscriptions,
-                spawned_tasks,
-                event_tx,
+                endpoint: endpoint.clone(),
+                peer_map: Arc::clone(peer_map),
+                pending_pushlog_replies: Arc::clone(pending_pushlog_replies),
+                subscription_senders: snapshot_subscription_senders(subscriptions),
+                spawned_tasks: Arc::clone(spawned_tasks),
+                event_tx: event_tx.clone(),
             };
-            let result = handle_dial(ctx, &peer_id, addrs).await;
-            let _ = reply.send(result);
+            let task = tokio::spawn(async move {
+                let result = handle_dial(ctx, &peer_id, addrs).await;
+                let _ = reply.send(result);
+            });
+            track_task(spawned_tasks, task);
         }
         IrohCommand::Disconnect { peer_id, reply } => {
             let result = handle_disconnect(peer_id, peer_map, connection_cache);
@@ -672,18 +682,21 @@ pub(super) async fn handle_command(
     false
 }
 
-/// Long-lived endpoint state borrowed for a single dial. Groups the
-/// references that `handle_dial` needs so the function signature stays
-/// under clippy's `too_many_arguments` budget without losing the
-/// lifetime-by-reference semantics of the individual fields.
-struct DialContext<'a> {
-    endpoint: &'a Endpoint,
-    peer_map: &'a Arc<parking_lot::Mutex<PeerMap>>,
-    pending_pushlog_replies:
-        &'a Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
-    subscriptions: &'a HashMap<String, TopicSubscription>,
-    spawned_tasks: &'a SpawnedTasks,
-    event_tx: &'a mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
+/// OWNED endpoint state for a single dial. Owned (not borrowed) so the dial can
+/// run in a SPAWNED task off the endpoint command loop: `endpoint.connect()`
+/// blocks for up to the dial timeout, and awaiting it inline in the command
+/// branch of the endpoint `select!` starves the sibling `accept()` branch — so
+/// two peers dialing each other in-window deadlock (neither accepts the other's
+/// inbound connection). Spawning the dial (like `accept()` already spawns) keeps
+/// the loop free to accept. `subscriptions` is captured as an owned senders
+/// snapshot (the only previously-borrowed field).
+struct DialContext {
+    endpoint: Endpoint,
+    peer_map: Arc<parking_lot::Mutex<PeerMap>>,
+    pending_pushlog_replies: Arc<parking_lot::Mutex<HashMap<String, oneshot::Sender<PushLogReply>>>>,
+    subscription_senders: SubscriptionSenders,
+    spawned_tasks: SpawnedTasks,
+    event_tx: mpsc::Sender<TransportEvent<iroh::endpoint::SendStream>>,
 }
 
 /// Dial a peer by EndpointId.
@@ -691,7 +704,7 @@ struct DialContext<'a> {
 /// Keeps the connection alive by spawning a stream handler task.
 #[allow(clippy::too_many_arguments)]
 async fn handle_dial(
-    ctx: DialContext<'_>,
+    ctx: DialContext,
     peer_id: &PeerId,
     addrs: Vec<PeerAddr>,
 ) -> crate::error::Result<()> {
@@ -708,7 +721,7 @@ async fn handle_dial(
     // edge dial back over the path the peer opened to us, instead of failing
     // "Address Lookup failed" under no-relay/no-discovery.
     if endpoint_addr.ip_addrs().next().is_none() {
-        if let Some(observed) = peer_direct_addr(ctx.peer_map, peer_id) {
+        if let Some(observed) = peer_direct_addr(&ctx.peer_map, peer_id) {
             endpoint_addr = endpoint_addr.with_ip_addr(observed);
         }
     }
@@ -740,14 +753,14 @@ async fn handle_dial(
     }
 
     if is_new {
-        join_peer_to_subscriptions(ctx.subscriptions, endpoint_id).await;
+        join_peer_to_subscription_senders(&ctx.subscription_senders, endpoint_id).await;
     }
 
     // Keep connection alive by spawning a handler for incoming streams.
     let event_tx = ctx.event_tx.clone();
-    let peer_map = Arc::clone(ctx.peer_map);
-    let pending_pushlog_replies = Arc::clone(ctx.pending_pushlog_replies);
-    let spawned_tasks_for_connection = Arc::clone(ctx.spawned_tasks);
+    let peer_map = Arc::clone(&ctx.peer_map);
+    let pending_pushlog_replies = Arc::clone(&ctx.pending_pushlog_replies);
+    let spawned_tasks_for_connection = Arc::clone(&ctx.spawned_tasks);
     let task = tokio::spawn(async move {
         super::endpoint_streams::handle_connection_streams_from_dial(
             connection,
@@ -760,7 +773,7 @@ async fn handle_dial(
         )
         .await;
     });
-    track_task(ctx.spawned_tasks, task);
+    track_task(&ctx.spawned_tasks, task);
 
     Ok(())
 }


### PR DESCRIPTION
Three fixes that together make direct-only (no-relay, no-discovery) peer connection reliable — surfaced by a downstream 5-node trusted-fleet e2e (sourcenetwork/defra-agent#511) where a coordinator and subagents could not reliably form reverse mesh edges on loopback.

## A — don't advertise addr-less tickets
`best_shareable_public_addr` could return an identity-only iroh `EndpointTicket` (no embedded transport addrs — e.g. emitted before direct-address discovery populated `endpoint.addr()`). It is a valid ticket string but resolves to zero dial hints, so `shareable_address()` (and the PeerEndpoint heartbeat / invite token built on it) advertised an undialable address → `Address Lookup failed`. Now skipped like the bare endpoint-id fallback. (+regression test)

## B — reuse the observed address on reverse dial
`handle_dial` passed only the advertised addrs to `endpoint.connect`. iroh rc.0 `connect()` needs the dial hints in the `EndpointAddr` (no persistent address book to seed), so an advertised identity-only address couldn't be dialed even when the peer already had a live inbound connection. When no direct addr is supplied, reuse the observed address `peer_map` recorded from the peer's inbound connection.

## C — spawn the dial off the command loop (the big one)
The iroh command loop `select!`s over `accept()` and the command channel and **awaited `handle_dial` inline**. `handle_dial` blocks on `endpoint.connect()` (up to the dial timeout), so the loop stopped polling `accept()` while a dial was in flight. Two peers dialing each other in-window → each blocks on its outbound dial, neither accepts the other's inbound → **mutual-dial deadlock**.

A standalone iroh-1.0.0-rc.0 probe (no relay, no address lookup, loopback) isolates it:
- separate-task dial: **30/30** sequential, **30/30** simultaneous-bidirectional
- single-`select!`-loop + inline-awaited dial (defradb's pattern), simultaneous: **0/10 — 100% deadlock**

So iroh is fine; the inline await starves `accept()`. Fix: spawn the dial (as the `accept()` branch already spawns), `DialContext` becomes owned. Downstream 2-node reconciler pairing went from ~40% flake to **0/8**.

## Tests
- `best_shareable_public_addr_skips_identity_only_ticket` added.
- `cargo test -p p2p --features iroh-transport --lib` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)