### PR TITLE
feat(acp): widen delete_relationship to Subject (revoke cross-object edges)

### DIFF
--- a/crates/acp/src/dac.rs
+++ b/crates/acp/src/dac.rs
@@ -199,6 +199,47 @@ pub trait DocumentACP: MaybeSendSync {
         managing_relations: &[String],
     ) -> Result<bool>;
 
+    /// Remove a relationship whose target may be any [`Subject`] — an actor DID,
+    /// the all-actors wildcard, a cross-object edge, or a userset.
+    ///
+    /// This is the revoke mirror of [`add_relationship`](Self::add_relationship):
+    /// an edge that can be granted through a structured subject must also be
+    /// removable through one, so a cross-object edge can be revoked rather than
+    /// leaking access forever.
+    ///
+    /// The default implementation supports only actor subjects (a DID or `*`),
+    /// delegating to [`delete_actor_relationship`](Self::delete_actor_relationship),
+    /// and rejects anything a bare-DID backend cannot represent with
+    /// [`Error::UnsupportedSubject`]. Backends that model the full subject
+    /// language (the Zanzibar backend) override this to remove cross-object and
+    /// userset edges.
+    async fn delete_relationship(
+        &self,
+        requestor: &Did,
+        target: Subject,
+        policy_id: &str,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
+        managing_relations: &[String],
+    ) -> Result<bool> {
+        let actor = match target {
+            Subject::Entity(did) => did,
+            Subject::Wildcard => Did::wildcard(),
+            other => return Err(Error::UnsupportedSubject(other.to_string())),
+        };
+        self.delete_actor_relationship(
+            requestor,
+            &actor,
+            policy_id,
+            collection_id,
+            doc_id,
+            relation,
+            managing_relations,
+        )
+        .await
+    }
+
     /// Unregister a document, removing all ACP tuples.
     ///
     /// This should be called when a document is deleted to clean up

--- a/crates/acp/src/zanzibar/acp/document_acp.rs
+++ b/crates/acp/src/zanzibar/acp/document_acp.rs
@@ -272,6 +272,30 @@ impl<S: ZanzibarStore + ?Sized + 'static> DocumentACP for ZanzibarDocumentACP<S>
         collection_id: &str,
         doc_id: &str,
         relation: &str,
+        managing_relations: &[String],
+    ) -> Result<bool> {
+        // The actor path is a thin wrapper over the general subject path, so
+        // authority runs through a single implementation.
+        self.delete_relationship(
+            requestor,
+            actor_subject(target),
+            policy_id,
+            collection_id,
+            doc_id,
+            relation,
+            managing_relations,
+        )
+        .await
+    }
+
+    async fn delete_relationship(
+        &self,
+        requestor: &Did,
+        target: Subject,
+        policy_id: &str,
+        collection_id: &str,
+        doc_id: &str,
+        relation: &str,
         _managing_relations: &[String],
     ) -> Result<bool> {
         self.ensure_policy(policy_id, collection_id).await?;
@@ -292,7 +316,9 @@ impl<S: ZanzibarStore + ?Sized + 'static> DocumentACP for ZanzibarDocumentACP<S>
         )
         .await?;
 
-        let rel = Relationship::new(collection_id, doc_id, relation, actor_subject(target));
+        // No floor validation on the revoke path: type validation guards what a
+        // grant introduces, but a revoke only removes an existing edge.
+        let rel = Relationship::new(collection_id, doc_id, relation, target);
         let deleted = self.store.delete_relationship(policy_id, &rel).await?;
 
         if deleted {
@@ -300,18 +326,18 @@ impl<S: ZanzibarStore + ?Sized + 'static> DocumentACP for ZanzibarDocumentACP<S>
                 target: "acp::audit",
                 event = "relationship_deleted",
                 requestor = %requestor,
-                target = %target,
+                subject = %rel.subject,
                 relation = %relation,
                 collection = %collection_id,
                 doc_id = %doc_id,
-                "Actor relationship deleted via Zanzibar"
+                "Relationship deleted via Zanzibar"
             );
         } else {
             tracing::debug!(
                 target: "acp::audit",
                 event = "relationship_not_found",
                 requestor = %requestor,
-                target = %target,
+                subject = %rel.subject,
                 relation = %relation,
                 collection = %collection_id,
                 doc_id = %doc_id,

--- a/crates/acp/tests/cross_object_ttu.rs
+++ b/crates/acp/tests/cross_object_ttu.rs
@@ -192,6 +192,93 @@ async fn add_relationship_enforces_the_subject_floor() {
 }
 
 #[tokio::test]
+async fn cross_object_revoke_removes_inherited_access() {
+    // The security property: an inherited cross-object grant can be REVOKED.
+    let (acp, policy_id) = fs_acp().await;
+    let owner = did_owner();
+
+    // alice is a direct reader on the directory.
+    acp.add_relationship(
+        &owner,
+        Subject::Entity(did_alice()),
+        &policy_id,
+        "directory",
+        "teamdir",
+        "reader",
+        &[],
+    )
+    .await
+    .unwrap();
+
+    // Seed the cross-object parent edge so the file inherits directory reads.
+    acp.add_relationship(
+        &owner,
+        Subject::entity_set("directory", "teamdir", ""),
+        &policy_id,
+        "file",
+        "report",
+        "parent",
+        &[],
+    )
+    .await
+    .unwrap();
+    assert!(
+        can_read(&acp, &policy_id, did_alice(), "file", "report").await,
+        "alice reads the file via the cross-object parent edge"
+    );
+
+    // Revoke the cross-object edge through the widened delete API.
+    let deleted = acp
+        .delete_relationship(
+            &owner,
+            Subject::entity_set("directory", "teamdir", ""),
+            &policy_id,
+            "file",
+            "report",
+            "parent",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(deleted, "the cross-object parent edge should be removed");
+
+    // AFTER revoke: alice can no longer reach the file. Access did not leak.
+    assert!(
+        !can_read(&acp, &policy_id, did_alice(), "file", "report").await,
+        "revoking the parent edge must remove inherited file access"
+    );
+}
+
+#[tokio::test]
+async fn local_backend_rejects_cross_object_delete() {
+    // The Local backend stores bare DIDs and cannot represent a cross-object
+    // edge; it must reject a delete of one with a typed UnsupportedSubject error.
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let owner = did_owner();
+    acp.register_doc_object(&owner, "policy1", "file", "report")
+        .await
+        .unwrap();
+
+    let err = acp
+        .delete_relationship(
+            &owner,
+            Subject::entity_set("directory", "teamdir", ""),
+            "policy1",
+            "file",
+            "report",
+            "parent",
+            &[],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::UnsupportedSubject(_)),
+        "Local backend must reject a cross-object delete subject, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
 async fn local_backend_rejects_cross_object_subjects() {
     // The Local backend stores bare DIDs and cannot represent a cross-object
     // edge; it must reject one with a typed UnsupportedSubject error.

--- a/crates/cli/src/doc_acp_adapter.rs
+++ b/crates/cli/src/doc_acp_adapter.rs
@@ -176,9 +176,12 @@ impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
 
         let (policy_id, resource_name) = self.get_policy_info(collection)?;
 
-        let target: identity::Did = target_actor
-            .parse()
-            .map_err(|e| format!("invalid target actor DID: {}", e))?;
+        // Parse the target into a structured subject once, at the edge: an actor
+        // DID, all-actors `*`, a cross-object edge, or a userset. A revoke must
+        // accept every subject a grant accepts, or a cross-object edge could be
+        // granted but never removed.
+        let target = acp::parse_target_subject(target_actor)
+            .map_err(|e| format!("invalid target: {}", e))?;
 
         let managing = self
             .validate_and_get_managing_relations(&policy_id, &resource_name, relation)
@@ -186,9 +189,9 @@ impl<S: Store + 'static> DocumentAcpOperations for DocumentAcpAdapter<S> {
 
         let deleted = self
             .acp
-            .delete_actor_relationship(
+            .delete_relationship(
                 requestor,
-                &target,
+                target,
                 &policy_id,
                 &resource_name,
                 doc_id,


### PR DESCRIPTION
## What

Closes a **security-critical** grant/revoke asymmetry surfaced in review: a cross-object ACP edge could be **granted** via `add_relationship(Subject)` (#1060) but **never revoked** — delete was DID-only at the trait/CLI/HTTP, so a bad `parent` cone leaked inherited access **forever**.

## Changes (exact mirror of the add-side)
- `DocumentACP::delete_relationship(target: Subject)` — provided trait default (actor/`*` → `delete_actor_relationship`; else → typed `UnsupportedSubject`).
- Zanzibar backend overrides it (manage-relation `"delete"` auth + owner guard → `store.delete_relationship`) and routes `delete_actor_relationship` through it. **No floor validate on revoke** — validation guards grants; a revoke only removes an existing edge.
- CLI + HTTP delete edge (one shared adapter) → `parse_target_subject` → `delete_relationship`.

## Tests
- `cross_object_revoke_removes_inherited_access` — the security property: grant alice via the cross-object `parent` cone, confirm inherited read, **revoke the edge, confirm read is gone**.
- `local_backend_rejects_cross_object_delete` → `UnsupportedSubject`.

Full `acp` suite green; clippy `-D warnings` clean; cli+http build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)