### PR TITLE
Enable SourceHub cross-object ACP relationship subjects

### DIFF
--- a/crates/sourcehub/src/cosmos/cosmos_provider.rs
+++ b/crates/sourcehub/src/cosmos/cosmos_provider.rs
@@ -86,6 +86,44 @@ fn subject_to_json(subject: &SubjectRef) -> serde_json::Value {
     }
 }
 
+fn structured_subject_to_json(
+    kind: u8,
+    subject_resource: &str,
+    subject_object_id: &str,
+    subject_relation: &str,
+) -> Result<serde_json::Value, ProviderError> {
+    match kind {
+        2 if !subject_resource.is_empty()
+            && !subject_object_id.is_empty()
+            && subject_relation.is_empty() =>
+        {
+            Ok(serde_json::json!({
+                "object": {
+                    "resource": subject_resource,
+                    "id": subject_object_id,
+                }
+            }))
+        }
+        3 if !subject_resource.is_empty()
+            && !subject_object_id.is_empty()
+            && !subject_relation.is_empty() =>
+        {
+            Ok(serde_json::json!({
+                "actor_set": {
+                    "object": {
+                        "resource": subject_resource,
+                        "id": subject_object_id,
+                    },
+                    "relation": subject_relation,
+                }
+            }))
+        }
+        _ => Err(ProviderError::Unsupported(format!(
+            "unsupported structured subject tuple kind={kind} resource='{subject_resource}' object_id='{subject_object_id}' relation='{subject_relation}'"
+        ))),
+    }
+}
+
 fn resolve_cosmos_bearer_token(
     did: &str,
     authorized_account: &str,
@@ -265,6 +303,86 @@ impl SourceHubProvider for CosmosProvider {
         Ok(record_found)
     }
 
+    async fn set_relationship_subject(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        kind: u8,
+        subject_resource: &str,
+        subject_object_id: &str,
+        subject_relation: &str,
+    ) -> Result<bool, ProviderError> {
+        let subject = structured_subject_to_json(
+            kind,
+            subject_resource,
+            subject_object_id,
+            subject_relation,
+        )?;
+        let cmd = serde_json::json!({
+            "set_relationship_cmd": {
+                "relationship": {
+                    "object": { "resource": resource, "id": object_id },
+                    "relation": relation,
+                    "subject": subject,
+                }
+            }
+        });
+        let result = self
+            .signer
+            .bearer_policy_cmd(&self.client, bearer_token, policy_id, cmd)
+            .await
+            .map_err(|e| ProviderError::Transaction(e.to_string()))?;
+
+        let record_existed = result
+            .get("record_existed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        Ok(!record_existed)
+    }
+
+    async fn delete_relationship_subject(
+        &self,
+        bearer_token: &str,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        relation: &str,
+        kind: u8,
+        subject_resource: &str,
+        subject_object_id: &str,
+        subject_relation: &str,
+    ) -> Result<bool, ProviderError> {
+        let subject = structured_subject_to_json(
+            kind,
+            subject_resource,
+            subject_object_id,
+            subject_relation,
+        )?;
+        let cmd = serde_json::json!({
+            "delete_relationship_cmd": {
+                "relationship": {
+                    "object": { "resource": resource, "id": object_id },
+                    "relation": relation,
+                    "subject": subject,
+                }
+            }
+        });
+        let result = self
+            .signer
+            .bearer_policy_cmd(&self.client, bearer_token, policy_id, cmd)
+            .await
+            .map_err(|e| ProviderError::Transaction(e.to_string()))?;
+
+        let record_found = result
+            .get("record_found")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        Ok(record_found)
+    }
+
     /// Query a policy by ID, using the local cache when available.
     ///
     /// A cache miss (absent or expired entry) always falls back to an on-chain
@@ -349,6 +467,49 @@ mod tests {
                 signing_authorization: None,
             },
         );
+    }
+
+    #[test]
+    fn structured_subject_to_json_encodes_object_edges() {
+        let subject =
+            structured_subject_to_json(2, "directory", "team", "").expect("object subject");
+
+        assert_eq!(
+            subject,
+            serde_json::json!({
+                "object": {
+                    "resource": "directory",
+                    "id": "team",
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn structured_subject_to_json_encodes_usersets() {
+        let subject =
+            structured_subject_to_json(3, "directory", "team", "reader").expect("userset subject");
+
+        assert_eq!(
+            subject,
+            serde_json::json!({
+                "actor_set": {
+                    "object": {
+                        "resource": "directory",
+                        "id": "team",
+                    },
+                    "relation": "reader",
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn structured_subject_to_json_rejects_invalid_tuples() {
+        let err = structured_subject_to_json(2, "directory", "team", "reader")
+            .expect_err("object edges must not carry a relation");
+
+        assert!(matches!(err, ProviderError::Unsupported(_)));
     }
 
     #[test]

--- a/crates/sourcehub/src/cosmos/dac.rs
+++ b/crates/sourcehub/src/cosmos/dac.rs
@@ -343,11 +343,13 @@ impl DocumentACP for SourceHubDocumentACP {
                 .await
             }
             Subject::EntitySet { .. } => {
+                let bearer_token = self.create_bearer_token(requestor.as_str()).await?;
                 let (kind, sr, so, srel) =
                     zanzibar::encode_subject(&target).map_err(acp::Error::from)?;
                 let result = self
                     .provider
                     .set_relationship_subject(
+                        &bearer_token,
                         policy_id,
                         resource_name,
                         doc_id,
@@ -391,11 +393,13 @@ impl DocumentACP for SourceHubDocumentACP {
                 .await
             }
             Subject::EntitySet { .. } => {
+                let bearer_token = self.create_bearer_token(requestor.as_str()).await?;
                 let (kind, sr, so, srel) =
                     zanzibar::encode_subject(&target).map_err(acp::Error::from)?;
                 let result = self
                     .provider
                     .delete_relationship_subject(
+                        &bearer_token,
                         policy_id,
                         resource_name,
                         doc_id,
@@ -562,6 +566,7 @@ mod tests {
 
         async fn set_relationship_subject(
             &self,
+            _bearer_token: &str,
             _policy_id: &str,
             _resource: &str,
             _object_id: &str,
@@ -582,6 +587,7 @@ mod tests {
 
         async fn delete_relationship_subject(
             &self,
+            _bearer_token: &str,
             _policy_id: &str,
             _resource: &str,
             _object_id: &str,

--- a/crates/sourcehub/src/cosmos/dac.rs
+++ b/crates/sourcehub/src/cosmos/dac.rs
@@ -464,8 +464,8 @@ mod tests {
     struct RelationshipCalls {
         set_relationship: bool,
         delete_relationship: bool,
-        set_subject: Option<(u8, String, String, String)>,
-        delete_subject: Option<(u8, String, String, String)>,
+        set_subject: Option<(String, u8, String, String, String)>,
+        delete_subject: Option<(String, u8, String, String, String)>,
     }
 
     struct MockProvider {
@@ -566,7 +566,7 @@ mod tests {
 
         async fn set_relationship_subject(
             &self,
-            _bearer_token: &str,
+            bearer_token: &str,
             _policy_id: &str,
             _resource: &str,
             _object_id: &str,
@@ -577,6 +577,7 @@ mod tests {
             subject_relation: &str,
         ) -> std::result::Result<bool, ProviderError> {
             self.rel_calls.lock().unwrap().set_subject = Some((
+                bearer_token.to_string(),
                 kind,
                 subject_resource.to_string(),
                 subject_object_id.to_string(),
@@ -587,7 +588,7 @@ mod tests {
 
         async fn delete_relationship_subject(
             &self,
-            _bearer_token: &str,
+            bearer_token: &str,
             _policy_id: &str,
             _resource: &str,
             _object_id: &str,
@@ -598,6 +599,7 @@ mod tests {
             subject_relation: &str,
         ) -> std::result::Result<bool, ProviderError> {
             self.rel_calls.lock().unwrap().delete_subject = Some((
+                bearer_token.to_string(),
                 kind,
                 subject_resource.to_string(),
                 subject_object_id.to_string(),
@@ -801,7 +803,13 @@ mod tests {
         );
         assert_eq!(
             calls.set_subject,
-            Some((2, "directory".to_string(), "d1".to_string(), String::new()))
+            Some((
+                "mock.bearer.token".to_string(),
+                2,
+                "directory".to_string(),
+                "d1".to_string(),
+                String::new()
+            ))
         );
     }
 
@@ -827,6 +835,7 @@ mod tests {
         assert_eq!(
             calls.set_subject,
             Some((
+                "mock.bearer.token".to_string(),
                 3,
                 "directory".to_string(),
                 "d1".to_string(),
@@ -857,7 +866,13 @@ mod tests {
         assert!(!calls.delete_relationship);
         assert_eq!(
             calls.delete_subject,
-            Some((2, "directory".to_string(), "d1".to_string(), String::new()))
+            Some((
+                "mock.bearer.token".to_string(),
+                2,
+                "directory".to_string(),
+                "d1".to_string(),
+                String::new()
+            ))
         );
     }
 

--- a/crates/sourcehub/src/cosmos/tx.rs
+++ b/crates/sourcehub/src/cosmos/tx.rs
@@ -361,8 +361,21 @@ fn encode_subject_from_json(json: &serde_json::Value) -> Vec<u8> {
             encode_string_field(&mut actor_buf, 1, id);
         }
         encode_bytes_field(&mut buf, 1, &actor_buf);
+    } else if let Some(actor_set) = json.get("actor_set") {
+        let mut actor_set_buf = Vec::new();
+        if let Some(obj) = actor_set.get("object") {
+            let obj_bytes = encode_object_from_json(obj);
+            encode_bytes_field(&mut actor_set_buf, 1, &obj_bytes);
+        }
+        if let Some(relation) = actor_set.get("relation").and_then(|v| v.as_str()) {
+            encode_string_field(&mut actor_set_buf, 2, relation);
+        }
+        encode_bytes_field(&mut buf, 2, &actor_set_buf);
     } else if json.get("all_actors").is_some() {
         encode_bytes_field(&mut buf, 3, &[]);
+    } else if let Some(obj) = json.get("object") {
+        let obj_bytes = encode_object_from_json(obj);
+        encode_bytes_field(&mut buf, 4, &obj_bytes);
     }
     buf
 }

--- a/crates/sourcehub/src/cosmos/tx/tests.rs
+++ b/crates/sourcehub/src/cosmos/tx/tests.rs
@@ -109,6 +109,33 @@ async fn sign_and_broadcast_resets_sequence_after_inclusion_failure() {
     assert_eq!(state.broadcasts.load(Ordering::SeqCst), 2);
 }
 
+#[test]
+fn encode_subject_from_json_encodes_object_subject() {
+    let bytes = encode_subject_from_json(&serde_json::json!({
+        "object": { "resource": "directory", "id": "team" }
+    }));
+
+    let object = decode_field_bytes(&bytes, 4).expect("subject.object");
+    assert_eq!(field_string(&object, 1), "directory");
+    assert_eq!(field_string(&object, 2), "team");
+}
+
+#[test]
+fn encode_subject_from_json_encodes_actor_set_subject() {
+    let bytes = encode_subject_from_json(&serde_json::json!({
+        "actor_set": {
+            "object": { "resource": "directory", "id": "team" },
+            "relation": "reader",
+        }
+    }));
+
+    let actor_set = decode_field_bytes(&bytes, 2).expect("subject.actor_set");
+    let object = decode_field_bytes(&actor_set, 1).expect("actor_set.object");
+    assert_eq!(field_string(&object, 1), "directory");
+    assert_eq!(field_string(&object, 2), "team");
+    assert_eq!(field_string(&actor_set, 2), "reader");
+}
+
 async fn spawn_sourcehub_rpc(state: Arc<RpcState>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -293,4 +320,9 @@ fn test_msg(name: &str) -> Any {
         type_url: format!("/test.{name}"),
         value: Vec::new(),
     }
+}
+
+fn field_string(bytes: &[u8], field: u32) -> String {
+    String::from_utf8(decode_field_bytes(bytes, field).expect("field bytes"))
+        .expect("field should be utf8")
 }

--- a/crates/sourcehub/src/hub_rs/provider.rs
+++ b/crates/sourcehub/src/hub_rs/provider.rs
@@ -475,6 +475,7 @@ impl SourceHubProvider for HubRsProvider {
 
     async fn set_relationship_subject(
         &self,
+        _bearer_token: &str,
         policy_id: &str,
         resource: &str,
         object_id: &str,
@@ -502,6 +503,7 @@ impl SourceHubProvider for HubRsProvider {
 
     async fn delete_relationship_subject(
         &self,
+        _bearer_token: &str,
         policy_id: &str,
         resource: &str,
         object_id: &str,

--- a/crates/sourcehub/src/provider.rs
+++ b/crates/sourcehub/src/provider.rs
@@ -96,12 +96,13 @@ pub trait SourceHubProvider: MaybeSendSync {
     /// (`kind` 2 = object edge, `kind` 3 = userset). The `subject_*` fields are
     /// the codec output of [`zanzibar::encode_subject`].
     ///
-    /// Authentication is by the provider's own signing key (no bearer token);
-    /// only backends that implement the typed precompile override this. The
-    /// default rejects with [`ProviderError::Unsupported`].
+    /// Backends that route through SourceHub policy commands may use the bearer
+    /// token; typed-precompile backends may ignore it. The default rejects with
+    /// [`ProviderError::Unsupported`].
     #[allow(clippy::too_many_arguments)]
     async fn set_relationship_subject(
         &self,
+        bearer_token: &str,
         policy_id: &str,
         resource: &str,
         object_id: &str,
@@ -112,6 +113,7 @@ pub trait SourceHubProvider: MaybeSendSync {
         subject_relation: &str,
     ) -> Result<bool, ProviderError> {
         let _ = (
+            bearer_token,
             policy_id,
             resource,
             object_id,
@@ -132,6 +134,7 @@ pub trait SourceHubProvider: MaybeSendSync {
     #[allow(clippy::too_many_arguments)]
     async fn delete_relationship_subject(
         &self,
+        bearer_token: &str,
         policy_id: &str,
         resource: &str,
         object_id: &str,
@@ -142,6 +145,7 @@ pub trait SourceHubProvider: MaybeSendSync {
         subject_relation: &str,
     ) -> Result<bool, ProviderError> {
         let _ = (
+            bearer_token,
             policy_id,
             resource,
             object_id,

--- a/tools/integration-test/tests/sourcehub.rs
+++ b/tools/integration-test/tests/sourcehub.rs
@@ -2,6 +2,8 @@
 mod acp_tuning;
 #[path = "sourcehub/compartments.rs"]
 mod compartments;
+#[path = "sourcehub/cross_object.rs"]
+mod cross_object;
 #[path = "sourcehub/encryption_acp.rs"]
 mod encryption_acp;
 #[path = "sourcehub/p2p_acp.rs"]

--- a/tools/integration-test/tests/sourcehub/cross_object.rs
+++ b/tools/integration-test/tests/sourcehub/cross_object.rs
@@ -1,0 +1,166 @@
+//! SourceHub-backed cross-object ACP regression coverage.
+//!
+//! The local ACP variant proves the Zanzibar engine can evaluate `parent->read`;
+//! this test proves the SourceHub transaction path can persist the structured
+//! object-edge relationship that makes that inheritance possible.
+
+use integration_test::node::{DefraNode, RustNode};
+use integration_test::{generate_identity, TestCluster};
+
+fn fs_policy() -> &'static str {
+    r#"
+name: filesystem
+description: cross-object filesystem policy
+resources:
+  - name: directory
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: reader
+      - name: delete
+        expr: reader
+    relations:
+      - name: reader
+        types:
+          - actor
+  - name: file
+    permissions:
+      - name: read
+        expr: reader + parent->read
+      - name: update
+        expr: reader
+      - name: delete
+        expr: reader
+    relations:
+      - name: reader
+        types:
+          - actor
+      - name: parent
+        types:
+          - directory
+"#
+}
+
+fn fs_schema(policy_id: &str) -> String {
+    format!(
+        r#"type Directory @policy(id: "{pid}", resource: "directory") {{ name: String }}
+type File @policy(id: "{pid}", resource: "file") {{ title: String }}"#,
+        pid = policy_id
+    )
+}
+
+fn extract_policy_id(value: &serde_json::Value) -> String {
+    value["PolicyID"]
+        .as_str()
+        .or_else(|| value["policyID"].as_str())
+        .expect("missing PolicyID")
+        .to_string()
+}
+
+fn file_count(node: &integration_test::DefraClient, key: &str) -> usize {
+    node.query_with_identity("query { File { _docID title } }", key)
+        .expect("query File")["File"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0)
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn rust_sourcehub_cross_object_parent_read_inheritance() {
+    let binary = RustNode::from_workspace().binary_path().to_path_buf();
+    RustNode::build().expect("build rust binary");
+    let owner = generate_identity(&binary).expect("owner identity");
+    let alice = generate_identity(&binary).expect("alice identity");
+    let bob = generate_identity(&binary).expect("bob identity");
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .skip_build()
+        .with_source_hub()
+        .with_identity(&owner.private_key_hex)
+        .build()
+        .await
+        .expect("failed to build sourcehub cluster");
+    let node = cluster.client(0);
+
+    let policy = node
+        .acp_policy_add(fs_policy(), &owner.private_key_hex)
+        .expect("add filesystem policy");
+    let policy_id = extract_policy_id(&policy);
+    node.schema_add_with_identity(&fs_schema(&policy_id), &owner.private_key_hex)
+        .expect("add filesystem schema");
+
+    let dir = node
+        .query_with_identity(
+            r#"mutation { add_Directory(input: {name: "team"}) { _docID } }"#,
+            &owner.private_key_hex,
+        )
+        .expect("create directory");
+    let dir_id = dir["add_Directory"][0]["_docID"]
+        .as_str()
+        .expect("directory _docID")
+        .to_string();
+
+    let file = node
+        .query_with_identity(
+            r#"mutation { add_File(input: {title: "report"}) { _docID } }"#,
+            &owner.private_key_hex,
+        )
+        .expect("create file");
+    let file_id = file["add_File"][0]["_docID"]
+        .as_str()
+        .expect("file _docID")
+        .to_string();
+
+    node.acp_relationship_add(
+        "Directory",
+        &dir_id,
+        "reader",
+        &alice.did,
+        &owner.private_key_hex,
+    )
+    .expect("grant alice reader on directory");
+
+    assert_eq!(
+        file_count(&node, &alice.private_key_hex),
+        0,
+        "directory reader must not see the file before the parent edge"
+    );
+
+    let parent_target = format!("directory:{dir_id}");
+    node.acp_relationship_add(
+        "File",
+        &file_id,
+        "parent",
+        &parent_target,
+        &owner.private_key_hex,
+    )
+    .expect("seed SourceHub cross-object parent edge");
+
+    assert_eq!(
+        file_count(&node, &alice.private_key_hex),
+        1,
+        "alice must inherit file read through parent->read"
+    );
+    assert_eq!(
+        file_count(&node, &bob.private_key_hex),
+        0,
+        "bob has no grant and must stay denied"
+    );
+
+    node.acp_relationship_delete(
+        "File",
+        &file_id,
+        "parent",
+        &parent_target,
+        &owner.private_key_hex,
+    )
+    .expect("delete SourceHub cross-object parent edge");
+    assert_eq!(
+        file_count(&node, &alice.private_key_hex),
+        0,
+        "deleting the parent edge must remove inherited access"
+    );
+}

--- a/tools/integration-test/tests/sourcehub/cross_object.rs
+++ b/tools/integration-test/tests/sourcehub/cross_object.rs
@@ -1,11 +1,17 @@
 //! SourceHub-backed cross-object ACP regression coverage.
 //!
 //! The local ACP variant proves the Zanzibar engine can evaluate `parent->read`;
-//! this test proves the SourceHub transaction path can persist the structured
-//! object-edge relationship that makes that inheritance possible.
+//! these tests prove SourceHub can persist and enforce the structured object and
+//! userset relationship subjects through the live provider path.
+
+use std::time::Duration;
 
 use integration_test::node::{DefraNode, RustNode};
-use integration_test::{generate_identity, TestCluster};
+use integration_test::{extract_p2p_addr, generate_identity, poll_until, TestCluster};
+
+const P2P_TIMEOUT: Duration = Duration::from_secs(15);
+const POLL_INTERVAL: Duration = Duration::from_millis(300);
+const REPLICATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn fs_policy() -> &'static str {
     r#"
@@ -50,6 +56,43 @@ type File @policy(id: "{pid}", resource: "file") {{ title: String }}"#,
     )
 }
 
+fn userset_policy() -> &'static str {
+    r#"
+name: userset-sharing
+description: userset-backed article sharing policy
+resources:
+  - name: group
+    permissions:
+      - name: read
+        expr: participant
+    relations:
+      - name: participant
+        types:
+          - actor
+  - name: article
+    permissions:
+      - name: read
+        expr: reader
+      - name: update
+        expr: reader
+      - name: delete
+        expr: reader
+    relations:
+      - name: reader
+        types:
+          - actor
+          - group->participant
+"#
+}
+
+fn userset_schema(policy_id: &str) -> String {
+    format!(
+        r#"type Group @policy(id: "{pid}", resource: "group") {{ name: String }}
+type Article @policy(id: "{pid}", resource: "article") {{ title: String }}"#,
+        pid = policy_id
+    )
+}
+
 fn extract_policy_id(value: &serde_json::Value) -> String {
     value["PolicyID"]
         .as_str()
@@ -58,20 +101,62 @@ fn extract_policy_id(value: &serde_json::Value) -> String {
         .to_string()
 }
 
+fn collection_count(node: &integration_test::DefraClient, key: &str, collection: &str) -> usize {
+    let query = format!("query {{ {collection} {{ _docID }} }}");
+    let result = node
+        .query_with_identity(&query, key)
+        .unwrap_or_else(|err| panic!("query {collection}: {err}"));
+    result
+        .get(collection)
+        .and_then(|value| value.as_array())
+        .unwrap_or_else(|| panic!("query result must contain {collection} array: {result}"))
+        .len()
+}
+
 fn file_count(node: &integration_test::DefraClient, key: &str) -> usize {
-    node.query_with_identity("query { File { _docID title } }", key)
-        .expect("query File")["File"]
-        .as_array()
-        .map(|a| a.len())
-        .unwrap_or(0)
+    collection_count(node, key, "File")
+}
+
+fn article_count(node: &integration_test::DefraClient, key: &str) -> usize {
+    collection_count(node, key, "Article")
+}
+
+async fn wait_for_collection_count(
+    node: &integration_test::DefraClient,
+    key: &str,
+    collection: &str,
+    expected: usize,
+    reason: &str,
+) {
+    let key = key.to_string();
+    poll_until(
+        || collection_count(node, &key, collection) == expected,
+        REPLICATION_TIMEOUT,
+        POLL_INTERVAL,
+        reason,
+    )
+    .await;
+}
+
+fn sourcehub_owner() -> (std::path::PathBuf, String) {
+    let binary = RustNode::from_workspace().binary_path().to_path_buf();
+    RustNode::build().expect("build rust binary");
+    let owner = generate_identity(&binary).expect("owner identity");
+    (binary, owner.private_key_hex)
+}
+
+fn object_target(resource: &str, id: &str) -> String {
+    format!("{resource}:\"{id}\"")
+}
+
+fn userset_target(resource: &str, id: &str, relation: &str) -> String {
+    format!("{resource}:\"{id}\"#{relation}")
 }
 
 #[tokio::test]
 #[serial_test::serial]
 async fn rust_sourcehub_cross_object_parent_read_inheritance() {
-    let binary = RustNode::from_workspace().binary_path().to_path_buf();
-    RustNode::build().expect("build rust binary");
-    let owner = generate_identity(&binary).expect("owner identity");
+    let (binary, owner_key) = sourcehub_owner();
     let alice = generate_identity(&binary).expect("alice identity");
     let bob = generate_identity(&binary).expect("bob identity");
 
@@ -79,23 +164,23 @@ async fn rust_sourcehub_cross_object_parent_read_inheritance() {
         .rust_nodes(1)
         .skip_build()
         .with_source_hub()
-        .with_identity(&owner.private_key_hex)
+        .with_identity(&owner_key)
         .build()
         .await
         .expect("failed to build sourcehub cluster");
     let node = cluster.client(0);
 
     let policy = node
-        .acp_policy_add(fs_policy(), &owner.private_key_hex)
+        .acp_policy_add(fs_policy(), &owner_key)
         .expect("add filesystem policy");
     let policy_id = extract_policy_id(&policy);
-    node.schema_add_with_identity(&fs_schema(&policy_id), &owner.private_key_hex)
+    node.schema_add_with_identity(&fs_schema(&policy_id), &owner_key)
         .expect("add filesystem schema");
 
     let dir = node
         .query_with_identity(
             r#"mutation { add_Directory(input: {name: "team"}) { _docID } }"#,
-            &owner.private_key_hex,
+            &owner_key,
         )
         .expect("create directory");
     let dir_id = dir["add_Directory"][0]["_docID"]
@@ -106,7 +191,7 @@ async fn rust_sourcehub_cross_object_parent_read_inheritance() {
     let file = node
         .query_with_identity(
             r#"mutation { add_File(input: {title: "report"}) { _docID } }"#,
-            &owner.private_key_hex,
+            &owner_key,
         )
         .expect("create file");
     let file_id = file["add_File"][0]["_docID"]
@@ -114,14 +199,8 @@ async fn rust_sourcehub_cross_object_parent_read_inheritance() {
         .expect("file _docID")
         .to_string();
 
-    node.acp_relationship_add(
-        "Directory",
-        &dir_id,
-        "reader",
-        &alice.did,
-        &owner.private_key_hex,
-    )
-    .expect("grant alice reader on directory");
+    node.acp_relationship_add("Directory", &dir_id, "reader", &alice.did, &owner_key)
+        .expect("grant alice reader on directory");
 
     assert_eq!(
         file_count(&node, &alice.private_key_hex),
@@ -129,15 +208,9 @@ async fn rust_sourcehub_cross_object_parent_read_inheritance() {
         "directory reader must not see the file before the parent edge"
     );
 
-    let parent_target = format!("directory:{dir_id}");
-    node.acp_relationship_add(
-        "File",
-        &file_id,
-        "parent",
-        &parent_target,
-        &owner.private_key_hex,
-    )
-    .expect("seed SourceHub cross-object parent edge");
+    let parent_target = object_target("directory", &dir_id);
+    node.acp_relationship_add("File", &file_id, "parent", &parent_target, &owner_key)
+        .expect("seed SourceHub cross-object parent edge");
 
     assert_eq!(
         file_count(&node, &alice.private_key_hex),
@@ -150,17 +223,218 @@ async fn rust_sourcehub_cross_object_parent_read_inheritance() {
         "bob has no grant and must stay denied"
     );
 
-    node.acp_relationship_delete(
-        "File",
-        &file_id,
-        "parent",
-        &parent_target,
-        &owner.private_key_hex,
-    )
-    .expect("delete SourceHub cross-object parent edge");
+    node.acp_relationship_delete("File", &file_id, "parent", &parent_target, &owner_key)
+        .expect("delete SourceHub cross-object parent edge");
     assert_eq!(
         file_count(&node, &alice.private_key_hex),
         0,
         "deleting the parent edge must remove inherited access"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn rust_sourcehub_iroh_cross_object_parent_read_inheritance() {
+    let (binary, owner_key) = sourcehub_owner();
+    let alice = generate_identity(&binary).expect("alice identity");
+    let bob = generate_identity(&binary).expect("bob identity");
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_source_hub()
+        .with_iroh_transport()
+        .with_identity(&owner_key)
+        .build()
+        .await
+        .expect("failed to build sourcehub iroh cluster");
+
+    for idx in 0..2 {
+        cluster
+            .wait_for_log(idx, "p2p_listening", P2P_TIMEOUT)
+            .await
+            .unwrap_or_else(|_| panic!("node{idx} P2P listener did not start"));
+    }
+
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    let policy = node0
+        .acp_policy_add(fs_policy(), &owner_key)
+        .expect("add filesystem policy");
+    let policy_id = extract_policy_id(&policy);
+    let schema = fs_schema(&policy_id);
+    node0
+        .schema_add_with_identity(&schema, &owner_key)
+        .expect("add filesystem schema on node0");
+    node1
+        .schema_add_with_identity(&schema, &owner_key)
+        .expect("add filesystem schema on node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    node0.p2p_connect(&[&addr1]).expect("p2p connect");
+    node0
+        .p2p_collection_add(&["Directory", "File"])
+        .expect("p2p collection add node0");
+    node1
+        .p2p_collection_add(&["Directory", "File"])
+        .expect("p2p collection add node1");
+    node0
+        .p2p_replicator_set_with_identity(&["Directory", "File"], &addr1, &owner_key)
+        .expect("set iroh replicator");
+
+    let file = node0
+        .query_with_identity(
+            r#"mutation { add_File(input: {title: "report"}) { _docID } }"#,
+            &owner_key,
+        )
+        .expect("create child file before parent directory");
+    let file_id = file["add_File"][0]["_docID"]
+        .as_str()
+        .expect("file _docID")
+        .to_string();
+
+    wait_for_collection_count(
+        &node1,
+        &owner_key,
+        "File",
+        1,
+        "child file did not replicate to node1 before parent directory existed",
+    )
+    .await;
+    assert_eq!(
+        file_count(&node1, &alice.private_key_hex),
+        0,
+        "node1 must fail closed while the child file exists without the parent edge"
+    );
+
+    let dir = node0
+        .query_with_identity(
+            r#"mutation { add_Directory(input: {name: "team"}) { _docID } }"#,
+            &owner_key,
+        )
+        .expect("create parent directory after child file");
+    let dir_id = dir["add_Directory"][0]["_docID"]
+        .as_str()
+        .expect("directory _docID")
+        .to_string();
+
+    node0
+        .acp_relationship_add("Directory", &dir_id, "reader", &alice.did, &owner_key)
+        .expect("grant alice reader on directory");
+    let parent_target = object_target("directory", &dir_id);
+    node0
+        .acp_relationship_add("File", &file_id, "parent", &parent_target, &owner_key)
+        .expect("seed parent edge after child file replicated");
+
+    wait_for_collection_count(
+        &node1,
+        &owner_key,
+        "Directory",
+        1,
+        "parent directory did not replicate to node1 after child file",
+    )
+    .await;
+    wait_for_collection_count(
+        &node1,
+        &alice.private_key_hex,
+        "File",
+        1,
+        "alice did not inherit file read on node1 after SourceHub parent edge was visible",
+    )
+    .await;
+    assert_eq!(
+        file_count(&node1, &bob.private_key_hex),
+        0,
+        "bob has no grant and must stay denied on the replicated node"
+    );
+
+    node0
+        .acp_relationship_delete("File", &file_id, "parent", &parent_target, &owner_key)
+        .expect("delete SourceHub parent edge");
+    wait_for_collection_count(
+        &node1,
+        &alice.private_key_hex,
+        "File",
+        0,
+        "alice access did not revoke on node1 after deleting the parent edge",
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn rust_sourcehub_userset_reader_relationship() {
+    let (binary, owner_key) = sourcehub_owner();
+    let alice = generate_identity(&binary).expect("alice identity");
+    let bob = generate_identity(&binary).expect("bob identity");
+
+    let cluster = TestCluster::builder()
+        .rust_nodes(1)
+        .skip_build()
+        .with_source_hub()
+        .with_identity(&owner_key)
+        .build()
+        .await
+        .expect("failed to build sourcehub cluster");
+    let node = cluster.client(0);
+
+    let policy = node
+        .acp_policy_add(userset_policy(), &owner_key)
+        .expect("add userset policy");
+    let policy_id = extract_policy_id(&policy);
+    node.schema_add_with_identity(&userset_schema(&policy_id), &owner_key)
+        .expect("add userset schema");
+
+    let group = node
+        .query_with_identity(
+            r#"mutation { add_Group(input: {name: "eng"}) { _docID } }"#,
+            &owner_key,
+        )
+        .expect("create group");
+    let group_id = group["add_Group"][0]["_docID"]
+        .as_str()
+        .expect("group _docID")
+        .to_string();
+
+    let article = node
+        .query_with_identity(
+            r#"mutation { add_Article(input: {title: "plan"}) { _docID } }"#,
+            &owner_key,
+        )
+        .expect("create article");
+    let article_id = article["add_Article"][0]["_docID"]
+        .as_str()
+        .expect("article _docID")
+        .to_string();
+
+    node.acp_relationship_add("Group", &group_id, "participant", &alice.did, &owner_key)
+        .expect("grant alice group participant");
+    assert_eq!(
+        article_count(&node, &alice.private_key_hex),
+        0,
+        "group membership alone must not read the article before userset edge"
+    );
+
+    let target = userset_target("group", &group_id, "participant");
+    node.acp_relationship_add("Article", &article_id, "reader", &target, &owner_key)
+        .expect("seed SourceHub userset reader edge");
+
+    assert_eq!(
+        article_count(&node, &alice.private_key_hex),
+        1,
+        "alice must read the article through group#participant userset"
+    );
+    assert_eq!(
+        article_count(&node, &bob.private_key_hex),
+        0,
+        "bob is not in the group userset and must stay denied"
+    );
+
+    node.acp_relationship_delete("Article", &article_id, "reader", &target, &owner_key)
+        .expect("delete SourceHub userset reader edge");
+    assert_eq!(
+        article_count(&node, &alice.private_key_hex),
+        0,
+        "deleting the userset edge must revoke article access"
     );
 }


### PR DESCRIPTION
## Summary

- add SourceHub support for structured relationship subjects (`object` edges and `actor_set` usersets)
- pass bearer tokens through SourceHub structured-subject relationship writes/deletes
- encode SourceHub protobuf `Subject.object` and `Subject.actor_set` in transaction payloads
- add SourceHub cross-object ACP regression coverage for `file.parent -> directory.read` inheritance

Part of #1057

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p sourcehub`
- [x] `cargo check -p cli`
- [x] `cargo clippy -p sourcehub --all-targets -- -D warnings`
- [x] `cargo clippy -p cli -- -D warnings`
- [x] `RUST_LOG=info SOURCEHUB_BINARY=/Users/ivan/Source/sourcehub/build/sourcehubd cargo test -p integration-test --test sourcehub -- cross_object --nocapture`
- [x] `RUST_LOG=info SOURCEHUB_BINARY=/Users/ivan/Source/sourcehub/build/sourcehubd cargo test -p integration-test --test sourcehub -- rust_sourcehub_smoke --nocapture`
