### PR TITLE
fix(p2p): only emit PeerDisconnected when the last connection closes (Linux sync stall)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,68 @@ jobs:
           git clean -fd
           pkill -f "target/(debug|ci)/defra" || true
 
+  p2p-linux:
+    # The macOS `integration` matrix above only runs the P2P suite on the studio
+    # host. Several P2P sync races are exposed only by Linux's socket/thread
+    # scheduling (e.g. duplicate connections that form under multi-core
+    # kqueue-vs-epoll timing), so mirror the pure-Rust P2P leg on the self-hosted
+    # Linux runner. Builds its own binary — the `build` job caches Mach-O
+    # binaries that cannot run here.
+    name: P2P Integration (Linux)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 45
+    env:
+      # The workflow-level PROTOC points at a macOS Homebrew path; override it
+      # with the apt-installed protoc for this Linux job.
+      PROTOC: /usr/bin/protoc
+      DEFRA_RUST_BINARY: ${{ github.workspace }}/target/debug/defra
+      DEFRA_IROH_BINARY: ${{ github.workspace }}/target/debug/defra
+      DEFRA_WORKSPACE_ROOT: ${{ github.workspace }}
+      # The harness waits on INFO-level p2p_listening / readiness log lines; pin
+      # the child filter so an inherited RUST_LOG=warn can't hide readiness.
+      RUST_LOG: info
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Configure private repo access
+        run: git config --global url."https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/".insteadOf "https://github.com/sourcenetwork/"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-ci"
+          shared-key: "p2p-linux"
+
+      - name: Install system dependencies
+        # protobuf-compiler: prost-build. clang/libclang-dev: bindgen (rocksdb).
+        # cmake: librocksdb-sys. libdbus-1-dev: keyring secret-service backend.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler clang libclang-dev cmake pkg-config libssl-dev libdbus-1-dev
+
+      - name: Build defra binary
+        run: |
+          cargo build -p cli
+          "$DEFRA_RUST_BINARY" version --format json
+
+      # Same selection as the macOS rust leg: pure-Rust P2P topologies only
+      # (`--skip ::go_` drops the go_go_/go_rust_ variants). Serialized because
+      # the harness port allocator has a TOCTOU bind race under parallelism.
+      - name: Run rust P2P integration tests
+        run: >-
+          cargo test -p integration-test
+          --test p2p
+          -- --test-threads=1 --skip ::go_
+
+      - name: Cleanup
+        if: always()
+        run: |
+          git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
+          git checkout -- .
+          git clean -fd
+          pkill -f "target/debug/defra" || true
+
   artifacts:
     name: Release Artifacts
     runs-on: [self-hosted, macOS, ARM64, studio]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,8 +448,8 @@ jobs:
       # The workflow-level PROTOC points at a macOS Homebrew path; override it
       # with the apt-installed protoc for this Linux job.
       PROTOC: /usr/bin/protoc
-      DEFRA_RUST_BINARY: ${{ github.workspace }}/target/debug/defra
-      DEFRA_IROH_BINARY: ${{ github.workspace }}/target/debug/defra
+      DEFRA_RUST_BINARY: ${{ github.workspace }}/target/ci/defra
+      DEFRA_IROH_BINARY: ${{ github.workspace }}/target/ci/defra-iroh
       DEFRA_WORKSPACE_ROOT: ${{ github.workspace }}
       # The harness waits on INFO-level p2p_listening / readiness log lines; pin
       # the child filter so an inherited RUST_LOG=warn can't hide readiness.
@@ -474,10 +474,19 @@ jobs:
         # cmake: librocksdb-sys. libdbus-1-dev: keyring secret-service backend.
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler clang libclang-dev cmake pkg-config libssl-dev libdbus-1-dev
 
-      - name: Build defra binary
+      # Build both the standard and iroh-enabled binaries — the p2p suite's
+      # `rust_*_iroh` filtered-replication tests spawn iroh-transport nodes via
+      # DEFRA_IROH_BINARY, which must be built with `--features iroh`. Mirrors the
+      # macOS build/integration jobs' target/ci/{defra,defra-iroh} layout.
+      - name: Build defra binaries
         run: |
+          mkdir -p target/ci
           cargo build -p cli
+          cp target/debug/defra target/ci/defra
+          cargo build -p cli --features iroh
+          cp target/debug/defra target/ci/defra-iroh
           "$DEFRA_RUST_BINARY" version --format json
+          "$DEFRA_IROH_BINARY" version --format json
 
       # Same selection as the macOS rust leg: pure-Rust P2P topologies only
       # (`--skip ::go_` drops the go_go_/go_rust_ variants). Serialized because
@@ -494,7 +503,7 @@ jobs:
           git config --global --remove-section "url.https://${{ secrets.PRIVATE_REPO_PAT }}@github.com/sourcenetwork/" 2>/dev/null || true
           git checkout -- .
           git clean -fd
-          pkill -f "target/debug/defra" || true
+          pkill -f "target/(debug|ci)/defra" || true
 
   artifacts:
     name: Release Artifacts

--- a/crates/p2p/src/host/p2p_host/swarm.rs
+++ b/crates/p2p/src/host/p2p_host/swarm.rs
@@ -1,7 +1,8 @@
 //! Swarm event handling.
 
 use iroh_bitswap::Store;
-use libp2p::swarm::SwarmEvent;
+use libp2p::swarm::{ConnectionId, SwarmEvent};
+use libp2p::PeerId;
 use tracing::{debug, error, info, warn};
 
 use crate::behaviour::DefraEvent;
@@ -100,19 +101,8 @@ impl<S: Store> P2PHost<S> {
                 num_established,
                 ..
             } => {
-                info!(peer_id = %peer_id, "Peer disconnected");
-                self.connection_manager.on_closed(connection_id);
-                if num_established == 0 {
-                    self.peer_addrs.remove(&peer_id);
-                }
-                if self
-                    .event_tx
-                    .send(HostEvent::PeerDisconnected(peer_id))
-                    .await
-                    .is_err()
-                {
-                    warn!(peer_id = %peer_id, "Failed to send PeerDisconnected event - receiver dropped");
-                }
+                self.handle_connection_closed(peer_id, connection_id, num_established)
+                    .await;
                 false
             }
 
@@ -254,5 +244,100 @@ impl<S: Store> P2PHost<S> {
                 false
             }
         }
+    }
+
+    /// Handle a closed connection.
+    ///
+    /// `num_established` is the number of connections to `peer_id` that remain
+    /// open *after* this one closed. We only treat the peer as disconnected —
+    /// dropping its cached address and surfacing `PeerDisconnected` to the sync
+    /// layer — once the last connection closes. Emitting `PeerDisconnected` while
+    /// another connection is still live flips the peer's `connected` gate off,
+    /// which stalls provider selection, subscription targeting and ingress
+    /// authorization even though the peer is still reachable, leaving blocks
+    /// unreconciled until a brand-new connection forms. Duplicate connections
+    /// (e.g. a simultaneous dial-dial between two peers) form far more readily
+    /// under Linux's multi-core socket scheduling than on macOS loopback, so the
+    /// previous unconditional emit surfaced as Linux-only P2P sync stalls. The
+    /// iroh transport already refcounts connections per peer; this matches it.
+    pub(super) async fn handle_connection_closed(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        num_established: u32,
+    ) {
+        self.connection_manager.on_closed(connection_id);
+
+        if num_established > 0 {
+            debug!(
+                peer_id = %peer_id,
+                remaining_connections = num_established,
+                "Connection closed but peer still reachable; not emitting PeerDisconnected"
+            );
+            return;
+        }
+
+        info!(peer_id = %peer_id, "Peer disconnected");
+        self.peer_addrs.remove(&peer_id);
+        if self
+            .event_tx
+            .send(HostEvent::PeerDisconnected(peer_id))
+            .await
+            .is_err()
+        {
+            warn!(peer_id = %peer_id, "Failed to send PeerDisconnected event - receiver dropped");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::swarm::ConnectionId;
+    use libp2p::PeerId;
+
+    use crate::host::event::HostEvent;
+    use crate::host::P2PHost;
+    use crate::testutil::MockBitswapStore;
+
+    fn drain(rx: &mut tokio::sync::mpsc::Receiver<HostEvent>) -> Vec<HostEvent> {
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+
+    fn saw_disconnect(events: &[HostEvent], peer: PeerId) -> bool {
+        events
+            .iter()
+            .any(|event| matches!(event, HostEvent::PeerDisconnected(p) if *p == peer))
+    }
+
+    /// Closing one of several connections to a peer must NOT report the peer as
+    /// disconnected; only the last connection closing does. Before the fix,
+    /// `ConnectionClosed` emitted `PeerDisconnected` unconditionally, so tearing
+    /// down a duplicate connection (common under Linux socket scheduling) flipped
+    /// the peer's `connected` gate off and stalled block reconciliation.
+    #[tokio::test]
+    async fn peer_disconnect_only_on_last_connection_close() {
+        let store = MockBitswapStore::new();
+        let (mut host, _handle, mut events, _registry) = P2PHost::new(store).await.unwrap();
+        let peer = PeerId::random();
+
+        // One of two connections closes; one remains (num_established == 1).
+        host.handle_connection_closed(peer, ConnectionId::new_unchecked(1), 1)
+            .await;
+        assert!(
+            !saw_disconnect(&drain(&mut events), peer),
+            "PeerDisconnected must not fire while the peer still has a live connection"
+        );
+
+        // The last connection closes (num_established == 0).
+        host.handle_connection_closed(peer, ConnectionId::new_unchecked(2), 0)
+            .await;
+        assert!(
+            saw_disconnect(&drain(&mut events), peer),
+            "PeerDisconnected must fire once the last connection closes"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes a Linux-specific P2P reconciliation stall and adds a Linux CI job so this class of bug is caught in CI.

The libp2p `ConnectionClosed` handler dropped the peer's cached address only when `num_established == 0`, but sent `HostEvent::PeerDisconnected` on **every** connection close — even while other connections to that peer were still live.

`PeerDisconnected` flips the peer's `connected` gate off in the sync coordinator, and that gate drives provider selection (`peers_with_cid` / `connected_peers`), subscription targeting, and ingress authorization. Nothing re-sets it true without a fresh `ConnectionEstablished`, so **pull-based reconciliation silently stalls** until a brand-new connection forms.

Duplicate connections (e.g. a simultaneous dial-dial in bidirectional replication) form far more readily under Linux's multi-core socket scheduling than on macOS loopback — so when one of the pair closes (`num_established == 1`) the spurious disconnect fired and blocks stopped reconciling. This is why a dev hit it on Linux but it was invisible on the macOS dev box.

The **iroh transport already refcounts connections per peer** and only emits `PeerDisconnected` on the last close; this brings libp2p (the main transport) in line.

## Changes

- **`crates/p2p/src/host/p2p_host/swarm.rs`** — extract `handle_connection_closed()` and gate both the address removal and the `PeerDisconnected` emit on `num_established == 0`. The connection-prune path already routes closures through a real `ConnectionClosed` event, so it's covered by the same fix.
- Deterministic regression test `peer_disconnect_only_on_last_connection_close` — closes one of two connections and asserts no disconnect fires, then closes the last and asserts it does. It **fails on the old unconditional emit** and passes now.
- **`.github/workflows/ci.yml`** — new `P2P Integration (Linux)` job on the existing self-hosted `[Linux, X64]` runner, mirroring the macOS rust P2P leg (`cargo test -p integration-test --test p2p -- --test-threads=1 --skip ::go_`), with a Linux `PROTOC` override and the needed apt deps (`libdbus-1-dev` for the keyring backend, etc.).

## Testing

Reproduced on a real Linux environment (Docker, from a macOS box). All green on **both** Linux and macOS:

- New regression test fails without the fix, passes with it (verified on both platforms)
- `cargo test -p p2p --features test-utils --lib` — 319 passed
- `cargo test -p p2p --features test-utils --test host_tests` — 17 passed (Linux)
- P2P integration reconciliation suite — 8/8 passed on both, including the bidirectional `write_contention::rust_rust_*` tests that create the duplicate connections triggering the bug
- `cargo fmt --all --check` and `cargo clippy --all -- -D warnings` clean

## Notes

The investigation also surfaced secondary Linux-timing hazards worth separate issues (fixed 10s/30s DAG-fetch timeouts + a 20-iteration cap in `dag_fetcher.rs`, and arrival-order counter-reconcile paths related to #1061/#1043). Those are "loosen a timeout" / CRDT-algebra concerns rather than this crisp logic bug, so they're out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
