### PR TITLE
feat(p2p): log the resolved iroh relay set at endpoint spawn

### DIFF
--- a/crates/p2p/src/iroh/endpoint.rs
+++ b/crates/p2p/src/iroh/endpoint.rs
@@ -111,6 +111,13 @@ pub async fn spawn_endpoint(
     alpns.push(iroh_gossip::net::GOSSIP_ALPN.to_vec());
 
     let relay_mode = relay_mode_from_config(&config.relay_mode)?;
+    let relay_urls: Vec<String> = relay_mode
+        .relay_map()
+        .urls::<Vec<_>>()
+        .iter()
+        .map(|u| u.to_string())
+        .collect();
+    tracing::info!(?relay_urls, "iroh endpoint relay configuration");
     let mut builder = Endpoint::builder(iroh::endpoint::presets::Minimal)
         .relay_mode(relay_mode)
         .secret_key(config.secret_key.clone())


### PR DESCRIPTION
## Why

Follow-up to the defra-agent#588 incident (relay `open_path` flood against unreachable n0 **canary** relays). During the incident nothing in the logs showed which relay infrastructure the endpoint was pointed at — canary vs production was invisible at default verbosity.

## What

**Slimmed down after #1084 merged** (which landed the iroh 1.0.1 / gossip 0.101 / blobs 0.103 / tickets 1.0.0 bump this PR originally carried — thanks!). What remains is the observability piece: log the resolved relay URL set once at `spawn_endpoint` in `crates/p2p/src/iroh/endpoint.rs`, so every deployment shows its relay infrastructure at startup.

## Verification

- `cargo check -p p2p --all-features` green on top of #1084
- `cargo fmt --check` green

The `fix/iroh-1.0-on-v0.15.1` branch mentioned earlier is now obsolete (defra-agent pins the #1084 merge rev directly) — I'll delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)