### PR TITLE
feat(ffi): expose filtered replication via p2p_add_replicator_with_filter and defra_mobile_add_replicator

### DIFF
--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -255,7 +255,7 @@ pub use index::{create_index, delete_index, get_indexes, list_all_indexes};
 pub use lens::{lens_add, lens_add_in_txn, lens_list, lens_list_in_txn};
 pub use mobile::{
     defra_mobile_add_replicator, defra_mobile_close_node, defra_mobile_connect,
-    defra_mobile_ensure_schema, defra_mobile_execute, defra_mobile_init,
+    defra_mobile_disconnect, defra_mobile_ensure_schema, defra_mobile_execute, defra_mobile_init,
     defra_mobile_notify_network_change, defra_mobile_open_node, defra_mobile_peer_info,
     defra_mobile_sync_collection,
 };
@@ -263,9 +263,9 @@ pub use node::{new_node, node_close};
 pub use p2p::{
     new_node_with_p2p, p2p_active_peers, p2p_add_collections, p2p_add_documents,
     p2p_add_replicator, p2p_add_replicator_with_filter, p2p_connect, p2p_delete_collections,
-    p2p_delete_documents, p2p_delete_replicator, p2p_list_collections, p2p_list_documents,
-    p2p_list_replicators, p2p_notify_network_change, p2p_peer_info, p2p_sync_branchable_collection,
-    p2p_sync_collection_versions, p2p_sync_documents,
+    p2p_delete_documents, p2p_delete_replicator, p2p_disconnect, p2p_list_collections,
+    p2p_list_documents, p2p_list_replicators, p2p_notify_network_change, p2p_peer_info,
+    p2p_sync_branchable_collection, p2p_sync_collection_versions, p2p_sync_documents,
 };
 pub use query::exec_request;
 pub use schema::{add_schema, add_schema_in_txn, get_collections, get_collections_in_txn};

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -254,16 +254,17 @@ pub use encrypted_index::{
 pub use index::{create_index, delete_index, get_indexes, list_all_indexes};
 pub use lens::{lens_add, lens_add_in_txn, lens_list, lens_list_in_txn};
 pub use mobile::{
-    defra_mobile_close_node, defra_mobile_connect, defra_mobile_ensure_schema,
-    defra_mobile_execute, defra_mobile_init, defra_mobile_notify_network_change,
-    defra_mobile_open_node, defra_mobile_peer_info, defra_mobile_sync_collection,
+    defra_mobile_add_replicator, defra_mobile_close_node, defra_mobile_connect,
+    defra_mobile_ensure_schema, defra_mobile_execute, defra_mobile_init,
+    defra_mobile_notify_network_change, defra_mobile_open_node, defra_mobile_peer_info,
+    defra_mobile_sync_collection,
 };
 pub use node::{new_node, node_close};
 pub use p2p::{
     new_node_with_p2p, p2p_active_peers, p2p_add_collections, p2p_add_documents,
-    p2p_add_replicator, p2p_connect, p2p_delete_collections, p2p_delete_documents,
-    p2p_delete_replicator, p2p_list_collections, p2p_list_documents, p2p_list_replicators,
-    p2p_notify_network_change, p2p_peer_info, p2p_sync_branchable_collection,
+    p2p_add_replicator, p2p_add_replicator_with_filter, p2p_connect, p2p_delete_collections,
+    p2p_delete_documents, p2p_delete_replicator, p2p_list_collections, p2p_list_documents,
+    p2p_list_replicators, p2p_notify_network_change, p2p_peer_info, p2p_sync_branchable_collection,
     p2p_sync_collection_versions, p2p_sync_documents,
 };
 pub use query::exec_request;

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -8,14 +8,15 @@ use acp::nac::NodePermission;
 
 use crate::helpers::get_rt;
 use crate::mobile_config::{
-    c_string_ptr, decode_hex_field, ffi_result_error, maybe_cstring, MobileExecuteRequest,
-    MobileNodeConfig, MobileSyncRequest,
+    c_string_ptr, decode_hex_field, ffi_result_error, maybe_cstring, MobileAddReplicatorRequest,
+    MobileExecuteRequest, MobileNodeConfig, MobileSyncRequest,
 };
 use crate::nac_check::check_nac_for_node;
 use crate::node::{new_node, node_close};
 use crate::p2p::{
-    new_node_with_p2p, p2p_connect, p2p_notify_network_change, p2p_peer_info,
-    p2p_sync_branchable_collection, p2p_sync_collection_versions, p2p_sync_documents,
+    new_node_with_p2p, p2p_add_replicator_with_filter, p2p_connect, p2p_notify_network_change,
+    p2p_peer_info, p2p_sync_branchable_collection, p2p_sync_collection_versions,
+    p2p_sync_documents,
 };
 use crate::query::exec_request;
 use crate::schema::validate_collection_policy;
@@ -615,10 +616,98 @@ pub extern "C" fn defra_mobile_sync_collection(
     }
 }
 
+/// Add a P2P replicator with optional per-collection filters for mobile embedding.
+///
+/// `request_json` is camelCase and accepts `collections`, `peerAddr`, optional
+/// `identityDid`, and optional HTTP-shaped `filters` keyed by collection name.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_mobile_add_replicator(
+    node_ptr: usize,
+    request_json: *const c_char,
+) -> FfiResult {
+    ffi_entry! {
+        let request_str = match unsafe { c_str_to_string(request_json) } {
+            Some(value) => value,
+            None => return FfiResult::error("invalid request_json parameter"),
+        };
+        let request: MobileAddReplicatorRequest = match serde_json::from_str(&request_str) {
+            Ok(request) => request,
+            Err(error) => return FfiResult::error(format!("invalid request_json: {}", error)),
+        };
+
+        let identity_did = if request.identity_did.is_some() {
+            match maybe_cstring(request.identity_did.as_deref(), "identityDid") {
+                Ok(value) => value,
+                Err(error) => return FfiResult::error(error),
+            }
+        } else {
+            match default_identity_cstring(node_ptr) {
+                Ok(value) => value,
+                Err(error) => return FfiResult::error(error),
+            }
+        };
+
+        let collections = match CString::new(serde_json::to_string(&request.collections).unwrap_or_default()) {
+            Ok(value) => value,
+            Err(_) => return FfiResult::error("collections contains an embedded null byte"),
+        };
+        let peer_addr = match CString::new(request.peer_addr) {
+            Ok(value) => value,
+            Err(_) => return FfiResult::error("peerAddr contains an embedded null byte"),
+        };
+        let filters = match CString::new(serde_json::to_string(&request.filters).unwrap_or_default()) {
+            Ok(value) => value,
+            Err(_) => return FfiResult::error("filters contains an embedded null byte"),
+        };
+
+        unsafe {
+            p2p_add_replicator_with_filter(
+                node_ptr,
+                c_string_ptr(&identity_did),
+                peer_addr.as_ptr(),
+                collections.as_ptr(),
+                filters.as_ptr(),
+            )
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::ffi::CStr;
+
+    #[test]
+    fn test_mobile_add_replicator_request_parse() {
+        let json = r#"{
+            "collections": ["Users"],
+            "peerAddr": "/ip4/1.2.3.4/tcp/9000/p2p/12D3",
+            "filters": {"Users": {"Conditions": {"agent_did": {"_eq": "did:key:z6"}}}}
+        }"#;
+        let request: MobileAddReplicatorRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.collections, vec!["Users".to_string()]);
+        assert_eq!(request.peer_addr, "/ip4/1.2.3.4/tcp/9000/p2p/12D3");
+        assert!(request.filters.contains_key("Users"));
+        assert!(request.filters["Users"].conditions.is_some());
+        assert!(request.identity_did.is_none());
+    }
+
+    #[test]
+    fn test_mobile_add_replicator_request_minimal() {
+        let json = r#"{"collections":["Posts"],"peerAddr":"/ip4/127.0.0.1/tcp/9000"}"#;
+        let request: MobileAddReplicatorRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.collections, vec!["Posts".to_string()]);
+        assert_eq!(request.peer_addr, "/ip4/127.0.0.1/tcp/9000");
+        assert!(request.filters.is_empty());
+    }
+
+    #[test]
+    fn test_mobile_add_replicator_request_accepts_address_alias() {
+        let json = r#"{"collections":["Posts"],"address":"/ip4/127.0.0.1/tcp/9000"}"#;
+        let request: MobileAddReplicatorRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.peer_addr, "/ip4/127.0.0.1/tcp/9000");
+    }
 
     #[test]
     fn test_mobile_open_schema_and_execute() {

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -656,7 +656,7 @@ pub extern "C" fn defra_mobile_add_replicator(
             Ok(value) => value,
             Err(_) => return FfiResult::error("peerAddr contains an embedded null byte"),
         };
-        let filters = match CString::new(serde_json::to_string(&request.filters).unwrap_or_default()) {
+        let filters = match CString::new(serde_json::to_string(&request.filters).unwrap_or_else(|_| "null".to_string())) {
             Ok(value) => value,
             Err(_) => return FfiResult::error("filters contains an embedded null byte"),
         };
@@ -688,8 +688,9 @@ mod tests {
         let request: MobileAddReplicatorRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.collections, vec!["Users".to_string()]);
         assert_eq!(request.peer_addr, "/ip4/1.2.3.4/tcp/9000/p2p/12D3");
-        assert!(request.filters.contains_key("Users"));
-        assert!(request.filters["Users"].conditions.is_some());
+        let filters = request.filters.as_ref().unwrap();
+        assert!(filters.contains_key("Users"));
+        assert!(filters["Users"].conditions.is_some());
         assert!(request.identity_did.is_none());
     }
 
@@ -699,7 +700,15 @@ mod tests {
         let request: MobileAddReplicatorRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.collections, vec!["Posts".to_string()]);
         assert_eq!(request.peer_addr, "/ip4/127.0.0.1/tcp/9000");
-        assert!(request.filters.is_empty());
+        assert!(request.filters.is_none());
+    }
+
+    #[test]
+    fn test_mobile_add_replicator_request_accepts_null_filters() {
+        let json =
+            r#"{"collections":["Posts"],"peerAddr":"/ip4/127.0.0.1/tcp/9000","filters":null}"#;
+        let request: MobileAddReplicatorRequest = serde_json::from_str(json).unwrap();
+        assert!(request.filters.is_none());
     }
 
     #[test]

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -14,9 +14,9 @@ use crate::mobile_config::{
 use crate::nac_check::check_nac_for_node;
 use crate::node::{new_node, node_close};
 use crate::p2p::{
-    new_node_with_p2p, p2p_add_replicator_with_filter, p2p_connect, p2p_notify_network_change,
-    p2p_peer_info, p2p_sync_branchable_collection, p2p_sync_collection_versions,
-    p2p_sync_documents,
+    new_node_with_p2p, p2p_add_replicator_with_filter, p2p_connect, p2p_disconnect,
+    p2p_notify_network_change, p2p_peer_info, p2p_sync_branchable_collection,
+    p2p_sync_collection_versions, p2p_sync_documents,
 };
 use crate::query::exec_request;
 use crate::schema::validate_collection_policy;
@@ -518,6 +518,19 @@ pub extern "C" fn defra_mobile_connect(node_ptr: usize, addr: *const c_char) -> 
     }
 }
 
+/// Disconnect the node from a peer address.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_mobile_disconnect(node_ptr: usize, addr: *const c_char) -> FfiResult {
+    ffi_entry! {
+        let identity = match default_identity_cstring(node_ptr) {
+            Ok(value) => value,
+            Err(error) => return FfiResult::error(error),
+        };
+        unsafe { p2p_disconnect(node_ptr, c_string_ptr(&identity), addr) }
+    }
+}
+
 /// Notify the embedded iroh transport that network conditions may have changed.
 #[no_mangle]
 pub extern "C" fn defra_mobile_notify_network_change(node_ptr: usize) -> FfiResult {
@@ -707,6 +720,12 @@ mod tests {
         let json = r#"{"collections":["Posts"],"address":"/ip4/127.0.0.1/tcp/9000"}"#;
         let request: MobileAddReplicatorRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.peer_addr, "/ip4/127.0.0.1/tcp/9000");
+    }
+
+    #[test]
+    fn defra_mobile_disconnect_exports_connect_style_ffi_signature() {
+        let symbol: extern "C" fn(usize, *const c_char) -> FfiResult = defra_mobile_disconnect;
+        let _ = symbol;
     }
 
     #[test]

--- a/crates/ffi/src/mobile_config.rs
+++ b/crates/ffi/src/mobile_config.rs
@@ -88,8 +88,7 @@ pub(crate) struct MobileAddReplicatorRequest {
     pub collections: Vec<String>,
     #[serde(alias = "address")]
     pub peer_addr: String,
-    #[serde(default)]
-    pub filters: defra_http::router::ReplicationFilters,
+    pub filters: Option<defra_http::router::ReplicationFilters>,
 }
 
 pub(crate) fn maybe_cstring(

--- a/crates/ffi/src/mobile_config.rs
+++ b/crates/ffi/src/mobile_config.rs
@@ -81,6 +81,17 @@ pub(crate) struct MobileSyncRequest {
     pub version_ids: Option<Vec<String>>,
 }
 
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MobileAddReplicatorRequest {
+    pub identity_did: Option<String>,
+    pub collections: Vec<String>,
+    #[serde(alias = "address")]
+    pub peer_addr: String,
+    #[serde(default)]
+    pub filters: defra_http::router::ReplicationFilters,
+}
+
 pub(crate) fn maybe_cstring(
     value: Option<&str>,
     field_name: &str,

--- a/crates/ffi/src/p2p/mod.rs
+++ b/crates/ffi/src/p2p/mod.rs
@@ -21,7 +21,9 @@ pub use documents::{p2p_add_documents, p2p_delete_documents, p2p_list_documents}
 pub use node::new_node_with_p2p;
 pub use peer::{p2p_active_peers, p2p_connect, p2p_notify_network_change, p2p_peer_info};
 pub use push::p2p_retry_replicators;
-pub use replicator::{p2p_add_replicator, p2p_delete_replicator, p2p_list_replicators};
+pub use replicator::{
+    p2p_add_replicator, p2p_add_replicator_with_filter, p2p_delete_replicator, p2p_list_replicators,
+};
 pub use sync::{p2p_sync_branchable_collection, p2p_sync_documents};
 pub use version_sync::p2p_sync_collection_versions;
 
@@ -147,6 +149,22 @@ pub(crate) fn parse_collections_json(json_str: &str) -> FfiP2PResult<Vec<String>
     Ok(opt.unwrap_or_default())
 }
 
+/// Parse a JSON map of per-collection replication filters keyed by collection name.
+///
+/// Accepts `null`, `{}`, or an empty string as an empty (unfiltered) map. The
+/// accepted shape mirrors the HTTP `"Filters"` field (`ReplicationFilters`).
+pub(crate) fn parse_filters_json(
+    json_str: &str,
+) -> FfiP2PResult<defra_http::router::ReplicationFilters> {
+    if json_str.is_empty() {
+        return Ok(defra_http::router::ReplicationFilters::new());
+    }
+
+    let opt: Option<defra_http::router::ReplicationFilters> = serde_json::from_str(json_str)
+        .map_err(|e| FfiP2PError::invalid_input(format!("invalid filters JSON: {}", e)))?;
+    Ok(opt.unwrap_or_default())
+}
+
 pub(crate) fn parse_doc_ids_json(json_str: &str) -> FfiP2PResult<Vec<String>> {
     let opt: Option<Vec<String>> = serde_json::from_str(json_str)
         .map_err(|e| FfiP2PError::invalid_input(format!("invalid doc_ids JSON: {}", e)))?;
@@ -177,5 +195,48 @@ mod tests {
         let error = parse_collections_json("{").unwrap_err();
         assert_eq!(error.code, FfiP2PErrorCode::InvalidInput);
         assert!(error.message.contains("invalid collections JSON"));
+    }
+
+    #[test]
+    fn parse_filters_valid_map_with_http_conditions() {
+        use super::parse_filters_json;
+
+        let json = r#"{
+            "Users": {"Conditions": {"agent_did": {"_eq": "did:key:z6"}}},
+            "Posts": {"Conditions": {"active": {"_eq": true}}}
+        }"#;
+        let filters = parse_filters_json(json).unwrap();
+        assert_eq!(filters.len(), 2);
+        assert!(filters.contains_key("Users"));
+        assert!(filters.contains_key("Posts"));
+        assert!(filters["Users"].conditions.is_some());
+    }
+
+    #[test]
+    fn parse_filters_legacy_shape() {
+        use super::parse_filters_json;
+
+        let json = r#"{"Users": {"Field": "agent_did", "Value": "did:key:z6"}}"#;
+        let filters = parse_filters_json(json).unwrap();
+        assert_eq!(filters.len(), 1);
+        assert!(filters.contains_key("Users"));
+    }
+
+    #[test]
+    fn parse_filters_null_or_empty_yields_empty_map() {
+        use super::parse_filters_json;
+
+        assert!(parse_filters_json("null").unwrap().is_empty());
+        assert!(parse_filters_json("{}").unwrap().is_empty());
+        assert!(parse_filters_json("").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_filters_invalid_json_is_invalid_input() {
+        use super::parse_filters_json;
+
+        let err = parse_filters_json("{not json}").unwrap_err();
+        assert_eq!(err.code, FfiP2PErrorCode::InvalidInput);
+        assert!(err.message.contains("invalid filters JSON"));
     }
 }

--- a/crates/ffi/src/p2p/mod.rs
+++ b/crates/ffi/src/p2p/mod.rs
@@ -19,7 +19,9 @@ mod version_sync;
 pub use collections::{p2p_add_collections, p2p_delete_collections, p2p_list_collections};
 pub use documents::{p2p_add_documents, p2p_delete_documents, p2p_list_documents};
 pub use node::new_node_with_p2p;
-pub use peer::{p2p_active_peers, p2p_connect, p2p_notify_network_change, p2p_peer_info};
+pub use peer::{
+    p2p_active_peers, p2p_connect, p2p_disconnect, p2p_notify_network_change, p2p_peer_info,
+};
 pub use push::p2p_retry_replicators;
 pub use replicator::{
     p2p_add_replicator, p2p_add_replicator_with_filter, p2p_delete_replicator, p2p_list_replicators,

--- a/crates/ffi/src/p2p/mod.rs
+++ b/crates/ffi/src/p2p/mod.rs
@@ -223,6 +223,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_filters_accepts_predicate_alias() {
+        use super::parse_filters_json;
+
+        let json = r#"{"Users": {"predicate": {"agent_did": {"_eq": "did:key:z6"}}}}"#;
+        let filters = parse_filters_json(json).unwrap();
+        assert_eq!(filters.len(), 1);
+        assert!(filters["Users"].conditions.is_some());
+    }
+
+    #[test]
     fn parse_filters_null_or_empty_yields_empty_map() {
         use super::parse_filters_json;
 

--- a/crates/ffi/src/p2p/peer.rs
+++ b/crates/ffi/src/p2p/peer.rs
@@ -243,3 +243,68 @@ pub unsafe extern "C" fn p2p_connect(
         into_ffi_ok(result)
     }
 }
+
+/// Disconnect from a peer address.
+///
+/// # Safety
+///
+/// `identity_did` and `addr` must be valid null-terminated UTF-8 strings when non-null.
+/// `node_ptr` must reference a live node handle created by this library.
+#[no_mangle]
+pub unsafe extern "C" fn p2p_disconnect(
+    node_ptr: usize,
+    identity_did: *const c_char,
+    addr: *const c_char,
+) -> FfiResult {
+    ffi_entry! {
+        let rt = try_ffi!(get_rt());
+        try_ffi!(check_nac_for_node(
+            rt,
+            node_ptr,
+            identity_did,
+            NodePermission::P2pPeerConnect
+        ));
+
+        // Bind the caller's identity so the adapter's inner NAC check resolves the
+        // actual caller instead of the wildcard. The body runs on this thread via
+        // `block_on`, so the thread-local is visible throughout; the guard restores
+        // on drop so it never leaks into the next request on this pooled thread.
+        let _identity_guard = defra_core::current_identity::scoped_current_identity(
+            crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty()),
+        );
+
+        let addr_str = try_ffi!(require_c_str(addr, "addr"));
+
+        let result = NODES
+            .get(node_ptr, |state| {
+                let p2p = match &state.p2p {
+                    Some(p2p) => p2p,
+                    None => return Err(FfiP2PError::no_p2p_system()),
+                };
+
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .disconnect_peer(&addr_str)
+                        .await
+                        .map_err(FfiP2PError::from)
+                })
+            })
+            .ok_or_else(FfiP2PError::invalid_node_handle)
+            .and_then(|result| result);
+
+        into_ffi_ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn p2p_disconnect_exports_connect_style_ffi_signature() {
+        let symbol: unsafe extern "C" fn(usize, *const c_char, *const c_char) -> FfiResult =
+            p2p_disconnect;
+        let _ = symbol;
+    }
+}

--- a/crates/ffi/src/p2p/replicator.rs
+++ b/crates/ffi/src/p2p/replicator.rs
@@ -9,7 +9,9 @@ use crate::state::NODES;
 use crate::try_ffi;
 use crate::types::{c_str_to_string, FfiResult};
 
-use super::{into_ffi_ok, into_ffi_result, parse_collections_json, FfiP2PError};
+use super::{
+    into_ffi_ok, into_ffi_result, parse_collections_json, parse_filters_json, FfiP2PError,
+};
 
 /// Set (add/update) a replicator for collections.
 ///
@@ -63,6 +65,86 @@ pub unsafe extern "C" fn p2p_add_replicator(
                     p2p.system
                         .ops()
                         .add_replicator(collections, Some(&addr), Default::default(), Vec::new(), None)
+                        .await
+                        .map_err(FfiP2PError::from)
+                })
+            })
+            .ok_or_else(FfiP2PError::invalid_node_handle)
+            .and_then(|result| result);
+
+        into_ffi_ok(result)
+    }
+}
+
+/// Set (add/update) a replicator for collections with per-collection filters.
+///
+/// `filters_json` is a JSON object keyed by collection name, mirroring the HTTP
+/// `"Filters"` field. `null`, `{}`, or an empty string is treated as
+/// unfiltered, matching [`p2p_add_replicator`]. This symbol is additive;
+/// [`p2p_add_replicator`] is unchanged for ABI stability.
+///
+/// # Safety
+///
+/// All string pointers must be valid null-terminated UTF-8 strings.
+/// `filters_json` may be null.
+#[no_mangle]
+pub unsafe extern "C" fn p2p_add_replicator_with_filter(
+    node_ptr: usize,
+    identity_did: *const c_char,
+    peer_addr: *const c_char,
+    collections_json: *const c_char,
+    filters_json: *const c_char,
+) -> FfiResult {
+    ffi_entry! {
+        let rt = try_ffi!(get_rt());
+        try_ffi!(check_nac_for_node(
+            rt,
+            node_ptr,
+            identity_did,
+            NodePermission::P2pReplicatorAdd
+        ));
+
+        // Bind the caller's identity so the adapter's inner NAC check resolves the
+        // actual caller instead of the wildcard. The body runs on this thread via
+        // `block_on`, so the thread-local is visible throughout; the guard restores
+        // on drop so it never leaks into the next request on this pooled thread.
+        let _identity_guard = defra_core::current_identity::scoped_current_identity(
+            c_str_to_string(identity_did).filter(|s| !s.is_empty()),
+        );
+
+        let addr_str = try_ffi!(require_c_str(peer_addr, "peer_addr"));
+        let collections_str = try_ffi!(require_c_str(collections_json, "collections_json"));
+        let collections = match parse_collections_json(&collections_str) {
+            Ok(collections) => collections,
+            Err(error) => return FfiResult::error(error.message),
+        };
+        let filters = if filters_json.is_null() {
+            defra_http::router::ReplicationFilters::new()
+        } else {
+            let filters_str = try_ffi!(require_c_str(filters_json, "filters_json"));
+            match parse_filters_json(&filters_str) {
+                Ok(filters) => filters,
+                Err(error) => return FfiResult::error(error.message),
+            }
+        };
+
+        let result = NODES
+            .get(node_ptr, |state| {
+                let p2p = match &state.p2p {
+                    Some(p2p) => p2p,
+                    None => return Err(FfiP2PError::no_p2p_system()),
+                };
+                state
+                    .sync_replicator_push_options()
+                    .map_err(FfiP2PError::internal)?;
+
+                let addr = addr_str.clone();
+                let collections = collections.clone();
+                let filters = filters.clone();
+                rt.block_on(async move {
+                    p2p.system
+                        .ops()
+                        .add_replicator(collections, Some(&addr), filters, Vec::new(), None)
                         .await
                         .map_err(FfiP2PError::from)
                 })

--- a/crates/http/src/router/traits.rs
+++ b/crates/http/src/router/traits.rs
@@ -8,7 +8,8 @@ pub type ReplicationFilters = std::collections::BTreeMap<String, ReplicationFilt
 ///
 /// Supports two forms:
 /// - Legacy scalar equality: `{"Field": "f", "Value": <scalar>}`
-/// - Rich predicate (any DefraDB query-filter conditions object): `{"Conditions": {"f": {"_in": [...]}}}`
+/// - Rich predicate (any DefraDB query-filter conditions object):
+///   `{"Conditions": {"f": {"_in": [...]}}}` or `{"predicate": {"f": {"_in": [...]}}}`
 ///
 /// When `conditions` is present it takes precedence over `field`/`value`.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -25,6 +26,7 @@ pub struct ReplicationFilter {
     /// When present, `field`/`value` are ignored during conversion.
     #[serde(
         rename = "Conditions",
+        alias = "predicate",
         default,
         skip_serializing_if = "Option::is_none"
     )]

--- a/tools/apple/README.md
+++ b/tools/apple/README.md
@@ -76,12 +76,17 @@ The mobile-oriented entry points are:
 - `defra_mobile_execute(node, request_json)`
 - `defra_mobile_peer_info(node)`
 - `defra_mobile_connect(node, addr)`
+- `defra_mobile_disconnect(node, addr)`
 - `defra_mobile_sync_collection(node, request_json)`
 - `defra_mobile_add_replicator(node, request_json)`
 - `register_remote_identity(...)`
 - `register_remote_identity_bytes(...)`
 - `bind_identity_bearer_token(did, bearer_token)`
 - `node_set_default_identity(node, did)`
+
+Rebuild the XCFramework after updating the FFI crate so the generated header
+includes newly added symbols such as `defra_mobile_add_replicator` and
+`defra_mobile_disconnect`.
 
 `defra_mobile_open_node` accepts a JSON blob so Swift can avoid hand-building
 `NodeInitOptions`. Example:
@@ -110,8 +115,7 @@ The mobile-oriented entry points are:
 ```
 
 `defra_mobile_add_replicator` accepts a single peer address, collection names,
-and optional per-collection filters. Rebuild the XCFramework after updating the
-FFI crate so the generated header includes the new symbol.
+and optional per-collection filters.
 
 ```json
 {

--- a/tools/apple/README.md
+++ b/tools/apple/README.md
@@ -77,6 +77,7 @@ The mobile-oriented entry points are:
 - `defra_mobile_peer_info(node)`
 - `defra_mobile_connect(node, addr)`
 - `defra_mobile_sync_collection(node, request_json)`
+- `defra_mobile_add_replicator(node, request_json)`
 - `register_remote_identity(...)`
 - `register_remote_identity_bytes(...)`
 - `bind_identity_bearer_token(did, bearer_token)`
@@ -105,6 +106,31 @@ The mobile-oriented entry points are:
 {
   "identityDid": "did:key:z...",
   "query": "mutation { add_Book(input: {name: \"Dune\"}) { _docID } }"
+}
+```
+
+`defra_mobile_add_replicator` accepts a single peer address, collection names,
+and optional per-collection filters. Rebuild the XCFramework after updating the
+FFI crate so the generated header includes the new symbol.
+
+```json
+{
+  "identityDid": "did:key:z...",
+  "collections": ["Users"],
+  "peerAddr": "/ip4/1.2.3.4/tcp/9000/p2p/12D3Koo...",
+  "filters": {
+    "Users": {"predicate": {"agent_did": {"_eq": "did:key:z..."}}}
+  }
+}
+```
+
+The `filters` field may be omitted or set to `null` for unfiltered replication.
+It also accepts the HTTP `Conditions` form and the legacy scalar form:
+
+```json
+{
+  "Users": {"Conditions": {"agent_did": {"_eq": "did:key:z..."}}},
+  "Posts": {"Field": "agent_did", "Value": "did:key:z..."}
 }
 ```
 


### PR DESCRIPTION
Closes #1075.

## Problem
Filtered P2P replication is available through the HTTP API and the underlying P2P adapter, but not through the C FFI. `p2p_add_replicator` keeps using an empty filter map, and mobile embedding did not have a convenience wrapper for adding a replicator.

## Approach
- Added the non-breaking C symbol `p2p_add_replicator_with_filter(node_ptr, identity_did, peer_addr, collections_json, filters_json)` while leaving `p2p_add_replicator` unchanged for ABI stability.
- Added `parse_filters_json` for HTTP-compatible filter JSON, with `null`, `{}`, and `""` treated as unfiltered.
- Added `defra_mobile_add_replicator(node_ptr, request_json)` with camelCase request JSON: `collections`, `peerAddr`, optional `identityDid`, and optional `filters`.
- Re-exported the new FFI and mobile symbols.

## Filters wire format
`filters_json` mirrors the HTTP `Filters` field: a map keyed by collection name. Each value is the HTTP replication filter shape:

```json
{
  "Users": {"Conditions": {"agent_did": {"_eq": "did:key:z..."}}}
}
```

The legacy scalar equality shape is also accepted:

```json
{
  "Users": {"Field": "agent_did", "Value": "did:key:z..."}
}
```

## Validation
- `cargo fmt -p ffi -- --check`: ✅
- `cargo test -p ffi --lib parse_filters`: ✅
- `cargo test -p ffi --lib mobile_add_replicator_request`: ✅
- `cargo build -p ffi --lib`: ✅
- `cargo clippy -p ffi --lib`: ✅

Not covered here: a live two-node P2P dial/replication integration test or a full mobile XCFramework rebuild.
