### PR TITLE
Prove document materialization tombstone convergence

### DIFF
--- a/proofs/README.md
+++ b/proofs/README.md
@@ -20,7 +20,7 @@ Status of the effort across the 40-crate surface, from the per-crate survey in
 are plumbing covered by integration tests / Go-FFI parity / unit tests. The point of this
 section is the **diff**: what is proven vs. the accepted gap.
 
-### Modeled — 18 families (proven)
+### Modeled — 19 families (proven)
 | Family | Tool | Crates it covers |
 |---|---|---|
 | B3 filtered replication | TLA+ | p2p, db-merge |
@@ -36,6 +36,7 @@ section is the **diff**: what is proven vs. the accepted gap.
 | P2P explicit-replay capability gate | TLA+ | p2p |
 | NAC lifecycle privilege-escalation | TLA+ | acp, db-nac |
 | Transaction & merge-queue concurrency | TLA+ | db, db-merge |
+| Document materialization status convergence | TLA+ & Lean | db-merge, crdt, db |
 | JWT issuer / algorithm binding | TLA+ | identity |
 | CID content-addressing determinism + Block canonicalization | Lean | defra-core |
 | Deferred-ACP overlay consistency | TLA+ | query-plan |
@@ -94,9 +95,9 @@ substrate) — so a green run never reads as "this was proven against the
 artifact." `matrix::every_modeled_family_is_bound` fails if a model lands without
 a binding.
 
-### Realized status — all 18 families bound
+### Realized status — all 19 families bound
 
-**17 behavioral tests** (driven against `target/release/defra`, each break-tested
+**18 behavioral tests** (driven against `target/release/defra`, each break-tested
 for non-vacuity), **2 Lean-axis contract bindings**, **6 honest Boundaries** (one,
 Transaction & merge-queue concurrency, is now both — a Behavioral no-loss/no-double-apply
 storm leg plus a Boundary internal-serialization leg). One
@@ -116,6 +117,7 @@ headstore); go↔go vs rust↔rust parity (`parity.rs`) localized it to Rust.
 | Management-channel auth (NAC gate) | Behavioral | `nac.rs` |
 | NAC lifecycle priv-escalation | Behavioral | `nac_lifecycle.rs` |
 | Transaction & merge-queue concurrency | Behavioral + Boundary | `partition::convergence_concurrent_same_doc_merge_storm` (no-loss/no-double-apply exact-sum oracle); `partition::{convergence_concurrent_mixed_lww_and_counter_fields_merge,convergence_restart_mixed_lww_and_counter_fields_merge,convergence_mixed_lww_and_counter_3node_full_mesh}` (mixed Counter×LWW exact-state); `MC_MixedFieldMaterialization_{Red_WholeDoc,Green}`; the internal "≤1 worker in the critical section" + txn-registry sweep stay Boundary |
+| Document materialization status convergence | Behavioral | `partition::convergence_delete_update_race_preserves_tombstone`; `MC_DocumentMaterialization_{Red_Overwrite,Green}`; `DefraConvergence.DocumentMaterialization` |
 | Deferred-ACP overlay | Behavioral | `deferred_acp.rs` (txn-local gating) |
 | CID determinism | Behavioral | `cid.rs` |
 | Index-maintenance | Behavioral | `index.rs` |

--- a/proofs/lean/DefraConvergence.lean
+++ b/proofs/lean/DefraConvergence.lean
@@ -3,3 +3,4 @@ import DefraConvergence.CrdtField
 import DefraConvergence.PriorityReconcile
 import DefraConvergence.CounterReconcile
 import DefraConvergence.MixedField
+import DefraConvergence.DocumentMaterialization

--- a/proofs/lean/DefraConvergence/DocumentMaterialization.lean
+++ b/proofs/lean/DefraConvergence/DocumentMaterialization.lean
@@ -1,0 +1,63 @@
+namespace DefraConvergence.DocumentMaterialization
+
+/-!
+# Document materialization status
+
+Composite/document materialization keeps the deletion marker as a status component
+separate from mutable field bytes. A later active field rematerialization may update
+the retained bytes, but it must not clear the tombstone.
+-/
+
+inductive Status
+  | active
+  | deleted
+deriving Repr, DecidableEq
+
+namespace Status
+
+/-- Deletion is absorbing over active document status. -/
+def merge : Status → Status → Status
+  | .deleted, _ => .deleted
+  | _, .deleted => .deleted
+  | .active, .active => .active
+
+theorem merge_comm (a b : Status) : merge a b = merge b a := by
+  cases a <;> cases b <;> rfl
+
+theorem merge_assoc (a b c : Status) : merge (merge a b) c = merge a (merge b c) := by
+  cases a <;> cases b <;> cases c <;> rfl
+
+theorem merge_idem (a : Status) : merge a a = a := by
+  cases a <;> rfl
+
+theorem deleted_absorbs_active : merge .deleted .active = .deleted := by
+  rfl
+
+end Status
+
+structure MaterializedDoc where
+  status : Status
+  age : Nat
+deriving Repr, DecidableEq
+
+def mergeDelete (doc : MaterializedDoc) : MaterializedDoc :=
+  { doc with status := Status.merge doc.status .deleted }
+
+def mergeActiveAge (doc : MaterializedDoc) (age : Nat) : MaterializedDoc :=
+  { doc with status := Status.merge doc.status .active, age }
+
+/-- An active field update after a delete may update bytes, but keeps the tombstone. -/
+theorem active_age_after_delete_keeps_deleted (doc : MaterializedDoc) (age : Nat) :
+    (mergeActiveAge (mergeDelete doc) age).status = Status.deleted := by
+  cases doc with
+  | mk status currentAge =>
+    cases status <;> rfl
+
+/-- Delete and active field rematerialization converge when status is componentwise. -/
+theorem delete_active_age_converge (doc : MaterializedDoc) (age : Nat) :
+    mergeActiveAge (mergeDelete doc) age = mergeDelete (mergeActiveAge doc age) := by
+  cases doc with
+  | mk status currentAge =>
+    cases status <;> rfl
+
+end DefraConvergence.DocumentMaterialization

--- a/proofs/lean/README.md
+++ b/proofs/lean/README.md
@@ -28,6 +28,7 @@ The model proves:
 | `CrdtField.dup_absorb` / `nonidem_has_dup_witness` | Idempotence is the dedup dividing line: idempotent ⇒ re-delivery-safe (no dedup); ¬idempotent ⇒ a duplicate changes the result (must dedup). | — |
 | `CounterReconcile.counterCM` + `counter_not_idempotent`; `PriorityReconcile.lwwCM` + `lww_idempotent` | Both fields fully instantiate the core: the counter (op-based, `Int +`, **not** idempotent ⇒ must apply each delta once — the algebraic root of the #4935 double-apply) and LWW (state-based join, **idempotent** ⇒ re-delivery-safe). | `crates/crdt/src/{counter,lww}.rs` |
 | `MixedField.mixedCM` + `mixed_two_converge` / `mixed_three_converge` + `mixed_not_idempotent` | Same-document `Counter × LWW` is a componentwise product of the two #1041 field instances. It converges when both components receive the same operations, but the product is still non-idempotent because the counter component still needs exactly-once dedup. The cross-field stale whole-document materialization hazard is modeled red/green by `MixedFieldMaterialization.tla`. | `crates/crdt/src/composite.rs`; `crates/crdt/src/{counter,lww}.rs` |
+| `DocumentMaterialization.active_age_after_delete_keeps_deleted` / `delete_active_age_converge` | Document status is a component of materialization: active field rematerialization may update retained bytes, but cannot clear a tombstone. | `crates/db-merge/src/merge_handler/composite_persist.rs`; `crates/crdt/src/composite.rs` |
 
 `#print axioms` status checked with Lean 4.18:
 
@@ -62,6 +63,8 @@ Field instantiations:
 - `MixedField.mixed_three_converge`: `[propext, Classical.choice, Quot.sound]`
 - `MixedField.mixed_not_idempotent`: `[propext, Classical.choice, Quot.sound]`
 - `MixedField.mixed_lww_component_dup_safe`: `[propext, Classical.choice, Quot.sound]`
+- `DocumentMaterialization.active_age_after_delete_keeps_deleted`: *(no axioms)*
+- `DocumentMaterialization.delete_active_age_converge`: *(no axioms)*
 
 `nonidem_has_dup_witness` is the generic core's only classical lemma (it pulls in
 `Classical.choice` via `Classical.byContradiction`), and it is the trivial

--- a/proofs/src/matrix.rs
+++ b/proofs/src/matrix.rs
@@ -23,6 +23,7 @@ pub const MODELED_FAMILIES: &[&str] = &[
     "P2P explicit-replay capability gate",
     "NAC lifecycle privilege-escalation",
     "Transaction & merge-queue concurrency",
+    "Document materialization status convergence",
     "JWT issuer / algorithm binding",
     "CID content-addressing determinism + Block canonicalization",
     "Deferred-ACP overlay consistency",

--- a/proofs/src/registry.rs
+++ b/proofs/src/registry.rs
@@ -200,6 +200,20 @@ pub const PROPERTIES: &[Property] = &[
         tiers: &[Behavioral, Boundary],
     },
     Property {
+        // `partition::convergence_delete_update_race_preserves_tombstone`
+        // partitions a replicated doc, deletes on one side, updates a mutable field
+        // on the other, then heals and asserts the merged materialized view stays
+        // tombstoned on both replicas. The TLA red leg captures the bad policy:
+        // committing an active update from a stale whole-document snapshot clears
+        // the delete marker.
+        family: "Document materialization status convergence",
+        name: "INV_DeletedMarkerAbsorbs — active rematerialization never clears a tombstone",
+        axis: Tla,
+        anchor: "crates/db-merge/src/merge_handler/composite_persist.rs handle_deletion / persist_merged_document; crates/crdt/src/composite.rs status",
+        model_ref: "MC_DocumentMaterialization_Green.cfg; DefraConvergence.DocumentMaterialization.delete_active_age_converge",
+        tiers: &[Behavioral],
+    },
+    Property {
         // The DID-binding half (a distinct identity cannot impersonate another)
         // IS observed behaviorally by the ACP test (ungranted bob denied). The
         // signer-binding half — forging a malformed / alg-confused token, or one

--- a/proofs/tests/behavioral/partition.rs
+++ b/proofs/tests/behavioral/partition.rs
@@ -73,6 +73,75 @@ async fn poll_field_state(node: &DefraClient, age: i64, city: &str, timeout: Dur
     }
 }
 
+fn user_age(node: &DefraClient) -> i64 {
+    node.query("query { User { age } }").unwrap_or_default()["User"]
+        .as_array()
+        .and_then(|rows| rows.first())
+        .and_then(|doc| doc["age"].as_i64())
+        .unwrap_or(-1)
+}
+
+async fn poll_user_age(node: &DefraClient, age: i64, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if user_age(node) == age {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+fn visible_user_docs(node: &DefraClient) -> Vec<serde_json::Value> {
+    node.query("query { User { _docID age } }")
+        .unwrap_or_default()["User"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn show_deleted_user_docs(node: &DefraClient) -> Vec<serde_json::Value> {
+    node.query("query { User(showDeleted: true) { _docID age _deleted } }")
+        .unwrap_or_default()["User"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn delete_materialized(node: &DefraClient, doc_id: &str) -> bool {
+    let visible_has_doc = visible_user_docs(node)
+        .iter()
+        .any(|doc| doc["_docID"].as_str() == Some(doc_id));
+    let tombstone = show_deleted_user_docs(node)
+        .into_iter()
+        .find(|doc| doc["_docID"].as_str() == Some(doc_id));
+
+    !visible_has_doc && tombstone.as_ref().and_then(|doc| doc["_deleted"].as_bool()) == Some(true)
+}
+
+async fn poll_delete_materialized(node: &DefraClient, doc_id: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if delete_materialized(node, doc_id) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+fn delete_materialization_state(node: &DefraClient) -> String {
+    format!(
+        "visible={:?}, showDeleted={:?}",
+        visible_user_docs(node),
+        show_deleted_user_docs(node)
+    )
+}
+
 #[tokio::test]
 async fn convergence_partition_both_directions_merge() {
     let mut cluster = TestCluster::builder()
@@ -446,6 +515,30 @@ fn wire_full_mesh(cluster: &TestCluster, nodes: usize, collection: &str) {
                 .expect("replicator set");
         }
     }
+}
+
+fn rewire_bidirectional(cluster: &TestCluster, collection: &str) {
+    let (a0, a1) = (node_addr(cluster, 0), node_addr(cluster, 1));
+    cluster.client(0).p2p_connect(&[a1.as_str()]).ok();
+    cluster.client(1).p2p_connect(&[a0.as_str()]).ok();
+    cluster.client(0).p2p_collection_add(&[collection]).ok();
+    cluster.client(1).p2p_collection_add(&[collection]).ok();
+    cluster
+        .client(0)
+        .p2p_replicator_delete(&[collection], Some(&a1))
+        .ok();
+    cluster
+        .client(1)
+        .p2p_replicator_delete(&[collection], Some(&a0))
+        .ok();
+    cluster
+        .client(0)
+        .p2p_replicator_set(&[collection], &a1)
+        .expect("rewire replicator 0->1");
+    cluster
+        .client(1)
+        .p2p_replicator_set(&[collection], &a0)
+        .expect("rewire replicator 1->0");
 }
 
 fn mixed_state(node: &DefraClient) -> (String, i64) {
@@ -1233,6 +1326,91 @@ async fn run_mixed_lww_counter_merge(restart_node: Option<usize>) {
         mixed_state(&cluster.client(0)),
         mixed_state(&cluster.client(1)),
         "replicas must materialize identical mixed-field state"
+    );
+}
+
+/// Delete-vs-active-update materialization convergence. While partitioned, node0
+/// deletes a document and node1 updates a mutable field on that same document.
+/// After reconnect the active update may rematerialize retained bytes, but it
+/// must not overwrite the deletion marker back to visible.
+#[tokio::test]
+async fn convergence_delete_update_race_preserves_tombstone() {
+    let mut cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .with_store("redb")
+        .with_keyring()
+        .with_rust_binary(support::release_binary())
+        .build()
+        .await
+        .expect("build 2-node p2p cluster");
+
+    let schema = "type User { name: String  age: Int }";
+    cluster.client(0).schema_add(schema).expect("schema node0");
+    cluster.client(1).schema_add(schema).expect("schema node1");
+    wire_bidirectional(&cluster, "User");
+
+    let created = cluster
+        .client(0)
+        .query(r#"mutation { add_User(input: {name: "Alice", age: 30}) { _docID } }"#)
+        .expect("create");
+    let id = created["add_User"][0]["_docID"]
+        .as_str()
+        .expect("_docID")
+        .to_string();
+    assert!(
+        poll_user_age(&cluster.client(1), 30, Duration::from_secs(20)).await,
+        "seed document must replicate to node1 before the delete/update partition"
+    );
+
+    cluster
+        .restart_node(1, Duration::from_secs(30))
+        .await
+        .expect("restart node1");
+
+    cluster
+        .client(0)
+        .query(&format!(
+            r#"mutation {{ delete_User(docID: "{id}") {{ _docID }} }}"#
+        ))
+        .expect("node0 deletes document");
+    cluster
+        .client(1)
+        .query(&format!(
+            r#"mutation {{ update_User(docID: "{id}", input: {{age: 99}}) {{ _docID }} }}"#
+        ))
+        .expect("node1 updates document while partitioned");
+
+    rewire_bidirectional(&cluster, "User");
+    assert!(
+        support::poll_dags_converged(
+            &cluster.client(0),
+            &cluster.client(1),
+            &id,
+            Duration::from_secs(40)
+        )
+        .await,
+        "delete/update DAGs did not converge; node0={:?} node1={:?}",
+        support::commit_cids(&cluster.client(0), &id),
+        support::commit_cids(&cluster.client(1), &id)
+    );
+
+    if !poll_delete_materialized(&cluster.client(0), &id, Duration::from_secs(30)).await {
+        panic!(
+            "node0 cleared or lost the tombstone after delete/update merge; {}",
+            delete_materialization_state(&cluster.client(0))
+        );
+    }
+    if !poll_delete_materialized(&cluster.client(1), &id, Duration::from_secs(30)).await {
+        panic!(
+            "node1 cleared or lost the tombstone after delete/update merge; {}",
+            delete_materialization_state(&cluster.client(1))
+        );
+    }
+    assert_eq!(
+        show_deleted_user_docs(&cluster.client(0)),
+        show_deleted_user_docs(&cluster.client(1)),
+        "replicas must expose the same tombstoned materialized document"
     );
 }
 

--- a/proofs/tla/DocumentMaterialization.tla
+++ b/proofs/tla/DocumentMaterialization.tla
@@ -1,0 +1,88 @@
+---- MODULE DocumentMaterialization ----
+\* Document/composite materialization status under a delete-vs-active-update race.
+\*
+\* RED: an active composite update snapshots the whole document while it is visible,
+\* a delete commits, then the active update commits its stale snapshot and overwrites
+\* the deletion marker back to active.
+\*
+\* GREEN: status is a component of the materialized document. Active updates may
+\* update retained field bytes, but they preserve the current deletion marker.
+EXTENDS Naturals
+
+CONSTANTS
+  StatusMode \* "Overwrite" | "DeletedAbsorbs"
+
+ASSUME StatusMode \in {"Overwrite", "DeletedAbsorbs"}
+
+VARIABLES
+  deleted,         \* Bool: query visibility is derived from this marker
+  age,             \* Nat: retained materialized field bytes
+  expectedDeleted, \* oracle status after committed operations
+  expectedAge,     \* oracle bytes after committed active updates
+  pc,              \* per-operation phase
+  snapDeleted,     \* active update's whole-document status snapshot
+  snapAge          \* active update's whole-document field snapshot
+
+vars == <<deleted, age, expectedDeleted, expectedAge, pc, snapDeleted, snapAge>>
+
+Ops == {"delete", "update"}
+Phases == {"todo", "snap", "done"}
+
+TypeOK ==
+  /\ deleted \in BOOLEAN
+  /\ age \in Nat
+  /\ expectedDeleted \in BOOLEAN
+  /\ expectedAge \in Nat
+  /\ pc \in [Ops -> Phases]
+  /\ snapDeleted \in BOOLEAN
+  /\ snapAge \in Nat
+
+Init ==
+  /\ deleted = FALSE
+  /\ age = 30
+  /\ expectedDeleted = FALSE
+  /\ expectedAge = 30
+  /\ pc = [o \in Ops |-> "todo"]
+  /\ snapDeleted = FALSE
+  /\ snapAge = 30
+
+DeleteCommit ==
+  /\ pc["delete"] = "todo"
+  /\ deleted' = TRUE
+  /\ expectedDeleted' = TRUE
+  /\ pc' = [pc EXCEPT !["delete"] = "done"]
+  /\ UNCHANGED <<age, expectedAge, snapDeleted, snapAge>>
+
+ActiveUpdateSnap ==
+  /\ pc["update"] = "todo"
+  /\ snapDeleted' = deleted
+  /\ snapAge' = age
+  /\ pc' = [pc EXCEPT !["update"] = "snap"]
+  /\ UNCHANGED <<deleted, age, expectedDeleted, expectedAge>>
+
+ActiveUpdateCommit ==
+  /\ pc["update"] = "snap"
+  /\ IF StatusMode = "Overwrite"
+       THEN deleted' = snapDeleted
+       ELSE deleted' = deleted
+  /\ age' = 99
+  /\ expectedDeleted' = expectedDeleted
+  /\ expectedAge' = 99
+  /\ pc' = [pc EXCEPT !["update"] = "done"]
+  /\ UNCHANGED <<snapDeleted, snapAge>>
+
+Next ==
+  \/ DeleteCommit
+  \/ ActiveUpdateSnap
+  \/ ActiveUpdateCommit
+
+Spec == Init /\ [][Next]_vars
+
+INV_DeletedMarkerAbsorbs == deleted = expectedDeleted
+
+INV_Exact ==
+  /\ deleted = expectedDeleted
+  /\ age = expectedAge
+
+INV_TypeOK == TypeOK
+====

--- a/proofs/tla/MC_DocumentMaterialization_Green.cfg
+++ b/proofs/tla/MC_DocumentMaterialization_Green.cfg
@@ -1,0 +1,8 @@
+\* GREEN: active rematerialization updates field bytes componentwise and preserves
+\* the current deletion marker.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  StatusMode = "DeletedAbsorbs"
+INVARIANT INV_TypeOK
+INVARIANT INV_Exact

--- a/proofs/tla/MC_DocumentMaterialization_Red_Overwrite.cfg
+++ b/proofs/tla/MC_DocumentMaterialization_Red_Overwrite.cfg
@@ -1,0 +1,8 @@
+\* RED: active rematerialization overwrites status from a stale whole-document
+\* snapshot, so a delete can be made visible again.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  StatusMode = "Overwrite"
+INVARIANT INV_TypeOK
+INVARIANT INV_DeletedMarkerAbsorbs

--- a/proofs/tla/README.md
+++ b/proofs/tla/README.md
@@ -19,6 +19,8 @@ grounded facts for B3 live in [DESIGN.md](DESIGN.md); each later slice has its o
   Lean half under [`../lean/`](../lean/README.md).
 - **Mixed-field materialization** — Counter×LWW componentwise document state
   (`MixedFieldMaterialization_DESIGN.md`).
+- **Document materialization status** — delete/update status stays componentwise
+  (`DocumentMaterialization.tla`).
 
 Run all configured models at once with `./run-all.sh` (red/green oracle, exits non-zero on mismatch).
 

--- a/proofs/tla/run-all.sh
+++ b/proofs/tla/run-all.sh
@@ -74,6 +74,8 @@ RUNS=(
   "MC_TwoStoreCounter_Green.cfg     TwoStoreCounter.tla           GREEN" # unified RMW + merged-set dedup -> exact (no loss, no double)
   "MC_MixedFieldMaterialization_Red_WholeDoc.cfg MixedFieldMaterialization.tla RED" # stale whole-doc field merge clobbers another field
   "MC_MixedFieldMaterialization_Green.cfg MixedFieldMaterialization.tla GREEN" # componentwise field materialization preserves mixed product state
+  "MC_DocumentMaterialization_Red_Overwrite.cfg DocumentMaterialization.tla RED" # active rematerialization must not clear delete marker
+  "MC_DocumentMaterialization_Green.cfg DocumentMaterialization.tla GREEN" # deletion marker is componentwise/absorbing
   "MC_InteractiveTxnCounter_Green.cfg MC_InteractiveTxnCounter_Common.tla GREEN" # #1044: gate On + commit-only finalize -> deadlock-free + gate never held across idle
   "MC_InteractiveTxnCounter_Red_NoGate.cfg MC_InteractiveTxnCounter_Common.tla RED" # gate Off -> arbitrary-order batch vs finalize circular-wait DEADLOCK (gate is load-bearing)
   "MC_InteractiveTxnCounter_Red_AcrossLifetime.cfg MC_InteractiveTxnCounter_Common.tla RED" # #1041 old path: gate held across user-controlled idle lifetime (INV_GateBoundedHold)


### PR DESCRIPTION
## Summary

Closes #1047.

This adds a proof/conformance slice for composite/document materialization status convergence, specifically the delete-vs-active-update case where an active rematerialization must not clear a tombstone.

## What changed

- Added `DocumentMaterialization` Lean laws showing delete status is absorbing over active field rematerialization.
- Added TLA+ red/green configs for stale whole-document status overwrite vs componentwise status preservation.
- Promoted the delete/update race from report-only coverage into an asserting Rust conformance regression.
- Wired the new modeled family into the proof registry, matrix, and proof READMEs.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `lake build`
- [x] `cargo test -p conformance --test lean_conformance`
- [x] `cargo test -p conformance --lib matrix::`
- [x] `cargo build -p cli`
- [x] `cargo clippy -p conformance --all-targets -- -D warnings`
- [x] `env RUST_LOG=info cargo test -p conformance --test tla_conformance convergence_delete_update_race_preserves_tombstone -- --test-threads=1 --nocapture`
- [x] `git diff --check`

Note: targeted TLC runs for the new configs were attempted locally, but this machine has no usable JDK installed, so TLC could not start.