### PR TITLE
feat(acp): widen DocumentACP to add_relationship(Subject) (step 2a)

### DIFF
--- a/crates/acp/src/dac.rs
+++ b/crates/acp/src/dac.rs
@@ -5,8 +5,9 @@
 use async_trait::async_trait;
 use identity::Did;
 use storage::corekv::MaybeSendSync;
+use zanzibar::types::Subject;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::identity::Identity;
 use crate::permission::DocumentPermission;
 
@@ -132,6 +133,43 @@ pub trait DocumentACP: MaybeSendSync {
         relation: &str,
         managing_relations: &[String],
     ) -> Result<bool>;
+
+    /// Add a relationship whose target may be any [`Subject`] — an actor DID,
+    /// the all-actors wildcard, a cross-object edge, or a userset — subject to
+    /// the policy's declared relation `types:`.
+    ///
+    /// The default implementation supports only actor subjects (a DID or `*`),
+    /// delegating to [`add_actor_relationship`](Self::add_actor_relationship),
+    /// and rejects anything a bare-DID backend cannot represent with
+    /// [`Error::UnsupportedSubject`]. Backends that model the full subject
+    /// language (the Zanzibar backend) override this to store cross-object and
+    /// userset edges, validating the subject against the policy first.
+    async fn add_relationship(
+        &self,
+        requestor: &Did,
+        target: Subject,
+        policy_id: &str,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+        managing_relations: &[String],
+    ) -> Result<bool> {
+        let actor = match target {
+            Subject::Entity(did) => did,
+            Subject::Wildcard => Did::wildcard(),
+            other => return Err(Error::UnsupportedSubject(other.to_string())),
+        };
+        self.add_actor_relationship(
+            requestor,
+            &actor,
+            policy_id,
+            collection_id,
+            doc_id,
+            relation,
+            managing_relations,
+        )
+        .await
+    }
 
     /// Remove actor relationship.
     ///

--- a/crates/acp/src/error.rs
+++ b/crates/acp/src/error.rs
@@ -29,6 +29,11 @@ pub enum Error {
     #[error("invalid relation: {0}")]
     InvalidRelation(String),
 
+    /// The backend cannot represent the requested subject (e.g. a cross-object
+    /// or userset edge on the Local or SourceHub backend, which store bare DIDs).
+    #[error("unsupported subject for this backend: {0}")]
+    UnsupportedSubject(String),
+
     /// Not the owner of the document (UNAUTHORIZED)
     #[error("UNAUTHORIZED: not document owner, cannot {operation}")]
     NotOwner { operation: String },

--- a/crates/acp/src/zanzibar/acp/document_acp.rs
+++ b/crates/acp/src/zanzibar/acp/document_acp.rs
@@ -181,6 +181,30 @@ impl<S: ZanzibarStore + ?Sized + 'static> DocumentACP for ZanzibarDocumentACP<S>
         collection_id: &str,
         doc_id: &str,
         relation: &str,
+        managing_relations: &[String],
+    ) -> Result<bool> {
+        // The actor path is a thin wrapper over the general subject path, so
+        // authority and floor validation run through a single implementation.
+        self.add_relationship(
+            requestor,
+            actor_subject(target),
+            policy_id,
+            collection_id,
+            doc_id,
+            relation,
+            managing_relations,
+        )
+        .await
+    }
+
+    async fn add_relationship(
+        &self,
+        requestor: &Did,
+        target: Subject,
+        policy_id: &str,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
         _managing_relations: &[String],
     ) -> Result<bool> {
         self.ensure_policy(policy_id, collection_id).await?;
@@ -201,38 +225,40 @@ impl<S: ZanzibarStore + ?Sized + 'static> DocumentACP for ZanzibarDocumentACP<S>
         )
         .await?;
 
-        let subject = actor_subject(target);
+        // Soundness floor: a declared relation's subject must satisfy its
+        // `types:` (and any cross-object reference must point at a declared
+        // resource) before it is stored. Undeclared relations are still accepted
+        // — relation-vs-policy validation is an adapter-layer concern in Go, and
+        // an undeclared relation carries no type contract to enforce.
+        let rel = Relationship::new(collection_id, doc_id, relation, target);
+        let policy = self
+            .store
+            .get_policy(policy_id)
+            .await?
+            .ok_or_else(|| Error::InvalidPolicy(format!("policy '{}' not found", policy_id)))?;
+        if policy.get_relation(collection_id, relation).is_some() {
+            rel.validate(&policy)?;
+        }
+
         let has = self
             .store
-            .has_relationship(policy_id, collection_id, doc_id, relation, &subject)
+            .has_relationship(policy_id, collection_id, doc_id, relation, &rel.subject)
             .await?;
-
         if has {
-            tracing::debug!(
-                target: "acp::audit",
-                event = "relationship_exists",
-                requestor = %requestor,
-                target = %target,
-                relation = %relation,
-                collection = %collection_id,
-                doc_id = %doc_id,
-                "Relationship already exists"
-            );
             return Ok(false);
         }
 
-        let rel = Relationship::new(collection_id, doc_id, relation, subject);
         self.store.store_relationship(policy_id, &rel).await?;
 
         tracing::info!(
             target: "acp::audit",
             event = "relationship_added",
             requestor = %requestor,
-            target = %target,
+            subject = %rel.subject,
             relation = %relation,
             collection = %collection_id,
             doc_id = %doc_id,
-            "Actor relationship added via Zanzibar"
+            "Relationship added via Zanzibar"
         );
 
         Ok(true)

--- a/crates/acp/tests/cross_object_ttu.rs
+++ b/crates/acp/tests/cross_object_ttu.rs
@@ -1,0 +1,221 @@
+//! Cross-object (collection-level) ACP through the widened `DocumentACP` trait.
+//!
+//! Carried forward from the #1056 spike, but now seeded through the real
+//! `DocumentACP::add_relationship(Subject)` API instead of an inherent
+//! backdoor: a `directory -> file` read cone (`file.read = reader +
+//! parent->read`) resolves end-to-end once the cross-object `parent` edge is
+//! seeded as a `Subject::EntitySet`. The Zanzibar backend validates the subject
+//! against the policy's declared `types:` (the soundness floor) before storing;
+//! backends that cannot represent a non-actor subject reject it.
+
+use std::sync::Arc;
+
+use acp::{
+    policy_yaml::{build_policy, parse_policy_yaml},
+    DocumentACP, DocumentPermission, Error, Identity, LocalDocumentACP, MemoryAcpStore,
+    MemoryZanzibarStore, Subject, ZanzibarDocumentACP, ZanzibarStore,
+};
+use identity::Did;
+
+fn did_owner() -> Did {
+    Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+}
+fn did_alice() -> Did {
+    Did::new("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap()
+}
+fn did_bob() -> Did {
+    Did::new("did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi").unwrap()
+}
+
+const FS_POLICY: &str = r#"
+name: filesystem
+resources:
+- name: directory
+  permissions:
+  - name: read
+    expr: reader
+  - name: update
+    expr: reader
+  - name: delete
+    expr: reader
+  relations:
+  - name: reader
+    types: [actor]
+- name: file
+  permissions:
+  - name: read
+    expr: reader + parent->read
+  - name: update
+    expr: reader
+  - name: delete
+    expr: reader
+  relations:
+  - name: reader
+    types: [actor]
+  - name: parent
+    types: [directory]
+"#;
+
+async fn can_read(
+    acp: &ZanzibarDocumentACP<MemoryZanzibarStore>,
+    policy_id: &str,
+    who: Did,
+    resource: &str,
+    doc: &str,
+) -> bool {
+    acp.check_doc_access(
+        &Identity::Authenticated(who),
+        DocumentPermission::Read,
+        policy_id,
+        resource,
+        doc,
+    )
+    .await
+    .unwrap()
+}
+
+async fn fs_acp() -> (ZanzibarDocumentACP<MemoryZanzibarStore>, String) {
+    let parsed = parse_policy_yaml(FS_POLICY).unwrap();
+    let policy = build_policy(&parsed, 1).unwrap();
+    let policy_id = policy.id.clone();
+
+    let store = Arc::new(MemoryZanzibarStore::new());
+    store.store_policy(&policy).await.unwrap();
+    let acp = ZanzibarDocumentACP::new(store.clone());
+
+    let owner = did_owner();
+    acp.register_doc_object(&owner, &policy_id, "directory", "teamdir")
+        .await
+        .unwrap();
+    acp.register_doc_object(&owner, &policy_id, "file", "report")
+        .await
+        .unwrap();
+    (acp, policy_id)
+}
+
+#[tokio::test]
+async fn cross_object_parent_edge_grants_read_inheritance() {
+    let (acp, policy_id) = fs_acp().await;
+    let owner = did_owner();
+
+    // alice gets a direct reader grant on the DIRECTORY (a normal actor grant
+    // through the same widened API).
+    acp.add_relationship(
+        &owner,
+        Subject::Entity(did_alice()),
+        &policy_id,
+        "directory",
+        "teamdir",
+        "reader",
+        &[],
+    )
+    .await
+    .unwrap();
+    assert!(can_read(&acp, &policy_id, did_alice(), "directory", "teamdir").await);
+
+    // BEFORE the cross-object edge: directory access must NOT leak to the file.
+    assert!(!can_read(&acp, &policy_id, did_alice(), "file", "report").await);
+
+    // Seed the cross-object edge through the widened trait API. The subject is a
+    // `directory` object reference (EntitySet, empty relation) — the parent edge.
+    let added = acp
+        .add_relationship(
+            &owner,
+            Subject::entity_set("directory", "teamdir", ""),
+            &policy_id,
+            "file",
+            "report",
+            "parent",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(added, "the cross-object parent edge should be newly added");
+
+    // AFTER: alice reaches the file via parent->read -> directory#read -> reader.
+    assert!(
+        can_read(&acp, &policy_id, did_alice(), "file", "report").await,
+        "alice reads the file via cross-object parent->read inheritance"
+    );
+
+    // bob has no grant anywhere -> still denied through the TTU cone.
+    assert!(!can_read(&acp, &policy_id, did_bob(), "file", "report").await);
+}
+
+#[tokio::test]
+async fn add_actor_relationship_still_works_via_delegation() {
+    // The actor convenience path now routes through add_relationship; it must
+    // behave exactly as before.
+    let (acp, policy_id) = fs_acp().await;
+    let owner = did_owner();
+
+    let added = acp
+        .add_actor_relationship(
+            &owner,
+            &did_alice(),
+            &policy_id,
+            "directory",
+            "teamdir",
+            "reader",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(added);
+    assert!(can_read(&acp, &policy_id, did_alice(), "directory", "teamdir").await);
+}
+
+#[tokio::test]
+async fn add_relationship_enforces_the_subject_floor() {
+    // A `directory` object edge on an actor-typed relation (`reader`) must be
+    // rejected by the floor validation wired into the add path.
+    let (acp, policy_id) = fs_acp().await;
+    let owner = did_owner();
+
+    let err = acp
+        .add_relationship(
+            &owner,
+            Subject::entity_set("directory", "teamdir", ""),
+            &policy_id,
+            "file",
+            "report",
+            "reader",
+            &[],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::SubjectRestrictionViolation { .. }),
+        "an object edge on an actor-typed relation must be rejected, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn local_backend_rejects_cross_object_subjects() {
+    // The Local backend stores bare DIDs and cannot represent a cross-object
+    // edge; it must reject one with a typed UnsupportedSubject error.
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let owner = did_owner();
+    acp.register_doc_object(&owner, "policy1", "file", "report")
+        .await
+        .unwrap();
+
+    let err = acp
+        .add_relationship(
+            &owner,
+            Subject::entity_set("directory", "teamdir", ""),
+            "policy1",
+            "file",
+            "report",
+            "parent",
+            &[],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::UnsupportedSubject(_)),
+        "Local backend must reject a cross-object subject, got {:?}",
+        err
+    );
+}


### PR DESCRIPTION
## What

Step 2a of the document-path track: widen the `DocumentACP` API so a relationship target can be any `Subject` (actor DID, all-actors `*`, cross-object/TTU edge, or userset), built on the soundness floor (#1059). No CLI/HTTP yet (that's 2b); no default-backend flip; no SourceHub subject support (that's the hub.rs sub-epic).

## Design — additive, zero churn to other backends

- **`add_relationship(target: Subject)`** is a **provided** trait method. Its default supports only actor subjects (delegates to `add_actor_relationship`) and rejects anything a bare-DID backend can't represent with the new typed **`Error::UnsupportedSubject`**. So **Local, SourceHub, and all 5 mock impls inherit correct reject-on-`EntitySet` behaviour with no code change** (verified: all dependent crates build clean).
- **Zanzibar backend overrides `add_relationship`** for full cross-object/userset support, and routes its own `add_actor_relationship` through it — one authority+validation path.
- **Floor wired in:** before storing, a *declared* relation's subject is validated against its `types:` (and cross-object references against the policy's resources). **Undeclared relations stay accepted** — relation-vs-policy validation is an adapter-layer concern in Go (preserves the `test_invalid_relation` contract; only `owner` is universally rejected).

## Tests

`crates/acp/tests/cross_object_ttu.rs` (carried from the #1056 spike, now through the real API):
- cross-object `parent` edge grants read inheritance (`file.read = reader + parent->read`), before/after + bob-denied control;
- `add_actor_relationship` still works via delegation;
- floor enforcement: an object edge on an actor-typed relation → `SubjectRestrictionViolation`;
- Local backend rejects a cross-object subject → `UnsupportedSubject`.

Full `acp` + `zanzibar` suites green; clippy `-D warnings` clean; all DocumentACP-impl crates (sourcehub/query/query-plan/db-merge/kms/embedded/ffi) build unchanged.

## Follow-ups (not in 2a)
- #1056 spike to be **closed** (its seam is superseded; its test is carried here — not merged).
- 2b: CLI/HTTP parsing (`parse_target_subject`) on top of this.
- Backend selection (run Zanzibar DocumentACP on an embedded node) to make cross-object enforce end-to-end — scoped separately.
- Cross-node subjects = hub.rs sub-epic (hub_rs provider + chain); cosmos stays reject-unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)