### PR TITLE
Fix live P2P replicator authorization reporting

### DIFF
--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -314,6 +314,11 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorList)
             .await?;
 
+        // #1074: report the LIVE replicator registry, not the persisted peerstore,
+        // so a reconciler can observe authorization drift. The coordinator and the
+        // raw transport read the same shared registry (the coordinator delegates to
+        // the same transport), so both branches are equally live-authoritative;
+        // persisted rows only overlay address/status metadata below.
         let p2p_infos = if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .list_replicators()

--- a/crates/cli/src/iroh_p2p_adapter.rs
+++ b/crates/cli/src/iroh_p2p_adapter.rs
@@ -314,21 +314,25 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorList)
             .await?;
 
-        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
-            match pusher.load_persisted_replicators().await {
-                Ok(Some(infos)) => infos,
-                Ok(None) => self
-                    .transport
-                    .list_replicators()
-                    .await
-                    .map_err(|e| P2PError::Transport(e.to_string()))?,
-                Err(e) => return Err(P2PError::Internal(e)),
-            }
+        let p2p_infos = if let Some(ref coordinator) = self.sync_coordinator {
+            coordinator
+                .list_replicators()
+                .await
+                .map_err(|e| P2PError::Transport(e.to_string()))?
         } else {
             self.transport
                 .list_replicators()
                 .await
                 .map_err(|e| P2PError::Transport(e.to_string()))?
+        };
+        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
+            let persisted = pusher
+                .load_persisted_replicators()
+                .await
+                .map_err(P2PError::Internal)?;
+            defra_p2p_adapter::merge_live_replicators_with_persisted_metadata(p2p_infos, persisted)
+        } else {
+            p2p_infos
         };
 
         let http_infos: Vec<ReplicatorInfo> = p2p_infos

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -360,6 +360,11 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorList)
             .await?;
 
+        // #1074: report the LIVE replicator registry, not the persisted peerstore,
+        // so a reconciler can observe authorization drift. The coordinator and the
+        // raw handle read the same shared registry (the coordinator delegates to the
+        // same transport), so both branches are equally live-authoritative; persisted
+        // rows only overlay address/status metadata below.
         let p2p_infos = if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .list_replicators()

--- a/crates/cli/src/p2p_adapter.rs
+++ b/crates/cli/src/p2p_adapter.rs
@@ -360,21 +360,25 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorList)
             .await?;
 
-        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
-            match pusher.load_persisted_replicators().await {
-                Ok(Some(infos)) => infos,
-                Ok(None) => self
-                    .handle
-                    .list_replicators()
-                    .await
-                    .map_err(|e| P2PError::Transport(e.to_string()))?,
-                Err(e) => return Err(P2PError::Internal(e)),
-            }
+        let p2p_infos = if let Some(ref coordinator) = self.sync_coordinator {
+            coordinator
+                .list_replicators()
+                .await
+                .map_err(|e| P2PError::Transport(e.to_string()))?
         } else {
             self.handle
                 .list_replicators()
                 .await
                 .map_err(|e| P2PError::Transport(e.to_string()))?
+        };
+        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
+            let persisted = pusher
+                .load_persisted_replicators()
+                .await
+                .map_err(P2PError::Internal)?;
+            defra_p2p_adapter::merge_live_replicators_with_persisted_metadata(p2p_infos, persisted)
+        } else {
+            p2p_infos
         };
 
         let http_infos: Vec<ReplicatorInfo> = p2p_infos

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -325,6 +325,11 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorList)
             .await?;
 
+        // #1074: report the LIVE replicator registry, not the persisted peerstore,
+        // so a reconciler can observe authorization drift. The coordinator and the
+        // raw transport read the same shared registry (the coordinator delegates to
+        // the same transport), so both branches are equally live-authoritative;
+        // persisted rows only overlay address/status metadata below.
         let p2p_infos = if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .list_replicators()

--- a/crates/p2p-adapter/src/iroh.rs
+++ b/crates/p2p-adapter/src/iroh.rs
@@ -325,20 +325,24 @@ impl<B: Blockstore + 'static> P2POperations for IrohP2PAdapter<B> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorList)
             .await?;
 
-        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
-            match pusher.load_persisted_replicators().await? {
-                Some(infos) => infos,
-                None => self
-                    .transport
-                    .list_replicators()
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?,
-            }
+        let p2p_infos = if let Some(ref coordinator) = self.sync_coordinator {
+            coordinator
+                .list_replicators()
+                .await
+                .map_err(|error| P2PError::transport(error.to_string()))?
         } else {
             self.transport
                 .list_replicators()
                 .await
                 .map_err(|error| P2PError::transport(error.to_string()))?
+        };
+        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
+            crate::merge_live_replicators_with_persisted_metadata(
+                p2p_infos,
+                pusher.load_persisted_replicators().await?,
+            )
+        } else {
+            p2p_infos
         };
 
         Ok(p2p_infos

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -57,9 +57,45 @@ where
         .collect()
 }
 
+/// Overlay persisted peer metadata onto live replicator authorization state.
+///
+/// The live registry/transport is authoritative for which peers and collections
+/// are currently replicators. Peerstore rows are persisted metadata and may lag
+/// live authorization changes, so they must not introduce peers or collections.
+pub fn merge_live_replicators_with_persisted_metadata(
+    live: Vec<p2p::ReplicatorInfo>,
+    persisted: Option<Vec<p2p::ReplicatorInfo>>,
+) -> Vec<p2p::ReplicatorInfo> {
+    let Some(persisted) = persisted else {
+        return live;
+    };
+
+    let persisted_by_peer: std::collections::BTreeMap<String, p2p::ReplicatorInfo> = persisted
+        .into_iter()
+        .map(|info| (info.peer_id_str().to_string(), info))
+        .collect();
+
+    live.into_iter()
+        .map(|mut info| {
+            let Some(persisted_info) = persisted_by_peer.get(info.peer_id_str()) else {
+                return info;
+            };
+
+            for address in &persisted_info.addresses {
+                if !info.addresses.iter().any(|existing| existing == address) {
+                    info.addresses.push(address.clone());
+                }
+            }
+            info.status = persisted_info.status;
+            info.last_status_change = persisted_info.last_status_change;
+            info
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod resolve_remove_collections_tests {
-    use super::resolve_remove_collections;
+    use super::{merge_live_replicators_with_persisted_metadata, resolve_remove_collections};
     use std::collections::HashMap;
 
     fn resolver(map: HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
@@ -85,6 +121,44 @@ mod resolve_remove_collections_tests {
         let map = HashMap::from([("AgentDoc", "bafyCID")]);
         let out = resolve_remove_collections(Vec::new(), resolver(map));
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn live_replicator_state_is_authoritative_over_persisted_collections() {
+        let peer = "peer-1".to_string();
+        let live = vec![p2p::ReplicatorInfo::from_raw(
+            peer.clone(),
+            vec!["allowed".to_string()],
+            vec!["live-addr".to_string()],
+        )];
+
+        let mut persisted = p2p::ReplicatorInfo::from_raw(
+            peer.clone(),
+            vec!["allowed".to_string(), "revoked".to_string()],
+            vec!["persisted-addr".to_string()],
+        );
+        persisted.set_status_if_changed_now(p2p::ReplicatorStatus::Inactive);
+
+        let persisted_only = p2p::ReplicatorInfo::from_raw(
+            "stale-peer".to_string(),
+            vec!["stale".to_string()],
+            vec!["stale-addr".to_string()],
+        );
+
+        let merged = merge_live_replicators_with_persisted_metadata(
+            live,
+            Some(vec![persisted.clone(), persisted_only]),
+        );
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].peer_id_str(), peer);
+        assert_eq!(merged[0].collections, vec!["allowed".to_string()]);
+        assert_eq!(
+            merged[0].addresses,
+            vec!["live-addr".to_string(), "persisted-addr".to_string()]
+        );
+        assert_eq!(merged[0].status, p2p::ReplicatorStatus::Inactive);
+        assert_eq!(merged[0].last_status_change, persisted.last_status_change);
     }
 }
 

--- a/crates/p2p-adapter/src/lib.rs
+++ b/crates/p2p-adapter/src/lib.rs
@@ -62,6 +62,10 @@ where
 /// The live registry/transport is authoritative for which peers and collections
 /// are currently replicators. Peerstore rows are persisted metadata and may lag
 /// live authorization changes, so they must not introduce peers or collections.
+///
+/// A persisted peer with no live counterpart is intentionally omitted (it is no
+/// longer an authorized replicator), but it is logged so the divergence is
+/// observable rather than a silently under-reported list.
 pub fn merge_live_replicators_with_persisted_metadata(
     live: Vec<p2p::ReplicatorInfo>,
     persisted: Option<Vec<p2p::ReplicatorInfo>>,
@@ -69,6 +73,17 @@ pub fn merge_live_replicators_with_persisted_metadata(
     let Some(persisted) = persisted else {
         return live;
     };
+
+    let live_peers: std::collections::HashSet<&str> =
+        live.iter().map(|info| info.peer_id_str()).collect();
+    for persisted_info in &persisted {
+        if !live_peers.contains(persisted_info.peer_id_str()) {
+            tracing::debug!(
+                peer_id = persisted_info.peer_id_str(),
+                "persisted replicator absent from live registry; omitting from reported state"
+            );
+        }
+    }
 
     let persisted_by_peer: std::collections::BTreeMap<String, p2p::ReplicatorInfo> = persisted
         .into_iter()

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -313,6 +313,11 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorList)
             .await?;
 
+        // #1074: report the LIVE replicator registry, not the persisted peerstore,
+        // so a reconciler can observe authorization drift. The coordinator and the
+        // raw handle read the same shared registry (the coordinator delegates to the
+        // same transport), so both branches are equally live-authoritative; persisted
+        // rows only overlay address/status metadata below.
         let p2p_infos = if let Some(ref coordinator) = self.sync_coordinator {
             coordinator
                 .list_replicators()

--- a/crates/p2p-adapter/src/libp2p.rs
+++ b/crates/p2p-adapter/src/libp2p.rs
@@ -313,20 +313,24 @@ impl<B: Blockstore + 'static> P2POperations for P2PAdapter<B> {
         self.check_nac(acp::nac::NodePermission::P2pReplicatorList)
             .await?;
 
-        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
-            match pusher.load_persisted_replicators().await? {
-                Some(infos) => infos,
-                None => self
-                    .handle
-                    .list_replicators()
-                    .await
-                    .map_err(|error| P2PError::transport(error.to_string()))?,
-            }
+        let p2p_infos = if let Some(ref coordinator) = self.sync_coordinator {
+            coordinator
+                .list_replicators()
+                .await
+                .map_err(|error| P2PError::transport(error.to_string()))?
         } else {
             self.handle
                 .list_replicators()
                 .await
                 .map_err(|error| P2PError::transport(error.to_string()))?
+        };
+        let p2p_infos = if let Some(ref pusher) = self.doc_pusher {
+            crate::merge_live_replicators_with_persisted_metadata(
+                p2p_infos,
+                pusher.load_persisted_replicators().await?,
+            )
+        } else {
+            p2p_infos
         };
 
         Ok(p2p_infos

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -3203,9 +3203,13 @@ async fn list_replicators_http(cluster: &TestCluster, node: usize) -> serde_json
 async fn rust_filtered_replication_partial_delete_keeps_remaining() {
     const OTHER_SCHEMA: &str = "type OtherDoc { body: String }";
 
-    let cluster = TestCluster::builder()
+    // Keyring => stable peer identity across restart; redb => persistent peerstore
+    // so the survivor's re-persisted row must actually be reloaded after restart.
+    let mut cluster = TestCluster::builder()
         .rust_nodes(2)
         .with_p2p()
+        .with_keyring()
+        .with_store("redb")
         .build()
         .await
         .unwrap();
@@ -3326,5 +3330,167 @@ async fn rust_filtered_replication_partial_delete_keeps_remaining() {
     assert!(
         !agent_ids.contains(&removed_id.as_str()),
         "a doc in the removed collection must NOT replicate after partial delete, found: {agent_ids:?}"
+    );
+
+    // #1077 regression guard. `getall` now reports the LIVE in-memory registry, so
+    // a partial-delete that wiped the whole peerstore row would be MASKED here (the
+    // survivor stays in the registry until the process exits). Restart node0 so the
+    // registry is rebuilt from the peerstore: if the row had been clobbered, the
+    // survivor now vanishes from `getall` and stops replicating.
+    cluster.nodes[0].process.kill();
+    cluster
+        .restart_node(0, Duration::from_secs(60))
+        .await
+        .expect("restart node0 after partial delete");
+    cluster
+        .wait_for_log(0, "p2p_listening", P2P_TIMEOUT)
+        .await
+        .expect("node0 P2P after restart");
+
+    let after_restart = list_replicators_http(&cluster, 0).await;
+    let after_restart_arr = after_restart.as_array().cloned().unwrap_or_default();
+    assert_eq!(
+        after_restart_arr.len(),
+        1,
+        "survivor must persist as a replicator across restart (peerstore not wiped), got: {after_restart}"
+    );
+    assert_eq!(
+        after_restart_arr[0]["CollectionIDs"]
+            .as_array()
+            .map(Vec::len)
+            .unwrap_or(0),
+        1,
+        "exactly the survivor collection must persist across restart, got: {after_restart}"
+    );
+
+    // Ephemeral transport state is lost on restart; reconnect so the reloaded
+    // replicator has a live channel, then prove the survivor still replicates.
+    let addr1_after = extract_p2p_addr(&cluster, 1);
+    cluster
+        .client(0)
+        .p2p_connect(&[&addr1_after])
+        .expect("reconnect 0->1 after restart");
+
+    let node0_after = cluster.client(0);
+    let survivor_after = node0_after
+        .query(r#"mutation { add_OtherDoc(input: {body: "survivor-after-restart"}) { _docID } }"#)
+        .expect("create OtherDoc after restart");
+    let survivor_after_id = extract_doc_id(&survivor_after, "add_OtherDoc");
+
+    let node1_after = cluster.client(1);
+    let survivor_after_poll = survivor_after_id.clone();
+    poll_until(
+        || {
+            let result = node1_after
+                .query("query { OtherDoc { _docID } }")
+                .unwrap_or_default();
+            result["OtherDoc"].as_array().is_some_and(|rows| {
+                rows.iter()
+                    .any(|r| r["_docID"].as_str() == Some(survivor_after_poll.as_str()))
+            })
+        },
+        P2P_TIMEOUT + Duration::from_secs(30),
+        P2P_POLL_INTERVAL,
+        "survivor (OtherDoc) did not replicate after source restart",
+    )
+    .await;
+}
+
+/// #1074 reporting contract: `getall` reports the LIVE registry membership (peer
+/// identity + collections) while overlaying persisted peerstore metadata
+/// (`Addresses` + `Status`). This drives the four-adapter live-read + merge wiring
+/// through the real HTTP surface — coverage the pure-function merge unit test
+/// (`merge_live_replicators_with_persisted_metadata`) cannot provide, since it
+/// never proves the `get_replicators` call sites actually read live and overlay.
+#[tokio::test]
+async fn rust_replicator_getall_reports_live_membership_and_persisted_metadata() {
+    let cluster = TestCluster::builder()
+        .rust_nodes(2)
+        .with_p2p()
+        .build()
+        .await
+        .unwrap();
+    wait_for_log_ready(&cluster, 2).await;
+    let node0 = cluster.client(0);
+    let node1 = cluster.client(1);
+
+    node0
+        .schema_add(AGENT_SCHEMA)
+        .expect("AgentDoc schema node0");
+    node1
+        .schema_add(AGENT_SCHEMA)
+        .expect("AgentDoc schema node1");
+
+    let addr1 = extract_p2p_addr(&cluster, 1);
+    let peer_id = addr1.rsplit("/p2p/").next().unwrap_or(&addr1).to_string();
+    node0.p2p_connect(&[&addr1]).expect("connect 0->1");
+    node0
+        .p2p_collection_add(&["AgentDoc"])
+        .expect("subscribe 0 to AgentDoc");
+
+    let out = run_replicator_add_plain(&cluster, 0, &["AgentDoc"], &addr1);
+    assert!(
+        out.status.success(),
+        "replicator add failed: status={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let listed = list_replicators_http(&cluster, 0).await;
+    let entry = listed
+        .as_array()
+        .and_then(|arr| arr.first())
+        .cloned()
+        .unwrap_or_else(|| panic!("expected exactly one replicator listed, got: {listed}"));
+
+    // Live registry is authoritative for identity + collection membership.
+    assert_eq!(
+        entry["ID"].as_str(),
+        Some(peer_id.as_str()),
+        "getall must report the live peer id, got: {entry}"
+    );
+    let cols: Vec<&str> = entry["CollectionIDs"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|c| c.as_str()).collect())
+        .unwrap_or_default();
+    assert_eq!(
+        cols.len(),
+        1,
+        "getall must report exactly the live collection membership, got: {entry}"
+    );
+
+    // Persisted peerstore metadata is overlaid: the address survives the merge and
+    // a numeric Status (0=Active / 1=Inactive) is surfaced rather than dropped.
+    assert!(
+        entry["Addresses"]
+            .as_array()
+            .is_some_and(|addrs| !addrs.is_empty()),
+        "getall must surface the persisted replicator address, got: {entry}"
+    );
+    assert!(
+        entry["Status"].is_u64(),
+        "getall must surface the persisted status field, got: {entry}"
+    );
+
+    // #1074 reporting contract: a live auth change must be reflected in getall so
+    // a reconciler can observe drift. Fully removing the replicator's only
+    // collection drops it from the live registry; getall must then no longer list
+    // the peer (it is not resurrected from persisted-only state).
+    node0
+        .p2p_replicator_delete(&["AgentDoc"], Some(&addr1))
+        .or_else(|_| node0.p2p_replicator_delete(&["AgentDoc"], Some(&peer_id)))
+        .expect("full p2p_replicator_delete");
+
+    let after_delete = list_replicators_http(&cluster, 0).await;
+    let still_listed = after_delete
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .any(|r| r["ID"].as_str() == Some(peer_id.as_str()))
+        })
+        .unwrap_or(false);
+    assert!(
+        !still_listed,
+        "getall must reflect the live removal of the replicator, got: {after_delete}"
     );
 }

--- a/tools/integration-test/tests/p2p/filtered_replication.rs
+++ b/tools/integration-test/tests/p2p/filtered_replication.rs
@@ -3396,14 +3396,20 @@ async fn rust_filtered_replication_partial_delete_keeps_remaining() {
     .await;
 }
 
-/// #1074 reporting contract: `getall` reports the LIVE registry membership (peer
-/// identity + collections) while overlaying persisted peerstore metadata
-/// (`Addresses` + `Status`). This drives the four-adapter live-read + merge wiring
-/// through the real HTTP surface — coverage the pure-function merge unit test
-/// (`merge_live_replicators_with_persisted_metadata`) cannot provide, since it
-/// never proves the `get_replicators` call sites actually read live and overlay.
+/// HTTP lifecycle/wiring smoke test for `getall` (`GET /api/v0/p2p/replicators`):
+/// adding a replicator surfaces its peer id, collections, `Addresses`, and
+/// `Status` over the real adapter+HTTP path, and fully deleting it removes the
+/// peer from the listing.
+///
+/// Note on scope: `add`/`delete` mutate the live registry and the peerstore
+/// together, so this does NOT distinguish live-authoritative reporting from a
+/// peerstore read — those divergence semantics (live wins, persisted-only peers
+/// dropped, metadata overlay) are locked by the unit test
+/// `live_replicator_state_is_authoritative_over_persisted_collections`. This test
+/// only locks that the `get_replicators` call sites are wired and the wire shape
+/// is correct end to end.
 #[tokio::test]
-async fn rust_replicator_getall_reports_live_membership_and_persisted_metadata() {
+async fn rust_replicator_getall_reports_replicator_lifecycle() {
     let cluster = TestCluster::builder()
         .rust_nodes(2)
         .with_p2p()
@@ -3443,11 +3449,11 @@ async fn rust_replicator_getall_reports_live_membership_and_persisted_metadata()
         .cloned()
         .unwrap_or_else(|| panic!("expected exactly one replicator listed, got: {listed}"));
 
-    // Live registry is authoritative for identity + collection membership.
+    // Identity + collection membership are reported.
     assert_eq!(
         entry["ID"].as_str(),
         Some(peer_id.as_str()),
-        "getall must report the live peer id, got: {entry}"
+        "getall must report the peer id, got: {entry}"
     );
     let cols: Vec<&str> = entry["CollectionIDs"]
         .as_array()
@@ -3456,11 +3462,12 @@ async fn rust_replicator_getall_reports_live_membership_and_persisted_metadata()
     assert_eq!(
         cols.len(),
         1,
-        "getall must report exactly the live collection membership, got: {entry}"
+        "getall must report exactly the replicator's collection membership, got: {entry}"
     );
 
-    // Persisted peerstore metadata is overlaid: the address survives the merge and
-    // a numeric Status (0=Active / 1=Inactive) is surfaced rather than dropped.
+    // The address and a numeric Status (0=Active / 1=Inactive) are present in the
+    // wire shape. (Both come from the peerstore record written by `add`, so this
+    // checks the HTTP shape, not the live-vs-persisted overlay.)
     assert!(
         entry["Addresses"]
             .as_array()
@@ -3472,10 +3479,10 @@ async fn rust_replicator_getall_reports_live_membership_and_persisted_metadata()
         "getall must surface the persisted status field, got: {entry}"
     );
 
-    // #1074 reporting contract: a live auth change must be reflected in getall so
-    // a reconciler can observe drift. Fully removing the replicator's only
-    // collection drops it from the live registry; getall must then no longer list
-    // the peer (it is not resurrected from persisted-only state).
+    // Lifecycle: fully removing the replicator's only collection deletes the peer
+    // from both the live registry and the peerstore, so getall must no longer list
+    // it. (This exercises the delete->report path; it does not isolate live from
+    // persisted, since the delete clears both.)
     node0
         .p2p_replicator_delete(&["AgentDoc"], Some(&addr1))
         .or_else(|_| node0.p2p_replicator_delete(&["AgentDoc"], Some(&peer_id)))
@@ -3491,6 +3498,6 @@ async fn rust_replicator_getall_reports_live_membership_and_persisted_metadata()
         .unwrap_or(false);
     assert!(
         !still_listed,
-        "getall must reflect the live removal of the replicator, got: {after_delete}"
+        "getall must reflect the deleted replicator's removal, got: {after_delete}"
     );
 }


### PR DESCRIPTION
## Summary
- make P2P replicator listing read live coordinator/transport state before peerstore metadata
- preserve persisted address/status metadata only for peers that are still live replicators
- update libp2p, iroh, and CLI-local adapter paths consistently
- add a regression test proving persisted-only/stale collections do not leak into reported state

Fixes #1074

## Testing
- cargo test -p defra-p2p-adapter live_replicator_state_is_authoritative_over_persisted_collections
- cargo check -p p2p -p defra-p2p-adapter -p cli
- cargo fmt --check
- git diff --check