### PR TITLE
fix(zanzibar): don't memoize cycle-truncated check results

### DIFF
--- a/crates/acp/tests/zanzibar_engine_tests.rs
+++ b/crates/acp/tests/zanzibar_engine_tests.rs
@@ -443,3 +443,52 @@ async fn test_explain_denied() {
         .collect();
     assert!(!denied_steps.is_empty());
 }
+
+// Regression: a cycle-truncated `false` must not be memoized under the
+// trail-independent cache key, or a diamond+cycle replays a wrong DENY.
+//
+// perm = y & x ; y = x + this ; x = y. A direct grant on `y` makes x genuinely
+// true (x = y = granted). Evaluating the intersection's `y` arm first walks
+// y -> x -> y, truncating the cycle to x=false and (buggily) caching it; the
+// `x` arm then reads that poisoned false and the intersection wrongly denies.
+#[tokio::test]
+async fn cache_does_not_replay_cycle_truncated_deny() {
+    let store = Arc::new(MemoryZanzibarStore::new());
+    let mut engine = PermissionEngine::new(store.clone());
+
+    let policy = Policy::new("policy1", "Test").with_resource(
+        Resource::new("doc")
+            .with_relation(Relation::computed(
+                "x",
+                RelationExpression::computed_userset("y"),
+            ))
+            .with_relation(Relation::computed(
+                "y",
+                RelationExpression::union(vec![
+                    RelationExpression::computed_userset("x"),
+                    RelationExpression::this(),
+                ]),
+            ))
+            .with_relation(Relation::computed(
+                "perm",
+                RelationExpression::intersection(vec![
+                    RelationExpression::computed_userset("y"),
+                    RelationExpression::computed_userset("x"),
+                ]),
+            )),
+    );
+    engine.add_policy(&policy);
+
+    let did = test_did();
+    let rel = Relationship::with_entity("doc", "doc1", "y", did.clone());
+    store.store_relationship("policy1", &rel).await.unwrap();
+
+    let granted = engine
+        .check("policy1", "doc", "doc1", "perm", &did)
+        .await
+        .unwrap();
+    assert!(
+        granted,
+        "perm = y & x must be granted; the cache must not replay the cycle-truncated x=false"
+    );
+}

--- a/crates/zanzibar/src/engine/evaluate.rs
+++ b/crates/zanzibar/src/engine/evaluate.rs
@@ -10,6 +10,15 @@ use crate::expression::RelationExpression;
 use crate::store::ZanzibarStore;
 use crate::types::Subject;
 
+/// Evaluation result paired with a `tainted` flag.
+///
+/// A result is *tainted* when it depended on a cycle truncation (a node revisited
+/// on the current trail, evaluated as `false`). Such a result is only valid for
+/// the trail that produced it — the same node reached via a different trail can
+/// resolve differently — so a tainted result must NOT be memoized in the
+/// trail-independent [`CheckCache`].
+type Eval = (bool, bool);
+
 impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn evaluate_expr_cached<'a>(
@@ -22,13 +31,14 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
         expression: &'a RelationExpression,
         trail: NodeTrail,
         cache: Arc<CheckCache>,
-    ) -> MaybeBoxFuture<'a, Result<bool>> {
+    ) -> MaybeBoxFuture<'a, Result<Eval>> {
         Box::pin(async move {
             if let Some(cached) = cache.get(resource, object_id, relation, subject).await {
-                return Ok(cached);
+                // Only untainted results are ever stored, so a hit is trail-independent.
+                return Ok((cached, false));
             }
 
-            let result = self
+            let (value, tainted) = self
                 .evaluate_expr_inner(
                     policy_id,
                     resource,
@@ -41,11 +51,13 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                 )
                 .await?;
 
-            cache
-                .set(resource, object_id, relation, subject, result)
-                .await;
+            if !tainted {
+                cache
+                    .set(resource, object_id, relation, subject, value)
+                    .await;
+            }
 
-            Ok(result)
+            Ok((value, tainted))
         })
     }
 
@@ -60,13 +72,15 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
         expression: &'a RelationExpression,
         trail: NodeTrail,
         cache: Arc<CheckCache>,
-    ) -> MaybeBoxFuture<'a, Result<bool>> {
+    ) -> MaybeBoxFuture<'a, Result<Eval>> {
         Box::pin(async move {
             match expression {
                 RelationExpression::This => {
-                    self.store
+                    let granted = self
+                        .store
                         .check_permission_direct(policy_id, resource, object_id, relation, subject)
-                        .await
+                        .await?;
+                    Ok((granted, false))
                 }
 
                 RelationExpression::ComputedUserset {
@@ -74,7 +88,8 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                 } => {
                     let node_id = NodeId::new(resource, object_id, computed_rel);
                     if trail.contains(&node_id) {
-                        return Ok(false);
+                        // Cycle truncation: trail-dependent, must not be cached.
+                        return Ok((false, true));
                     }
                     let new_trail = trail.with_node(node_id);
 
@@ -99,6 +114,8 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                     tuple_relation,
                     computed_relation,
                 } => {
+                    let mut tainted = false;
+
                     let targets = self
                         .store
                         .get_relation_targets(policy_id, resource, object_id, tuple_relation)
@@ -108,6 +125,8 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                         let node_id =
                             NodeId::new(&target.resource, &target.object_id, computed_relation);
                         if trail.contains(&node_id) {
+                            // Skipping a cycled target taints the eventual `false`.
+                            tainted = true;
                             continue;
                         }
                         let new_trail = trail.with_node(node_id);
@@ -118,7 +137,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                             computed_relation,
                         )?;
 
-                        if self
+                        let (granted, t) = self
                             .evaluate_expr_cached(
                                 policy_id,
                                 &target.resource,
@@ -129,10 +148,11 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                 new_trail,
                                 cache.clone(),
                             )
-                            .await?
-                        {
-                            return Ok(true);
+                            .await?;
+                        if granted {
+                            return Ok((true, t));
                         }
+                        tainted |= t;
                     }
 
                     let subjects = self
@@ -153,6 +173,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                     computed_relation,
                                 );
                                 if trail.contains(&node_id) {
+                                    tainted = true;
                                     continue;
                                 }
                                 let new_trail = trail.with_node(node_id);
@@ -163,7 +184,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                     computed_relation,
                                 )?;
 
-                                if self
+                                let (granted, t) = self
                                     .evaluate_expr_cached(
                                         policy_id,
                                         &target_resource,
@@ -174,13 +195,14 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                         new_trail,
                                         cache.clone(),
                                     )
-                                    .await?
-                                {
-                                    return Ok(true);
+                                    .await?;
+                                if granted {
+                                    return Ok((true, t));
                                 }
+                                tainted |= t;
                             }
                             Subject::Wildcard | Subject::TypedWildcard { .. } => {
-                                return Ok(true);
+                                return Ok((true, false));
                             }
                             Subject::Entity(_) => {
                                 continue;
@@ -188,12 +210,13 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                         }
                     }
 
-                    Ok(false)
+                    Ok((false, tainted))
                 }
 
                 RelationExpression::Union(exprs) => {
+                    let mut tainted = false;
                     for expr in exprs {
-                        if self
+                        let (granted, t) = self
                             .evaluate_expr_inner(
                                 policy_id,
                                 resource,
@@ -204,17 +227,20 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                 trail.clone(),
                                 cache.clone(),
                             )
-                            .await?
-                        {
-                            return Ok(true);
+                            .await?;
+                        if granted {
+                            // A true short-circuits on this branch alone.
+                            return Ok((true, t));
                         }
+                        tainted |= t;
                     }
-                    Ok(false)
+                    Ok((false, tainted))
                 }
 
                 RelationExpression::Intersection(exprs) => {
+                    let mut tainted = false;
                     for expr in exprs {
-                        if !self
+                        let (granted, t) = self
                             .evaluate_expr_inner(
                                 policy_id,
                                 resource,
@@ -225,16 +251,18 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                 trail.clone(),
                                 cache.clone(),
                             )
-                            .await?
-                        {
-                            return Ok(false);
+                            .await?;
+                        if !granted {
+                            // A false short-circuits on this branch alone.
+                            return Ok((false, t));
                         }
+                        tainted |= t;
                     }
-                    Ok(true)
+                    Ok((true, tainted))
                 }
 
                 RelationExpression::Difference { base, subtract } => {
-                    let base_result = self
+                    let (base_granted, base_tainted) = self
                         .evaluate_expr_inner(
                             policy_id,
                             resource,
@@ -247,18 +275,18 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                         )
                         .await?;
 
-                    if !base_result {
-                        return Ok(false);
+                    if !base_granted {
+                        return Ok((false, base_tainted));
                     }
 
-                    let subtract_result = self
+                    let (subtract_granted, subtract_tainted) = self
                         .evaluate_expr_inner(
                             policy_id, resource, object_id, relation, subject, subtract, trail,
                             cache,
                         )
                         .await?;
 
-                    Ok(!subtract_result)
+                    Ok((!subtract_granted, base_tainted || subtract_tainted))
                 }
             }
         })

--- a/crates/zanzibar/src/engine/mod.rs
+++ b/crates/zanzibar/src/engine/mod.rs
@@ -151,10 +151,12 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
 
         let cache = Arc::new(CheckCache::new());
 
-        self.evaluate_expr_cached(
-            policy_id, resource, object_id, relation, subject, expression, trail, cache,
-        )
-        .await
+        let (granted, _tainted) = self
+            .evaluate_expr_cached(
+                policy_id, resource, object_id, relation, subject, expression, trail, cache,
+            )
+            .await?;
+        Ok(granted)
     }
 
     /// Synchronous, runtime-free wrapper over [`check`](Self::check) for
@@ -225,10 +227,12 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
         let node_id = NodeId::new(resource, object_id, relation);
         let trail = NodeTrail::new().with_node(node_id);
 
-        self.evaluate_expr_cached(
-            policy_id, resource, object_id, relation, subject, expression, trail, cache,
-        )
-        .await
+        let (granted, _tainted) = self
+            .evaluate_expr_cached(
+                policy_id, resource, object_id, relation, subject, expression, trail, cache,
+            )
+            .await?;
+        Ok(granted)
     }
 
     pub async fn explain(

--- a/crates/zanzibar/src/engine/trace.rs
+++ b/crates/zanzibar/src/engine/trace.rs
@@ -166,6 +166,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                 cache.clone(),
                             )
                             .await?
+                            .0
                         {
                             trace.add_step(EvaluationStep {
                                 expression_type: "TTU target match".to_string(),
@@ -222,6 +223,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                         cache.clone(),
                                     )
                                     .await?
+                                    .0
                                 {
                                     trace.add_step(EvaluationStep {
                                         expression_type: "TTU EntitySet match".to_string(),
@@ -289,6 +291,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                 cache.clone(),
                             )
                             .await?
+                            .0
                         {
                             trace.add_step(EvaluationStep {
                                 expression_type: format!("Union branch {}", i + 1),
@@ -337,6 +340,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                                 cache.clone(),
                             )
                             .await?
+                            .0
                         {
                             trace.add_step(EvaluationStep {
                                 expression_type: format!("Intersection branch {}", i + 1),
@@ -372,7 +376,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                         details: Some("Evaluating base AND NOT subtract".to_string()),
                     });
 
-                    let base_result = self
+                    let (base_result, _) = self
                         .evaluate_expr_inner(
                             policy_id,
                             resource,
@@ -397,7 +401,7 @@ impl<S: ZanzibarStore + ?Sized> PermissionEngine<S> {
                         return Ok(false);
                     }
 
-                    let subtract_result = self
+                    let (subtract_result, _) = self
                         .evaluate_expr_inner(
                             policy_id, resource, object_id, relation, subject, subtract, trail,
                             cache,


### PR DESCRIPTION
## The bug (shared engine — hits all three consumers)

`PermissionEngine`'s `CheckCache` keys on `(resource, object_id, relation, subject)` — **trail-independent** — but a cycle truncation (`evaluate.rs`: a node revisited on the current trail → `false`) is **trail-dependent**: the same node reached via a different trail can resolve `true`. Memoizing that truncated `false` (`cache.rs:55` / the `cache.set` at `evaluate.rs:44-46`) lets a **diamond+cycle graph replay a wrong DENY**. Fail-closed, but incorrect — and the engine is shared by node, the RL harness, and hub.

## Fix — taint propagation

`evaluate_expr_inner`/`evaluate_expr_cached` now return `(value, tainted)`. `tainted` marks a result that consumed a cycle truncation; **tainted results are never cached**, and taint propagates precisely:
- Union/Intersection: short-circuit carries only the deciding branch's taint; a non-deciding result ORs all branches'.
- Difference: `base` (if false) else `base | subtract`.
- TTU: accumulates over skipped-cycle targets and evaluated-false targets; a grant carries only its branch's taint.

Cache hits are untainted by construction.

## Regression test

`cache_does_not_replay_cycle_truncated_deny`: `perm = y & x`, `y = x + this`, `x = y`, direct grant on `y`. The intersection's `y` arm evaluates first, truncating `x→y→x` and (pre-fix) caching `x=false`; the `x` arm replayed it → wrong DENY. **Confirmed red before, green after.** `x` is genuinely true (`x = y`, granted), so `perm` must grant.

Full `zanzibar` + `acp` suites green (incl. all TTU/stress/cycle tests); clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)