### PR TITLE
feat(acp): branchable collection ACP — registration, read & sync enforcement (A1–A3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -619,7 +619,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "defra-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#68838b3bb03a1b60f5927184bd5feab9dd3f1d20"
 dependencies = [
  "eyre",
  "futures",
@@ -4370,7 +4370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5505,7 +5505,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#68838b3bb03a1b60f5927184bd5feab9dd3f1d20"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8200,7 +8200,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10875,7 +10875,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10967,7 +10967,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11263,7 +11263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11802,7 +11802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11862,7 +11862,7 @@ dependencies = [
 [[package]]
 name = "sourcehub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#68838b3bb03a1b60f5927184bd5feab9dd3f1d20"
 dependencies = [
  "cosmrs",
  "eyre",
@@ -12312,7 +12312,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12419,7 +12419,7 @@ dependencies = [
 [[package]]
 name = "test-infra"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#68838b3bb03a1b60f5927184bd5feab9dd3f1d20"
 dependencies = [
  "eyre",
  "futures",
@@ -13110,7 +13110,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13992,7 +13992,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -619,7 +619,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2186,7 +2186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3363,7 +3363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "defra-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#68838b3bb03a1b60f5927184bd5feab9dd3f1d20"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
 dependencies = [
  "eyre",
  "futures",
@@ -4370,7 +4370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4945,7 +4945,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -5505,7 +5505,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#68838b3bb03a1b60f5927184bd5feab9dd3f1d20"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8200,7 +8200,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8356,7 +8356,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9712,7 +9712,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -10862,7 +10862,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10875,7 +10875,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10967,7 +10967,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11263,7 +11263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11802,7 +11802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11862,7 +11862,7 @@ dependencies = [
 [[package]]
 name = "sourcehub-harness"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#68838b3bb03a1b60f5927184bd5feab9dd3f1d20"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
 dependencies = [
  "cosmrs",
  "eyre",
@@ -11974,7 +11974,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -12313,7 +12312,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12420,7 +12419,7 @@ dependencies = [
 [[package]]
 name = "test-infra"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#68838b3bb03a1b60f5927184bd5feab9dd3f1d20"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=feat%2Fshared-se-key-harness#adaf59db7aaea3e8d48a9b5e14846c24e59d2456"
 dependencies = [
  "eyre",
  "futures",
@@ -13111,7 +13110,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13993,7 +13992,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/acp/src/dac.rs
+++ b/crates/acp/src/dac.rs
@@ -39,7 +39,22 @@ pub trait DocumentACP: MaybeSendSync {
         doc_id: &str,
     ) -> Result<()>;
 
-    /// Check if document is registered with ACP.
+    /// Register an ACP object with creator as owner.
+    ///
+    /// Documents use `id = docID`; branchable collections use
+    /// `id = collectionID` to gate their collection-level commit DAG.
+    async fn register_object(
+        &self,
+        identity: &Did,
+        policy_id: &str,
+        resource_name: &str,
+        object_id: &str,
+    ) -> Result<()> {
+        self.register_doc_object(identity, policy_id, resource_name, object_id)
+            .await
+    }
+
+    /// Check if document/object is registered with ACP.
     ///
     /// Documents created without identity are unregistered (public).
     /// Documents created with identity are registered.

--- a/crates/acp/src/lib.rs
+++ b/crates/acp/src/lib.rs
@@ -34,6 +34,7 @@ pub mod nac;
 mod permission;
 mod persistent;
 pub mod policy_yaml;
+pub mod read_access;
 mod relation;
 mod store;
 mod target_subject;
@@ -47,6 +48,7 @@ pub use identity::Identity;
 pub use local::{LocalDocumentACP, MemoryAcpStore};
 pub use permission::DocumentPermission;
 pub use persistent::PersistentAcpStore;
+pub use read_access::{check_doc_read_access, DirectChecker, DocAccess, ObjectAccessChecker};
 pub use relation::{
     RelationTuple, DELETER_RELATION, OWNER_RELATION, READER_RELATION, UPDATER_RELATION,
 };

--- a/crates/acp/src/read_access.rs
+++ b/crates/acp/src/read_access.rs
@@ -1,0 +1,113 @@
+//! Shared document/collection read-access rule.
+
+use async_trait::async_trait;
+use identity::Did;
+use storage::corekv::MaybeSendSync;
+
+use crate::{DocumentACP, DocumentPermission, Identity, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DocAccess {
+    pub has_access: bool,
+    pub explicit: bool,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait ObjectAccessChecker: MaybeSendSync {
+    async fn object_access(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        object_id: &str,
+    ) -> Result<DocAccess>;
+}
+
+pub struct DirectChecker<'a> {
+    pub acp: &'a dyn DocumentACP,
+    pub identity: &'a Identity,
+    pub node_did: Option<&'a Did>,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl ObjectAccessChecker for DirectChecker<'_> {
+    async fn object_access(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        object_id: &str,
+    ) -> Result<DocAccess> {
+        if defra_core::dac_bypass::get_dac_bypass() {
+            return Ok(DocAccess {
+                has_access: true,
+                explicit: true,
+            });
+        }
+
+        if let (Some(node), Identity::Authenticated(requester)) = (self.node_did, self.identity) {
+            if node == requester {
+                return Ok(DocAccess {
+                    has_access: true,
+                    explicit: true,
+                });
+            }
+        }
+
+        if !self
+            .acp
+            .is_doc_registered(policy_id, resource_name, object_id)
+            .await?
+        {
+            return Ok(DocAccess {
+                has_access: true,
+                explicit: false,
+            });
+        }
+
+        let has_access = self
+            .acp
+            .check_doc_access(
+                self.identity,
+                DocumentPermission::Read,
+                policy_id,
+                resource_name,
+                object_id,
+            )
+            .await?;
+        Ok(DocAccess {
+            has_access,
+            explicit: true,
+        })
+    }
+}
+
+/// Branchable read rule. `doc_id == ""` means a collection-level commit.
+pub async fn check_doc_read_access(
+    checker: &dyn ObjectAccessChecker,
+    policy_id: &str,
+    resource_name: &str,
+    collection_id: &str,
+    is_branchable: bool,
+    doc_id: &str,
+) -> Result<bool> {
+    if !doc_id.is_empty() {
+        let access = checker
+            .object_access(policy_id, resource_name, doc_id)
+            .await?;
+        if access.explicit {
+            return Ok(access.has_access);
+        }
+    }
+
+    if is_branchable {
+        let access = checker
+            .object_access(policy_id, resource_name, collection_id)
+            .await?;
+        if !access.has_access {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}

--- a/crates/acp/tests/read_access_tests.rs
+++ b/crates/acp/tests/read_access_tests.rs
@@ -1,0 +1,125 @@
+use std::sync::{Arc, Mutex};
+
+use acp::read_access::{check_doc_read_access, DocAccess, ObjectAccessChecker};
+use async_trait::async_trait;
+
+struct FakeChecker {
+    doc_access: DocAccess,
+    collection_access: DocAccess,
+    calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl FakeChecker {
+    fn new(doc_access: DocAccess, collection_access: DocAccess) -> Self {
+        Self {
+            doc_access,
+            collection_access,
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ObjectAccessChecker for FakeChecker {
+    async fn object_access(
+        &self,
+        _policy_id: &str,
+        _resource_name: &str,
+        object_id: &str,
+    ) -> acp::Result<DocAccess> {
+        self.calls.lock().unwrap().push(object_id.to_string());
+        Ok(if object_id == "col1" {
+            self.collection_access
+        } else {
+            self.doc_access
+        })
+    }
+}
+
+#[tokio::test]
+async fn branchable_public_doc_requires_collection_read() {
+    let checker = FakeChecker::new(
+        DocAccess {
+            has_access: true,
+            explicit: false,
+        },
+        DocAccess {
+            has_access: false,
+            explicit: true,
+        },
+    );
+
+    let allowed = check_doc_read_access(&checker, "policy1", "resource1", "col1", true, "doc1")
+        .await
+        .unwrap();
+
+    assert!(!allowed);
+    assert_eq!(checker.calls(), vec!["doc1", "col1"]);
+}
+
+#[tokio::test]
+async fn branchable_explicit_doc_grant_wins_over_collection_denial() {
+    let checker = FakeChecker::new(
+        DocAccess {
+            has_access: true,
+            explicit: true,
+        },
+        DocAccess {
+            has_access: false,
+            explicit: true,
+        },
+    );
+
+    let allowed = check_doc_read_access(&checker, "policy1", "resource1", "col1", true, "doc1")
+        .await
+        .unwrap();
+
+    assert!(allowed);
+    assert_eq!(checker.calls(), vec!["doc1"]);
+}
+
+#[tokio::test]
+async fn non_branchable_public_doc_does_not_check_collection() {
+    let checker = FakeChecker::new(
+        DocAccess {
+            has_access: true,
+            explicit: false,
+        },
+        DocAccess {
+            has_access: false,
+            explicit: true,
+        },
+    );
+
+    let allowed = check_doc_read_access(&checker, "policy1", "resource1", "col1", false, "doc1")
+        .await
+        .unwrap();
+
+    assert!(allowed);
+    assert_eq!(checker.calls(), vec!["doc1"]);
+}
+
+#[tokio::test]
+async fn branchable_collection_level_commit_checks_collection_object() {
+    let checker = FakeChecker::new(
+        DocAccess {
+            has_access: false,
+            explicit: true,
+        },
+        DocAccess {
+            has_access: true,
+            explicit: true,
+        },
+    );
+
+    let allowed = check_doc_read_access(&checker, "policy1", "resource1", "col1", true, "")
+        .await
+        .unwrap();
+
+    assert!(allowed);
+    assert_eq!(checker.calls(), vec!["col1"]);
+}

--- a/crates/cli/src/commands/start/p2p.rs
+++ b/crates/cli/src/commands/start/p2p.rs
@@ -93,6 +93,8 @@ impl Node {
         bitswap_store: S,
         keypair: Option<p2p::Keypair>,
         enable_pubsub: bool,
+        classifier: std::sync::Arc<dyn p2p::bitswap::BlockClassifier>,
+        serve_acp: std::sync::Arc<p2p::bitswap::LateBoundServeAcp>,
     ) -> Result<(
         p2p::P2PHostHandle,
         tokio::sync::mpsc::Receiver<p2p::HostEvent>,
@@ -119,14 +121,18 @@ impl Node {
             max_connections_per_peer: config.net.max_connections_per_peer,
             access_mode,
         };
-        let (host, handle, events, replicators) = match keypair {
-            Some(kp) => p2p::P2PHost::with_keypair_and_config(kp, bitswap_store, p2p_config)
-                .await
-                .map_err(Error::P2P)?,
-            None => p2p::P2PHost::with_config(bitswap_store, p2p_config)
-                .await
-                .map_err(Error::P2P)?,
-        };
+        let keypair = keypair.unwrap_or_else(p2p::Keypair::generate_ed25519);
+        let (host, handle, events, replicators) =
+            p2p::P2PHost::with_keypair_and_config_and_identity_and_serve_gate(
+                keypair,
+                bitswap_store,
+                p2p_config,
+                None,
+                classifier,
+                serve_acp,
+            )
+            .await
+            .map_err(Error::P2P)?;
 
         // Spawn the host event loop FIRST - it must be running to process commands
         // Track the task handle for graceful shutdown

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -157,8 +157,15 @@ impl Node {
         server = server.with_schema_arc(schema_adapter);
         info!("Schema HTTP endpoint enabled");
 
-        let view_adapter =
-            crate::view_adapter::ViewAdapter::new_arc(database.clone(), query_limits);
+        let view_adapter = if config.acp.document_type != AcpDocumentType::None {
+            crate::view_adapter::ViewAdapter::new_arc_with_acp(
+                database.clone(),
+                query_limits,
+                acp_setup.document_acp.clone(),
+            )
+        } else {
+            crate::view_adapter::ViewAdapter::new_arc(database.clone(), query_limits)
+        };
         server = server.with_view_arc(view_adapter);
         info!("View HTTP endpoints enabled");
 

--- a/crates/cli/src/commands/start/server_http.rs
+++ b/crates/cli/src/commands/start/server_http.rs
@@ -150,6 +150,7 @@ impl Node {
             Some(acp) => crate::schema_adapter::SchemaAdapter::new_arc_with_acp(
                 database.clone(),
                 acp.clone(),
+                acp_setup.document_acp.clone(),
             ),
             None => crate::schema_adapter::SchemaAdapter::new_arc(database.clone()),
         };
@@ -170,8 +171,14 @@ impl Node {
         server = server.with_collection_mgmt_arc(collection_mgmt_adapter);
         info!("Collection management HTTP endpoints enabled");
 
-        let txn_adapter =
-            crate::txn_adapter::TxnRegistryAdapter::new_arc(query_setup.registry.clone());
+        let txn_adapter = if config.acp.document_type != AcpDocumentType::None {
+            crate::txn_adapter::TxnRegistryAdapter::new_arc_with_acp(
+                query_setup.registry.clone(),
+                acp_setup.document_acp.clone(),
+            )
+        } else {
+            crate::txn_adapter::TxnRegistryAdapter::new_arc(query_setup.registry.clone())
+        };
         server = server.with_txn_ops_arc(txn_adapter);
         info!("Transaction-scoped HTTP endpoints enabled");
 
@@ -243,7 +250,11 @@ impl Node {
                     db::node_access_checker(database.clone()),
                 )
             });
-            crate::schema_adapter::SchemaAdapter::new_pg_arc_with_acp(database, acp_adapter)
+            crate::schema_adapter::SchemaAdapter::new_pg_arc_with_acp(
+                database,
+                acp_adapter,
+                acp_setup.document_acp.clone(),
+            )
         } else {
             crate::schema_adapter::SchemaAdapter::new_pg_arc(database)
         };

--- a/crates/cli/src/commands/start/server_p2p.rs
+++ b/crates/cli/src/commands/start/server_p2p.rs
@@ -170,11 +170,15 @@ impl Node {
 
         let blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), true));
         let bitswap_store = p2p::BitswapStoreAdapter::new(blockstore);
+        let classifier = defra_p2p_adapter::DbBlockClassifier::new_arc(database.clone());
+        let serve_acp = Arc::new(p2p::bitswap::LateBoundServeAcp::new());
         let (handle, mut events, replicator_registry, host_task) = Self::start_p2p(
             config,
             bitswap_store,
             peer_keypair,
             config.net.pubsub_enabled,
+            classifier.clone(),
+            serve_acp.clone(),
         )
         .await?;
 
@@ -200,22 +204,28 @@ impl Node {
         let head_provider: Arc<dyn p2p::sync::DocumentHeadProvider> =
             Arc::new(db_merge::create_head_provider(database.clone()));
 
-        let (mut coordinator, sync_events) = p2p::sync::SyncCoordinator::with_head_provider(
-            p2p::Libp2pTransport::new(handle.clone()),
-            sync_blockstore,
-            Self::sync_config(config),
-            Self::access_mode(config),
-            replicator_registry,
-            collection_store,
-            head_provider,
-            std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
-        )
-        .await
-        .map_err(Error::P2P)?;
+        let (mut coordinator, sync_events) =
+            p2p::sync::SyncCoordinator::with_head_provider_and_serve_gate(
+                p2p::Libp2pTransport::new(handle.clone()),
+                sync_blockstore,
+                Self::sync_config(config),
+                Self::access_mode(config),
+                replicator_registry,
+                collection_store,
+                head_provider,
+                std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
+                classifier,
+                serve_acp.clone(),
+            )
+            .await
+            .map_err(Error::P2P)?;
 
         let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
         let coordinator = Arc::new(coordinator);
         let coordinator_for_acp = coordinator.clone();
+        let serve_acp_for_acp = serve_acp.clone();
+        let handle_for_acp = handle.clone();
+        let database_for_acp = database.clone();
 
         // Build the KMS pubsub transport and install it on the coordinator so
         // raw gossip on the encryption topic is routed to it (mirrors
@@ -691,6 +701,13 @@ impl Node {
             mutator: broadcast_mutator,
             http_adapter: Some(manage_controller.clone()),
             wire_merge_acp: Some(Box::new(move |acp| {
+                serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
+                    resolver: Arc::new(p2p::HandlePeerIdentityResolver::new(handle_for_acp)),
+                    gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
+                        acp.clone(),
+                        database_for_acp.node_did(),
+                    ),
+                });
                 coordinator_for_acp.set_document_acp(acp.clone());
                 // Wire the document ACP into the broadcast mutator so newly
                 // created ACP-protected docs are registered *before* their
@@ -768,23 +785,30 @@ impl Node {
         let manage_query_correlator = p2p::ManageQueryCorrelator::new();
         let manage_hooks = defra_p2p_adapter::manage::hooks::new_manage_hooks_cell();
         let manage_hooks_for_events = manage_hooks.clone();
+        let classifier = defra_p2p_adapter::DbBlockClassifier::new_arc(database.clone());
+        let serve_acp = Arc::new(p2p::bitswap::LateBoundServeAcp::new());
 
-        let (mut coordinator, sync_events) = p2p::sync::SyncCoordinator::with_head_provider(
-            transport.clone(),
-            sync_blockstore,
-            Self::sync_config(config),
-            Self::access_mode(config),
-            replicator_registry,
-            collection_store,
-            head_provider,
-            std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
-        )
-        .await
-        .map_err(Error::P2P)?;
+        let (mut coordinator, sync_events) =
+            p2p::sync::SyncCoordinator::with_head_provider_and_serve_gate(
+                transport.clone(),
+                sync_blockstore,
+                Self::sync_config(config),
+                Self::access_mode(config),
+                replicator_registry,
+                collection_store,
+                head_provider,
+                std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
+                classifier,
+                serve_acp.clone(),
+            )
+            .await
+            .map_err(Error::P2P)?;
 
         let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
         let coordinator = Arc::new(coordinator);
         let coordinator_for_acp = coordinator.clone();
+        let serve_acp_for_acp = serve_acp.clone();
+        let database_for_acp = database.clone();
 
         // Build the KMS pubsub transport and install it on the coordinator so
         // raw gossip on the encryption topic is routed to it (mirrors
@@ -1201,6 +1225,13 @@ impl Node {
             http_adapter: Some(manage_controller.clone()),
             txn_broadcaster: Some(txn_broadcaster),
             wire_merge_acp: Some(Box::new(move |acp| {
+                serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
+                    resolver: Arc::new(p2p::AnonymousResolver),
+                    gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
+                        acp.clone(),
+                        database_for_acp.node_did(),
+                    ),
+                });
                 coordinator_for_acp.set_document_acp(acp.clone());
                 // Wire the document ACP into the broadcast mutator so newly
                 // created ACP-protected docs are registered *before* their

--- a/crates/cli/src/commands/start/server_query.rs
+++ b/crates/cli/src/commands/start/server_query.rs
@@ -49,6 +49,7 @@ impl Node {
         )
         .with_mutator(mutator)
         .with_acp(document_acp)
+        .with_node_did(database.node_did())
         .with_lens_store(database.lens_store().clone())
         .with_query_timeout(config.api.query_timeout)
         .with_query_limits(query::QueryLimits {

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use defra_http::router::{AcpOperations, SchemaOperations};
+use identity::Did;
 use schema::CollectionVersion;
 use storage::corekv::Store;
 
@@ -20,6 +21,8 @@ pub struct SchemaAdapter<S: Store> {
     /// permissions. When `None` (legacy / tests without ACP wired in),
     /// the validator is skipped.
     acp: Option<Arc<dyn AcpOperations>>,
+    /// Optional document ACP handle for branchable collection object registration.
+    document_acp: Option<Arc<dyn acp::DocumentACP>>,
 }
 
 impl<S: Store + 'static> SchemaAdapter<S> {
@@ -28,14 +31,20 @@ impl<S: Store + 'static> SchemaAdapter<S> {
         Self {
             database,
             acp: None,
+            document_acp: None,
         }
     }
 
     /// Create a new adapter with ACP wired in for schema-time DRI validation.
-    pub fn new_with_acp(database: Arc<db::DB<S>>, acp: Arc<dyn AcpOperations>) -> Self {
+    pub fn new_with_acp(
+        database: Arc<db::DB<S>>,
+        acp: Arc<dyn AcpOperations>,
+        document_acp: Arc<dyn acp::DocumentACP>,
+    ) -> Self {
         Self {
             database,
             acp: Some(acp),
+            document_acp: Some(document_acp),
         }
     }
 
@@ -49,8 +58,9 @@ impl<S: Store + 'static> SchemaAdapter<S> {
     pub fn new_arc_with_acp(
         database: Arc<db::DB<S>>,
         acp: Arc<dyn AcpOperations>,
+        document_acp: Arc<dyn acp::DocumentACP>,
     ) -> Arc<dyn SchemaOperations> {
-        Arc::new(Self::new_with_acp(database, acp))
+        Arc::new(Self::new_with_acp(database, acp, document_acp))
     }
 
     /// Create an Arc-wrapped adapter for PG wire protocol schema operations.
@@ -69,11 +79,15 @@ impl<S: Store + 'static> SchemaAdapter<S> {
     pub fn new_pg_arc_with_acp(
         database: Arc<db::DB<S>>,
         acp: Arc<dyn AcpOperations>,
+        document_acp: Arc<dyn acp::DocumentACP>,
     ) -> Arc<dyn pg_compat::SchemaManager> {
-        Arc::new(Self::new_with_acp(database, acp))
+        Arc::new(Self::new_with_acp(database, acp, document_acp))
     }
 
     async fn add_schema_inner(&self, sdl: &str) -> Result<Vec<CollectionVersion>, String> {
+        let creator = defra_core::current_identity::try_get_scoped_identity()
+            .or_else(defra_core::current_identity::get_current_identity)
+            .and_then(|did| Did::new(did).ok());
         let known_types: std::collections::HashSet<String> = self
             .database
             .list_collections()
@@ -104,12 +118,28 @@ impl<S: Store + 'static> SchemaAdapter<S> {
 
         let mut created = Vec::new();
         for collection in collections {
-            let col_clone = collection.clone();
+            let collection_name = collection.name.clone();
             self.database
                 .create_collection(collection)
                 .await
                 .map_err(|e| format!("failed to create collection: {}", e))?;
-            created.push(col_clone);
+            let finalized = self
+                .database
+                .get_collection(&collection_name)
+                .map_err(|e| format!("failed to load created collection: {}", e))?
+                .ok_or_else(|| {
+                    format!("created collection '{}' was not cached", collection_name)
+                })?;
+            if let Some(document_acp) = &self.document_acp {
+                db::register_collection_if_needed(
+                    document_acp.as_ref(),
+                    creator.as_ref(),
+                    finalized.schema(),
+                )
+                .await
+                .map_err(|e| format!("failed to register collection with ACP: {}", e))?;
+            }
+            created.push(finalized.schema().clone());
         }
 
         Ok(created)

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -116,31 +116,18 @@ impl<S: Store + 'static> SchemaAdapter<S> {
             }
         }
 
-        let mut created = Vec::new();
-        for collection in collections {
-            let collection_name = collection.name.clone();
+        let created = if let Some(document_acp) = &self.document_acp {
             self.database
-                .create_collection(collection)
-                .await
-                .map_err(|e| format!("failed to create collection: {}", e))?;
-            let finalized = self
-                .database
-                .get_collection(&collection_name)
-                .map_err(|e| format!("failed to load created collection: {}", e))?
-                .ok_or_else(|| {
-                    format!("created collection '{}' was not cached", collection_name)
-                })?;
-            if let Some(document_acp) = &self.document_acp {
-                db::register_collection_if_needed(
-                    document_acp.as_ref(),
-                    creator.as_ref(),
-                    finalized.schema(),
+                .create_collections_atomic_with_acp_registration(
+                    collections,
+                    document_acp.clone(),
+                    creator,
                 )
                 .await
-                .map_err(|e| format!("failed to register collection with ACP: {}", e))?;
-            }
-            created.push(finalized.schema().clone());
+        } else {
+            self.database.create_collections_atomic(collections).await
         }
+        .map_err(|e| format!("failed to create collection: {}", e))?;
 
         Ok(created)
     }

--- a/crates/cli/src/schema_adapter.rs
+++ b/crates/cli/src/schema_adapter.rs
@@ -85,9 +85,16 @@ impl<S: Store + 'static> SchemaAdapter<S> {
     }
 
     async fn add_schema_inner(&self, sdl: &str) -> Result<Vec<CollectionVersion>, String> {
-        let creator = defra_core::current_identity::try_get_scoped_identity()
+        // Fail closed: a present-but-malformed ambient identity must error, not
+        // silently degrade a permissioned collection to public (unregistered).
+        let creator = match defra_core::current_identity::try_get_scoped_identity()
             .or_else(defra_core::current_identity::get_current_identity)
-            .and_then(|did| Did::new(did).ok());
+        {
+            Some(raw) => {
+                Some(Did::new(raw).map_err(|e| format!("malformed ambient identity: {}", e))?)
+            }
+            None => None,
+        };
         let known_types: std::collections::HashSet<String> = self
             .database
             .list_collections()

--- a/crates/cli/src/txn_adapter.rs
+++ b/crates/cli/src/txn_adapter.rs
@@ -10,17 +10,33 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use defra_http::router::TransactionOperations;
+use identity::Did;
 use storage::corekv::Store;
 
 /// Adapter that implements TransactionOperations using a shared DbTransactionRegistry.
 pub struct TxnRegistryAdapter<S: Store> {
     registry: Arc<db::DbTransactionRegistry<S>>,
+    document_acp: Option<Arc<dyn acp::DocumentACP>>,
 }
 
 impl<S: Store + 'static> TxnRegistryAdapter<S> {
     /// Create an Arc-wrapped adapter backed by the shared transaction registry.
     pub fn new_arc(registry: Arc<db::DbTransactionRegistry<S>>) -> Arc<dyn TransactionOperations> {
-        Arc::new(Self { registry })
+        Arc::new(Self {
+            registry,
+            document_acp: None,
+        })
+    }
+
+    /// Create an Arc-wrapped adapter with document ACP registration support.
+    pub fn new_arc_with_acp(
+        registry: Arc<db::DbTransactionRegistry<S>>,
+        document_acp: Arc<dyn acp::DocumentACP>,
+    ) -> Arc<dyn TransactionOperations> {
+        Arc::new(Self {
+            registry,
+            document_acp: Some(document_acp),
+        })
     }
 }
 
@@ -73,6 +89,10 @@ impl<S: Store + 'static> TransactionOperations for TxnRegistryAdapter<S> {
         sdl: &str,
     ) -> Result<Vec<schema::CollectionVersion>, String> {
         let registry = self.registry.clone();
+        let document_acp = self.document_acp.clone();
+        let creator = defra_core::current_identity::try_get_scoped_identity()
+            .or_else(defra_core::current_identity::get_current_identity)
+            .and_then(|did| Did::new(did).ok());
         let txn_id = txn_id.to_string();
         let sdl = sdl.to_string();
         let handle = tokio::runtime::Handle::current();
@@ -80,7 +100,7 @@ impl<S: Store + 'static> TransactionOperations for TxnRegistryAdapter<S> {
         tokio::task::spawn_blocking(move || {
             handle.block_on(async {
                 registry
-                    .add_schema_in_txn(&txn_id, &sdl)
+                    .add_schema_in_txn_with_acp(&txn_id, &sdl, document_acp, creator)
                     .await
                     .map_err(|e| format!("{}", e))
             })

--- a/crates/cli/src/txn_adapter.rs
+++ b/crates/cli/src/txn_adapter.rs
@@ -90,9 +90,16 @@ impl<S: Store + 'static> TransactionOperations for TxnRegistryAdapter<S> {
     ) -> Result<Vec<schema::CollectionVersion>, String> {
         let registry = self.registry.clone();
         let document_acp = self.document_acp.clone();
-        let creator = defra_core::current_identity::try_get_scoped_identity()
+        // Fail closed: a present-but-malformed ambient identity must error, not
+        // silently degrade a permissioned collection to public (unregistered).
+        let creator = match defra_core::current_identity::try_get_scoped_identity()
             .or_else(defra_core::current_identity::get_current_identity)
-            .and_then(|did| Did::new(did).ok());
+        {
+            Some(raw) => {
+                Some(Did::new(raw).map_err(|e| format!("malformed ambient identity: {}", e))?)
+            }
+            None => None,
+        };
         let txn_id = txn_id.to_string();
         let sdl = sdl.to_string();
         let handle = tokio::runtime::Handle::current();

--- a/crates/cli/src/view_adapter.rs
+++ b/crates/cli/src/view_adapter.rs
@@ -126,9 +126,16 @@ impl<S: Store + 'static> ViewOperations for ViewAdapter<S> {
             }
         }
 
-        let creator = defra_core::current_identity::try_get_scoped_identity()
+        // Fail closed: a present-but-malformed ambient identity must error, not
+        // silently degrade a permissioned collection to public (unregistered).
+        let creator = match defra_core::current_identity::try_get_scoped_identity()
             .or_else(defra_core::current_identity::get_current_identity)
-            .and_then(|did| Did::new(did).ok());
+        {
+            Some(raw) => {
+                Some(Did::new(raw).map_err(|e| format!("malformed ambient identity: {}", e))?)
+            }
+            None => None,
+        };
         let created_versions = if let Some(document_acp) = &self.document_acp {
             self.database
                 .create_collections_atomic_with_acp_registration(

--- a/crates/cli/src/view_adapter.rs
+++ b/crates/cli/src/view_adapter.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use defra_http::router::ViewOperations;
+use identity::Did;
 use schema::CollectionVersion;
 use storage::corekv::Store;
 
@@ -12,6 +13,7 @@ use storage::corekv::Store;
 pub struct ViewAdapter<S: Store> {
     database: Arc<db::DB<S>>,
     query_limits: query::QueryLimits,
+    document_acp: Option<Arc<dyn acp::DocumentACP>>,
 }
 
 impl<S: Store + 'static> ViewAdapter<S> {
@@ -20,6 +22,20 @@ impl<S: Store + 'static> ViewAdapter<S> {
         Self {
             database,
             query_limits,
+            document_acp: None,
+        }
+    }
+
+    /// Create a new adapter with document ACP registration support.
+    pub fn new_with_acp(
+        database: Arc<db::DB<S>>,
+        query_limits: query::QueryLimits,
+        document_acp: Arc<dyn acp::DocumentACP>,
+    ) -> Self {
+        Self {
+            database,
+            query_limits,
+            document_acp: Some(document_acp),
         }
     }
 
@@ -29,6 +45,15 @@ impl<S: Store + 'static> ViewAdapter<S> {
         query_limits: query::QueryLimits,
     ) -> Arc<dyn ViewOperations> {
         Arc::new(Self::new(database, query_limits))
+    }
+
+    /// Create an Arc-wrapped adapter with document ACP registration support.
+    pub fn new_arc_with_acp(
+        database: Arc<db::DB<S>>,
+        query_limits: query::QueryLimits,
+        document_acp: Arc<dyn acp::DocumentACP>,
+    ) -> Arc<dyn ViewOperations> {
+        Arc::new(Self::new_with_acp(database, query_limits, document_acp))
     }
 }
 
@@ -101,11 +126,23 @@ impl<S: Store + 'static> ViewOperations for ViewAdapter<S> {
             }
         }
 
-        let created_versions = self
-            .database
-            .create_collections_atomic(view_collections)
-            .await
-            .map_err(|e| format!("failed to create view collection: {}", e))?;
+        let creator = defra_core::current_identity::try_get_scoped_identity()
+            .or_else(defra_core::current_identity::get_current_identity)
+            .and_then(|did| Did::new(did).ok());
+        let created_versions = if let Some(document_acp) = &self.document_acp {
+            self.database
+                .create_collections_atomic_with_acp_registration(
+                    view_collections,
+                    document_acp.clone(),
+                    creator,
+                )
+                .await
+        } else {
+            self.database
+                .create_collections_atomic(view_collections)
+                .await
+        }
+        .map_err(|e| format!("failed to create view collection: {}", e))?;
 
         let materialized_names: Vec<String> = created_versions
             .iter()

--- a/crates/db/src/block_verify.rs
+++ b/crates/db/src/block_verify.rs
@@ -13,7 +13,7 @@ use crate::txn::DbTxn;
 /// public key.
 ///
 /// Also checks document-level ACP permission (Read) if the block has a delta
-/// with doc_id and schema_version_id.
+/// with schema_version_id.
 pub async fn verify_block_signature<S: Store>(
     database: &Arc<DB<S>>,
     document_acp: &dyn acp::DocumentACP,
@@ -107,30 +107,40 @@ async fn verify_block_signature_with_blockstore<S: Store>(
         (block, signature)
     };
 
-    // Check document-level ACP permission (Read) if block has delta with doc_id
-    if let (Some(doc_id_bytes), Some(schema_version_id)) =
-        (block.delta.doc_id(), block.delta.schema_version_id())
-    {
-        let doc_id = String::from_utf8_lossy(doc_id_bytes).to_string();
-
+    // Check document/collection-level ACP permission (Read) if the block has
+    // collection metadata.
+    if let Some(schema_version_id) = block.delta.schema_version_id() {
         if let Some(collection) = database
             .get_collection_by_version_id(schema_version_id)
             .map_err(|e| format!("failed to get collection: {}", e))?
         {
-            let node_did = database.node_did();
-            let has_permission = crate::check_doc_permission(
-                document_acp,
-                caller_identity,
-                acp::DocumentPermission::Read,
-                collection.schema(),
-                &doc_id,
-                node_did.as_ref(),
-            )
-            .await
-            .map_err(|e| format!("ACP check failed: {}", e))?;
+            let collection = collection.schema();
+            if let Some(policy) = &collection.policy {
+                let doc_id = block
+                    .delta
+                    .doc_id()
+                    .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+                    .unwrap_or_default();
+                let node_did = database.node_did();
+                let checker = acp::read_access::DirectChecker {
+                    acp: document_acp,
+                    identity: caller_identity,
+                    node_did: node_did.as_ref(),
+                };
+                let has_permission = acp::read_access::check_doc_read_access(
+                    &checker,
+                    &policy.id,
+                    &policy.resource_name,
+                    &collection.collection_id,
+                    collection.is_branchable,
+                    &doc_id,
+                )
+                .await
+                .map_err(|e| format!("ACP check failed: {}", e))?;
 
-            if !has_permission {
-                return Err("missing permission".to_string());
+                if !has_permission {
+                    return Err("missing permission".to_string());
+                }
             }
         }
     }

--- a/crates/db/src/collection_acp.rs
+++ b/crates/db/src/collection_acp.rs
@@ -115,8 +115,11 @@ pub async fn register_doc_if_needed(
 /// 3. Identity is provided
 ///
 /// The ACP object id is the stable collection ID. Re-registering an existing
-/// collection object is a no-op: the same collection can be defined on multiple
-/// nodes backed by a shared ACP store.
+/// collection object owned by the same identity is a no-op: the same collection
+/// can be defined on multiple nodes backed by a shared ACP store. A
+/// registration that finds the object already owned by a *different* identity
+/// fails closed (mirrors Go's `bridgeDocumentACP.RegisterDocObject`, which
+/// no-ops only when the existing owner equals the caller and otherwise errors).
 pub async fn register_collection_if_needed(
     acp: &dyn DocumentACP,
     identity: Option<&Did>,
@@ -135,7 +138,28 @@ pub async fn register_collection_if_needed(
         .is_doc_registered(&policy.id, &policy.resource_name, &collection.collection_id)
         .await?
     {
-        return Ok(());
+        // Already registered (e.g. the same collection defined on another node
+        // of a shared ACP store). The local/zanzibar backends error on ANY
+        // pre-existing object, so the owner check must live here rather than in
+        // `register_object`. Same-owner => idempotent no-op; different or
+        // unknown owner => fail closed so the collection is not persisted under
+        // someone else's ACP ownership.
+        let existing_owner = acp
+            .get_doc_owner(&policy.id, &policy.resource_name, &collection.collection_id)
+            .await?;
+        if existing_owner.as_ref() == Some(did) {
+            return Ok(());
+        }
+        return Err(acp::Error::DocumentAlreadyRegistered(format!(
+            "collection object '{}' under resource '{}' is already registered to a different owner (expected {}, found {})",
+            collection.collection_id,
+            policy.resource_name,
+            did,
+            existing_owner
+                .as_ref()
+                .map(|o| o.to_string())
+                .unwrap_or_else(|| "<unknown>".to_string()),
+        )));
     }
 
     acp.register_object(

--- a/crates/db/src/collection_acp.rs
+++ b/crates/db/src/collection_acp.rs
@@ -107,6 +107,46 @@ pub async fn register_doc_if_needed(
         .await
 }
 
+/// Register a branchable collection as an ACP object after creation.
+///
+/// Only registers if:
+/// 1. Collection is branchable
+/// 2. Collection has a policy
+/// 3. Identity is provided
+///
+/// The ACP object id is the stable collection ID. Re-registering an existing
+/// collection object is a no-op: the same collection can be defined on multiple
+/// nodes backed by a shared ACP store.
+pub async fn register_collection_if_needed(
+    acp: &dyn DocumentACP,
+    identity: Option<&Did>,
+    collection: &CollectionVersion,
+) -> acp::Result<()> {
+    if !collection.is_branchable {
+        return Ok(());
+    }
+
+    let (policy, did) = match (&collection.policy, identity) {
+        (Some(p), Some(id)) => (p, id),
+        _ => return Ok(()),
+    };
+
+    if acp
+        .is_doc_registered(&policy.id, &policy.resource_name, &collection.collection_id)
+        .await?
+    {
+        return Ok(());
+    }
+
+    acp.register_object(
+        did,
+        &policy.id,
+        &policy.resource_name,
+        &collection.collection_id,
+    )
+    .await
+}
+
 /// Clean up ACP relations when deleting a document.
 ///
 /// This should be called when deleting a document to remove all
@@ -199,6 +239,11 @@ impl AcpContext {
         doc_id: &str,
     ) -> acp::Result<()> {
         register_doc_if_needed(self.acp.as_ref(), self.identity.did(), collection, doc_id).await
+    }
+
+    /// Register a branchable collection after creation.
+    pub async fn register_collection(&self, collection: &CollectionVersion) -> acp::Result<()> {
+        register_collection_if_needed(self.acp.as_ref(), self.identity.did(), collection).await
     }
 }
 

--- a/crates/db/src/collection_ops/create.rs
+++ b/crates/db/src/collection_ops/create.rs
@@ -264,12 +264,45 @@ impl<S: Store> crate::database::DB<S> {
     /// and updates the process-wide cache.
     #[instrument(skip(self, schema), fields(collection = %schema.name), name = "db.create_collection_auto")]
     pub async fn create_collection(&self, schema: CollectionVersion) -> Result<()> {
+        self.create_collection_inner(schema, None, None)
+            .await
+            .map(|_| ())
+    }
+
+    /// Create a new collection, registering branchable ACP before commit.
+    ///
+    /// If collection ACP registration fails, the DB transaction is discarded so
+    /// the protected collection is not persisted without its ACP object.
+    pub async fn create_collection_with_acp_registration(
+        &self,
+        schema: CollectionVersion,
+        document_acp: std::sync::Arc<dyn acp::DocumentACP>,
+        creator: Option<identity::Did>,
+    ) -> Result<CollectionVersion> {
+        self.create_collection_inner(schema, Some(document_acp), creator)
+            .await
+    }
+
+    async fn create_collection_inner(
+        &self,
+        schema: CollectionVersion,
+        document_acp: Option<std::sync::Arc<dyn acp::DocumentACP>>,
+        creator: Option<identity::Did>,
+    ) -> Result<CollectionVersion> {
         self.check_node_access(None, acp::nac::NodePermission::CollectionPatch)
             .await?;
         let name = schema.name.clone();
         let mut txn = self.new_txn(false).await?;
 
         let finalized_schema = self.create_collection_with_txn(&mut txn, schema).await?;
+
+        if let (Some(document_acp), Some(creator)) = (document_acp, creator) {
+            txn.stage_collection_acp_registration(
+                document_acp,
+                creator,
+                vec![finalized_schema.clone()],
+            );
+        }
 
         txn.commit().await?;
         self.unforbid_collection_id(finalized_schema.collection_id.as_str())?;
@@ -279,9 +312,9 @@ impl<S: Store> crate::database::DB<S> {
             tracing::error!(error = ?e, collection_name = %name, "Collection cache lock poisoned after create");
             Error::CacheUpdateFailedAfterCommit(name.clone())
         })?;
-        cache.insert(name, Collection::new(finalized_schema));
+        cache.insert(name, Collection::new(finalized_schema.clone()));
 
-        Ok(())
+        Ok(finalized_schema)
     }
 
     /// Create multiple collections atomically in a single transaction.
@@ -291,6 +324,30 @@ impl<S: Store> crate::database::DB<S> {
     pub async fn create_collections_atomic(
         &self,
         schemas: Vec<CollectionVersion>,
+    ) -> Result<Vec<CollectionVersion>> {
+        self.create_collections_atomic_inner(schemas, None, None)
+            .await
+    }
+
+    /// Create multiple collections atomically, registering branchable ACP before commit.
+    ///
+    /// If any collection ACP registration fails, the DB transaction is discarded
+    /// and none of the collections are persisted.
+    pub async fn create_collections_atomic_with_acp_registration(
+        &self,
+        schemas: Vec<CollectionVersion>,
+        document_acp: std::sync::Arc<dyn acp::DocumentACP>,
+        creator: Option<identity::Did>,
+    ) -> Result<Vec<CollectionVersion>> {
+        self.create_collections_atomic_inner(schemas, Some(document_acp), creator)
+            .await
+    }
+
+    async fn create_collections_atomic_inner(
+        &self,
+        schemas: Vec<CollectionVersion>,
+        document_acp: Option<std::sync::Arc<dyn acp::DocumentACP>>,
+        creator: Option<identity::Did>,
     ) -> Result<Vec<CollectionVersion>> {
         self.check_node_access(None, acp::nac::NodePermission::CollectionPatch)
             .await?;
@@ -374,6 +431,10 @@ impl<S: Store> crate::database::DB<S> {
                         .map_err(Error::Storage)?;
                 }
             }
+        }
+
+        if let (Some(document_acp), Some(creator)) = (document_acp, creator) {
+            txn.stage_collection_acp_registration(document_acp, creator, finalized_schemas.clone());
         }
 
         txn.commit().await?;

--- a/crates/db/src/collection_provider.rs
+++ b/crates/db/src/collection_provider.rs
@@ -56,6 +56,17 @@ impl<S: Store + 'static> CollectionProvider for DbCollectionProvider<S> {
             .list_collections()
             .map_err(|e| QueryError::execution(e.to_string()))
     }
+
+    async fn get_collection_by_version_id(
+        &self,
+        version_id: &str,
+    ) -> QueryResult<Option<Arc<CollectionVersion>>> {
+        match self.db.get_collection_by_version_id_full(version_id).await {
+            Ok(Some(coll)) => Ok(Some(Arc::new(coll.schema().clone()))),
+            Ok(None) => Ok(None),
+            Err(e) => Err(QueryError::execution(e.to_string())),
+        }
+    }
 }
 
 /// Transaction-aware collection provider.
@@ -169,5 +180,18 @@ impl<S: Store + 'static> CollectionProvider for TxnCollectionProvider<S> {
         }
 
         Ok(names.into_iter().collect())
+    }
+
+    async fn get_collection_by_version_id(
+        &self,
+        version_id: &str,
+    ) -> QueryResult<Option<Arc<CollectionVersion>>> {
+        // Committed history (active + inactive) is sufficient for the ACP-gated
+        // `_commits` path; the DB full lookup scans all stored versions.
+        match self.db.get_collection_by_version_id_full(version_id).await {
+            Ok(Some(coll)) => Ok(Some(Arc::new(coll.schema().clone()))),
+            Ok(None) => Ok(None),
+            Err(e) => Err(QueryError::execution(e.to_string())),
+        }
     }
 }

--- a/crates/db/src/collection_retriever.rs
+++ b/crates/db/src/collection_retriever.rs
@@ -26,6 +26,8 @@ pub struct DocCollectionInfo {
     pub policy_id: String,
     /// Resource name within the policy.
     pub resource_name: String,
+    /// Whether the collection is branchable.
+    pub is_branchable: bool,
 }
 
 /// Resolve the collection metadata for a given document.
@@ -124,6 +126,7 @@ pub async fn resolve_collection_from_doc_id<S: Store>(
             collection_id: collection.collection_id.clone(),
             policy_id: policy.id,
             resource_name: policy.resource_name,
+            is_branchable: collection.is_branchable,
         }),
         Ok(None) => None,
         Err(e) => {

--- a/crates/db/src/kms_adapters.rs
+++ b/crates/db/src/kms_adapters.rs
@@ -43,6 +43,7 @@ impl<S: storage::corekv::Store + Send + Sync + 'static> DocCollectionLookup
                 collection_id: info.collection_id,
                 policy_id: info.policy_id,
                 resource_name: info.resource_name,
+                is_branchable: info.is_branchable,
             })),
             Ok(None) => Ok(None),
             Err(e) => Err(kms::Error::Storage(e.to_string())),

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -107,8 +107,8 @@ pub use block_builder::{build_blocks_from_document, BlockResult};
 pub use collection::{collection_short_id, Collection};
 pub use collection_acp::{
     block_unsafe_policy_transition, check_doc_permission, check_policy_transition,
-    register_doc_if_needed, unregister_doc_if_needed, warn_on_unsafe_policy_transition, AcpContext,
-    PolicyTransitionCheck,
+    register_collection_if_needed, register_doc_if_needed, unregister_doc_if_needed,
+    warn_on_unsafe_policy_transition, AcpContext, PolicyTransitionCheck,
 };
 pub use collection_cache::CollectionCache;
 pub use collection_name::CollectionName;

--- a/crates/db/src/txn.rs
+++ b/crates/db/src/txn.rs
@@ -11,6 +11,7 @@ use async_lock::MutexGuardArc;
 use datastore::{AsyncCallback, BasicTxn, NamespaceView, RootView, TxnCallback};
 use schema::CollectionVersion;
 use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
 use storage::corekv::{IterOptions, Key, Store};
 use storage::keys::systemstore::{CollectionKey, CollectionNameKey};
 
@@ -42,6 +43,46 @@ pub struct PendingCounterOp {
     pub base: Option<document::NormalValue>,
     /// Whether this op was recorded on a CREATE (seed) vs an UPDATE (delta RMW).
     pub is_create: bool,
+}
+
+struct PendingCollectionAcpRegistration {
+    acp: Arc<dyn acp::DocumentACP>,
+    creator: identity::Did,
+    request_bearer_token: Option<String>,
+    schemas: Vec<CollectionVersion>,
+}
+
+impl PendingCollectionAcpRegistration {
+    async fn run(self) -> Result<()> {
+        let previous_token = self.request_bearer_token.as_ref().map(|token| {
+            let previous = defra_core::signing::get_request_bearer_token(self.creator.as_str());
+            defra_core::signing::set_request_bearer_token(self.creator.as_str(), token.clone());
+            previous
+        });
+
+        let result: acp::Result<()> = async {
+            for schema in &self.schemas {
+                crate::collection_acp::register_collection_if_needed(
+                    self.acp.as_ref(),
+                    Some(&self.creator),
+                    schema,
+                )
+                .await?;
+            }
+            Ok(())
+        }
+        .await;
+
+        if self.request_bearer_token.is_some() {
+            if let Some(Some(previous)) = previous_token {
+                defra_core::signing::set_request_bearer_token(self.creator.as_str(), previous);
+            } else {
+                defra_core::signing::clear_request_bearer_token(self.creator.as_str());
+            }
+        }
+
+        result.map_err(Error::from)
+    }
 }
 
 /// Database transaction wrapper.
@@ -87,6 +128,10 @@ pub struct DbTxn<S: Store> {
     /// yet applied to the authoritative CRDT accumulation store. Drained and
     /// RMW'd at the commit-time finalize under per-doc guards (#1044).
     pending_counter_ops: Vec<PendingCounterOp>,
+    /// Branchable collection ACP registrations that must succeed before the
+    /// storage commit, otherwise a protected collection could be persisted
+    /// without its collection-level ACP object.
+    pending_collection_acp_registrations: Vec<PendingCollectionAcpRegistration>,
     /// Phantom data for the store type.
     _marker: std::marker::PhantomData<S>,
 }
@@ -101,6 +146,7 @@ impl<S: Store> DbTxn<S> {
             locally_created_collection_ids: HashSet::new(),
             doc_guards: BTreeMap::new(),
             pending_counter_ops: Vec::new(),
+            pending_collection_acp_registrations: Vec::new(),
             _marker: std::marker::PhantomData,
         }
     }
@@ -114,6 +160,7 @@ impl<S: Store> DbTxn<S> {
             locally_created_collection_ids: HashSet::new(),
             doc_guards: BTreeMap::new(),
             pending_counter_ops: Vec::new(),
+            pending_collection_acp_registrations: Vec::new(),
             _marker: std::marker::PhantomData,
         }
     }
@@ -561,6 +608,33 @@ impl<S: Store> DbTxn<S> {
         !self.pending_counter_ops.is_empty()
     }
 
+    /// Stage branchable collection ACP registration to run before commit.
+    pub(crate) fn stage_collection_acp_registration(
+        &mut self,
+        acp: Arc<dyn acp::DocumentACP>,
+        creator: identity::Did,
+        schemas: Vec<CollectionVersion>,
+    ) {
+        if schemas.is_empty() {
+            return;
+        }
+        let request_bearer_token = defra_core::signing::get_request_bearer_token(creator.as_str());
+        self.pending_collection_acp_registrations
+            .push(PendingCollectionAcpRegistration {
+                acp,
+                creator,
+                request_bearer_token,
+                schemas,
+            });
+    }
+
+    async fn run_pending_collection_acp_registrations(&mut self) -> Result<()> {
+        for registration in std::mem::take(&mut self.pending_collection_acp_registrations) {
+            registration.run().await?;
+        }
+        Ok(())
+    }
+
     // =========================================================================
     // Transaction Lifecycle Methods
     // =========================================================================
@@ -575,6 +649,16 @@ impl<S: Store> DbTxn<S> {
         }
         if !self.pending_counter_ops.is_empty() {
             return Err(Error::UnfinalizedCounterOps);
+        }
+
+        if let Err(error) = self.run_pending_collection_acp_registrations().await {
+            if let Err(discard_error) = self.discard_active_txn() {
+                tracing::warn!(
+                    error = %discard_error,
+                    "failed to discard transaction after collection ACP registration error"
+                );
+            }
+            return Err(error);
         }
 
         match self.txn.take() {
@@ -616,6 +700,15 @@ impl<S: Store> DbTxn<S> {
         if !self.pending_counter_ops.is_empty() {
             return Err(Error::UnfinalizedCounterOps);
         }
+        if let Err(error) = self.run_pending_collection_acp_registrations().await {
+            if let Err(discard_error) = self.discard_active_txn() {
+                tracing::warn!(
+                    error = %discard_error,
+                    "failed to discard transaction after collection ACP registration error"
+                );
+            }
+            return Err(error);
+        }
         match self.txn.take() {
             Some(txn) => {
                 txn.commit().await.map_err(Error::Datastore)?;
@@ -648,5 +741,16 @@ impl<S: Store> DbTxn<S> {
     /// releasing here makes the release point unambiguous.
     fn release_doc_guards(&mut self) {
         self.doc_guards.clear();
+    }
+
+    fn discard_active_txn(&mut self) -> Result<()> {
+        match self.txn.take() {
+            Some(txn) => {
+                let result = txn.discard().map_err(Error::Datastore);
+                self.release_doc_guards();
+                result
+            }
+            None => Err(Error::TxnNotActive),
+        }
     }
 }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -517,6 +517,19 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         txn_id: &str,
         sdl: &str,
     ) -> Result<Vec<schema::CollectionVersion>> {
+        self.add_schema_in_txn_with_acp(txn_id, sdl, None, None)
+            .await
+    }
+
+    /// Add a schema within an existing transaction, optionally registering
+    /// branchable collection ACP objects after the storage commit succeeds.
+    pub async fn add_schema_in_txn_with_acp(
+        &self,
+        txn_id: &str,
+        sdl: &str,
+        document_acp: Option<Arc<dyn acp::DocumentACP>>,
+        creator: Option<identity::Did>,
+    ) -> Result<Vec<schema::CollectionVersion>> {
         let ctx = self
             .get_ctx(txn_id)?
             .ok_or_else(|| Error::TransactionNotFound(txn_id.to_string()))?;
@@ -552,6 +565,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
         // Register on_success callback to update the process-wide cache after commit
         let db = self.db.clone();
         let schemas_for_cache = finalized.clone();
+        let schemas_for_acp = finalized.clone();
         txn.on_success(Box::new(move || {
             for schema in &schemas_for_cache {
                 let _ = db.unforbid_collection_id(&schema.collection_id);
@@ -562,6 +576,56 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
                 }
             }
         }))?;
+
+        if let (Some(document_acp), Some(creator)) = (document_acp, creator) {
+            let request_bearer_token =
+                defra_core::signing::get_request_bearer_token(creator.as_str());
+            txn.on_success_async(Box::new(move || {
+                let document_acp = document_acp.clone();
+                let creator = creator.clone();
+                let schemas = schemas_for_acp.clone();
+                let request_bearer_token = request_bearer_token.clone();
+                Box::pin(async move {
+                    let previous_token = request_bearer_token.as_ref().map(|token| {
+                        let previous =
+                            defra_core::signing::get_request_bearer_token(creator.as_str());
+                        defra_core::signing::set_request_bearer_token(
+                            creator.as_str(),
+                            token.clone(),
+                        );
+                        previous
+                    });
+
+                    for schema in &schemas {
+                        if let Err(error) = crate::collection_acp::register_collection_if_needed(
+                            document_acp.as_ref(),
+                            Some(&creator),
+                            schema,
+                        )
+                        .await
+                        {
+                            tracing::error!(
+                                collection = %schema.name,
+                                collection_id = %schema.collection_id,
+                                error = %error,
+                                "Deferred ACP collection registration failed after commit"
+                            );
+                        }
+                    }
+
+                    if request_bearer_token.is_some() {
+                        if let Some(Some(previous)) = previous_token {
+                            defra_core::signing::set_request_bearer_token(
+                                creator.as_str(),
+                                previous,
+                            );
+                        } else {
+                            defra_core::signing::clear_request_bearer_token(creator.as_str());
+                        }
+                    }
+                })
+            }))?;
+        }
 
         Ok(finalized)
     }

--- a/crates/db/src/txn_registry.rs
+++ b/crates/db/src/txn_registry.rs
@@ -522,7 +522,7 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
     }
 
     /// Add a schema within an existing transaction, optionally registering
-    /// branchable collection ACP objects after the storage commit succeeds.
+    /// branchable collection ACP objects before the storage commit.
     pub async fn add_schema_in_txn_with_acp(
         &self,
         txn_id: &str,
@@ -562,10 +562,13 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
             finalized.push(schema);
         }
 
+        if let (Some(document_acp), Some(creator)) = (document_acp, creator) {
+            txn.stage_collection_acp_registration(document_acp, creator, finalized.clone());
+        }
+
         // Register on_success callback to update the process-wide cache after commit
         let db = self.db.clone();
         let schemas_for_cache = finalized.clone();
-        let schemas_for_acp = finalized.clone();
         txn.on_success(Box::new(move || {
             for schema in &schemas_for_cache {
                 let _ = db.unforbid_collection_id(&schema.collection_id);
@@ -576,56 +579,6 @@ impl<S: Store + 'static> DbTransactionRegistry<S> {
                 }
             }
         }))?;
-
-        if let (Some(document_acp), Some(creator)) = (document_acp, creator) {
-            let request_bearer_token =
-                defra_core::signing::get_request_bearer_token(creator.as_str());
-            txn.on_success_async(Box::new(move || {
-                let document_acp = document_acp.clone();
-                let creator = creator.clone();
-                let schemas = schemas_for_acp.clone();
-                let request_bearer_token = request_bearer_token.clone();
-                Box::pin(async move {
-                    let previous_token = request_bearer_token.as_ref().map(|token| {
-                        let previous =
-                            defra_core::signing::get_request_bearer_token(creator.as_str());
-                        defra_core::signing::set_request_bearer_token(
-                            creator.as_str(),
-                            token.clone(),
-                        );
-                        previous
-                    });
-
-                    for schema in &schemas {
-                        if let Err(error) = crate::collection_acp::register_collection_if_needed(
-                            document_acp.as_ref(),
-                            Some(&creator),
-                            schema,
-                        )
-                        .await
-                        {
-                            tracing::error!(
-                                collection = %schema.name,
-                                collection_id = %schema.collection_id,
-                                error = %error,
-                                "Deferred ACP collection registration failed after commit"
-                            );
-                        }
-                    }
-
-                    if request_bearer_token.is_some() {
-                        if let Some(Some(previous)) = previous_token {
-                            defra_core::signing::set_request_bearer_token(
-                                creator.as_str(),
-                                previous,
-                            );
-                        } else {
-                            defra_core::signing::clear_request_bearer_token(creator.as_str());
-                        }
-                    }
-                })
-            }))?;
-        }
 
         Ok(finalized)
     }

--- a/crates/db/tests/collection_acp_tests.rs
+++ b/crates/db/tests/collection_acp_tests.rs
@@ -309,6 +309,39 @@ async fn double_collection_registration_is_idempotent() {
 }
 
 #[tokio::test]
+async fn different_owner_collection_registration_fails_closed() {
+    // Mirrors Go's bridgeDocumentACP.RegisterDocObject: a re-registration that
+    // finds the collection object already owned by a different identity must
+    // error (not silently no-op), so a node cannot persist a protected
+    // collection whose ACP object is owned by someone else.
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = branchable_collection_with_policy();
+    let owner_a = test_did();
+    let owner_b = test_did2();
+
+    register_collection_if_needed(&acp, Some(&owner_a), &collection)
+        .await
+        .unwrap();
+
+    let err = register_collection_if_needed(&acp, Some(&owner_b), &collection)
+        .await
+        .expect_err("different-owner re-registration must fail closed");
+    assert!(
+        err.to_string().contains("different owner"),
+        "error should describe the owner mismatch, got: {err}"
+    );
+
+    // The original owner is unchanged.
+    let policy = collection.policy.as_ref().unwrap();
+    assert_eq!(
+        acp.get_doc_owner(&policy.id, &policy.resource_name, &collection.collection_id)
+            .await
+            .unwrap(),
+        Some(owner_a)
+    );
+}
+
+#[tokio::test]
 async fn branchable_permissioned_create_fails_closed_if_collection_acp_registration_fails() {
     let db = db::DB::new(MemoryStore::new()).unwrap();
     let acp = Arc::new(FailingDocumentAcp);

--- a/crates/db/tests/collection_acp_tests.rs
+++ b/crates/db/tests/collection_acp_tests.rs
@@ -10,6 +10,7 @@ use db::collection_acp::{
 };
 use identity::Did;
 use schema::{CollectionVersion, FieldDescription, FieldKind, PolicyDescription};
+use storage::backends::MemoryStore;
 
 fn test_did() -> Did {
     Did::new("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK").unwrap()
@@ -55,6 +56,85 @@ fn branchable_collection_without_policy() -> CollectionVersion {
     let mut col = collection_without_policy();
     col.is_branchable = true;
     col
+}
+
+struct FailingDocumentAcp;
+
+#[async_trait::async_trait]
+impl DocumentACP for FailingDocumentAcp {
+    async fn register_doc_object(
+        &self,
+        _identity: &Did,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<()> {
+        Err(acp::Error::Storage("registration failed".into()))
+    }
+
+    async fn is_doc_registered(
+        &self,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<bool> {
+        Ok(false)
+    }
+
+    async fn get_doc_owner(
+        &self,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<Option<Did>> {
+        Ok(None)
+    }
+
+    async fn check_doc_access(
+        &self,
+        _identity: &Identity,
+        _permission: DocumentPermission,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<bool> {
+        Ok(true)
+    }
+
+    async fn add_actor_relationship(
+        &self,
+        _requestor: &Did,
+        _target: &Did,
+        _policy_id: &str,
+        _collection_id: &str,
+        _doc_id: &str,
+        _relation: &str,
+        _managing_relations: &[String],
+    ) -> acp::Result<bool> {
+        Ok(false)
+    }
+
+    async fn delete_actor_relationship(
+        &self,
+        _requestor: &Did,
+        _target: &Did,
+        _policy_id: &str,
+        _collection_id: &str,
+        _doc_id: &str,
+        _relation: &str,
+        _managing_relations: &[String],
+    ) -> acp::Result<bool> {
+        Ok(false)
+    }
+
+    async fn unregister_doc_object(
+        &self,
+        _policy_id: &str,
+        _resource_name: &str,
+        _doc_id: &str,
+    ) -> acp::Result<()> {
+        Ok(())
+    }
 }
 
 #[tokio::test]
@@ -226,6 +306,25 @@ async fn double_collection_registration_is_idempotent() {
             .unwrap(),
         Some(owner)
     );
+}
+
+#[tokio::test]
+async fn branchable_permissioned_create_fails_closed_if_collection_acp_registration_fails() {
+    let db = db::DB::new(MemoryStore::new()).unwrap();
+    let acp = Arc::new(FailingDocumentAcp);
+    let owner = test_did();
+
+    let err = db
+        .create_collection_with_acp_registration(
+            branchable_collection_with_policy(),
+            acp,
+            Some(owner),
+        )
+        .await
+        .expect_err("ACP registration failure must abort collection create");
+
+    assert!(err.to_string().contains("registration failed"));
+    assert!(db.get_collection("users").unwrap().is_none());
 }
 
 #[tokio::test]

--- a/crates/db/tests/collection_acp_tests.rs
+++ b/crates/db/tests/collection_acp_tests.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use acp::{DocumentACP, DocumentPermission, Identity, LocalDocumentACP, MemoryAcpStore};
 use db::collection_acp::{
     block_unsafe_policy_transition, check_doc_permission, check_policy_transition,
-    register_doc_if_needed, warn_on_unsafe_policy_transition, AcpContext,
+    register_collection_if_needed, register_doc_if_needed, warn_on_unsafe_policy_transition,
+    AcpContext,
 };
 use identity::Did;
 use schema::{CollectionVersion, FieldDescription, FieldKind, PolicyDescription};
@@ -41,6 +42,18 @@ fn collection_with_policy() -> CollectionVersion {
         ],
     );
     col.policy = Some(PolicyDescription::new("policy1", "users"));
+    col
+}
+
+fn branchable_collection_with_policy() -> CollectionVersion {
+    let mut col = collection_with_policy();
+    col.is_branchable = true;
+    col
+}
+
+fn branchable_collection_without_policy() -> CollectionVersion {
+    let mut col = collection_without_policy();
+    col.is_branchable = true;
     col
 }
 
@@ -103,6 +116,116 @@ async fn test_no_register_without_identity() {
         .await
         .unwrap();
     assert!(!is_registered);
+}
+
+#[tokio::test]
+async fn branchable_permissioned_with_identity_registers_collection_object_owned_by_creator() {
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = branchable_collection_with_policy();
+    let owner = test_did();
+
+    register_collection_if_needed(&acp, Some(&owner), &collection)
+        .await
+        .unwrap();
+
+    let policy = collection.policy.as_ref().unwrap();
+    assert!(acp
+        .is_doc_registered(&policy.id, &policy.resource_name, &collection.collection_id)
+        .await
+        .unwrap());
+    assert_eq!(
+        acp.get_doc_owner(&policy.id, &policy.resource_name, &collection.collection_id)
+            .await
+            .unwrap(),
+        Some(owner)
+    );
+}
+
+#[tokio::test]
+async fn branchable_permissioned_no_identity_registers_nothing_public() {
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = branchable_collection_with_policy();
+
+    register_collection_if_needed(&acp, None, &collection)
+        .await
+        .unwrap();
+
+    let policy = collection.policy.as_ref().unwrap();
+    assert!(!acp
+        .is_doc_registered(&policy.id, &policy.resource_name, &collection.collection_id)
+        .await
+        .unwrap());
+    assert!(acp
+        .check_doc_access(
+            &Identity::Anonymous,
+            DocumentPermission::Read,
+            &policy.id,
+            &policy.resource_name,
+            &collection.collection_id,
+        )
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn non_branchable_registers_no_collection_object() {
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = collection_with_policy();
+    let owner = test_did();
+
+    register_collection_if_needed(&acp, Some(&owner), &collection)
+        .await
+        .unwrap();
+
+    let policy = collection.policy.as_ref().unwrap();
+    assert!(!acp
+        .is_doc_registered(&policy.id, &policy.resource_name, &collection.collection_id)
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn unpermissioned_branchable_is_fully_public() {
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = branchable_collection_without_policy();
+    let owner = test_did();
+
+    register_collection_if_needed(&acp, Some(&owner), &collection)
+        .await
+        .unwrap();
+
+    assert!(check_doc_permission(
+        &acp,
+        &Identity::Anonymous,
+        DocumentPermission::Read,
+        &collection,
+        &collection.collection_id,
+        None,
+    )
+    .await
+    .unwrap());
+}
+
+#[tokio::test]
+async fn double_collection_registration_is_idempotent() {
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let collection = branchable_collection_with_policy();
+    let owner = test_did();
+
+    register_collection_if_needed(&acp, Some(&owner), &collection)
+        .await
+        .unwrap();
+    register_collection_if_needed(&acp, Some(&owner), &collection)
+        .await
+        .unwrap();
+
+    let policy = collection.policy.as_ref().unwrap();
+    assert_eq!(
+        acp.get_doc_owner(&policy.id, &policy.resource_name, &collection.collection_id)
+            .await
+            .unwrap(),
+        Some(owner)
+    );
 }
 
 #[tokio::test]

--- a/crates/defra-core/src/block.rs
+++ b/crates/defra-core/src/block.rs
@@ -332,13 +332,19 @@ impl CrdtDelta {
         }
     }
 
-    /// Check if this is a schema definition delta
+    /// Check if this is a schema definition delta.
+    ///
+    /// Mirrors Go's `IsDefinition()` (collection + field definitions only). This
+    /// gates the P2P serve whitelist: definition blocks carry no user data and
+    /// are served to any peer. `CollectionSet` is deliberately excluded — it has
+    /// no collection-version id, cannot be ACP-scoped, and (unlike Go, which
+    /// stores but denies serving it) is never transferred over P2P at all:
+    /// circular-relation groups converge by local deterministic reconstruction
+    /// (`schema/cid.rs`), so it must not be unconditionally served.
     pub fn is_definition(&self) -> bool {
         matches!(
             self,
-            CrdtDelta::FieldDefinition(_)
-                | CrdtDelta::CollectionDefinition(_)
-                | CrdtDelta::CollectionSet(_)
+            CrdtDelta::FieldDefinition(_) | CrdtDelta::CollectionDefinition(_)
         )
     }
 }

--- a/crates/defra-core/src/ipld/tests.rs
+++ b/crates/defra-core/src/ipld/tests.rs
@@ -7,9 +7,9 @@ use ipld_core::ipld::Ipld;
 
 use super::traversal::{collect_block_links, extract_links, walk_ipld, IpldVisitor};
 use crate::block::{
-    Block, CollectionDefinitionDeltaPayload, CollectionDeltaPayload, CompositeDeltaPayload,
-    CounterDeltaPayload, CrdtDelta, DAGLink, Encryption, FieldDefinitionDeltaPayload,
-    LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
+    Block, CollectionDefinitionDeltaPayload, CollectionDeltaPayload, CollectionSetDeltaPayload,
+    CompositeDeltaPayload, CounterDeltaPayload, CrdtDelta, DAGLink, Encryption,
+    FieldDefinitionDeltaPayload, LwwDeltaPayload, Signature, SignatureHeader, SignatureType,
 };
 
 fn test_cid() -> cid::Cid {
@@ -657,6 +657,13 @@ fn test_crdt_delta_is_definition() {
 
     let col_def = CrdtDelta::CollectionDefinition(CollectionDefinitionDeltaPayload::new(1));
     assert!(col_def.is_definition());
+
+    // CollectionSet is NOT a definition (matches Go's IsDefinition). It has no
+    // collection-version id and is never served over P2P — circular-relation
+    // groups converge by local reconstruction, so the serve whitelist must
+    // exclude it.
+    let col_set = CrdtDelta::CollectionSet(CollectionSetDeltaPayload::new(1));
+    assert!(!col_set.is_definition());
 }
 
 #[test]

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -49,26 +49,14 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
         schema::definition_validation::validate_new_collections(&collections)
             .map_err(|e| anyhow::anyhow!("schema validation error: {}", e))?;
 
-        for collection in collections {
-            let collection_name = collection.name.clone();
-            db::DB::create_collection(&self.database, collection)
-                .await
-                .map_err(|e| anyhow::anyhow!("create collection error: {}", e))?;
-            let finalized = self
-                .database
-                .get_collection(&collection_name)
-                .map_err(anyhow::Error::new)?
-                .ok_or_else(|| {
-                    anyhow::anyhow!("created collection '{}' was not cached", collection_name)
-                })?;
-            db::register_collection_if_needed(
-                self.document_acp.as_ref(),
-                creator.as_ref(),
-                finalized.schema(),
+        self.database
+            .create_collections_atomic_with_acp_registration(
+                collections,
+                self.document_acp.clone(),
+                creator,
             )
             .await
-            .map_err(anyhow::Error::new)?;
-        }
+            .map_err(|e| anyhow::anyhow!("create collection error: {}", e))?;
         Ok(())
     }
 
@@ -121,22 +109,15 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
             }
         }
 
-        let finalized = self
-            .database
-            .create_collections_atomic(collections)
-            .await
-            .map_err(|e| anyhow::anyhow!("create view collection error: {}", e))?;
-
         let creator = Self::current_identity();
-        for collection in &finalized {
-            db::register_collection_if_needed(
-                self.document_acp.as_ref(),
-                creator.as_ref(),
-                collection,
+        self.database
+            .create_collections_atomic_with_acp_registration(
+                collections,
+                self.document_acp.clone(),
+                creator,
             )
             .await
-            .map_err(anyhow::Error::new)?;
-        }
+            .map_err(|e| anyhow::anyhow!("create view collection error: {}", e))?;
 
         if !materialized_names.is_empty() {
             self.database

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -27,17 +27,28 @@ impl<S: storage::corekv::Store + 'static> DbSchemaOps<S> {
         }
     }
 
-    fn current_identity() -> Option<Did> {
-        defra_core::current_identity::try_get_scoped_identity()
+    /// Resolve the ambient identity into a creator DID. Returns `Ok(None)` when
+    /// no identity is present (collection stays public), but fails closed when an
+    /// identity string is present yet malformed, so a permissioned collection is
+    /// never silently created unregistered.
+    fn current_identity() -> anyhow::Result<Option<Did>> {
+        match defra_core::current_identity::try_get_scoped_identity()
             .or_else(defra_core::current_identity::get_current_identity)
-            .and_then(|did| Did::new(did).ok())
+        {
+            Some(raw) => {
+                Ok(Some(Did::new(raw).map_err(|e| {
+                    anyhow::anyhow!("malformed ambient identity: {}", e)
+                })?))
+            }
+            None => Ok(None),
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
     async fn add_schema(&self, sdl: &str) -> anyhow::Result<()> {
-        let creator = Self::current_identity();
+        let creator = Self::current_identity()?;
         self.database
             .check_node_access(None, acp::nac::NodePermission::CollectionPatch)
             .await
@@ -109,7 +120,7 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
             }
         }
 
-        let creator = Self::current_identity();
+        let creator = Self::current_identity()?;
         self.database
             .create_collections_atomic_with_acp_registration(
                 collections,

--- a/crates/defra-node/src/db_impls.rs
+++ b/crates/defra-node/src/db_impls.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use identity::Did;
 use lens::{LensConfig, TransformId};
 use schema::CollectionVersion;
 
@@ -10,20 +11,33 @@ use crate::SchemaOps;
 pub(crate) struct DbSchemaOps<S: storage::corekv::Store + 'static> {
     database: Arc<db::DB<S>>,
     query_limits: query::QueryLimits,
+    document_acp: Arc<dyn acp::DocumentACP>,
 }
 
 impl<S: storage::corekv::Store + 'static> DbSchemaOps<S> {
-    pub(crate) fn new(database: Arc<db::DB<S>>, query_limits: query::QueryLimits) -> Self {
+    pub(crate) fn new(
+        database: Arc<db::DB<S>>,
+        query_limits: query::QueryLimits,
+        document_acp: Arc<dyn acp::DocumentACP>,
+    ) -> Self {
         Self {
             database,
             query_limits,
+            document_acp,
         }
+    }
+
+    fn current_identity() -> Option<Did> {
+        defra_core::current_identity::try_get_scoped_identity()
+            .or_else(defra_core::current_identity::get_current_identity)
+            .and_then(|did| Did::new(did).ok())
     }
 }
 
 #[async_trait::async_trait]
 impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
     async fn add_schema(&self, sdl: &str) -> anyhow::Result<()> {
+        let creator = Self::current_identity();
         self.database
             .check_node_access(None, acp::nac::NodePermission::CollectionPatch)
             .await
@@ -36,9 +50,24 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
             .map_err(|e| anyhow::anyhow!("schema validation error: {}", e))?;
 
         for collection in collections {
+            let collection_name = collection.name.clone();
             db::DB::create_collection(&self.database, collection)
                 .await
                 .map_err(|e| anyhow::anyhow!("create collection error: {}", e))?;
+            let finalized = self
+                .database
+                .get_collection(&collection_name)
+                .map_err(anyhow::Error::new)?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("created collection '{}' was not cached", collection_name)
+                })?;
+            db::register_collection_if_needed(
+                self.document_acp.as_ref(),
+                creator.as_ref(),
+                finalized.schema(),
+            )
+            .await
+            .map_err(anyhow::Error::new)?;
         }
         Ok(())
     }
@@ -92,10 +121,22 @@ impl<S: storage::corekv::Store + 'static> SchemaOps for DbSchemaOps<S> {
             }
         }
 
-        self.database
+        let finalized = self
+            .database
             .create_collections_atomic(collections)
             .await
             .map_err(|e| anyhow::anyhow!("create view collection error: {}", e))?;
+
+        let creator = Self::current_identity();
+        for collection in &finalized {
+            db::register_collection_if_needed(
+                self.document_acp.as_ref(),
+                creator.as_ref(),
+                collection,
+            )
+            .await
+            .map_err(anyhow::Error::new)?;
+        }
 
         if !materialized_names.is_empty() {
             self.database

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1289,6 +1289,7 @@ impl NodeBuilder {
             query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry)
                 .with_mutator(mutator)
                 .with_acp(document_acp.clone())
+                .with_node_did(database.node_did())
                 .with_lens_store(database.lens_store().clone())
                 .with_query_limits(query_limits);
         let query_runner = if let Some(timeout) = query_timeout {
@@ -1356,6 +1357,8 @@ impl NodeBuilder {
 
         // 5. Blockstore for sync coordinator + merge handler
         let sync_blockstore = Arc::new(blockstore::DefraBlockstore::new(store.clone(), true));
+        let classifier = defra_p2p_adapter::DbBlockClassifier::new_arc(database.clone());
+        let serve_acp = Arc::new(p2p::bitswap::LateBoundServeAcp::new());
 
         // 6. Collection store (persists subscriptions)
         let collection_store: Arc<dyn p2p::sync::P2PCollectionStorage> =
@@ -1370,17 +1373,20 @@ impl NodeBuilder {
             rate_limit_rate: config.rate_limit_rate,
             ..Default::default()
         };
-        let (mut coordinator, sync_events) = p2p::sync::SyncCoordinator::with_access_control(
-            transport.clone(),
-            sync_blockstore.clone(),
-            sync_config,
-            p2p::AccessMode::Controlled,
-            replicator_registry,
-            collection_store,
-            Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("SyncCoordinator creation failed: {}", e))?;
+        let (mut coordinator, sync_events) =
+            p2p::sync::SyncCoordinator::with_access_control_and_serve_gate(
+                transport.clone(),
+                sync_blockstore.clone(),
+                sync_config,
+                p2p::AccessMode::Controlled,
+                replicator_registry,
+                collection_store,
+                Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
+                classifier,
+                serve_acp.clone(),
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!("SyncCoordinator creation failed: {}", e))?;
 
         // Failure channel (required by replication loop)
         let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
@@ -1405,6 +1411,8 @@ impl NodeBuilder {
         let merge_handler_for_loop = replication.merge_handler.clone();
         let broadcast_mutator = replication.broadcast_mutator.clone();
         let merge_handler_for_acp = replication.merge_handler.clone();
+        let serve_acp_for_acp = serve_acp.clone();
+        let database_for_acp = database.clone();
 
         // 9. Replication loop (transport-generic)
         let coord_for_repl = coordinator.clone();
@@ -1472,6 +1480,13 @@ impl NodeBuilder {
             })),
             mutator,
             wire_document_acp: Some(Box::new(move |acp, strict| {
+                serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
+                    resolver: Arc::new(p2p::AnonymousResolver),
+                    gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
+                        acp.clone(),
+                        database_for_acp.node_did(),
+                    ),
+                });
                 merge_handler_for_acp.set_document_acp(acp.clone());
                 merge_handler_for_acp.set_strict_replicated_doc_access(strict);
                 doc_pusher_for_acp.set_document_acp(acp.clone());

--- a/crates/defra-node/src/lib.rs
+++ b/crates/defra-node/src/lib.rs
@@ -1288,7 +1288,7 @@ impl NodeBuilder {
         let query_runner =
             query::QueryRunner::with_arc_registry_and_provider(fetcher, provider, registry)
                 .with_mutator(mutator)
-                .with_acp(document_acp)
+                .with_acp(document_acp.clone())
                 .with_lens_store(database.lens_store().clone())
                 .with_query_limits(query_limits);
         let query_runner = if let Some(timeout) = query_timeout {
@@ -1298,8 +1298,11 @@ impl NodeBuilder {
         };
 
         let runner: Arc<dyn QueryExecutor> = Arc::new(query_runner);
-        let schema_ops: Arc<dyn SchemaOps> =
-            Arc::new(db_impls::DbSchemaOps::new(database.clone(), query_limits));
+        let schema_ops: Arc<dyn SchemaOps> = Arc::new(db_impls::DbSchemaOps::new(
+            database.clone(),
+            query_limits,
+            document_acp,
+        ));
 
         #[cfg(feature = "p2p")]
         let (p2p_ops, p2p_lifecycle) = match p2p_result {

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -674,6 +674,7 @@ where
             .unwrap_or_else(|| Arc::new(db::AutoCommitMutator::new(database.clone()))),
     )
     .with_acp(document_acp.clone())
+    .with_node_did(database.node_did())
     .with_lens_store(database.lens_store().clone())
     .with_query_limits(config.query_limits);
 

--- a/crates/embedded/src/node.rs
+++ b/crates/embedded/src/node.rs
@@ -23,6 +23,24 @@ type EmbeddedTxnRegistry<S> = db::DbTransactionRegistry<S>;
 pub(crate) type WireDocumentAcpCallback = Box<dyn FnOnce(Arc<dyn acp::DocumentACP>)>;
 pub(crate) type WireKmsCallback = Box<dyn FnOnce(Arc<dyn kms::KmsService>) + Send>;
 
+/// Resolve the ambient (scoped, then process) identity into a creator DID for
+/// ACP registration. Returns `Ok(None)` when no identity is present (the
+/// collection stays public/unregistered, as intended), but fails closed when an
+/// identity string is present yet malformed — never silently degrading a
+/// permissioned collection to public.
+fn resolve_creator_identity() -> Result<Option<identity::Did>> {
+    match defra_core::current_identity::try_get_scoped_identity()
+        .or_else(defra_core::current_identity::get_current_identity)
+    {
+        Some(raw) => {
+            Ok(Some(identity::Did::new(raw).map_err(|error| {
+                anyhow!("malformed ambient identity: {error}")
+            })?))
+        }
+        None => Ok(None),
+    }
+}
+
 /// Embedded DefraDB node assembled for native/mobile embedding.
 pub struct EmbeddedNode<S: storage::corekv::Store> {
     pub database: Arc<db::DB<S>>,
@@ -73,12 +91,15 @@ impl<S: storage::corekv::Store + 'static> EmbeddedNode<S> {
 
         let _id_guard =
             defra_core::current_identity::scoped_current_identity(self.node_identity_did.clone());
-        for collection in collections {
-            self.database
-                .create_collection(collection)
-                .await
-                .map_err(|error| anyhow!("create collection error: {error}"))?;
-        }
+        let creator = resolve_creator_identity()?;
+        self.database
+            .create_collections_atomic_with_acp_registration(
+                collections,
+                self.document_acp.clone(),
+                creator,
+            )
+            .await
+            .map_err(|error| anyhow!("create collection error: {error}"))?;
 
         Ok(())
     }

--- a/crates/embedded/src/node_p2p.rs
+++ b/crates/embedded/src/node_p2p.rs
@@ -98,12 +98,16 @@ where
         }
     };
 
+    let classifier = defra_p2p_adapter::DbBlockClassifier::new_arc(database.clone());
+    let serve_acp = Arc::new(p2p::bitswap::LateBoundServeAcp::new());
     let (host, handle, event_rx, replicator_registry) =
-        p2p::P2PHost::with_keypair_and_config_and_identity(
+        p2p::P2PHost::with_keypair_and_config_and_identity_and_serve_gate(
             p2p_keypair,
             bitswap_store,
             p2p::P2PHostConfig::default(),
             database.node_identity(),
+            classifier.clone(),
+            serve_acp.clone(),
         )
         .await
         .map_err(|error| anyhow!("failed to create P2P host: {error}"))?;
@@ -134,18 +138,21 @@ where
         Arc::new(p2p::sync::P2PCollectionStore::new(store.clone()));
     let head_provider: Arc<dyn DocumentHeadProvider> =
         Arc::new(db_merge::create_head_provider(database.clone()));
-    let (mut coordinator, sync_events_rx) = p2p::sync::SyncCoordinator::with_head_provider(
-        p2p::Libp2pTransport::new(handle.clone()),
-        blockstore.clone(),
-        sync_config,
-        p2p::bitswap::AccessMode::Controlled,
-        replicator_registry,
-        collection_store,
-        head_provider,
-        std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
-    )
-    .await
-    .map_err(|error| anyhow!("failed to create sync coordinator: {error}"))?;
+    let (mut coordinator, sync_events_rx) =
+        p2p::sync::SyncCoordinator::with_head_provider_and_serve_gate(
+            p2p::Libp2pTransport::new(handle.clone()),
+            blockstore.clone(),
+            sync_config,
+            p2p::bitswap::AccessMode::Controlled,
+            replicator_registry,
+            collection_store,
+            head_provider,
+            std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
+            classifier,
+            serve_acp.clone(),
+        )
+        .await
+        .map_err(|error| anyhow!("failed to create sync coordinator: {error}"))?;
 
     let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
     let coordinator = Arc::new(coordinator);
@@ -243,6 +250,9 @@ where
     .with_replicator_push_options_state(replicator_push_options.clone());
     adapter.set_initial_tracked_documents(restored_doc_ids);
     let coordinator_for_acp = coordinator.clone();
+    let serve_acp_for_acp = serve_acp.clone();
+    let handle_for_acp = handle.clone();
+    let database_for_acp = database.clone();
     let broadcast_mutator_for_acp = replication.broadcast_mutator.clone();
     let broadcast_mutator_for_se = replication.broadcast_mutator.clone();
     // Lazy SE-key handle: teed by the callback below (runtime provisioning),
@@ -319,6 +329,13 @@ where
             merge_handler_inner_for_kms.set_kms(kms);
         })),
         wire_document_acp: Some(Box::new(move |acp| {
+            serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
+                resolver: Arc::new(p2p::HandlePeerIdentityResolver::new(handle_for_acp)),
+                gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
+                    acp.clone(),
+                    database_for_acp.node_did(),
+                ),
+            });
             coordinator_for_acp.set_document_acp(acp.clone());
             doc_pusher_for_acp.set_document_acp(acp.clone());
             broadcast_mutator_for_acp.set_document_acp(acp);
@@ -389,22 +406,27 @@ where
 
     let transport = p2p::iroh::IrohTransport::new(command_tx, secret_key);
     let blockstore = Arc::new(EmbeddedBlockstore::new(store.clone(), true));
+    let classifier = defra_p2p_adapter::DbBlockClassifier::new_arc(database.clone());
+    let serve_acp = Arc::new(p2p::bitswap::LateBoundServeAcp::new());
     let collection_store: Arc<dyn p2p::sync::P2PCollectionStorage> =
         Arc::new(p2p::sync::P2PCollectionStore::new(store.clone()));
     let head_provider: Arc<dyn p2p::sync::DocumentHeadProvider> =
         Arc::new(db_merge::create_head_provider(database.clone()));
-    let (mut coordinator, sync_events_rx) = p2p::sync::SyncCoordinator::with_head_provider(
-        transport.clone(),
-        blockstore.clone(),
-        sync_config,
-        p2p::bitswap::AccessMode::Controlled,
-        replicator_registry,
-        collection_store,
-        head_provider,
-        std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
-    )
-    .await
-    .map_err(|error| anyhow!("failed to create iroh sync coordinator: {error}"))?;
+    let (mut coordinator, sync_events_rx) =
+        p2p::sync::SyncCoordinator::with_head_provider_and_serve_gate(
+            transport.clone(),
+            blockstore.clone(),
+            sync_config,
+            p2p::bitswap::AccessMode::Controlled,
+            replicator_registry,
+            collection_store,
+            head_provider,
+            std::sync::Arc::new(replication_filter::QueryReplicationFilterMatcher::new()),
+            classifier,
+            serve_acp.clone(),
+        )
+        .await
+        .map_err(|error| anyhow!("failed to create iroh sync coordinator: {error}"))?;
 
     let failure_rx = db_merge::attach_failure_channel(&mut coordinator, 1024);
     let coordinator = Arc::new(coordinator);
@@ -488,6 +510,8 @@ where
     .with_replicator_push_options_state(replicator_push_options.clone());
     adapter.set_initial_tracked_documents(restored_doc_ids);
     let coordinator_for_acp = coordinator.clone();
+    let serve_acp_for_acp = serve_acp.clone();
+    let database_for_acp = database.clone();
     let broadcast_mutator_for_acp = replication.broadcast_mutator.clone();
     let broadcast_mutator_for_se = replication.broadcast_mutator.clone();
     let se_key_handle = db_merge::empty_se_key_handle();
@@ -555,6 +579,13 @@ where
             merge_handler_inner_for_kms.set_kms(kms);
         })),
         wire_document_acp: Some(Box::new(move |acp| {
+            serve_acp_for_acp.set(p2p::bitswap::ServeAcp {
+                resolver: Arc::new(p2p::AnonymousResolver),
+                gate: defra_p2p_adapter::DbBlockReadGate::new_arc(
+                    acp.clone(),
+                    database_for_acp.node_did(),
+                ),
+            });
             coordinator_for_acp.set_document_acp(acp.clone());
             doc_pusher_for_acp.set_document_acp(acp.clone());
             broadcast_mutator_for_acp.set_document_acp(acp);

--- a/crates/ffi/src/collection/view.rs
+++ b/crates/ffi/src/collection/view.rs
@@ -4,6 +4,7 @@ use acp::nac::NodePermission;
 
 use crate::helpers::{get_node_database, get_rt, require_c_str};
 use crate::nac_check::check_nac_for_node;
+use crate::schema::parse_optional_identity_did;
 use crate::state::NODES;
 use crate::types::{c_str_to_string, FfiResult};
 use crate::{ffi_async, ffi_entry, try_ffi};
@@ -63,20 +64,23 @@ pub unsafe extern "C" fn add_view(
         let query_str = try_ffi!(require_c_str(gql_query, "gql_query"));
         let sdl_str = try_ffi!(require_c_str(sdl, "sdl"));
         let transform_opt = c_str_to_string(transform);
-        let (database, query_limits) = match NODES.get(node_ptr, |state| {
-            (state.database.clone(), state.query_limits)
+        let (database, query_limits, document_acp) = match NODES.get(node_ptr, |state| {
+            (
+                state.database.clone(),
+                state.query_limits,
+                state.document_acp.clone(),
+            )
         }) {
             Some(state) => state,
             None => return FfiResult::error(crate::ERR_INVALID_NODE_HANDLE),
         };
+        let (identity_str, creator) = try_ffi!(parse_optional_identity_did(identity_did));
 
         // Bind the caller's identity into the ambient context so the DB-layer NAC
         // gate on create_collections_atomic resolves the actual caller instead of
         // the wildcard. The body runs on this thread via `block_on`, so the
         // thread-local is visible throughout it; the guard restores on drop.
-        let _identity_guard = defra_core::current_identity::scoped_current_identity(
-            c_str_to_string(identity_did).filter(|s| !s.is_empty()),
-        );
+        let _identity_guard = defra_core::current_identity::scoped_current_identity(identity_str);
 
         ffi_async!(rt, {
             // Get existing collection names so the SDL parser can resolve external type references
@@ -144,7 +148,11 @@ pub unsafe extern "C" fn add_view(
 
             // Create all view collections atomically (all-or-nothing)
             let created_versions = database
-                .create_collections_atomic(view_collections)
+                .create_collections_atomic_with_acp_registration(
+                    view_collections,
+                    document_acp.clone(),
+                    creator,
+                )
                 .await
                 .map_err(|e| format!("failed to create view collection: {}", e))?;
 

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -376,11 +376,25 @@ pub extern "C" fn defra_mobile_ensure_schema(
             NodePermission::CollectionPatch
         ));
 
-        let (database, policy_store, node_identity_did) = match NODES.get(node_ptr, |state| {
-            (state.database.clone(), state.policy_store.clone(), state.node_identity_did.clone())
+        let (database, policy_store, document_acp, node_identity_did) = match NODES.get(node_ptr, |state| {
+            (
+                state.database.clone(),
+                state.policy_store.clone(),
+                state.document_acp.clone(),
+                state.node_identity_did.clone(),
+            )
         }) {
             Some(value) => value,
             None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
+        };
+        let creator = match node_identity_did.as_deref() {
+            Some(did) => match identity::Did::new(did) {
+                Ok(did) => Some(did),
+                Err(error) => {
+                    return FfiResult::error(format!("invalid node identity DID: {}", error));
+                }
+            },
+            None => None,
         };
 
         // Bind the node's own identity into the ambient context so the DB-layer
@@ -410,17 +424,23 @@ pub extern "C" fn defra_mobile_ensure_schema(
             schema::definition_validation::validate_new_collections(&to_create)
                 .map_err(|error| format!("failed to validate schema: {}", error))?;
 
-            let mut created = Vec::new();
-            for collection in to_create {
+            for collection in &to_create {
                 if let Some(ref policy) = collection.policy {
                     validate_collection_policy(policy, &policy_store)?;
                 }
-                created.push(collection.name.clone());
-                database
-                    .create_collection(collection)
-                    .await
-                    .map_err(|error| format!("failed to create collection: {}", error))?;
             }
+            let created = to_create
+                .iter()
+                .map(|collection| collection.name.clone())
+                .collect::<Vec<_>>();
+            database
+                .create_collections_atomic_with_acp_registration(
+                    to_create,
+                    document_acp.clone(),
+                    creator,
+                )
+                .await
+                .map_err(|error| format!("failed to create collection: {}", error))?;
 
             Ok(serde_json::json!({
                 "created": created,

--- a/crates/ffi/src/negative_tests.rs
+++ b/crates/ffi/src/negative_tests.rs
@@ -48,8 +48,6 @@ mod tests {
         node_close(node);
     }
 
-    /// add_schema with a malformed non-empty identity DID must error instead of
-    /// silently treating the caller as anonymous.
     #[test]
     fn add_schema_malformed_identity_did_returns_error() {
         init();

--- a/crates/ffi/src/negative_tests.rs
+++ b/crates/ffi/src/negative_tests.rs
@@ -48,6 +48,28 @@ mod tests {
         node_close(node);
     }
 
+    /// add_schema with a malformed non-empty identity DID must error instead of
+    /// silently treating the caller as anonymous.
+    #[test]
+    fn add_schema_malformed_identity_did_returns_error() {
+        init();
+        let node = new_in_memory_node();
+
+        let identity = CString::new("not-a-did").unwrap();
+        let sdl = CString::new("type User { name: String }").unwrap();
+        let result = unsafe { add_schema(node, identity.as_ptr(), sdl.as_ptr()) };
+
+        assert_eq!(result.status, 1, "malformed identity DID must be an error");
+        assert!(!result.error.is_null());
+        let msg = unsafe { CStr::from_ptr(result.error).to_string_lossy() };
+        assert!(
+            msg.contains("invalid identity DID"),
+            "error should describe the invalid identity DID, got: {msg}"
+        );
+        unsafe { defra_free_string(result.error) };
+        node_close(node);
+    }
+
     /// exec_request with a NULL query must return an error, not crash.
     #[test]
     fn exec_request_null_query_returns_error() {

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -17,6 +17,22 @@ use crate::state::{PolicyStore, NODES};
 use crate::types::FfiResult;
 use crate::{ffi_async, try_ffi, ERR_INVALID_NODE_HANDLE};
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub(crate) fn parse_optional_identity_did(
+    identity_did: *const c_char,
+) -> Result<(Option<String>, Option<Did>), FfiResult> {
+    // SAFETY: `identity_did` is either null or a valid C string from the FFI caller.
+    let identity_str =
+        unsafe { crate::types::c_str_to_string(identity_did) }.filter(|s| !s.is_empty());
+    let creator = match identity_str.as_deref() {
+        Some(did) => Some(
+            Did::new(did).map_err(|e| FfiResult::error(format!("invalid identity DID: {}", e)))?,
+        ),
+        None => None,
+    };
+    Ok((identity_str, creator))
+}
+
 /// Add a schema to the database.
 ///
 /// The schema should be a GraphQL SDL string defining types.
@@ -51,7 +67,6 @@ pub unsafe extern "C" fn add_schema(
         ));
         let schema_str = try_ffi!(require_c_str(schema_sdl, "schema_sdl"));
 
-        // Validate node handle and get database, policy store, and document ACP
         let (database, policy_store, document_acp) = match NODES.get(node_ptr, |state| {
             (
                 state.database.clone(),
@@ -62,8 +77,7 @@ pub unsafe extern "C" fn add_schema(
             Some(tuple) => tuple,
             None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
         };
-        let identity_str = crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty());
-        let creator = identity_str.as_ref().and_then(|did| Did::new(did).ok());
+        let (identity_str, creator) = try_ffi!(parse_optional_identity_did(identity_did));
 
         // Bind the caller's identity into the ambient context so the DB-layer NAC
         // gate on create_collection resolves the actual caller instead of the
@@ -95,27 +109,14 @@ pub unsafe extern "C" fn add_schema(
                 }
             }
 
-            // Create each collection
-            let mut created_versions = Vec::new();
-            for schema in collections {
-                let collection_name = schema.name.clone();
-                database
-                    .create_collection(schema)
-                    .await
-                    .map_err(|e| format!("failed to create collection: {}", e))?;
-                let finalized = database
-                    .get_collection(&collection_name)
-                    .map_err(|e| format!("failed to load created collection: {}", e))?
-                    .ok_or_else(|| format!("created collection '{}' was not cached", collection_name))?;
-                db::register_collection_if_needed(
-                    document_acp.as_ref(),
-                    creator.as_ref(),
-                    finalized.schema(),
+            let created_versions = database
+                .create_collections_atomic_with_acp_registration(
+                    collections,
+                    document_acp.clone(),
+                    creator,
                 )
                 .await
-                .map_err(|e| format!("failed to register collection with ACP: {}", e))?;
-                created_versions.push(finalized.schema().clone());
-            }
+                .map_err(|e| format!("failed to create collection: {}", e))?;
 
             // Return JSON array of created collection versions
             let json = serde_json::to_string(&created_versions)
@@ -161,8 +162,7 @@ pub unsafe extern "C" fn add_schema_in_txn(
             Some(tuple) => tuple,
             None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
         };
-        let identity_str = crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty());
-        let creator = identity_str.as_ref().and_then(|did| Did::new(did).ok());
+        let (identity_str, creator) = try_ffi!(parse_optional_identity_did(identity_did));
 
         // Bind the caller's identity into the ambient context so the registry-layer
         // NAC gate on add_schema_in_txn resolves the actual caller instead of the

--- a/crates/ffi/src/schema.rs
+++ b/crates/ffi/src/schema.rs
@@ -7,6 +7,7 @@ use std::ffi::c_char;
 use std::sync::Arc;
 
 use acp::nac::NodePermission;
+use identity::Did;
 
 use crate::ffi_entry;
 use crate::helpers::{get_node_database, get_rt, require_c_str};
@@ -50,21 +51,25 @@ pub unsafe extern "C" fn add_schema(
         ));
         let schema_str = try_ffi!(require_c_str(schema_sdl, "schema_sdl"));
 
-        // Validate node handle and get both database and policy store
-        let (database, policy_store) = match NODES.get(node_ptr, |state| {
-            (state.database.clone(), state.policy_store.clone())
+        // Validate node handle and get database, policy store, and document ACP
+        let (database, policy_store, document_acp) = match NODES.get(node_ptr, |state| {
+            (
+                state.database.clone(),
+                state.policy_store.clone(),
+                state.document_acp.clone(),
+            )
         }) {
-            Some(pair) => pair,
+            Some(tuple) => tuple,
             None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
         };
+        let identity_str = crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty());
+        let creator = identity_str.as_ref().and_then(|did| Did::new(did).ok());
 
         // Bind the caller's identity into the ambient context so the DB-layer NAC
         // gate on create_collection resolves the actual caller instead of the
         // wildcard. The body runs on this thread via `block_on`, so the
         // thread-local is visible throughout it; the guard restores on drop.
-        let _identity_guard = defra_core::current_identity::scoped_current_identity(
-            crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty()),
-        );
+        let _identity_guard = defra_core::current_identity::scoped_current_identity(identity_str);
 
         ffi_async!(rt, {
             // Get existing collection names so the SDL parser can resolve external type references
@@ -93,12 +98,23 @@ pub unsafe extern "C" fn add_schema(
             // Create each collection
             let mut created_versions = Vec::new();
             for schema in collections {
-                let version = schema.clone();
+                let collection_name = schema.name.clone();
                 database
                     .create_collection(schema)
                     .await
                     .map_err(|e| format!("failed to create collection: {}", e))?;
-                created_versions.push(version);
+                let finalized = database
+                    .get_collection(&collection_name)
+                    .map_err(|e| format!("failed to load created collection: {}", e))?
+                    .ok_or_else(|| format!("created collection '{}' was not cached", collection_name))?;
+                db::register_collection_if_needed(
+                    document_acp.as_ref(),
+                    creator.as_ref(),
+                    finalized.schema(),
+                )
+                .await
+                .map_err(|e| format!("failed to register collection with ACP: {}", e))?;
+                created_versions.push(finalized.schema().clone());
             }
 
             // Return JSON array of created collection versions
@@ -135,20 +151,24 @@ pub unsafe extern "C" fn add_schema_in_txn(
         let txn_str = try_ffi!(require_c_str(txn_id, "txn_id"));
         let schema_str = try_ffi!(require_c_str(schema_sdl, "schema_sdl"));
 
-        let (registry, policy_store) = match NODES.get(node_ptr, |state| {
-            (state.txn_registry.clone(), state.policy_store.clone())
+        let (registry, policy_store, document_acp) = match NODES.get(node_ptr, |state| {
+            (
+                state.txn_registry.clone(),
+                state.policy_store.clone(),
+                state.document_acp.clone(),
+            )
         }) {
-            Some(pair) => pair,
+            Some(tuple) => tuple,
             None => return FfiResult::error(ERR_INVALID_NODE_HANDLE),
         };
+        let identity_str = crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty());
+        let creator = identity_str.as_ref().and_then(|did| Did::new(did).ok());
 
         // Bind the caller's identity into the ambient context so the registry-layer
         // NAC gate on add_schema_in_txn resolves the actual caller instead of the
         // wildcard. The body runs on this thread via `block_on`, so the
         // thread-local is visible throughout it; the guard restores on drop.
-        let _identity_guard = defra_core::current_identity::scoped_current_identity(
-            crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty()),
-        );
+        let _identity_guard = defra_core::current_identity::scoped_current_identity(identity_str);
 
         ffi_async!(rt, {
             let known_types: std::collections::HashSet<String> = registry
@@ -172,7 +192,12 @@ pub unsafe extern "C" fn add_schema_in_txn(
             }
 
             let created_versions = registry
-                .add_schema_in_txn(&txn_str, &schema_str)
+                .add_schema_in_txn_with_acp(
+                    &txn_str,
+                    &schema_str,
+                    Some(document_acp.clone()),
+                    creator.clone(),
+                )
                 .await
                 .map_err(|e| format!("failed to create collection in txn: {}", e))?;
 

--- a/crates/kms/src/nac_dac_policy.rs
+++ b/crates/kms/src/nac_dac_policy.rs
@@ -90,19 +90,22 @@ impl AccessPolicy for NacDacPolicy {
                     return Ok(PolicyDecision::Allow);
                 };
 
-                // DAC permission check runs as the actor.
                 let actor_id: acp::Identity = actor.into();
-                let allowed = self
-                    .doc_acp
-                    .check_doc_access(
-                        &actor_id,
-                        acp::DocumentPermission::Read,
-                        &info.policy_id,
-                        &info.resource_name,
-                        doc_id,
-                    )
-                    .await
-                    .map_err(classify_acp_error)?;
+                let checker = acp::read_access::DirectChecker {
+                    acp: self.doc_acp.as_ref(),
+                    identity: &actor_id,
+                    node_did: None,
+                };
+                let allowed = acp::read_access::check_doc_read_access(
+                    &checker,
+                    &info.policy_id,
+                    &info.resource_name,
+                    &info.collection_id,
+                    info.is_branchable,
+                    doc_id,
+                )
+                .await
+                .map_err(classify_acp_error)?;
                 Ok(if allowed {
                     PolicyDecision::Allow
                 } else {
@@ -205,6 +208,63 @@ mod tests {
         }
     }
 
+    struct BranchableDac {
+        doc_registered: bool,
+        doc_granted: bool,
+    }
+    #[async_trait::async_trait]
+    impl acp::DocumentACP for BranchableDac {
+        async fn register_doc_object(
+            &self,
+            _: &identity::Did,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> acp::Result<()> {
+            Ok(())
+        }
+        async fn is_doc_registered(&self, _: &str, _: &str, object_id: &str) -> acp::Result<bool> {
+            Ok(object_id == "col-1" || (object_id == "d1" && self.doc_registered))
+        }
+        async fn check_doc_access(
+            &self,
+            _: &acp::Identity,
+            _: acp::DocumentPermission,
+            _: &str,
+            _: &str,
+            object_id: &str,
+        ) -> acp::Result<bool> {
+            Ok(object_id == "d1" && self.doc_granted)
+        }
+        async fn add_actor_relationship(
+            &self,
+            _: &identity::Did,
+            _: &identity::Did,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &[String],
+        ) -> acp::Result<bool> {
+            Ok(true)
+        }
+        async fn delete_actor_relationship(
+            &self,
+            _: &identity::Did,
+            _: &identity::Did,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &str,
+            _: &[String],
+        ) -> acp::Result<bool> {
+            Ok(true)
+        }
+        async fn unregister_doc_object(&self, _: &str, _: &str, _: &str) -> acp::Result<()> {
+            Ok(())
+        }
+    }
+
     struct FakeNac {
         allow: bool,
     }
@@ -223,6 +283,20 @@ mod tests {
                 collection_id: "col-1".into(),
                 policy_id: "policy-1".into(),
                 resource_name: "doc".into(),
+                is_branchable: false,
+            }))
+        }
+    }
+
+    struct BranchableLookup;
+    #[async_trait::async_trait]
+    impl DocCollectionLookup for BranchableLookup {
+        async fn collection_for_doc(&self, _: &str) -> crate::Result<Option<DocCollectionInfo>> {
+            Ok(Some(DocCollectionInfo {
+                collection_id: "col-1".into(),
+                policy_id: "policy-1".into(),
+                resource_name: "doc".into(),
+                is_branchable: true,
             }))
         }
     }
@@ -359,6 +433,54 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(result, PolicyDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn branchable_public_doc_denies_when_collection_denies() {
+        let policy = NacDacPolicy::new(
+            Arc::new(BranchableDac {
+                doc_registered: false,
+                doc_granted: false,
+            }),
+            Arc::new(BranchableLookup),
+        );
+
+        let result = policy
+            .check_release(
+                Some(&did("did:key:zalice")),
+                &KeyScope::Document {
+                    doc_id: "d1".into(),
+                    field: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, PolicyDecision::Deny);
+    }
+
+    #[tokio::test]
+    async fn branchable_explicit_doc_grant_allows_despite_collection_denial() {
+        let policy = NacDacPolicy::new(
+            Arc::new(BranchableDac {
+                doc_registered: true,
+                doc_granted: true,
+            }),
+            Arc::new(BranchableLookup),
+        );
+
+        let result = policy
+            .check_release(
+                Some(&did("did:key:zalice")),
+                &KeyScope::Document {
+                    doc_id: "d1".into(),
+                    field: None,
+                },
+            )
+            .await
+            .unwrap();
+
         assert_eq!(result, PolicyDecision::Allow);
     }
 }

--- a/crates/kms/src/policy.rs
+++ b/crates/kms/src/policy.rs
@@ -65,6 +65,8 @@ pub struct DocCollectionInfo {
     pub policy_id: String,
     /// Resource name within the policy.
     pub resource_name: String,
+    /// Whether the collection is branchable.
+    pub is_branchable: bool,
 }
 
 #[cfg(test)]

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -11,6 +11,7 @@ mod libp2p;
 #[cfg(feature = "libp2p")]
 mod libp2p_doc_pusher;
 pub mod manage;
+mod read_gate;
 mod replicator_status;
 #[cfg(feature = "iroh")]
 mod transport_doc_pusher;
@@ -25,6 +26,7 @@ pub use iroh::IrohP2PAdapter;
 pub use libp2p::{CollectionLookup, P2PAdapter, VersionSyncer};
 #[cfg(feature = "libp2p")]
 pub use libp2p_doc_pusher::{DbDocPusher, DocPusher};
+pub use read_gate::{DbBlockClassifier, DbBlockReadGate};
 pub use replicator_status::{load_persisted_replicators, set_persisted_replicator_status};
 #[cfg(feature = "iroh")]
 pub use transport_doc_pusher::{DbTransportDocPusher, TransportDocPusher};

--- a/crates/p2p-adapter/src/read_gate.rs
+++ b/crates/p2p-adapter/src/read_gate.rs
@@ -33,7 +33,7 @@ impl<S: Store + 'static> DbBlockClassifier<S> {
             return Some(doc_ids);
         }
 
-        let no_heads = block.heads.as_ref().map_or(true, Vec::is_empty);
+        let no_heads = block.heads.as_ref().is_none_or(Vec::is_empty);
         if matches!(block.delta, defra_core::CrdtDelta::Composite(_))
             && block.delta.priority() == 1
             && no_heads

--- a/crates/p2p-adapter/src/read_gate.rs
+++ b/crates/p2p-adapter/src/read_gate.rs
@@ -1,0 +1,309 @@
+//! DB-backed serve-gate adapters shared by libp2p Bitswap and CAR.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cid::Cid;
+use defra_core::{is_lens_block, Block as DefraBlock, Signature};
+use p2p::bitswap::{BlockAcpMeta, BlockClass, BlockClassifier, BlockReadGate};
+use storage::corekv::{IterOptions, Store};
+
+pub struct DbBlockClassifier<S: Store + 'static> {
+    db: Arc<db::DB<S>>,
+}
+
+impl<S: Store + 'static> DbBlockClassifier<S> {
+    pub fn new(db: Arc<db::DB<S>>) -> Self {
+        Self { db }
+    }
+
+    pub fn new_arc(db: Arc<db::DB<S>>) -> Arc<dyn BlockClassifier> {
+        Arc::new(Self::new(db))
+    }
+
+    async fn doc_ids_for_block(&self, cid: &Cid, block: &DefraBlock) -> Option<Vec<String>> {
+        let Some(doc_id_bytes) = block.delta.doc_id() else {
+            return Some(Vec::new());
+        };
+
+        let mut doc_ids = self.doc_ids_for_cid_from_headstore(cid).await?;
+        if !doc_ids.is_empty() {
+            doc_ids.sort();
+            doc_ids.dedup();
+            return Some(doc_ids);
+        }
+
+        let no_heads = block.heads.as_ref().map_or(true, Vec::is_empty);
+        if matches!(block.delta, defra_core::CrdtDelta::Composite(_))
+            && block.delta.priority() == 1
+            && no_heads
+        {
+            return Some(vec![String::from_utf8_lossy(doc_id_bytes).to_string()]);
+        }
+
+        None
+    }
+
+    async fn doc_ids_for_cid_from_headstore(&self, cid: &Cid) -> Option<Vec<String>> {
+        let txn = self.db.new_txn(true).await.ok()?;
+        let headstore = match txn.headstore() {
+            Ok(headstore) => headstore,
+            Err(_) => {
+                let _ = txn.discard();
+                return None;
+            }
+        };
+        let mut iter = match headstore
+            .iterator(IterOptions::new().with_prefix(b"/p/".to_vec()))
+            .await
+        {
+            Ok(iter) => iter,
+            Err(_) => {
+                let _ = txn.discard();
+                return None;
+            }
+        };
+
+        let target = cid.to_bytes();
+        let mut doc_ids = Vec::new();
+        loop {
+            let pair = match iter.next().await {
+                Ok(Some(pair)) => pair,
+                Ok(None) => break,
+                Err(_) => {
+                    let _ = iter.close().await;
+                    let _ = txn.discard();
+                    return None;
+                }
+            };
+
+            if !pair.key.ends_with(&target) {
+                continue;
+            }
+            if let Some(doc_id) = parse_priority_doc_id(&pair.key) {
+                doc_ids.push(doc_id);
+            }
+        }
+
+        let _ = iter.close().await;
+        let _ = txn.discard();
+        Some(doc_ids)
+    }
+}
+
+fn parse_priority_doc_id(key: &[u8]) -> Option<String> {
+    let rest = key.strip_prefix(b"/p/")?;
+    let doc_end = rest.iter().position(|b| *b == b'/')?;
+    let doc_id = std::str::from_utf8(&rest[..doc_end]).ok()?;
+    Some(doc_id.to_string())
+}
+
+#[async_trait]
+impl<S: Store + 'static> BlockClassifier for DbBlockClassifier<S> {
+    async fn classify(&self, cid: &Cid, data: &[u8]) -> BlockClass {
+        match defra_core::block::generate_cid_from_bytes(data) {
+            Ok(actual) if &actual == cid => {}
+            _ => return BlockClass::Deny,
+        }
+
+        if Signature::from_dag_cbor(data).is_ok() {
+            return BlockClass::Allow;
+        }
+
+        match DefraBlock::from_dag_cbor(data) {
+            Ok(block) => {
+                if block.delta.is_definition() {
+                    return BlockClass::Allow;
+                }
+
+                let Some(schema_version_id) = block.delta.schema_version_id() else {
+                    return BlockClass::Deny;
+                };
+                let collection = match self
+                    .db
+                    .get_collection_by_version_id_full(schema_version_id)
+                    .await
+                {
+                    Ok(Some(collection)) => collection,
+                    Ok(None) | Err(_) => return BlockClass::Deny,
+                };
+                let collection = collection.schema();
+                let policy = collection
+                    .policy
+                    .as_ref()
+                    .map(|p| (p.id.clone(), p.resource_name.clone()));
+                let Some(doc_ids) = self.doc_ids_for_block(cid, &block).await else {
+                    return BlockClass::Deny;
+                };
+
+                BlockClass::Data(BlockAcpMeta {
+                    collection_id: collection.collection_id.clone(),
+                    is_branchable: collection.is_branchable,
+                    policy,
+                    doc_ids,
+                })
+            }
+            Err(_) if is_lens_block(data) => BlockClass::Allow,
+            Err(_) => BlockClass::Deny,
+        }
+    }
+}
+
+pub struct DbBlockReadGate {
+    acp: Arc<dyn acp::DocumentACP>,
+    node_did: Option<identity::Did>,
+}
+
+impl DbBlockReadGate {
+    pub fn new(acp: Arc<dyn acp::DocumentACP>, node_did: Option<identity::Did>) -> Self {
+        Self { acp, node_did }
+    }
+
+    pub fn new_arc(
+        acp: Arc<dyn acp::DocumentACP>,
+        node_did: Option<identity::Did>,
+    ) -> Arc<dyn BlockReadGate> {
+        Arc::new(Self::new(acp, node_did))
+    }
+}
+
+#[async_trait]
+impl BlockReadGate for DbBlockReadGate {
+    async fn may_read(&self, identity: &acp::Identity, meta: &BlockAcpMeta) -> bool {
+        let Some((policy_id, resource_name)) = meta.policy.as_ref() else {
+            return true;
+        };
+
+        let checker = acp::read_access::DirectChecker {
+            acp: self.acp.as_ref(),
+            identity,
+            node_did: self.node_did.as_ref(),
+        };
+
+        if meta.doc_ids.is_empty() {
+            return acp::read_access::check_doc_read_access(
+                &checker,
+                policy_id,
+                resource_name,
+                &meta.collection_id,
+                meta.is_branchable,
+                "",
+            )
+            .await
+            .unwrap_or(false);
+        }
+
+        for doc_id in &meta.doc_ids {
+            if acp::read_access::check_doc_read_access(
+                &checker,
+                policy_id,
+                resource_name,
+                &meta.collection_id,
+                meta.is_branchable,
+                doc_id,
+            )
+            .await
+            .unwrap_or(false)
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{parse_priority_doc_id, DbBlockClassifier};
+    use p2p::bitswap::{BlockClass, BlockClassifier};
+    use schema::{CollectionVersion, FieldDescription, FieldKind, PolicyDescription};
+    use storage::backends::MemoryStore;
+    use storage::corekv::Key;
+
+    #[test]
+    fn parses_doc_id_from_priority_headstore_key() {
+        let cid = defra_core::block::generate_cid_from_bytes(b"block").unwrap();
+        let key = storage::keys::HeadstorePriorityKey::new("doc-1", 42, cid).bytes();
+
+        assert_eq!(parse_priority_doc_id(&key).as_deref(), Some("doc-1"));
+    }
+
+    fn test_collection() -> CollectionVersion {
+        CollectionVersion::new(
+            "User",
+            "version-1",
+            "collection-1",
+            vec![
+                FieldDescription::new("1", "_docID", FieldKind::doc_id()),
+                FieldDescription::new("2", "name", FieldKind::string()),
+            ],
+        )
+        .with_policy(PolicyDescription::new("policy1", "users"))
+        .as_branchable()
+    }
+
+    fn data_block(doc_id: &str) -> (cid::Cid, Vec<u8>) {
+        let block = defra_core::Block::new(
+            defra_core::CrdtDelta::Lww(defra_core::LwwDeltaPayload {
+                doc_id: doc_id.as_bytes().to_vec(),
+                field_name: "name".to_string(),
+                priority: 1,
+                schema_version_id: "version-1".to_string(),
+                data: b"Alice".to_vec(),
+            }),
+            vec![],
+            vec![],
+        );
+        let bytes = block.to_dag_cbor().unwrap();
+        let cid = defra_core::block::generate_cid_from_bytes(&bytes).unwrap();
+        (cid, bytes)
+    }
+
+    #[tokio::test]
+    async fn classifier_uses_serving_cid_owner_metadata() {
+        let db = Arc::new(db::DB::new(MemoryStore::new()).unwrap());
+        db.create_collection(test_collection()).await.unwrap();
+        let (cid, bytes) = data_block("doc-from-delta");
+
+        let txn = db.new_txn(false).await.unwrap();
+        txn.headstore()
+            .unwrap()
+            .set(
+                &storage::keys::HeadstorePriorityKey::new("doc-from-index", 1, cid).bytes(),
+                &[],
+            )
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+
+        let classifier = DbBlockClassifier::new(db);
+        let class = classifier.classify(&cid, &bytes).await;
+
+        match class {
+            BlockClass::Data(meta) => {
+                assert_eq!(meta.collection_id, "collection-1");
+                assert!(meta.is_branchable);
+                assert_eq!(
+                    meta.policy,
+                    Some(("policy1".to_string(), "users".to_string()))
+                );
+                assert_eq!(meta.doc_ids, vec!["doc-from-index"]);
+            }
+            other => panic!("expected data block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn classifier_denies_field_block_without_owner_metadata() {
+        let db = Arc::new(db::DB::new(MemoryStore::new()).unwrap());
+        db.create_collection(test_collection()).await.unwrap();
+        let (cid, bytes) = data_block("doc-from-delta");
+
+        let classifier = DbBlockClassifier::new(db);
+
+        assert_eq!(classifier.classify(&cid, &bytes).await, BlockClass::Deny);
+    }
+}

--- a/crates/p2p/src/behaviour.rs
+++ b/crates/p2p/src/behaviour.rs
@@ -42,7 +42,10 @@ use libp2p_stream as stream;
 
 use libp2p::identity::Keypair;
 
-use crate::bitswap::{make_peer_block_access_filter, AccessMode, ReplicatorRegistry};
+use crate::bitswap::{
+    make_peer_block_access_filter, AccessMode, BlockClassifier, LateBoundServeAcp,
+    ReplicatorRegistry,
+};
 use crate::codec::PushLogCodec;
 use crate::message::{PushLogReply, PushLogRequest};
 
@@ -234,6 +237,8 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
         bitswap_store: S,
         access_mode: AccessMode,
         replicators: Arc<ReplicatorRegistry>,
+        classifier: Arc<dyn BlockClassifier>,
+        serve_acp: Arc<LateBoundServeAcp>,
         enable_pubsub: bool,
         config: &super::P2PHostConfig,
         resource_manager_system_memory_budget_bytes: usize,
@@ -293,6 +298,8 @@ impl<S: Store + Clone + Send + Sync + 'static> DefraBehaviour<S> {
             access_mode,
             Arc::clone(&replicators),
             bitswap_store.clone(),
+            classifier,
+            serve_acp,
         );
         let mut bitswap_config = BitswapConfig::default();
         if let Some(server_cfg) = bitswap_config.server.as_mut() {
@@ -536,6 +543,8 @@ mod tests {
             store,
             AccessMode::Open,
             registry,
+            Arc::new(crate::bitswap::DefaultBlockClassifier),
+            Arc::new(crate::bitswap::LateBoundServeAcp::new()),
             true,
             &config,
             usize::MAX,
@@ -600,6 +609,8 @@ mod tests {
             store,
             AccessMode::Open,
             registry,
+            Arc::new(crate::bitswap::DefaultBlockClassifier),
+            Arc::new(crate::bitswap::LateBoundServeAcp::new()),
             false,
             &config,
             usize::MAX,

--- a/crates/p2p/src/bitswap/filter.rs
+++ b/crates/p2p/src/bitswap/filter.rs
@@ -12,30 +12,22 @@
 //!
 //! 1. `AccessMode::Open` → allow all.
 //! 2. Block not in store → deny (prevents existence leaks too).
-//! 3. Block decodes as a `Signature` → allow (signature blocks carry no
-//!    collection data and are required to verify sibling blocks).
-//! 4. Block decodes as a CRDT `Block` with a definition delta → allow
-//!    (schema/collection definitions are broadcast to all replicators).
-//! 5. Block decodes as a CRDT `Block` with a data delta → allow iff the
-//!    requesting peer is registered as a replicator for the block's
-//!    collection.
-//! 6. Block decodes as a lens IPLD shape (config / module / WASM /
-//!    chunk) → allow. Schema-migration artifacts carry no user data
-//!    and mirror Go's `hasAccess` passthrough at `internal/db/p2p/
-//!    p2p.go:335-348`.
-//! 7. Anything else (decode errors on all known shapes) → deny.
+//! 3. Classifier allows signature / definition / lens blocks.
+//! 4. Data blocks get metadata from the classifier.
+//! 5. Replicators for the block's stable collection id bypass ACP.
+//! 6. Non-replicators resolve identity and run the late-bound ACP read gate.
+//! 7. Unknown blocks or ACP errors deny.
 
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use cid::Cid;
-use defra_core::{is_lens_block, Block as DefraBlock, Signature};
 use iroh_bitswap::Store;
 use libp2p::PeerId;
 use tracing::debug;
 
-use super::{AccessMode, ReplicatorRegistry};
+use super::{AccessMode, BlockClass, BlockClassifier, LateBoundServeAcp, ReplicatorRegistry};
 
 /// Build a filter closure that satisfies iroh-bitswap's
 /// `PeerBlockRequestFilter` trait.
@@ -46,6 +38,8 @@ pub fn make_peer_block_access_filter<S>(
     mode: AccessMode,
     registry: Arc<ReplicatorRegistry>,
     store: S,
+    classifier: Arc<dyn BlockClassifier>,
+    serve_acp: Arc<LateBoundServeAcp>,
 ) -> impl Fn(&PeerId, &Cid) -> Pin<Box<dyn Future<Output = bool> + Send + 'static>> + Send + Sync + 'static
 where
     S: Store + Clone + Send + Sync + 'static,
@@ -54,8 +48,21 @@ where
         let peer_id = *peer_id;
         let cid = *cid;
         let registry = Arc::clone(&registry);
+        let classifier = Arc::clone(&classifier);
+        let serve_acp = Arc::clone(&serve_acp);
         let store = store.clone();
-        Box::pin(async move { check_access(mode, &registry, &store, &peer_id, &cid).await })
+        Box::pin(async move {
+            check_access(
+                mode,
+                &registry,
+                &store,
+                classifier.as_ref(),
+                serve_acp.as_ref(),
+                &peer_id,
+                &cid,
+            )
+            .await
+        })
     }
 }
 
@@ -63,6 +70,8 @@ async fn check_access<S: Store>(
     mode: AccessMode,
     registry: &ReplicatorRegistry,
     store: &S,
+    classifier: &dyn BlockClassifier,
+    serve_acp: &LateBoundServeAcp,
     peer_id: &PeerId,
     cid: &Cid,
 ) -> bool {
@@ -87,57 +96,50 @@ async fn check_access<S: Store>(
     };
     let data = block.data();
 
-    // Signature blocks are required for peers to verify data they already
-    // have, and carry no authored data themselves. Always serve.
-    if Signature::from_dag_cbor(data).is_ok() {
-        return true;
-    }
-
-    match DefraBlock::from_dag_cbor(data) {
-        Ok(defra_block) => {
-            if defra_block.delta.is_definition() {
-                return true;
-            }
-            let Some(collection_id) = defra_block.delta.schema_version_id() else {
-                debug!(
-                    cid = %cid,
-                    peer = %peer_id,
-                    "bitswap request denied: data delta missing collection id"
-                );
-                return false;
-            };
+    match classifier.classify(cid, data).await {
+        BlockClass::Allow => true,
+        BlockClass::Deny => {
+            debug!(cid = %cid, peer = %peer_id, "bitswap request denied by block classifier");
+            false
+        }
+        BlockClass::Data(meta) => {
             let peer_str = peer_id.to_string();
-            if registry.is_filtered_replicator(collection_id, &peer_str) {
+            if registry.is_filtered_replicator(&meta.collection_id, &peer_str) {
                 debug!(
                     cid = %cid,
                     peer = %peer_id,
-                    collection = %collection_id,
+                    collection = %meta.collection_id,
                     "bitswap request denied: filtered replicator data-block access uses direct push"
                 );
                 return false;
             }
-            if registry.is_replicator(collection_id, &peer_str) {
+            if registry.is_replicator(&meta.collection_id, &peer_str) {
+                return true;
+            }
+
+            let Some(serve) = serve_acp.get() else {
+                debug!(
+                    cid = %cid,
+                    peer = %peer_id,
+                    collection = %meta.collection_id,
+                    "bitswap request denied: serve ACP gate not installed"
+                );
+                return false;
+            };
+            let transport_peer_id = crate::transport::PeerId::from(peer_id);
+            let identity = match serve.resolver.resolve(&transport_peer_id).await {
+                Some(did) => acp::Identity::Authenticated(did),
+                None => acp::Identity::Anonymous,
+            };
+            if serve.gate.may_read(&identity, &meta).await {
                 return true;
             }
             debug!(
                 cid = %cid,
                 peer = %peer_id,
-                collection = %collection_id,
-                "bitswap request denied: peer not a replicator for collection"
-            );
-            false
-        }
-        Err(_) => {
-            // Not a CRDT block. Go's hasAccess lets lens IPLD artifacts
-            // (config / module / WASM / chunks) through unconditionally —
-            // they carry no user data. Match that or deny.
-            if is_lens_block(data) {
-                return true;
-            }
-            debug!(
-                cid = %cid,
-                peer = %peer_id,
-                "bitswap request denied: block is neither CRDT, signature, nor lens"
+                collection = %meta.collection_id,
+                identity = %identity,
+                "bitswap request denied: ACP read gate denied"
             );
             false
         }
@@ -147,8 +149,13 @@ async fn check_access<S: Store>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bitswap::{
+        AllowAllBlockReadGate, BlockAcpMeta, DefaultBlockClassifier, LateBoundServeAcp, ServeAcp,
+    };
+    use crate::peer_identity::AnonymousResolver;
     use crate::replicator::{ReplicationFilter, ReplicationFilters, ReplicatorInfo};
     use async_trait::async_trait;
+    use defra_core::Block as DefraBlock;
     use iroh_bitswap::{Block, Store};
     use std::collections::HashMap;
     use std::sync::Mutex;
@@ -195,6 +202,36 @@ mod tests {
         defra_core::block::generate_cid_from_bytes(data).unwrap()
     }
 
+    async fn check_access_with_defaults<S: Store>(
+        mode: AccessMode,
+        registry: &ReplicatorRegistry,
+        store: &S,
+        peer_id: &PeerId,
+        cid: &Cid,
+    ) -> bool {
+        let classifier = DefaultBlockClassifier;
+        let serve_acp = LateBoundServeAcp::new();
+        check_access(mode, registry, store, &classifier, &serve_acp, peer_id, cid).await
+    }
+
+    async fn check_access_with_data_classifier<S: Store>(
+        mode: AccessMode,
+        registry: &ReplicatorRegistry,
+        store: &S,
+        peer_id: &PeerId,
+        cid: &Cid,
+        collection_id: &str,
+    ) -> bool {
+        let classifier = StaticClassifier(BlockClass::Data(BlockAcpMeta {
+            collection_id: collection_id.to_string(),
+            is_branchable: false,
+            policy: None,
+            doc_ids: vec!["doc1".to_string()],
+        }));
+        let serve_acp = LateBoundServeAcp::new();
+        check_access(mode, registry, store, &classifier, &serve_acp, peer_id, cid).await
+    }
+
     fn make_data_block(collection_id: &str) -> (Cid, Vec<u8>) {
         use defra_core::{CompositeDeltaPayload, CrdtDelta};
 
@@ -219,7 +256,8 @@ mod tests {
         store.put(cid, bytes);
 
         let peer = PeerId::random();
-        let allowed = check_access(AccessMode::Open, &registry, &store, &peer, &cid).await;
+        let allowed =
+            check_access_with_defaults(AccessMode::Open, &registry, &store, &peer, &cid).await;
         assert!(allowed);
     }
 
@@ -231,7 +269,9 @@ mod tests {
         store.put(cid, bytes);
 
         let peer = PeerId::random();
-        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        let allowed =
+            check_access_with_defaults(AccessMode::Controlled, &registry, &store, &peer, &cid)
+                .await;
         assert!(!allowed, "unknown peer must be denied in Controlled mode");
     }
 
@@ -245,7 +285,15 @@ mod tests {
         let peer = PeerId::random();
         registry.add_replicator("users", &peer.to_string());
 
-        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        let allowed = check_access_with_data_classifier(
+            AccessMode::Controlled,
+            &registry,
+            &store,
+            &peer,
+            &cid,
+            "users",
+        )
+        .await;
         assert!(allowed, "registered replicator must be served");
     }
 
@@ -269,7 +317,15 @@ mod tests {
             filters,
         ));
 
-        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        let allowed = check_access_with_data_classifier(
+            AccessMode::Controlled,
+            &registry,
+            &store,
+            &peer,
+            &cid,
+            "users",
+        )
+        .await;
         assert!(
             !allowed,
             "filtered replicators receive matching full DAGs by direct push, not collection-wide Bitswap"
@@ -287,7 +343,15 @@ mod tests {
         // Peer is a replicator for a different collection.
         registry.add_replicator("posts", &peer.to_string());
 
-        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        let allowed = check_access_with_data_classifier(
+            AccessMode::Controlled,
+            &registry,
+            &store,
+            &peer,
+            &cid,
+            "users",
+        )
+        .await;
         assert!(
             !allowed,
             "replicator for a different collection must not fetch this one"
@@ -304,7 +368,8 @@ mod tests {
         registry.add_replicator("users", &peer.to_string());
 
         let allowed =
-            check_access(AccessMode::Controlled, &registry, &store, &peer, &missing).await;
+            check_access_with_defaults(AccessMode::Controlled, &registry, &store, &peer, &missing)
+                .await;
         assert!(!allowed, "missing block must be denied");
     }
 
@@ -321,7 +386,9 @@ mod tests {
         store.put(cid, bytes);
 
         let peer = PeerId::random();
-        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        let allowed =
+            check_access_with_defaults(AccessMode::Controlled, &registry, &store, &peer, &cid)
+                .await;
         assert!(
             allowed,
             "signature blocks must be served even in Controlled mode"
@@ -349,7 +416,9 @@ mod tests {
         store.put(cid, bytes);
 
         let peer = PeerId::random();
-        let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, &cid).await;
+        let allowed =
+            check_access_with_defaults(AccessMode::Controlled, &registry, &store, &peer, &cid)
+                .await;
         assert!(
             allowed,
             "definition deltas must be served even to non-replicator peers"
@@ -376,11 +445,90 @@ mod tests {
 
         let peer = PeerId::random();
         for (cid, _) in &blocks {
-            let allowed = check_access(AccessMode::Controlled, &registry, &store, &peer, cid).await;
+            let allowed =
+                check_access_with_defaults(AccessMode::Controlled, &registry, &store, &peer, cid)
+                    .await;
             assert!(
                 allowed,
                 "lens block at {cid} must be served without replicator trust"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn controlled_mode_uses_late_bound_gate_for_non_replicator() {
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        let cid = cid_for(b"opaque-data-block");
+        store.put(cid, b"opaque-data-block".to_vec());
+        let classifier = StaticClassifier(BlockClass::Data(BlockAcpMeta {
+            collection_id: "users".to_string(),
+            is_branchable: true,
+            policy: Some(("policy1".to_string(), "user".to_string())),
+            doc_ids: vec!["doc1".to_string()],
+        }));
+        let serve_acp = LateBoundServeAcp::new();
+        serve_acp.set(ServeAcp {
+            resolver: Arc::new(AnonymousResolver),
+            gate: Arc::new(AllowAllBlockReadGate),
+        });
+
+        let peer = PeerId::random();
+        let allowed = check_access(
+            AccessMode::Controlled,
+            &registry,
+            &store,
+            &classifier,
+            &serve_acp,
+            &peer,
+            &cid,
+        )
+        .await;
+        assert!(
+            allowed,
+            "non-replicator data blocks must be served when the late-bound gate grants read"
+        );
+    }
+
+    #[tokio::test]
+    async fn controlled_mode_replicator_bypasses_uninstalled_gate() {
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        let cid = cid_for(b"opaque-data-block");
+        store.put(cid, b"opaque-data-block".to_vec());
+        let classifier = StaticClassifier(BlockClass::Data(BlockAcpMeta {
+            collection_id: "users".to_string(),
+            is_branchable: true,
+            policy: Some(("policy1".to_string(), "user".to_string())),
+            doc_ids: vec!["doc1".to_string()],
+        }));
+        let serve_acp = LateBoundServeAcp::new();
+
+        let peer = PeerId::random();
+        registry.add_replicator("users", &peer.to_string());
+        let allowed = check_access(
+            AccessMode::Controlled,
+            &registry,
+            &store,
+            &classifier,
+            &serve_acp,
+            &peer,
+            &cid,
+        )
+        .await;
+        assert!(
+            allowed,
+            "replicator passthrough must not depend on serve ACP initialization"
+        );
+    }
+
+    #[derive(Clone)]
+    struct StaticClassifier(BlockClass);
+
+    #[async_trait]
+    impl BlockClassifier for StaticClassifier {
+        async fn classify(&self, _cid: &Cid, _data: &[u8]) -> BlockClass {
+            self.0.clone()
         }
     }
 }

--- a/crates/p2p/src/bitswap/filter.rs
+++ b/crates/p2p/src/bitswap/filter.rs
@@ -395,17 +395,17 @@ mod tests {
         );
     }
 
-    /// Schema/collection definitions are broadcast to every replicator
-    /// regardless of per-collection registration. A peer that has no
-    /// entry in the registry must still be able to fetch them.
+    /// Schema/collection definitions are broadcast to every peer regardless of
+    /// per-collection registration (they carry no user data and must propagate
+    /// for schema convergence). A peer with no registry entry can fetch them.
     #[tokio::test]
     async fn definition_delta_is_served_without_registry_check() {
-        use defra_core::{CollectionSetDeltaPayload, CrdtDelta};
+        use defra_core::{CollectionDefinitionDeltaPayload, CrdtDelta};
 
-        let delta = CrdtDelta::CollectionSet(CollectionSetDeltaPayload::new(1));
+        let delta = CrdtDelta::CollectionDefinition(CollectionDefinitionDeltaPayload::new(1));
         assert!(
             delta.is_definition(),
-            "test precondition: CollectionSet is a definition delta"
+            "test precondition: CollectionDefinition is a definition delta"
         );
         let block = DefraBlock::new(delta, Vec::new(), Vec::new());
         let bytes = block.to_dag_cbor().unwrap();
@@ -422,6 +422,37 @@ mod tests {
         assert!(
             allowed,
             "definition deltas must be served even to non-replicator peers"
+        );
+    }
+
+    /// Go parity: a `CollectionSet` block (circular-relation group root) is NOT
+    /// a definition — it has no collection-version id, cannot be ACP-scoped, and
+    /// is never transferred over P2P (circular-relation groups converge by local
+    /// reconstruction). A non-replicator, unauthorized peer must be DENIED.
+    #[tokio::test]
+    async fn collection_set_block_is_denied_to_non_replicator() {
+        use defra_core::{CollectionSetDeltaPayload, CrdtDelta};
+
+        let delta = CrdtDelta::CollectionSet(CollectionSetDeltaPayload::new(1));
+        assert!(
+            !delta.is_definition(),
+            "CollectionSet must not be classified as a servable definition"
+        );
+        let block = DefraBlock::new(delta, Vec::new(), Vec::new());
+        let bytes = block.to_dag_cbor().unwrap();
+        let cid = cid_for(&bytes);
+
+        let registry = Arc::new(ReplicatorRegistry::new());
+        let store = InMemoryStore::default();
+        store.put(cid, bytes);
+
+        let peer = PeerId::random();
+        let allowed =
+            check_access_with_defaults(AccessMode::Controlled, &registry, &store, &peer, &cid)
+                .await;
+        assert!(
+            !allowed,
+            "CollectionSet blocks must not be served to a non-replicator peer"
         );
     }
 

--- a/crates/p2p/src/bitswap/mod.rs
+++ b/crates/p2p/src/bitswap/mod.rs
@@ -26,6 +26,7 @@
 mod access;
 #[cfg(feature = "libp2p-transport")]
 mod filter;
+mod read_gate;
 mod registry;
 #[cfg(feature = "libp2p-transport")]
 mod store;
@@ -33,6 +34,10 @@ mod store;
 pub use access::AccessMode;
 #[cfg(feature = "libp2p-transport")]
 pub use filter::make_peer_block_access_filter;
+pub use read_gate::{
+    AllowAllBlockReadGate, BlockAcpMeta, BlockClass, BlockClassifier, BlockReadGate,
+    DefaultBlockClassifier, LateBoundServeAcp, ServeAcp,
+};
 pub use registry::ReplicatorRegistry;
 #[cfg(feature = "libp2p-transport")]
 pub use store::BitswapStoreAdapter;

--- a/crates/p2p/src/bitswap/read_gate.rs
+++ b/crates/p2p/src/bitswap/read_gate.rs
@@ -1,0 +1,94 @@
+//! Shared serve-boundary read gate primitives for Bitswap and CAR.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cid::Cid;
+use defra_core::{is_lens_block, Block as DefraBlock, Signature};
+
+use crate::peer_identity::PeerIdentityResolver;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockAcpMeta {
+    pub collection_id: String,
+    pub is_branchable: bool,
+    pub policy: Option<(String, String)>,
+    pub doc_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlockClass {
+    Allow,
+    Data(BlockAcpMeta),
+    Deny,
+}
+
+#[async_trait]
+pub trait BlockClassifier: Send + Sync {
+    async fn classify(&self, cid: &Cid, data: &[u8]) -> BlockClass;
+}
+
+#[async_trait]
+pub trait BlockReadGate: Send + Sync {
+    async fn may_read(&self, identity: &acp::Identity, meta: &BlockAcpMeta) -> bool;
+}
+
+pub struct ServeAcp {
+    pub resolver: Arc<dyn PeerIdentityResolver>,
+    pub gate: Arc<dyn BlockReadGate>,
+}
+
+#[derive(Default)]
+pub struct LateBoundServeAcp(std::sync::OnceLock<ServeAcp>);
+
+impl LateBoundServeAcp {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn set(&self, serve: ServeAcp) {
+        let _ = self.0.set(serve);
+    }
+
+    pub fn get(&self) -> Option<&ServeAcp> {
+        self.0.get()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DefaultBlockClassifier;
+
+#[async_trait]
+impl BlockClassifier for DefaultBlockClassifier {
+    async fn classify(&self, cid: &Cid, data: &[u8]) -> BlockClass {
+        match defra_core::block::generate_cid_from_bytes(data) {
+            Ok(actual) if &actual == cid => {}
+            _ => return BlockClass::Deny,
+        }
+
+        if Signature::from_dag_cbor(data).is_ok() {
+            return BlockClass::Allow;
+        }
+
+        match DefraBlock::from_dag_cbor(data) {
+            Ok(block) => {
+                if block.delta.is_definition() {
+                    return BlockClass::Allow;
+                }
+                BlockClass::Deny
+            }
+            Err(_) if is_lens_block(data) => BlockClass::Allow,
+            Err(_) => BlockClass::Deny,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AllowAllBlockReadGate;
+
+#[async_trait]
+impl BlockReadGate for AllowAllBlockReadGate {
+    async fn may_read(&self, _identity: &acp::Identity, _meta: &BlockAcpMeta) -> bool {
+        true
+    }
+}

--- a/crates/p2p/src/host/p2p_host/mod.rs
+++ b/crates/p2p/src/host/p2p_host/mod.rs
@@ -26,7 +26,9 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::behaviour::DefraBehaviour;
-use crate::bitswap::{AccessMode, ReplicatorRegistry};
+use crate::bitswap::{
+    AccessMode, BlockClassifier, DefaultBlockClassifier, LateBoundServeAcp, ReplicatorRegistry,
+};
 use crate::error::{Error, Result};
 use crate::message::PushLogReply;
 use crate::two_stream::{TwoStreamHandler, TwoStreamRunner};
@@ -371,6 +373,32 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
         mpsc::Receiver<HostEvent>,
         Arc<ReplicatorRegistry>,
     )> {
+        Self::with_keypair_and_config_and_identity_and_serve_gate(
+            keypair,
+            bitswap_store,
+            config,
+            node_identity,
+            Arc::new(DefaultBlockClassifier),
+            Arc::new(LateBoundServeAcp::new()),
+        )
+        .await
+    }
+
+    /// Create a new P2P host with explicit serve-gate metadata and ACP wiring.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn with_keypair_and_config_and_identity_and_serve_gate(
+        keypair: Keypair,
+        bitswap_store: S,
+        config: P2PHostConfig,
+        node_identity: Option<Arc<identity::RawIdentity>>,
+        classifier: Arc<dyn BlockClassifier>,
+        serve_acp: Arc<LateBoundServeAcp>,
+    ) -> Result<(
+        Self,
+        P2PHostHandle,
+        mpsc::Receiver<HostEvent>,
+        Arc<ReplicatorRegistry>,
+    )> {
         let local_peer_id = keypair.public().to_peer_id();
         let local_public_key = keypair.public();
 
@@ -401,6 +429,8 @@ impl<S: Store + Clone + Send + Sync + 'static> P2PHost<S> {
             bitswap_store,
             config.access_mode,
             Arc::clone(&replicators),
+            classifier,
+            serve_acp,
             config.enable_pubsub,
             &config,
             resource_limits.system_memory_budget_usize(),

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -68,6 +68,7 @@ pub mod host;
 pub mod kms;
 pub mod manage_correlator;
 pub mod message;
+pub mod peer_identity;
 pub mod protocol;
 #[cfg(feature = "libp2p-transport")]
 pub mod pubsub_rpc;
@@ -108,6 +109,9 @@ pub use host::{
     P2PHostHandle, ResponseChannel,
 };
 pub use message::{Message, MetaData, PushLogBroadcast, PushLogReply, PushLogRequest};
+#[cfg(feature = "libp2p-transport")]
+pub use peer_identity::HandlePeerIdentityResolver;
+pub use peer_identity::{AnonymousResolver, PeerIdentityResolver};
 pub use protocol::{
     BASE_PROTOCOL_ID, CODE, MESSAGE_VERSION, NAME, PROTOCOL_BASE, REP_REQUEST_PROTOCOL,
     REP_RESPONSE_PROTOCOL, VERSION,

--- a/crates/p2p/src/peer_identity.rs
+++ b/crates/p2p/src/peer_identity.rs
@@ -1,0 +1,42 @@
+//! Peer ACP identity resolution for serve-boundary checks.
+
+use async_trait::async_trait;
+
+use crate::transport::PeerId;
+
+#[async_trait]
+pub trait PeerIdentityResolver: Send + Sync {
+    async fn resolve(&self, peer_id: &PeerId) -> Option<identity::Did>;
+}
+
+#[cfg(feature = "libp2p-transport")]
+#[derive(Clone)]
+pub struct HandlePeerIdentityResolver {
+    handle: crate::P2PHostHandle,
+}
+
+#[cfg(feature = "libp2p-transport")]
+impl HandlePeerIdentityResolver {
+    pub fn new(handle: crate::P2PHostHandle) -> Self {
+        Self { handle }
+    }
+}
+
+#[cfg(feature = "libp2p-transport")]
+#[async_trait]
+impl PeerIdentityResolver for HandlePeerIdentityResolver {
+    async fn resolve(&self, peer_id: &PeerId) -> Option<identity::Did> {
+        let peer_id = peer_id.as_str().parse::<libp2p::PeerId>().ok()?;
+        self.handle.get_peer_identity(peer_id).await.ok().flatten()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AnonymousResolver;
+
+#[async_trait]
+impl PeerIdentityResolver for AnonymousResolver {
+    async fn resolve(&self, _peer_id: &PeerId) -> Option<identity::Did> {
+        None
+    }
+}

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -271,6 +271,7 @@ struct NoopTransport {
     replicators: Arc<RwLock<std::collections::HashMap<String, Vec<String>>>>,
     connected_peers: Arc<RwLock<Vec<PeerId>>>,
     doc_sync_replies: Arc<RwLock<Vec<DocSyncReply>>>,
+    car_responses: Arc<RwLock<Vec<Vec<u8>>>>,
 }
 
 impl NoopTransport {
@@ -281,6 +282,7 @@ impl NoopTransport {
             replicators: Arc::new(RwLock::new(std::collections::HashMap::new())),
             connected_peers: Arc::new(RwLock::new(Vec::new())),
             doc_sync_replies: Arc::new(RwLock::new(Vec::new())),
+            car_responses: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -290,6 +292,12 @@ impl NoopTransport {
 
     fn doc_sync_replies(&self) -> Vec<DocSyncReply> {
         self.doc_sync_replies.read().clone()
+    }
+
+    /// CARv1 payloads the coordinator sent, in order (used to assert which
+    /// blocks were actually served after per-block serve filtering).
+    fn car_responses(&self) -> Vec<Vec<u8>> {
+        self.car_responses.read().clone()
     }
 }
 
@@ -422,15 +430,17 @@ impl P2PTransport for NoopTransport {
         Ok(())
     }
 
-    async fn send_car_response(&self, _peer_id: &PeerId, _car_data: Vec<u8>) -> crate::Result<()> {
+    async fn send_car_response(&self, _peer_id: &PeerId, car_data: Vec<u8>) -> crate::Result<()> {
+        self.car_responses.write().push(car_data);
         Ok(())
     }
 
     async fn send_car_response_token(
         &self,
         _token: Self::ResponseToken,
-        _car_data: Vec<u8>,
+        car_data: Vec<u8>,
     ) -> crate::Result<()> {
+        self.car_responses.write().push(car_data);
         Ok(())
     }
 
@@ -848,8 +858,16 @@ async fn doc_sync_filters_heads_outside_replicator_collection() {
     );
 }
 
+// Go parity: the CAR serve path no longer returns a coarse AccessDenied for a
+// wrong-collection root (that Rust-only gate also waved permissioned blocks
+// through to any connected peer / subscriber with no ACP check). It now filters
+// PER BLOCK, matching Go's `hasAccess`: a replicator-for-the-block's-collection
+// or an ACP-authorized identity is served; everyone else is dropped and a
+// well-formed (here header-only) CAR is returned. The test coordinator's
+// DefaultBlockClassifier classifies a Composite/data block as Deny, so the block
+// is filtered out and no data is served.
 #[tokio::test]
-async fn car_fetch_controlled_mode_rejects_wrong_collection_root() {
+async fn car_fetch_controlled_mode_filters_unauthorized_data_block() {
     use defra_core::{Block, CompositeDeltaPayload, CrdtDelta};
 
     let replicators = Arc::new(ReplicatorRegistry::new());
@@ -859,6 +877,7 @@ async fn car_fetch_controlled_mode_rejects_wrong_collection_root() {
     replicators.add_replicator("collection_a", peer.as_str());
 
     let transport = NoopTransport::new();
+    let transport_handle = transport.clone();
     let local_peer_id = transport.local_peer_id().to_string();
     let broadcaster = Broadcaster::new(transport.clone());
     let store = Arc::new(MemoryStore::new());
@@ -893,10 +912,15 @@ async fn car_fetch_controlled_mode_rejects_wrong_collection_root() {
         .handle_transport_event(car_fetch_event(peer, cid))
         .await;
 
+    assert!(result.is_ok(), "CAR serve must not error, got {:?}", result);
+
+    let cars = transport_handle.car_responses();
+    assert_eq!(cars.len(), 1, "handler must send exactly one CAR response");
+    let (_roots, served) = crate::sync::car::decode_car(&cars[0]).unwrap();
     assert!(
-        matches!(result, Err(Error::AccessDenied { .. })),
-        "CAR root access must be collection-scoped in Controlled mode, got {:?}",
-        result
+        served.is_empty(),
+        "no data blocks may be served for a classifier-denied block, got {}",
+        served.len()
     );
 }
 

--- a/crates/p2p/src/sync/coordinator/access_tests.rs
+++ b/crates/p2p/src/sync/coordinator/access_tests.rs
@@ -165,6 +165,8 @@ fn create_test_coordinator_with_blockstore_and_head_provider<B: Blockstore + 'st
             head_provider,
         },
         authorizer,
+        classifier: Arc::new(crate::bitswap::DefaultBlockClassifier),
+        serve_acp: Arc::new(crate::bitswap::LateBoundServeAcp::new()),
         document_acp: std::sync::OnceLock::new(),
         kms_transport: std::sync::OnceLock::new(),
         pubsub_services: None,

--- a/crates/p2p/src/sync/coordinator/constructor.rs
+++ b/crates/p2p/src/sync/coordinator/constructor.rs
@@ -12,7 +12,9 @@ use super::authorizer::RuntimeAuthorizer;
 use super::{
     DagFetchLimiter, SyncAccessState, SyncCoordinator, SyncRuntime, SyncSubscriptionState,
 };
-use crate::bitswap::{AccessMode, ReplicatorRegistry};
+use crate::bitswap::{
+    AccessMode, BlockClassifier, DefaultBlockClassifier, LateBoundServeAcp, ReplicatorRegistry,
+};
 use crate::error::Result;
 use crate::replicator::{EqOnlyFilterMatcher, ReplicationFilterMatcher};
 use crate::sync::broadcaster::Broadcaster;
@@ -82,7 +84,34 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collection_store: Arc<dyn P2PCollectionStorage>,
         filter_matcher: Arc<dyn ReplicationFilterMatcher>,
     ) -> Result<(Self, mpsc::Receiver<SyncEvent>)> {
-        Self::with_head_provider(
+        Self::with_access_control_and_serve_gate(
+            transport,
+            blockstore,
+            config,
+            access_mode,
+            replicators,
+            collection_store,
+            filter_matcher,
+            Arc::new(DefaultBlockClassifier),
+            Arc::new(LateBoundServeAcp::new()),
+        )
+        .await
+    }
+
+    /// Create a new sync coordinator with access control and explicit serve gate.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn with_access_control_and_serve_gate(
+        transport: T,
+        blockstore: Arc<B>,
+        config: SyncConfig,
+        access_mode: AccessMode,
+        replicators: Arc<ReplicatorRegistry>,
+        collection_store: Arc<dyn P2PCollectionStorage>,
+        filter_matcher: Arc<dyn ReplicationFilterMatcher>,
+        classifier: Arc<dyn BlockClassifier>,
+        serve_acp: Arc<LateBoundServeAcp>,
+    ) -> Result<(Self, mpsc::Receiver<SyncEvent>)> {
+        Self::with_head_provider_and_serve_gate(
             transport,
             blockstore,
             config,
@@ -91,6 +120,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             collection_store,
             Arc::new(NoOpHeadProvider),
             filter_matcher,
+            classifier,
+            serve_acp,
         )
         .await
     }
@@ -108,6 +139,35 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
         collection_store: Arc<dyn P2PCollectionStorage>,
         head_provider: Arc<dyn DocumentHeadProvider>,
         filter_matcher: Arc<dyn ReplicationFilterMatcher>,
+    ) -> Result<(Self, mpsc::Receiver<SyncEvent>)> {
+        Self::with_head_provider_and_serve_gate(
+            transport,
+            blockstore,
+            config,
+            access_mode,
+            replicators,
+            collection_store,
+            head_provider,
+            filter_matcher,
+            Arc::new(DefaultBlockClassifier),
+            Arc::new(LateBoundServeAcp::new()),
+        )
+        .await
+    }
+
+    /// Create a new sync coordinator with a document head provider and explicit serve gate.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn with_head_provider_and_serve_gate(
+        transport: T,
+        blockstore: Arc<B>,
+        config: SyncConfig,
+        access_mode: AccessMode,
+        replicators: Arc<ReplicatorRegistry>,
+        collection_store: Arc<dyn P2PCollectionStorage>,
+        head_provider: Arc<dyn DocumentHeadProvider>,
+        filter_matcher: Arc<dyn ReplicationFilterMatcher>,
+        classifier: Arc<dyn BlockClassifier>,
+        serve_acp: Arc<LateBoundServeAcp>,
     ) -> Result<(Self, mpsc::Receiver<SyncEvent>)> {
         let local_peer_id = transport.local_peer_id().to_string();
         let broadcaster = Broadcaster::new(transport.clone());
@@ -172,6 +232,8 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                     head_provider,
                 },
                 authorizer,
+                classifier,
+                serve_acp,
                 document_acp: std::sync::OnceLock::new(),
                 #[cfg(feature = "libp2p-transport")]
                 kms_transport: std::sync::OnceLock::new(),

--- a/crates/p2p/src/sync/coordinator/event_handler/car.rs
+++ b/crates/p2p/src/sync/coordinator/event_handler/car.rs
@@ -1,13 +1,13 @@
 //! CAR fetch event handling for the sync coordinator.
 
 use blockstore::{verify_block_cid, Blockstore};
+use bytes::Bytes;
 use cid::Cid;
 
-use super::super::authorizer::AccessAuthorizer;
-use crate::error::{Error, Result};
+use crate::bitswap::BlockClass;
+use crate::error::Result;
 use crate::message::CarFetchRequest;
 use crate::sync::car::{collect_dag_blocks, collect_exact_blocks, decode_car, encode_car};
-use crate::sync::coordinator::dag_context::block_context_from_data;
 use crate::sync::coordinator::SyncCoordinator;
 use crate::transport::{P2PTransport, PeerId};
 
@@ -16,70 +16,6 @@ fn sample_cids(cids: &[Cid]) -> Vec<String> {
 }
 
 impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
-    async fn check_car_fetch_access(
-        &self,
-        peer_id: &PeerId,
-        request: &CarFetchRequest,
-    ) -> Result<()> {
-        if self.access.access_mode.is_open() {
-            return Ok(());
-        }
-        if self.access.peer_state.is_connected(peer_id.as_str()) {
-            return Ok(());
-        }
-
-        let mut checked_collection = false;
-        for cid in request.response_roots() {
-            let block_data = match self.manager.blockstore().get(&cid).await {
-                Ok(Some(data)) => data,
-                Ok(None) => continue,
-                Err(error) => {
-                    tracing::debug!(
-                        cid = %cid,
-                        peer_id = %peer_id,
-                        error = %error,
-                        "CAR handler: failed to read requested block for collection access check"
-                    );
-                    continue;
-                }
-            };
-
-            let Some(collection_id) = block_context_from_data(&block_data).collection_id else {
-                continue;
-            };
-
-            checked_collection = true;
-            let is_collection_replicator = self
-                .authorizer
-                .peer_authorized_for_collection(peer_id.as_str(), &collection_id)
-                .await;
-            let is_collection_subscriber = self
-                .access
-                .peer_state
-                .peer_subscribed_to_collection(peer_id.as_str(), &collection_id);
-
-            if !is_collection_replicator && !is_collection_subscriber {
-                tracing::warn!(
-                    peer_id = %peer_id,
-                    collection_id = %collection_id,
-                    is_collection_replicator,
-                    is_collection_subscriber,
-                    "Access denied: peer cannot fetch CAR blocks for this collection"
-                );
-                return Err(Error::AccessDenied {
-                    peer_id: peer_id.to_string(),
-                    collection_id,
-                });
-            }
-        }
-
-        if checked_collection {
-            Ok(())
-        } else {
-            self.check_peer_is_replicator(peer_id).await
-        }
-    }
-
     /// Handle an inbound CAR fetch request: collect the DAG and send CARv1 response.
     pub(crate) async fn handle_car_fetch_request(
         &self,
@@ -100,21 +36,6 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             }
         };
 
-        if let Err(error) = self.check_car_fetch_access(&peer_id, &request).await {
-            tracing::warn!(
-                root_cid = %request.root_cid,
-                peer_id = %peer_id,
-                recursive = request.recursive,
-                requested_count = request.wanted_cids.len(),
-                root_present = ?root_present,
-                connected = self.access.peer_state.is_connected(peer_id.as_str()),
-                registered_any = self.access.replicators.is_any_replicator(peer_id.as_str()),
-                error = %error,
-                "CAR handler rejected request"
-            );
-            return Err(error);
-        }
-
         tracing::debug!(
             root_cid = %request.root_cid,
             peer_id = %peer_id,
@@ -130,7 +51,9 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
             collect_exact_blocks(self.manager.blockstore().as_ref(), &request.wanted_cids).await?
         };
         let truncated = collected.truncated();
-        let blocks = collected.blocks;
+        let blocks = self
+            .filter_car_response_blocks(&peer_id, collected.blocks)
+            .await;
 
         if blocks.is_empty() {
             self.manager.diagnostics.record_car_no_blocks_served();
@@ -213,6 +136,70 @@ impl<B: Blockstore + 'static, T: P2PTransport> SyncCoordinator<B, T> {
                 .await?;
         }
         Ok(())
+    }
+
+    async fn filter_car_response_blocks(
+        &self,
+        peer_id: &PeerId,
+        blocks: Vec<(Cid, Bytes)>,
+    ) -> Vec<(Cid, Bytes)> {
+        if self.access.access_mode.is_open() {
+            return blocks;
+        }
+
+        let peer_str = peer_id.to_string();
+        let serve = self.serve_acp.get();
+        let mut identity: Option<acp::Identity> = None;
+        let mut kept = Vec::with_capacity(blocks.len());
+
+        for (cid, data) in blocks {
+            match self.classifier.classify(&cid, &data).await {
+                BlockClass::Allow => kept.push((cid, data)),
+                BlockClass::Deny => {
+                    tracing::debug!(
+                        cid = %cid,
+                        peer_id = %peer_id,
+                        "CAR handler: dropping block denied by classifier"
+                    );
+                }
+                BlockClass::Data(meta) => {
+                    if self
+                        .access
+                        .replicators
+                        .is_filtered_replicator(&meta.collection_id, &peer_str)
+                    {
+                        continue;
+                    }
+                    if self
+                        .access
+                        .replicators
+                        .is_replicator(&meta.collection_id, &peer_str)
+                    {
+                        kept.push((cid, data));
+                        continue;
+                    }
+
+                    let Some(serve) = serve else {
+                        continue;
+                    };
+                    if identity.is_none() {
+                        identity = Some(match serve.resolver.resolve(peer_id).await {
+                            Some(did) => acp::Identity::Authenticated(did),
+                            None => acp::Identity::Anonymous,
+                        });
+                    }
+                    if serve
+                        .gate
+                        .may_read(identity.as_ref().expect("identity set"), &meta)
+                        .await
+                    {
+                        kept.push((cid, data));
+                    }
+                }
+            }
+        }
+
+        kept
     }
 
     /// Handle an inbound CAR fetch response: decode and store blocks.

--- a/crates/p2p/src/sync/coordinator/mod.rs
+++ b/crates/p2p/src/sync/coordinator/mod.rs
@@ -320,6 +320,12 @@ pub struct SyncCoordinator<B: Blockstore, T: P2PTransport> {
     /// the same decision for the same peer state.
     pub(super) authorizer: Arc<authorizer::RuntimeAuthorizer<T>>,
 
+    /// CID-aware block classifier shared by Bitswap and CAR serve paths.
+    pub(super) classifier: Arc<dyn crate::bitswap::BlockClassifier>,
+
+    /// Late-bound ACP resolver/gate shared by Bitswap and CAR serve paths.
+    pub(super) serve_acp: Arc<crate::bitswap::LateBoundServeAcp>,
+
     /// Optional document ACP used for local ACP relationship snapshot replay.
     pub(super) document_acp: std::sync::OnceLock<Arc<dyn DocumentACP>>,
 

--- a/crates/p2p/tests/bitswap_acp_filter_tests.rs
+++ b/crates/p2p/tests/bitswap_acp_filter_tests.rs
@@ -5,8 +5,10 @@
 //! issues Bitswap WANTs from the consumer for both allowed and denied
 //! block/peer pairs.
 
+use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use defra_core::{Block as DefraBlock, CompositeDeltaPayload, CrdtDelta};
 use p2p::testutil::MockBitswapStore;
 use p2p::{bitswap::AccessMode, HostEvent, P2PHost, P2PHostConfig};
@@ -52,6 +54,57 @@ fn controlled_config() -> P2PHostConfig {
     }
 }
 
+struct SyntheticBlockClassifier;
+
+#[async_trait]
+impl p2p::bitswap::BlockClassifier for SyntheticBlockClassifier {
+    async fn classify(&self, cid: &cid::Cid, data: &[u8]) -> p2p::bitswap::BlockClass {
+        match defra_core::block::generate_cid_from_bytes(data) {
+            Ok(actual) if &actual == cid => {}
+            _ => return p2p::bitswap::BlockClass::Deny,
+        }
+
+        let Ok(block) = DefraBlock::from_dag_cbor(data) else {
+            return p2p::bitswap::BlockClass::Deny;
+        };
+        let Some(collection_id) = block.delta.schema_version_id() else {
+            return p2p::bitswap::BlockClass::Deny;
+        };
+        let doc_ids = block
+            .delta
+            .doc_id()
+            .map(|bytes| vec![String::from_utf8_lossy(bytes).to_string()])
+            .unwrap_or_default();
+
+        p2p::bitswap::BlockClass::Data(p2p::bitswap::BlockAcpMeta {
+            collection_id: collection_id.to_string(),
+            is_branchable: false,
+            policy: None,
+            doc_ids,
+        })
+    }
+}
+
+async fn controlled_host_with_synthetic_classifier(
+    store: MockBitswapStore,
+) -> (
+    P2PHost<MockBitswapStore>,
+    p2p::P2PHostHandle,
+    tokio::sync::mpsc::Receiver<HostEvent>,
+    Arc<p2p::bitswap::ReplicatorRegistry>,
+) {
+    P2PHost::with_keypair_and_config_and_identity_and_serve_gate(
+        p2p::Keypair::generate_ed25519(),
+        store,
+        controlled_config(),
+        None,
+        Arc::new(SyntheticBlockClassifier),
+        Arc::new(p2p::bitswap::LateBoundServeAcp::new()),
+    )
+    .await
+    .unwrap()
+}
+
 async fn drain_until_complete(
     events: &mut tokio::sync::mpsc::Receiver<HostEvent>,
     query: p2p::QueryId,
@@ -88,9 +141,7 @@ async fn controlled_mode_denies_unregistered_bitswap_peer() {
     let consumer_store = MockBitswapStore::new();
 
     let (producer, producer_handle, _producer_events, producer_replicators) =
-        P2PHost::with_config(producer_store, controlled_config())
-            .await
-            .unwrap();
+        controlled_host_with_synthetic_classifier(producer_store).await;
     let (consumer, consumer_handle, mut consumer_events, _consumer_replicators) =
         P2PHost::with_config(consumer_store, controlled_config())
             .await
@@ -149,9 +200,7 @@ async fn controlled_mode_serves_registered_replicator() {
     let consumer_store = MockBitswapStore::new();
 
     let (producer, producer_handle, _producer_events, producer_replicators) =
-        P2PHost::with_config(producer_store, controlled_config())
-            .await
-            .unwrap();
+        controlled_host_with_synthetic_classifier(producer_store).await;
     let (consumer, consumer_handle, mut consumer_events, _consumer_replicators) =
         P2PHost::with_config(consumer_store, controlled_config())
             .await
@@ -203,9 +252,7 @@ async fn controlled_mode_denies_replicator_for_other_collection() {
     let consumer_store = MockBitswapStore::new();
 
     let (producer, producer_handle, _producer_events, producer_replicators) =
-        P2PHost::with_config(producer_store, controlled_config())
-            .await
-            .unwrap();
+        controlled_host_with_synthetic_classifier(producer_store).await;
     let (consumer, consumer_handle, mut consumer_events, _consumer_replicators) =
         P2PHost::with_config(consumer_store, controlled_config())
             .await

--- a/crates/query-plan/src/plan/permission_filter.rs
+++ b/crates/query-plan/src/plan/permission_filter.rs
@@ -98,6 +98,7 @@ impl PermissionFilterNode {
             &self.policy_id,
             &self.resource_name,
             doc_id,
+            None,
         )
         .await
         .unwrap_or_else(|e| {

--- a/crates/query-plan/src/txn/context.rs
+++ b/crates/query-plan/src/txn/context.rs
@@ -332,7 +332,14 @@ pub async fn check_doc_access_with_overlay(
     policy_id: &str,
     resource_name: &str,
     doc_id: &str,
+    node_did: Option<&Did>,
 ) -> AcpResult<bool> {
+    if let (Some(node), Identity::Authenticated(requester)) = (node_did, identity) {
+        if node == requester {
+            return Ok(true);
+        }
+    }
+
     if let Some(mutations) = current_deferred_acp_mutations() {
         if let Some(projected) =
             mutations.projected_registration(policy_id, resource_name, doc_id)?
@@ -452,6 +459,7 @@ mod tests {
                 "policy",
                 "User",
                 "doc-1",
+                None,
             ),
         )
         .await
@@ -467,6 +475,7 @@ mod tests {
                 "policy",
                 "User",
                 "doc-1",
+                None,
             ),
         )
         .await
@@ -495,6 +504,7 @@ mod tests {
                 "policy",
                 "User",
                 "doc-1",
+                None,
             ),
         )
         .await

--- a/crates/query-plan/src/txn/mod.rs
+++ b/crates/query-plan/src/txn/mod.rs
@@ -10,6 +10,7 @@
 
 mod context;
 mod handle;
+mod read_access;
 mod registry;
 mod result;
 
@@ -19,6 +20,7 @@ pub use context::{
     scope_deferred_acp_mutations, DeferredAcpMutations, TransactionContext,
 };
 pub use handle::TransactionHandle;
+pub use read_access::OverlayChecker;
 pub use registry::{NoOpTransactionRegistry, TransactionRegistry};
 pub use result::GetTransactionResult;
 

--- a/crates/query-plan/src/txn/read_access.rs
+++ b/crates/query-plan/src/txn/read_access.rs
@@ -22,6 +22,15 @@ impl ObjectAccessChecker for OverlayChecker<'_> {
         resource_name: &str,
         object_id: &str,
     ) -> acp::Result<DocAccess> {
+        // NAC `bypass-dac` privilege grants full access, exactly as DirectChecker
+        // and Go's checkDocAccess (canDACBypass is the first check on every path).
+        if defra_core::dac_bypass::get_dac_bypass() {
+            return Ok(DocAccess {
+                has_access: true,
+                explicit: true,
+            });
+        }
+
         if let (Some(node), Identity::Authenticated(requester)) = (self.node_did, self.identity) {
             if node == requester {
                 return Ok(DocAccess {

--- a/crates/query-plan/src/txn/read_access.rs
+++ b/crates/query-plan/src/txn/read_access.rs
@@ -1,0 +1,57 @@
+//! Txn-overlay ACP checker for the shared read-access rule.
+
+use acp::read_access::{DocAccess, ObjectAccessChecker};
+use acp::{DocumentACP, DocumentPermission, Identity};
+use async_trait::async_trait;
+use identity::Did;
+
+use super::context::{check_doc_access_with_overlay, is_doc_registered_with_overlay};
+
+pub struct OverlayChecker<'a> {
+    pub acp: &'a dyn DocumentACP,
+    pub identity: &'a Identity,
+    pub node_did: Option<&'a Did>,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl ObjectAccessChecker for OverlayChecker<'_> {
+    async fn object_access(
+        &self,
+        policy_id: &str,
+        resource_name: &str,
+        object_id: &str,
+    ) -> acp::Result<DocAccess> {
+        if let (Some(node), Identity::Authenticated(requester)) = (self.node_did, self.identity) {
+            if node == requester {
+                return Ok(DocAccess {
+                    has_access: true,
+                    explicit: true,
+                });
+            }
+        }
+
+        if !is_doc_registered_with_overlay(self.acp, policy_id, resource_name, object_id).await? {
+            return Ok(DocAccess {
+                has_access: true,
+                explicit: false,
+            });
+        }
+
+        let has_access = check_doc_access_with_overlay(
+            self.acp,
+            self.identity,
+            DocumentPermission::Read,
+            policy_id,
+            resource_name,
+            object_id,
+            self.node_did,
+        )
+        .await?;
+
+        Ok(DocAccess {
+            has_access,
+            explicit: true,
+        })
+    }
+}

--- a/crates/query-plan/tests/cross_object_read_path.rs
+++ b/crates/query-plan/tests/cross_object_read_path.rs
@@ -13,12 +13,13 @@
 use std::sync::Arc;
 
 use acp::{
+    check_doc_read_access,
     policy_yaml::{build_policy, parse_policy_yaml},
-    DocumentACP, DocumentPermission, Identity, MemoryZanzibarStore, Subject, ZanzibarDocumentACP,
-    ZanzibarStore,
+    DocumentACP, DocumentPermission, Identity, LocalDocumentACP, MemoryAcpStore,
+    MemoryZanzibarStore, Subject, ZanzibarDocumentACP, ZanzibarStore, READER_RELATION,
 };
 use identity::Did;
-use query_plan::txn::check_doc_access_with_overlay;
+use query_plan::txn::{check_doc_access_with_overlay, OverlayChecker};
 
 const FS_POLICY: &str = r#"
 name: filesystem
@@ -67,6 +68,7 @@ async fn gate_allows(
         policy_id,
         resource,
         doc,
+        None,
     )
     .await
     .unwrap()
@@ -130,4 +132,54 @@ async fn query_gate_honours_cross_object_read_inheritance() {
 
     // bob has no grant -> still denied through the cone.
     assert!(!gate_allows(&acp, &policy_id, &bob, "file", "report").await);
+}
+
+#[tokio::test]
+async fn overlay_checker_applies_branchable_collection_fallback() {
+    let owner = did("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK");
+    let alice = did("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH");
+    let acp = LocalDocumentACP::new(Arc::new(MemoryAcpStore::new()));
+    let identity = Identity::Authenticated(alice.clone());
+
+    acp.register_doc_object(&owner, "policy1", "users", "col1")
+        .await
+        .unwrap();
+    let checker = OverlayChecker {
+        acp: &acp,
+        identity: &identity,
+        node_did: None,
+    };
+
+    let public_doc_allowed =
+        check_doc_read_access(&checker, "policy1", "users", "col1", true, "public-doc")
+            .await
+            .unwrap();
+    assert!(
+        !public_doc_allowed,
+        "public doc in a protected branchable collection must fall back to the collection object"
+    );
+
+    acp.register_doc_object(&owner, "policy1", "users", "shared-doc")
+        .await
+        .unwrap();
+    acp.add_actor_relationship(
+        &owner,
+        &alice,
+        "policy1",
+        "users",
+        "shared-doc",
+        READER_RELATION,
+        &[],
+    )
+    .await
+    .unwrap();
+
+    let shared_doc_allowed =
+        check_doc_read_access(&checker, "policy1", "users", "col1", true, "shared-doc")
+            .await
+            .unwrap();
+    assert!(
+        shared_doc_allowed,
+        "explicit document grants must win before checking the collection object"
+    );
 }

--- a/crates/query-types/src/collection_provider.rs
+++ b/crates/query-types/src/collection_provider.rs
@@ -17,6 +17,19 @@ pub trait CollectionProvider: MaybeSendSync {
 
     /// List all collection names.
     async fn list_collections(&self) -> Result<Vec<String>>;
+
+    /// Resolve a collection by its (schema) version id, **including inactive
+    /// versions**. This is required by ACP-gated paths (e.g. `_commits`) that
+    /// must resolve the collection a historical block was authored under — after
+    /// a schema migration, older blocks carry a now-inactive version id. The
+    /// default returns `None`; callers must fail closed on `None`.
+    async fn get_collection_by_version_id(
+        &self,
+        version_id: &str,
+    ) -> Result<Option<Arc<CollectionVersion>>> {
+        let _ = version_id;
+        Ok(None)
+    }
 }
 
 /// Static collection provider for tests and backward compatibility.
@@ -49,5 +62,16 @@ impl CollectionProvider for StaticCollectionProvider {
 
     async fn list_collections(&self) -> Result<Vec<String>> {
         Ok(self.collections.keys().cloned().collect())
+    }
+
+    async fn get_collection_by_version_id(
+        &self,
+        version_id: &str,
+    ) -> Result<Option<Arc<CollectionVersion>>> {
+        Ok(self
+            .collections
+            .values()
+            .find(|c| c.version_id == version_id)
+            .cloned())
     }
 }

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -734,108 +734,66 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             commits = self.fetcher.get_commits(&base_options).await?;
         }
 
-        // ACP filtering: check read permission for each commit's document.
-        // _commits must enforce the same ACP rules as regular document queries.
+        // ACP filtering: check read permission for each commit's document or
+        // collection-level DAG. _commits must enforce the same ACP rules as
+        // regular document queries.
         {
-            use acp::{DocumentPermission, Identity};
+            use acp::Identity;
 
             let identity = Identity::from(caller_identity.clone());
+            let node_did = self.node_did().cloned();
 
-            // Build a versionID -> policy map so each commit is checked against
-            // the collection version that produced it. Go routes _commits access
-            // checks by commit collection version; checking every policy leaks
-            // documents whose docID is simply unregistered on another protected
-            // collection.
             let collections = self.collections_map().await?;
-            let policies_by_version: std::collections::HashMap<String, Option<(String, String)>> =
-                collections
-                    .values()
-                    .map(|c| {
-                        (
-                            c.version_id.clone(),
-                            c.policy
-                                .as_ref()
-                                .map(|p| (p.id.clone(), p.resource_name.clone())),
-                        )
-                    })
-                    .collect();
-            let has_protected_collections = policies_by_version.values().any(Option::is_some);
+            let by_version: std::collections::HashMap<
+                String,
+                std::sync::Arc<schema::CollectionVersion>,
+            > = collections
+                .values()
+                .map(|c| (c.version_id.clone(), c.clone()))
+                .collect();
 
-            if has_protected_collections {
-                // Collect the set of doc_ids that the caller is allowed to read.
-                let mut denied_commits: std::collections::HashSet<(String, Option<String>)> =
-                    std::collections::HashSet::new();
-                let mut checked_commits: std::collections::HashSet<(String, Option<String>)> =
-                    std::collections::HashSet::new();
+            let mut keep = Vec::with_capacity(commits.len());
+            for commit in &commits {
+                let version_id = commit.get("collectionVersionId").and_then(|v| v.as_str());
+                let doc_id = commit.get("docID").and_then(|v| v.as_str()).unwrap_or("");
 
-                for commit in &commits {
-                    let doc_id = match commit.get("docID").and_then(|v| v.as_str()) {
-                        Some(id) => id.to_string(),
-                        None => continue,
-                    };
-                    let version_id = commit
-                        .get("collectionVersionId")
-                        .and_then(|v| v.as_str())
-                        .map(str::to_string);
-                    let commit_key = (doc_id.clone(), version_id.clone());
-                    if checked_commits.contains(&commit_key) {
-                        continue;
-                    }
-                    checked_commits.insert(commit_key.clone());
-
-                    let allowed = match version_id
-                        .as_ref()
-                        .and_then(|id| policies_by_version.get(id))
-                    {
-                        Some(None) => true,
-                        Some(Some((policy_id, resource_name))) => {
-                            match crate::txn::check_doc_access_with_overlay(
-                                self.acp.as_ref(),
-                                &identity,
-                                DocumentPermission::Read,
-                                policy_id,
-                                resource_name,
-                                &doc_id,
+                let allowed = match version_id.and_then(|v| by_version.get(v)) {
+                    None => true,
+                    Some(collection) => match &collection.policy {
+                        None => true,
+                        Some(policy) => {
+                            let checker = crate::txn::OverlayChecker {
+                                acp: self.acp.as_ref(),
+                                identity: &identity,
+                                node_did: node_did.as_ref(),
+                            };
+                            acp::read_access::check_doc_read_access(
+                                &checker,
+                                &policy.id,
+                                &policy.resource_name,
+                                &collection.collection_id,
+                                collection.is_branchable,
+                                doc_id,
                             )
                             .await
-                            {
-                                Ok(granted) => granted,
-                                Err(e) => {
-                                    tracing::debug!(
-                                        target: "acp::audit",
-                                        event = "commits_acp_check_error",
-                                        doc_id = %doc_id,
-                                        error = %e,
-                                        "ACP check error during _commits query, denying access"
-                                    );
-                                    false
-                                }
-                            }
+                            .unwrap_or_else(|e| {
+                                tracing::debug!(
+                                    target: "acp::audit",
+                                    event = "commits_acp_check_error",
+                                    doc_id = %doc_id,
+                                    collection_version_id = ?version_id,
+                                    error = %e,
+                                    "ACP check error during _commits query, denying access"
+                                );
+                                false
+                            })
                         }
-                        None => false,
-                    };
-
-                    if !allowed {
-                        denied_commits.insert(commit_key);
-                    }
-                }
-
-                if !denied_commits.is_empty() {
-                    commits.retain(|commit| {
-                        let doc_id = commit
-                            .get("docID")
-                            .and_then(|v| v.as_str())
-                            .map(str::to_string);
-                        let version_id = commit
-                            .get("collectionVersionId")
-                            .and_then(|v| v.as_str())
-                            .map(str::to_string);
-                        doc_id
-                            .map(|id| !denied_commits.contains(&(id, version_id)))
-                            .unwrap_or(true)
-                    });
-                }
+                    },
+                };
+                keep.push(allowed);
             }
+            let mut keep = keep.into_iter();
+            commits.retain(|_| keep.next().unwrap_or(false));
         }
 
         // Build a mapping for commit fields (needed for filter evaluation)

--- a/crates/query/src/runner/commits.rs
+++ b/crates/query/src/runner/commits.rs
@@ -743,6 +743,9 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             let identity = Identity::from(caller_identity.clone());
             let node_did = self.node_did().cloned();
 
+            // Active-version fast path. Historical commits authored under a
+            // now-inactive version (after a schema migration) are NOT in this
+            // map and are resolved on demand below — never left ungated.
             let collections = self.collections_map().await?;
             let by_version: std::collections::HashMap<
                 String,
@@ -751,14 +754,42 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 .values()
                 .map(|c| (c.version_id.clone(), c.clone()))
                 .collect();
+            let provider = self.effective_provider();
+            let mut resolved_versions: std::collections::HashMap<
+                String,
+                Option<std::sync::Arc<schema::CollectionVersion>>,
+            > = std::collections::HashMap::new();
 
             let mut keep = Vec::with_capacity(commits.len());
             for commit in &commits {
                 let version_id = commit.get("collectionVersionId").and_then(|v| v.as_str());
                 let doc_id = commit.get("docID").and_then(|v| v.as_str()).unwrap_or("");
 
-                let allowed = match version_id.and_then(|v| by_version.get(v)) {
-                    None => true,
+                // Resolve the commit's collection by its version id, INCLUDING
+                // inactive versions. Mirrors Go's dagScanNode (GetInactive=true)
+                // + fail-closed on an unresolvable version.
+                let collection = match version_id {
+                    None => None,
+                    Some(vid) => match by_version.get(vid) {
+                        Some(c) => Some(c.clone()),
+                        None => {
+                            if !resolved_versions.contains_key(vid) {
+                                let looked_up = provider
+                                    .get_collection_by_version_id(vid)
+                                    .await
+                                    .unwrap_or(None);
+                                resolved_versions.insert(vid.to_string(), looked_up);
+                            }
+                            resolved_versions.get(vid).and_then(|c| c.clone())
+                        }
+                    },
+                };
+
+                let allowed = match collection {
+                    // Fail closed: a commit whose collection version cannot be
+                    // resolved is denied (Go errors the query here). Never allow
+                    // an unresolved version through unchecked.
+                    None => false,
                     Some(collection) => match &collection.policy {
                         None => true,
                         Some(policy) => {

--- a/crates/query/src/runner/mod.rs
+++ b/crates/query/src/runner/mod.rs
@@ -178,6 +178,8 @@ pub struct QueryRunner<F: DocFetcher, R: TransactionRegistry = NoOpTransactionRe
     /// Used when a request doesn't include an explicit identity (e.g., no bearer token).
     /// Typically set from the `--identity` CLI flag.
     pub(crate) default_identity: Option<Did>,
+    /// Local node DID for Go-parity ACP node-identity shortcuts.
+    pub(crate) node_did: Option<Did>,
     /// Optional lens transform store for view queries with transforms
     pub(crate) lens_store: Option<Arc<dyn lens::TransformStore>>,
     /// NAC checker for query-level enforcement.
@@ -209,6 +211,7 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             mutator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
+            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -229,6 +232,7 @@ impl<F: DocFetcher + 'static> QueryRunner<F, NoOpTransactionRegistry> {
             mutator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
+            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -251,6 +255,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             mutator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
+            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -276,6 +281,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             mutator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
+            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -300,6 +306,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
             mutator: None,
             acp: Arc::new(NoOpDocumentAcp),
             default_identity: None,
+            node_did: None,
             lens_store: None,
             nac: Arc::new(NoOpNacChecker),
             query_timeout: 30,
@@ -361,6 +368,16 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
     pub fn with_default_identity(mut self, identity: Did) -> Self {
         self.default_identity = Some(identity);
         self
+    }
+
+    /// Set the local node DID for ACP node-identity shortcuts.
+    pub fn with_node_did(mut self, node_did: Option<Did>) -> Self {
+        self.node_did = node_did;
+        self
+    }
+
+    pub(crate) fn node_did(&self) -> Option<&Did> {
+        self.node_did.as_ref()
     }
 
     /// Set query execution timeout in seconds (0 = no timeout).

--- a/crates/query/src/runner/mutation.rs
+++ b/crates/query/src/runner/mutation.rs
@@ -306,6 +306,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
+                                None,
                             )
                             .await
                             .unwrap_or(false);
@@ -323,6 +324,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
+                                None,
                             )
                             .await
                             .map_err(|e| QueryError::acp_check_failed("update", doc_id, e))?;
@@ -350,6 +352,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
+                                None,
                             )
                             .await
                             .unwrap_or(false);
@@ -367,6 +370,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                                 &policy.id,
                                 &policy.resource_name,
                                 doc_id,
+                                None,
                             )
                             .await
                             .map_err(|e| QueryError::acp_check_failed("delete", doc_id, e))?;

--- a/crates/query/src/runner/query/aggregate.rs
+++ b/crates/query/src/runner/query/aggregate.rs
@@ -52,6 +52,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                             &policy.id,
                             &policy.resource_name,
                             doc_id,
+                            None,
                         )
                         .await
                         .unwrap_or(false);

--- a/crates/query/src/runner/query/select.rs
+++ b/crates/query/src/runner/query/select.rs
@@ -446,6 +446,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                 &policy.id,
                 &policy.resource_name,
                 doc_id,
+                None,
             )
             .await
             .unwrap_or_else(|e| {

--- a/crates/query/src/runner/version.rs
+++ b/crates/query/src/runner/version.rs
@@ -98,6 +98,7 @@ impl<F: DocFetcher + 'static, R: TransactionRegistry> QueryRunner<F, R> {
                     &policy.id,
                     &policy.resource_name,
                     &doc_id,
+                    None,
                 )
                 .await
                 {

--- a/crates/query/src/txn/mod.rs
+++ b/crates/query/src/txn/mod.rs
@@ -15,7 +15,8 @@ mod guard;
 pub use query_plan::txn::{
     check_doc_access_with_overlay, current_deferred_acp_mutations, is_doc_registered_with_overlay,
     scope_deferred_acp_mutations, DeferredAcpMutations, GetTransactionResult,
-    NoOpTransactionRegistry, TransactionContext, TransactionHandle, TransactionRegistry,
+    NoOpTransactionRegistry, OverlayChecker, TransactionContext, TransactionHandle,
+    TransactionRegistry,
 };
 
 pub use guard::TransactionGuard;

--- a/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
+++ b/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
@@ -35,7 +35,7 @@
 - `crates/kms/src/policy.rs` — `is_branchable` on `DocCollectionInfo`; KMS gate calls `acp::check_doc_read_access`.
 - `crates/kms/src/nac_dac_policy.rs` — wire the rule into `check_release`.
 - `crates/p2p/src/peer_identity.rs` (new) — `PeerIdentityResolver`; `HandlePeerIdentityResolver` (libp2p, active token exchange via `get_peer_identity`) + `AnonymousResolver` (Iroh).
-- `crates/p2p/src/bitswap/{filter.rs,read_gate.rs}` — `BlockCollectionResolver` (DB-backed metadata) + `BlockReadGate` (ACP) + `LateBoundServeAcp` (resolver+gate, installed at wire-time) + metadata-first serve gate.
+- `crates/p2p/src/bitswap/{filter.rs,read_gate.rs}` — DB-backed `BlockClassifier` (whitelist + metadata incl. policy) + `BlockReadGate` (ACP) + `LateBoundServeAcp` (resolver+gate, installed at wire-time) + classify-first serve gate (shared by bitswap + CAR).
 - `crates/p2p/src/sync/coordinator/event_handler/car.rs` — CAR per-block serve filtering.
 - `tools/integration-test/tests/acp.rs` — cross-impl scenarios.
 
@@ -710,27 +710,37 @@ git commit -m "feat(p2p): PeerIdentityResolver (Go-style signed-token exchange; 
 ## Task 9: A3 — split metadata from ACP; Bitswap per-block serve gate
 
 **Files:**
-- Create: `crates/p2p/src/bitswap/read_gate.rs` (`BlockCollectionResolver` + `BlockReadGate` traits + `ServeAcp` / `LateBoundServeAcp`)
-- Modify: `crates/p2p/src/bitswap/filter.rs:62-145`, `crates/p2p/src/behaviour.rs:292`
-- Modify: node assembly (`crates/embedded/src/node.rs:553-558`) to install the ACP gate via `wire_document_acp`
+- Create: `crates/p2p/src/bitswap/read_gate.rs` (`BlockClassifier` + `BlockReadGate` traits + `BlockAcpMeta`/`BlockClass` + `ServeAcp`/`LateBoundServeAcp`)
+- Modify: `crates/p2p/src/bitswap/filter.rs:62-145` (delegate classification to the classifier), `crates/p2p/src/behaviour.rs:292`, `crates/p2p/src/host/p2p_host/mod.rs` (thread classifier + serve_acp through the constructor/config)
+- Modify: node assembly (`crates/embedded/src/node.rs:553-558` + `defra-node`) to build the DB-backed classifier, create the `serve_acp` Arc, and install `ServeAcp` via `wire_document_acp`
 - Test: `crates/p2p/tests/bitswap_acp_filter_tests.rs`
 
-**Interfaces (finding #2 — metadata split from ACP; finding #3 — DB-backed metadata):**
+**Interfaces (findings #2 metadata-split, #3 DB-backed, #4 policy source):** one DB-backed
+`BlockClassifier` owns BOTH the serve whitelist (signature/definition/lens → allow, unknown → deny —
+matching the current `filter.rs:88-144` shape) AND, for data blocks, the metadata the gate needs —
+**including the policy** (so the gate has `policy_id`/`resource_name`, finding #4). No ACP, no
+identity; available at construction.
 ```rust
-/// Pure metadata: block -> (stable collection_id, doc ids) + is_branchable. NO ACP, NO identity.
-/// Backed by DB/SCHEMA metadata (get_collection_by_version_id + collection cache), NOT the P2P
-/// subscription store (collection_store.rs only holds subscribed collection ids). The DB exists
-/// before P2P, so this is available at filter-construction.
+pub struct BlockAcpMeta {
+    pub collection_id: String,                 // stable id (for replicator passthrough + ACP object)
+    pub is_branchable: bool,
+    pub policy: Option<(String, String)>,      // (policy_id, resource_name); None => unpermissioned
+    pub doc_ids: Vec<String>,                  // empty => collection-level commit
+}
+pub enum BlockClass { Allow, Data(BlockAcpMeta), Deny }
+
+/// DB/SCHEMA-backed (get_collection_by_version_id + collection cache), NOT the P2P subscription
+/// store. Decodes the raw block once and classifies it. Available before P2P (DB exists first).
 #[async_trait]
-pub trait BlockCollectionResolver: Send + Sync {
-    async fn resolve(&self, block: &DefraBlock)
-        -> Option<(String /*collection_id*/, bool /*is_branchable*/, Vec<String> /*doc_ids; empty => collection-level*/)>;
+pub trait BlockClassifier: Send + Sync {
+    async fn classify(&self, data: &[u8]) -> BlockClass;
 }
 
-/// ACP evaluation only. Never consulted for replicators.
+/// ACP evaluation only. Late-bound. Never consulted for replicators. policy comes from the meta;
+/// `policy: None` short-circuits to allow (unpermissioned = public, Go parity).
 #[async_trait]
 pub trait BlockReadGate: Send + Sync {
-    async fn may_read(&self, identity: &acp::Identity, collection_id: &str, is_branchable: bool, doc_ids: &[String]) -> bool;
+    async fn may_read(&self, identity: &acp::Identity, meta: &BlockAcpMeta) -> bool;
 }
 
 /// Late-bound serve-ACP context: the resolver (active token exchange, Task 8) AND the gate are
@@ -740,7 +750,18 @@ pub struct ServeAcp { pub resolver: Arc<dyn PeerIdentityResolver>, pub gate: Arc
 pub struct LateBoundServeAcp(std::sync::OnceLock<ServeAcp>);
 ```
 
-**Ordering (finding #2):** metadata → replicator passthrough → (non-replicator) identity + ACP. The replicator path uses ONLY `BlockCollectionResolver` + the registry; it never touches the resolver or the ACP gate, so a not-yet-installed `ServeAcp` or an ACP error cannot deny a replicator.
+**Ordering (finding #2):** classify → (data) replicator passthrough on `meta.collection_id` →
+(non-replicator) identity + ACP. The replicator path uses ONLY the classifier + the registry; it
+never touches the resolver or the ACP gate, so a not-yet-installed `ServeAcp` or an ACP error cannot
+deny a replicator. **`Allow`/`Deny` classes are decided with no identity/ACP at all.**
+
+**Plumbing (finding #3):** `DefraBehaviour::new` has no DB and `P2PHost::with_keypair_and_config_and_identity`
+returns `(Self, handle, event_rx, replicators)` (`p2p_host/mod.rs:363`) — neither can build the
+DB-backed classifier. So **node assembly** creates `classifier: Arc<dyn BlockClassifier>` (DB-backed)
+and an empty `serve_acp: Arc<LateBoundServeAcp>`, threads BOTH through `P2PHostConfig` →
+`with_keypair_and_config_and_identity` → `DefraBehaviour::new` → `make_peer_block_access_filter`, and
+captures the SAME `serve_acp` `Arc` in the `wire_document_acp` closure (`node.rs:557`) to install
+`ServeAcp { resolver, gate }`. The CAR path (Task 10) receives the same two `Arc`s on `SyncCoordinator`.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -751,35 +772,35 @@ In `crates/p2p/tests/bitswap_acp_filter_tests.rs`: (a) non-replicator, DID lacks
 Run: `cargo test -p p2p --test bitswap_acp_filter_tests`
 Expected: FAIL.
 
-- [ ] **Step 3: Rewrite `check_access` with the metadata-first ordering**
+- [ ] **Step 3: Rewrite `check_access` to delegate to the classifier**
 
-Keep the signature/definition/lens passthroughs. Then:
+Replace the in-filter signature/definition/lens/data classification (`filter.rs:88-144`) with a call to the classifier; gate only the `Data` class:
 
 ```rust
-// 1) METADATA ONLY — stable collection id, is_branchable, doc ids. No ACP, no identity.
-let Some((collection_id, is_branchable, doc_ids)) = meta.resolve(&defra_block).await else {
-    return false; // can't classify the block => deny (no existence leak)
-};
-let peer_str = peer_id.to_string();
-
-// 2) REPLICATOR PASSTHROUGH on the STABLE collection_id — independent of ACP/identity.
-if registry.is_filtered_replicator(&collection_id, &peer_str) { return false; }
-if registry.is_replicator(&collection_id, &peer_str) { return true; }
-
-// 3) NON-REPLICATOR — needs the late-bound ServeAcp (resolver + gate). Fail closed until installed.
-let Some(serve) = serve_acp.get() else { return false; };
-let identity = match serve.resolver.resolve(&peer_id.clone().into()).await {  // libp2p::PeerId -> transport::PeerId
-    Some(did) => acp::Identity::Authenticated(did),  // active signed-token exchange (Go parity)
-    None => acp::Identity::Anonymous,
-};
-serve.gate.may_read(&identity, &collection_id, is_branchable, &doc_ids).await
+match classifier.classify(data).await {
+    BlockClass::Allow => return true,   // signature / definition / lens — no user data
+    BlockClass::Deny  => return false,  // undecodable / unknown shape — no existence leak
+    BlockClass::Data(meta) => {
+        let peer_str = peer_id.to_string();
+        // REPLICATOR PASSTHROUGH on the STABLE collection_id — no ACP, no identity.
+        if registry.is_filtered_replicator(&meta.collection_id, &peer_str) { return false; }
+        if registry.is_replicator(&meta.collection_id, &peer_str) { return true; }
+        // NON-REPLICATOR — needs the late-bound ServeAcp. Fail closed until installed.
+        let Some(serve) = serve_acp.get() else { return false; };
+        let identity = match serve.resolver.resolve(&(*peer_id).into()).await { // libp2p::PeerId -> transport::PeerId
+            Some(did) => acp::Identity::Authenticated(did),                     // active signed-token exchange (Go parity)
+            None => acp::Identity::Anonymous,
+        };
+        serve.gate.may_read(&identity, &meta).await
+    }
+}
 ```
 
-Thread `meta: Arc<dyn BlockCollectionResolver>` and `serve_acp: Arc<LateBoundServeAcp>` through `make_peer_block_access_filter` + the closure. `behaviour.rs:292` constructs the empty `LateBoundServeAcp` and the `meta` resolver (DB/schema-backed, available at construction).
+Thread `classifier: Arc<dyn BlockClassifier>` and `serve_acp: Arc<LateBoundServeAcp>` through `make_peer_block_access_filter` + the closure (and through `P2PHostConfig` → `with_keypair_and_config_and_identity` → `DefraBehaviour::new`, per the Plumbing note above). The `store.get(cid)` for the raw bytes stays; `classify` takes those bytes.
 
-- [ ] **Step 4: Implement the metadata resolver + install `ServeAcp` via `wire_document_acp`**
+- [ ] **Step 4: Implement the classifier + gate, install `ServeAcp` via `wire_document_acp`**
 
-`BlockCollectionResolver` impl (db/embedded layer, up-front): the filter passes the decoded `&DefraBlock`; read `schema_version_id`; resolve `→ CollectionVersion` via `get_collection_by_version_id` (DB/schema, NOT the P2P subscription store); return `(collection.collection_id, collection.is_branchable, doc_ids)` (collection-level => empty vec). `BlockReadGate` impl: `may_read` runs `acp::read_access::check_doc_read_access(DirectChecker{ acp, identity, node_did }, policy.id, policy.resource_name, collection_id, is_branchable, doc)` per doc id (empty list => one check with `""`), true if ANY grants. Install `ServeAcp { resolver, gate }` into `LateBoundServeAcp` inside the `wire_document_acp` closure at `node.rs:557` (handle exists here), where `resolver` = `HandlePeerIdentityResolver(handle)` for libp2p or `AnonymousResolver` for Iroh, and `gate` = the `BlockReadGate` impl. (+ defra-node equivalent.)
+`BlockClassifier` impl (db/embedded layer, up-front, DB-backed): `Signature::from_dag_cbor(data).is_ok()` → `Allow`; else `DefraBlock::from_dag_cbor(data)`: `delta.is_definition()` → `Allow`, else (data delta) read `schema_version_id`, resolve `→ CollectionVersion` via `get_collection_by_version_id`, return `Data(BlockAcpMeta { collection_id, is_branchable, policy: collection.policy.map(|p| (p.id, p.resource_name)), doc_ids })` (collection-level => empty `doc_ids`); on decode error, `is_lens_block(data)` → `Allow` else `Deny`. `BlockReadGate` impl: `may_read` — if `meta.policy` is `None` return `true` (unpermissioned = public); else run `acp::read_access::check_doc_read_access(DirectChecker{ acp, identity, node_did }, &policy.0, &policy.1, &meta.collection_id, meta.is_branchable, doc)` per doc id (empty list => one check with `""`), true if ANY grants. Install `ServeAcp { resolver, gate }` into the shared `LateBoundServeAcp` inside the `wire_document_acp` closure at `node.rs:557` (handle exists here): `resolver` = `HandlePeerIdentityResolver(handle)` for libp2p or `AnonymousResolver` for Iroh; `gate` = the `BlockReadGate` impl. (+ defra-node equivalent.)
 
 - [ ] **Step 5: Verify**
 
@@ -800,10 +821,10 @@ git commit -m "feat(p2p): A3 bitswap serve gate — metadata-first ordering, sta
 
 **Files:**
 - Modify: `crates/p2p/src/sync/coordinator/event_handler/car.rs:83-179`
-- Modify: `SyncCoordinator` construction to inject `BlockCollectionResolver` (meta, up-front) + `LateBoundServeAcp` (resolver+gate)
+- Modify: `SyncCoordinator` construction to inject `classifier: Arc<dyn BlockClassifier>` (up-front) + `serve_acp: Arc<LateBoundServeAcp>` (same Arc installed via `wire_document_acp`)
 - Test: CAR test module under `crates/p2p/src/sync/coordinator/`
 
-**Context (finding #2):** same metadata-first ordering. Per block: resolve stable collection_id (metadata) → replicator passthrough on that id → non-replicator identity + ACP. Never `is_any_replicator`.
+**Context (findings #1, #2):** same classifier + ordering as bitswap. Per block: classify → `Allow` keep / `Deny` drop / `Data` → replicator passthrough on `meta.collection_id` → non-replicator identity + ACP. Never `is_any_replicator`. Identity is resolved **lazily** — only after the first `Data` block fails the replicator passthrough — so a replicator-only request never triggers a token exchange (finding #1).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -820,38 +841,36 @@ After `let blocks = collected.blocks;` (car.rs:133), before the empty check:
 
 ```rust
 let peer_str = peer_id.to_string();
-// ServeAcp (resolver + gate) is late-bound; if absent only replicator passthrough works.
-let serve = self.serve_acp.get();
-// Resolve the peer identity ONCE (only when ServeAcp is installed); None => Anonymous.
-let identity = match serve {
-    Some(s) => match s.resolver.resolve(&peer_id).await {
-        Some(did) => acp::Identity::Authenticated(did),
-        None => acp::Identity::Anonymous,
-    },
-    None => acp::Identity::Anonymous,
-};
+let serve = self.serve_acp.get();           // late-bound; absent => only passthrough works
+let mut identity: Option<acp::Identity> = None; // resolved lazily on first non-replicator Data block
 let mut kept = Vec::with_capacity(blocks.len());
 for (cid, data) in blocks {
-    let block = match DefraBlock::from_dag_cbor(&data) {
-        Ok(b) => b,
-        Err(_) => { kept.push((cid, data)); continue; } // signature/lens/non-CRDT passthrough
-    };
-    let Some((collection_id, is_branchable, doc_ids)) = self.meta.resolve(&block).await else {
-        continue; // unclassifiable => drop (no existence leak)
-    };
-    // Replicator passthrough on the STABLE collection_id — no ACP/identity.
-    if self.access.replicators.is_filtered_replicator(&collection_id, &peer_str) { continue; }
-    if self.access.replicators.is_replicator(&collection_id, &peer_str) { kept.push((cid, data)); continue; }
-    // Non-replicator: needs ServeAcp (fail closed until installed).
-    let Some(serve) = serve else { continue; };
-    if serve.gate.may_read(&identity, &collection_id, is_branchable, &doc_ids).await {
-        kept.push((cid, data));
+    match self.classifier.classify(&data).await {
+        BlockClass::Allow => kept.push((cid, data)),     // signature / definition / lens
+        BlockClass::Deny  => {}                           // undecodable / unknown => drop
+        BlockClass::Data(meta) => {
+            // Replicator passthrough on the STABLE collection_id — no ACP/identity.
+            if self.access.replicators.is_filtered_replicator(&meta.collection_id, &peer_str) { continue; }
+            if self.access.replicators.is_replicator(&meta.collection_id, &peer_str) { kept.push((cid, data)); continue; }
+            // Non-replicator: needs ServeAcp (fail closed until installed).
+            let Some(serve) = serve else { continue; };
+            // Resolve identity lazily, exactly once, only now (finding #1).
+            if identity.is_none() {
+                identity = Some(match serve.resolver.resolve(&peer_id).await {
+                    Some(did) => acp::Identity::Authenticated(did),
+                    None => acp::Identity::Anonymous,
+                });
+            }
+            if serve.gate.may_read(identity.as_ref().unwrap(), &meta).await {
+                kept.push((cid, data));
+            }
+        }
     }
 }
 let blocks = kept;
 ```
 
-Hold `meta: Arc<dyn BlockCollectionResolver>` and `serve_acp: Arc<LateBoundServeAcp>` on `SyncCoordinator` (inject alongside `authorizer`; populate `serve_acp` via the same `wire_document_acp` path).
+Hold `classifier: Arc<dyn BlockClassifier>` and `serve_acp: Arc<LateBoundServeAcp>` on `SyncCoordinator` (inject alongside `authorizer`; populate `serve_acp` via the same `wire_document_acp` path). The classifier is the SAME impl the bitswap filter uses (Task 9), so both transports decide identically.
 
 - [ ] **Step 4: Verify**
 
@@ -951,11 +970,13 @@ Change the PR description from "A1 registration" to the full A1–A3 security fe
 
 **Spec coverage:** rule once in `acp` (Tasks 1,3 — direct + overlay checkers) ✔; node_did (Tasks 2,4) ✔; version→collection_id at every site (Tasks 5,6,9,10) ✔; commits (5) ✔; verify (6) ✔; KMS is_branchable + corrected semantics (7) ✔; peer-DID resolver, libp2p + Iroh-native (8) ✔; bitswap late-bound serve gate + stable-collection passthrough (9) ✔; CAR serve filter, no is_any_replicator (10) ✔; unresolved-DID→Anonymous (9,10) ✔; pushlog CID already-done (11) ✔; cross-impl (12) ✔; regression gate + adversarial audit (13) ✔.
 
-**Review findings closed (round 2):** #1 KMS test semantics (Task 7 step 1: public-doc+deny → Deny, explicit-grant → Allow) ✔; #2 per-block stable-collection passthrough (Tasks 9,10; Global Constraints) ✔; #3 late-bound `LateBoundReadGate` via `wire_document_acp` (Task 9) ✔; #4 Iroh NodeId→did:key derivation + documented constraint (Task 8) ✔; #5 single rule in `acp`, two checker impls (Tasks 1,3,7 all call `acp::read_access::check_doc_read_access`) ✔; #6 explicit `node_did` field + builder + wiring on the query runner (Task 4) ✔.
+**Review findings closed (round 5 — A3 wiring detail):** #1 CAR resolves identity **lazily** inside the non-replicator branch, never before replicator passthrough (Task 10 snippet) ✔; #2 CAR uses the shared `BlockClassifier` whitelist (signature/definition/lens allow, unknown deny) instead of keeping any undecodable block (Tasks 9,10) ✔; #3 explicit plumbing — node assembly builds the DB-backed classifier + `serve_acp` Arc and threads them through `P2PHostConfig` → `with_keypair_and_config_and_identity` → `DefraBehaviour::new` → filter, capturing the same Arc in `wire_document_acp` (Task 9 Plumbing note + Files) ✔; #4 `BlockClassifier` returns `policy` in `BlockAcpMeta`, so the gate has `policy_id`/`resource_name` (Task 9 interfaces + step 4) ✔; #5 stale self-review claims cleaned (below) ✔.
 
-**Review findings closed (round 4 — Go-parity identity):** #1 dropped Iroh `NodeId→did:key` + ed25519 key-binding (Go decouples transport id from ACP id); resolver uses Go's signed-token exchange, late-bound at `wire_document_acp` when the handle exists; Iroh → Anonymous narrowing + follow-up issue (Task 8) ✔; #2 libp2p resolver uses the **active** `get_peer_identity` (cache→fetch→verify→cache, `messaging.rs:348`), not cache-only (Task 8 step 3) ✔; #3 `BlockCollectionResolver` is **DB/schema-backed** (`get_collection_by_version_id`), not the P2P subscription store (Task 9 interfaces + step 4) ✔.
+**Review findings closed (round 2):** #1 KMS test semantics (Task 7 step 1: public-doc+deny → Deny, explicit-grant → Allow) ✔; #2 per-block stable-collection passthrough (Tasks 9,10; Global Constraints) ✔; #3 late-bound serve gate via `wire_document_acp` (Task 9) ✔; #4 Iroh identity — see round 4 (NodeId→did:key was reverted; Iroh resolves via Anonymous narrowing) ✔; #5 single rule in `acp`, two checker impls (Tasks 1,3,7 all call `acp::read_access::check_doc_read_access`) ✔; #6 explicit `node_did` field + builder + wiring on the query runner (Task 4) ✔.
 
-**Review findings closed (round 3):** #1 resolver lifecycle — shared `PeerIdentityStore` created up-front (mirrors the `ReplicatorRegistry` Arc), `StoreResolver` constructible at filter build, not the handle (Task 8 steps 3-4) ✔; #2 ordering — `BlockCollectionResolver` (metadata, no ACP/identity) → replicator passthrough → non-replicator ACP; replicator path never touches the gate/identity (Tasks 9,10; Global Constraints serve-gate ordering) ✔; #3 Iroh binding enforced — derive endpoint key from the ed25519 node identity + startup error on secp256k1 (Task 8 step 5) ✔; #4 `crate::transport::PeerId` in the trait + conversion at the bitswap call site (Task 8 interfaces; Global Constraints) ✔; #5 `collections_map()` returns `Arc<CollectionVersion>` — `by_version` stores `Arc` (Task 5 step 3) ✔.
+**Review findings closed (round 4 — Go-parity identity):** #1 dropped Iroh `NodeId→did:key` + ed25519 key-binding (Go decouples transport id from ACP id); resolver uses Go's signed-token exchange, late-bound at `wire_document_acp` when the handle exists; Iroh → Anonymous narrowing + follow-up issue (Task 8) ✔; #2 libp2p resolver uses the **active** `get_peer_identity` (cache→fetch→verify→cache, `messaging.rs:348`), not cache-only (Task 8 step 3) ✔; #3 the metadata source (now the `BlockClassifier`, round 5) is **DB/schema-backed** (`get_collection_by_version_id`), not the P2P subscription store (Task 9 interfaces + step 4) ✔.
+
+**Review findings closed (round 3):** #1 resolver lifecycle — **superseded by round 4**: instead of hoisting `peer_identities` into a shared store, the resolver is late-bound with the gate at `wire_document_acp` (handle exists there) and reuses the existing active `get_peer_identity`; no `PeerIdentityStore`/`StoreResolver` (Task 8) ✔; #2 ordering — classify → replicator passthrough → non-replicator ACP; replicator path never touches the gate/identity (Tasks 9,10; Global Constraints serve-gate ordering) ✔; #3 Iroh binding — **reverted in round 4**: no ed25519 endpoint-key binding (Go decouples transport id from ACP id); Iroh non-replicator → Anonymous narrowing (Task 8) ✔; #4 `crate::transport::PeerId` in the trait + conversion at the bitswap call site (Task 8 interfaces; Global Constraints) ✔; #5 `collections_map()` returns `Arc<CollectionVersion>` — `by_version` stores `Arc` (Task 5 step 3) ✔.
 
 **Placeholders:** none — every code step shows real code; the `BlockReadGate`/`DocCollectionLookup` producer impls reference the existing block→docID and version→collection resolution rather than re-deriving, which is concrete guidance.
 

--- a/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
+++ b/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
@@ -1,0 +1,1057 @@
+# Branchable Collection ACP — A2 + A3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce branchable-collection ACP on local read paths (A2) and the P2P serve boundary (A3), consuming the A1 collection-object registration, at full parity with Go v1.0.0 `3f627855`.
+
+**Architecture:** One new rule, `check_doc_read_access`, with an internal `DocAccess { has_access, explicit }` verdict, defined once over an `ObjectAccessChecker` capability (overlay + direct impls) and wired into five sites: commits query, signature verify, KMS key-gate, Bitswap serve filter, CAR serve handler. A transport-agnostic `PeerIdentityResolver` supplies the requesting peer's DID at the serve boundary.
+
+**Tech Stack:** Rust, async-trait, tokio; crates `acp`, `db`, `query`, `query-plan`, `kms`, `p2p`; integration harness in `tools/integration-test`.
+
+## Global Constraints
+
+- Parity oracle: Go v1.0.0 commit `3f627855`. Behavior must match unless a deviation is explicitly recorded in the spec.
+- ACP objects are keyed by the **stable `collection_id`**, never `schema_version_id`. Every site resolves `schema_version_id → CollectionVersion` first.
+- Spec: `docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md`.
+- `cargo clippy --all -- -D warnings` must stay clean; `cargo fmt --all` applied before each commit.
+- Unresolved peer DID at the serve boundary → treat as `Identity::Anonymous` (Go parity), not blanket-deny.
+- Replicator passthrough at the serve boundary is preserved (registered replicators served without per-doc check).
+- Do NOT flip the `strict_replicated_doc_access` merge default; merge gating stays as-is.
+- Commit after each task. Keep A2 and A3 in separate commits. The A3 serve-path work requires an adversarial re-audit (Task 13) before the PR merges.
+
+---
+
+## File Structure
+
+- `crates/acp/src/error.rs` — (existing) reused error variants.
+- `crates/db/src/collection_acp.rs` — home of `DocAccess`, `check_doc_access_ext`, `check_doc_read_access`, `ObjectAccessChecker` + direct impl. **Primary new logic.**
+- `crates/db/tests/collection_acp_tests.rs` — unit truth-table for the rule.
+- `crates/query-plan/src/txn/context.rs` — overlay `ObjectAccessChecker` impl; thread `node_did`.
+- `crates/query/src/runner/commits.rs` — A2 commits gating.
+- `crates/db/src/block_verify.rs` — A2 signature-verify gating.
+- `crates/kms/src/policy.rs` — add `is_branchable` to `DocCollectionInfo`.
+- `crates/kms/src/nac_dac_policy.rs` — KMS gate uses the read rule.
+- `crates/p2p/src/transport.rs` + `crates/p2p/src/peer_identity.rs` (new) — `PeerIdentityResolver`.
+- `crates/p2p/src/bitswap/filter.rs` — Bitswap per-doc serve gate.
+- `crates/p2p/src/sync/coordinator/event_handler/car.rs` — CAR per-block serve filtering.
+- `tools/integration-test/tests/acp.rs` (+ submodules) — cross-impl integration scenarios.
+
+---
+
+## Task 1: `DocAccess` verdict + explicit-reporting single-object check
+
+**Files:**
+- Modify: `crates/db/src/collection_acp.rs` (add after `check_doc_permission`, ~line 84)
+- Test: `crates/db/tests/collection_acp_tests.rs`
+
+**Interfaces:**
+- Consumes: `acp::{DocumentACP, DocumentPermission, Identity}`, `identity::Did`, `schema::CollectionVersion`, existing `defra_core::dac_bypass::get_dac_bypass()`.
+- Produces:
+  ```rust
+  pub struct DocAccess { pub has_access: bool, pub explicit: bool }
+  // Single-object check that also reports whether the verdict was explicit.
+  pub async fn check_object_access(
+      acp: &dyn DocumentACP,
+      identity: &Identity,
+      permission: DocumentPermission,
+      policy_id: &str,
+      resource_name: &str,
+      object_id: &str,
+      node_identity: Option<&Did>,
+  ) -> acp::Result<DocAccess>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/db/tests/collection_acp_tests.rs` add:
+
+```rust
+use db::collection_acp::{check_object_access, DocAccess};
+
+#[tokio::test]
+async fn check_object_access_reports_explicit() {
+    let store = std::sync::Arc::new(MemoryAcpStore::new());
+    let acp = LocalDocumentACP::new(store);
+    let owner = test_did();
+    let policy = ("polid".to_string(), "users".to_string());
+
+    // Unregistered object => public, not explicit.
+    let pub_access = check_object_access(
+        &acp, &Identity::Anonymous, DocumentPermission::Read,
+        &policy.0, &policy.1, "objX", None,
+    ).await.unwrap();
+    assert_eq!(pub_access.has_access, true);
+    assert_eq!(pub_access.explicit, false);
+
+    // Registered to owner => owner has explicit access.
+    acp.register_doc_object(&owner, &policy.0, &policy.1, "objX").await.unwrap();
+    let owner_access = check_object_access(
+        &acp, &Identity::Authenticated(owner.clone()), DocumentPermission::Read,
+        &policy.0, &policy.1, "objX", None,
+    ).await.unwrap();
+    assert_eq!(owner_access.has_access, true);
+    assert_eq!(owner_access.explicit, true);
+
+    // Anonymous against a registered object => explicit denial.
+    let anon = check_object_access(
+        &acp, &Identity::Anonymous, DocumentPermission::Read,
+        &policy.0, &policy.1, "objX", None,
+    ).await.unwrap();
+    assert_eq!(anon.has_access, false);
+    assert_eq!(anon.explicit, true);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p db --test collection_acp_tests check_object_access_reports_explicit`
+Expected: FAIL — `check_object_access` / `DocAccess` not found.
+
+- [ ] **Step 3: Implement `DocAccess` + `check_object_access`**
+
+In `crates/db/src/collection_acp.rs`:
+
+```rust
+/// Outcome of a single-object access check: the verdict plus whether it was
+/// decided by something specific to the actor (an ACP registration or a
+/// DAC-bypass / node-identity grant) vs. unrestricted-for-everyone access.
+/// Mirrors Go `internal/db/acp/check.go::docAccess`.
+#[derive(Debug, Clone, Copy)]
+pub struct DocAccess {
+    pub has_access: bool,
+    pub explicit: bool,
+}
+
+/// Single-object access check that also reports `explicit`. Used as the
+/// building block of [`check_doc_read_access`]. `policy_id`/`resource_name`
+/// come from the collection's policy; `object_id` is a docID or a collection_id.
+pub async fn check_object_access(
+    acp: &dyn DocumentACP,
+    identity: &Identity,
+    permission: DocumentPermission,
+    policy_id: &str,
+    resource_name: &str,
+    object_id: &str,
+    node_identity: Option<&Did>,
+) -> acp::Result<DocAccess> {
+    if defra_core::dac_bypass::get_dac_bypass() {
+        return Ok(DocAccess { has_access: true, explicit: true });
+    }
+    if let (Some(node_did), Identity::Authenticated(req_did)) = (node_identity, identity) {
+        if node_did == req_did {
+            return Ok(DocAccess { has_access: true, explicit: true });
+        }
+    }
+    if !acp.is_doc_registered(policy_id, resource_name, object_id).await? {
+        return Ok(DocAccess { has_access: true, explicit: false });
+    }
+    let has_access = acp
+        .check_doc_access(identity, permission, policy_id, resource_name, object_id)
+        .await?;
+    Ok(DocAccess { has_access, explicit: true })
+}
+```
+
+Ensure `pub mod collection_acp;` re-exports are present (the crate already exposes `check_doc_permission`; add `DocAccess` and the new fn to the same `pub use` if one exists in `crates/db/src/lib.rs`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p db --test collection_acp_tests check_object_access_reports_explicit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/db/src/collection_acp.rs crates/db/src/lib.rs crates/db/tests/collection_acp_tests.rs
+git commit -m "feat(acp): add DocAccess + explicit-reporting object access check"
+```
+
+---
+
+## Task 2: `check_doc_read_access` rule + direct backend
+
+**Files:**
+- Modify: `crates/db/src/collection_acp.rs`
+- Test: `crates/db/tests/collection_acp_tests.rs`
+
+**Interfaces:**
+- Consumes: `check_object_access`, `DocAccess` (Task 1), `schema::CollectionVersion`.
+- Produces:
+  ```rust
+  pub async fn check_doc_read_access(
+      acp: &dyn DocumentACP,
+      identity: &Identity,
+      collection: &CollectionVersion,
+      doc_id: &str,                 // "" for a collection-level commit
+      node_identity: Option<&Did>,
+  ) -> acp::Result<bool>;
+  ```
+
+- [ ] **Step 1: Write the failing tests** (truth table)
+
+In `crates/db/tests/collection_acp_tests.rs`:
+
+```rust
+use db::collection_acp::check_doc_read_access;
+
+#[tokio::test]
+async fn read_access_branchable_public_doc_requires_collection() {
+    let acp = LocalDocumentACP::new(std::sync::Arc::new(MemoryAcpStore::new()));
+    let owner = test_did();
+    let stranger = test_did2();
+    let col = branchable_collection_with_policy(); // is_branchable + policy
+    let policy = col.policy.clone().unwrap();
+
+    // Register the collection object to owner; leave the doc public (unregistered).
+    acp.register_doc_object(&owner, &policy.id, &policy.resource_name, &col.collection_id)
+        .await.unwrap();
+
+    // Owner: public doc + collection access => GRANT.
+    assert!(check_doc_read_access(
+        &acp, &Identity::Authenticated(owner.clone()), &col, "docA", None,
+    ).await.unwrap());
+
+    // Stranger: public doc but NO collection access => DENY (branchable gates public docs).
+    assert!(!check_doc_read_access(
+        &acp, &Identity::Authenticated(stranger.clone()), &col, "docA", None,
+    ).await.unwrap());
+
+    // Collection-level commit (empty doc_id): gated purely on collection object.
+    assert!(check_doc_read_access(
+        &acp, &Identity::Authenticated(owner), &col, "", None,
+    ).await.unwrap());
+    assert!(!check_doc_read_access(
+        &acp, &Identity::Authenticated(stranger), &col, "", None,
+    ).await.unwrap());
+}
+
+#[tokio::test]
+async fn read_access_explicit_doc_grant_overrides_collection() {
+    let acp = LocalDocumentACP::new(std::sync::Arc::new(MemoryAcpStore::new()));
+    let owner = test_did();
+    let reader = test_did2();
+    let col = branchable_collection_with_policy();
+    let policy = col.policy.clone().unwrap();
+
+    // Collection owned by owner (reader has no collection access).
+    acp.register_doc_object(&owner, &policy.id, &policy.resource_name, &col.collection_id)
+        .await.unwrap();
+    // Doc registered to reader explicitly (reader IS the doc owner).
+    acp.register_doc_object(&reader, &policy.id, &policy.resource_name, "docShared")
+        .await.unwrap();
+
+    // Reader has an explicit grant on docShared => GRANT despite no collection access.
+    assert!(check_doc_read_access(
+        &acp, &Identity::Authenticated(reader), &col, "docShared", None,
+    ).await.unwrap());
+}
+
+#[tokio::test]
+async fn read_access_nonbranchable_reduces_to_doc() {
+    let acp = LocalDocumentACP::new(std::sync::Arc::new(MemoryAcpStore::new()));
+    let owner = test_did();
+    let stranger = test_did2();
+    let col = collection_with_policy(); // permissioned, NOT branchable
+    let policy = col.policy.clone().unwrap();
+    acp.register_doc_object(&owner, &policy.id, &policy.resource_name, "docA")
+        .await.unwrap();
+
+    assert!(check_doc_read_access(
+        &acp, &Identity::Authenticated(owner), &col, "docA", None,
+    ).await.unwrap());
+    assert!(!check_doc_read_access(
+        &acp, &Identity::Authenticated(stranger), &col, "docA", None,
+    ).await.unwrap());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p db --test collection_acp_tests read_access_`
+Expected: FAIL — `check_doc_read_access` not found.
+
+- [ ] **Step 3: Implement the rule**
+
+In `crates/db/src/collection_acp.rs`:
+
+```rust
+/// Reports whether `identity` may read the object identified by `doc_id` on
+/// `collection`. Gates the object's entire commit DAG, not just current field
+/// values. `doc_id` is "" for a collection-level commit (branchable only).
+///
+/// GRANT if EITHER an explicit grant on the document, OR read access to every
+/// object the document relates to: the document itself and — for a branchable
+/// collection — the collection object (keyed by collection_id). Explicit denial
+/// on the document always denies. Mirrors Go
+/// `internal/db/acp/check.go::CheckDocReadAccessWithIdentityFunc`.
+pub async fn check_doc_read_access(
+    acp: &dyn DocumentACP,
+    identity: &Identity,
+    collection: &CollectionVersion,
+    doc_id: &str,
+    node_identity: Option<&Did>,
+) -> acp::Result<bool> {
+    // Unpermissioned collection => unrestricted (matches check_object_access's
+    // public path, but short-circuit here to avoid needing a policy below).
+    let Some(policy) = &collection.policy else {
+        return Ok(true);
+    };
+
+    let mut doc_accessible = true;
+    if !doc_id.is_empty() {
+        let access = check_object_access(
+            acp, identity, DocumentPermission::Read,
+            &policy.id, &policy.resource_name, doc_id, node_identity,
+        ).await?;
+        if access.explicit && access.has_access {
+            return Ok(true); // explicit grant on the document is sufficient
+        }
+        if !access.has_access {
+            return Ok(false); // explicit denial on the document always wins
+        }
+        doc_accessible = access.has_access;
+    }
+    if !doc_accessible {
+        return Ok(false);
+    }
+
+    if collection.is_branchable {
+        let access = check_object_access(
+            acp, identity, DocumentPermission::Read,
+            &policy.id, &policy.resource_name, &collection.collection_id, node_identity,
+        ).await?;
+        if !access.has_access {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p db --test collection_acp_tests read_access_`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/db/src/collection_acp.rs crates/db/tests/collection_acp_tests.rs
+git commit -m "feat(acp): add check_doc_read_access branchable read rule"
+```
+
+---
+
+## Task 3: Thread `node_did` into the overlay access check
+
+**Files:**
+- Modify: `crates/query-plan/src/txn/context.rs:328` (`check_doc_access_with_overlay`)
+- Modify: call sites in `crates/query-plan/src/plan/permission_filter.rs` and `crates/query/src/runner/commits.rs`
+- Test: `crates/query-plan/tests/cross_object_read_path.rs`
+
+**Interfaces:**
+- Produces (changed signature):
+  ```rust
+  pub async fn check_doc_access_with_overlay(
+      acp: &dyn DocumentACP,
+      identity: &Identity,
+      permission: DocumentPermission,
+      policy_id: &str,
+      resource_name: &str,
+      doc_id: &str,
+      node_did: Option<&Did>,        // NEW trailing param
+  ) -> AcpResult<bool>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/query-plan/tests/cross_object_read_path.rs`, add a case asserting the node identity is granted access to a registered object it does not own:
+
+```rust
+#[tokio::test]
+async fn overlay_grants_node_identity_full_access() {
+    // build acp with object registered to some other owner; node_did = NODE.
+    let (acp, node_did, other_owner) = setup_registered_object().await;
+    let granted = query_plan::txn::check_doc_access_with_overlay(
+        acp.as_ref(),
+        &acp::Identity::Authenticated(node_did.clone()),
+        acp::DocumentPermission::Read,
+        "polid", "users", "objX",
+        Some(&node_did),
+    ).await.unwrap();
+    assert!(granted, "node identity must get full access via the shortcut");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p query-plan --test cross_object_read_path overlay_grants_node_identity_full_access`
+Expected: FAIL — arity mismatch (function takes 6 args) / not granted.
+
+- [ ] **Step 3: Add the `node_did` shortcut to the overlay check**
+
+In `crates/query-plan/src/txn/context.rs`, change the signature and add the shortcut before the projected-registration logic:
+
+```rust
+pub async fn check_doc_access_with_overlay(
+    acp: &dyn DocumentACP,
+    identity: &Identity,
+    permission: DocumentPermission,
+    policy_id: &str,
+    resource_name: &str,
+    doc_id: &str,
+    node_did: Option<&Did>,
+) -> AcpResult<bool> {
+    if let (Some(node), Identity::Authenticated(req)) = (node_did, identity) {
+        if node == req {
+            return Ok(true);
+        }
+    }
+    if let Some(mutations) = current_deferred_acp_mutations() {
+        // ... unchanged projected-registration block ...
+    }
+    acp.check_doc_access(identity, permission, policy_id, resource_name, doc_id).await
+}
+```
+
+Update the internal recursive calls at context.rs:448/463/491 to pass `node_did` through.
+
+- [ ] **Step 4: Update other call sites**
+
+In `crates/query-plan/src/plan/permission_filter.rs` and any other caller, pass the node DID where available (thread it from the planner/registry; pass `None` where not yet plumbed — behavior unchanged there). Compile to find all call sites:
+
+Run: `cargo build -p query-plan -p query 2>&1 | grep "this function takes"`
+Fix each by adding the trailing `node_did` argument.
+
+- [ ] **Step 5: Run test + build to verify**
+
+Run: `cargo test -p query-plan --test cross_object_read_path overlay_grants_node_identity_full_access && cargo build -p query`
+Expected: PASS + clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/query-plan crates/query
+git commit -m "feat(acp): thread node_did into overlay access check"
+```
+
+---
+
+## Task 4: Overlay `ObjectAccessChecker` + read rule over overlay
+
+**Files:**
+- Create: `crates/query-plan/src/txn/read_access.rs`
+- Modify: `crates/query-plan/src/txn/mod.rs` (re-export)
+- Test: `crates/query-plan/tests/cross_object_read_path.rs`
+
+**Interfaces:**
+- Consumes: `check_doc_access_with_overlay` (Task 3, with `node_did`), `is_doc_registered_with_overlay`.
+- Produces:
+  ```rust
+  // Overlay-aware read rule used by the commits query.
+  pub async fn check_doc_read_access_overlay(
+      acp: &dyn DocumentACP,
+      identity: &Identity,
+      collection: &CollectionVersion,
+      doc_id: &str,
+      node_did: Option<&Did>,
+  ) -> AcpResult<bool>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn overlay_read_rule_gates_branchable_public_doc() {
+    let (acp, owner, stranger, col) = setup_branchable_registered_collection().await;
+    assert!(query_plan::txn::check_doc_read_access_overlay(
+        acp.as_ref(), &Identity::Authenticated(owner), &col, "docA", None,
+    ).await.unwrap());
+    assert!(!query_plan::txn::check_doc_read_access_overlay(
+        acp.as_ref(), &Identity::Authenticated(stranger), &col, "docA", None,
+    ).await.unwrap());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p query-plan --test cross_object_read_path overlay_read_rule_gates_branchable_public_doc`
+Expected: FAIL — function not found.
+
+- [ ] **Step 3: Implement the overlay read rule**
+
+In `crates/query-plan/src/txn/read_access.rs`, replicate the Task-2 algorithm but call the overlay-aware `is_doc_registered_with_overlay` + `check_doc_access_with_overlay` for each object. Factor the per-object verdict into a local helper mirroring `check_object_access`:
+
+```rust
+async fn object_access_overlay(
+    acp: &dyn DocumentACP, identity: &Identity, policy_id: &str, resource_name: &str,
+    object_id: &str, node_did: Option<&Did>,
+) -> AcpResult<(bool /*has*/, bool /*explicit*/)> {
+    if let (Some(node), Identity::Authenticated(req)) = (node_did, identity) {
+        if node == req { return Ok((true, true)); }
+    }
+    if !is_doc_registered_with_overlay(acp, policy_id, resource_name, object_id).await? {
+        return Ok((true, false));
+    }
+    let has = check_doc_access_with_overlay(
+        acp, identity, DocumentPermission::Read, policy_id, resource_name, object_id, node_did,
+    ).await?;
+    Ok((has, true))
+}
+
+pub async fn check_doc_read_access_overlay(
+    acp: &dyn DocumentACP, identity: &Identity, collection: &CollectionVersion,
+    doc_id: &str, node_did: Option<&Did>,
+) -> AcpResult<bool> {
+    let Some(policy) = &collection.policy else { return Ok(true); };
+    if !doc_id.is_empty() {
+        let (has, explicit) = object_access_overlay(
+            acp, identity, &policy.id, &policy.resource_name, doc_id, node_did).await?;
+        if explicit && has { return Ok(true); }
+        if !has { return Ok(false); }
+    }
+    if collection.is_branchable {
+        let (has, _) = object_access_overlay(
+            acp, identity, &policy.id, &policy.resource_name,
+            &collection.collection_id, node_did).await?;
+        if !has { return Ok(false); }
+    }
+    Ok(true)
+}
+```
+
+Add `pub mod read_access;` and re-export `check_doc_read_access_overlay` in `crates/query-plan/src/txn/mod.rs`, and re-export through `crates/query/src/txn/mod.rs`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p query-plan --test cross_object_read_path overlay_read_rule_gates_branchable_public_doc`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/query-plan crates/query
+git commit -m "feat(acp): overlay-aware check_doc_read_access for query path"
+```
+
+---
+
+## Task 5: A2 — gate the commits query
+
+**Files:**
+- Modify: `crates/query/src/runner/commits.rs:737-839` (the ACP filtering block in `execute_commits_query`)
+- Test: `tools/integration-test/tests/acp.rs` (new module `branchable_commits`)
+
+**Interfaces:**
+- Consumes: `check_doc_read_access_overlay` (Task 4), `self.collections_map()`, `caller_identity`, `self.node_did()` (add accessor if absent — the registry already holds `db.node_did()`).
+
+**Context:** Today the block at commits.rs:771-775 does `docID None => continue`, so collection-level commits are never gated; doc commits are gated per-doc via `check_doc_access_with_overlay` against the version's policy. Replace both with the read rule keyed on the resolved `CollectionVersion`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `tools/integration-test/tests/acp.rs`, add `mod branchable_commits;` and create the scenario (driving the real node via the harness): a branchable `@policy` collection created by identity A; a public doc added; identity B (no collection access) queries `_commits` for both the collection-level DAG and the doc — expects **empty**; identity A expects the commits. Use the existing harness helpers (mirror `acp::basic`). Assert B sees `[]` and A sees non-empty.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p integration-test --test acp -- branchable_commits::`
+Expected: FAIL — B currently sees collection-level commits (ungated).
+
+- [ ] **Step 3: Rewrite the ACP filter block**
+
+In `execute_commits_query`, replace the per-doc-only filter with a per-commit read-rule check. Resolve each commit's `collectionVersionId` to its `CollectionVersion` (via `self.collections_map()` keyed by `version_id`) and call the rule; treat an empty/absent `docID` as a collection-level commit (`""`):
+
+```rust
+let node_did = self.node_did(); // Option<Did>
+let identity = Identity::from(caller_identity.clone());
+let collections = self.collections_map().await?;
+let by_version: HashMap<String, CollectionVersion> = collections
+    .values().map(|c| (c.version_id.clone(), c.clone())).collect();
+
+let mut keep: Vec<bool> = Vec::with_capacity(commits.len());
+for commit in &commits {
+    let version_id = commit.get("collectionVersionId").and_then(|v| v.as_str());
+    let doc_id = commit.get("docID").and_then(|v| v.as_str()).unwrap_or("");
+    let allowed = match version_id.and_then(|v| by_version.get(v)) {
+        None => true, // unknown version: no policy to enforce here
+        Some(col) => match crate::txn::check_doc_read_access_overlay(
+            self.acp.as_ref(), &identity, col, doc_id, node_did.as_ref(),
+        ).await {
+            Ok(granted) => granted,
+            Err(e) => {
+                tracing::debug!(target: "acp::audit", event = "commits_acp_check_error",
+                    doc_id = %doc_id, error = %e, "denying commit on ACP error");
+                false
+            }
+        },
+    };
+    keep.push(allowed);
+}
+let mut iter = keep.into_iter();
+commits.retain(|_| iter.next().unwrap_or(false));
+```
+
+Remove the now-dead `policies_by_version` / `denied_commits` machinery (lines ~744-838) it replaces. Keep the `has_protected_collections` short-circuit if cheap, but the rule already no-ops unpermissioned collections.
+
+- [ ] **Step 4: Run integration test to verify it passes**
+
+Run: `cargo test -p integration-test --test acp -- branchable_commits::`
+Expected: PASS — B sees `[]`, A sees commits.
+
+- [ ] **Step 5: Run the full ACP + query suites (no regressions)**
+
+Run: `cargo test -p integration-test --test acp && cargo test -p integration-test --test query -- commits`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/query/src/runner/commits.rs tools/integration-test/tests/acp.rs tools/integration-test/tests/acp/
+git commit -m "feat(acp): A2 gate commits query on branchable read rule"
+```
+
+---
+
+## Task 6: A2 — gate signature verification
+
+**Files:**
+- Modify: `crates/db/src/block_verify.rs:110-136`
+- Test: `crates/db/tests/` (add a block-verify ACP test) or `tools/integration-test/tests/acp.rs::branchable_commits` extension.
+
+**Interfaces:**
+- Consumes: `check_doc_read_access` (Task 2), `database.get_collection_by_version_id`, `database.node_did()`.
+
+**Context:** Today verify only checks when `delta.doc_id()` is `Some`; collection-level blocks bypass. Replace with the read rule, resolving the collection from `schema_version_id` and using `""` for collection-level blocks.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a `crates/db/tests/block_verify_acp_tests.rs` test: build a DB with a branchable permissioned collection registered to owner A; produce a collection-level signed block; call `verify_block_signature` as stranger B → expect `Err("missing permission")`; as A → expect `Ok`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p db --test block_verify_acp_tests`
+Expected: FAIL — B currently passes (collection-level block bypasses the gate).
+
+- [ ] **Step 3: Replace the gate with the read rule**
+
+In `verify_block_signature_with_blockstore`, replace lines 110-136:
+
+```rust
+// Read-access gate: a block's signature is only verifiable by an actor who can
+// read the block's document(s) / collection DAG. Collection-level blocks have
+// no docID and are gated on the collection object for a branchable collection.
+if let Some(schema_version_id) = block.delta.schema_version_id() {
+    if let Some(collection) = database
+        .get_collection_by_version_id(schema_version_id)
+        .map_err(|e| format!("failed to get collection: {}", e))?
+    {
+        let doc_id = block
+            .delta
+            .doc_id()
+            .map(|b| String::from_utf8_lossy(b).to_string())
+            .unwrap_or_default();
+        let node_did = database.node_did();
+        let has_permission = crate::collection_acp::check_doc_read_access(
+            document_acp,
+            caller_identity,
+            collection.schema(),
+            &doc_id,
+            node_did.as_ref(),
+        )
+        .await
+        .map_err(|e| format!("ACP check failed: {}", e))?;
+        if !has_permission {
+            return Err("missing permission".to_string());
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test + ACP suite**
+
+Run: `cargo test -p db --test block_verify_acp_tests && cargo test -p integration-test --test acp`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/db/src/block_verify.rs crates/db/tests/block_verify_acp_tests.rs
+git commit -m "feat(acp): A2 gate signature verification on branchable read rule"
+```
+
+---
+
+## Task 7: A3 — KMS key-gate uses the read rule
+
+**Files:**
+- Modify: `crates/kms/src/policy.rs:61` (`DocCollectionInfo`) and its `DocCollectionLookup`
+- Modify: `crates/kms/src/nac_dac_policy.rs:80-111` (`check_release` Document arm)
+- Modify: the `DocCollectionLookup` producer (in the embedded-node layer, "Phase K"): grep `impl DocCollectionLookup`
+- Test: `crates/kms/src/nac_dac_policy.rs` tests (extend fakes)
+
+**Interfaces:**
+- Produces (changed struct):
+  ```rust
+  pub struct DocCollectionInfo {
+      pub collection_id: String,
+      pub policy_id: String,
+      pub resource_name: String,
+      pub is_branchable: bool,   // NEW
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/kms/src/nac_dac_policy.rs` tests, extend the fake `collection_for_doc` to return `is_branchable: true` and have the fake DAC grant the doc but deny the collection object; assert `check_release` returns `Deny` (the branchable collection gate must apply). Add a second case `is_branchable: false` → `Allow` (doc-only).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p kms nac_dac_policy`
+Expected: FAIL — struct has no `is_branchable`; gate ignores collection object.
+
+- [ ] **Step 3: Add `is_branchable` and switch the gate**
+
+Add the field to `DocCollectionInfo`. In `check_release`'s `KeyScope::Document` arm, replace the direct `check_doc_access` call with a read-rule check. Since KMS depends on `acp` (not `db`), inline the same algorithm using the `DocCollectionInfo` (it has policy_id/resource_name/collection_id/is_branchable):
+
+```rust
+let actor_id: acp::Identity = actor.into();
+let read_allowed = kms_check_doc_read_access(
+    self.doc_acp.as_ref(), &actor_id, &info, doc_id,
+).await.map_err(classify_acp_error)?;
+Ok(if read_allowed { PolicyDecision::Allow } else { PolicyDecision::Deny })
+```
+
+Add a small helper in `crates/kms/src/policy.rs`:
+
+```rust
+/// KMS-local read rule mirroring db::collection_acp::check_doc_read_access,
+/// expressed over DocCollectionInfo (kms cannot depend on the db crate).
+pub async fn kms_check_doc_read_access(
+    acp: &dyn acp::DocumentACP,
+    identity: &acp::Identity,
+    info: &DocCollectionInfo,
+    doc_id: &str,
+) -> acp::Result<bool> {
+    let object = |id: &str| async move {
+        if !acp.is_doc_registered(&info.policy_id, &info.resource_name, id).await? {
+            return Ok::<(bool, bool), acp::Error>((true, false));
+        }
+        let has = acp.check_doc_access(
+            identity, acp::DocumentPermission::Read,
+            &info.policy_id, &info.resource_name, id,
+        ).await?;
+        Ok((has, true))
+    };
+    if !doc_id.is_empty() {
+        let (has, explicit) = object(doc_id).await?;
+        if explicit && has { return Ok(true); }
+        if !has { return Ok(false); }
+    }
+    if info.is_branchable {
+        let (has, _) = object(&info.collection_id).await?;
+        if !has { return Ok(false); }
+    }
+    Ok(true)
+}
+```
+
+(No node-identity shortcut here: KMS release already resolves node-level access via `check_node_release`; the document arm matches Go's `pubsub.go` which calls `CheckDocReadAccess` without a separate node bypass.)
+
+- [ ] **Step 4: Update the producer**
+
+Grep `impl DocCollectionLookup` (embedded-node layer) and populate `is_branchable` from the resolved `CollectionVersion.is_branchable`.
+
+Run: `cargo build -p kms -p embedded`
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p kms`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/kms crates/embedded
+git commit -m "feat(acp): A3 KMS key-gate honors branchable read rule"
+```
+
+---
+
+## Task 8: A3 — `PeerIdentityResolver` abstraction
+
+**Files:**
+- Create: `crates/p2p/src/peer_identity.rs`
+- Modify: `crates/p2p/src/lib.rs` (module + re-export), `crates/p2p/src/host/handle.rs` (impl for libp2p), Iroh endpoint (impl/wiring)
+- Test: `crates/p2p/src/peer_identity.rs` unit test with a fake
+
+**Interfaces:**
+- Produces:
+  ```rust
+  #[async_trait]
+  pub trait PeerIdentityResolver: Send + Sync {
+      /// Resolve a transport peer id to a verified DefraDB DID, or None when
+      /// unknown/unverifiable. Callers treat None as Anonymous (Go parity).
+      async fn resolve(&self, peer_id: &PeerId) -> Option<identity::Did>;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn libp2p_resolver_delegates_to_handle() {
+    // fake handle returning Some(did) for a known peer, None otherwise
+    let resolver = make_test_resolver();
+    assert_eq!(resolver.resolve(&known_peer()).await, Some(known_did()));
+    assert_eq!(resolver.resolve(&unknown_peer()).await, None);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p p2p peer_identity`
+Expected: FAIL — trait not found.
+
+- [ ] **Step 3: Define the trait + libp2p impl**
+
+In `crates/p2p/src/peer_identity.rs` define the trait. Implement it for a wrapper holding a `P2PHostHandle`, delegating to `get_peer_identity(peer_id).await.ok().flatten()`. For Iroh, implement a wrapper over the Iroh endpoint's identity mechanism (or, if Iroh shares the `peer_identities` cache, expose an equivalent `get_peer_identity` and delegate). Add `pub mod peer_identity;` + re-export in `lib.rs`.
+
+- [ ] **Step 4: Run test**
+
+Run: `cargo test -p p2p peer_identity`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/p2p/src/peer_identity.rs crates/p2p/src/lib.rs crates/p2p/src/host crates/p2p/src/iroh
+git commit -m "feat(p2p): add transport-agnostic PeerIdentityResolver"
+```
+
+---
+
+## Task 9: A3 — Bitswap serve filter per-doc gate
+
+**Files:**
+- Modify: `crates/p2p/src/bitswap/filter.rs:62-145` (`check_access`, `make_peer_block_access_filter`)
+- Test: `crates/p2p/tests/bitswap_acp_filter_tests.rs`
+
+**Interfaces:**
+- Consumes: `PeerIdentityResolver` (Task 8), `check_doc_read_access` (Task 2), a way to resolve a block's `schema_version_id → CollectionVersion` + its docID(s). The filter must be given a `ReadAccessContext` (DB/ACP handle) at construction. Define:
+  ```rust
+  #[async_trait]
+  pub trait BlockReadGate: Send + Sync {
+      // Resolve the block's collection + doc id(s) and apply check_doc_read_access
+      // for `identity`. Empty doc id => collection-level. Returns true if ANY owner doc grants.
+      async fn may_read_block(&self, identity: &acp::Identity, block: &DefraBlock) -> bool;
+  }
+  ```
+  implemented in the db/embedded layer (it has DB + ACP). The filter holds `Arc<dyn BlockReadGate>` + `Arc<dyn PeerIdentityResolver>`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/p2p/tests/bitswap_acp_filter_tests.rs` add: non-replicator peer whose resolved DID lacks collection access requests a branchable data block → filter denies; replicator peer → allowed (passthrough); non-replicator with no resolvable DID requesting a public/unregistered block → allowed (Anonymous, Go parity); requesting a registered/private block → denied.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p p2p --test bitswap_acp_filter_tests`
+Expected: FAIL — filter has no read gate; non-replicator currently always denied.
+
+- [ ] **Step 3: Extend `check_access`**
+
+After the existing definition/lens/signature passthroughs and the replicator check, when the peer is NOT a replicator, resolve identity and apply the read gate instead of returning false:
+
+```rust
+// (unchanged) signature / definition / lens passthroughs ...
+let peer_str = peer_id.to_string();
+if registry.is_filtered_replicator(collection_id, &peer_str) { /* unchanged deny */ }
+if registry.is_replicator(collection_id, &peer_str) {
+    return true; // replicator passthrough (Go parity)
+}
+// Non-replicator: Go's hasAccess falls through to a per-doc read check using the
+// requesting peer's resolved identity. Unresolved DID => Anonymous (Go parity).
+let identity = match resolver.resolve(peer_id).await {
+    Some(did) => acp::Identity::Authenticated(did),
+    None => acp::Identity::Anonymous,
+};
+return read_gate.may_read_block(&identity, &defra_block).await;
+```
+
+Thread `resolver: Arc<dyn PeerIdentityResolver>` and `read_gate: Arc<dyn BlockReadGate>` through `make_peer_block_access_filter` and the closure (clone into the async block). Update `behaviour.rs:292` construction to pass them (the embedded/node assembly provides the `BlockReadGate` impl).
+
+- [ ] **Step 4: Implement `BlockReadGate` in the db/embedded layer**
+
+Where the filter is constructed (node assembly), build a gate that: decodes the block (already decoded by the filter — pass the `DefraBlock`), resolves `schema_version_id → CollectionVersion`, computes the block's docID(s) (collection-level => `""`), and returns true if `check_doc_read_access` grants for any. Reuse the existing block→docID resolution used elsewhere on the merge path.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p p2p --test bitswap_acp_filter_tests`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/p2p/src/bitswap crates/p2p/src/behaviour.rs crates/p2p/tests/bitswap_acp_filter_tests.rs
+git commit -m "feat(p2p): A3 bitswap serve filter enforces branchable read rule"
+```
+
+---
+
+## Task 10: A3 — CAR handler per-block serve filtering
+
+**Files:**
+- Modify: `crates/p2p/src/sync/coordinator/event_handler/car.rs:83-179` (`handle_car_fetch_request`)
+- Test: `crates/p2p/src/sync/coordinator/access_tests.rs` (or a new CAR test module)
+
+**Interfaces:**
+- Consumes: `PeerIdentityResolver`, `BlockReadGate` (Task 9), the existing `collected.blocks` Vec.
+
+**Context:** `check_car_fetch_access` gates only root collection access, then `collect_dag_blocks`/`collect_exact_blocks` returns the whole DAG. Add a per-block filter pass over `blocks` before encoding, for **both** recursive and exact fetches, when the peer is not a replicator.
+
+- [ ] **Step 1: Write the failing test**
+
+A branchable collection with a private doc; a connected-but-non-replicator peer issues a CAR fetch for the DAG → response must exclude blocks the peer can't read; a replicator peer → full DAG.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p p2p car_fetch`
+Expected: FAIL — CAR serves the full DAG regardless of per-block read access.
+
+- [ ] **Step 3: Filter response blocks**
+
+After `let blocks = collected.blocks;` (car.rs:133) and before the empty check, when the peer is not a replicator for the collection, resolve identity once and retain only readable blocks:
+
+```rust
+let blocks = if self.access.replicators.is_any_replicator(peer_id.as_str()) {
+    blocks // replicator passthrough
+} else {
+    let identity = match self.peer_identity_resolver.resolve(&peer_id).await {
+        Some(did) => acp::Identity::Authenticated(did),
+        None => acp::Identity::Anonymous,
+    };
+    let mut kept = Vec::with_capacity(blocks.len());
+    for (cid, data) in blocks {
+        let allow = match DefraBlock::from_dag_cbor(&data) {
+            Ok(b) => self.read_gate.may_read_block(&identity, &b).await,
+            Err(_) => true, // non-CRDT (signature/lens) — passthrough, matches bitswap
+        };
+        if allow { kept.push((cid, data)); }
+    }
+    kept
+};
+```
+
+Hold `peer_identity_resolver` + `read_gate` on the `SyncCoordinator` (inject at construction alongside the existing `authorizer`).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p p2p car_fetch`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/p2p/src/sync/coordinator
+git commit -m "feat(p2p): A3 CAR handler filters served blocks by read access"
+```
+
+---
+
+## Task 11: CID-integrity regression coverage (already implemented)
+
+**Files:**
+- Test: `crates/p2p/src/sync/manager/process/pushlog.rs` tests + CAR test module
+
+**Context:** `verify_block_cid` already rejects content/CID mismatch (pushlog.rs:235; CAR handler). No production change — add explicit regression tests so the `ErrBlockCIDMismatch` analog can never silently regress.
+
+- [ ] **Step 1: Write the test**
+
+Pushlog: craft a `PushLogMessage` whose `block` bytes do not hash to `cid` → assert the handler returns the CID-verify error and does not store the block. CAR: a CAR response containing a block whose bytes mismatch its CID → assert it is rejected on ingest.
+
+- [ ] **Step 2: Run test to verify behavior**
+
+Run: `cargo test -p p2p verify_block_cid`
+Expected: PASS (confirms existing behavior).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/p2p/src/sync
+git commit -m "test(p2p): regression cover block CID-integrity on pushlog/CAR"
+```
+
+---
+
+## Task 12: Cross-implementation integration scenarios
+
+**Files:**
+- Modify: `tools/integration-test/tests/acp.rs` (`branchable_commits`, new `branchable_peer`)
+- Modify: `tools/integration-test/tests/p2p.rs` (cross-impl serve scenario) if the matrix harness lives there
+
+**Context:** Port Go #4990's `collection_commits_test.go` and `peer_test.go`. Run the matrix the harness supports: rust↔rust, go↔go, go↔rust.
+
+- [ ] **Step 1: Write the serve-boundary scenario**
+
+Two nodes; node A (owner) hosts a branchable `@policy` collection with a private doc; node B connects as a **non-replicator** and attempts to sync/fetch → B must NOT receive the private blocks; then grant B a reader relationship → B receives them. Add a variant where B is a **replicator** → B receives (passthrough).
+
+- [ ] **Step 2: Run rust↔rust**
+
+Run: `cargo test -p integration-test --test acp -- branchable_peer::`
+Expected: PASS.
+
+- [ ] **Step 3: Run go↔rust matrix**
+
+Run the harness with a Go binary as producer and Rust as consumer and vice-versa (per the harness's cross-impl switch; see `reference_go_parity_binary` — Go defradb at `GO_COMPAT_COMMIT` on PATH). Expected: identical withhold/serve behavior in both directions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/integration-test/tests
+git commit -m "test(acp): cross-impl branchable read + serve-boundary parity"
+```
+
+---
+
+## Task 13: Adversarial re-audit of the A3 serve boundary (gate before merge)
+
+**Files:** none (verification)
+
+**Context:** The serve gate is the private-data leak boundary. Before the PR merges, run a dedicated adversarial review (a Workflow) over the A3 diff (Tasks 8–10) + the merge handler, specifically hunting: a path that serves a private branchable block to a non-replicator without read access; an unresolved-DID path that grants more than Anonymous; a recursive-vs-exact CAR asymmetry; a transport (libp2p vs Iroh) that skips the gate; a block→docID resolution that misses collection-level blocks.
+
+- [ ] **Step 1: Run the existing P2P/encryption/SE/identity suites (regression gate from the spec's top risk)**
+
+Run:
+```bash
+cargo test -p integration-test --test p2p
+cargo test -p integration-test --test p2p_iroh
+cargo test -p integration-test --test encryption
+cargo test -p integration-test --test identity
+```
+Expected: PASS. Any regression here is a **blocker** → revisit serve-scope per the spec.
+
+- [ ] **Step 2: Adversarial review**
+
+Run a multi-agent review (ultracode Workflow) scoped to the A3 diff vs Go `3f627855` `hasAccess`/`trySelfHasAccess`. Resolve or explicitly accept every CONFIRMED/PLAUSIBLE finding.
+
+- [ ] **Step 3: Update PR body**
+
+Change the PR description from "A1 registration" to the full A1–A3 security feature; note the cross-impl matrix and the adversarial audit outcome.
+
+---
+
+## Self-Review
+
+**Spec coverage:** core rule (Tasks 1–2,4) ✔; node_did (Task 3) ✔; version→collection_id (Tasks 5,6,9,10 resolve via `get_collection_by_version_id`/`collections_map`) ✔; commits query (5) ✔; signature verify (6) ✔; KMS is_branchable (7) ✔; peer-DID resolver (8) ✔; bitswap serve (9) ✔; CAR serve (10) ✔; unresolved-DID→Anonymous (9,10) ✔; replicator passthrough (9,10) ✔; pushlog CID already-done (11) ✔; cross-impl tests (12) ✔; top-risk regression gate + adversarial audit (13) ✔.
+
+**Placeholders:** none — every code step shows real code; the two block→docID/`BlockReadGate` impls (Tasks 9 step 4) reference the existing merge-path resolution rather than re-deriving it, which is concrete guidance, not a placeholder.
+
+**Type consistency:** `check_doc_read_access(acp, identity, &CollectionVersion, doc_id, node_identity)` used identically in Tasks 2/6; overlay variant `check_doc_read_access_overlay` with the same shape in Tasks 4/5; `DocAccess { has_access, explicit }` consistent; `PeerIdentityResolver::resolve -> Option<Did>` consistent across Tasks 8/9/10; `DocCollectionInfo.is_branchable` added once (7) and consumed in `kms_check_doc_read_access`.

--- a/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
+++ b/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
@@ -4,431 +4,266 @@
 
 **Goal:** Enforce branchable-collection ACP on local read paths (A2) and the P2P serve boundary (A3), consuming the A1 collection-object registration, at full parity with Go v1.0.0 `3f627855`.
 
-**Architecture:** One new rule, `check_doc_read_access`, with an internal `DocAccess { has_access, explicit }` verdict, defined once over an `ObjectAccessChecker` capability (overlay + direct impls) and wired into five sites: commits query, signature verify, KMS key-gate, Bitswap serve filter, CAR serve handler. A transport-agnostic `PeerIdentityResolver` supplies the requesting peer's DID at the serve boundary.
+**Architecture:** ONE algorithm — `acp::read_access::check_doc_read_access` — defined over an `ObjectAccessChecker` trait, with two checker impls: `DirectChecker` (in `acp`, used by signature-verify, KMS, and the P2P serve gate) and `OverlayChecker` (in `query-plan`, txn-aware, used by the commits query). It lives in the `acp` crate because `db`, `query-plan`, and `kms` all depend on `acp` (none can depend on `db`). The rule takes primitive params (`policy_id`, `resource_name`, `collection_id`, `is_branchable`, `doc_id`) so every caller — including KMS, which only has a `DocCollectionInfo` — can use it. A transport-agnostic `PeerIdentityResolver` supplies the requesting peer's DID at the serve boundary: libp2p via the existing token protocol, Iroh via direct `NodeId → did:key` derivation.
 
 **Tech Stack:** Rust, async-trait, tokio; crates `acp`, `db`, `query`, `query-plan`, `kms`, `p2p`; integration harness in `tools/integration-test`.
 
 ## Global Constraints
 
 - Parity oracle: Go v1.0.0 commit `3f627855`. Behavior must match unless a deviation is explicitly recorded in the spec.
-- ACP objects are keyed by the **stable `collection_id`**, never `schema_version_id`. Every site resolves `schema_version_id → CollectionVersion` first.
+- ACP objects are keyed by the **stable `collection_id`**, never `schema_version_id`. Every site resolves `schema_version_id → CollectionVersion` first and uses `collection.collection_id` + `collection.is_branchable`.
 - Spec: `docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md`.
-- `cargo clippy --all -- -D warnings` must stay clean; `cargo fmt --all` applied before each commit.
-- Unresolved peer DID at the serve boundary → treat as `Identity::Anonymous` (Go parity), not blanket-deny.
-- Replicator passthrough at the serve boundary is preserved (registered replicators served without per-doc check).
-- Do NOT flip the `strict_replicated_doc_access` merge default; merge gating stays as-is.
-- Commit after each task. Keep A2 and A3 in separate commits. The A3 serve-path work requires an adversarial re-audit (Task 13) before the PR merges.
+- `cargo clippy --all -- -D warnings` clean; `cargo fmt --all` applied before each commit.
+- Unresolved peer DID at the serve boundary → `Identity::Anonymous` (Go parity), not blanket-deny.
+- Replicator passthrough is **per-block, keyed on the block's stable `collection_id`** — never `is_any_replicator` and never the raw `schema_version_id`.
+- Do NOT flip the `strict_replicated_doc_access` merge default.
+- A2 and A3 in separate commits. The A3 serve-path work requires the Task 13 adversarial re-audit before the PR merges.
 
 ---
 
 ## File Structure
 
-- `crates/acp/src/error.rs` — (existing) reused error variants.
-- `crates/db/src/collection_acp.rs` — home of `DocAccess`, `check_doc_access_ext`, `check_doc_read_access`, `ObjectAccessChecker` + direct impl. **Primary new logic.**
-- `crates/db/tests/collection_acp_tests.rs` — unit truth-table for the rule.
-- `crates/query-plan/src/txn/context.rs` — overlay `ObjectAccessChecker` impl; thread `node_did`.
-- `crates/query/src/runner/commits.rs` — A2 commits gating.
+- `crates/acp/src/read_access.rs` (new) — `DocAccess`, `ObjectAccessChecker` trait, `DirectChecker`, `check_doc_read_access`. **The one algorithm.**
+- `crates/acp/src/lib.rs` — module + re-exports.
+- `crates/acp/tests/read_access_tests.rs` (new) — truth-table over `DirectChecker`.
+- `crates/query-plan/src/txn/read_access.rs` (new) — `OverlayChecker: ObjectAccessChecker`.
+- `crates/query-plan/src/txn/context.rs` — thread `node_did` into `check_doc_access_with_overlay`.
+- `crates/query/src/runner/commits.rs` — A2 commits gating; `node_did` field on the runner.
 - `crates/db/src/block_verify.rs` — A2 signature-verify gating.
-- `crates/kms/src/policy.rs` — add `is_branchable` to `DocCollectionInfo`.
-- `crates/kms/src/nac_dac_policy.rs` — KMS gate uses the read rule.
-- `crates/p2p/src/transport.rs` + `crates/p2p/src/peer_identity.rs` (new) — `PeerIdentityResolver`.
-- `crates/p2p/src/bitswap/filter.rs` — Bitswap per-doc serve gate.
+- `crates/kms/src/policy.rs` — `is_branchable` on `DocCollectionInfo`; KMS gate calls `acp::check_doc_read_access`.
+- `crates/kms/src/nac_dac_policy.rs` — wire the rule into `check_release`.
+- `crates/p2p/src/peer_identity.rs` (new) — `PeerIdentityResolver` (libp2p + Iroh impls).
+- `crates/p2p/src/bitswap/{filter.rs,read_gate.rs}` — late-bound `BlockReadGate` + per-block serve gate.
 - `crates/p2p/src/sync/coordinator/event_handler/car.rs` — CAR per-block serve filtering.
-- `tools/integration-test/tests/acp.rs` (+ submodules) — cross-impl integration scenarios.
+- `tools/integration-test/tests/acp.rs` — cross-impl scenarios.
 
 ---
 
-## Task 1: `DocAccess` verdict + explicit-reporting single-object check
+## Task 1: Core rule in the `acp` crate (`ObjectAccessChecker` + `DirectChecker` + `check_doc_read_access`)
 
 **Files:**
-- Modify: `crates/db/src/collection_acp.rs` (add after `check_doc_permission`, ~line 84)
-- Test: `crates/db/tests/collection_acp_tests.rs`
+- Create: `crates/acp/src/read_access.rs`
+- Modify: `crates/acp/src/lib.rs`
+- Test: `crates/acp/tests/read_access_tests.rs`
 
 **Interfaces:**
-- Consumes: `acp::{DocumentACP, DocumentPermission, Identity}`, `identity::Did`, `schema::CollectionVersion`, existing `defra_core::dac_bypass::get_dac_bypass()`.
+- Consumes: `crate::{DocumentACP, DocumentPermission, Identity}`, `identity::Did`, `defra_core::dac_bypass::get_dac_bypass`.
 - Produces:
   ```rust
   pub struct DocAccess { pub has_access: bool, pub explicit: bool }
-  // Single-object check that also reports whether the verdict was explicit.
-  pub async fn check_object_access(
-      acp: &dyn DocumentACP,
-      identity: &Identity,
-      permission: DocumentPermission,
+
+  #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+  #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+  pub trait ObjectAccessChecker {
+      /// Verdict for ONE object (docID or collection_id) under (policy_id, resource_name).
+      async fn object_access(&self, policy_id: &str, resource_name: &str, object_id: &str)
+          -> crate::Result<DocAccess>;
+  }
+
+  pub struct DirectChecker<'a> {
+      pub acp: &'a dyn DocumentACP,
+      pub identity: &'a Identity,
+      pub node_did: Option<&'a Did>,
+  }
+
+  /// The branchable read rule. doc_id == "" means a collection-level commit.
+  pub async fn check_doc_read_access(
+      checker: &dyn ObjectAccessChecker,
       policy_id: &str,
       resource_name: &str,
-      object_id: &str,
-      node_identity: Option<&Did>,
-  ) -> acp::Result<DocAccess>;
+      collection_id: &str,
+      is_branchable: bool,
+      doc_id: &str,
+  ) -> crate::Result<bool>;
   ```
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing truth-table tests**
 
-In `crates/db/tests/collection_acp_tests.rs` add:
-
-```rust
-use db::collection_acp::{check_object_access, DocAccess};
-
-#[tokio::test]
-async fn check_object_access_reports_explicit() {
-    let store = std::sync::Arc::new(MemoryAcpStore::new());
-    let acp = LocalDocumentACP::new(store);
-    let owner = test_did();
-    let policy = ("polid".to_string(), "users".to_string());
-
-    // Unregistered object => public, not explicit.
-    let pub_access = check_object_access(
-        &acp, &Identity::Anonymous, DocumentPermission::Read,
-        &policy.0, &policy.1, "objX", None,
-    ).await.unwrap();
-    assert_eq!(pub_access.has_access, true);
-    assert_eq!(pub_access.explicit, false);
-
-    // Registered to owner => owner has explicit access.
-    acp.register_doc_object(&owner, &policy.0, &policy.1, "objX").await.unwrap();
-    let owner_access = check_object_access(
-        &acp, &Identity::Authenticated(owner.clone()), DocumentPermission::Read,
-        &policy.0, &policy.1, "objX", None,
-    ).await.unwrap();
-    assert_eq!(owner_access.has_access, true);
-    assert_eq!(owner_access.explicit, true);
-
-    // Anonymous against a registered object => explicit denial.
-    let anon = check_object_access(
-        &acp, &Identity::Anonymous, DocumentPermission::Read,
-        &policy.0, &policy.1, "objX", None,
-    ).await.unwrap();
-    assert_eq!(anon.has_access, false);
-    assert_eq!(anon.explicit, true);
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test -p db --test collection_acp_tests check_object_access_reports_explicit`
-Expected: FAIL — `check_object_access` / `DocAccess` not found.
-
-- [ ] **Step 3: Implement `DocAccess` + `check_object_access`**
-
-In `crates/db/src/collection_acp.rs`:
+In `crates/acp/tests/read_access_tests.rs` (use `LocalDocumentACP` + an in-memory store, mirroring existing acp tests):
 
 ```rust
-/// Outcome of a single-object access check: the verdict plus whether it was
-/// decided by something specific to the actor (an ACP registration or a
-/// DAC-bypass / node-identity grant) vs. unrestricted-for-everyone access.
-/// Mirrors Go `internal/db/acp/check.go::docAccess`.
-#[derive(Debug, Clone, Copy)]
-pub struct DocAccess {
-    pub has_access: bool,
-    pub explicit: bool,
-}
+use acp::read_access::{check_doc_read_access, DirectChecker};
+use acp::{DocumentACP, Identity};
 
-/// Single-object access check that also reports `explicit`. Used as the
-/// building block of [`check_doc_read_access`]. `policy_id`/`resource_name`
-/// come from the collection's policy; `object_id` is a docID or a collection_id.
-pub async fn check_object_access(
-    acp: &dyn DocumentACP,
-    identity: &Identity,
-    permission: DocumentPermission,
-    policy_id: &str,
-    resource_name: &str,
-    object_id: &str,
-    node_identity: Option<&Did>,
-) -> acp::Result<DocAccess> {
-    if defra_core::dac_bypass::get_dac_bypass() {
-        return Ok(DocAccess { has_access: true, explicit: true });
-    }
-    if let (Some(node_did), Identity::Authenticated(req_did)) = (node_identity, identity) {
-        if node_did == req_did {
-            return Ok(DocAccess { has_access: true, explicit: true });
-        }
-    }
-    if !acp.is_doc_registered(policy_id, resource_name, object_id).await? {
-        return Ok(DocAccess { has_access: true, explicit: false });
-    }
-    let has_access = acp
-        .check_doc_access(identity, permission, policy_id, resource_name, object_id)
-        .await?;
-    Ok(DocAccess { has_access, explicit: true })
-}
-```
-
-Ensure `pub mod collection_acp;` re-exports are present (the crate already exposes `check_doc_permission`; add `DocAccess` and the new fn to the same `pub use` if one exists in `crates/db/src/lib.rs`).
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `cargo test -p db --test collection_acp_tests check_object_access_reports_explicit`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-cargo fmt --all
-git add crates/db/src/collection_acp.rs crates/db/src/lib.rs crates/db/tests/collection_acp_tests.rs
-git commit -m "feat(acp): add DocAccess + explicit-reporting object access check"
-```
-
----
-
-## Task 2: `check_doc_read_access` rule + direct backend
-
-**Files:**
-- Modify: `crates/db/src/collection_acp.rs`
-- Test: `crates/db/tests/collection_acp_tests.rs`
-
-**Interfaces:**
-- Consumes: `check_object_access`, `DocAccess` (Task 1), `schema::CollectionVersion`.
-- Produces:
-  ```rust
-  pub async fn check_doc_read_access(
-      acp: &dyn DocumentACP,
-      identity: &Identity,
-      collection: &CollectionVersion,
-      doc_id: &str,                 // "" for a collection-level commit
-      node_identity: Option<&Did>,
-  ) -> acp::Result<bool>;
-  ```
-
-- [ ] **Step 1: Write the failing tests** (truth table)
-
-In `crates/db/tests/collection_acp_tests.rs`:
-
-```rust
-use db::collection_acp::check_doc_read_access;
-
-#[tokio::test]
-async fn read_access_branchable_public_doc_requires_collection() {
-    let acp = LocalDocumentACP::new(std::sync::Arc::new(MemoryAcpStore::new()));
-    let owner = test_did();
-    let stranger = test_did2();
-    let col = branchable_collection_with_policy(); // is_branchable + policy
-    let policy = col.policy.clone().unwrap();
-
-    // Register the collection object to owner; leave the doc public (unregistered).
-    acp.register_doc_object(&owner, &policy.id, &policy.resource_name, &col.collection_id)
-        .await.unwrap();
-
-    // Owner: public doc + collection access => GRANT.
-    assert!(check_doc_read_access(
-        &acp, &Identity::Authenticated(owner.clone()), &col, "docA", None,
-    ).await.unwrap());
-
-    // Stranger: public doc but NO collection access => DENY (branchable gates public docs).
-    assert!(!check_doc_read_access(
-        &acp, &Identity::Authenticated(stranger.clone()), &col, "docA", None,
-    ).await.unwrap());
-
-    // Collection-level commit (empty doc_id): gated purely on collection object.
-    assert!(check_doc_read_access(
-        &acp, &Identity::Authenticated(owner), &col, "", None,
-    ).await.unwrap());
-    assert!(!check_doc_read_access(
-        &acp, &Identity::Authenticated(stranger), &col, "", None,
-    ).await.unwrap());
+async fn rule(acp: &dyn DocumentACP, ident: &Identity, branchable: bool, doc: &str) -> bool {
+    let checker = DirectChecker { acp, identity: ident, node_did: None };
+    check_doc_read_access(&checker, "pol", "users", "COL", branchable, doc).await.unwrap()
 }
 
 #[tokio::test]
-async fn read_access_explicit_doc_grant_overrides_collection() {
-    let acp = LocalDocumentACP::new(std::sync::Arc::new(MemoryAcpStore::new()));
-    let owner = test_did();
-    let reader = test_did2();
-    let col = branchable_collection_with_policy();
-    let policy = col.policy.clone().unwrap();
-
-    // Collection owned by owner (reader has no collection access).
-    acp.register_doc_object(&owner, &policy.id, &policy.resource_name, &col.collection_id)
-        .await.unwrap();
-    // Doc registered to reader explicitly (reader IS the doc owner).
-    acp.register_doc_object(&reader, &policy.id, &policy.resource_name, "docShared")
-        .await.unwrap();
-
-    // Reader has an explicit grant on docShared => GRANT despite no collection access.
-    assert!(check_doc_read_access(
-        &acp, &Identity::Authenticated(reader), &col, "docShared", None,
-    ).await.unwrap());
+async fn branchable_public_doc_requires_collection() {
+    let acp = local_acp();
+    let owner = did_a(); let stranger = did_b();
+    acp.register_doc_object(&owner, "pol", "users", "COL").await.unwrap(); // collection -> owner
+    // public doc + collection access => grant; + no collection access => deny
+    assert!(rule(&acp, &Identity::Authenticated(owner.clone()), true, "docA").await);
+    assert!(!rule(&acp, &Identity::Authenticated(stranger.clone()), true, "docA").await);
+    // collection-level commit ("" doc): purely the collection object
+    assert!(rule(&acp, &Identity::Authenticated(owner), true, "").await);
+    assert!(!rule(&acp, &Identity::Authenticated(stranger), true, "").await);
 }
 
 #[tokio::test]
-async fn read_access_nonbranchable_reduces_to_doc() {
-    let acp = LocalDocumentACP::new(std::sync::Arc::new(MemoryAcpStore::new()));
-    let owner = test_did();
-    let stranger = test_did2();
-    let col = collection_with_policy(); // permissioned, NOT branchable
-    let policy = col.policy.clone().unwrap();
-    acp.register_doc_object(&owner, &policy.id, &policy.resource_name, "docA")
-        .await.unwrap();
+async fn explicit_doc_grant_overrides_collection() {
+    let acp = local_acp();
+    let owner = did_a(); let reader = did_b();
+    acp.register_doc_object(&owner, "pol", "users", "COL").await.unwrap();   // collection -> owner
+    acp.register_doc_object(&reader, "pol", "users", "docS").await.unwrap(); // doc -> reader
+    assert!(rule(&acp, &Identity::Authenticated(reader), true, "docS").await); // grant despite no col access
+}
 
-    assert!(check_doc_read_access(
-        &acp, &Identity::Authenticated(owner), &col, "docA", None,
-    ).await.unwrap());
-    assert!(!check_doc_read_access(
-        &acp, &Identity::Authenticated(stranger), &col, "docA", None,
-    ).await.unwrap());
+#[tokio::test]
+async fn nonbranchable_reduces_to_doc() {
+    let acp = local_acp();
+    let owner = did_a(); let stranger = did_b();
+    acp.register_doc_object(&owner, "pol", "users", "docA").await.unwrap();
+    assert!(rule(&acp, &Identity::Authenticated(owner), false, "docA").await);
+    assert!(!rule(&acp, &Identity::Authenticated(stranger), false, "docA").await);
 }
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
 
-Run: `cargo test -p db --test collection_acp_tests read_access_`
-Expected: FAIL — `check_doc_read_access` not found.
+Run: `cargo test -p acp --test read_access_tests`
+Expected: FAIL — module `read_access` not found.
 
-- [ ] **Step 3: Implement the rule**
+- [ ] **Step 3: Implement the rule + DirectChecker**
 
-In `crates/db/src/collection_acp.rs`:
+In `crates/acp/src/read_access.rs`:
 
 ```rust
-/// Reports whether `identity` may read the object identified by `doc_id` on
-/// `collection`. Gates the object's entire commit DAG, not just current field
-/// values. `doc_id` is "" for a collection-level commit (branchable only).
-///
-/// GRANT if EITHER an explicit grant on the document, OR read access to every
-/// object the document relates to: the document itself and — for a branchable
-/// collection — the collection object (keyed by collection_id). Explicit denial
-/// on the document always denies. Mirrors Go
-/// `internal/db/acp/check.go::CheckDocReadAccessWithIdentityFunc`.
+use async_trait::async_trait;
+use identity::Did;
+use crate::{DocumentACP, DocumentPermission, Identity, Result};
+
+#[derive(Debug, Clone, Copy)]
+pub struct DocAccess { pub has_access: bool, pub explicit: bool }
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub trait ObjectAccessChecker {
+    async fn object_access(&self, policy_id: &str, resource_name: &str, object_id: &str)
+        -> Result<DocAccess>;
+}
+
+pub struct DirectChecker<'a> {
+    pub acp: &'a dyn DocumentACP,
+    pub identity: &'a Identity,
+    pub node_did: Option<&'a Did>,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl ObjectAccessChecker for DirectChecker<'_> {
+    async fn object_access(&self, policy_id: &str, resource_name: &str, object_id: &str)
+        -> Result<DocAccess> {
+        if defra_core::dac_bypass::get_dac_bypass() {
+            return Ok(DocAccess { has_access: true, explicit: true });
+        }
+        if let (Some(node), Identity::Authenticated(req)) = (self.node_did, self.identity) {
+            if node == req { return Ok(DocAccess { has_access: true, explicit: true }); }
+        }
+        if !self.acp.is_doc_registered(policy_id, resource_name, object_id).await? {
+            return Ok(DocAccess { has_access: true, explicit: false });
+        }
+        let has = self.acp
+            .check_doc_access(self.identity, DocumentPermission::Read, policy_id, resource_name, object_id)
+            .await?;
+        Ok(DocAccess { has_access: has, explicit: true })
+    }
+}
+
+/// Branchable read rule. Mirrors Go internal/db/acp/check.go::CheckDocReadAccessWithIdentityFunc.
 pub async fn check_doc_read_access(
-    acp: &dyn DocumentACP,
-    identity: &Identity,
-    collection: &CollectionVersion,
+    checker: &dyn ObjectAccessChecker,
+    policy_id: &str,
+    resource_name: &str,
+    collection_id: &str,
+    is_branchable: bool,
     doc_id: &str,
-    node_identity: Option<&Did>,
-) -> acp::Result<bool> {
-    // Unpermissioned collection => unrestricted (matches check_object_access's
-    // public path, but short-circuit here to avoid needing a policy below).
-    let Some(policy) = &collection.policy else {
-        return Ok(true);
-    };
-
-    let mut doc_accessible = true;
+) -> Result<bool> {
     if !doc_id.is_empty() {
-        let access = check_object_access(
-            acp, identity, DocumentPermission::Read,
-            &policy.id, &policy.resource_name, doc_id, node_identity,
-        ).await?;
-        if access.explicit && access.has_access {
-            return Ok(true); // explicit grant on the document is sufficient
-        }
-        if !access.has_access {
-            return Ok(false); // explicit denial on the document always wins
-        }
-        doc_accessible = access.has_access;
+        let a = checker.object_access(policy_id, resource_name, doc_id).await?;
+        if a.explicit && a.has_access { return Ok(true); }   // explicit doc grant wins
+        if !a.has_access { return Ok(false); }               // explicit doc denial wins
     }
-    if !doc_accessible {
-        return Ok(false);
-    }
-
-    if collection.is_branchable {
-        let access = check_object_access(
-            acp, identity, DocumentPermission::Read,
-            &policy.id, &policy.resource_name, &collection.collection_id, node_identity,
-        ).await?;
-        if !access.has_access {
-            return Ok(false);
-        }
+    if is_branchable {
+        let a = checker.object_access(policy_id, resource_name, collection_id).await?;
+        if !a.has_access { return Ok(false); }
     }
     Ok(true)
 }
 ```
 
+Add `pub mod read_access;` to `crates/acp/src/lib.rs` and re-export `read_access::{check_doc_read_access, DirectChecker, ObjectAccessChecker, DocAccess}`.
+
+Note: callers with an unpermissioned collection must skip the rule (no `policy_id`); the rule assumes a policy exists. Each call site already branches on `collection.policy.is_some()`.
+
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p db --test collection_acp_tests read_access_`
+Run: `cargo test -p acp --test read_access_tests`
 Expected: PASS (3 tests).
 
 - [ ] **Step 5: Commit**
 
 ```bash
 cargo fmt --all
-git add crates/db/src/collection_acp.rs crates/db/tests/collection_acp_tests.rs
-git commit -m "feat(acp): add check_doc_read_access branchable read rule"
+git add crates/acp/src/read_access.rs crates/acp/src/lib.rs crates/acp/tests/read_access_tests.rs
+git commit -m "feat(acp): branchable read rule (check_doc_read_access + DirectChecker)"
 ```
 
 ---
 
-## Task 3: Thread `node_did` into the overlay access check
+## Task 2: Thread `node_did` into the overlay access check
 
 **Files:**
-- Modify: `crates/query-plan/src/txn/context.rs:328` (`check_doc_access_with_overlay`)
-- Modify: call sites in `crates/query-plan/src/plan/permission_filter.rs` and `crates/query/src/runner/commits.rs`
+- Modify: `crates/query-plan/src/txn/context.rs:328` (`check_doc_access_with_overlay`) + internal recursive calls (448/463/491)
+- Modify: callers in `crates/query-plan/src/plan/permission_filter.rs` and elsewhere
 - Test: `crates/query-plan/tests/cross_object_read_path.rs`
 
 **Interfaces:**
-- Produces (changed signature):
-  ```rust
-  pub async fn check_doc_access_with_overlay(
-      acp: &dyn DocumentACP,
-      identity: &Identity,
-      permission: DocumentPermission,
-      policy_id: &str,
-      resource_name: &str,
-      doc_id: &str,
-      node_did: Option<&Did>,        // NEW trailing param
-  ) -> AcpResult<bool>;
-  ```
+- Produces (changed signature): `check_doc_access_with_overlay(acp, identity, permission, policy_id, resource_name, doc_id, node_did: Option<&Did>)`.
 
 - [ ] **Step 1: Write the failing test**
-
-In `crates/query-plan/tests/cross_object_read_path.rs`, add a case asserting the node identity is granted access to a registered object it does not own:
 
 ```rust
 #[tokio::test]
 async fn overlay_grants_node_identity_full_access() {
-    // build acp with object registered to some other owner; node_did = NODE.
-    let (acp, node_did, other_owner) = setup_registered_object().await;
+    let (acp, node_did) = setup_registered_object_other_owner().await;
     let granted = query_plan::txn::check_doc_access_with_overlay(
-        acp.as_ref(),
-        &acp::Identity::Authenticated(node_did.clone()),
-        acp::DocumentPermission::Read,
-        "polid", "users", "objX",
-        Some(&node_did),
+        acp.as_ref(), &acp::Identity::Authenticated(node_did.clone()),
+        acp::DocumentPermission::Read, "pol", "users", "objX", Some(&node_did),
     ).await.unwrap();
-    assert!(granted, "node identity must get full access via the shortcut");
+    assert!(granted);
 }
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cargo test -p query-plan --test cross_object_read_path overlay_grants_node_identity_full_access`
-Expected: FAIL — arity mismatch (function takes 6 args) / not granted.
+Expected: FAIL — arity mismatch / not granted.
 
-- [ ] **Step 3: Add the `node_did` shortcut to the overlay check**
+- [ ] **Step 3: Add the `node_did` shortcut**
 
-In `crates/query-plan/src/txn/context.rs`, change the signature and add the shortcut before the projected-registration logic:
+In `crates/query-plan/src/txn/context.rs`, add the trailing `node_did: Option<&Did>` param and, at the top of the function body:
 
 ```rust
-pub async fn check_doc_access_with_overlay(
-    acp: &dyn DocumentACP,
-    identity: &Identity,
-    permission: DocumentPermission,
-    policy_id: &str,
-    resource_name: &str,
-    doc_id: &str,
-    node_did: Option<&Did>,
-) -> AcpResult<bool> {
-    if let (Some(node), Identity::Authenticated(req)) = (node_did, identity) {
-        if node == req {
-            return Ok(true);
-        }
-    }
-    if let Some(mutations) = current_deferred_acp_mutations() {
-        // ... unchanged projected-registration block ...
-    }
-    acp.check_doc_access(identity, permission, policy_id, resource_name, doc_id).await
+if let (Some(node), Identity::Authenticated(req)) = (node_did, identity) {
+    if node == req { return Ok(true); }
 }
 ```
 
-Update the internal recursive calls at context.rs:448/463/491 to pass `node_did` through.
+Pass `node_did` through the internal recursive calls at 448/463/491.
 
-- [ ] **Step 4: Update other call sites**
+- [ ] **Step 4: Fix all call sites**
 
-In `crates/query-plan/src/plan/permission_filter.rs` and any other caller, pass the node DID where available (thread it from the planner/registry; pass `None` where not yet plumbed — behavior unchanged there). Compile to find all call sites:
+Run: `cargo build -p query-plan -p query 2>&1 | grep -E "takes .* arguments|expected .* arguments"`
+Add the trailing `node_did` arg at each (pass `None` where not yet plumbed).
 
-Run: `cargo build -p query-plan -p query 2>&1 | grep "this function takes"`
-Fix each by adding the trailing `node_did` argument.
-
-- [ ] **Step 5: Run test + build to verify**
+- [ ] **Step 5: Verify**
 
 Run: `cargo test -p query-plan --test cross_object_read_path overlay_grants_node_identity_full_access && cargo build -p query`
-Expected: PASS + clean build.
+Expected: PASS + clean.
 
 - [ ] **Step 6: Commit**
 
@@ -440,94 +275,85 @@ git commit -m "feat(acp): thread node_did into overlay access check"
 
 ---
 
-## Task 4: Overlay `ObjectAccessChecker` + read rule over overlay
+## Task 3: `OverlayChecker` implementing `ObjectAccessChecker`
 
 **Files:**
 - Create: `crates/query-plan/src/txn/read_access.rs`
-- Modify: `crates/query-plan/src/txn/mod.rs` (re-export)
+- Modify: `crates/query-plan/src/txn/mod.rs`, `crates/query/src/txn/mod.rs` (re-export)
 - Test: `crates/query-plan/tests/cross_object_read_path.rs`
 
 **Interfaces:**
-- Consumes: `check_doc_access_with_overlay` (Task 3, with `node_did`), `is_doc_registered_with_overlay`.
+- Consumes: `acp::read_access::{check_doc_read_access, ObjectAccessChecker, DocAccess}`, `is_doc_registered_with_overlay`, `check_doc_access_with_overlay` (Task 2).
 - Produces:
   ```rust
-  // Overlay-aware read rule used by the commits query.
-  pub async fn check_doc_read_access_overlay(
-      acp: &dyn DocumentACP,
-      identity: &Identity,
-      collection: &CollectionVersion,
-      doc_id: &str,
-      node_did: Option<&Did>,
-  ) -> AcpResult<bool>;
+  pub struct OverlayChecker<'a> {
+      pub acp: &'a dyn DocumentACP,
+      pub identity: &'a Identity,
+      pub node_did: Option<&'a Did>,
+  }
+  // impl acp::read_access::ObjectAccessChecker for OverlayChecker<'_>
   ```
 
 - [ ] **Step 1: Write the failing test**
 
 ```rust
 #[tokio::test]
-async fn overlay_read_rule_gates_branchable_public_doc() {
-    let (acp, owner, stranger, col) = setup_branchable_registered_collection().await;
-    assert!(query_plan::txn::check_doc_read_access_overlay(
-        acp.as_ref(), &Identity::Authenticated(owner), &col, "docA", None,
-    ).await.unwrap());
-    assert!(!query_plan::txn::check_doc_read_access_overlay(
-        acp.as_ref(), &Identity::Authenticated(stranger), &col, "docA", None,
-    ).await.unwrap());
+async fn overlay_checker_gates_branchable_public_doc() {
+    let (acp, owner, stranger) = setup_branchable_registered_collection().await; // COL -> owner
+    let c_owner = query_plan::txn::OverlayChecker { acp: acp.as_ref(), identity: &owner_ident, node_did: None };
+    let c_other = query_plan::txn::OverlayChecker { acp: acp.as_ref(), identity: &stranger_ident, node_did: None };
+    assert!(acp::read_access::check_doc_read_access(&c_owner, "pol","users","COL",true,"docA").await.unwrap());
+    assert!(!acp::read_access::check_doc_read_access(&c_other, "pol","users","COL",true,"docA").await.unwrap());
 }
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cargo test -p query-plan --test cross_object_read_path overlay_read_rule_gates_branchable_public_doc`
-Expected: FAIL — function not found.
+Run: `cargo test -p query-plan --test cross_object_read_path overlay_checker_gates_branchable_public_doc`
+Expected: FAIL — `OverlayChecker` not found.
 
-- [ ] **Step 3: Implement the overlay read rule**
+- [ ] **Step 3: Implement `OverlayChecker`**
 
-In `crates/query-plan/src/txn/read_access.rs`, replicate the Task-2 algorithm but call the overlay-aware `is_doc_registered_with_overlay` + `check_doc_access_with_overlay` for each object. Factor the per-object verdict into a local helper mirroring `check_object_access`:
+In `crates/query-plan/src/txn/read_access.rs`:
 
 ```rust
-async fn object_access_overlay(
-    acp: &dyn DocumentACP, identity: &Identity, policy_id: &str, resource_name: &str,
-    object_id: &str, node_did: Option<&Did>,
-) -> AcpResult<(bool /*has*/, bool /*explicit*/)> {
-    if let (Some(node), Identity::Authenticated(req)) = (node_did, identity) {
-        if node == req { return Ok((true, true)); }
-    }
-    if !is_doc_registered_with_overlay(acp, policy_id, resource_name, object_id).await? {
-        return Ok((true, false));
-    }
-    let has = check_doc_access_with_overlay(
-        acp, identity, DocumentPermission::Read, policy_id, resource_name, object_id, node_did,
-    ).await?;
-    Ok((has, true))
+use async_trait::async_trait;
+use acp::read_access::{DocAccess, ObjectAccessChecker};
+use acp::{DocumentACP, DocumentPermission, Identity};
+use identity::Did;
+use super::context::{check_doc_access_with_overlay, is_doc_registered_with_overlay};
+
+pub struct OverlayChecker<'a> {
+    pub acp: &'a dyn DocumentACP,
+    pub identity: &'a Identity,
+    pub node_did: Option<&'a Did>,
 }
 
-pub async fn check_doc_read_access_overlay(
-    acp: &dyn DocumentACP, identity: &Identity, collection: &CollectionVersion,
-    doc_id: &str, node_did: Option<&Did>,
-) -> AcpResult<bool> {
-    let Some(policy) = &collection.policy else { return Ok(true); };
-    if !doc_id.is_empty() {
-        let (has, explicit) = object_access_overlay(
-            acp, identity, &policy.id, &policy.resource_name, doc_id, node_did).await?;
-        if explicit && has { return Ok(true); }
-        if !has { return Ok(false); }
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl ObjectAccessChecker for OverlayChecker<'_> {
+    async fn object_access(&self, policy_id: &str, resource_name: &str, object_id: &str)
+        -> acp::Result<DocAccess> {
+        if let (Some(node), Identity::Authenticated(req)) = (self.node_did, self.identity) {
+            if node == req { return Ok(DocAccess { has_access: true, explicit: true }); }
+        }
+        if !is_doc_registered_with_overlay(self.acp, policy_id, resource_name, object_id).await? {
+            return Ok(DocAccess { has_access: true, explicit: false });
+        }
+        let has = check_doc_access_with_overlay(
+            self.acp, self.identity, DocumentPermission::Read,
+            policy_id, resource_name, object_id, self.node_did,
+        ).await?;
+        Ok(DocAccess { has_access: has, explicit: true })
     }
-    if collection.is_branchable {
-        let (has, _) = object_access_overlay(
-            acp, identity, &policy.id, &policy.resource_name,
-            &collection.collection_id, node_did).await?;
-        if !has { return Ok(false); }
-    }
-    Ok(true)
 }
 ```
 
-Add `pub mod read_access;` and re-export `check_doc_read_access_overlay` in `crates/query-plan/src/txn/mod.rs`, and re-export through `crates/query/src/txn/mod.rs`.
+Add `pub mod read_access;` + re-export `OverlayChecker` in `crates/query-plan/src/txn/mod.rs`, and re-export through `crates/query/src/txn/mod.rs`.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Verify**
 
-Run: `cargo test -p query-plan --test cross_object_read_path overlay_read_rule_gates_branchable_public_doc`
+Run: `cargo test -p query-plan --test cross_object_read_path overlay_checker_gates_branchable_public_doc`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -535,7 +361,53 @@ Expected: PASS.
 ```bash
 cargo fmt --all
 git add crates/query-plan crates/query
-git commit -m "feat(acp): overlay-aware check_doc_read_access for query path"
+git commit -m "feat(acp): overlay ObjectAccessChecker for the query path"
+```
+
+---
+
+## Task 4: Plumb `node_did` into the commits query runner
+
+**Files:**
+- Modify: `crates/query/src/runner/mod.rs` (QueryRunner struct + builder) — add `node_did: Option<Did>`
+- Modify: `crates/embedded/src/node.rs` + `crates/defra-node/src/lib.rs` (runner construction) — wire `db.node_did()`
+- Test: `crates/query/src/runner/mod.rs` unit test (builder sets the field)
+
+**Interfaces:**
+- Produces: `QueryRunner` gains `node_did: Option<Did>` + `with_node_did(Option<Did>) -> Self`; an accessor `fn node_did(&self) -> Option<&Did>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn runner_carries_node_did() {
+    let runner = test_runner().with_node_did(Some(did_a()));
+    assert_eq!(runner.node_did(), Some(&did_a()));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p query runner_carries_node_did`
+Expected: FAIL — no `with_node_did`/`node_did`.
+
+- [ ] **Step 3: Add the field, builder, accessor**
+
+Add `node_did: Option<Did>` to the runner struct (default `None`), a `with_node_did` builder, and a `node_did(&self)` accessor. At every runner construction site (embedded `node.rs`, `defra-node/src/lib.rs`), call `.with_node_did(db.node_did())`.
+
+Run: `cargo build -p query -p embedded -p defra-node`
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo test -p query runner_carries_node_did`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/query/src/runner crates/embedded/src/node.rs crates/defra-node/src/lib.rs
+git commit -m "feat(query): carry node_did on the query runner"
 ```
 
 ---
@@ -543,70 +415,68 @@ git commit -m "feat(acp): overlay-aware check_doc_read_access for query path"
 ## Task 5: A2 — gate the commits query
 
 **Files:**
-- Modify: `crates/query/src/runner/commits.rs:737-839` (the ACP filtering block in `execute_commits_query`)
-- Test: `tools/integration-test/tests/acp.rs` (new module `branchable_commits`)
+- Modify: `crates/query/src/runner/commits.rs:737-839`
+- Test: `tools/integration-test/tests/acp.rs` (`mod branchable_commits`)
 
 **Interfaces:**
-- Consumes: `check_doc_read_access_overlay` (Task 4), `self.collections_map()`, `caller_identity`, `self.node_did()` (add accessor if absent — the registry already holds `db.node_did()`).
+- Consumes: `OverlayChecker` (Task 3), `acp::read_access::check_doc_read_access`, `self.collections_map()`, `caller_identity`, `self.node_did()` (Task 4).
 
-**Context:** Today the block at commits.rs:771-775 does `docID None => continue`, so collection-level commits are never gated; doc commits are gated per-doc via `check_doc_access_with_overlay` against the version's policy. Replace both with the read rule keyed on the resolved `CollectionVersion`.
+**Context:** Today commits.rs:771-775 does `docID None => continue` (collection-level commits ungated) and gates doc commits per-doc. Replace with the rule keyed on the resolved `CollectionVersion`.
 
 - [ ] **Step 1: Write the failing integration test**
 
-In `tools/integration-test/tests/acp.rs`, add `mod branchable_commits;` and create the scenario (driving the real node via the harness): a branchable `@policy` collection created by identity A; a public doc added; identity B (no collection access) queries `_commits` for both the collection-level DAG and the doc — expects **empty**; identity A expects the commits. Use the existing harness helpers (mirror `acp::basic`). Assert B sees `[]` and A sees non-empty.
+In `tools/integration-test/tests/acp.rs`, `mod branchable_commits`: identity A creates a branchable `@policy` collection; a public doc is added; identity B (no collection access) queries `_commits` for the collection-level DAG and the doc → expects `[]`; A → expects commits.
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cargo test -p integration-test --test acp -- branchable_commits::`
-Expected: FAIL — B currently sees collection-level commits (ungated).
+Expected: FAIL — B sees collection-level commits.
 
 - [ ] **Step 3: Rewrite the ACP filter block**
 
-In `execute_commits_query`, replace the per-doc-only filter with a per-commit read-rule check. Resolve each commit's `collectionVersionId` to its `CollectionVersion` (via `self.collections_map()` keyed by `version_id`) and call the rule; treat an empty/absent `docID` as a collection-level commit (`""`):
+Replace lines ~737-839 with a per-commit rule check:
 
 ```rust
-let node_did = self.node_did(); // Option<Did>
+use acp::Identity;
+let node_did = self.node_did().cloned();
 let identity = Identity::from(caller_identity.clone());
 let collections = self.collections_map().await?;
-let by_version: HashMap<String, CollectionVersion> = collections
-    .values().map(|c| (c.version_id.clone(), c.clone())).collect();
+let by_version: std::collections::HashMap<String, schema::CollectionVersion> =
+    collections.values().map(|c| (c.version_id.clone(), c.clone())).collect();
 
-let mut keep: Vec<bool> = Vec::with_capacity(commits.len());
+let mut keep = Vec::with_capacity(commits.len());
 for commit in &commits {
     let version_id = commit.get("collectionVersionId").and_then(|v| v.as_str());
     let doc_id = commit.get("docID").and_then(|v| v.as_str()).unwrap_or("");
     let allowed = match version_id.and_then(|v| by_version.get(v)) {
-        None => true, // unknown version: no policy to enforce here
-        Some(col) => match crate::txn::check_doc_read_access_overlay(
-            self.acp.as_ref(), &identity, col, doc_id, node_did.as_ref(),
-        ).await {
-            Ok(granted) => granted,
-            Err(e) => {
-                tracing::debug!(target: "acp::audit", event = "commits_acp_check_error",
-                    doc_id = %doc_id, error = %e, "denying commit on ACP error");
-                false
+        None => true,
+        Some(col) => match &col.policy {
+            None => true,
+            Some(policy) => {
+                let checker = crate::txn::OverlayChecker {
+                    acp: self.acp.as_ref(), identity: &identity, node_did: node_did.as_ref(),
+                };
+                acp::read_access::check_doc_read_access(
+                    &checker, &policy.id, &policy.resource_name,
+                    &col.collection_id, col.is_branchable, doc_id,
+                ).await.unwrap_or(false)
             }
         },
     };
     keep.push(allowed);
 }
-let mut iter = keep.into_iter();
-commits.retain(|_| iter.next().unwrap_or(false));
+let mut it = keep.into_iter();
+commits.retain(|_| it.next().unwrap_or(false));
 ```
 
-Remove the now-dead `policies_by_version` / `denied_commits` machinery (lines ~744-838) it replaces. Keep the `has_protected_collections` short-circuit if cheap, but the rule already no-ops unpermissioned collections.
+Delete the now-dead `policies_by_version` / `denied_commits` machinery it replaces.
 
-- [ ] **Step 4: Run integration test to verify it passes**
+- [ ] **Step 4: Verify + full suites**
 
-Run: `cargo test -p integration-test --test acp -- branchable_commits::`
-Expected: PASS — B sees `[]`, A sees commits.
-
-- [ ] **Step 5: Run the full ACP + query suites (no regressions)**
-
-Run: `cargo test -p integration-test --test acp && cargo test -p integration-test --test query -- commits`
+Run: `cargo test -p integration-test --test acp -- branchable_commits:: && cargo test -p integration-test --test acp && cargo test -p integration-test --test query -- commits`
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 cargo fmt --all
@@ -620,58 +490,50 @@ git commit -m "feat(acp): A2 gate commits query on branchable read rule"
 
 **Files:**
 - Modify: `crates/db/src/block_verify.rs:110-136`
-- Test: `crates/db/tests/` (add a block-verify ACP test) or `tools/integration-test/tests/acp.rs::branchable_commits` extension.
+- Test: `crates/db/tests/block_verify_acp_tests.rs`
 
 **Interfaces:**
-- Consumes: `check_doc_read_access` (Task 2), `database.get_collection_by_version_id`, `database.node_did()`.
-
-**Context:** Today verify only checks when `delta.doc_id()` is `Some`; collection-level blocks bypass. Replace with the read rule, resolving the collection from `schema_version_id` and using `""` for collection-level blocks.
+- Consumes: `acp::read_access::{check_doc_read_access, DirectChecker}`, `database.get_collection_by_version_id`, `database.node_did()`.
 
 - [ ] **Step 1: Write the failing test**
 
-Add a `crates/db/tests/block_verify_acp_tests.rs` test: build a DB with a branchable permissioned collection registered to owner A; produce a collection-level signed block; call `verify_block_signature` as stranger B → expect `Err("missing permission")`; as A → expect `Ok`.
+`crates/db/tests/block_verify_acp_tests.rs`: branchable permissioned collection registered to A; produce a collection-level signed block; `verify_block_signature` as B → `Err("missing permission")`; as A → `Ok`.
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cargo test -p db --test block_verify_acp_tests`
-Expected: FAIL — B currently passes (collection-level block bypasses the gate).
+Expected: FAIL — B passes (collection-level bypass).
 
-- [ ] **Step 3: Replace the gate with the read rule**
+- [ ] **Step 3: Replace the gate**
 
 In `verify_block_signature_with_blockstore`, replace lines 110-136:
 
 ```rust
-// Read-access gate: a block's signature is only verifiable by an actor who can
-// read the block's document(s) / collection DAG. Collection-level blocks have
-// no docID and are gated on the collection object for a branchable collection.
 if let Some(schema_version_id) = block.delta.schema_version_id() {
     if let Some(collection) = database
         .get_collection_by_version_id(schema_version_id)
         .map_err(|e| format!("failed to get collection: {}", e))?
     {
-        let doc_id = block
-            .delta
-            .doc_id()
-            .map(|b| String::from_utf8_lossy(b).to_string())
-            .unwrap_or_default();
-        let node_did = database.node_did();
-        let has_permission = crate::collection_acp::check_doc_read_access(
-            document_acp,
-            caller_identity,
-            collection.schema(),
-            &doc_id,
-            node_did.as_ref(),
-        )
-        .await
-        .map_err(|e| format!("ACP check failed: {}", e))?;
-        if !has_permission {
-            return Err("missing permission".to_string());
+        let col = collection.schema();
+        if let Some(policy) = &col.policy {
+            let doc_id = block.delta.doc_id()
+                .map(|b| String::from_utf8_lossy(b).to_string())
+                .unwrap_or_default();
+            let node_did = database.node_did();
+            let checker = acp::read_access::DirectChecker {
+                acp: document_acp, identity: caller_identity, node_did: node_did.as_ref(),
+            };
+            let has = acp::read_access::check_doc_read_access(
+                &checker, &policy.id, &policy.resource_name,
+                &col.collection_id, col.is_branchable, &doc_id,
+            ).await.map_err(|e| format!("ACP check failed: {}", e))?;
+            if !has { return Err("missing permission".to_string()); }
         }
     }
 }
 ```
 
-- [ ] **Step 4: Run test + ACP suite**
+- [ ] **Step 4: Verify**
 
 Run: `cargo test -p db --test block_verify_acp_tests && cargo test -p integration-test --test acp`
 Expected: PASS.
@@ -686,89 +548,77 @@ git commit -m "feat(acp): A2 gate signature verification on branchable read rule
 
 ---
 
-## Task 7: A3 — KMS key-gate uses the read rule
+## Task 7: A3 — KMS key-gate uses the shared rule
 
 **Files:**
-- Modify: `crates/kms/src/policy.rs:61` (`DocCollectionInfo`) and its `DocCollectionLookup`
+- Modify: `crates/kms/src/policy.rs:61` (`DocCollectionInfo` += `is_branchable`)
 - Modify: `crates/kms/src/nac_dac_policy.rs:80-111` (`check_release` Document arm)
-- Modify: the `DocCollectionLookup` producer (in the embedded-node layer, "Phase K"): grep `impl DocCollectionLookup`
-- Test: `crates/kms/src/nac_dac_policy.rs` tests (extend fakes)
+- Modify: the `DocCollectionLookup` producer (embedded layer; grep `impl DocCollectionLookup`)
+- Test: `crates/kms/src/nac_dac_policy.rs` tests
 
 **Interfaces:**
-- Produces (changed struct):
-  ```rust
-  pub struct DocCollectionInfo {
-      pub collection_id: String,
-      pub policy_id: String,
-      pub resource_name: String,
-      pub is_branchable: bool,   // NEW
-  }
-  ```
+- Produces: `DocCollectionInfo { collection_id, policy_id, resource_name, is_branchable: bool }`.
+- Consumes: `acp::read_access::{check_doc_read_access, DirectChecker}` (kms already depends on `acp`).
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the failing tests (corrected semantics — finding #1)**
 
-In `crates/kms/src/nac_dac_policy.rs` tests, extend the fake `collection_for_doc` to return `is_branchable: true` and have the fake DAC grant the doc but deny the collection object; assert `check_release` returns `Deny` (the branchable collection gate must apply). Add a second case `is_branchable: false` → `Allow` (doc-only).
+The rule grants on an explicit doc grant *before* the collection check, so a "doc grant + collection deny" case CANNOT test the collection gate. Use a **public/unregistered doc + denied collection => Deny**, plus an **explicit doc grant => Allow**, plus **non-branchable => doc-only**.
 
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test -p kms nac_dac_policy`
-Expected: FAIL — struct has no `is_branchable`; gate ignores collection object.
-
-- [ ] **Step 3: Add `is_branchable` and switch the gate**
-
-Add the field to `DocCollectionInfo`. In `check_release`'s `KeyScope::Document` arm, replace the direct `check_doc_access` call with a read-rule check. Since KMS depends on `acp` (not `db`), inline the same algorithm using the `DocCollectionInfo` (it has policy_id/resource_name/collection_id/is_branchable):
+In `crates/kms/src/nac_dac_policy.rs` tests, extend the fakes so `collection_for_doc` returns `is_branchable` and the fake DAC can answer per-object (registered? owner?):
 
 ```rust
-let actor_id: acp::Identity = actor.into();
-let read_allowed = kms_check_doc_read_access(
-    self.doc_acp.as_ref(), &actor_id, &info, doc_id,
-).await.map_err(classify_acp_error)?;
-Ok(if read_allowed { PolicyDecision::Allow } else { PolicyDecision::Deny })
-```
+#[tokio::test]
+async fn branchable_public_doc_denied_without_collection_access() {
+    // doc "d1" UNREGISTERED (public); collection "COL" registered, actor NOT granted.
+    let policy = NacDacPolicy::new(/* dac: deny COL, allow nothing */, lookup_branchable(true));
+    let decision = policy.check_release(Some(&actor()), &doc_scope("d1")).await.unwrap();
+    assert_eq!(decision, PolicyDecision::Deny); // branchable collection gate denies
+}
 
-Add a small helper in `crates/kms/src/policy.rs`:
+#[tokio::test]
+async fn explicit_doc_grant_allows_release() {
+    // doc "d1" registered to actor (explicit grant) => allow regardless of collection.
+    let policy = NacDacPolicy::new(/* dac: doc grant */, lookup_branchable(true));
+    let decision = policy.check_release(Some(&actor()), &doc_scope("d1")).await.unwrap();
+    assert_eq!(decision, PolicyDecision::Allow);
+}
 
-```rust
-/// KMS-local read rule mirroring db::collection_acp::check_doc_read_access,
-/// expressed over DocCollectionInfo (kms cannot depend on the db crate).
-pub async fn kms_check_doc_read_access(
-    acp: &dyn acp::DocumentACP,
-    identity: &acp::Identity,
-    info: &DocCollectionInfo,
-    doc_id: &str,
-) -> acp::Result<bool> {
-    let object = |id: &str| async move {
-        if !acp.is_doc_registered(&info.policy_id, &info.resource_name, id).await? {
-            return Ok::<(bool, bool), acp::Error>((true, false));
-        }
-        let has = acp.check_doc_access(
-            identity, acp::DocumentPermission::Read,
-            &info.policy_id, &info.resource_name, id,
-        ).await?;
-        Ok((has, true))
-    };
-    if !doc_id.is_empty() {
-        let (has, explicit) = object(doc_id).await?;
-        if explicit && has { return Ok(true); }
-        if !has { return Ok(false); }
-    }
-    if info.is_branchable {
-        let (has, _) = object(&info.collection_id).await?;
-        if !has { return Ok(false); }
-    }
-    Ok(true)
+#[tokio::test]
+async fn nonbranchable_uses_doc_only() {
+    let policy = NacDacPolicy::new(/* dac: doc grant */, lookup_branchable(false));
+    let decision = policy.check_release(Some(&actor()), &doc_scope("d1")).await.unwrap();
+    assert_eq!(decision, PolicyDecision::Allow);
 }
 ```
 
-(No node-identity shortcut here: KMS release already resolves node-level access via `check_node_release`; the document arm matches Go's `pubsub.go` which calls `CheckDocReadAccess` without a separate node bypass.)
+(The fake `DocumentACP` must implement `is_doc_registered` + `check_doc_access` consistently so the rule’s explicit/public branches are exercised — extend the existing `FakeDac` from a single `allow` bool to a small map of registered objects + granted (object,actor) pairs.)
 
-- [ ] **Step 4: Update the producer**
+- [ ] **Step 2: Run tests to verify they fail**
 
-Grep `impl DocCollectionLookup` (embedded-node layer) and populate `is_branchable` from the resolved `CollectionVersion.is_branchable`.
+Run: `cargo test -p kms nac_dac_policy`
+Expected: FAIL — no `is_branchable`; gate ignores the collection object.
 
+- [ ] **Step 3: Add `is_branchable` + call the shared rule**
+
+Add `pub is_branchable: bool` to `DocCollectionInfo`. In `check_release`'s `KeyScope::Document` arm, replace the direct `check_doc_access` with:
+
+```rust
+let actor_id: acp::Identity = actor.into();
+let checker = acp::read_access::DirectChecker {
+    acp: self.doc_acp.as_ref(), identity: &actor_id, node_did: None,
+};
+let allowed = acp::read_access::check_doc_read_access(
+    &checker, &info.policy_id, &info.resource_name, &info.collection_id, info.is_branchable, doc_id,
+).await.map_err(classify_acp_error)?;
+Ok(if allowed { PolicyDecision::Allow } else { PolicyDecision::Deny })
+```
+
+- [ ] **Step 4: Update the producer + build**
+
+Grep `impl DocCollectionLookup`; set `is_branchable` from the resolved `CollectionVersion.is_branchable`.
 Run: `cargo build -p kms -p embedded`
 
-- [ ] **Step 5: Run tests**
+- [ ] **Step 5: Verify**
 
 Run: `cargo test -p kms`
 Expected: PASS.
@@ -778,51 +628,59 @@ Expected: PASS.
 ```bash
 cargo fmt --all
 git add crates/kms crates/embedded
-git commit -m "feat(acp): A3 KMS key-gate honors branchable read rule"
+git commit -m "feat(acp): A3 KMS key-gate uses shared branchable read rule"
 ```
 
 ---
 
-## Task 8: A3 — `PeerIdentityResolver` abstraction
+## Task 8: A3 — `PeerIdentityResolver` (libp2p token + Iroh NodeId derivation)
 
 **Files:**
 - Create: `crates/p2p/src/peer_identity.rs`
-- Modify: `crates/p2p/src/lib.rs` (module + re-export), `crates/p2p/src/host/handle.rs` (impl for libp2p), Iroh endpoint (impl/wiring)
-- Test: `crates/p2p/src/peer_identity.rs` unit test with a fake
+- Modify: `crates/p2p/src/lib.rs`; libp2p impl wraps `host::handle::get_peer_identity`; Iroh impl derives `NodeId → did:key`
+- Test: `crates/p2p/src/peer_identity.rs` unit tests
 
 **Interfaces:**
 - Produces:
   ```rust
   #[async_trait]
   pub trait PeerIdentityResolver: Send + Sync {
-      /// Resolve a transport peer id to a verified DefraDB DID, or None when
-      /// unknown/unverifiable. Callers treat None as Anonymous (Go parity).
       async fn resolve(&self, peer_id: &PeerId) -> Option<identity::Did>;
   }
+  // Libp2pPeerIdentityResolver(handle): delegates to get_peer_identity().ok().flatten()
+  // IrohPeerIdentityResolver: PeerId string is the ed25519 NodeId -> did:key
   ```
 
-- [ ] **Step 1: Write the failing test**
+**Iroh note:** the Iroh `PeerId` is the ed25519 NodeId string (`transport.rs:44` `PeerId::new(node_id.to_string())`). Derive the DID from the 32-byte ed25519 public key via the `identity` crate's did:key derivation. This is verifiable (Iroh's QUIC handshake authenticates the NodeId) and needs no exchange protocol. It resolves the peer's **node** DID; ACP-over-Iroh deployments therefore bind the node's DefraDB identity to its ed25519 endpoint key. If the bytes can't be parsed as an ed25519 did:key (e.g. a non-ed25519 node identity), return `None` (→ Anonymous), a documented Iroh constraint.
+
+- [ ] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
+async fn iroh_resolver_derives_did_from_node_id() {
+    let (node_id_str, expected_did) = ed25519_node_id_and_did();
+    let r = IrohPeerIdentityResolver::default();
+    assert_eq!(r.resolve(&PeerId::new(node_id_str)).await, Some(expected_did));
+}
+
+#[tokio::test]
 async fn libp2p_resolver_delegates_to_handle() {
-    // fake handle returning Some(did) for a known peer, None otherwise
-    let resolver = make_test_resolver();
-    assert_eq!(resolver.resolve(&known_peer()).await, Some(known_did()));
-    assert_eq!(resolver.resolve(&unknown_peer()).await, None);
+    let r = make_libp2p_resolver_with(known_peer(), known_did());
+    assert_eq!(r.resolve(&known_peer()).await, Some(known_did()));
+    assert_eq!(r.resolve(&unknown_peer()).await, None);
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run tests to verify they fail**
 
 Run: `cargo test -p p2p peer_identity`
-Expected: FAIL — trait not found.
+Expected: FAIL — trait/impls not found.
 
-- [ ] **Step 3: Define the trait + libp2p impl**
+- [ ] **Step 3: Implement trait + both resolvers**
 
-In `crates/p2p/src/peer_identity.rs` define the trait. Implement it for a wrapper holding a `P2PHostHandle`, delegating to `get_peer_identity(peer_id).await.ok().flatten()`. For Iroh, implement a wrapper over the Iroh endpoint's identity mechanism (or, if Iroh shares the `peer_identities` cache, expose an equivalent `get_peer_identity` and delegate). Add `pub mod peer_identity;` + re-export in `lib.rs`.
+Define the trait. `Libp2pPeerIdentityResolver` holds a `P2PHostHandle` and calls `get_peer_identity(peer_id).await.ok().flatten()`. `IrohPeerIdentityResolver::resolve` parses the `PeerId` string as an `iroh::PublicKey`/`EndpointId`, takes its 32 ed25519 bytes, and derives a `did:key` `identity::Did` (add an `identity::Did::from_ed25519_public_key(&[u8;32])` helper if absent, using the existing did:key derivation). Add `pub mod peer_identity;` + re-exports in `lib.rs`.
 
-- [ ] **Step 4: Run test**
+- [ ] **Step 4: Verify**
 
 Run: `cargo test -p p2p peer_identity`
 Expected: PASS.
@@ -831,66 +689,76 @@ Expected: PASS.
 
 ```bash
 cargo fmt --all
-git add crates/p2p/src/peer_identity.rs crates/p2p/src/lib.rs crates/p2p/src/host crates/p2p/src/iroh
-git commit -m "feat(p2p): add transport-agnostic PeerIdentityResolver"
+git add crates/p2p/src/peer_identity.rs crates/p2p/src/lib.rs crates/identity/src
+git commit -m "feat(p2p): PeerIdentityResolver (libp2p token + Iroh NodeId did:key)"
 ```
 
 ---
 
-## Task 9: A3 — Bitswap serve filter per-doc gate
+## Task 9: A3 — late-bound `BlockReadGate` + Bitswap per-block serve gate
 
 **Files:**
-- Modify: `crates/p2p/src/bitswap/filter.rs:62-145` (`check_access`, `make_peer_block_access_filter`)
+- Create: `crates/p2p/src/bitswap/read_gate.rs` (`BlockReadGate` trait + `LateBoundReadGate` holder)
+- Modify: `crates/p2p/src/bitswap/filter.rs:62-145`, `crates/p2p/src/behaviour.rs:292`
+- Modify: node assembly (`crates/embedded/src/node.rs:553-558` wiring) to install the gate via the existing `wire_document_acp` callback
 - Test: `crates/p2p/tests/bitswap_acp_filter_tests.rs`
 
 **Interfaces:**
-- Consumes: `PeerIdentityResolver` (Task 8), `check_doc_read_access` (Task 2), a way to resolve a block's `schema_version_id → CollectionVersion` + its docID(s). The filter must be given a `ReadAccessContext` (DB/ACP handle) at construction. Define:
+- Produces:
   ```rust
   #[async_trait]
   pub trait BlockReadGate: Send + Sync {
-      // Resolve the block's collection + doc id(s) and apply check_doc_read_access
-      // for `identity`. Empty doc id => collection-level. Returns true if ANY owner doc grants.
-      async fn may_read_block(&self, identity: &acp::Identity, block: &DefraBlock) -> bool;
+      /// Resolve the block's stable collection_id + doc id(s), then apply the read
+      /// rule for `identity`. Returns (collection_id, allow). collection_id lets the
+      /// caller do replicator passthrough keyed on the STABLE id (finding #2).
+      async fn evaluate(&self, identity: &acp::Identity, block: &DefraBlock)
+          -> Option<(String /*collection_id*/, bool /*allow*/)>;
   }
+
+  /// OnceLock-backed holder installed at filter-construction; fail-closed until set.
+  pub struct LateBoundReadGate(std::sync::OnceLock<Arc<dyn BlockReadGate>>);
   ```
-  implemented in the db/embedded layer (it has DB + ACP). The filter holds `Arc<dyn BlockReadGate>` + `Arc<dyn PeerIdentityResolver>`.
 
-- [ ] **Step 1: Write the failing test**
+**Context (finding #3):** the bitswap filter is built at `behaviour.rs:292` before `document_acp` exists. So the filter takes a `LateBoundReadGate` (empty), and the node assembly populates it inside the existing `wire_document_acp` callback (`node.rs:557`). Until populated, the gate denies non-replicator/non-public access (fail-closed).
+**Context (finding #2):** never use the raw `schema_version_id` for replicator checks. The gate returns the block's **stable `collection_id`**; the filter uses THAT for `registry.is_replicator`.
 
-In `crates/p2p/tests/bitswap_acp_filter_tests.rs` add: non-replicator peer whose resolved DID lacks collection access requests a branchable data block → filter denies; replicator peer → allowed (passthrough); non-replicator with no resolvable DID requesting a public/unregistered block → allowed (Anonymous, Go parity); requesting a registered/private block → denied.
+- [ ] **Step 1: Write the failing tests**
 
-- [ ] **Step 2: Run test to verify it fails**
+In `crates/p2p/tests/bitswap_acp_filter_tests.rs`: (a) non-replicator peer whose DID lacks collection access requests a branchable data block → deny; (b) replicator **for that block's collection** → allow (passthrough); (c) peer that is a replicator of a *different* collection → still gated (deny if no access) — guards finding #2; (d) unresolved DID + public/unregistered block → allow (Anonymous); + registered block → deny; (e) gate not yet installed → deny non-replicator.
+
+- [ ] **Step 2: Run tests to verify they fail**
 
 Run: `cargo test -p p2p --test bitswap_acp_filter_tests`
-Expected: FAIL — filter has no read gate; non-replicator currently always denied.
+Expected: FAIL.
 
-- [ ] **Step 3: Extend `check_access`**
+- [ ] **Step 3: Rewrite `check_access`**
 
-After the existing definition/lens/signature passthroughs and the replicator check, when the peer is NOT a replicator, resolve identity and apply the read gate instead of returning false:
+Keep the signature/definition/lens passthroughs. Then:
 
 ```rust
-// (unchanged) signature / definition / lens passthroughs ...
-let peer_str = peer_id.to_string();
-if registry.is_filtered_replicator(collection_id, &peer_str) { /* unchanged deny */ }
-if registry.is_replicator(collection_id, &peer_str) {
-    return true; // replicator passthrough (Go parity)
-}
-// Non-replicator: Go's hasAccess falls through to a per-doc read check using the
-// requesting peer's resolved identity. Unresolved DID => Anonymous (Go parity).
+// resolve the read gate's verdict (also yields the STABLE collection_id).
 let identity = match resolver.resolve(peer_id).await {
     Some(did) => acp::Identity::Authenticated(did),
     None => acp::Identity::Anonymous,
 };
-return read_gate.may_read_block(&identity, &defra_block).await;
+let Some((collection_id, allow)) = read_gate.evaluate(&identity, &defra_block).await else {
+    // gate not installed yet => fail closed for non-replicators.
+    return false;
+};
+let peer_str = peer_id.to_string();
+// Replicator passthrough keyed on the STABLE collection_id (finding #2).
+if registry.is_filtered_replicator(&collection_id, &peer_str) { return false; }
+if registry.is_replicator(&collection_id, &peer_str) { return true; }
+allow
 ```
 
-Thread `resolver: Arc<dyn PeerIdentityResolver>` and `read_gate: Arc<dyn BlockReadGate>` through `make_peer_block_access_filter` and the closure (clone into the async block). Update `behaviour.rs:292` construction to pass them (the embedded/node assembly provides the `BlockReadGate` impl).
+Thread `resolver: Arc<dyn PeerIdentityResolver>` and `read_gate: Arc<LateBoundReadGate>` through `make_peer_block_access_filter` + the closure. `behaviour.rs:292` constructs the `LateBoundReadGate` (empty) and passes a default `resolver` appropriate to the transport (libp2p resolver from the host handle).
 
-- [ ] **Step 4: Implement `BlockReadGate` in the db/embedded layer**
+- [ ] **Step 4: Implement `BlockReadGate` + install via `wire_document_acp`**
 
-Where the filter is constructed (node assembly), build a gate that: decodes the block (already decoded by the filter — pass the `DefraBlock`), resolves `schema_version_id → CollectionVersion`, computes the block's docID(s) (collection-level => `""`), and returns true if `check_doc_read_access` grants for any. Reuse the existing block→docID resolution used elsewhere on the merge path.
+Implement the gate in the node/db layer: decode is already done (pass `&DefraBlock`); resolve `schema_version_id → CollectionVersion`; compute the block's docID(s) (collection-level => `""`); return `(collection.collection_id, check_doc_read_access(DirectChecker{...}) for any owner doc)`. Install it into the `LateBoundReadGate` inside the `wire_document_acp` closure at `crates/embedded/src/node.rs:557` (and the `defra-node` equivalent).
 
-- [ ] **Step 5: Run tests**
+- [ ] **Step 5: Verify**
 
 Run: `cargo test -p p2p --test bitswap_acp_filter_tests`
 Expected: PASS.
@@ -899,8 +767,8 @@ Expected: PASS.
 
 ```bash
 cargo fmt --all
-git add crates/p2p/src/bitswap crates/p2p/src/behaviour.rs crates/p2p/tests/bitswap_acp_filter_tests.rs
-git commit -m "feat(p2p): A3 bitswap serve filter enforces branchable read rule"
+git add crates/p2p/src/bitswap crates/p2p/src/behaviour.rs crates/embedded/src/node.rs crates/defra-node/src crates/p2p/tests/bitswap_acp_filter_tests.rs
+git commit -m "feat(p2p): A3 bitswap per-block serve gate (late-bound, stable-collection passthrough)"
 ```
 
 ---
@@ -908,50 +776,52 @@ git commit -m "feat(p2p): A3 bitswap serve filter enforces branchable read rule"
 ## Task 10: A3 — CAR handler per-block serve filtering
 
 **Files:**
-- Modify: `crates/p2p/src/sync/coordinator/event_handler/car.rs:83-179` (`handle_car_fetch_request`)
-- Test: `crates/p2p/src/sync/coordinator/access_tests.rs` (or a new CAR test module)
+- Modify: `crates/p2p/src/sync/coordinator/event_handler/car.rs:83-179`
+- Modify: `SyncCoordinator` construction to inject `PeerIdentityResolver` + `BlockReadGate`
+- Test: CAR test module under `crates/p2p/src/sync/coordinator/`
 
-**Interfaces:**
-- Consumes: `PeerIdentityResolver`, `BlockReadGate` (Task 9), the existing `collected.blocks` Vec.
-
-**Context:** `check_car_fetch_access` gates only root collection access, then `collect_dag_blocks`/`collect_exact_blocks` returns the whole DAG. Add a per-block filter pass over `blocks` before encoding, for **both** recursive and exact fetches, when the peer is not a replicator.
+**Context (finding #2):** do NOT use `is_any_replicator`. Filter each block, doing replicator passthrough per the block's **stable collection_id** returned by the gate.
 
 - [ ] **Step 1: Write the failing test**
 
-A branchable collection with a private doc; a connected-but-non-replicator peer issues a CAR fetch for the DAG → response must exclude blocks the peer can't read; a replicator peer → full DAG.
+Branchable collection, private doc. A connected non-replicator peer issues a CAR fetch → response excludes blocks it can't read; a replicator **for that collection** → full DAG; a peer that is a replicator of a *different* collection → still gated.
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cargo test -p p2p car_fetch`
-Expected: FAIL — CAR serves the full DAG regardless of per-block read access.
+Expected: FAIL — CAR serves the full DAG.
 
-- [ ] **Step 3: Filter response blocks**
+- [ ] **Step 3: Filter response blocks per block**
 
-After `let blocks = collected.blocks;` (car.rs:133) and before the empty check, when the peer is not a replicator for the collection, resolve identity once and retain only readable blocks:
+After `let blocks = collected.blocks;` (car.rs:133), before the empty check:
 
 ```rust
-let blocks = if self.access.replicators.is_any_replicator(peer_id.as_str()) {
-    blocks // replicator passthrough
-} else {
-    let identity = match self.peer_identity_resolver.resolve(&peer_id).await {
-        Some(did) => acp::Identity::Authenticated(did),
-        None => acp::Identity::Anonymous,
-    };
-    let mut kept = Vec::with_capacity(blocks.len());
-    for (cid, data) in blocks {
-        let allow = match DefraBlock::from_dag_cbor(&data) {
-            Ok(b) => self.read_gate.may_read_block(&identity, &b).await,
-            Err(_) => true, // non-CRDT (signature/lens) — passthrough, matches bitswap
-        };
-        if allow { kept.push((cid, data)); }
-    }
-    kept
+let identity = match self.peer_identity_resolver.resolve(&peer_id).await {
+    Some(did) => acp::Identity::Authenticated(did),
+    None => acp::Identity::Anonymous,
 };
+let peer_str = peer_id.to_string();
+let mut kept = Vec::with_capacity(blocks.len());
+for (cid, data) in blocks {
+    let allow = match DefraBlock::from_dag_cbor(&data) {
+        Ok(b) => match self.read_gate.evaluate(&identity, &b).await {
+            None => false, // gate not installed => fail closed
+            Some((collection_id, rule_allow)) => {
+                self.access.replicators.is_replicator(&collection_id, &peer_str)
+                    && !self.access.replicators.is_filtered_replicator(&collection_id, &peer_str)
+                    || rule_allow
+            }
+        },
+        Err(_) => true, // signature / lens / non-CRDT — passthrough (matches bitswap)
+    };
+    if allow { kept.push((cid, data)); }
+}
+let blocks = kept;
 ```
 
-Hold `peer_identity_resolver` + `read_gate` on the `SyncCoordinator` (inject at construction alongside the existing `authorizer`).
+Hold `peer_identity_resolver: Arc<dyn PeerIdentityResolver>` + `read_gate: Arc<LateBoundReadGate>` on `SyncCoordinator` (inject alongside `authorizer`; populate the gate via the same `wire_document_acp` path).
 
-- [ ] **Step 4: Run tests**
+- [ ] **Step 4: Verify**
 
 Run: `cargo test -p p2p car_fetch`
 Expected: PASS.
@@ -961,7 +831,7 @@ Expected: PASS.
 ```bash
 cargo fmt --all
 git add crates/p2p/src/sync/coordinator
-git commit -m "feat(p2p): A3 CAR handler filters served blocks by read access"
+git commit -m "feat(p2p): A3 CAR per-block serve filtering (stable-collection passthrough)"
 ```
 
 ---
@@ -971,16 +841,16 @@ git commit -m "feat(p2p): A3 CAR handler filters served blocks by read access"
 **Files:**
 - Test: `crates/p2p/src/sync/manager/process/pushlog.rs` tests + CAR test module
 
-**Context:** `verify_block_cid` already rejects content/CID mismatch (pushlog.rs:235; CAR handler). No production change — add explicit regression tests so the `ErrBlockCIDMismatch` analog can never silently regress.
+**Context:** `verify_block_cid` already rejects content/CID mismatch (pushlog.rs:235; CAR ingest). No production change — lock it in.
 
-- [ ] **Step 1: Write the test**
+- [ ] **Step 1: Write the tests**
 
-Pushlog: craft a `PushLogMessage` whose `block` bytes do not hash to `cid` → assert the handler returns the CID-verify error and does not store the block. CAR: a CAR response containing a block whose bytes mismatch its CID → assert it is rejected on ingest.
+Pushlog: a `PushLogMessage` whose `block` bytes don't hash to `cid` → handler returns the CID-verify error and does not store. CAR: a CARv1 with a mismatched block → rejected on ingest.
 
-- [ ] **Step 2: Run test to verify behavior**
+- [ ] **Step 2: Verify**
 
 Run: `cargo test -p p2p verify_block_cid`
-Expected: PASS (confirms existing behavior).
+Expected: PASS.
 
 - [ ] **Step 3: Commit**
 
@@ -994,14 +864,13 @@ git commit -m "test(p2p): regression cover block CID-integrity on pushlog/CAR"
 ## Task 12: Cross-implementation integration scenarios
 
 **Files:**
-- Modify: `tools/integration-test/tests/acp.rs` (`branchable_commits`, new `branchable_peer`)
-- Modify: `tools/integration-test/tests/p2p.rs` (cross-impl serve scenario) if the matrix harness lives there
+- Modify: `tools/integration-test/tests/acp.rs` (`branchable_commits`, `branchable_peer`)
 
-**Context:** Port Go #4990's `collection_commits_test.go` and `peer_test.go`. Run the matrix the harness supports: rust↔rust, go↔go, go↔rust.
+**Context:** port Go #4990's `collection_commits_test.go` + `peer_test.go`; run rust↔rust, go↔go, go↔rust.
 
 - [ ] **Step 1: Write the serve-boundary scenario**
 
-Two nodes; node A (owner) hosts a branchable `@policy` collection with a private doc; node B connects as a **non-replicator** and attempts to sync/fetch → B must NOT receive the private blocks; then grant B a reader relationship → B receives them. Add a variant where B is a **replicator** → B receives (passthrough).
+Node A (owner) hosts a branchable `@policy` collection with a private doc; node B connects as a **non-replicator** and tries to fetch → must NOT receive private blocks; grant B reader → receives. Variant: B as **replicator** → receives (passthrough).
 
 - [ ] **Step 2: Run rust↔rust**
 
@@ -1010,7 +879,7 @@ Expected: PASS.
 
 - [ ] **Step 3: Run go↔rust matrix**
 
-Run the harness with a Go binary as producer and Rust as consumer and vice-versa (per the harness's cross-impl switch; see `reference_go_parity_binary` — Go defradb at `GO_COMPAT_COMMIT` on PATH). Expected: identical withhold/serve behavior in both directions.
+Run with a Go defradb at `GO_COMPAT_COMMIT` on PATH (see `reference_go_parity_binary`), Go-producer/Rust-consumer and vice-versa. Expected: identical withhold/serve behavior.
 
 - [ ] **Step 4: Commit**
 
@@ -1021,13 +890,11 @@ git commit -m "test(acp): cross-impl branchable read + serve-boundary parity"
 
 ---
 
-## Task 13: Adversarial re-audit of the A3 serve boundary (gate before merge)
+## Task 13: Adversarial re-audit of the A3 serve boundary (merge gate)
 
 **Files:** none (verification)
 
-**Context:** The serve gate is the private-data leak boundary. Before the PR merges, run a dedicated adversarial review (a Workflow) over the A3 diff (Tasks 8–10) + the merge handler, specifically hunting: a path that serves a private branchable block to a non-replicator without read access; an unresolved-DID path that grants more than Anonymous; a recursive-vs-exact CAR asymmetry; a transport (libp2p vs Iroh) that skips the gate; a block→docID resolution that misses collection-level blocks.
-
-- [ ] **Step 1: Run the existing P2P/encryption/SE/identity suites (regression gate from the spec's top risk)**
+- [ ] **Step 1: Regression gate (spec top risk)**
 
 Run:
 ```bash
@@ -1038,20 +905,22 @@ cargo test -p integration-test --test identity
 ```
 Expected: PASS. Any regression here is a **blocker** → revisit serve-scope per the spec.
 
-- [ ] **Step 2: Adversarial review**
+- [ ] **Step 2: Adversarial review (ultracode Workflow)**
 
-Run a multi-agent review (ultracode Workflow) scoped to the A3 diff vs Go `3f627855` `hasAccess`/`trySelfHasAccess`. Resolve or explicitly accept every CONFIRMED/PLAUSIBLE finding.
+Scope to the A3 diff (Tasks 8–10) + merge handler vs Go `3f627855` `hasAccess`/`trySelfHasAccess`. Hunt: private branchable block served to a non-replicator without access; unresolved-DID granting more than Anonymous; recursive-vs-exact CAR asymmetry; a transport skipping the gate; `is_any_replicator`/`schema_version_id` passthrough leaks (finding #2); block→docID resolution missing collection-level blocks; the `LateBoundReadGate` serving before initialization. Resolve or explicitly accept every CONFIRMED/PLAUSIBLE finding.
 
 - [ ] **Step 3: Update PR body**
 
-Change the PR description from "A1 registration" to the full A1–A3 security feature; note the cross-impl matrix and the adversarial audit outcome.
+Change the PR description from "A1 registration" to the full A1–A3 security feature; note the cross-impl matrix, the Iroh NodeId-derivation constraint, and the adversarial audit outcome.
 
 ---
 
 ## Self-Review
 
-**Spec coverage:** core rule (Tasks 1–2,4) ✔; node_did (Task 3) ✔; version→collection_id (Tasks 5,6,9,10 resolve via `get_collection_by_version_id`/`collections_map`) ✔; commits query (5) ✔; signature verify (6) ✔; KMS is_branchable (7) ✔; peer-DID resolver (8) ✔; bitswap serve (9) ✔; CAR serve (10) ✔; unresolved-DID→Anonymous (9,10) ✔; replicator passthrough (9,10) ✔; pushlog CID already-done (11) ✔; cross-impl tests (12) ✔; top-risk regression gate + adversarial audit (13) ✔.
+**Spec coverage:** rule once in `acp` (Tasks 1,3 — direct + overlay checkers) ✔; node_did (Tasks 2,4) ✔; version→collection_id at every site (Tasks 5,6,9,10) ✔; commits (5) ✔; verify (6) ✔; KMS is_branchable + corrected semantics (7) ✔; peer-DID resolver, libp2p + Iroh-native (8) ✔; bitswap late-bound serve gate + stable-collection passthrough (9) ✔; CAR serve filter, no is_any_replicator (10) ✔; unresolved-DID→Anonymous (9,10) ✔; pushlog CID already-done (11) ✔; cross-impl (12) ✔; regression gate + adversarial audit (13) ✔.
 
-**Placeholders:** none — every code step shows real code; the two block→docID/`BlockReadGate` impls (Tasks 9 step 4) reference the existing merge-path resolution rather than re-deriving it, which is concrete guidance, not a placeholder.
+**Review findings closed:** #1 KMS test semantics (Task 7 step 1: public-doc+deny → Deny, explicit-grant → Allow) ✔; #2 per-block stable-collection passthrough (Tasks 9,10; Global Constraints) ✔; #3 late-bound `LateBoundReadGate` via `wire_document_acp` (Task 9) ✔; #4 Iroh NodeId→did:key derivation + documented constraint (Task 8) ✔; #5 single rule in `acp`, two checker impls (Tasks 1,3,7 all call `acp::read_access::check_doc_read_access`) ✔; #6 explicit `node_did` field + builder + wiring on the query runner (Task 4) ✔.
 
-**Type consistency:** `check_doc_read_access(acp, identity, &CollectionVersion, doc_id, node_identity)` used identically in Tasks 2/6; overlay variant `check_doc_read_access_overlay` with the same shape in Tasks 4/5; `DocAccess { has_access, explicit }` consistent; `PeerIdentityResolver::resolve -> Option<Did>` consistent across Tasks 8/9/10; `DocCollectionInfo.is_branchable` added once (7) and consumed in `kms_check_doc_read_access`.
+**Placeholders:** none — every code step shows real code; the `BlockReadGate`/`DocCollectionLookup` producer impls reference the existing block→docID and version→collection resolution rather than re-deriving, which is concrete guidance.
+
+**Type consistency:** `check_doc_read_access(checker, policy_id, resource_name, collection_id, is_branchable, doc_id)` used identically in Tasks 1,5,6,7; `ObjectAccessChecker::object_access(policy_id, resource_name, object_id) -> DocAccess` consistent across `DirectChecker` (1) and `OverlayChecker` (3); `DocAccess { has_access, explicit }` consistent; `PeerIdentityResolver::resolve -> Option<Did>` consistent (8,9,10); `BlockReadGate::evaluate -> Option<(String, bool)>` consistent (9,10); `DocCollectionInfo.is_branchable` added once (7).

--- a/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
+++ b/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
@@ -4,7 +4,7 @@
 
 **Goal:** Enforce branchable-collection ACP on local read paths (A2) and the P2P serve boundary (A3), consuming the A1 collection-object registration, at full parity with Go v1.0.0 `3f627855`.
 
-**Architecture:** ONE algorithm — `acp::read_access::check_doc_read_access` — defined over an `ObjectAccessChecker` trait, with two checker impls: `DirectChecker` (in `acp`, used by signature-verify, KMS, and the P2P serve gate) and `OverlayChecker` (in `query-plan`, txn-aware, used by the commits query). It lives in the `acp` crate because `db`, `query-plan`, and `kms` all depend on `acp` (none can depend on `db`). The rule takes primitive params (`policy_id`, `resource_name`, `collection_id`, `is_branchable`, `doc_id`) so every caller — including KMS, which only has a `DocCollectionInfo` — can use it. A transport-agnostic `PeerIdentityResolver` supplies the requesting peer's DID at the serve boundary: libp2p via the existing token protocol, Iroh via direct `NodeId → did:key` derivation.
+**Architecture:** ONE algorithm — `acp::read_access::check_doc_read_access` — defined over an `ObjectAccessChecker` trait, with two checker impls: `DirectChecker` (in `acp`, used by signature-verify, KMS, and the P2P serve gate) and `OverlayChecker` (in `query-plan`, txn-aware, used by the commits query). It lives in the `acp` crate because `db`, `query-plan`, and `kms` all depend on `acp` (none can depend on `db`). The rule takes primitive params (`policy_id`, `resource_name`, `collection_id`, `is_branchable`, `doc_id`) so every caller — including KMS, which only has a `DocCollectionInfo` — can use it. A transport-agnostic `PeerIdentityResolver` supplies the requesting peer's ACP DID at the serve boundary via Go's signed-token exchange (transport identity ≠ ACP identity): libp2p reuses the existing active `get_peer_identity` token path; Iroh has no token exchange yet, so non-replicator Iroh peers resolve to Anonymous (documented narrowing).
 
 **Tech Stack:** Rust, async-trait, tokio; crates `acp`, `db`, `query`, `query-plan`, `kms`, `p2p`; integration harness in `tools/integration-test`.
 
@@ -34,10 +34,8 @@
 - `crates/db/src/block_verify.rs` — A2 signature-verify gating.
 - `crates/kms/src/policy.rs` — `is_branchable` on `DocCollectionInfo`; KMS gate calls `acp::check_doc_read_access`.
 - `crates/kms/src/nac_dac_policy.rs` — wire the rule into `check_release`.
-- `crates/p2p/src/peer_identity.rs` (new) — `PeerIdentityResolver`, shared `PeerIdentityStore`, `StoreResolver` (libp2p) + `IrohPeerIdentityResolver`.
-- `crates/p2p/src/host/p2p_host/mod.rs` — hoist `peer_identities` into the shared `PeerIdentityStore`.
-- `crates/embedded/src/{node_p2p.rs,node_identity.rs}` — bind the Iroh endpoint key to the ed25519 node identity when ACP+Iroh.
-- `crates/p2p/src/bitswap/{filter.rs,read_gate.rs}` — `BlockCollectionResolver` (metadata) + late-bound `BlockReadGate` (ACP) + metadata-first serve gate.
+- `crates/p2p/src/peer_identity.rs` (new) — `PeerIdentityResolver`; `HandlePeerIdentityResolver` (libp2p, active token exchange via `get_peer_identity`) + `AnonymousResolver` (Iroh).
+- `crates/p2p/src/bitswap/{filter.rs,read_gate.rs}` — `BlockCollectionResolver` (DB-backed metadata) + `BlockReadGate` (ACP) + `LateBoundServeAcp` (resolver+gate, installed at wire-time) + metadata-first serve gate.
 - `crates/p2p/src/sync/coordinator/event_handler/car.rs` — CAR per-block serve filtering.
 - `tools/integration-test/tests/acp.rs` — cross-impl scenarios.
 
@@ -637,55 +635,51 @@ git commit -m "feat(acp): A3 KMS key-gate uses shared branchable read rule"
 
 ---
 
-## Task 8: A3 — `PeerIdentityResolver` (shared store) + Iroh identity binding
+## Task 8: A3 — `PeerIdentityResolver` (Go-style token exchange, late-bound)
 
 **Files:**
 - Create: `crates/p2p/src/peer_identity.rs`
-- Modify: `crates/p2p/src/lib.rs`; `crates/p2p/src/host/p2p_host/mod.rs` (hoist `peer_identities` into a shared store); `crates/embedded/src/{node_p2p.rs,node_identity.rs}` (Iroh binding)
+- Modify: `crates/p2p/src/lib.rs`
 - Test: `crates/p2p/src/peer_identity.rs` unit tests
 
+**Go model (do NOT bind transport key to ACP DID).** Go's `hasAccess` resolves the requesting peer's ACP identity by asking the peer for a **signed identity token**, verifying it against the local peer id as audience, and caching it — transport identity and ACP identity are independent (`internal/db/p2p/p2p.go:411,418,433`). Rust already implements exactly this active path: `P2PHostHandle::get_peer_identity` → `HostCommand::GetPeerIdentity` → `handle_get_peer_identity` (`messaging.rs:348`): cache hit, else sign an `IdentityRequest` (local peer id audience), send to the peer, `from_token` + `verify_auth_token`, extract DID, cache. The resolver must use THIS, not a cache-only read.
+
 **Interfaces:**
-- Produces:
-  ```rust
-  use crate::transport::PeerId;   // NOT the crate-root libp2p::PeerId re-export (finding #4)
+```rust
+use crate::transport::PeerId;   // NOT the crate-root libp2p::PeerId re-export (finding #4)
 
-  #[async_trait]
-  pub trait PeerIdentityResolver: Send + Sync {
-      async fn resolve(&self, peer_id: &PeerId) -> Option<identity::Did>;
-  }
+#[async_trait]
+pub trait PeerIdentityResolver: Send + Sync {
+    /// Resolve the peer's ACP DID (active token exchange on cache miss), or None
+    /// when the peer presents no verifiable identity. None => Anonymous (Go parity).
+    async fn resolve(&self, peer_id: &PeerId) -> Option<identity::Did>;
+}
 
-  /// Shared, mutable peer→DID cache, created BEFORE DefraBehaviour::new (like the
-  /// ReplicatorRegistry Arc at p2p_host/mod.rs:394) so the bitswap filter can hold
-  /// a resolver at construction time while the identity protocol populates it later.
-  #[derive(Default, Clone)]
-  pub struct PeerIdentityStore(Arc<RwLock<HashMap<PeerId, identity::Did>>>);
-  impl PeerIdentityStore { pub fn insert(&self, p: PeerId, d: identity::Did); pub fn get(&self, p: &PeerId) -> Option<identity::Did>; }
+// HandlePeerIdentityResolver(P2PHostHandle): libp2p — calls get_peer_identity (active
+//   fetch+verify+cache). Built at wire-time when the handle exists (see Task 9 late binding).
+// AnonymousResolver: Iroh — no identity-token exchange exists on Iroh today, so non-replicator
+//   Iroh peers resolve to None (Anonymous). Documented narrowing; tracked by a follow-up issue
+//   to port the signed-token exchange onto Iroh streams. (Iroh replicators are unaffected —
+//   they pass the replicator gate before identity is consulted.)
+```
 
-  // StoreResolver(PeerIdentityStore): libp2p — reads the shared store the host fills.
-  // IrohPeerIdentityResolver: PeerId string is the ed25519 NodeId -> did:key (no store needed).
-  ```
-
-**Finding #1 (resolver lifecycle):** the bitswap filter is installed in `DefraBehaviour::new` (`behaviour.rs:292`) **before** `P2PHostHandle` exists, so a handle-backed resolver is not constructible there. Instead, hoist the host's `peer_identities` field (`p2p_host/mod.rs:258`) into a shared `PeerIdentityStore` created up-front and passed into both the host (which inserts verified DIDs from the identity protocol) and a `StoreResolver` given to the filter. This mirrors the existing up-front `ReplicatorRegistry` Arc.
-
-**Finding #3 (Iroh binding):** Iroh `NodeId` is ed25519 and authenticated by the QUIC handshake; deriving `NodeId → did:key` is only a valid identity if the node's DefraDB identity IS that ed25519 key. By default the node identity is secp256k1 (`node_identity.rs:32`) and the Iroh secret key is generated independently (`node_p2p.rs:376`). So binding must be enforced, not assumed.
+**Lifecycle (finding #1):** the bitswap filter is installed in `DefraBehaviour::new` (`behaviour.rs:292`) **before** the handle exists. But the resolver is only needed on the **non-replicator ACP path**, which only runs after the ACP gate is installed — and the gate is installed at `wire_document_acp` (`node.rs:557`), which fires **after** the P2P system is built, when the handle exists. So the resolver is **late-bound together with the gate** (Task 9), not constructed at filter-build. No shared `peer_identities` hoist is needed — the existing handle cache + active path is reused.
 
 - [ ] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
-async fn iroh_resolver_derives_did_from_node_id() {
-    let (node_id_str, expected_did) = ed25519_node_id_and_did(); // same ed25519 key, two encodings
-    let r = IrohPeerIdentityResolver::default();
-    assert_eq!(r.resolve(&PeerId::new(node_id_str)).await, Some(expected_did));
+async fn handle_resolver_does_active_fetch_then_caches() {
+    // fake handle whose get_peer_identity returns Some(did) for a peer that presents
+    // a valid token, None otherwise.
+    let r = HandlePeerIdentityResolver::new(fake_handle_granting(known_peer(), known_did()));
+    assert_eq!(r.resolve(&known_peer()).await, Some(known_did()));
+    assert_eq!(r.resolve(&unknown_peer()).await, None);
 }
 
 #[tokio::test]
-async fn store_resolver_reads_shared_store() {
-    let store = PeerIdentityStore::default();
-    store.insert(known_peer(), known_did());
-    let r = StoreResolver(store.clone());
-    assert_eq!(r.resolve(&known_peer()).await, Some(known_did()));
-    assert_eq!(r.resolve(&unknown_peer()).await, None);
+async fn anonymous_resolver_returns_none() {
+    assert_eq!(AnonymousResolver.resolve(&any_peer()).await, None);
 }
 ```
 
@@ -694,44 +688,21 @@ async fn store_resolver_reads_shared_store() {
 Run: `cargo test -p p2p peer_identity`
 Expected: FAIL — trait/types not found.
 
-- [ ] **Step 3: Implement trait + `PeerIdentityStore` + both resolvers**
+- [ ] **Step 3: Implement the trait + both resolvers**
 
-Define the trait over `crate::transport::PeerId`. `PeerIdentityStore` wraps `Arc<RwLock<HashMap<PeerId, Did>>>`. `StoreResolver(store)` reads it. `IrohPeerIdentityResolver::resolve` parses the `PeerId` string as an `iroh::PublicKey`, takes its 32 ed25519 bytes, and derives a `did:key` `identity::Did` (add `identity::Did::from_ed25519_public_key(&[u8;32])` if absent). Add `pub mod peer_identity;` + re-exports in `lib.rs`.
+Define the trait over `crate::transport::PeerId`. `HandlePeerIdentityResolver` holds a `P2PHostHandle` and calls `get_peer_identity(peer_id).await.ok().flatten()` (this already does cache → active signed-token fetch → `verify_auth_token` → cache, matching Go). `AnonymousResolver::resolve` returns `None`. Add `pub mod peer_identity;` + re-exports in `lib.rs`. No changes to `node_identity.rs`/`node_p2p.rs`, no Iroh key binding.
 
-- [ ] **Step 4: Hoist `peer_identities` into the shared store**
+- [ ] **Step 4: Verify**
 
-In `crates/p2p/src/host/p2p_host/mod.rs`, replace the `peer_identities: HashMap<PeerId, Did>` field (line 258) with a `PeerIdentityStore` created up-front (alongside `replicators` at `mod.rs:394`) and inserted into on identity-protocol verification (`two_stream.rs:205`, `messaging.rs:383` insert sites). Keep `get_peer_identity` working by reading the store.
-
-Run: `cargo build -p p2p`
-
-- [ ] **Step 5: Enforce the Iroh identity binding**
-
-In `crates/embedded/src/node_p2p.rs` Iroh assembly: when `document_acp` is enabled, derive the Iroh `SecretKey` from the node's **ed25519** identity private-key bytes (instead of `load_or_generate_secret_key`), so the endpoint NodeId equals the node DID's key. In `node_identity.rs`, when ACP + Iroh are both configured, require an ed25519 node identity — return a startup error otherwise:
-
-```rust
-// node_p2p.rs (iroh + acp):
-let secret_key = if acp_enabled {
-    let ed = node_ed25519_secret_bytes()
-        .ok_or_else(|| anyhow!("ACP over Iroh requires an ed25519 node identity bound to the endpoint key"))?;
-    p2p::iroh::SecretKey::from_bytes(&ed)
-} else {
-    p2p::iroh::load_or_generate_secret_key(config.secret_key_path.as_deref()).await?
-};
-```
-
-Add a unit/assembly test asserting: ACP + Iroh + secp256k1 identity → startup error; ACP + Iroh + ed25519 identity → endpoint NodeId derives to the node DID.
-
-- [ ] **Step 6: Verify**
-
-Run: `cargo test -p p2p peer_identity && cargo test -p embedded iroh_acp_binding`
+Run: `cargo test -p p2p peer_identity`
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 cargo fmt --all
-git add crates/p2p/src/peer_identity.rs crates/p2p/src/lib.rs crates/p2p/src/host crates/identity/src crates/embedded/src/node_p2p.rs crates/embedded/src/node_identity.rs
-git commit -m "feat(p2p): PeerIdentityResolver (shared store + Iroh NodeId), enforce Iroh ACP key binding"
+git add crates/p2p/src/peer_identity.rs crates/p2p/src/lib.rs
+git commit -m "feat(p2p): PeerIdentityResolver (Go-style signed-token exchange; Iroh anonymous)"
 ```
 
 ---
@@ -739,29 +710,37 @@ git commit -m "feat(p2p): PeerIdentityResolver (shared store + Iroh NodeId), enf
 ## Task 9: A3 — split metadata from ACP; Bitswap per-block serve gate
 
 **Files:**
-- Create: `crates/p2p/src/bitswap/read_gate.rs` (`BlockCollectionResolver` + `BlockReadGate` traits + `LateBoundReadGate`)
+- Create: `crates/p2p/src/bitswap/read_gate.rs` (`BlockCollectionResolver` + `BlockReadGate` traits + `ServeAcp` / `LateBoundServeAcp`)
 - Modify: `crates/p2p/src/bitswap/filter.rs:62-145`, `crates/p2p/src/behaviour.rs:292`
 - Modify: node assembly (`crates/embedded/src/node.rs:553-558`) to install the ACP gate via `wire_document_acp`
 - Test: `crates/p2p/tests/bitswap_acp_filter_tests.rs`
 
-**Interfaces (finding #2 — metadata split from ACP):**
+**Interfaces (finding #2 — metadata split from ACP; finding #3 — DB-backed metadata):**
 ```rust
-/// Pure metadata: block -> (stable collection_id, doc ids). NO ACP, NO identity.
-/// Available at construction (backed by the collection store, which exists before P2P).
+/// Pure metadata: block -> (stable collection_id, doc ids) + is_branchable. NO ACP, NO identity.
+/// Backed by DB/SCHEMA metadata (get_collection_by_version_id + collection cache), NOT the P2P
+/// subscription store (collection_store.rs only holds subscribed collection ids). The DB exists
+/// before P2P, so this is available at filter-construction.
 #[async_trait]
 pub trait BlockCollectionResolver: Send + Sync {
-    async fn resolve(&self, block: &DefraBlock) -> Option<(String /*collection_id*/, Vec<String> /*doc_ids; empty => collection-level*/)>;
+    async fn resolve(&self, block: &DefraBlock)
+        -> Option<(String /*collection_id*/, bool /*is_branchable*/, Vec<String> /*doc_ids; empty => collection-level*/)>;
 }
 
-/// ACP evaluation only. Late-bound (needs document_acp). Never consulted for replicators.
+/// ACP evaluation only. Never consulted for replicators.
 #[async_trait]
 pub trait BlockReadGate: Send + Sync {
     async fn may_read(&self, identity: &acp::Identity, collection_id: &str, is_branchable: bool, doc_ids: &[String]) -> bool;
 }
-pub struct LateBoundReadGate(std::sync::OnceLock<Arc<dyn BlockReadGate>>);
+
+/// Late-bound serve-ACP context: the resolver (active token exchange, Task 8) AND the gate are
+/// installed TOGETHER at wire_document_acp, when both the host handle and document_acp exist.
+/// Empty until then => non-replicator serve denied (fail-closed).
+pub struct ServeAcp { pub resolver: Arc<dyn PeerIdentityResolver>, pub gate: Arc<dyn BlockReadGate> }
+pub struct LateBoundServeAcp(std::sync::OnceLock<ServeAcp>);
 ```
 
-**Ordering (finding #2):** metadata → replicator passthrough → (non-replicator) identity + ACP. The replicator path uses ONLY `BlockCollectionResolver` + the registry; it never touches the ACP gate or identity, so a not-yet-installed gate or an ACP error cannot deny a replicator.
+**Ordering (finding #2):** metadata → replicator passthrough → (non-replicator) identity + ACP. The replicator path uses ONLY `BlockCollectionResolver` + the registry; it never touches the resolver or the ACP gate, so a not-yet-installed `ServeAcp` or an ACP error cannot deny a replicator.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -777,8 +756,8 @@ Expected: FAIL.
 Keep the signature/definition/lens passthroughs. Then:
 
 ```rust
-// 1) METADATA ONLY — stable collection id + doc ids. No ACP, no identity.
-let Some((collection_id, doc_ids)) = meta.resolve(&defra_block).await else {
+// 1) METADATA ONLY — stable collection id, is_branchable, doc ids. No ACP, no identity.
+let Some((collection_id, is_branchable, doc_ids)) = meta.resolve(&defra_block).await else {
     return false; // can't classify the block => deny (no existence leak)
 };
 let peer_str = peer_id.to_string();
@@ -787,21 +766,20 @@ let peer_str = peer_id.to_string();
 if registry.is_filtered_replicator(&collection_id, &peer_str) { return false; }
 if registry.is_replicator(&collection_id, &peer_str) { return true; }
 
-// 3) NON-REPLICATOR — resolve identity (None => Anonymous) and run the ACP gate.
-let Some(gate) = read_gate.get() else { return false; }; // fail closed until installed
-let identity = match resolver.resolve(&peer_id.clone().into()).await {  // libp2p::PeerId -> transport::PeerId
-    Some(did) => acp::Identity::Authenticated(did),
+// 3) NON-REPLICATOR — needs the late-bound ServeAcp (resolver + gate). Fail closed until installed.
+let Some(serve) = serve_acp.get() else { return false; };
+let identity = match serve.resolver.resolve(&peer_id.clone().into()).await {  // libp2p::PeerId -> transport::PeerId
+    Some(did) => acp::Identity::Authenticated(did),  // active signed-token exchange (Go parity)
     None => acp::Identity::Anonymous,
 };
-let is_branchable = meta.is_branchable(&collection_id).await; // cheap collection-store lookup
-gate.may_read(&identity, &collection_id, is_branchable, &doc_ids).await
+serve.gate.may_read(&identity, &collection_id, is_branchable, &doc_ids).await
 ```
 
-Thread `meta: Arc<dyn BlockCollectionResolver>`, `resolver: Arc<dyn PeerIdentityResolver>`, `read_gate: Arc<LateBoundReadGate>` through `make_peer_block_access_filter` + the closure. `behaviour.rs:292` constructs the `LateBoundReadGate` (empty), the `StoreResolver` (from the up-front `PeerIdentityStore`), and the `meta` resolver (from the collection store), all available at construction.
+Thread `meta: Arc<dyn BlockCollectionResolver>` and `serve_acp: Arc<LateBoundServeAcp>` through `make_peer_block_access_filter` + the closure. `behaviour.rs:292` constructs the empty `LateBoundServeAcp` and the `meta` resolver (DB/schema-backed, available at construction).
 
-- [ ] **Step 4: Implement the resolvers + install the ACP gate via `wire_document_acp`**
+- [ ] **Step 4: Implement the metadata resolver + install `ServeAcp` via `wire_document_acp`**
 
-`BlockCollectionResolver` impl (node/db layer, available up-front): decode is done by the filter (pass `&DefraBlock`); read `schema_version_id`; resolve `→ CollectionVersion` via the collection store; return `(collection.collection_id, doc_ids)` (collection-level => empty vec). `is_branchable(collection_id)` is a collection-store lookup. `BlockReadGate` impl (late-bound): `may_read` runs `acp::read_access::check_doc_read_access(DirectChecker{..}, policy, .., collection_id, is_branchable, doc)` for each doc id (empty list => one check with `""`), returning true if ANY grants. Install the gate into `LateBoundReadGate` inside the `wire_document_acp` closure at `node.rs:557` (+ defra-node equivalent).
+`BlockCollectionResolver` impl (db/embedded layer, up-front): the filter passes the decoded `&DefraBlock`; read `schema_version_id`; resolve `→ CollectionVersion` via `get_collection_by_version_id` (DB/schema, NOT the P2P subscription store); return `(collection.collection_id, collection.is_branchable, doc_ids)` (collection-level => empty vec). `BlockReadGate` impl: `may_read` runs `acp::read_access::check_doc_read_access(DirectChecker{ acp, identity, node_did }, policy.id, policy.resource_name, collection_id, is_branchable, doc)` per doc id (empty list => one check with `""`), true if ANY grants. Install `ServeAcp { resolver, gate }` into `LateBoundServeAcp` inside the `wire_document_acp` closure at `node.rs:557` (handle exists here), where `resolver` = `HandlePeerIdentityResolver(handle)` for libp2p or `AnonymousResolver` for Iroh, and `gate` = the `BlockReadGate` impl. (+ defra-node equivalent.)
 
 - [ ] **Step 5: Verify**
 
@@ -822,7 +800,7 @@ git commit -m "feat(p2p): A3 bitswap serve gate — metadata-first ordering, sta
 
 **Files:**
 - Modify: `crates/p2p/src/sync/coordinator/event_handler/car.rs:83-179`
-- Modify: `SyncCoordinator` construction to inject `BlockCollectionResolver` + `PeerIdentityResolver` + `LateBoundReadGate`
+- Modify: `SyncCoordinator` construction to inject `BlockCollectionResolver` (meta, up-front) + `LateBoundServeAcp` (resolver+gate)
 - Test: CAR test module under `crates/p2p/src/sync/coordinator/`
 
 **Context (finding #2):** same metadata-first ordering. Per block: resolve stable collection_id (metadata) → replicator passthrough on that id → non-replicator identity + ACP. Never `is_any_replicator`.
@@ -842,9 +820,14 @@ After `let blocks = collected.blocks;` (car.rs:133), before the empty check:
 
 ```rust
 let peer_str = peer_id.to_string();
-// Resolve the peer identity ONCE per request (None => Anonymous, Go parity).
-let identity = match self.peer_identity_resolver.resolve(&peer_id).await {
-    Some(did) => acp::Identity::Authenticated(did),
+// ServeAcp (resolver + gate) is late-bound; if absent only replicator passthrough works.
+let serve = self.serve_acp.get();
+// Resolve the peer identity ONCE (only when ServeAcp is installed); None => Anonymous.
+let identity = match serve {
+    Some(s) => match s.resolver.resolve(&peer_id).await {
+        Some(did) => acp::Identity::Authenticated(did),
+        None => acp::Identity::Anonymous,
+    },
     None => acp::Identity::Anonymous,
 };
 let mut kept = Vec::with_capacity(blocks.len());
@@ -853,23 +836,22 @@ for (cid, data) in blocks {
         Ok(b) => b,
         Err(_) => { kept.push((cid, data)); continue; } // signature/lens/non-CRDT passthrough
     };
-    let Some((collection_id, doc_ids)) = self.meta.resolve(&block).await else {
+    let Some((collection_id, is_branchable, doc_ids)) = self.meta.resolve(&block).await else {
         continue; // unclassifiable => drop (no existence leak)
     };
     // Replicator passthrough on the STABLE collection_id — no ACP/identity.
     if self.access.replicators.is_filtered_replicator(&collection_id, &peer_str) { continue; }
     if self.access.replicators.is_replicator(&collection_id, &peer_str) { kept.push((cid, data)); continue; }
-    // Non-replicator: ACP gate (fail closed until installed).
-    let Some(gate) = self.read_gate.get() else { continue; };
-    let is_branchable = self.meta.is_branchable(&collection_id).await;
-    if gate.may_read(&identity, &collection_id, is_branchable, &doc_ids).await {
+    // Non-replicator: needs ServeAcp (fail closed until installed).
+    let Some(serve) = serve else { continue; };
+    if serve.gate.may_read(&identity, &collection_id, is_branchable, &doc_ids).await {
         kept.push((cid, data));
     }
 }
 let blocks = kept;
 ```
 
-Hold `meta: Arc<dyn BlockCollectionResolver>`, `peer_identity_resolver: Arc<dyn PeerIdentityResolver>`, `read_gate: Arc<LateBoundReadGate>` on `SyncCoordinator` (inject alongside `authorizer`; populate the gate via the same `wire_document_acp` path).
+Hold `meta: Arc<dyn BlockCollectionResolver>` and `serve_acp: Arc<LateBoundServeAcp>` on `SyncCoordinator` (inject alongside `authorizer`; populate `serve_acp` via the same `wire_document_acp` path).
 
 - [ ] **Step 4: Verify**
 
@@ -957,11 +939,11 @@ Expected: PASS. Any regression here is a **blocker** → revisit serve-scope per
 
 - [ ] **Step 2: Adversarial review (ultracode Workflow)**
 
-Scope to the A3 diff (Tasks 8–10) + merge handler vs Go `3f627855` `hasAccess`/`trySelfHasAccess`. Hunt: private branchable block served to a non-replicator without access; unresolved-DID granting more than Anonymous; recursive-vs-exact CAR asymmetry; a transport skipping the gate; `is_any_replicator`/`schema_version_id` passthrough leaks (finding #2); block→docID resolution missing collection-level blocks; the `LateBoundReadGate` serving before initialization. Resolve or explicitly accept every CONFIRMED/PLAUSIBLE finding.
+Scope to the A3 diff (Tasks 8–10) + merge handler vs Go `3f627855` `hasAccess`/`trySelfHasAccess`. Hunt: private branchable block served to a non-replicator without access; unresolved-DID granting more than Anonymous; recursive-vs-exact CAR asymmetry; a transport skipping the gate; `is_any_replicator`/`schema_version_id` passthrough leaks (finding #2); block→docID resolution missing collection-level blocks; the `LateBoundServeAcp` serving before initialization; an Iroh non-replicator path leaking registered docs while resolving to Anonymous. Resolve or explicitly accept every CONFIRMED/PLAUSIBLE finding.
 
 - [ ] **Step 3: Update PR body**
 
-Change the PR description from "A1 registration" to the full A1–A3 security feature; note the cross-impl matrix, the Iroh NodeId-derivation constraint, and the adversarial audit outcome.
+Change the PR description from "A1 registration" to the full A1–A3 security feature; note the cross-impl matrix, the Iroh non-replicator Anonymous narrowing (+ follow-up issue to port the signed-token exchange to Iroh), and the adversarial audit outcome.
 
 ---
 
@@ -970,6 +952,8 @@ Change the PR description from "A1 registration" to the full A1–A3 security fe
 **Spec coverage:** rule once in `acp` (Tasks 1,3 — direct + overlay checkers) ✔; node_did (Tasks 2,4) ✔; version→collection_id at every site (Tasks 5,6,9,10) ✔; commits (5) ✔; verify (6) ✔; KMS is_branchable + corrected semantics (7) ✔; peer-DID resolver, libp2p + Iroh-native (8) ✔; bitswap late-bound serve gate + stable-collection passthrough (9) ✔; CAR serve filter, no is_any_replicator (10) ✔; unresolved-DID→Anonymous (9,10) ✔; pushlog CID already-done (11) ✔; cross-impl (12) ✔; regression gate + adversarial audit (13) ✔.
 
 **Review findings closed (round 2):** #1 KMS test semantics (Task 7 step 1: public-doc+deny → Deny, explicit-grant → Allow) ✔; #2 per-block stable-collection passthrough (Tasks 9,10; Global Constraints) ✔; #3 late-bound `LateBoundReadGate` via `wire_document_acp` (Task 9) ✔; #4 Iroh NodeId→did:key derivation + documented constraint (Task 8) ✔; #5 single rule in `acp`, two checker impls (Tasks 1,3,7 all call `acp::read_access::check_doc_read_access`) ✔; #6 explicit `node_did` field + builder + wiring on the query runner (Task 4) ✔.
+
+**Review findings closed (round 4 — Go-parity identity):** #1 dropped Iroh `NodeId→did:key` + ed25519 key-binding (Go decouples transport id from ACP id); resolver uses Go's signed-token exchange, late-bound at `wire_document_acp` when the handle exists; Iroh → Anonymous narrowing + follow-up issue (Task 8) ✔; #2 libp2p resolver uses the **active** `get_peer_identity` (cache→fetch→verify→cache, `messaging.rs:348`), not cache-only (Task 8 step 3) ✔; #3 `BlockCollectionResolver` is **DB/schema-backed** (`get_collection_by_version_id`), not the P2P subscription store (Task 9 interfaces + step 4) ✔.
 
 **Review findings closed (round 3):** #1 resolver lifecycle — shared `PeerIdentityStore` created up-front (mirrors the `ReplicatorRegistry` Arc), `StoreResolver` constructible at filter build, not the handle (Task 8 steps 3-4) ✔; #2 ordering — `BlockCollectionResolver` (metadata, no ACP/identity) → replicator passthrough → non-replicator ACP; replicator path never touches the gate/identity (Tasks 9,10; Global Constraints serve-gate ordering) ✔; #3 Iroh binding enforced — derive endpoint key from the ed25519 node identity + startup error on secp256k1 (Task 8 step 5) ✔; #4 `crate::transport::PeerId` in the trait + conversion at the bitswap call site (Task 8 interfaces; Global Constraints) ✔; #5 `collections_map()` returns `Arc<CollectionVersion>` — `by_version` stores `Arc` (Task 5 step 3) ✔.
 

--- a/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
+++ b/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
@@ -16,6 +16,8 @@
 - `cargo clippy --all -- -D warnings` clean; `cargo fmt --all` applied before each commit.
 - Unresolved peer DID at the serve boundary → `Identity::Anonymous` (Go parity), not blanket-deny.
 - Replicator passthrough is **per-block, keyed on the block's stable `collection_id`** — never `is_any_replicator` and never the raw `schema_version_id`.
+- **Serve-gate ordering (finding #2):** resolve block→stable `collection_id` (metadata, no ACP/identity) → check replicator passthrough → **only then**, for non-replicators, resolve peer identity + run the ACP read gate. The replicator path must never depend on the ACP gate being installed or on identity resolution, so a not-yet-wired gate or an ACP/backend error can never deny a registered replicator.
+- **`PeerId` type:** the `PeerIdentityResolver` trait uses `crate::transport::PeerId` (the transport-agnostic id), not the crate-root `libp2p::PeerId` re-export (`lib.rs:174`). Bitswap converts its `libp2p::PeerId` to `transport::PeerId` at the call site.
 - Do NOT flip the `strict_replicated_doc_access` merge default.
 - A2 and A3 in separate commits. The A3 serve-path work requires the Task 13 adversarial re-audit before the PR merges.
 
@@ -32,8 +34,10 @@
 - `crates/db/src/block_verify.rs` — A2 signature-verify gating.
 - `crates/kms/src/policy.rs` — `is_branchable` on `DocCollectionInfo`; KMS gate calls `acp::check_doc_read_access`.
 - `crates/kms/src/nac_dac_policy.rs` — wire the rule into `check_release`.
-- `crates/p2p/src/peer_identity.rs` (new) — `PeerIdentityResolver` (libp2p + Iroh impls).
-- `crates/p2p/src/bitswap/{filter.rs,read_gate.rs}` — late-bound `BlockReadGate` + per-block serve gate.
+- `crates/p2p/src/peer_identity.rs` (new) — `PeerIdentityResolver`, shared `PeerIdentityStore`, `StoreResolver` (libp2p) + `IrohPeerIdentityResolver`.
+- `crates/p2p/src/host/p2p_host/mod.rs` — hoist `peer_identities` into the shared `PeerIdentityStore`.
+- `crates/embedded/src/{node_p2p.rs,node_identity.rs}` — bind the Iroh endpoint key to the ed25519 node identity when ACP+Iroh.
+- `crates/p2p/src/bitswap/{filter.rs,read_gate.rs}` — `BlockCollectionResolver` (metadata) + late-bound `BlockReadGate` (ACP) + metadata-first serve gate.
 - `crates/p2p/src/sync/coordinator/event_handler/car.rs` — CAR per-block serve filtering.
 - `tools/integration-test/tests/acp.rs` — cross-impl scenarios.
 
@@ -440,8 +444,8 @@ Replace lines ~737-839 with a per-commit rule check:
 use acp::Identity;
 let node_did = self.node_did().cloned();
 let identity = Identity::from(caller_identity.clone());
-let collections = self.collections_map().await?;
-let by_version: std::collections::HashMap<String, schema::CollectionVersion> =
+let collections = self.collections_map().await?; // HashMap<String, Arc<CollectionVersion>>
+let by_version: std::collections::HashMap<String, std::sync::Arc<schema::CollectionVersion>> =
     collections.values().map(|c| (c.version_id.clone(), c.clone())).collect();
 
 let mut keep = Vec::with_capacity(commits.len());
@@ -633,39 +637,53 @@ git commit -m "feat(acp): A3 KMS key-gate uses shared branchable read rule"
 
 ---
 
-## Task 8: A3 — `PeerIdentityResolver` (libp2p token + Iroh NodeId derivation)
+## Task 8: A3 — `PeerIdentityResolver` (shared store) + Iroh identity binding
 
 **Files:**
 - Create: `crates/p2p/src/peer_identity.rs`
-- Modify: `crates/p2p/src/lib.rs`; libp2p impl wraps `host::handle::get_peer_identity`; Iroh impl derives `NodeId → did:key`
+- Modify: `crates/p2p/src/lib.rs`; `crates/p2p/src/host/p2p_host/mod.rs` (hoist `peer_identities` into a shared store); `crates/embedded/src/{node_p2p.rs,node_identity.rs}` (Iroh binding)
 - Test: `crates/p2p/src/peer_identity.rs` unit tests
 
 **Interfaces:**
 - Produces:
   ```rust
+  use crate::transport::PeerId;   // NOT the crate-root libp2p::PeerId re-export (finding #4)
+
   #[async_trait]
   pub trait PeerIdentityResolver: Send + Sync {
       async fn resolve(&self, peer_id: &PeerId) -> Option<identity::Did>;
   }
-  // Libp2pPeerIdentityResolver(handle): delegates to get_peer_identity().ok().flatten()
-  // IrohPeerIdentityResolver: PeerId string is the ed25519 NodeId -> did:key
+
+  /// Shared, mutable peer→DID cache, created BEFORE DefraBehaviour::new (like the
+  /// ReplicatorRegistry Arc at p2p_host/mod.rs:394) so the bitswap filter can hold
+  /// a resolver at construction time while the identity protocol populates it later.
+  #[derive(Default, Clone)]
+  pub struct PeerIdentityStore(Arc<RwLock<HashMap<PeerId, identity::Did>>>);
+  impl PeerIdentityStore { pub fn insert(&self, p: PeerId, d: identity::Did); pub fn get(&self, p: &PeerId) -> Option<identity::Did>; }
+
+  // StoreResolver(PeerIdentityStore): libp2p — reads the shared store the host fills.
+  // IrohPeerIdentityResolver: PeerId string is the ed25519 NodeId -> did:key (no store needed).
   ```
 
-**Iroh note:** the Iroh `PeerId` is the ed25519 NodeId string (`transport.rs:44` `PeerId::new(node_id.to_string())`). Derive the DID from the 32-byte ed25519 public key via the `identity` crate's did:key derivation. This is verifiable (Iroh's QUIC handshake authenticates the NodeId) and needs no exchange protocol. It resolves the peer's **node** DID; ACP-over-Iroh deployments therefore bind the node's DefraDB identity to its ed25519 endpoint key. If the bytes can't be parsed as an ed25519 did:key (e.g. a non-ed25519 node identity), return `None` (→ Anonymous), a documented Iroh constraint.
+**Finding #1 (resolver lifecycle):** the bitswap filter is installed in `DefraBehaviour::new` (`behaviour.rs:292`) **before** `P2PHostHandle` exists, so a handle-backed resolver is not constructible there. Instead, hoist the host's `peer_identities` field (`p2p_host/mod.rs:258`) into a shared `PeerIdentityStore` created up-front and passed into both the host (which inserts verified DIDs from the identity protocol) and a `StoreResolver` given to the filter. This mirrors the existing up-front `ReplicatorRegistry` Arc.
+
+**Finding #3 (Iroh binding):** Iroh `NodeId` is ed25519 and authenticated by the QUIC handshake; deriving `NodeId → did:key` is only a valid identity if the node's DefraDB identity IS that ed25519 key. By default the node identity is secp256k1 (`node_identity.rs:32`) and the Iroh secret key is generated independently (`node_p2p.rs:376`). So binding must be enforced, not assumed.
 
 - [ ] **Step 1: Write the failing tests**
 
 ```rust
 #[tokio::test]
 async fn iroh_resolver_derives_did_from_node_id() {
-    let (node_id_str, expected_did) = ed25519_node_id_and_did();
+    let (node_id_str, expected_did) = ed25519_node_id_and_did(); // same ed25519 key, two encodings
     let r = IrohPeerIdentityResolver::default();
     assert_eq!(r.resolve(&PeerId::new(node_id_str)).await, Some(expected_did));
 }
 
 #[tokio::test]
-async fn libp2p_resolver_delegates_to_handle() {
-    let r = make_libp2p_resolver_with(known_peer(), known_did());
+async fn store_resolver_reads_shared_store() {
+    let store = PeerIdentityStore::default();
+    store.insert(known_peer(), known_did());
+    let r = StoreResolver(store.clone());
     assert_eq!(r.resolve(&known_peer()).await, Some(known_did()));
     assert_eq!(r.resolve(&unknown_peer()).await, None);
 }
@@ -674,101 +692,128 @@ async fn libp2p_resolver_delegates_to_handle() {
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `cargo test -p p2p peer_identity`
-Expected: FAIL — trait/impls not found.
+Expected: FAIL — trait/types not found.
 
-- [ ] **Step 3: Implement trait + both resolvers**
+- [ ] **Step 3: Implement trait + `PeerIdentityStore` + both resolvers**
 
-Define the trait. `Libp2pPeerIdentityResolver` holds a `P2PHostHandle` and calls `get_peer_identity(peer_id).await.ok().flatten()`. `IrohPeerIdentityResolver::resolve` parses the `PeerId` string as an `iroh::PublicKey`/`EndpointId`, takes its 32 ed25519 bytes, and derives a `did:key` `identity::Did` (add an `identity::Did::from_ed25519_public_key(&[u8;32])` helper if absent, using the existing did:key derivation). Add `pub mod peer_identity;` + re-exports in `lib.rs`.
+Define the trait over `crate::transport::PeerId`. `PeerIdentityStore` wraps `Arc<RwLock<HashMap<PeerId, Did>>>`. `StoreResolver(store)` reads it. `IrohPeerIdentityResolver::resolve` parses the `PeerId` string as an `iroh::PublicKey`, takes its 32 ed25519 bytes, and derives a `did:key` `identity::Did` (add `identity::Did::from_ed25519_public_key(&[u8;32])` if absent). Add `pub mod peer_identity;` + re-exports in `lib.rs`.
 
-- [ ] **Step 4: Verify**
+- [ ] **Step 4: Hoist `peer_identities` into the shared store**
 
-Run: `cargo test -p p2p peer_identity`
+In `crates/p2p/src/host/p2p_host/mod.rs`, replace the `peer_identities: HashMap<PeerId, Did>` field (line 258) with a `PeerIdentityStore` created up-front (alongside `replicators` at `mod.rs:394`) and inserted into on identity-protocol verification (`two_stream.rs:205`, `messaging.rs:383` insert sites). Keep `get_peer_identity` working by reading the store.
+
+Run: `cargo build -p p2p`
+
+- [ ] **Step 5: Enforce the Iroh identity binding**
+
+In `crates/embedded/src/node_p2p.rs` Iroh assembly: when `document_acp` is enabled, derive the Iroh `SecretKey` from the node's **ed25519** identity private-key bytes (instead of `load_or_generate_secret_key`), so the endpoint NodeId equals the node DID's key. In `node_identity.rs`, when ACP + Iroh are both configured, require an ed25519 node identity — return a startup error otherwise:
+
+```rust
+// node_p2p.rs (iroh + acp):
+let secret_key = if acp_enabled {
+    let ed = node_ed25519_secret_bytes()
+        .ok_or_else(|| anyhow!("ACP over Iroh requires an ed25519 node identity bound to the endpoint key"))?;
+    p2p::iroh::SecretKey::from_bytes(&ed)
+} else {
+    p2p::iroh::load_or_generate_secret_key(config.secret_key_path.as_deref()).await?
+};
+```
+
+Add a unit/assembly test asserting: ACP + Iroh + secp256k1 identity → startup error; ACP + Iroh + ed25519 identity → endpoint NodeId derives to the node DID.
+
+- [ ] **Step 6: Verify**
+
+Run: `cargo test -p p2p peer_identity && cargo test -p embedded iroh_acp_binding`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 cargo fmt --all
-git add crates/p2p/src/peer_identity.rs crates/p2p/src/lib.rs crates/identity/src
-git commit -m "feat(p2p): PeerIdentityResolver (libp2p token + Iroh NodeId did:key)"
+git add crates/p2p/src/peer_identity.rs crates/p2p/src/lib.rs crates/p2p/src/host crates/identity/src crates/embedded/src/node_p2p.rs crates/embedded/src/node_identity.rs
+git commit -m "feat(p2p): PeerIdentityResolver (shared store + Iroh NodeId), enforce Iroh ACP key binding"
 ```
 
 ---
 
-## Task 9: A3 — late-bound `BlockReadGate` + Bitswap per-block serve gate
+## Task 9: A3 — split metadata from ACP; Bitswap per-block serve gate
 
 **Files:**
-- Create: `crates/p2p/src/bitswap/read_gate.rs` (`BlockReadGate` trait + `LateBoundReadGate` holder)
+- Create: `crates/p2p/src/bitswap/read_gate.rs` (`BlockCollectionResolver` + `BlockReadGate` traits + `LateBoundReadGate`)
 - Modify: `crates/p2p/src/bitswap/filter.rs:62-145`, `crates/p2p/src/behaviour.rs:292`
-- Modify: node assembly (`crates/embedded/src/node.rs:553-558` wiring) to install the gate via the existing `wire_document_acp` callback
+- Modify: node assembly (`crates/embedded/src/node.rs:553-558`) to install the ACP gate via `wire_document_acp`
 - Test: `crates/p2p/tests/bitswap_acp_filter_tests.rs`
 
-**Interfaces:**
-- Produces:
-  ```rust
-  #[async_trait]
-  pub trait BlockReadGate: Send + Sync {
-      /// Resolve the block's stable collection_id + doc id(s), then apply the read
-      /// rule for `identity`. Returns (collection_id, allow). collection_id lets the
-      /// caller do replicator passthrough keyed on the STABLE id (finding #2).
-      async fn evaluate(&self, identity: &acp::Identity, block: &DefraBlock)
-          -> Option<(String /*collection_id*/, bool /*allow*/)>;
-  }
+**Interfaces (finding #2 — metadata split from ACP):**
+```rust
+/// Pure metadata: block -> (stable collection_id, doc ids). NO ACP, NO identity.
+/// Available at construction (backed by the collection store, which exists before P2P).
+#[async_trait]
+pub trait BlockCollectionResolver: Send + Sync {
+    async fn resolve(&self, block: &DefraBlock) -> Option<(String /*collection_id*/, Vec<String> /*doc_ids; empty => collection-level*/)>;
+}
 
-  /// OnceLock-backed holder installed at filter-construction; fail-closed until set.
-  pub struct LateBoundReadGate(std::sync::OnceLock<Arc<dyn BlockReadGate>>);
-  ```
+/// ACP evaluation only. Late-bound (needs document_acp). Never consulted for replicators.
+#[async_trait]
+pub trait BlockReadGate: Send + Sync {
+    async fn may_read(&self, identity: &acp::Identity, collection_id: &str, is_branchable: bool, doc_ids: &[String]) -> bool;
+}
+pub struct LateBoundReadGate(std::sync::OnceLock<Arc<dyn BlockReadGate>>);
+```
 
-**Context (finding #3):** the bitswap filter is built at `behaviour.rs:292` before `document_acp` exists. So the filter takes a `LateBoundReadGate` (empty), and the node assembly populates it inside the existing `wire_document_acp` callback (`node.rs:557`). Until populated, the gate denies non-replicator/non-public access (fail-closed).
-**Context (finding #2):** never use the raw `schema_version_id` for replicator checks. The gate returns the block's **stable `collection_id`**; the filter uses THAT for `registry.is_replicator`.
+**Ordering (finding #2):** metadata → replicator passthrough → (non-replicator) identity + ACP. The replicator path uses ONLY `BlockCollectionResolver` + the registry; it never touches the ACP gate or identity, so a not-yet-installed gate or an ACP error cannot deny a replicator.
 
 - [ ] **Step 1: Write the failing tests**
 
-In `crates/p2p/tests/bitswap_acp_filter_tests.rs`: (a) non-replicator peer whose DID lacks collection access requests a branchable data block → deny; (b) replicator **for that block's collection** → allow (passthrough); (c) peer that is a replicator of a *different* collection → still gated (deny if no access) — guards finding #2; (d) unresolved DID + public/unregistered block → allow (Anonymous); + registered block → deny; (e) gate not yet installed → deny non-replicator.
+In `crates/p2p/tests/bitswap_acp_filter_tests.rs`: (a) non-replicator, DID lacks collection access, branchable data block → deny; (b) replicator **for that block's collection** → allow even when the ACP gate is not installed (passthrough independent of ACP); (c) replicator of a *different* collection → gated (deny if no access); (d) unresolved DID + public block → allow; + registered block → deny; (e) non-replicator + gate not installed → deny.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
 Run: `cargo test -p p2p --test bitswap_acp_filter_tests`
 Expected: FAIL.
 
-- [ ] **Step 3: Rewrite `check_access`**
+- [ ] **Step 3: Rewrite `check_access` with the metadata-first ordering**
 
 Keep the signature/definition/lens passthroughs. Then:
 
 ```rust
-// resolve the read gate's verdict (also yields the STABLE collection_id).
-let identity = match resolver.resolve(peer_id).await {
+// 1) METADATA ONLY — stable collection id + doc ids. No ACP, no identity.
+let Some((collection_id, doc_ids)) = meta.resolve(&defra_block).await else {
+    return false; // can't classify the block => deny (no existence leak)
+};
+let peer_str = peer_id.to_string();
+
+// 2) REPLICATOR PASSTHROUGH on the STABLE collection_id — independent of ACP/identity.
+if registry.is_filtered_replicator(&collection_id, &peer_str) { return false; }
+if registry.is_replicator(&collection_id, &peer_str) { return true; }
+
+// 3) NON-REPLICATOR — resolve identity (None => Anonymous) and run the ACP gate.
+let Some(gate) = read_gate.get() else { return false; }; // fail closed until installed
+let identity = match resolver.resolve(&peer_id.clone().into()).await {  // libp2p::PeerId -> transport::PeerId
     Some(did) => acp::Identity::Authenticated(did),
     None => acp::Identity::Anonymous,
 };
-let Some((collection_id, allow)) = read_gate.evaluate(&identity, &defra_block).await else {
-    // gate not installed yet => fail closed for non-replicators.
-    return false;
-};
-let peer_str = peer_id.to_string();
-// Replicator passthrough keyed on the STABLE collection_id (finding #2).
-if registry.is_filtered_replicator(&collection_id, &peer_str) { return false; }
-if registry.is_replicator(&collection_id, &peer_str) { return true; }
-allow
+let is_branchable = meta.is_branchable(&collection_id).await; // cheap collection-store lookup
+gate.may_read(&identity, &collection_id, is_branchable, &doc_ids).await
 ```
 
-Thread `resolver: Arc<dyn PeerIdentityResolver>` and `read_gate: Arc<LateBoundReadGate>` through `make_peer_block_access_filter` + the closure. `behaviour.rs:292` constructs the `LateBoundReadGate` (empty) and passes a default `resolver` appropriate to the transport (libp2p resolver from the host handle).
+Thread `meta: Arc<dyn BlockCollectionResolver>`, `resolver: Arc<dyn PeerIdentityResolver>`, `read_gate: Arc<LateBoundReadGate>` through `make_peer_block_access_filter` + the closure. `behaviour.rs:292` constructs the `LateBoundReadGate` (empty), the `StoreResolver` (from the up-front `PeerIdentityStore`), and the `meta` resolver (from the collection store), all available at construction.
 
-- [ ] **Step 4: Implement `BlockReadGate` + install via `wire_document_acp`**
+- [ ] **Step 4: Implement the resolvers + install the ACP gate via `wire_document_acp`**
 
-Implement the gate in the node/db layer: decode is already done (pass `&DefraBlock`); resolve `schema_version_id → CollectionVersion`; compute the block's docID(s) (collection-level => `""`); return `(collection.collection_id, check_doc_read_access(DirectChecker{...}) for any owner doc)`. Install it into the `LateBoundReadGate` inside the `wire_document_acp` closure at `crates/embedded/src/node.rs:557` (and the `defra-node` equivalent).
+`BlockCollectionResolver` impl (node/db layer, available up-front): decode is done by the filter (pass `&DefraBlock`); read `schema_version_id`; resolve `→ CollectionVersion` via the collection store; return `(collection.collection_id, doc_ids)` (collection-level => empty vec). `is_branchable(collection_id)` is a collection-store lookup. `BlockReadGate` impl (late-bound): `may_read` runs `acp::read_access::check_doc_read_access(DirectChecker{..}, policy, .., collection_id, is_branchable, doc)` for each doc id (empty list => one check with `""`), returning true if ANY grants. Install the gate into `LateBoundReadGate` inside the `wire_document_acp` closure at `node.rs:557` (+ defra-node equivalent).
 
 - [ ] **Step 5: Verify**
 
 Run: `cargo test -p p2p --test bitswap_acp_filter_tests`
-Expected: PASS.
+Expected: PASS (including case (b): replicator allowed with no ACP gate installed).
 
 - [ ] **Step 6: Commit**
 
 ```bash
 cargo fmt --all
 git add crates/p2p/src/bitswap crates/p2p/src/behaviour.rs crates/embedded/src/node.rs crates/defra-node/src crates/p2p/tests/bitswap_acp_filter_tests.rs
-git commit -m "feat(p2p): A3 bitswap per-block serve gate (late-bound, stable-collection passthrough)"
+git commit -m "feat(p2p): A3 bitswap serve gate — metadata-first ordering, stable-collection passthrough"
 ```
 
 ---
@@ -777,49 +822,54 @@ git commit -m "feat(p2p): A3 bitswap per-block serve gate (late-bound, stable-co
 
 **Files:**
 - Modify: `crates/p2p/src/sync/coordinator/event_handler/car.rs:83-179`
-- Modify: `SyncCoordinator` construction to inject `PeerIdentityResolver` + `BlockReadGate`
+- Modify: `SyncCoordinator` construction to inject `BlockCollectionResolver` + `PeerIdentityResolver` + `LateBoundReadGate`
 - Test: CAR test module under `crates/p2p/src/sync/coordinator/`
 
-**Context (finding #2):** do NOT use `is_any_replicator`. Filter each block, doing replicator passthrough per the block's **stable collection_id** returned by the gate.
+**Context (finding #2):** same metadata-first ordering. Per block: resolve stable collection_id (metadata) → replicator passthrough on that id → non-replicator identity + ACP. Never `is_any_replicator`.
 
 - [ ] **Step 1: Write the failing test**
 
-Branchable collection, private doc. A connected non-replicator peer issues a CAR fetch → response excludes blocks it can't read; a replicator **for that collection** → full DAG; a peer that is a replicator of a *different* collection → still gated.
+Branchable collection, private doc. Connected non-replicator → response excludes unreadable blocks; replicator **for that collection** → full DAG (even with no ACP gate installed); replicator of a *different* collection → gated.
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cargo test -p p2p car_fetch`
 Expected: FAIL — CAR serves the full DAG.
 
-- [ ] **Step 3: Filter response blocks per block**
+- [ ] **Step 3: Filter response blocks per block (metadata-first)**
 
 After `let blocks = collected.blocks;` (car.rs:133), before the empty check:
 
 ```rust
+let peer_str = peer_id.to_string();
+// Resolve the peer identity ONCE per request (None => Anonymous, Go parity).
 let identity = match self.peer_identity_resolver.resolve(&peer_id).await {
     Some(did) => acp::Identity::Authenticated(did),
     None => acp::Identity::Anonymous,
 };
-let peer_str = peer_id.to_string();
 let mut kept = Vec::with_capacity(blocks.len());
 for (cid, data) in blocks {
-    let allow = match DefraBlock::from_dag_cbor(&data) {
-        Ok(b) => match self.read_gate.evaluate(&identity, &b).await {
-            None => false, // gate not installed => fail closed
-            Some((collection_id, rule_allow)) => {
-                self.access.replicators.is_replicator(&collection_id, &peer_str)
-                    && !self.access.replicators.is_filtered_replicator(&collection_id, &peer_str)
-                    || rule_allow
-            }
-        },
-        Err(_) => true, // signature / lens / non-CRDT — passthrough (matches bitswap)
+    let block = match DefraBlock::from_dag_cbor(&data) {
+        Ok(b) => b,
+        Err(_) => { kept.push((cid, data)); continue; } // signature/lens/non-CRDT passthrough
     };
-    if allow { kept.push((cid, data)); }
+    let Some((collection_id, doc_ids)) = self.meta.resolve(&block).await else {
+        continue; // unclassifiable => drop (no existence leak)
+    };
+    // Replicator passthrough on the STABLE collection_id — no ACP/identity.
+    if self.access.replicators.is_filtered_replicator(&collection_id, &peer_str) { continue; }
+    if self.access.replicators.is_replicator(&collection_id, &peer_str) { kept.push((cid, data)); continue; }
+    // Non-replicator: ACP gate (fail closed until installed).
+    let Some(gate) = self.read_gate.get() else { continue; };
+    let is_branchable = self.meta.is_branchable(&collection_id).await;
+    if gate.may_read(&identity, &collection_id, is_branchable, &doc_ids).await {
+        kept.push((cid, data));
+    }
 }
 let blocks = kept;
 ```
 
-Hold `peer_identity_resolver: Arc<dyn PeerIdentityResolver>` + `read_gate: Arc<LateBoundReadGate>` on `SyncCoordinator` (inject alongside `authorizer`; populate the gate via the same `wire_document_acp` path).
+Hold `meta: Arc<dyn BlockCollectionResolver>`, `peer_identity_resolver: Arc<dyn PeerIdentityResolver>`, `read_gate: Arc<LateBoundReadGate>` on `SyncCoordinator` (inject alongside `authorizer`; populate the gate via the same `wire_document_acp` path).
 
 - [ ] **Step 4: Verify**
 
@@ -831,7 +881,7 @@ Expected: PASS.
 ```bash
 cargo fmt --all
 git add crates/p2p/src/sync/coordinator
-git commit -m "feat(p2p): A3 CAR per-block serve filtering (stable-collection passthrough)"
+git commit -m "feat(p2p): A3 CAR per-block serve filtering — metadata-first ordering"
 ```
 
 ---
@@ -919,7 +969,9 @@ Change the PR description from "A1 registration" to the full A1–A3 security fe
 
 **Spec coverage:** rule once in `acp` (Tasks 1,3 — direct + overlay checkers) ✔; node_did (Tasks 2,4) ✔; version→collection_id at every site (Tasks 5,6,9,10) ✔; commits (5) ✔; verify (6) ✔; KMS is_branchable + corrected semantics (7) ✔; peer-DID resolver, libp2p + Iroh-native (8) ✔; bitswap late-bound serve gate + stable-collection passthrough (9) ✔; CAR serve filter, no is_any_replicator (10) ✔; unresolved-DID→Anonymous (9,10) ✔; pushlog CID already-done (11) ✔; cross-impl (12) ✔; regression gate + adversarial audit (13) ✔.
 
-**Review findings closed:** #1 KMS test semantics (Task 7 step 1: public-doc+deny → Deny, explicit-grant → Allow) ✔; #2 per-block stable-collection passthrough (Tasks 9,10; Global Constraints) ✔; #3 late-bound `LateBoundReadGate` via `wire_document_acp` (Task 9) ✔; #4 Iroh NodeId→did:key derivation + documented constraint (Task 8) ✔; #5 single rule in `acp`, two checker impls (Tasks 1,3,7 all call `acp::read_access::check_doc_read_access`) ✔; #6 explicit `node_did` field + builder + wiring on the query runner (Task 4) ✔.
+**Review findings closed (round 2):** #1 KMS test semantics (Task 7 step 1: public-doc+deny → Deny, explicit-grant → Allow) ✔; #2 per-block stable-collection passthrough (Tasks 9,10; Global Constraints) ✔; #3 late-bound `LateBoundReadGate` via `wire_document_acp` (Task 9) ✔; #4 Iroh NodeId→did:key derivation + documented constraint (Task 8) ✔; #5 single rule in `acp`, two checker impls (Tasks 1,3,7 all call `acp::read_access::check_doc_read_access`) ✔; #6 explicit `node_did` field + builder + wiring on the query runner (Task 4) ✔.
+
+**Review findings closed (round 3):** #1 resolver lifecycle — shared `PeerIdentityStore` created up-front (mirrors the `ReplicatorRegistry` Arc), `StoreResolver` constructible at filter build, not the handle (Task 8 steps 3-4) ✔; #2 ordering — `BlockCollectionResolver` (metadata, no ACP/identity) → replicator passthrough → non-replicator ACP; replicator path never touches the gate/identity (Tasks 9,10; Global Constraints serve-gate ordering) ✔; #3 Iroh binding enforced — derive endpoint key from the ed25519 node identity + startup error on secp256k1 (Task 8 step 5) ✔; #4 `crate::transport::PeerId` in the trait + conversion at the bitswap call site (Task 8 interfaces; Global Constraints) ✔; #5 `collections_map()` returns `Arc<CollectionVersion>` — `by_version` stores `Arc` (Task 5 step 3) ✔.
 
 **Placeholders:** none — every code step shows real code; the `BlockReadGate`/`DocCollectionLookup` producer impls reference the existing block→docID and version→collection resolution rather than re-deriving, which is concrete guidance.
 

--- a/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
+++ b/docs/superpowers/plans/2026-06-30-branchable-collection-acp-a2-a3.md
@@ -725,15 +725,17 @@ pub struct BlockAcpMeta {
     pub collection_id: String,                 // stable id (for replicator passthrough + ACP object)
     pub is_branchable: bool,
     pub policy: Option<(String, String)>,      // (policy_id, resource_name); None => unpermissioned
-    pub doc_ids: Vec<String>,                  // empty => collection-level commit
+    pub doc_ids: Vec<String>,                  // resolved from serving CID; empty => collection-level commit
 }
 pub enum BlockClass { Allow, Data(BlockAcpMeta), Deny }
 
 /// DB/SCHEMA-backed (get_collection_by_version_id + collection cache), NOT the P2P subscription
-/// store. Decodes the raw block once and classifies it. Available before P2P (DB exists first).
+/// store. Decodes the raw block once and classifies it. The serving CID is explicit because
+/// doc-owner lookup and genesis fallback are CID-keyed (Go parity). CID/data mismatch => Deny.
+/// Available before P2P (DB exists first).
 #[async_trait]
 pub trait BlockClassifier: Send + Sync {
-    async fn classify(&self, data: &[u8]) -> BlockClass;
+    async fn classify(&self, cid: &Cid, data: &[u8]) -> BlockClass;
 }
 
 /// ACP evaluation only. Late-bound. Never consulted for replicators. policy comes from the meta;
@@ -777,7 +779,7 @@ Expected: FAIL.
 Replace the in-filter signature/definition/lens/data classification (`filter.rs:88-144`) with a call to the classifier; gate only the `Data` class:
 
 ```rust
-match classifier.classify(data).await {
+match classifier.classify(cid, data).await {
     BlockClass::Allow => return true,   // signature / definition / lens — no user data
     BlockClass::Deny  => return false,  // undecodable / unknown shape — no existence leak
     BlockClass::Data(meta) => {
@@ -796,11 +798,11 @@ match classifier.classify(data).await {
 }
 ```
 
-Thread `classifier: Arc<dyn BlockClassifier>` and `serve_acp: Arc<LateBoundServeAcp>` through `make_peer_block_access_filter` + the closure (and through `P2PHostConfig` → `with_keypair_and_config_and_identity` → `DefraBehaviour::new`, per the Plumbing note above). The `store.get(cid)` for the raw bytes stays; `classify` takes those bytes.
+Thread `classifier: Arc<dyn BlockClassifier>` and `serve_acp: Arc<LateBoundServeAcp>` through `make_peer_block_access_filter` + the closure (and through `P2PHostConfig` → `with_keypair_and_config_and_identity` → `DefraBehaviour::new`, per the Plumbing note above). The `store.get(cid)` for the raw bytes stays; `classify` takes both the requested/serving CID and those bytes.
 
 - [ ] **Step 4: Implement the classifier + gate, install `ServeAcp` via `wire_document_acp`**
 
-`BlockClassifier` impl (db/embedded layer, up-front, DB-backed): `Signature::from_dag_cbor(data).is_ok()` → `Allow`; else `DefraBlock::from_dag_cbor(data)`: `delta.is_definition()` → `Allow`, else (data delta) read `schema_version_id`, resolve `→ CollectionVersion` via `get_collection_by_version_id`, return `Data(BlockAcpMeta { collection_id, is_branchable, policy: collection.policy.map(|p| (p.id, p.resource_name)), doc_ids })` (collection-level => empty `doc_ids`); on decode error, `is_lens_block(data)` → `Allow` else `Deny`. `BlockReadGate` impl: `may_read` — if `meta.policy` is `None` return `true` (unpermissioned = public); else run `acp::read_access::check_doc_read_access(DirectChecker{ acp, identity, node_did }, &policy.0, &policy.1, &meta.collection_id, meta.is_branchable, doc)` per doc id (empty list => one check with `""`), true if ANY grants. Install `ServeAcp { resolver, gate }` into the shared `LateBoundServeAcp` inside the `wire_document_acp` closure at `node.rs:557` (handle exists here): `resolver` = `HandlePeerIdentityResolver(handle)` for libp2p or `AnonymousResolver` for Iroh; `gate` = the `BlockReadGate` impl. (+ defra-node equivalent.)
+`BlockClassifier` impl (db/embedded layer, up-front, DB-backed): first verify the raw bytes match the serving CID (mismatch → `Deny`). `Signature::from_dag_cbor(data).is_ok()` → `Allow`; else `DefraBlock::from_dag_cbor(data)`: `delta.is_definition()` → `Allow`, else (data delta) read `schema_version_id`, resolve `→ CollectionVersion` via `get_collection_by_version_id`, derive `doc_ids` with Go-parity CID semantics, and return `Data(BlockAcpMeta { collection_id, is_branchable, policy: collection.policy.map(|p| (p.id, p.resource_name)), doc_ids })`. `doc_ids` derivation: collection-level commit → empty list; otherwise look up owners by the serving CID in the block-owner/system metadata; if owner metadata is empty for a composite genesis/no-heads block, use the CID-derived genesis doc id fallback; unknown/unresolvable owner metadata → `Deny` (no existence leak). On decode error, `is_lens_block(data)` → `Allow` else `Deny`. `BlockReadGate` impl: `may_read` — if `meta.policy` is `None` return `true` (unpermissioned = public); else run `acp::read_access::check_doc_read_access(DirectChecker{ acp, identity, node_did }, &policy.0, &policy.1, &meta.collection_id, meta.is_branchable, doc)` per doc id (empty list => one check with `""`), true if ANY grants. Install `ServeAcp { resolver, gate }` into the shared `LateBoundServeAcp` inside the `wire_document_acp` closure at `node.rs:557` (handle exists here): `resolver` = `HandlePeerIdentityResolver(handle)` for libp2p or `AnonymousResolver` for Iroh; `gate` = the `BlockReadGate` impl. (+ defra-node equivalent.)
 
 - [ ] **Step 5: Verify**
 
@@ -845,7 +847,7 @@ let serve = self.serve_acp.get();           // late-bound; absent => only passth
 let mut identity: Option<acp::Identity> = None; // resolved lazily on first non-replicator Data block
 let mut kept = Vec::with_capacity(blocks.len());
 for (cid, data) in blocks {
-    match self.classifier.classify(&data).await {
+    match self.classifier.classify(&cid, &data).await {
         BlockClass::Allow => kept.push((cid, data)),     // signature / definition / lens
         BlockClass::Deny  => {}                           // undecodable / unknown => drop
         BlockClass::Data(meta) => {
@@ -968,7 +970,7 @@ Change the PR description from "A1 registration" to the full A1–A3 security fe
 
 ## Self-Review
 
-**Spec coverage:** rule once in `acp` (Tasks 1,3 — direct + overlay checkers) ✔; node_did (Tasks 2,4) ✔; version→collection_id at every site (Tasks 5,6,9,10) ✔; commits (5) ✔; verify (6) ✔; KMS is_branchable + corrected semantics (7) ✔; peer-DID resolver, libp2p + Iroh-native (8) ✔; bitswap late-bound serve gate + stable-collection passthrough (9) ✔; CAR serve filter, no is_any_replicator (10) ✔; unresolved-DID→Anonymous (9,10) ✔; pushlog CID already-done (11) ✔; cross-impl (12) ✔; regression gate + adversarial audit (13) ✔.
+**Spec coverage:** rule once in `acp` (Tasks 1,3 — direct + overlay checkers) ✔; node_did (Tasks 2,4) ✔; version→collection_id at every site (Tasks 5,6,9,10) ✔; commits (5) ✔; verify (6) ✔; KMS is_branchable + corrected semantics (7) ✔; peer-DID resolver with active libp2p token exchange + Iroh Anonymous narrowing (8) ✔; bitswap late-bound serve gate + stable-collection passthrough (9) ✔; CAR serve filter, no is_any_replicator (10) ✔; unresolved-DID→Anonymous (9,10) ✔; pushlog CID already-done (11) ✔; cross-impl (12) ✔; regression gate + adversarial audit (13) ✔.
 
 **Review findings closed (round 5 — A3 wiring detail):** #1 CAR resolves identity **lazily** inside the non-replicator branch, never before replicator passthrough (Task 10 snippet) ✔; #2 CAR uses the shared `BlockClassifier` whitelist (signature/definition/lens allow, unknown deny) instead of keeping any undecodable block (Tasks 9,10) ✔; #3 explicit plumbing — node assembly builds the DB-backed classifier + `serve_acp` Arc and threads them through `P2PHostConfig` → `with_keypair_and_config_and_identity` → `DefraBehaviour::new` → filter, capturing the same Arc in `wire_document_acp` (Task 9 Plumbing note + Files) ✔; #4 `BlockClassifier` returns `policy` in `BlockAcpMeta`, so the gate has `policy_id`/`resource_name` (Task 9 interfaces + step 4) ✔; #5 stale self-review claims cleaned (below) ✔.
 
@@ -980,4 +982,4 @@ Change the PR description from "A1 registration" to the full A1–A3 security fe
 
 **Placeholders:** none — every code step shows real code; the `BlockReadGate`/`DocCollectionLookup` producer impls reference the existing block→docID and version→collection resolution rather than re-deriving, which is concrete guidance.
 
-**Type consistency:** `check_doc_read_access(checker, policy_id, resource_name, collection_id, is_branchable, doc_id)` used identically in Tasks 1,5,6,7; `ObjectAccessChecker::object_access(policy_id, resource_name, object_id) -> DocAccess` consistent across `DirectChecker` (1) and `OverlayChecker` (3); `DocAccess { has_access, explicit }` consistent; `PeerIdentityResolver::resolve -> Option<Did>` consistent (8,9,10); `BlockReadGate::evaluate -> Option<(String, bool)>` consistent (9,10); `DocCollectionInfo.is_branchable` added once (7).
+**Type consistency:** `check_doc_read_access(checker, policy_id, resource_name, collection_id, is_branchable, doc_id)` used identically in Tasks 1,5,6,7; `ObjectAccessChecker::object_access(policy_id, resource_name, object_id) -> DocAccess` consistent across `DirectChecker` (1) and `OverlayChecker` (3); `DocAccess { has_access, explicit }` consistent; `PeerIdentityResolver::resolve -> Option<Did>` consistent (8,9,10); `BlockReadGate::may_read(identity, meta) -> bool` consistent (9,10); `DocCollectionInfo.is_branchable` added once (7).

--- a/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
+++ b/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
@@ -83,10 +83,13 @@ This mirrors Go's `identityFunc` parameterization. The rule lives in
 `crates/db/src/collection_acp.rs` next to `check_doc_permission`; the overlay impl is wired from
 `query-plan`.
 
-**Node-identity shortcut (review finding #6):** `check_doc_access_with_overlay` currently carries no
-`node_did`, so the node-identity full-access shortcut is unavailable on the commits-query path. The
-new read-access API threads `node_did` uniformly into both backends so the shortcut is honored
-everywhere (rather than narrowing the stated semantics).
+**Node-identity shortcut (review finding #6):** the node-identity full-access shortcut is itself Go
+behavior (`collection_acp.go::checkAccessOfDoc` short-circuits when the requester DID equals the
+node identity). In Go the node identity rides the request context, so it is naturally available at
+every site. In Rust, `check_doc_access_with_overlay` currently carries no `node_did`, so the
+shortcut is unavailable on the commits-query path. Threading `node_did` uniformly into both backends
+is therefore a **Rust plumbing requirement to preserve that behavior**, not a Go-specific rule — the
+*shortcut* matches Go; the *threading* is Rust-internal.
 
 ## Shared prerequisites (every site)
 
@@ -96,14 +99,24 @@ These were gaps in the first draft, surfaced by spec review; they are explicit r
   registered ACP objects under the stable `collection_id`. Every A2/A3 site must resolve the block's
   `schema_version_id` to its `CollectionVersion` and check ACP on `collection.collection_id` and
   `collection.is_branchable` — never the version id.
-- **Peer DID resolution + fail-closed (finding #2).** The serve-path gates run as the *requesting
-  peer*. Rust already resolves this: `host::handle::get_peer_identity(peer_id) -> Option<Did>`
-  (handle.rs:232), backed by a verified peer-identity cache populated through the identity protocol
-  (`identity::from_token` + `verify_auth_token`, the analog of Go's `identityProtocol.GetIdentity` +
-  `VerifyAuthToken`). Serve filters must call it and, when it returns `None` (identity unknown /
-  unverifiable), **fail closed** (deny) — except where a higher-priority passthrough already applies
-  (see serve model below). The Iroh serve path must reach the same resolution (confirm the Iroh
-  endpoint shares the libp2p `peer_identities` cache or add an equivalent).
+- **Peer DID resolution via a transport-agnostic resolver (finding #2).** The serve-path gates run
+  as the *requesting peer*. libp2p already resolves this on the host handle
+  (`host::handle::get_peer_identity(peer_id) -> Option<Did>`, handle.rs:232), backed by a verified
+  peer-identity cache populated through the identity protocol (`identity::from_token` +
+  `verify_auth_token`, the analog of Go's `identityProtocol.GetIdentity` + `VerifyAuthToken`).
+  However, this method is **not on the `P2PTransport` trait** (transport.rs:258) and the Iroh path
+  only carries a `PeerId` into CAR handling. **Implementation requirement:** introduce a
+  `PeerIdentityResolver` abstraction (`async fn resolve(&self, peer_id) -> Option<Did>`), implement
+  it for libp2p (delegating to `get_peer_identity`) and Iroh, and inject it into **both** the Bitswap
+  filter and the CAR handler so peer-DID resolution is identical across transports.
+- **Unresolved DID → Anonymous, not blanket-deny (finding #1, Go parity).** When the resolver
+  returns `None`, the serve gate passes `Identity::Anonymous` into `check_doc_read_access` rather
+  than denying outright. This matches Go: `hasAccess`'s `identFunc` returns `None` on lookup failure
+  and Go still runs `CheckDocReadAccess`, which **grants for public/unregistered objects** while an
+  anonymous actor is **denied any registered (private) object**. So private branchable data is still
+  withheld from an unverifiable peer, but public blocks remain fetchable — exactly as Go. (A
+  stricter fail-closed posture — deny on unresolved DID even for public blocks — is available as a
+  *documented deviation from Go* if desired, but is not the default here.)
 
 ## How Go's serve boundary actually works (and what "full parity" means)
 
@@ -191,7 +204,8 @@ Unit tests:
   collection-level} × {branchable, non-branchable} × {permissioned, unpermissioned} × {node-identity
   vs other}.
 - Serve-filter per-block decision (bitswap + CAR): replicator passthrough; non-replicator with no
-  resolvable DID → deny (fail-closed); non-replicator without collection access → deny; signature /
+  resolvable DID → treated as Anonymous (denied registered/private objects, **allowed** for
+  public/unregistered — Go parity); non-replicator without collection access → deny; signature /
   lens / definition blocks → allow.
 - KMS gate honors `is_branchable`.
 - CID-mismatch rejection regression (bitswap/CAR/pushlog).
@@ -220,7 +234,7 @@ Unit tests:
   transports and the pull/pushlog paths.
 - **Two-transport drift.** libp2p (bitswap) and Iroh (CAR/coordinator) serve paths must apply
   identical decisions and share peer-DID resolution; mitigated by routing both through the same
-  `check_doc_read_access` + a shared test, and confirming Iroh reaches `get_peer_identity`.
+  `check_doc_read_access` and the same injected `PeerIdentityResolver` + a shared test.
 - **Overlay vs direct backend drift.** Commits-query (overlay) and serve/verify/KMS (direct) must not
   diverge on the rule; mitigated by the single shared algorithm over `ObjectAccessChecker`.
 - **Hot-path performance.** Per-block serve checks add ACP lookups; the rule short-circuits for

--- a/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
+++ b/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
@@ -133,7 +133,8 @@ These were gaps in the first draft, surfaced by spec review; they are explicit r
 5. **Replicator passthrough:** requesting peer is a registered replicator for the block's collection
    → **allow, no per-doc check.**
 6. Otherwise: resolve `pid → identity` (cache or identity-protocol round-trip, token-verified), then
-   per-doc `CheckDocReadAccess` (a block may have several owners; access to any one suffices).
+   per-doc `CheckDocReadAccess` (the serving CID is used to resolve block ownership; a block may
+   have several owners, and access to any one suffices).
 
 So **"full Go parity at the serve boundary" = preserve replicator passthrough (step 5, which Rust
 already implements) + add the non-replicator per-doc `check_doc_read_access` gate (step 6, new) +
@@ -152,8 +153,8 @@ Verified by enumerating every `CheckDocReadAccess*` / serve call in v1.0.0.
 |---|---------|---------|-----------|--------------------|--------|
 | 1 | Commits query (A2) | `planner/commit.go:325,348` | `query/src/runner/commits.rs::execute_commits_query` | `docID None => continue` — **collection-level DAG ungated**; doc commits filtered per-doc only | Gate collection-level commits on the collection object; route doc commits through `check_doc_read_access` (overlay backend, with `node_did`) so branchable public docs also require collection access |
 | 2 | Signature verify (A2) | `internal/db/verify.go:115` | `db/src/block_verify.rs:110` | gates only when `delta.doc_id()` is `Some` — **collection blocks bypass** | Resolve `version_id → CollectionVersion`; use `check_doc_read_access`; gate collection-level blocks on the collection object |
-| 3 | P2P serve — Bitswap (A3) | `p2p.go:197` `SetBlockAccessFunc(hasAccess)` | `p2p/src/bitswap/filter.rs::check_access` (libp2p) | replicator-membership gate only; no identity/ACP context (`filter.rs:45` gets only `PeerId`+`Cid`) | Keep replicator passthrough; for non-replicator peers, resolve DID via `get_peer_identity` (fail-closed) and apply per-block `check_doc_read_access`. Inject DB/ACP/identity-resolver into the filter |
-| 4 | P2P serve — CAR fetch (A3) | (same `hasAccess`, recursive + selective DAG) | `p2p/src/sync/coordinator/event_handler/car.rs::check_car_fetch_access` | checks only **root collection** access, then serves the whole DAG (`collect_dag_blocks` / `collect_exact_blocks`) | Filter CAR **response blocks per block** through `check_doc_read_access` for both recursive and exact (`collect_exact_blocks`) fetches; preserve replicator passthrough |
+| 3 | P2P serve — Bitswap (A3) | `p2p.go:197` `SetBlockAccessFunc(hasAccess)` | `p2p/src/bitswap/filter.rs::check_access` (libp2p) | replicator-membership gate only; no identity/ACP context (`filter.rs:45` gets only `PeerId`+`Cid`) | Keep replicator passthrough; for non-replicator peers, resolve DID via `get_peer_identity` (fail-closed) and apply per-block `check_doc_read_access`. Inject DB/ACP/identity-resolver into the filter, and preserve the requested CID for CID-keyed block-owner lookup |
+| 4 | P2P serve — CAR fetch (A3) | (same `hasAccess`, recursive + selective DAG) | `p2p/src/sync/coordinator/event_handler/car.rs::check_car_fetch_access` | checks only **root collection** access, then serves the whole DAG (`collect_dag_blocks` / `collect_exact_blocks`) | Filter CAR **response blocks per block** through `check_doc_read_access` for both recursive and exact (`collect_exact_blocks`) fetches; preserve replicator passthrough and the block CID for owner lookup |
 | 5 | KMS key gate (A3) | `internal/kms/pubsub.go:577` | `crates/kms` (`doesIdentityHaveDocPermission` analog) | per-doc read check; `DocCollectionInfo` lacks `is_branchable` (`policy.rs:61`) | Add `is_branchable` to `DocCollectionInfo` + its `DocCollectionLookup` producer; switch the gate to `check_doc_read_access` |
 
 ### Already implemented — regression coverage only (finding #5)
@@ -210,9 +211,11 @@ Unit tests:
 - Serve-filter per-block decision (bitswap + CAR): replicator passthrough; non-replicator with no
   resolvable DID → treated as Anonymous (denied registered/private objects, **allowed** for
   public/unregistered — Go parity); non-replicator without collection access → deny; signature /
-  lens / definition blocks → allow.
+  lens / definition blocks → allow; shared-field blocks use CID-keyed owner lookup and allow if ANY
+  owner grants.
 - KMS gate honors `is_branchable`.
-- CID-mismatch rejection regression (bitswap/CAR/pushlog).
+- CID-mismatch rejection regression (bitswap/CAR/pushlog), including serve classifier
+  CID/data mismatch → deny.
 
 ## Scope decisions (record)
 
@@ -238,7 +241,8 @@ Unit tests:
   transports and the pull/pushlog paths.
 - **Two-transport drift.** libp2p (bitswap) and Iroh (CAR/coordinator) serve paths must apply
   identical decisions and share peer-DID resolution; mitigated by routing both through the same
-  `check_doc_read_access` and the same injected `PeerIdentityResolver` + a shared test.
+  CID-aware block classifier, `check_doc_read_access`, and injected `PeerIdentityResolver` + a
+  shared test.
 - **Overlay vs direct backend drift.** Commits-query (overlay) and serve/verify/KMS (direct) must not
   diverge on the rule; mitigated by the single shared algorithm over `ObjectAccessChecker`.
 - **Hot-path performance.** Per-block serve checks add ACP lookups; the rule short-circuits for

--- a/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
+++ b/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
@@ -1,38 +1,39 @@
 # Branchable Collection ACP — A2 (read enforcement) + A3 (P2P sync enforcement)
 
-**Status:** Design approved (2026-06-30)
-**Branch:** `feat/branchable-collection-acp-a1` (will hold the full A1–A3 epic)
+**Status:** Design — revised after spec review (2026-06-30)
+**Branch:** `feat/branchable-collection-acp-a1` (will hold the full A1–A3 epic; PR body to be updated
+from "A1 registration" to the full security feature)
 **Parity oracle:** Go DefraDB v1.0.0, commit `3f627855` ("feat: Branchable collection ACP (#4990)")
-**Predecessor:** A1 (registration) — branchable + permissioned collections are registered as ACP
-objects keyed by `collection_id`. A2/A3 *consume* that registration to gate reads.
+**Predecessor:** A1 (registration) — branchable + permissioned collections register an ACP object
+keyed by the stable `collection_id`. A2/A3 *consume* that registration to gate reads.
 
 ## Background
 
 A1 made a branchable + permissioned collection register an ACP object whose id is the stable
-`collection_id`, gating its collection-level commit DAG the same way document registration gates a
-document. A1 is registration only — nothing yet *enforces* that gate. This design adds the
-enforcement:
+`collection_id`, gating its collection-level commit DAG the way document registration gates a
+document. A1 is registration only — nothing yet *enforces* the gate. This design adds enforcement:
 
 - **A2 — read enforcement** on local read paths (commits query, signature verification).
 - **A3 — sync enforcement** on the P2P path so private branchable data is never served to peers
-  that cannot read it, plus the encryption-key gate and a block-CID integrity check.
+  that cannot read it, plus the encryption-key gate.
 
-The entire Go epic landed as one commit (`3f627855`). It introduced exactly **one new rule** —
-`CheckDocReadAccess` — and wired it into five enforcement sites. This design ports that rule
-faithfully (the approved approach: *faithful port, single pass*) and wires it into the equivalent
-Rust sites, accounting for where Rust's architecture differs from Go's.
+The entire Go epic landed as one commit (`3f627855`), introducing exactly **one new rule** —
+`CheckDocReadAccess` — wired into five enforcement sites. This design ports that rule faithfully
+(approved approach: *faithful port, single pass*; approved sync scope: *full Go parity at the serve
+boundary*) into the equivalent Rust sites.
 
 ## The core rule: `check_doc_read_access`
 
 One function, expressed once, reused at every site. It returns the final boolean but is built on an
-internal verdict that distinguishes *explicit* from *public* access:
+internal verdict distinguishing *explicit* from *public* access:
 
 ```rust
 struct DocAccess {
     has_access: bool,
     // true when the verdict came from something specific to this actor: an ACP registration of the
-    // object (granted/denied a relationship on it) or a DAC-bypass grant. false for access that is
-    // unrestricted for everyone: an unpermissioned collection or a public (unregistered) object.
+    // object (granted/denied a relationship), or a DAC-bypass / node-identity grant. false for
+    // access unrestricted for everyone: an unpermissioned collection or a public (unregistered)
+    // object.
     explicit: bool,
 }
 ```
@@ -49,27 +50,27 @@ struct DocAccess {
    branchable collection gate its *public* documents and its collection-level DAG.
 3. Otherwise → **GRANT**.
 
-For a collection-level commit (no docID), step 1 is skipped and the verdict is purely the
-collection-object check (a no-op for non-branchable collections).
+A collection-level commit (no docID) skips step 1; the verdict is purely the collection-object check
+(a no-op for non-branchable collections).
 
-`DocAccess` itself is the existing single-object check (today's `check_doc_permission` /
+`DocAccess` itself is the existing single-object check (`check_doc_permission` /
 `check_doc_access_with_overlay`) extended to also report `explicit`:
 
-- DAC-bypass (thread-local / node-ACP) → `{true, explicit:true}`.
+- DAC-bypass (thread-local) or node-identity match → `{true, explicit:true}`.
 - Collection has no policy → `{true, explicit:false}`.
 - Object not registered (public) → `{true, explicit:false}`.
 - Registered → `{backend_decision, explicit:true}`.
 
 ### Two backends, one algorithm
 
-Rust has two ACP-check entry points and the rule must work over both without duplicating the logic:
+The rule must run over both Rust ACP-check entry points without duplicating logic:
 
 - **Overlay-backed** (`query-plan::txn::check_doc_access_with_overlay` + `is_doc_registered_with_overlay`):
-  txn-aware, sees same-transaction registrations. Used by the commits query.
-- **Direct-backed** (`acp::DocumentACP` trait): no transaction overlay. Used by merge, KMS,
-  signature verification, and the P2P serve path.
+  txn-aware; sees same-transaction registrations. Used by the commits query.
+- **Direct-backed** (`acp::DocumentACP` trait): no transaction overlay. Used by signature verify,
+  KMS, and the P2P serve path.
 
-The algorithm is defined once over a small internal capability:
+Defined once over a small internal capability with two thin impls:
 
 ```rust
 trait ObjectAccessChecker {
@@ -78,96 +79,166 @@ trait ObjectAccessChecker {
 }
 ```
 
-with two thin impls (overlay, direct). This mirrors Go's `identityFunc` parameterization. The rule
-lives in `crates/db/src/collection_acp.rs` next to `check_doc_permission`; the overlay impl is
-wired from `query-plan`.
+This mirrors Go's `identityFunc` parameterization. The rule lives in
+`crates/db/src/collection_acp.rs` next to `check_doc_permission`; the overlay impl is wired from
+`query-plan`.
+
+**Node-identity shortcut (review finding #6):** `check_doc_access_with_overlay` currently carries no
+`node_did`, so the node-identity full-access shortcut is unavailable on the commits-query path. The
+new read-access API threads `node_did` uniformly into both backends so the shortcut is honored
+everywhere (rather than narrowing the stated semantics).
+
+## Shared prerequisites (every site)
+
+These were gaps in the first draft, surfaced by spec review; they are explicit requirements now.
+
+- **Version ID → stable collection ID (finding #3).** Block paths expose `schema_version_id`, but A1
+  registered ACP objects under the stable `collection_id`. Every A2/A3 site must resolve the block's
+  `schema_version_id` to its `CollectionVersion` and check ACP on `collection.collection_id` and
+  `collection.is_branchable` — never the version id.
+- **Peer DID resolution + fail-closed (finding #2).** The serve-path gates run as the *requesting
+  peer*. Rust already resolves this: `host::handle::get_peer_identity(peer_id) -> Option<Did>`
+  (handle.rs:232), backed by a verified peer-identity cache populated through the identity protocol
+  (`identity::from_token` + `verify_auth_token`, the analog of Go's `identityProtocol.GetIdentity` +
+  `VerifyAuthToken`). Serve filters must call it and, when it returns `None` (identity unknown /
+  unverifiable), **fail closed** (deny) — except where a higher-priority passthrough already applies
+  (see serve model below). The Iroh serve path must reach the same resolution (confirm the Iroh
+  endpoint shares the libp2p `peer_identities` cache or add an equivalent).
+
+## How Go's serve boundary actually works (and what "full parity" means)
+
+`hasAccess` (p2p.go:338) decides, in order:
+
+1. No document ACP → allow.
+2. Signature block → allow (needed to verify sibling blocks; carries no collection data).
+3. Lens blocks (config/module/wasm/chunks) → allow (schema-migration artifacts, no user data).
+4. Definition delta (schema/collection definition) → allow.
+5. **Replicator passthrough:** requesting peer is a registered replicator for the block's collection
+   → **allow, no per-doc check.**
+6. Otherwise: resolve `pid → identity` (cache or identity-protocol round-trip, token-verified), then
+   per-doc `CheckDocReadAccess` (a block may have several owners; access to any one suffices).
+
+So **"full Go parity at the serve boundary" = preserve replicator passthrough (step 5, which Rust
+already implements) + add the non-replicator per-doc `check_doc_read_access` gate (step 6, new) +
+the branchable collection-object dimension inside that rule.** Replicator-mediated flows (including
+SE/KMS pre-positioning of not-yet-readable blocks) keep working because replicators are passthrough
+in both implementations; the new gate hits ad-hoc / pubsub / non-replicator fetchers.
+
+`trySelfHasAccess` (the pull side, in `processPushlogRequest`) mirrors the same rule for the local
+node before pulling.
 
 ## Enforcement sites
 
-Go enforces the read rule at five sites (verified by enumerating every `CheckDocReadAccess*`
-call in v1.0.0). The table maps each to its Rust home, noting current state and the architectural
-divergence.
+Verified by enumerating every `CheckDocReadAccess*` / serve call in v1.0.0.
 
 | # | Concern | Go site | Rust site | Current Rust state | Change |
 |---|---------|---------|-----------|--------------------|--------|
-| 1 | Commits query (A2) | `planner/commit.go:325,348` | `query/src/runner/commits.rs::execute_commits_query` | `docID None => continue` — **collection-level DAG ungated**; doc commits filtered per-doc only | Gate collection-level commits on the collection object; route doc commits through `check_doc_read_access` (overlay backend) so branchable public docs also require collection access |
-| 2 | Signature verify (A2) | `internal/db/verify.go:115` | `db/src/block_verify.rs:110` | gates only when `delta.doc_id()` is `Some` — **collection blocks bypass** | Resolve collection; use `check_doc_read_access`; gate collection-level blocks on the collection object |
-| 3 | P2P serve boundary (A3) | `p2p.go:197` `SetBlockAccessFunc(hasAccess)` + `trySelfHasAccess` (pull) | `p2p/src/bitswap/filter.rs` (libp2p) **and** Iroh serve path (`p2p/src/iroh/*`, via `ReplicatorRegistry`) | gates by **replicator membership per collection** only — no per-block read check | Add per-block `check_doc_read_access` (direct backend) so private branchable blocks are **never served** to a peer that cannot read them — the `hasAccess` analog, on **both** transports |
-| 4 | KMS key gate (A3) | `internal/kms/pubsub.go:577` | `crates/kms` (`doesIdentityHaveDocPermission` analog) | per-doc read check | Switch to `check_doc_read_access` so encryption-key access respects collection gating |
-| 5 | Pushlog CID integrity (A3) | `p2p.go:617` (`ErrBlockCIDMismatch`) | `p2p/src/sync/coordinator/event_handler/pushlog.rs` | (no equivalent check) | Reject a pushed block whose contents do not hash to the advertised CID — independent hardening bundled in #4990 |
+| 1 | Commits query (A2) | `planner/commit.go:325,348` | `query/src/runner/commits.rs::execute_commits_query` | `docID None => continue` — **collection-level DAG ungated**; doc commits filtered per-doc only | Gate collection-level commits on the collection object; route doc commits through `check_doc_read_access` (overlay backend, with `node_did`) so branchable public docs also require collection access |
+| 2 | Signature verify (A2) | `internal/db/verify.go:115` | `db/src/block_verify.rs:110` | gates only when `delta.doc_id()` is `Some` — **collection blocks bypass** | Resolve `version_id → CollectionVersion`; use `check_doc_read_access`; gate collection-level blocks on the collection object |
+| 3 | P2P serve — Bitswap (A3) | `p2p.go:197` `SetBlockAccessFunc(hasAccess)` | `p2p/src/bitswap/filter.rs::check_access` (libp2p) | replicator-membership gate only; no identity/ACP context (`filter.rs:45` gets only `PeerId`+`Cid`) | Keep replicator passthrough; for non-replicator peers, resolve DID via `get_peer_identity` (fail-closed) and apply per-block `check_doc_read_access`. Inject DB/ACP/identity-resolver into the filter |
+| 4 | P2P serve — CAR fetch (A3) | (same `hasAccess`, recursive + selective DAG) | `p2p/src/sync/coordinator/event_handler/car.rs::check_car_fetch_access` | checks only **root collection** access, then serves the whole DAG (`collect_dag_blocks` / `collect_exact_blocks`) | Filter CAR **response blocks per block** through `check_doc_read_access` for both recursive and exact (`collect_exact_blocks`) fetches; preserve replicator passthrough |
+| 5 | KMS key gate (A3) | `internal/kms/pubsub.go:577` | `crates/kms` (`doesIdentityHaveDocPermission` analog) | per-doc read check; `DocCollectionInfo` lacks `is_branchable` (`policy.rs:61`) | Add `is_branchable` to `DocCollectionInfo` + its `DocCollectionLookup` producer; switch the gate to `check_doc_read_access` |
 
-### The architectural divergence (decided)
+### Already implemented — regression coverage only (finding #5)
 
-Go has **no ACP check at merge** (`internal/db/merge.go` is clean). It enforces read access at the
-**serve boundary**: the producing node withholds blocks the requester cannot read, so private bytes
-never cross the wire.
+- **Pushlog/CAR block CID integrity.** `verify_block_cid` already rejects a block whose contents do
+  not hash to the advertised CID — `p2p/src/sync/manager/process/pushlog.rs:235` ("finding 06-29")
+  and in the CAR handler. This is **not new work**; the plan only adds/confirms regression tests
+  (the Go `ErrBlockCIDMismatch` analog).
 
-Rust today does the opposite: its serve filter gates only by *replicator membership*, and per-doc
-ACP is enforced **receiver-side at merge** (`AcpMergeHandler`). For branchable collections — the
-"private data leaks to peers" boundary — merge-time gating is too late: the bytes have already been
-transmitted.
+### Merge handler (receiver side)
 
-**Decision:** A3 enforces at the **serve boundary, matching Go** (site #3 above), on both the
-libp2p bitswap filter and the Iroh serve path. The existing merge-time ACP gating
-(`AcpMergeHandler`) is **kept as receiver-side defense-in-depth** and extended to also recognize
-collection-level branchable blocks, but the primary leak fix is at serve.
+With serve-boundary parity, the existing `AcpMergeHandler` (`on_protected_composite`,
+`on_encrypted_link`; enforced only under `strict_replicated_doc_access`) is **left as-is** as
+receiver-side defense-in-depth and to preserve the pre-position/replay model. A2/A3 do **not** flip
+the strict default. If a branchable collection-level block can reach merge without a docID and needs
+receiver-side gating, that is the one additive merge change to evaluate during implementation.
 
 ## Semantics preserved (parity-critical)
 
 - An **explicit denial** on a document always denies, regardless of collection access.
-- An **explicit grant** on a document always grants, even inside a private branchable collection
-  (single-document sharing out of a private collection works).
-- Node-identity full-access and `dac_bypass` shortcuts still apply and count as `explicit`.
+- An **explicit grant** on a document always grants, even inside a private branchable collection.
+- Node-identity full-access and `dac_bypass` shortcuts apply and count as `explicit`.
 - Anonymous + registered object → deny.
 - Unpermissioned collection or public object on a **non-branchable** collection → grant.
 - **Non-branchable collections behave exactly as today** — the rule reduces to the document's own
-  read access; no collection-object check is performed.
+  read access; no collection-object check.
+- **Serve replicator passthrough is preserved** — registered replicators are served without a
+  per-doc check, exactly as today and as Go.
 
 ## Testing
 
 Primary validation is Rust-native integration tests in `tools/integration-test`, run across a
 **cross-implementation matrix** (the harness can pair a Go binary and a Rust binary):
 
-- **rust ↔ rust**, **go ↔ go**, **go ↔ rust** — proves wire-level + enforcement parity on the sync
-  path, and specifically that a Rust producer withholds private branchable blocks from a peer the
-  same way a Go producer does.
+- **rust ↔ rust**, **go ↔ go**, **go ↔ rust** — proves wire-level + enforcement parity, and
+  specifically that a Rust producer withholds private branchable blocks from a non-replicator peer
+  the same way a Go producer does.
 
 Scenarios ported from Go #4990:
 
-- `tests/integration/acp/dac/branchable/collection_commits_test.go` → commits-query read gating
-  (collection-level DAG + doc commits, branchable vs non-branchable).
-- `collection_mutation_test.go` → mutation/registration interplay (mostly A1, regression guard).
-- `peer_test.go` → P2P serve-boundary enforcement (private collection blocks not served).
-- `tests/integration/encryption/peer_acp_branchable_test.go` → KMS key-gate under branchable ACP.
-- `tests/integration/signature/acp_branchable_test.go` → signature-verify read gating.
+- `acp/dac/branchable/collection_commits_test.go` → commits-query read gating (collection-level DAG
+  + doc commits; branchable vs non-branchable).
+- `acp/dac/branchable/peer_test.go` → P2P serve-boundary enforcement (non-replicator peer denied
+  private collection blocks; replicator still served).
+- `encryption/peer_acp_branchable_test.go` → KMS key-gate under branchable ACP.
+- `signature/acp_branchable_test.go` → signature-verify read gating.
+- `collection_mutation_test.go` → registration/mutation regression guard (mostly A1).
 
 Unit tests:
 
 - `check_doc_read_access` truth table in `crates/db`: {explicit-grant, explicit-deny, public-doc,
-  collection-level} × {branchable, non-branchable} × {permissioned, unpermissioned}.
-- Serve-filter per-block decision (bitswap + iroh): private branchable data block denied to a
-  non-authorized replicator; collection-definition blocks still allowed; signature blocks allowed.
-- Merge-handler collection-level-block gating (defense-in-depth).
-- Pushlog CID-mismatch rejection.
+  collection-level} × {branchable, non-branchable} × {permissioned, unpermissioned} × {node-identity
+  vs other}.
+- Serve-filter per-block decision (bitswap + CAR): replicator passthrough; non-replicator with no
+  resolvable DID → deny (fail-closed); non-replicator without collection access → deny; signature /
+  lens / definition blocks → allow.
+- KMS gate honors `is_branchable`.
+- CID-mismatch rejection regression (bitswap/CAR/pushlog).
+
+## Scope decisions (record)
+
+- **Approach:** faithful single-pass port of Go #4990's one rule into all Rust sites.
+- **Sync boundary:** enforce at the **serve boundary** (Go parity), not merge; merge gating stays as
+  receiver-side defense-in-depth.
+- **Serve block scope:** **full Go parity** = replicator passthrough (existing) + per-doc
+  `check_doc_read_access` for non-replicator peers + branchable collection-object dimension. This is
+  uniform across collections; non-branchable collections reduce to per-doc read access.
+- The contradictory "non-branchable serve gating out of scope" line from the first draft is
+  **removed** — non-branchable per-doc serve gating for non-replicator peers is *in scope* as a
+  consequence of full Go parity (and was a pre-existing Rust gap).
+
+## Risks
+
+- **Serve-gating vs SE/KMS & replay (top risk).** Full per-doc serve gating could regress flows that
+  rely on a node fetching not-yet-readable blocks. Replicator passthrough preserves the primary
+  pre-position path, but the implementation **must** run the existing P2P, encryption, SE, and
+  identity integration suites; any regression there is a **blocker** that forces a scope re-decision
+  (narrow to branchable-only, or to collection-level-DAG-only), not a paper-over.
+- **A3 leak boundary.** The serve gate is where private branchable data could leak; it gets a
+  **mandatory adversarial re-audit** (a dedicated verification workflow) before merge, covering both
+  transports and the pull/pushlog paths.
+- **Two-transport drift.** libp2p (bitswap) and Iroh (CAR/coordinator) serve paths must apply
+  identical decisions and share peer-DID resolution; mitigated by routing both through the same
+  `check_doc_read_access` + a shared test, and confirming Iroh reaches `get_peer_identity`.
+- **Overlay vs direct backend drift.** Commits-query (overlay) and serve/verify/KMS (direct) must not
+  diverge on the rule; mitigated by the single shared algorithm over `ObjectAccessChecker`.
+- **Hot-path performance.** Per-block serve checks add ACP lookups; the rule short-circuits for
+  unpermissioned/non-branchable + replicator-passthrough (the common cases) before any ACP call or
+  identity round-trip.
 
 ## Out of scope
 
 - Document create/update/delete mutation gating (unchanged; A1 covers registration).
-- Policy-transition logic, NAC behavior.
-- Retrofitting per-doc serve-boundary gating for **non-branchable** collections (Rust's pre-existing
-  merge-time model for ordinary documents is unchanged; this epic adds the serve gate for the
-  branchable read rule specifically — though the implementation naturally routes ordinary doc blocks
-  through the same `check_doc_read_access`, so the gate applies uniformly where wired).
+- Policy-transition logic; NAC behavior.
+- Flipping the `strict_replicated_doc_access` merge default.
 
-## Risks
+## Suggested implementation order
 
-- **A3 leak boundary (highest):** the serve-path gate is where private branchable data could leak to
-  peers. It gets a **mandatory adversarial re-audit** (a dedicated verification workflow) before
-  merge, covering both transports and the pull/pushlog paths.
-- **Two-transport drift:** libp2p and Iroh serve paths must apply identical per-block decisions;
-  mitigated by routing both through the same `check_doc_read_access` + a shared test.
-- **Overlay vs direct backend drift:** commits-query (overlay) and serve/merge (direct) must not
-  diverge on the rule; mitigated by the single shared algorithm over `ObjectAccessChecker`.
-- **Performance:** per-block read checks on serve add ACP lookups to the hot sync path; the rule
-  short-circuits for unpermissioned/non-branchable collections (the common case) before any ACP
-  call.
+1. Fix spec (this document). ✔
+2. Build the shared `check_doc_read_access` rule + `ObjectAccessChecker` (overlay + direct), with
+   `node_did`, and the `version_id → collection_id` resolution helper. Unit-test the truth table.
+3. Wire **A2** local reads: commits query, then signature verify. Integration + unit.
+4. Wire **A3**: KMS gate (`is_branchable`), then the serve gates (bitswap, then CAR) with peer-DID
+   resolution + fail-closed; confirm Iroh path. Cross-impl integration + adversarial re-audit.
+5. Confirm pushlog/CAR CID-integrity regression coverage.

--- a/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
+++ b/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
@@ -104,11 +104,15 @@ These were gaps in the first draft, surfaced by spec review; they are explicit r
   (`host::handle::get_peer_identity(peer_id) -> Option<Did>`, handle.rs:232), backed by a verified
   peer-identity cache populated through the identity protocol (`identity::from_token` +
   `verify_auth_token`, the analog of Go's `identityProtocol.GetIdentity` + `VerifyAuthToken`).
-  However, this method is **not on the `P2PTransport` trait** (transport.rs:258) and the Iroh path
-  only carries a `PeerId` into CAR handling. **Implementation requirement:** introduce a
-  `PeerIdentityResolver` abstraction (`async fn resolve(&self, peer_id) -> Option<Did>`), implement
-  it for libp2p (delegating to `get_peer_identity`) and Iroh, and inject it into **both** the Bitswap
-  filter and the CAR handler so peer-DID resolution is identical across transports.
+  Transport identity and ACP identity are **independent** (Go decouples them): the peer presents a
+  signed identity token, verified against the local peer id as audience — the transport key is never
+  reinterpreted as the ACP DID. **Implementation requirement:** introduce a `PeerIdentityResolver`
+  abstraction (`async fn resolve(&self, peer_id) -> Option<Did>`), inject it into **both** the
+  Bitswap filter and the CAR handler. libp2p delegates to the existing active `get_peer_identity`
+  (cache → signed-token fetch → verify → cache). Iroh has **no token exchange today**, so its
+  resolver returns `None` (→ Anonymous): non-replicator Iroh peers can read only public/unregistered
+  blocks until the signed-token exchange is ported to Iroh streams (tracked as a follow-up). Iroh
+  replicators are unaffected (passthrough precedes identity resolution).
 - **Unresolved DID → Anonymous, not blanket-deny (finding #1, Go parity).** When the resolver
   returns `None`, the serve gate passes `Identity::Anonymous` into `check_doc_read_access` rather
   than denying outright. This matches Go: `hasAccess`'s `identFunc` returns `None` on lookup failure

--- a/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
+++ b/docs/superpowers/specs/2026-06-30-branchable-collection-acp-a2-a3-design.md
@@ -1,0 +1,173 @@
+# Branchable Collection ACP — A2 (read enforcement) + A3 (P2P sync enforcement)
+
+**Status:** Design approved (2026-06-30)
+**Branch:** `feat/branchable-collection-acp-a1` (will hold the full A1–A3 epic)
+**Parity oracle:** Go DefraDB v1.0.0, commit `3f627855` ("feat: Branchable collection ACP (#4990)")
+**Predecessor:** A1 (registration) — branchable + permissioned collections are registered as ACP
+objects keyed by `collection_id`. A2/A3 *consume* that registration to gate reads.
+
+## Background
+
+A1 made a branchable + permissioned collection register an ACP object whose id is the stable
+`collection_id`, gating its collection-level commit DAG the same way document registration gates a
+document. A1 is registration only — nothing yet *enforces* that gate. This design adds the
+enforcement:
+
+- **A2 — read enforcement** on local read paths (commits query, signature verification).
+- **A3 — sync enforcement** on the P2P path so private branchable data is never served to peers
+  that cannot read it, plus the encryption-key gate and a block-CID integrity check.
+
+The entire Go epic landed as one commit (`3f627855`). It introduced exactly **one new rule** —
+`CheckDocReadAccess` — and wired it into five enforcement sites. This design ports that rule
+faithfully (the approved approach: *faithful port, single pass*) and wires it into the equivalent
+Rust sites, accounting for where Rust's architecture differs from Go's.
+
+## The core rule: `check_doc_read_access`
+
+One function, expressed once, reused at every site. It returns the final boolean but is built on an
+internal verdict that distinguishes *explicit* from *public* access:
+
+```rust
+struct DocAccess {
+    has_access: bool,
+    // true when the verdict came from something specific to this actor: an ACP registration of the
+    // object (granted/denied a relationship on it) or a DAC-bypass grant. false for access that is
+    // unrestricted for everyone: an unpermissioned collection or a public (unregistered) object.
+    explicit: bool,
+}
+```
+
+**Algorithm** (mirrors Go `internal/db/acp/check.go::CheckDocReadAccessWithIdentityFunc`):
+
+1. If `doc_id` is non-empty, compute `DocAccess` for the document:
+   - `explicit && has_access` → **GRANT** (a doc explicitly shared with the actor is readable even
+     inside an otherwise-private branchable collection).
+   - `!has_access` → **DENY** (an explicit denial on the document always wins).
+   - otherwise record `doc_accessible = has_access` and continue.
+2. If the collection `is_branchable`, additionally compute `DocAccess` for the **collection object**
+   (object id = `collection_id`). If `!has_access` → **DENY**. This is what makes a private
+   branchable collection gate its *public* documents and its collection-level DAG.
+3. Otherwise → **GRANT**.
+
+For a collection-level commit (no docID), step 1 is skipped and the verdict is purely the
+collection-object check (a no-op for non-branchable collections).
+
+`DocAccess` itself is the existing single-object check (today's `check_doc_permission` /
+`check_doc_access_with_overlay`) extended to also report `explicit`:
+
+- DAC-bypass (thread-local / node-ACP) → `{true, explicit:true}`.
+- Collection has no policy → `{true, explicit:false}`.
+- Object not registered (public) → `{true, explicit:false}`.
+- Registered → `{backend_decision, explicit:true}`.
+
+### Two backends, one algorithm
+
+Rust has two ACP-check entry points and the rule must work over both without duplicating the logic:
+
+- **Overlay-backed** (`query-plan::txn::check_doc_access_with_overlay` + `is_doc_registered_with_overlay`):
+  txn-aware, sees same-transaction registrations. Used by the commits query.
+- **Direct-backed** (`acp::DocumentACP` trait): no transaction overlay. Used by merge, KMS,
+  signature verification, and the P2P serve path.
+
+The algorithm is defined once over a small internal capability:
+
+```rust
+trait ObjectAccessChecker {
+    async fn is_registered(&self, object_id: &str) -> acp::Result<bool>;
+    async fn check_access(&self, object_id: &str, perm: DocumentPermission) -> acp::Result<bool>;
+}
+```
+
+with two thin impls (overlay, direct). This mirrors Go's `identityFunc` parameterization. The rule
+lives in `crates/db/src/collection_acp.rs` next to `check_doc_permission`; the overlay impl is
+wired from `query-plan`.
+
+## Enforcement sites
+
+Go enforces the read rule at five sites (verified by enumerating every `CheckDocReadAccess*`
+call in v1.0.0). The table maps each to its Rust home, noting current state and the architectural
+divergence.
+
+| # | Concern | Go site | Rust site | Current Rust state | Change |
+|---|---------|---------|-----------|--------------------|--------|
+| 1 | Commits query (A2) | `planner/commit.go:325,348` | `query/src/runner/commits.rs::execute_commits_query` | `docID None => continue` — **collection-level DAG ungated**; doc commits filtered per-doc only | Gate collection-level commits on the collection object; route doc commits through `check_doc_read_access` (overlay backend) so branchable public docs also require collection access |
+| 2 | Signature verify (A2) | `internal/db/verify.go:115` | `db/src/block_verify.rs:110` | gates only when `delta.doc_id()` is `Some` — **collection blocks bypass** | Resolve collection; use `check_doc_read_access`; gate collection-level blocks on the collection object |
+| 3 | P2P serve boundary (A3) | `p2p.go:197` `SetBlockAccessFunc(hasAccess)` + `trySelfHasAccess` (pull) | `p2p/src/bitswap/filter.rs` (libp2p) **and** Iroh serve path (`p2p/src/iroh/*`, via `ReplicatorRegistry`) | gates by **replicator membership per collection** only — no per-block read check | Add per-block `check_doc_read_access` (direct backend) so private branchable blocks are **never served** to a peer that cannot read them — the `hasAccess` analog, on **both** transports |
+| 4 | KMS key gate (A3) | `internal/kms/pubsub.go:577` | `crates/kms` (`doesIdentityHaveDocPermission` analog) | per-doc read check | Switch to `check_doc_read_access` so encryption-key access respects collection gating |
+| 5 | Pushlog CID integrity (A3) | `p2p.go:617` (`ErrBlockCIDMismatch`) | `p2p/src/sync/coordinator/event_handler/pushlog.rs` | (no equivalent check) | Reject a pushed block whose contents do not hash to the advertised CID — independent hardening bundled in #4990 |
+
+### The architectural divergence (decided)
+
+Go has **no ACP check at merge** (`internal/db/merge.go` is clean). It enforces read access at the
+**serve boundary**: the producing node withholds blocks the requester cannot read, so private bytes
+never cross the wire.
+
+Rust today does the opposite: its serve filter gates only by *replicator membership*, and per-doc
+ACP is enforced **receiver-side at merge** (`AcpMergeHandler`). For branchable collections — the
+"private data leaks to peers" boundary — merge-time gating is too late: the bytes have already been
+transmitted.
+
+**Decision:** A3 enforces at the **serve boundary, matching Go** (site #3 above), on both the
+libp2p bitswap filter and the Iroh serve path. The existing merge-time ACP gating
+(`AcpMergeHandler`) is **kept as receiver-side defense-in-depth** and extended to also recognize
+collection-level branchable blocks, but the primary leak fix is at serve.
+
+## Semantics preserved (parity-critical)
+
+- An **explicit denial** on a document always denies, regardless of collection access.
+- An **explicit grant** on a document always grants, even inside a private branchable collection
+  (single-document sharing out of a private collection works).
+- Node-identity full-access and `dac_bypass` shortcuts still apply and count as `explicit`.
+- Anonymous + registered object → deny.
+- Unpermissioned collection or public object on a **non-branchable** collection → grant.
+- **Non-branchable collections behave exactly as today** — the rule reduces to the document's own
+  read access; no collection-object check is performed.
+
+## Testing
+
+Primary validation is Rust-native integration tests in `tools/integration-test`, run across a
+**cross-implementation matrix** (the harness can pair a Go binary and a Rust binary):
+
+- **rust ↔ rust**, **go ↔ go**, **go ↔ rust** — proves wire-level + enforcement parity on the sync
+  path, and specifically that a Rust producer withholds private branchable blocks from a peer the
+  same way a Go producer does.
+
+Scenarios ported from Go #4990:
+
+- `tests/integration/acp/dac/branchable/collection_commits_test.go` → commits-query read gating
+  (collection-level DAG + doc commits, branchable vs non-branchable).
+- `collection_mutation_test.go` → mutation/registration interplay (mostly A1, regression guard).
+- `peer_test.go` → P2P serve-boundary enforcement (private collection blocks not served).
+- `tests/integration/encryption/peer_acp_branchable_test.go` → KMS key-gate under branchable ACP.
+- `tests/integration/signature/acp_branchable_test.go` → signature-verify read gating.
+
+Unit tests:
+
+- `check_doc_read_access` truth table in `crates/db`: {explicit-grant, explicit-deny, public-doc,
+  collection-level} × {branchable, non-branchable} × {permissioned, unpermissioned}.
+- Serve-filter per-block decision (bitswap + iroh): private branchable data block denied to a
+  non-authorized replicator; collection-definition blocks still allowed; signature blocks allowed.
+- Merge-handler collection-level-block gating (defense-in-depth).
+- Pushlog CID-mismatch rejection.
+
+## Out of scope
+
+- Document create/update/delete mutation gating (unchanged; A1 covers registration).
+- Policy-transition logic, NAC behavior.
+- Retrofitting per-doc serve-boundary gating for **non-branchable** collections (Rust's pre-existing
+  merge-time model for ordinary documents is unchanged; this epic adds the serve gate for the
+  branchable read rule specifically — though the implementation naturally routes ordinary doc blocks
+  through the same `check_doc_read_access`, so the gate applies uniformly where wired).
+
+## Risks
+
+- **A3 leak boundary (highest):** the serve-path gate is where private branchable data could leak to
+  peers. It gets a **mandatory adversarial re-audit** (a dedicated verification workflow) before
+  merge, covering both transports and the pull/pushlog paths.
+- **Two-transport drift:** libp2p and Iroh serve paths must apply identical per-block decisions;
+  mitigated by routing both through the same `check_doc_read_access` + a shared test.
+- **Overlay vs direct backend drift:** commits-query (overlay) and serve/merge (direct) must not
+  diverge on the rule; mitigated by the single shared algorithm over `ObjectAccessChecker`.
+- **Performance:** per-block read checks on serve add ACP lookups to the hot sync path; the rule
+  short-circuits for unpermissioned/non-branchable collections (the common case) before any ACP
+  call.

--- a/tools/integration-test/src/lib.rs
+++ b/tools/integration-test/src/lib.rs
@@ -105,6 +105,34 @@ macro_rules! for_each_runtime {
     };
 }
 
+/// Like `for_each_runtime!` but marks only the `go_<name>` variant `#[ignore]`d
+/// with a reason; the `rust_<name>` variant still runs. Use when a test asserts
+/// hardcoded DocID/CID vectors that diverge between the Rust port and the Go
+/// binary — e.g. Go #4838 (DocID derived from the genesis composite CID) is not
+/// yet ported to Rust, so a Go v1.0.0 node computes different identities. See
+/// defradb.rs#1080.
+#[macro_export]
+macro_rules! for_each_runtime_go_ignored {
+    ($name:ident, $inner:ident, $reason:literal) => {
+        ::paste::paste! {
+            #[tokio::test]
+            async fn [<rust_ $name>]() {
+                let _root = $crate::workspace_root();
+                let cluster = $crate::TestCluster::builder().rust_nodes(1).build().await.unwrap();
+                $inner(cluster).await;
+            }
+
+            #[tokio::test]
+            #[ignore = $reason]
+            async fn [<go_ $name>]() {
+                let _root = $crate::workspace_root();
+                let cluster = $crate::TestCluster::builder().go_nodes(1).build().await.unwrap();
+                $inner(cluster).await;
+            }
+        }
+    };
+}
+
 /// Generate `rust_rust_<name>`, `go_go_<name>`, and `go_rust_<name>` test wrappers
 /// for a multi-node P2P test.
 ///

--- a/tools/integration-test/src/lib.rs
+++ b/tools/integration-test/src/lib.rs
@@ -105,34 +105,6 @@ macro_rules! for_each_runtime {
     };
 }
 
-/// Like `for_each_runtime!` but marks only the `go_<name>` variant `#[ignore]`d
-/// with a reason; the `rust_<name>` variant still runs. Use when a test asserts
-/// hardcoded DocID/CID vectors that diverge between the Rust port and the Go
-/// binary — e.g. Go #4838 (DocID derived from the genesis composite CID) is not
-/// yet ported to Rust, so a Go v1.0.0 node computes different identities. See
-/// defradb.rs#1080.
-#[macro_export]
-macro_rules! for_each_runtime_go_ignored {
-    ($name:ident, $inner:ident, $reason:literal) => {
-        ::paste::paste! {
-            #[tokio::test]
-            async fn [<rust_ $name>]() {
-                let _root = $crate::workspace_root();
-                let cluster = $crate::TestCluster::builder().rust_nodes(1).build().await.unwrap();
-                $inner(cluster).await;
-            }
-
-            #[tokio::test]
-            #[ignore = $reason]
-            async fn [<go_ $name>]() {
-                let _root = $crate::workspace_root();
-                let cluster = $crate::TestCluster::builder().go_nodes(1).build().await.unwrap();
-                $inner(cluster).await;
-            }
-        }
-    };
-}
-
 /// Generate `rust_rust_<name>`, `go_go_<name>`, and `go_rust_<name>` test wrappers
 /// for a multi-node P2P test.
 ///

--- a/tools/integration-test/tests/acp/p2p_lifecycle.rs
+++ b/tools/integration-test/tests/acp/p2p_lifecycle.rs
@@ -189,27 +189,28 @@ async fn acp_p2p_subscribe_add_get_single_with_permissioned_collection_test(clus
         vec!["John".to_string()]
     );
 
-    let owner_key = owner.private_key_hex.clone();
-    poll_until(
-        || {
-            query_user_names(&node1, Some(&owner_key))
-                .iter()
-                .any(|name| name == "John")
-        },
-        Duration::from_secs(15),
-        Duration::from_millis(200),
-        "subscription-based sync did not materialize the protected document on node1",
-    )
-    .await;
+    // Go parity (acp/dac/p2p subscribe_test.go): a permissioned document does
+    // NOT sync to a NON-replicator subscriber. Subscription delivers the head
+    // via pubsub, but node1 must PULL the doc's blocks back from node0, and
+    // node0's serve-side ACP gate denies that pull — node1 is a subscriber (not
+    // a replicator, so the replicator bypass does not fire) and holds no reader
+    // grant, so it resolves to an unauthorized/anonymous actor for a registered
+    // private doc. Allow a settle window well beyond the replicator variant's
+    // normal sync latency, then assert node1 never received the doc.
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
-    // node0 is the creating node: the doc's owner is registered there, so Local ACP
-    // gates it and anonymous sees nothing.
+    assert!(
+        query_user_names(&node1, Some(&owner.private_key_hex)).is_empty(),
+        "permissioned doc must NOT reach a non-replicator subscriber, even under the owner identity on node1"
+    );
+    assert!(
+        query_user_names(&node1, None).is_empty(),
+        "permissioned doc must NOT be visible to anonymous on the subscriber node"
+    );
+
+    // node0 is the creating node: the doc's owner is registered there, so Local
+    // ACP gates it and anonymous sees nothing.
     assert!(query_user_names(&node0, None).is_empty());
-    // Local ACP is node-local; the replicated doc is public on the peer (matches Go).
-    // node1 never registered the owner, so anonymous sees the replicated "John".
-    assert!(query_user_names(&node1, None)
-        .iter()
-        .any(|name| name == "John"));
 }
 
 async fn acp_p2p_one_to_one_replicator_with_permissioned_collection_test(cluster: TestCluster) {

--- a/tools/integration-test/tests/query/multi_cid_vectors.rs
+++ b/tools/integration-test/tests/query/multi_cid_vectors.rs
@@ -1,4 +1,6 @@
-use integration_test::{for_each_runtime, generate_identity, TestCluster};
+use integration_test::{
+    for_each_runtime, for_each_runtime_go_ignored, generate_identity, TestCluster,
+};
 use serde_json::Value;
 
 // Mirrors the multi-CID vector cases added in Go PR #4794. Document CID tests
@@ -357,17 +359,24 @@ async fn multi_cid_commits_filters_unreadable_cid_test(cluster: TestCluster) {
     );
 }
 
-for_each_runtime!(
+// These assert hardcoded commit-CID vectors. Go v1.0.0 derives DocIDs from the
+// genesis composite CID (Go #4838), which the Rust port has not yet ported, so a
+// Go node computes different CIDs and the `go_` variants cannot match the baked
+// vectors. Tracked in defradb.rs#1080; the `rust_` variants still run.
+for_each_runtime_go_ignored!(
     multi_cid_simple_multiple_cids,
-    multi_cid_simple_multiple_cids_test
+    multi_cid_simple_multiple_cids_test,
+    "blocked on porting Go #4838 (DocID from genesis CID) to Rust; see defradb.rs#1080"
 );
-for_each_runtime!(
+for_each_runtime_go_ignored!(
     multi_cid_simple_duplicate_cids_for_same_doc,
-    multi_cid_simple_duplicate_cids_for_same_doc_test
+    multi_cid_simple_duplicate_cids_for_same_doc_test,
+    "blocked on porting Go #4838 (DocID from genesis CID) to Rust; see defradb.rs#1080"
 );
-for_each_runtime!(
+for_each_runtime_go_ignored!(
     multi_cid_simple_multiple_cids_for_same_doc,
-    multi_cid_simple_multiple_cids_for_same_doc_test
+    multi_cid_simple_multiple_cids_for_same_doc_test,
+    "blocked on porting Go #4838 (DocID from genesis CID) to Rust; see defradb.rs#1080"
 );
 for_each_runtime!(
     multi_cid_commits_different_docs,

--- a/tools/integration-test/tests/query/multi_cid_vectors.rs
+++ b/tools/integration-test/tests/query/multi_cid_vectors.rs
@@ -357,13 +357,6 @@ async fn multi_cid_commits_filters_unreadable_cid_test(cluster: TestCluster) {
     );
 }
 
-// NOTE: the `go_` variants below FAIL ON PURPOSE against a Go v1.0.0 node and are
-// left failing as a visible parity signal (not `#[ignore]`d). They assert
-// hardcoded commit-CID vectors, but Go v1.0.0 derives DocIDs from the genesis
-// composite CID (Go #4838), which the Rust port has not yet ported — so Go and
-// Rust compute different document identities and the baked vectors cannot match.
-// They go green once Rust ports #4838 and the vectors are refreshed. Tracked in
-// defradb.rs#1080. The `rust_` variants pass today.
 for_each_runtime!(
     multi_cid_simple_multiple_cids,
     multi_cid_simple_multiple_cids_test

--- a/tools/integration-test/tests/query/multi_cid_vectors.rs
+++ b/tools/integration-test/tests/query/multi_cid_vectors.rs
@@ -1,6 +1,4 @@
-use integration_test::{
-    for_each_runtime, for_each_runtime_go_ignored, generate_identity, TestCluster,
-};
+use integration_test::{for_each_runtime, generate_identity, TestCluster};
 use serde_json::Value;
 
 // Mirrors the multi-CID vector cases added in Go PR #4794. Document CID tests
@@ -359,24 +357,24 @@ async fn multi_cid_commits_filters_unreadable_cid_test(cluster: TestCluster) {
     );
 }
 
-// These assert hardcoded commit-CID vectors. Go v1.0.0 derives DocIDs from the
-// genesis composite CID (Go #4838), which the Rust port has not yet ported, so a
-// Go node computes different CIDs and the `go_` variants cannot match the baked
-// vectors. Tracked in defradb.rs#1080; the `rust_` variants still run.
-for_each_runtime_go_ignored!(
+// NOTE: the `go_` variants below FAIL ON PURPOSE against a Go v1.0.0 node and are
+// left failing as a visible parity signal (not `#[ignore]`d). They assert
+// hardcoded commit-CID vectors, but Go v1.0.0 derives DocIDs from the genesis
+// composite CID (Go #4838), which the Rust port has not yet ported — so Go and
+// Rust compute different document identities and the baked vectors cannot match.
+// They go green once Rust ports #4838 and the vectors are refreshed. Tracked in
+// defradb.rs#1080. The `rust_` variants pass today.
+for_each_runtime!(
     multi_cid_simple_multiple_cids,
-    multi_cid_simple_multiple_cids_test,
-    "blocked on porting Go #4838 (DocID from genesis CID) to Rust; see defradb.rs#1080"
+    multi_cid_simple_multiple_cids_test
 );
-for_each_runtime_go_ignored!(
+for_each_runtime!(
     multi_cid_simple_duplicate_cids_for_same_doc,
-    multi_cid_simple_duplicate_cids_for_same_doc_test,
-    "blocked on porting Go #4838 (DocID from genesis CID) to Rust; see defradb.rs#1080"
+    multi_cid_simple_duplicate_cids_for_same_doc_test
 );
-for_each_runtime_go_ignored!(
+for_each_runtime!(
     multi_cid_simple_multiple_cids_for_same_doc,
-    multi_cid_simple_multiple_cids_for_same_doc_test,
-    "blocked on porting Go #4838 (DocID from genesis CID) to Rust; see defradb.rs#1080"
+    multi_cid_simple_multiple_cids_for_same_doc_test
 );
 for_each_runtime!(
     multi_cid_commits_different_docs,


### PR DESCRIPTION
## Summary

Full branchable-collection ACP epic (mirrors Go #4990 `3f627855`), in three slices on one branch.

**A1 — registration.** Branchable + permissioned collections register an ACP object owned by the creator, keyed by the stable `collection_id`, fail-closed before DB persistence if registration fails. Owner-aware idempotency: same-owner re-register is a no-op; a different/unknown owner fails closed (Go `bridge.RegisterDocObject` parity).

**A2 — read enforcement.** One shared rule in `acp::read_access::check_doc_read_access` (direct + transaction-overlay `ObjectAccessChecker`s), gating the commits query and signature verification. Collection-level commit-DAG blocks (no docID) and a branchable collection's public documents are gated on the collection object.

**A3 — sync enforcement.** The same rule gates the P2P serve boundary (Bitswap filter + CAR fetch) and KMS document-key release, per-block, matching Go's `hasAccess` (replicator passthrough on the stable `collection_id`; libp2p resolves peers via the active signed-token identity path; Iroh non-replicators resolve to Anonymous). This also closed two pre-existing permissioned-data serve leaks (the old CAR gate served permissioned blocks to any connected peer / subscriber with no ACP check).

Semantics match Go: explicit doc grant is sufficient; explicit doc denial always denies; node-identity/DAC-bypass honored on every path; unresolved serve identity → Anonymous (public still served, private denied).

## Review & hardening (in-branch)

Multi-agent review + adversarial audits against the Go oracle. Fixes: embedded-crate fail-open and owner-aware idempotency (A1); `_commits` fail-open on inactive (post-migration) versions — now resolves inactive versions and fails closed; overlay `dac_bypass` shortcut; `CollectionSet` excluded from the serve whitelist (Go `IsDefinition` parity); CAR/subscriber serve tests updated to the Go-parity per-block model. `cargo clippy --all -- -D warnings` + `cargo fmt --all` clean; full workspace unit tests green.

## Verification
- `cargo test -p acp --test read_access_tests`
- `cargo test -p db --test collection_acp_tests`
- `cargo test -p query-plan --test cross_object_read_path`
- `cargo test -p kms nac_dac_policy`
- `cargo test --workspace --exclude integration-test --exclude ffi-test --exclude conformance`
- `cargo clippy --all -- -D warnings` / `cargo fmt --all -- --check`
- CI integration matrix (rust / go-compat @ develop `6c874754` / iroh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)