### PR TITLE
fix(acp): allow intersection (&) in DPI policies, guarding the owner invariant

### DIFF
--- a/crates/acp/tests/zanzibar_types_tests.rs
+++ b/crates/acp/tests/zanzibar_types_tests.rs
@@ -375,7 +375,11 @@ fn test_dpi_expression_missing_owner() {
 }
 
 #[test]
-fn test_dpi_disallowed_intersection() {
+fn test_dpi_intersection_requires_owner_in_all_branches() {
+    // `editor = owner & approved` is now structurally allowed (intersection is no
+    // longer a disallowed operation), but it must still be rejected: a pure owner
+    // who is not `approved` would have no access, violating the owner guarantee.
+    // The owner-presence check (`.all()` over intersection branches) catches it.
     let policy = Policy::new("policy1", "Test").with_resource(
         Resource::new("document")
             .with_relation(Relation::direct("owner"))
@@ -391,9 +395,41 @@ fn test_dpi_disallowed_intersection() {
 
     let result = policy.validate_dpi();
     assert!(
-        matches!(result, Err(Error::DpiDisallowedOperation { .. })),
-        "Expected DpiDisallowedOperation, got {:?}",
+        matches!(result, Err(Error::DpiExpressionMissingOwner { .. })),
+        "Expected DpiExpressionMissingOwner, got {:?}",
         result
+    );
+}
+
+#[test]
+fn test_dpi_intersection_allowed_when_owner_guaranteed() {
+    // Intersection is permitted when `owner` is present in EVERY branch, so the
+    // owner always satisfies the AND and retains access:
+    //   editor = (owner + reviewer) & (owner + approver)
+    let policy = Policy::new("policy1", "Test").with_resource(
+        Resource::new("document")
+            .with_relation(Relation::direct("owner"))
+            .with_relation(Relation::direct("reviewer"))
+            .with_relation(Relation::direct("approver"))
+            .with_relation(Relation::computed(
+                "editor",
+                RelationExpression::intersection(vec![
+                    RelationExpression::union(vec![
+                        RelationExpression::computed_userset("owner"),
+                        RelationExpression::computed_userset("reviewer"),
+                    ]),
+                    RelationExpression::union(vec![
+                        RelationExpression::computed_userset("owner"),
+                        RelationExpression::computed_userset("approver"),
+                    ]),
+                ]),
+            )),
+    );
+
+    assert!(
+        policy.validate_dpi().is_ok(),
+        "owner-guaranteed intersection should pass DPI, got {:?}",
+        policy.validate_dpi()
     );
 }
 

--- a/crates/zanzibar/src/types/policy.rs
+++ b/crates/zanzibar/src/types/policy.rs
@@ -104,8 +104,13 @@ impl Policy {
                 computed_relation, ..
             } => computed_relation == "owner",
             RelationExpression::Union(exprs) => exprs.iter().any(Self::expression_includes_owner),
+            // Intersection requires `owner` in EVERY branch. An actor only gains
+            // access through an intersection if they satisfy all branches, so the
+            // "owner always has access" guarantee holds only when each branch grants
+            // the owner (e.g. `(owner + a) & (owner + b)`). Using `.any()` here would
+            // let `owner & reader` pass DPI while leaving a pure owner without access.
             RelationExpression::Intersection(exprs) => {
-                exprs.iter().any(Self::expression_includes_owner)
+                exprs.iter().all(Self::expression_includes_owner)
             }
             RelationExpression::Difference { base, subtract } => {
                 Self::expression_includes_owner(base) || Self::expression_includes_owner(subtract)
@@ -121,7 +126,9 @@ impl Policy {
             RelationExpression::Union(exprs) => {
                 exprs.iter().find_map(Self::find_disallowed_operation)
             }
-            RelationExpression::Intersection(_) => Some("intersection (&)".to_string()),
+            RelationExpression::Intersection(exprs) => {
+                exprs.iter().find_map(Self::find_disallowed_operation)
+            }
             RelationExpression::Difference { base, subtract } => {
                 Self::find_disallowed_operation(base)
                     .or_else(|| Self::find_disallowed_operation(subtract))


### PR DESCRIPTION
## What

Allow the **intersection (`&`)** operator in DPI-validated policies. It was the only permission-expression operator still rejected by `find_disallowed_operation`, even though the Zanzibar evaluator implements it correctly (`engine/evaluate.rs`) and its siblings (difference, TTU) were already enabled. This unblocks AND-semantics permissions, e.g. `approve = manager & finance` or `read = owner + (reviewer & on_call)`.

Closes #1054.

## How — and the owner-invariant care

Two changes in `crates/zanzibar/src/types/policy.rs`:

1. **`find_disallowed_operation`** — `Intersection` now recurses through its branches (mirroring `Difference`/`Union`) instead of returning `Some("intersection (&)")`.

2. **`expression_includes_owner`** — for `Intersection`, changed `.any()` → **`.all()`**.

The second change is the load-bearing one. Intersection can erode the *"owner always has access"* guarantee that the DPI enforces: with `.any()`, a policy like `read = owner & reader` would pass the owner-presence check, yet a **pure owner who is not a `reader` would have no access**. Requiring owner in **every** branch (`.all()`) means the owner always satisfies the AND — e.g. `(owner + a) & (owner + b)` is allowed (owner is in both unions), while `owner & reader` is correctly rejected with `DpiExpressionMissingOwner`.

I'd appreciate a maintainer sanity-check on that owner semantics — it's the one judgment call here. If intersection was instead held back for a different reason, happy to adjust.

## Behavior

| policy | before | after |
|---|---|---|
| `read = owner + (reviewer & approver)` | `DpiDisallowedOperation` | ✅ allowed |
| `(owner + a) & (owner + b)` | `DpiDisallowedOperation` | ✅ allowed |
| `read = owner & reader` | `DpiDisallowedOperation` | `DpiExpressionMissingOwner` (owner not guaranteed) |

## Tests

`test_dpi_disallowed_intersection` is split into:
- `test_dpi_intersection_requires_owner_in_all_branches` — `owner & approved` → `DpiExpressionMissingOwner`
- `test_dpi_intersection_allowed_when_owner_guaranteed` — `(owner + reviewer) & (owner + approver)` → ok

Full `cargo test -p acp` is green (engine / types / expression / stress / cross-impl / nac / store, 250+ tests). The evaluator already had a correct `Intersection` arm, so no engine change was needed.

## Context

Found while building an RL training harness on DefraDB ACP (sourcenetwork/zanzibar-rl) — intersection was the one same-object operator we couldn't author against despite the engine supporting it.
