### PR TITLE
spike(acp): cross-object / collection-level ACP seam (TTU read inheritance)

### DIFF
--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -53,6 +53,7 @@ pub use store::AcpStore;
 pub use validation::{validate_resource_interface, REQUIRED_DOCUMENT_PERMISSIONS};
 
 // Re-export key zanzibar engine types from the standalone zanzibar crate
+pub use zanzibar::parse_target_subject;
 pub use zanzibar::PersistentZanzibarStore;
 pub use zanzibar::ZanzibarDocumentACP;
 

--- a/crates/acp/src/zanzibar/acp/mod.rs
+++ b/crates/acp/src/zanzibar/acp/mod.rs
@@ -9,12 +9,57 @@ use identity::Did;
 use zanzibar::engine::PermissionEngine;
 use zanzibar::expression::RelationExpression;
 use zanzibar::store::ZanzibarStore;
-use zanzibar::types::{Policy, Relation, Resource};
+use zanzibar::types::{Policy, Relation, Relationship, Resource, Subject};
 
 use crate::error::{Error, Result};
 use crate::permission::DocumentPermission;
 
 pub const OWNER_RELATION: &str = "owner";
+
+/// Parse a relationship-target string into a [`Subject`], supporting the full
+/// document-ACP language rather than only actor DIDs. This is the collection-
+/// level-ACP seam: it lets a document relation point at another object (a TTU
+/// parent edge) or at a userset, mirroring what the Zanzibar engine and store
+/// already resolve.
+///
+/// Forms:
+/// - `*`                     → [`Subject::Wildcard`] (all actors)
+/// - `did:...`               → [`Subject::Entity`] (a single actor)
+/// - `resource:id#relation`  → [`Subject::EntitySet`] (a userset)
+/// - `resource:id`           → [`Subject::EntitySet`] with an empty relation
+///   (a cross-object / TTU edge; the engine keys object edges on the
+///   (resource, object_id) pair and ignores the relation)
+pub fn parse_target_subject(target: &str) -> Result<Subject> {
+    if target == "*" {
+        return Ok(Subject::Wildcard);
+    }
+    if target.starts_with("did:") {
+        let did = Did::new(target).map_err(|e| {
+            Error::InvalidRelation(format!("invalid actor DID '{}': {}", target, e))
+        })?;
+        return Ok(Subject::Entity(did));
+    }
+
+    // Object form: `resource:object_id` with an optional `#relation` suffix.
+    let (object, relation) = match target.split_once('#') {
+        Some((object, relation)) => (object, relation),
+        None => (target, ""),
+    };
+    let (resource, object_id) = object.split_once(':').ok_or_else(|| {
+        Error::InvalidRelation(format!(
+            "invalid relationship target '{}': expected 'did:...', '*', \
+             'resource:id', or 'resource:id#relation'",
+            target
+        ))
+    })?;
+    if resource.is_empty() || object_id.is_empty() {
+        return Err(Error::InvalidRelation(format!(
+            "invalid relationship target '{}': empty resource or object id",
+            target
+        )));
+    }
+    Ok(Subject::entity_set(resource, object_id, relation))
+}
 pub const READER_RELATION: &str = "reader";
 pub const UPDATER_RELATION: &str = "updater";
 pub const DELETER_RELATION: &str = "deleter";
@@ -183,6 +228,55 @@ impl<S: ZanzibarStore + ?Sized> ZanzibarDocumentACP<S> {
         }
     }
 
+    /// Seed a relationship whose subject may be a userset or a cross-object
+    /// edge, not only an actor DID — the collection-level-ACP seam.
+    ///
+    /// Authority follows the same rule as `add_actor_relationship`: the
+    /// requestor must own the document or hold a managing relation for
+    /// `relation`. The `target` subject is stored verbatim, so a caller can pass
+    /// a [`Subject::EntitySet`] (userset / TTU parent edge) that the engine then
+    /// resolves through `TupleToUserset`.
+    pub async fn add_subject_relationship(
+        &self,
+        requestor: &Did,
+        target: Subject,
+        policy_id: &str,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+        _managing_relations: &[String],
+    ) -> Result<bool> {
+        self.ensure_policy(policy_id, collection_id).await?;
+
+        if relation == OWNER_RELATION {
+            return Err(Error::InvalidRelation(
+                "cannot add owner relation".to_string(),
+            ));
+        }
+
+        self.check_manage_relation(
+            requestor,
+            policy_id,
+            collection_id,
+            doc_id,
+            relation,
+            "create",
+        )
+        .await?;
+
+        let has = self
+            .store
+            .has_relationship(policy_id, collection_id, doc_id, relation, &target)
+            .await?;
+        if has {
+            return Ok(false);
+        }
+
+        let rel = Relationship::new(collection_id, doc_id, relation, target);
+        self.store.store_relationship(policy_id, &rel).await?;
+        Ok(true)
+    }
+
     fn permission_to_relation(permission: DocumentPermission) -> &'static str {
         match permission {
             DocumentPermission::Read => "read",
@@ -204,5 +298,68 @@ impl<S: ZanzibarStore + ?Sized> ZanzibarDocumentACP<S> {
     pub async fn clear_policy_cache(&self) {
         let mut engine = self.engine.write().await;
         engine.clear_cache();
+    }
+}
+
+#[cfg(test)]
+mod parse_target_subject_tests {
+    use super::*;
+
+    #[test]
+    fn parses_wildcard() {
+        assert!(matches!(
+            parse_target_subject("*").unwrap(),
+            Subject::Wildcard
+        ));
+    }
+
+    #[test]
+    fn parses_actor_did() {
+        let subject =
+            parse_target_subject("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
+                .unwrap();
+        assert!(subject.is_entity());
+    }
+
+    #[test]
+    fn parses_userset() {
+        match parse_target_subject("group:hr#participant").unwrap() {
+            Subject::EntitySet {
+                resource,
+                object_id,
+                relation,
+            } => {
+                assert_eq!(resource, "group");
+                assert_eq!(object_id, "hr");
+                assert_eq!(relation, "participant");
+            }
+            other => panic!("expected EntitySet userset, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_cross_object_edge() {
+        match parse_target_subject("directory:teamdir").unwrap() {
+            Subject::EntitySet {
+                resource,
+                object_id,
+                relation,
+            } => {
+                assert_eq!(resource, "directory");
+                assert_eq!(object_id, "teamdir");
+                assert_eq!(relation, "", "an object edge carries no subject relation");
+            }
+            other => panic!("expected EntitySet object edge, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rejects_unqualified_target() {
+        assert!(parse_target_subject("not-a-target").is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_did() {
+        assert!(parse_target_subject("did:bogus").is_err());
     }
 }

--- a/crates/acp/src/zanzibar/mod.rs
+++ b/crates/acp/src/zanzibar/mod.rs
@@ -10,5 +10,5 @@
 mod acp;
 pub mod store;
 
-pub use acp::ZanzibarDocumentACP;
+pub use acp::{parse_target_subject, ZanzibarDocumentACP};
 pub use store::PersistentZanzibarStore;

--- a/crates/acp/tests/spike_cross_object_ttu.rs
+++ b/crates/acp/tests/spike_cross_object_ttu.rs
@@ -1,0 +1,161 @@
+//! SPIKE: prove the live `ZanzibarDocumentACP` path resolves cross-object
+//! TupleToUserset (TTU) inheritance — a `directory -> file` read cone — once a
+//! cross-object `parent` edge can be seeded.
+//!
+//! Context: the live DefraDB document-ACP *seam* only accepts actor-DID targets
+//! (`add_actor_relationship(target: &Did)`), so today you cannot seed a
+//! cross-object edge like `file:report#parent@directory:teamdir`. But the
+//! underlying Zanzibar store + engine already model and resolve it: the engine's
+//! `TupleToUserset` arm reads `parent` subjects via `get_relation_subjects`/
+//! `get_relation_targets`, and `MemoryZanzibarStore::get_relation_targets` maps a
+//! `Subject::EntitySet { resource, object_id, .. }` to an `ObjectRef`.
+//!
+//! This spike seeds that edge directly through the store (standing in for the
+//! seam method we'd add) and asserts that `check_doc_access` then resolves
+//! `file#read` through `parent->read` to the directory's `reader`. The before/
+//! after assertions prove the cross-object edge is what grants access — not some
+//! pre-existing direct grant.
+
+use std::sync::Arc;
+
+use acp::{
+    policy_yaml::{build_policy, parse_policy_yaml, validate_policy_expressions},
+    DocumentACP, DocumentPermission, Identity, MemoryZanzibarStore, Relationship, Subject,
+    ZanzibarDocumentACP, ZanzibarStore,
+};
+use identity::Did;
+
+fn did_owner() -> Did {
+    Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+}
+fn did_alice() -> Did {
+    Did::new("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap()
+}
+fn did_bob() -> Did {
+    Did::new("did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi").unwrap()
+}
+
+/// A two-resource filesystem policy. `file.read` inherits from its parent
+/// directory via the cross-object TTU `parent->read`.
+// `owner` is a reserved relation auto-injected into every permission by the
+// Discretionary transformer, so it is neither declared nor referenced here.
+const FS_POLICY: &str = r#"
+name: filesystem
+resources:
+- name: directory
+  permissions:
+  - name: read
+    expr: reader
+  - name: update
+    expr: reader
+  - name: delete
+    expr: reader
+  relations:
+  - name: reader
+    types: [actor]
+- name: file
+  permissions:
+  - name: read
+    expr: reader + parent->read
+  - name: update
+    expr: reader
+  - name: delete
+    expr: reader
+  relations:
+  - name: reader
+    types: [actor]
+  - name: parent
+    types: [directory]
+"#;
+
+async fn can_read(
+    acp: &ZanzibarDocumentACP<MemoryZanzibarStore>,
+    policy_id: &str,
+    who: Did,
+    resource: &str,
+    doc: &str,
+) -> bool {
+    acp.check_doc_access(
+        &Identity::Authenticated(who),
+        DocumentPermission::Read,
+        policy_id,
+        resource,
+        doc,
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn spike_cross_object_ttu_read_inheritance() {
+    // --- build + store the multi-resource filesystem policy ---
+    let parsed = parse_policy_yaml(FS_POLICY).unwrap();
+    validate_policy_expressions(&parsed).unwrap();
+    let policy = build_policy(&parsed, 1).unwrap();
+    let policy_id = policy.id.clone();
+
+    let store = Arc::new(MemoryZanzibarStore::new());
+    store.store_policy(&policy).await.unwrap();
+    let acp = ZanzibarDocumentACP::new(store.clone());
+
+    let owner = did_owner();
+
+    // --- register a directory doc and a file doc (each gets an owner) ---
+    acp.register_doc_object(&owner, &policy_id, "directory", "teamdir")
+        .await
+        .unwrap();
+    acp.register_doc_object(&owner, &policy_id, "file", "report")
+        .await
+        .unwrap();
+
+    // --- grant alice direct reader on the DIRECTORY (a normal actor grant) ---
+    acp.add_actor_relationship(
+        &owner,
+        &did_alice(),
+        &policy_id,
+        "directory",
+        "teamdir",
+        "reader",
+        &[],
+    )
+    .await
+    .unwrap();
+
+    // Sanity: alice can read the directory directly.
+    assert!(
+        can_read(&acp, &policy_id, did_alice(), "directory", "teamdir").await,
+        "alice has a direct reader grant on the directory"
+    );
+
+    // BEFORE the cross-object edge exists: alice must NOT reach the file.
+    // (Proves the test isn't passing via some pre-existing direct grant.)
+    assert!(
+        !can_read(&acp, &policy_id, did_alice(), "file", "report").await,
+        "without a parent edge, directory access must NOT leak to the file"
+    );
+
+    // --- seed the cross-object edge: file:report#parent@directory:teamdir ---
+    // The live actor-DID-only seam cannot express this; we seed it directly
+    // through the store as the seam method would. An object subject is carried as
+    // `Subject::EntitySet { resource, object_id, .. }`; the engine's TTU arm and
+    // `get_relation_targets` key on (resource, object_id) and ignore the relation.
+    let parent_edge = Relationship::new(
+        "file",
+        "report",
+        "parent",
+        Subject::entity_set("directory", "teamdir", ""),
+    );
+    store.store_relationship(&policy_id, &parent_edge).await.unwrap();
+
+    // AFTER: alice now reaches the file via parent->read -> directory#read -> reader.
+    assert!(
+        can_read(&acp, &policy_id, did_alice(), "file", "report").await,
+        "HEADLINE: alice reads the file via cross-object parent->read inheritance"
+    );
+
+    // Control: bob has no grant anywhere -> still denied.
+    assert!(
+        !can_read(&acp, &policy_id, did_bob(), "file", "report").await,
+        "bob has no grant and must remain denied through the TTU cone"
+    );
+}

--- a/crates/acp/tests/spike_cross_object_ttu.rs
+++ b/crates/acp/tests/spike_cross_object_ttu.rs
@@ -10,18 +10,19 @@
 //! `get_relation_targets`, and `MemoryZanzibarStore::get_relation_targets` maps a
 //! `Subject::EntitySet { resource, object_id, .. }` to an `ObjectRef`.
 //!
-//! This spike seeds that edge directly through the store (standing in for the
-//! seam method we'd add) and asserts that `check_doc_access` then resolves
-//! `file#read` through `parent->read` to the directory's `reader`. The before/
-//! after assertions prove the cross-object edge is what grants access — not some
-//! pre-existing direct grant.
+//! This spike seeds that edge through the new seam (`parse_target_subject` +
+//! `ZanzibarDocumentACP::add_subject_relationship`) and asserts that
+//! `check_doc_access` then resolves `file#read` through `parent->read` to the
+//! directory's `reader`. The before/after assertions prove the cross-object edge
+//! is what grants access — not some pre-existing direct grant.
 
 use std::sync::Arc;
 
 use acp::{
+    parse_target_subject,
     policy_yaml::{build_policy, parse_policy_yaml, validate_policy_expressions},
-    DocumentACP, DocumentPermission, Identity, MemoryZanzibarStore, Relationship, Subject,
-    ZanzibarDocumentACP, ZanzibarStore,
+    DocumentACP, DocumentPermission, Identity, MemoryZanzibarStore, ZanzibarDocumentACP,
+    ZanzibarStore,
 };
 use identity::Did;
 
@@ -134,18 +135,25 @@ async fn spike_cross_object_ttu_read_inheritance() {
         "without a parent edge, directory access must NOT leak to the file"
     );
 
-    // --- seed the cross-object edge: file:report#parent@directory:teamdir ---
-    // The live actor-DID-only seam cannot express this; we seed it directly
-    // through the store as the seam method would. An object subject is carried as
-    // `Subject::EntitySet { resource, object_id, .. }`; the engine's TTU arm and
-    // `get_relation_targets` key on (resource, object_id) and ignore the relation.
-    let parent_edge = Relationship::new(
-        "file",
-        "report",
-        "parent",
-        Subject::entity_set("directory", "teamdir", ""),
-    );
-    store.store_relationship(&policy_id, &parent_edge).await.unwrap();
+    // --- seed the cross-object edge through the real seam API ---
+    // `parse_target_subject` turns the object reference `directory:teamdir` into a
+    // cross-object subject, and `add_subject_relationship` stores it under the same
+    // owner/manager authority check as an actor grant. This is the minimal
+    // collection-level-ACP seam — no store backdoor.
+    let parent_target = parse_target_subject("directory:teamdir").unwrap();
+    let added = acp
+        .add_subject_relationship(
+            &owner,
+            parent_target,
+            &policy_id,
+            "file",
+            "report",
+            "parent",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(added, "the cross-object parent edge should be newly added");
 
     // AFTER: alice now reaches the file via parent->read -> directory#read -> reader.
     assert!(


### PR DESCRIPTION
## What

Proves — and minimally unblocks — **cross-object (collection-level) ACP** on the live Rust document-ACP path. A `directory -> file` read cone (`file.read = reader + parent->read`) now resolves end-to-end through `ZanzibarDocumentACP::check_doc_access`.

## Why

Diagnosis showed the live node cannot *seed* cross-object / userset relationships on documents (e.g. `file:report#parent@directory:teamdir`), even though the Zanzibar engine + store already model and resolve them (the TTU evaluator is even Lean-proven). The gap is purely the **seeding seam**: `add_actor_relationship` flattens every target to an actor DID via `actor_subject()`. This is a shared limitation with Go DefraDB — not a Rust-behind-Go regression — and it is a seam-widening, **not** a V2 rebuild.

## Changes

- **`parse_target_subject(s)`** — maps a target string to the full subject language:
  - `*` → `Subject::Wildcard`
  - `did:...` → `Subject::Entity` (actor)
  - `resource:id#relation` → `Subject::EntitySet` (userset)
  - `resource:id` → `Subject::EntitySet` object / TTU edge
- **`ZanzibarDocumentACP::add_subject_relationship(...)`** — stores a relationship with an arbitrary `Subject` under the **same owner/manager authority check** as an actor grant.
- Re-exported both from the `acp` crate.
- **`tests/spike_cross_object_ttu.rs`** — seeds the cross-object `parent` edge through the real seam (no store backdoor) and asserts alice reads the file via `parent->read -> directory#read -> reader` (before = denied, after = granted; bob stays denied).
- 6 parser unit tests covering all four subject forms + malformed input.

Engine and store required **zero changes** — the TTU evaluator already reads parent subjects and the memory store already maps an `EntitySet` subject to a cross-object `ObjectRef`. Full `acp` suite green.

## Scope / not yet done

This is the proving seam. Making it the *full* live path is follow-up plumbing (not invention): the `DocumentACP` trait API (`&Did`-typed), the CLI `doc_acp_adapter.rs` DID-parse gate, the HTTP `target_actor: String`, routing the default backend through `ZanzibarDocumentACP` (the `Local` backend stores a bare `Did`), and multi-resource collection↔policy registration for cross-collection edges. Userset-subject-on-a-direct-relation (the `This`-path `check_permission_direct` EntitySet expansion) is a separate, deferred blocker; TTU-reached usersets already work.

**Open question this spike cannot answer:** whether a cross-object grant behaves correctly through a live *query* (planner / sync / indexing). That should be probed before widening further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)