### PR TITLE
feat(ffi): expose peer disconnect via p2p_disconnect and defra_mobile_disconnect

### DIFF
--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -255,7 +255,7 @@ pub use index::{create_index, delete_index, get_indexes, list_all_indexes};
 pub use lens::{lens_add, lens_add_in_txn, lens_list, lens_list_in_txn};
 pub use mobile::{
     defra_mobile_add_replicator, defra_mobile_close_node, defra_mobile_connect,
-    defra_mobile_ensure_schema, defra_mobile_execute, defra_mobile_init,
+    defra_mobile_disconnect, defra_mobile_ensure_schema, defra_mobile_execute, defra_mobile_init,
     defra_mobile_notify_network_change, defra_mobile_open_node, defra_mobile_peer_info,
     defra_mobile_sync_collection,
 };
@@ -263,9 +263,9 @@ pub use node::{new_node, node_close};
 pub use p2p::{
     new_node_with_p2p, p2p_active_peers, p2p_add_collections, p2p_add_documents,
     p2p_add_replicator, p2p_add_replicator_with_filter, p2p_connect, p2p_delete_collections,
-    p2p_delete_documents, p2p_delete_replicator, p2p_list_collections, p2p_list_documents,
-    p2p_list_replicators, p2p_notify_network_change, p2p_peer_info, p2p_sync_branchable_collection,
-    p2p_sync_collection_versions, p2p_sync_documents,
+    p2p_delete_documents, p2p_delete_replicator, p2p_disconnect, p2p_list_collections,
+    p2p_list_documents, p2p_list_replicators, p2p_notify_network_change, p2p_peer_info,
+    p2p_sync_branchable_collection, p2p_sync_collection_versions, p2p_sync_documents,
 };
 pub use query::exec_request;
 pub use schema::{add_schema, add_schema_in_txn, get_collections, get_collections_in_txn};

--- a/crates/ffi/src/mobile.rs
+++ b/crates/ffi/src/mobile.rs
@@ -14,9 +14,9 @@ use crate::mobile_config::{
 use crate::nac_check::check_nac_for_node;
 use crate::node::{new_node, node_close};
 use crate::p2p::{
-    new_node_with_p2p, p2p_add_replicator_with_filter, p2p_connect, p2p_notify_network_change,
-    p2p_peer_info, p2p_sync_branchable_collection, p2p_sync_collection_versions,
-    p2p_sync_documents,
+    new_node_with_p2p, p2p_add_replicator_with_filter, p2p_connect, p2p_disconnect,
+    p2p_notify_network_change, p2p_peer_info, p2p_sync_branchable_collection,
+    p2p_sync_collection_versions, p2p_sync_documents,
 };
 use crate::query::exec_request;
 use crate::schema::validate_collection_policy;
@@ -518,6 +518,19 @@ pub extern "C" fn defra_mobile_connect(node_ptr: usize, addr: *const c_char) -> 
     }
 }
 
+/// Disconnect the node from a peer address.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn defra_mobile_disconnect(node_ptr: usize, addr: *const c_char) -> FfiResult {
+    ffi_entry! {
+        let identity = match default_identity_cstring(node_ptr) {
+            Ok(value) => value,
+            Err(error) => return FfiResult::error(error),
+        };
+        unsafe { p2p_disconnect(node_ptr, c_string_ptr(&identity), addr) }
+    }
+}
+
 /// Notify the embedded iroh transport that network conditions may have changed.
 #[no_mangle]
 pub extern "C" fn defra_mobile_notify_network_change(node_ptr: usize) -> FfiResult {
@@ -707,6 +720,12 @@ mod tests {
         let json = r#"{"collections":["Posts"],"address":"/ip4/127.0.0.1/tcp/9000"}"#;
         let request: MobileAddReplicatorRequest = serde_json::from_str(json).unwrap();
         assert_eq!(request.peer_addr, "/ip4/127.0.0.1/tcp/9000");
+    }
+
+    #[test]
+    fn defra_mobile_disconnect_exports_connect_style_ffi_signature() {
+        let symbol: extern "C" fn(usize, *const c_char) -> FfiResult = defra_mobile_disconnect;
+        let _ = symbol;
     }
 
     #[test]

--- a/crates/ffi/src/p2p/mod.rs
+++ b/crates/ffi/src/p2p/mod.rs
@@ -19,7 +19,9 @@ mod version_sync;
 pub use collections::{p2p_add_collections, p2p_delete_collections, p2p_list_collections};
 pub use documents::{p2p_add_documents, p2p_delete_documents, p2p_list_documents};
 pub use node::new_node_with_p2p;
-pub use peer::{p2p_active_peers, p2p_connect, p2p_notify_network_change, p2p_peer_info};
+pub use peer::{
+    p2p_active_peers, p2p_connect, p2p_disconnect, p2p_notify_network_change, p2p_peer_info,
+};
 pub use push::p2p_retry_replicators;
 pub use replicator::{
     p2p_add_replicator, p2p_add_replicator_with_filter, p2p_delete_replicator, p2p_list_replicators,

--- a/crates/ffi/src/p2p/peer.rs
+++ b/crates/ffi/src/p2p/peer.rs
@@ -243,3 +243,68 @@ pub unsafe extern "C" fn p2p_connect(
         into_ffi_ok(result)
     }
 }
+
+/// Disconnect from a peer address.
+///
+/// # Safety
+///
+/// `identity_did` and `addr` must be valid null-terminated UTF-8 strings when non-null.
+/// `node_ptr` must reference a live node handle created by this library.
+#[no_mangle]
+pub unsafe extern "C" fn p2p_disconnect(
+    node_ptr: usize,
+    identity_did: *const c_char,
+    addr: *const c_char,
+) -> FfiResult {
+    ffi_entry! {
+        let rt = try_ffi!(get_rt());
+        try_ffi!(check_nac_for_node(
+            rt,
+            node_ptr,
+            identity_did,
+            NodePermission::P2pPeerConnect
+        ));
+
+        // Bind the caller's identity so the adapter's inner NAC check resolves the
+        // actual caller instead of the wildcard. The body runs on this thread via
+        // `block_on`, so the thread-local is visible throughout; the guard restores
+        // on drop so it never leaks into the next request on this pooled thread.
+        let _identity_guard = defra_core::current_identity::scoped_current_identity(
+            crate::types::c_str_to_string(identity_did).filter(|s| !s.is_empty()),
+        );
+
+        let addr_str = try_ffi!(require_c_str(addr, "addr"));
+
+        let result = NODES
+            .get(node_ptr, |state| {
+                let p2p = match &state.p2p {
+                    Some(p2p) => p2p,
+                    None => return Err(FfiP2PError::no_p2p_system()),
+                };
+
+                rt.block_on(async {
+                    p2p.system
+                        .ops()
+                        .disconnect_peer(&addr_str)
+                        .await
+                        .map_err(FfiP2PError::from)
+                })
+            })
+            .ok_or_else(FfiP2PError::invalid_node_handle)
+            .and_then(|result| result);
+
+        into_ffi_ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn p2p_disconnect_exports_connect_style_ffi_signature() {
+        let symbol: unsafe extern "C" fn(usize, *const c_char, *const c_char) -> FfiResult =
+            p2p_disconnect;
+        let _ = symbol;
+    }
+}

--- a/tools/apple/README.md
+++ b/tools/apple/README.md
@@ -76,12 +76,17 @@ The mobile-oriented entry points are:
 - `defra_mobile_execute(node, request_json)`
 - `defra_mobile_peer_info(node)`
 - `defra_mobile_connect(node, addr)`
+- `defra_mobile_disconnect(node, addr)`
 - `defra_mobile_sync_collection(node, request_json)`
 - `defra_mobile_add_replicator(node, request_json)`
 - `register_remote_identity(...)`
 - `register_remote_identity_bytes(...)`
 - `bind_identity_bearer_token(did, bearer_token)`
 - `node_set_default_identity(node, did)`
+
+Rebuild the XCFramework after updating the FFI crate so the generated header
+includes newly added symbols such as `defra_mobile_add_replicator` and
+`defra_mobile_disconnect`.
 
 `defra_mobile_open_node` accepts a JSON blob so Swift can avoid hand-building
 `NodeInitOptions`. Example:
@@ -110,8 +115,7 @@ The mobile-oriented entry points are:
 ```
 
 `defra_mobile_add_replicator` accepts a single peer address, collection names,
-and optional per-collection filters. Rebuild the XCFramework after updating the
-FFI crate so the generated header includes the new symbol.
+and optional per-collection filters.
 
 ```json
 {


### PR DESCRIPTION
Stacked on #1076 (FFI filtered replication); rebase to main after that merges.

## Summary
- Exposes `p2p_disconnect` in the FFI peer API, mirroring `p2p_connect` with the same `P2pPeerConnect` NAC gate and scoped identity handling.
- Adds `defra_mobile_disconnect(node_ptr, addr)` as the mobile convenience wrapper, matching the plain-address shape used by `defra_mobile_connect`.
- Re-exports the new symbols from the FFI crate root and P2P module.

## Notes
- This is additive and does not change any existing FFI symbols.
- The disconnect path delegates to the existing adapter `disconnect_peer` implementations.

Closes #1078.

## Validation
- `cargo fmt -p ffi -- --check`
- `cargo build -p ffi --lib --no-default-features --features redb`
- `cargo test -p ffi --lib --no-default-features --features redb` (145 passed)
- `cargo clippy -p ffi --lib --no-default-features --features redb -- -D warnings`

I used the redb-only feature set locally to keep the targeted FFI checks within runner disk limits; default-feature coverage is left to CI.
