### PR TITLE
feat(acp): parse target subjects at the CLI/HTTP edge (step 2b)

### DIFF
--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -36,6 +36,7 @@ mod persistent;
 pub mod policy_yaml;
 mod relation;
 mod store;
+mod target_subject;
 mod validation;
 pub mod zanzibar;
 
@@ -50,6 +51,7 @@ pub use relation::{
     RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION,
 };
 pub use store::AcpStore;
+pub use target_subject::parse_target_subject;
 pub use validation::{validate_resource_interface, REQUIRED_DOCUMENT_PERMISSIONS};
 
 // Re-export key zanzibar engine types from the standalone zanzibar crate

--- a/crates/acp/src/target_subject.rs
+++ b/crates/acp/src/target_subject.rs
@@ -1,0 +1,173 @@
+//! Parse a relationship-target string from the CLI/HTTP edge into a structured
+//! [`Subject`]. This is the *only* string→`Subject` boundary; everything
+//! downstream (the `DocumentACP` API, the SourceHub provider) carries the
+//! structured subject, never a re-stringified form.
+//!
+//! Grammar:
+//! ```text
+//! target    := "*"                         (all actors)
+//!            | "did:" …                     (a single actor)
+//!            | resource ":" object_id [ "#" relation ]
+//! object_id := '"' any-chars '"'           (quoted — may contain : / # …)
+//!            | bare_token                   (no ':' '#' or quotes)
+//! ```
+//! A quoted `object_id` lets collection-level object ids be path-like
+//! (`directory:"/team"`) or otherwise carry separators without mis-splitting.
+
+use identity::Did;
+use zanzibar::types::Subject;
+
+use crate::error::{Error, Result};
+
+fn invalid(target: &str, why: &str) -> Error {
+    Error::InvalidRelation(format!("invalid relationship target '{}': {}", target, why))
+}
+
+/// Parse a target string into a [`Subject`]. See the module docs for the grammar.
+pub fn parse_target_subject(target: &str) -> Result<Subject> {
+    if target == "*" {
+        return Ok(Subject::Wildcard);
+    }
+    if target.starts_with("did:") {
+        let did = Did::new(target)
+            .map_err(|e| invalid(target, &format!("not a valid actor DID: {}", e)))?;
+        return Ok(Subject::Entity(did));
+    }
+
+    let (resource, rest) = target.split_once(':').ok_or_else(|| {
+        invalid(
+            target,
+            "expected 'did:…', '*', 'resource:id', or 'resource:id#relation'",
+        )
+    })?;
+    if resource.is_empty() {
+        return Err(invalid(target, "empty resource"));
+    }
+
+    let (object_id, relation) = if let Some(after_quote) = rest.strip_prefix('"') {
+        // Quoted object id: take everything up to the closing quote verbatim.
+        let close = after_quote
+            .find('"')
+            .ok_or_else(|| invalid(target, "unterminated quoted object id"))?;
+        let object_id = &after_quote[..close];
+        let tail = &after_quote[close + 1..];
+        let relation = match tail.strip_prefix('#') {
+            Some(rel) => rel,
+            None if tail.is_empty() => "",
+            None => {
+                return Err(invalid(
+                    target,
+                    "unexpected characters after quoted object id",
+                ))
+            }
+        };
+        (object_id, relation)
+    } else {
+        // Unquoted: a bare object id with an optional '#relation'.
+        match rest.split_once('#') {
+            Some((object_id, relation)) => (object_id, relation),
+            None => (rest, ""),
+        }
+    };
+
+    if object_id.is_empty() {
+        return Err(invalid(target, "empty object id"));
+    }
+    if !relation.is_empty() && relation.contains('#') {
+        return Err(invalid(target, "relation must not contain '#'"));
+    }
+
+    Ok(Subject::entity_set(resource, object_id, relation))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn es(s: &str) -> (String, String, String) {
+        match parse_target_subject(s).unwrap() {
+            Subject::EntitySet {
+                resource,
+                object_id,
+                relation,
+            } => (resource, object_id, relation),
+            other => panic!("expected EntitySet, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_wildcard() {
+        assert!(matches!(
+            parse_target_subject("*").unwrap(),
+            Subject::Wildcard
+        ));
+    }
+
+    #[test]
+    fn parses_actor_did() {
+        let s = parse_target_subject("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
+            .unwrap();
+        assert!(s.is_entity());
+    }
+
+    #[test]
+    fn parses_object_edge() {
+        assert_eq!(
+            es("directory:teamdir"),
+            ("directory".into(), "teamdir".into(), String::new())
+        );
+    }
+
+    #[test]
+    fn parses_userset() {
+        assert_eq!(
+            es("group:hr#participant"),
+            ("group".into(), "hr".into(), "participant".into())
+        );
+    }
+
+    #[test]
+    fn parses_quoted_path_object_id() {
+        // The hardening case: a path-like object id that the naive split mangles.
+        assert_eq!(
+            es("directory:\"/team\""),
+            ("directory".into(), "/team".into(), String::new())
+        );
+    }
+
+    #[test]
+    fn parses_quoted_object_id_with_embedded_separators() {
+        assert_eq!(
+            es("directory:\"a:b#c\""),
+            ("directory".into(), "a:b#c".into(), String::new())
+        );
+    }
+
+    #[test]
+    fn parses_quoted_object_id_with_userset_relation() {
+        assert_eq!(
+            es("directory:\"/team\"#reader"),
+            ("directory".into(), "/team".into(), "reader".into())
+        );
+    }
+
+    #[test]
+    fn rejects_unqualified_target() {
+        assert!(parse_target_subject("not-a-target").is_err());
+    }
+
+    #[test]
+    fn rejects_unterminated_quote() {
+        assert!(parse_target_subject("directory:\"/team").is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_did() {
+        assert!(parse_target_subject("did:bogus").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_object_id() {
+        assert!(parse_target_subject("directory:").is_err());
+    }
+}

--- a/crates/cli/src/doc_acp_adapter.rs
+++ b/crates/cli/src/doc_acp_adapter.rs
@@ -128,9 +128,11 @@ impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
 
         let (policy_id, resource_name) = self.get_policy_info(collection)?;
 
-        let target: identity::Did = target_actor
-            .parse()
-            .map_err(|e| format!("invalid target actor DID: {}", e))?;
+        // Parse the target into a structured subject once, at the edge: an actor
+        // DID, all-actors `*`, a cross-object edge, or a userset. The structured
+        // subject is carried straight into the API, never re-stringified.
+        let target = acp::parse_target_subject(target_actor)
+            .map_err(|e| format!("invalid target: {}", e))?;
 
         let managing = self
             .validate_and_get_managing_relations(&policy_id, &resource_name, relation)
@@ -138,9 +140,9 @@ impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
 
         let added = self
             .acp
-            .add_actor_relationship(
+            .add_relationship(
                 requestor,
-                &target,
+                target,
                 &policy_id,
                 &resource_name,
                 doc_id,

--- a/crates/query-plan/tests/cross_object_read_path.rs
+++ b/crates/query-plan/tests/cross_object_read_path.rs
@@ -1,0 +1,133 @@
+//! Read-path coverage for cross-object (collection-level) ACP grants.
+//!
+//! The query engine gates every read — User queries (`select`, `aggregate`) and
+//! Commits queries alike — through `check_doc_access_with_overlay`. That gate's
+//! overlay only projects deferred *registration*; access resolution falls
+//! straight through to the backend's `check_doc_access`. So a cross-object grant
+//! resolved by the Zanzibar backend is honoured uniformly across both read
+//! paths. This proves it at the gate the runner actually calls.
+//!
+//! (True HTTP end-to-end waits on backend selection — the default embedded
+//! backend is Local, which cannot represent a cross-object subject.)
+
+use std::sync::Arc;
+
+use acp::{
+    policy_yaml::{build_policy, parse_policy_yaml},
+    DocumentACP, DocumentPermission, Identity, MemoryZanzibarStore, Subject, ZanzibarDocumentACP,
+    ZanzibarStore,
+};
+use identity::Did;
+use query_plan::txn::check_doc_access_with_overlay;
+
+const FS_POLICY: &str = r#"
+name: filesystem
+resources:
+- name: directory
+  permissions:
+  - name: read
+    expr: reader
+  - name: update
+    expr: reader
+  - name: delete
+    expr: reader
+  relations:
+  - name: reader
+    types: [actor]
+- name: file
+  permissions:
+  - name: read
+    expr: reader + parent->read
+  - name: update
+    expr: reader
+  - name: delete
+    expr: reader
+  relations:
+  - name: reader
+    types: [actor]
+  - name: parent
+    types: [directory]
+"#;
+
+fn did(s: &str) -> Did {
+    Did::new(s).unwrap()
+}
+
+async fn gate_allows(
+    acp: &ZanzibarDocumentACP<MemoryZanzibarStore>,
+    policy_id: &str,
+    who: &Did,
+    resource: &str,
+    doc: &str,
+) -> bool {
+    check_doc_access_with_overlay(
+        acp,
+        &Identity::Authenticated(who.clone()),
+        DocumentPermission::Read,
+        policy_id,
+        resource,
+        doc,
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn query_gate_honours_cross_object_read_inheritance() {
+    let owner = did("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+    let alice = did("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH");
+    let bob = did("did:key:z6MknSLrJoTcukLrE435hVNQT4JUhbvWLX4kUzqkEStBU8Vi");
+
+    let parsed = parse_policy_yaml(FS_POLICY).unwrap();
+    let policy = build_policy(&parsed, 1).unwrap();
+    let policy_id = policy.id.clone();
+
+    let store = Arc::new(MemoryZanzibarStore::new());
+    store.store_policy(&policy).await.unwrap();
+    let acp = ZanzibarDocumentACP::new(store);
+
+    acp.register_doc_object(&owner, &policy_id, "directory", "teamdir")
+        .await
+        .unwrap();
+    acp.register_doc_object(&owner, &policy_id, "file", "report")
+        .await
+        .unwrap();
+    acp.add_relationship(
+        &owner,
+        Subject::Entity(alice.clone()),
+        &policy_id,
+        "directory",
+        "teamdir",
+        "reader",
+        &[],
+    )
+    .await
+    .unwrap();
+
+    // Before the parent edge: the query gate denies alice on the file.
+    assert!(!gate_allows(&acp, &policy_id, &alice, "file", "report").await);
+
+    // Seed the cross-object parent edge through the widened API.
+    acp.add_relationship(
+        &owner,
+        Subject::entity_set("directory", "teamdir", ""),
+        &policy_id,
+        "file",
+        "report",
+        "parent",
+        &[],
+    )
+    .await
+    .unwrap();
+
+    // The query gate now resolves alice's read of the file via
+    // parent->read -> directory#read -> reader. This is the exact gate every
+    // User and Commits read funnels through.
+    assert!(
+        gate_allows(&acp, &policy_id, &alice, "file", "report").await,
+        "query gate must honour the cross-object read inheritance"
+    );
+
+    // bob has no grant -> still denied through the cone.
+    assert!(!gate_allows(&acp, &policy_id, &bob, "file", "report").await);
+}


### PR DESCRIPTION
## What

Step 2b of the document-path track: wire the widened `add_relationship(Subject)` API (#1060) through to the CLI and HTTP document-ACP relationship-add commands, so a target can be entered as a human string and become a structured `Subject` — actor DID, all-actors `*`, cross-object edge, or userset.

## Changes

- **`acp::parse_target_subject`** — the single string→`Subject` boundary. **Hardened** beyond the spike's naive `split_once`: object ids may be quoted to carry path-like / separator-bearing values without mis-splitting:
  - `directory:"/team"` → object-edge to `/team`
  - `directory:"a:b#c"` → object id `a:b#c` (embedded `:`/`#` preserved)
  - `group:hr#participant` → userset · `*` → wildcard · `did:…` → entity
  - 11 unit tests incl. quoted paths, embedded separators, unterminated-quote and malformed rejection.
- **CLI + HTTP edge** route through one shared adapter trait → parse **once** into a structured `Subject`, passed straight to `add_relationship` — **never re-stringified**, so structure survives to the backend (and later the SourceHub provider's per-kind wire encoding per the frozen contract).
- **Read-path coverage** — `query_gate_honours_cross_object_read_inheritance` drives `check_doc_access_with_overlay`, the exact gate **every User (select/aggregate) and Commits read** funnels through. Its overlay is subject-agnostic (projects registration only; access resolution falls through to `check_doc_access`), so a cross-object grant resolves uniformly across both paths.

## Scope / follow-ups
- **Delete stays actor-only** — `delete_relationship → Subject` is a queued follow-up (pairs with the SourceHub provider work against the frozen wire).
- **True HTTP e2e** waits on **backend selection** (the default embedded backend is Local, which cannot represent a cross-object subject) — called out in the read-path test.

Full `acp` + `query-plan` suites green; clippy `-D warnings` clean across acp/query-plan/cli/defra-http; cli+http build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)