### PR TITLE
feat(sourcehub): emit structured cross-object subjects to hub.rs (B3)

### DIFF
--- a/crates/sourcehub/src/cosmos/dac.rs
+++ b/crates/sourcehub/src/cosmos/dac.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use identity::Did;
 
-use acp::{DocumentACP, DocumentPermission, Identity, Result};
+use acp::{DocumentACP, DocumentPermission, Identity, Result, Subject};
 
 use crate::access_cache::AccessCache;
 use crate::provider::{AcpLightClientStatus, ProviderError, SourceHubProvider, SubjectRef};
@@ -100,6 +100,17 @@ fn did_to_subject(target: &Did) -> SubjectRef {
         SubjectRef::AllActors
     } else {
         SubjectRef::Actor(target.as_str().to_string())
+    }
+}
+
+/// Lowers an actor [`Subject`] (`Entity`/`Wildcard`) to the bare-DID actor the
+/// existing relationship path operates on. Non-actor subjects must be routed to
+/// the structured `*_relationship_subject` provider methods instead.
+fn subject_to_actor_did(target: &Subject) -> Did {
+    match target {
+        Subject::Wildcard => Did::wildcard(),
+        Subject::Entity(did) => Did::new_unchecked(did.to_string()),
+        _ => Did::new_unchecked(String::new()),
     }
 }
 
@@ -307,6 +318,102 @@ impl DocumentACP for SourceHubDocumentACP {
         Ok(result)
     }
 
+    async fn add_relationship(
+        &self,
+        requestor: &Did,
+        target: Subject,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+        relation: &str,
+        managing_relations: &[String],
+    ) -> Result<bool> {
+        match target {
+            Subject::Entity(_) | Subject::Wildcard => {
+                let actor = subject_to_actor_did(&target);
+                self.add_actor_relationship(
+                    requestor,
+                    &actor,
+                    policy_id,
+                    resource_name,
+                    doc_id,
+                    relation,
+                    managing_relations,
+                )
+                .await
+            }
+            Subject::EntitySet { .. } => {
+                let (kind, sr, so, srel) =
+                    zanzibar::encode_subject(&target).map_err(acp::Error::from)?;
+                let result = self
+                    .provider
+                    .set_relationship_subject(
+                        policy_id,
+                        resource_name,
+                        doc_id,
+                        relation,
+                        kind,
+                        &sr,
+                        &so,
+                        &srel,
+                    )
+                    .await
+                    .map_err(provider_err)?;
+                self.invalidate_cached_access(policy_id, resource_name, doc_id);
+                Ok(result)
+            }
+            other => Err(acp::Error::UnsupportedSubject(other.to_string())),
+        }
+    }
+
+    async fn delete_relationship(
+        &self,
+        requestor: &Did,
+        target: Subject,
+        policy_id: &str,
+        resource_name: &str,
+        doc_id: &str,
+        relation: &str,
+        managing_relations: &[String],
+    ) -> Result<bool> {
+        match target {
+            Subject::Entity(_) | Subject::Wildcard => {
+                let actor = subject_to_actor_did(&target);
+                self.delete_actor_relationship(
+                    requestor,
+                    &actor,
+                    policy_id,
+                    resource_name,
+                    doc_id,
+                    relation,
+                    managing_relations,
+                )
+                .await
+            }
+            Subject::EntitySet { .. } => {
+                let (kind, sr, so, srel) =
+                    zanzibar::encode_subject(&target).map_err(acp::Error::from)?;
+                let result = self
+                    .provider
+                    .delete_relationship_subject(
+                        policy_id,
+                        resource_name,
+                        doc_id,
+                        relation,
+                        kind,
+                        &sr,
+                        &so,
+                        &srel,
+                    )
+                    .await
+                    .map_err(provider_err)?;
+                self.invalidate_cached_access(policy_id, resource_name, doc_id);
+                Ok(result)
+            }
+            other => Err(acp::Error::UnsupportedSubject(other.to_string())),
+        }
+    }
+
     async fn unregister_doc_object(
         &self,
         policy_id: &str,
@@ -347,10 +454,21 @@ mod tests {
 
     use super::*;
 
+    /// Records which relationship-emitting provider method a routing test drove,
+    /// plus the structured-subject codec tuple for the EntitySet path.
+    #[derive(Default)]
+    struct RelationshipCalls {
+        set_relationship: bool,
+        delete_relationship: bool,
+        set_subject: Option<(u8, String, String, String)>,
+        delete_subject: Option<(u8, String, String, String)>,
+    }
+
     struct MockProvider {
         decisions: Mutex<VecDeque<bool>>,
         created_decision: Mutex<Option<String>>,
         verify_calls: Mutex<usize>,
+        rel_calls: Mutex<RelationshipCalls>,
     }
 
     impl MockProvider {
@@ -359,6 +477,7 @@ mod tests {
                 decisions: Mutex::new(decisions.into()),
                 created_decision: Mutex::new(None),
                 verify_calls: Mutex::new(0),
+                rel_calls: Mutex::new(RelationshipCalls::default()),
             }
         }
 
@@ -381,7 +500,7 @@ mod tests {
             &self,
             _did: &str,
         ) -> std::result::Result<String, ProviderError> {
-            unreachable!("create_bearer_token is not used in this test")
+            Ok("mock.bearer.token".to_string())
         }
 
         fn self_did(&self) -> Option<String> {
@@ -424,7 +543,8 @@ mod tests {
             _relation: &str,
             _subject: &SubjectRef,
         ) -> std::result::Result<bool, ProviderError> {
-            unreachable!("set_relationship is not used in this test")
+            self.rel_calls.lock().unwrap().set_relationship = true;
+            Ok(true)
         }
 
         async fn delete_relationship(
@@ -436,7 +556,48 @@ mod tests {
             _relation: &str,
             _subject: &SubjectRef,
         ) -> std::result::Result<bool, ProviderError> {
-            unreachable!("delete_relationship is not used in this test")
+            self.rel_calls.lock().unwrap().delete_relationship = true;
+            Ok(true)
+        }
+
+        async fn set_relationship_subject(
+            &self,
+            _policy_id: &str,
+            _resource: &str,
+            _object_id: &str,
+            _relation: &str,
+            kind: u8,
+            subject_resource: &str,
+            subject_object_id: &str,
+            subject_relation: &str,
+        ) -> std::result::Result<bool, ProviderError> {
+            self.rel_calls.lock().unwrap().set_subject = Some((
+                kind,
+                subject_resource.to_string(),
+                subject_object_id.to_string(),
+                subject_relation.to_string(),
+            ));
+            Ok(true)
+        }
+
+        async fn delete_relationship_subject(
+            &self,
+            _policy_id: &str,
+            _resource: &str,
+            _object_id: &str,
+            _relation: &str,
+            kind: u8,
+            subject_resource: &str,
+            subject_object_id: &str,
+            subject_relation: &str,
+        ) -> std::result::Result<bool, ProviderError> {
+            self.rel_calls.lock().unwrap().delete_subject = Some((
+                kind,
+                subject_resource.to_string(),
+                subject_object_id.to_string(),
+                subject_relation.to_string(),
+            ));
+            Ok(true)
         }
 
         async fn query_policy(
@@ -571,5 +732,242 @@ mod tests {
 
         assert_eq!(decision_id, Some(format!("decision-for-{}", did.as_str())));
         assert_eq!(provider.created_decision(), decision_id);
+    }
+
+    fn requestor() -> Did {
+        Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
+    }
+
+    #[tokio::test]
+    async fn add_relationship_routes_actor_to_set_relationship() {
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let acp = SourceHubDocumentACP::without_access_cache(provider.clone());
+        let target = Subject::Entity(zanzibar::Did::new_unchecked(
+            "did:key:zActorTarget".to_string(),
+        ));
+
+        let result = acp
+            .add_relationship(
+                &requestor(),
+                target,
+                "policy-1",
+                "users",
+                "doc-1",
+                "reader",
+                &[],
+            )
+            .await
+            .expect("actor relationship should route to set_relationship");
+        assert!(result);
+
+        let calls = provider.rel_calls.lock().unwrap();
+        assert!(calls.set_relationship, "actor must hit set_relationship");
+        assert!(
+            calls.set_subject.is_none(),
+            "actor must not hit subject path"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_relationship_routes_object_edge_to_subject_kind_2() {
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let acp = SourceHubDocumentACP::without_access_cache(provider.clone());
+        let target = Subject::entity_set("directory", "d1", "");
+
+        let result = acp
+            .add_relationship(
+                &requestor(),
+                target,
+                "policy-1",
+                "users",
+                "doc-1",
+                "reader",
+                &[],
+            )
+            .await
+            .expect("object edge should route to set_relationship_subject");
+        assert!(result);
+
+        let calls = provider.rel_calls.lock().unwrap();
+        assert!(
+            !calls.set_relationship,
+            "object edge must not hit actor path"
+        );
+        assert_eq!(
+            calls.set_subject,
+            Some((2, "directory".to_string(), "d1".to_string(), String::new()))
+        );
+    }
+
+    #[tokio::test]
+    async fn add_relationship_routes_userset_to_subject_kind_3() {
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let acp = SourceHubDocumentACP::without_access_cache(provider.clone());
+        let target = Subject::entity_set("directory", "d1", "member");
+
+        acp.add_relationship(
+            &requestor(),
+            target,
+            "policy-1",
+            "users",
+            "doc-1",
+            "reader",
+            &[],
+        )
+        .await
+        .expect("userset should route to set_relationship_subject");
+
+        let calls = provider.rel_calls.lock().unwrap();
+        assert_eq!(
+            calls.set_subject,
+            Some((
+                3,
+                "directory".to_string(),
+                "d1".to_string(),
+                "member".to_string()
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_relationship_routes_object_edge_to_subject_kind_2() {
+        let provider = Arc::new(MockProvider::new(vec![]));
+        let acp = SourceHubDocumentACP::without_access_cache(provider.clone());
+        let target = Subject::entity_set("directory", "d1", "");
+
+        acp.delete_relationship(
+            &requestor(),
+            target,
+            "policy-1",
+            "users",
+            "doc-1",
+            "reader",
+            &[],
+        )
+        .await
+        .expect("object edge delete should route to delete_relationship_subject");
+
+        let calls = provider.rel_calls.lock().unwrap();
+        assert!(!calls.delete_relationship);
+        assert_eq!(
+            calls.delete_subject,
+            Some((2, "directory".to_string(), "d1".to_string(), String::new()))
+        );
+    }
+
+    /// A provider that omits the structured-subject overrides, so the trait
+    /// default (`Unsupported`) is exercised on the EntitySet path.
+    struct NoSubjectProvider;
+
+    #[async_trait]
+    impl SourceHubProvider for NoSubjectProvider {
+        fn authorized_account(&self) -> String {
+            "0x0".to_string()
+        }
+        async fn create_bearer_token(
+            &self,
+            _did: &str,
+        ) -> std::result::Result<String, ProviderError> {
+            Ok("mock.bearer.token".to_string())
+        }
+        fn self_did(&self) -> Option<String> {
+            None
+        }
+        async fn create_policy(
+            &self,
+            _policy_yaml: &str,
+        ) -> std::result::Result<String, ProviderError> {
+            unreachable!()
+        }
+        async fn register_object(
+            &self,
+            _bearer_token: &str,
+            _policy_id: &str,
+            _resource: &str,
+            _object_id: &str,
+        ) -> std::result::Result<(), ProviderError> {
+            unreachable!()
+        }
+        async fn archive_object(
+            &self,
+            _bearer_token: &str,
+            _policy_id: &str,
+            _resource: &str,
+            _object_id: &str,
+        ) -> std::result::Result<(), ProviderError> {
+            unreachable!()
+        }
+        async fn set_relationship(
+            &self,
+            _bearer_token: &str,
+            _policy_id: &str,
+            _resource: &str,
+            _object_id: &str,
+            _relation: &str,
+            _subject: &SubjectRef,
+        ) -> std::result::Result<bool, ProviderError> {
+            unreachable!()
+        }
+        async fn delete_relationship(
+            &self,
+            _bearer_token: &str,
+            _policy_id: &str,
+            _resource: &str,
+            _object_id: &str,
+            _relation: &str,
+            _subject: &SubjectRef,
+        ) -> std::result::Result<bool, ProviderError> {
+            unreachable!()
+        }
+        async fn query_policy(
+            &self,
+            _policy_id: &str,
+        ) -> std::result::Result<Option<crate::provider::ProviderPolicyInfo>, ProviderError>
+        {
+            unreachable!()
+        }
+        async fn query_object_owner(
+            &self,
+            _policy_id: &str,
+            _resource: &str,
+            _object_id: &str,
+        ) -> std::result::Result<(bool, String), ProviderError> {
+            unreachable!()
+        }
+        async fn verify_access(
+            &self,
+            _policy_id: &str,
+            _resource: &str,
+            _object_id: &str,
+            _permission: &str,
+            _actor_did: &str,
+        ) -> std::result::Result<bool, ProviderError> {
+            unreachable!()
+        }
+    }
+
+    #[tokio::test]
+    async fn add_relationship_subject_default_is_unsupported() {
+        let provider = Arc::new(NoSubjectProvider);
+        let acp = SourceHubDocumentACP::without_access_cache(provider);
+        let target = Subject::entity_set("directory", "d1", "");
+
+        let err = acp
+            .add_relationship(
+                &requestor(),
+                target,
+                "policy-1",
+                "users",
+                "doc-1",
+                "reader",
+                &[],
+            )
+            .await
+            .expect_err("provider without subject support must fail");
+        let message = err.to_string();
+        assert!(
+            message.contains("unsupported"),
+            "expected Unsupported error, got: {message}"
+        );
     }
 }

--- a/crates/sourcehub/src/hub_rs/abi.rs
+++ b/crates/sourcehub/src/hub_rs/abi.rs
@@ -15,10 +15,92 @@ sol! {
         function archiveObject(bytes32 policyId, string objectId, string resource) external returns (bool found, uint64 relationshipsRemoved);
         function bearerPolicyCmd(string bearerToken, bytes32 policyId, bytes cmd) external returns (bytes);
 
+        function setRelationshipSubject(
+            bytes32 policyId, string resource, string objectId, string relation,
+            uint8  subjectKind,
+            string subjectResource,
+            string subjectObjectId,
+            string subjectRelation
+        ) external returns (bool recordExisted, bytes record);
+        function deleteRelationshipSubject(
+            bytes32 policyId, string resource, string objectId, string relation,
+            uint8  subjectKind,
+            string subjectResource,
+            string subjectObjectId,
+            string subjectRelation
+        ) external returns (bool recordFound);
+
         function checkAccess(bytes32 policyId, string[] resources, string[] objectIds, string[] permissions, string actor) external returns (bytes);
         function verifyAccessRequest(bytes32 policyId, string[] resources, string[] objectIds, string[] permissions, string actor) external view returns (bool);
         function getObjectOwner(bytes32 policyId, string resource, string objectId) external view returns (bool registered, bytes record);
         function getPolicy(bytes32 policyId) external view returns (bytes);
         function getPolicyIds() external view returns (string[]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::FixedBytes;
+    use alloy_sol_types::SolCall;
+
+    fn pid() -> FixedBytes<32> {
+        FixedBytes::from([7u8; 32])
+    }
+
+    #[test]
+    fn set_relationship_subject_object_edge_round_trips() {
+        let call = IAcp::setRelationshipSubjectCall {
+            policyId: pid(),
+            resource: "users".to_string(),
+            objectId: "doc-1".to_string(),
+            relation: "reader".to_string(),
+            subjectKind: 2,
+            subjectResource: "directory".to_string(),
+            subjectObjectId: "d1".to_string(),
+            subjectRelation: String::new(),
+        };
+        let encoded = call.abi_encode();
+        assert_eq!(
+            &encoded[..4],
+            IAcp::setRelationshipSubjectCall::SELECTOR.as_slice()
+        );
+
+        let decoded = IAcp::setRelationshipSubjectCall::abi_decode(&encoded)
+            .expect("object-edge call should decode");
+        assert_eq!(decoded.policyId, pid());
+        assert_eq!(decoded.resource, "users");
+        assert_eq!(decoded.objectId, "doc-1");
+        assert_eq!(decoded.relation, "reader");
+        assert_eq!(decoded.subjectKind, 2);
+        assert_eq!(decoded.subjectResource, "directory");
+        assert_eq!(decoded.subjectObjectId, "d1");
+        assert_eq!(decoded.subjectRelation, "");
+    }
+
+    #[test]
+    fn delete_relationship_subject_userset_round_trips() {
+        let call = IAcp::deleteRelationshipSubjectCall {
+            policyId: pid(),
+            resource: "users".to_string(),
+            objectId: "doc-1".to_string(),
+            relation: "reader".to_string(),
+            subjectKind: 3,
+            subjectResource: "directory".to_string(),
+            subjectObjectId: "d1".to_string(),
+            subjectRelation: "member".to_string(),
+        };
+        let encoded = call.abi_encode();
+        assert_eq!(
+            &encoded[..4],
+            IAcp::deleteRelationshipSubjectCall::SELECTOR.as_slice()
+        );
+
+        let decoded = IAcp::deleteRelationshipSubjectCall::abi_decode(&encoded)
+            .expect("userset call should decode");
+        assert_eq!(decoded.subjectKind, 3);
+        assert_eq!(decoded.subjectResource, "directory");
+        assert_eq!(decoded.subjectObjectId, "d1");
+        assert_eq!(decoded.subjectRelation, "member");
     }
 }

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -473,6 +473,60 @@ impl SourceHubProvider for HubRsProvider {
         Ok(true)
     }
 
+    async fn set_relationship_subject(
+        &self,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        kind: u8,
+        subject_resource: &str,
+        subject_object_id: &str,
+        subject_relation: &str,
+    ) -> Result<bool, ProviderError> {
+        let pid = Self::policy_id_to_bytes32(policy_id);
+        let call = IAcp::setRelationshipSubjectCall {
+            policyId: pid,
+            resource: resource.to_string(),
+            objectId: object_id.to_string(),
+            relation: relation.to_string(),
+            subjectKind: kind,
+            subjectResource: subject_resource.to_string(),
+            subjectObjectId: subject_object_id.to_string(),
+            subjectRelation: subject_relation.to_string(),
+        };
+        let calldata = Bytes::from(call.abi_encode());
+        self.send_tx(calldata).await?;
+        Ok(true)
+    }
+
+    async fn delete_relationship_subject(
+        &self,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        kind: u8,
+        subject_resource: &str,
+        subject_object_id: &str,
+        subject_relation: &str,
+    ) -> Result<bool, ProviderError> {
+        let pid = Self::policy_id_to_bytes32(policy_id);
+        let call = IAcp::deleteRelationshipSubjectCall {
+            policyId: pid,
+            resource: resource.to_string(),
+            objectId: object_id.to_string(),
+            relation: relation.to_string(),
+            subjectKind: kind,
+            subjectResource: subject_resource.to_string(),
+            subjectObjectId: subject_object_id.to_string(),
+            subjectRelation: subject_relation.to_string(),
+        };
+        let calldata = Bytes::from(call.abi_encode());
+        self.send_tx(calldata).await?;
+        Ok(true)
+    }
+
     async fn query_policy(
         &self,
         policy_id: &str,

--- a/crates/sourcehub/src/provider.rs
+++ b/crates/sourcehub/src/provider.rs
@@ -38,6 +38,10 @@ pub enum ProviderError {
     /// All access decisions must fail-closed when this is returned.
     #[error("SourceHub unavailable: {0}")]
     Unavailable(String),
+
+    /// The provider backend does not support the requested operation.
+    #[error("unsupported operation: {0}")]
+    Unsupported(String),
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -86,6 +90,71 @@ pub trait SourceHubProvider: MaybeSendSync {
         relation: &str,
         subject: &SubjectRef,
     ) -> Result<bool, ProviderError>;
+
+    /// Emit a structured cross-object (object-edge) or userset subject to the
+    /// backend, routed by `kind` per the frozen cross-object wire contract
+    /// (`kind` 2 = object edge, `kind` 3 = userset). The `subject_*` fields are
+    /// the codec output of [`zanzibar::encode_subject`].
+    ///
+    /// Authentication is by the provider's own signing key (no bearer token);
+    /// only backends that implement the typed precompile override this. The
+    /// default rejects with [`ProviderError::Unsupported`].
+    #[allow(clippy::too_many_arguments)]
+    async fn set_relationship_subject(
+        &self,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        kind: u8,
+        subject_resource: &str,
+        subject_object_id: &str,
+        subject_relation: &str,
+    ) -> Result<bool, ProviderError> {
+        let _ = (
+            policy_id,
+            resource,
+            object_id,
+            relation,
+            kind,
+            subject_resource,
+            subject_object_id,
+            subject_relation,
+        );
+        Err(ProviderError::Unsupported(
+            "structured cross-object/userset subjects are not supported by this provider".into(),
+        ))
+    }
+
+    /// Remove a structured cross-object or userset subject. Revoke mirror of
+    /// [`set_relationship_subject`](Self::set_relationship_subject); the default
+    /// rejects with [`ProviderError::Unsupported`].
+    #[allow(clippy::too_many_arguments)]
+    async fn delete_relationship_subject(
+        &self,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        kind: u8,
+        subject_resource: &str,
+        subject_object_id: &str,
+        subject_relation: &str,
+    ) -> Result<bool, ProviderError> {
+        let _ = (
+            policy_id,
+            resource,
+            object_id,
+            relation,
+            kind,
+            subject_resource,
+            subject_object_id,
+            subject_relation,
+        );
+        Err(ProviderError::Unsupported(
+            "structured cross-object/userset subjects are not supported by this provider".into(),
+        ))
+    }
 
     async fn query_policy(
         &self,


### PR DESCRIPTION
## What

The **defradb emit side** of the cross-node cross-object ACP path: the SourceHub provider now emits structured cross-object/userset subjects to the hub.rs EVM chain per the frozen wire contract, instead of rejecting `EntitySet` with `UnsupportedSubject`. Pairs with hub.rs #88 (chain side); validated by the cross-repo round-trip.

## Changes
- **`hub_rs/abi.rs`** — two new `IAcp` precompile methods `setRelationshipSubject` / `deleteRelationshipSubject(policyId, resource, objectId, relation, uint8 subjectKind, subjectResource, subjectObjectId, subjectRelation)`. **No bearer token** (msg.sender auth, per the frozen sig). ABI round-trip tests for kind 2 (object edge, empty subjectRelation) and kind 3 (userset).
- **`SourceHubProvider`** — `set_relationship_subject`/`delete_relationship_subject` with a **default `Err(Unsupported)`** impl (cosmos inherits it — its cross-object path is deferred); **hub_rs overrides** them, building the typed call + `send_tx`.
- **`SourceHubDocumentACP`** routes `add_relationship`/`delete_relationship` by kind: Entity/Wildcard → the existing actor path (unchanged); `EntitySet` → **`zanzibar::encode_subject`** (the centralized codec, #1065) → the new typed methods.

## Tests
ABI encode/decode round-trip (kind 2 & 3); routing tests (Entity→set_relationship, object-edge→kind 2, userset→kind 3, delete→kind 2); default-Unsupported test. Full `sourcehub` suite green (30); clippy `-D warnings` clean.

## Round-trip note
The new methods take no bearer (msg.sender auth), so the EntitySet path signs/sends with the node key (no bearer mint), unlike the actor path. Flagged for the cross-repo round-trip against hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)